### PR TITLE
[9.x] Add `paymentRequired` helper to Http Client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -195,6 +195,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response was a 402 "Payment Required" response.
+     *
+     * @return bool
+     */
+    public function paymentRequired()
+    {
+        return $this->status() === 402;
+    }
+
+    /**
      * Determine if the response was a 403 "Forbidden" response.
      *
      * @return bool

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -39,7 +39,7 @@ class HttpClientTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory = new Factory();
+        $this->factory = new Factory;
     }
 
     protected function tearDown(): void
@@ -267,7 +267,8 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable {
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable
+        {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -288,7 +289,8 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable, Arrayable {
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable, Arrayable
+        {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -559,8 +561,7 @@ class HttpClientTest extends TestCase
         $this->factory->fakeSequence()->pushStatus(200);
 
         $response = $this->factory->withCookies(
-            ['foo' => 'bar'],
-            'https://laravel.com'
+            ['foo' => 'bar'], 'https://laravel.com'
         )->get('https://laravel.com');
 
         $this->assertCount(1, $response->cookies()->toArray());

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -39,7 +39,7 @@ class HttpClientTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory = new Factory;
+        $this->factory = new Factory();
     }
 
     protected function tearDown(): void
@@ -65,6 +65,17 @@ class HttpClientTest extends TestCase
         $response = $this->factory->post('http://laravel.com');
 
         $this->assertTrue($response->unauthorized());
+    }
+
+    public function testPaymentRequiredRequest()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 402),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+
+        $this->assertTrue($response->paymentRequired());
     }
 
     public function testForbiddenRequest()
@@ -256,8 +267,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable
-        {
+        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -278,8 +288,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable, Arrayable
-        {
+        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable, Arrayable {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -550,7 +559,8 @@ class HttpClientTest extends TestCase
         $this->factory->fakeSequence()->pushStatus(200);
 
         $response = $this->factory->withCookies(
-            ['foo' => 'bar'], 'https://laravel.com'
+            ['foo' => 'bar'],
+            'https://laravel.com'
         )->get('https://laravel.com');
 
         $this->assertCount(1, $response->cookies()->toArray());


### PR DESCRIPTION
This PR adds the `paymentRequired` to the Http Client Response class. The 402 error page was just merged into the framework [ [9.x] Add 402 exception view #45682](https://github.com/laravel/framework/pull/45682)

Currently we have to use the following code to check if a response is 402 Payment Required.

```php
$response = Http::get('https://laravel.com');

if ($response->status() === 402) {
    doSomething();
}
```

With this PR you can do the following, which is a bit cleaner.

```php
$response = Http::get('https://laravel.com');

if ($response->paymentRequired()) {
    doSomething();
}
```

Thanks!