### PR TITLE
[9.x] Allow Artisan commands to be aliased with a class property 

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -61,6 +61,13 @@ class Command extends SymfonyCommand
     protected $hidden = false;
 
     /**
+     * The console command name aliases.
+     *
+     * @var array
+     */
+    protected $aliases;
+
+    /**
      * Create a new console command instance.
      *
      * @return void
@@ -88,6 +95,10 @@ class Command extends SymfonyCommand
         $this->setHelp((string) $this->help);
 
         $this->setHidden($this->isHidden());
+
+        if (isset($this->aliases)) {
+            $this->setAliases((array) $this->aliases);
+        }
 
         if (! isset($this->signature)) {
             $this->specifyParameters();

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -177,6 +177,19 @@ class CommandTest extends TestCase
         $this->assertFalse($command->parentIsHidden());
     }
 
+    public function testAliasesProperty()
+    {
+        $command = new class extends Command
+        {
+            protected $name = 'foo:bar';
+
+            protected $aliases = ['bar:baz', 'baz:qux'];
+        };
+
+        $this->assertSame('foo:bar', $command->getName());
+        $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
+    }
+
     public function testChoiceIsSingleSelectByDefault()
     {
         $output = m::mock(OutputStyle::class);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -186,7 +186,6 @@ class CommandTest extends TestCase
             protected $aliases = ['bar:baz', 'baz:qux'];
         };
 
-        $this->assertSame('foo:bar', $command->getName());
         $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
     }
 


### PR DESCRIPTION
This PR adds a new `aliases` convenience property to Artisan commands for defining name aliases, as opposed to implementing Symfony's `getAliases()` method or adding their `AsCommand` annotation.

In my use case I need to change the prefix on lots of commands, however doing so will break staging and production applications, but I can avoid this by aliasing the old command names to the new ones temporarily.