### PR TITLE
[9.x] Ensure decimal rule handles large values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Validation\Concerns;
 
 use Brick\Math\BigDecimal;
-use Brick\Math\Exception\MathException as BrickMathException;
 use Brick\Math\BigNumber;
+use Brick\Math\Exception\MathException as BrickMathException;
 use DateTime;
 use DateTimeInterface;
 use Egulias\EmailValidator\EmailValidator;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation\Concerns;
 
 use Brick\Math\BigDecimal;
 use Brick\Math\Exception\MathException as BrickMathException;
+use Brick\Math\BigNumber;
 use DateTime;
 use DateTimeInterface;
 use Egulias\EmailValidator\EmailValidator;
@@ -436,13 +437,10 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'between');
 
-        $size = $this->getSize($attribute, $value);
-
-        if (is_string($size)) {
-            return with(BigDecimal::of($size), fn ($size) => $size->isGreaterThanOrEqualTo($parameters[0]) && $size->isLessThanOrEqualTo($parameters[1]));
-        } else {
-            return $size >= $parameters[0] && $size <= $parameters[1];
-        }
+        return with(
+            BigNumber::of($this->getSize($attribute, $value)),
+            fn ($size) => $size->isGreaterThanOrEqualTo($parameters[0]) && $size->isLessThanOrEqualTo($parameters[1])
+        );
     }
 
     /**
@@ -1083,16 +1081,8 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        $compare = function ($left, $right) {
-            if (is_string($left)) {
-                return BigDecimal::of($left)->isGreaterThan($right);
-            } else {
-                return $left > $right;
-            }
-        };
-
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $compare($this->getSize($attribute, $value), $parameters[0]);
+            return BigNumber::of($this->getSize($attribute, $value))->isGreaterThan($parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1100,7 +1090,7 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $compare($value, $comparedToValue);
+            return BigNumber::of($value)->isGreaterThan($comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
@@ -1127,16 +1117,8 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        $compare = function ($left, $right) {
-            if (is_string($left)) {
-                return BigDecimal::of($left)->isLessThan($right);
-            } else {
-                return $left < $right;
-            }
-        };
-
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $compare($this->getSize($attribute, $value), $parameters[0]);
+            return BigNumber::of($this->getSize($attribute, $value))->isLessThan($parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1144,7 +1126,7 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $compare($value, $comparedToValue);
+            return BigNumber::of($value)->isLessThan($comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
@@ -1171,16 +1153,8 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        $compare = function ($left, $right) {
-            if (is_string($left)) {
-                return BigDecimal::of($left)->isGreaterThanOrEqualTo($right);
-            } else {
-                return $left >= $right;
-            }
-        };
-
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $compare($this->getSize($attribute, $value), $parameters[0]);
+            return BigNumber::of($this->getSize($attribute, $value))->isGreaterThanOrEqualTo($parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1188,7 +1162,7 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $compare($value, $comparedToValue);
+            return BigNumber::of($value)->isGreaterThanOrEqualTo($comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
@@ -1215,16 +1189,8 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        $compare = function ($left, $right) {
-            if (is_string($left)) {
-                return BigDecimal::of($left)->isLessThanOrEqualTo($right);
-            } else {
-                return $left <= $right;
-            }
-        };
-
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $compare($this->getSize($attribute, $value), $parameters[0]);
+            return BigNumber::of($this->getSize($attribute, $value))->isLessThanOrEqualTo($parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1232,7 +1198,7 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $compare($value, $comparedToValue);
+            return BigNumber::of($value)->isLessThanOrEqualTo($comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
@@ -1425,13 +1391,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        $size = $this->getSize($attribute, $value);
-
-        if (is_string($size)) {
-            return BigDecimal::of($size)->isLessThanOrEqualTo($parameters[0]);
-        } else {
-            return $size <= $parameters[0];
-        }
+        return BigNumber::of($this->getSize($attribute, $value))->isLessThanOrEqualTo($parameters[0]);
     }
 
     /**
@@ -1533,13 +1493,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'min');
 
-        $size = $this->getSize($attribute, $value);
-
-        if (is_string($size)) {
-            return BigDecimal::of($size)->isGreaterThanOrEqualTo($parameters[0]);
-        } else {
-            return $size >= $parameters[0];
-        }
+        return BigNumber::of($this->getSize($attribute, $value))->isGreaterThanOrEqualTo($parameters[0]);
     }
 
     /**
@@ -2214,13 +2168,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'size');
 
-        $size = $this->getSize($attribute, $value);
-
-        if (is_string($size)) {
-            return BigDecimal::of($size)->isEqualTo($parameters[0]);
-        } else {
-            return $size == $parameters[0];
-        }
+        return BigNumber::of($this->getSize($attribute, $value))->isEqualTo($parameters[0]);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1097,7 +1097,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // TODO?
         return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1133,7 +1132,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // TODO?
         return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1169,7 +1167,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // TODO?
         return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1205,7 +1202,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // TODO?
         return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue);
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -438,7 +438,11 @@ trait ValidatesAttributes
 
         $size = $this->getSize($attribute, $value);
 
-        return $size >= $parameters[0] && $size <= $parameters[1];
+        if (is_string($size)) {
+            return with(BigDecimal::of($size), fn ($size) => $size->isGreaterThanOrEqualTo($parameters[0]) && $size->isLessThanOrEqualTo($parameters[1]));
+        } else {
+            return $size >= $parameters[0] && $size <= $parameters[1];
+        }
     }
 
     /**
@@ -1079,8 +1083,16 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
+        $compare = function ($left, $right) {
+            if (is_string($left)) {
+                return BigDecimal::of($left)->isGreaterThan($right);
+            } else {
+                return $left > $right;
+            }
+        };
+
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $this->getSize($attribute, $value) > $parameters[0];
+            return $compare($this->getSize($attribute, $value), $parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1088,13 +1100,14 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $value > $comparedToValue;
+            return $compare($value, $comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
+        // TODO?
         return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1114,8 +1127,16 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
+        $compare = function ($left, $right) {
+            if (is_string($left)) {
+                return BigDecimal::of($left)->isLessThan($right);
+            } else {
+                return $left < $right;
+            }
+        };
+
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $this->getSize($attribute, $value) < $parameters[0];
+            return $compare($this->getSize($attribute, $value), $parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1123,13 +1144,14 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $value < $comparedToValue;
+            return $compare($value, $comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
+        // TODO?
         return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1149,8 +1171,16 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
+        $compare = function ($left, $right) {
+            if (is_string($left)) {
+                return BigDecimal::of($left)->isGreaterThanOrEqualTo($right);
+            } else {
+                return $left >= $right;
+            }
+        };
+
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $this->getSize($attribute, $value) >= $parameters[0];
+            return $compare($this->getSize($attribute, $value), $parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1158,13 +1188,14 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $value >= $comparedToValue;
+            return $compare($value, $comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
+        // TODO?
         return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1184,8 +1215,16 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
+        $compare = function ($left, $right) {
+            if (is_string($left)) {
+                return BigDecimal::of($left)->isLessThanOrEqualTo($right);
+            } else {
+                return $left <= $right;
+            }
+        };
+
         if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
-            return $this->getSize($attribute, $value) <= $parameters[0];
+            return $compare($this->getSize($attribute, $value), $parameters[0]);
         }
 
         if (is_numeric($parameters[0])) {
@@ -1193,13 +1232,14 @@ trait ValidatesAttributes
         }
 
         if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
-            return $value <= $comparedToValue;
+            return $compare($value, $comparedToValue);
         }
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
+        // TODO?
         return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1385,7 +1425,13 @@ trait ValidatesAttributes
             return false;
         }
 
-        return $this->getSize($attribute, $value) <= $parameters[0];
+        $size = $this->getSize($attribute, $value);
+
+        if (is_string($size)) {
+            return BigDecimal::of($size)->isLessThanOrEqualTo($parameters[0]);
+        } else {
+            return $size <= $parameters[0];
+        }
     }
 
     /**
@@ -1487,7 +1533,13 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'min');
 
-        return $this->getSize($attribute, $value) >= $parameters[0];
+        $size = $this->getSize($attribute, $value);
+
+        if (is_string($size)) {
+            return BigDecimal::of($size)->isGreaterThanOrEqualTo($parameters[0]);
+        } else {
+            return $size >= $parameters[0];
+        }
     }
 
     /**
@@ -2162,7 +2214,13 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'size');
 
-        return $this->getSize($attribute, $value) == $parameters[0];
+        $size = $this->getSize($attribute, $value);
+
+        if (is_string($size)) {
+            return BigDecimal::of($size)->isEqualTo($parameters[0]);
+        } else {
+            return $size == $parameters[0];
+        }
     }
 
     /**
@@ -2321,7 +2379,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return mixed
+     * @return int|float|string
      */
     protected function getSize($attribute, $value)
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2767,6 +2767,93 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:0,1']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.8888888888'], ['foo' => 'Decimal:10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Min:1.88888888888888888889']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Min:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Max:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Max:1.88888888888888888887']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Max:1.88888888888888888887']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Size:1.88888888888888888889']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Size:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889'], ['foo' => 'Decimal:20|Between:1.88888888888888888886,1.88888888888888888888']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888887'], ['foo' => 'Decimal:20|Between:1.88888888888888888886,1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gt:1.88888888888888888888']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889'], ['foo' => 'Decimal:20|Gt:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gt:bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gt:bar']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Lt:1.88888888888888888888']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888887'], ['foo' => 'Decimal:20|Lt:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Lt:bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888887', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Lt:bar']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888887'], ['foo' => 'Decimal:20|Gte:1.88888888888888888888']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gte:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888887', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gte:bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gte:bar']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889'], ['foo' => 'Decimal:20|Lte:1.88888888888888888888']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Lte:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Lte:bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888', 'bar' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Lte:bar']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889'], ['foo' => 'Decimal:20|Max:1.88888888888888888888']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Max:1.88888888888888888888']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateInt()


### PR DESCRIPTION
The validator does not currently handle arbitrary length floats when comparing the **size** of decimal numbers.

The following code currently passes when it should not...

```php
Validator::validate([
    'foo' => '1.88888888888888888888'
], [
    'foo' => [
        'decimal:20',
        'min:1.88888888888888888889',
    ],
]);

// [
//    "foo" => "1.88888888888888888888",
//  ]

```

This PR leans on `brick/math` further whenever we are comparing a value's size.