### PR TITLE
[9.x] Add FilterWithReorder method to Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -809,7 +809,7 @@ class Arr
     }
 
     /**
-     * Filter the array then reorder the filtered array key
+     * Filter the array then reorder the filtered array key.
      *
      * @param  array  $array
      * @param  callable  $callback

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -809,6 +809,18 @@ class Arr
     }
 
     /**
+     * Filter the array then reorder the filtered array key
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function filterWithReorder($array, callable $callback)
+    {
+        return array_values(static::where($array, $callback));
+    }
+
+    /**
      * If the given value is not an array and not null, wrap it in one.
      *
      * @param  mixed  $value

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1092,6 +1092,22 @@ class SupportArrTest extends TestCase
         ], Arr::keyBy($array, 'id'));
     }
 
+    public function testFilterWithReorder()
+    {
+        $languages = [
+            'java',
+            'javascript',
+            'python',
+            'php',
+        ];
+
+        $p = Arr::filterWithReorder($languages, fn ($arr) => str_starts_with($arr, 'p'));
+        $this->assertArrayHasKey(0, $p);
+        $this->assertArrayHasKey(1, $p);
+        $this->assertArrayNotHasKey(3, $p);
+        $this->assertArrayNotHasKey(2, $p);
+    }
+
     public function testPrependKeysWith()
     {
         $array = [


### PR DESCRIPTION
**what we do**

It's pretty common that we json encode a filtered array then return back to frontend.

but after ```array_filter()``` we need to reorder the key use ```array_values()```

Otherwise the encoded json is treating the key as object

**Example**

```
$languages = [
    'java',
    'javascript',
    'python',
    'php',
];

$p = array_filter($languages, fn ($arr) => str_starts_with($arr, 'p') );

//result of the json_encode without array_values()
//{"2":"python","3":"php"}

$p = array_values($p);

//result of the json_encode with array_values()
//["python","php"]
//this is what we want most of the time

```

Therefore I think we better have a wrapper method that will basically filter then reorder the keys.
Especially useful when we filter an Eloquent , collection , array from the controller then return back to the frontend.

