### PR TITLE
[9.x] Add assert methods for status code 400 and 408

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -171,6 +171,26 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a 400 status code.
+     *
+     * @return $this
+     */
+    public function assertBadRequest()
+    {
+        return $this->assertStatus(400);
+    }
+
+    /**
+     * Assert that the response has a 408 status code.
+     *
+     * @return $this
+     */
+    public function assertRequestTimeout()
+    {
+        return $this->assertStatus(408);
+    }
+
+    /**
      * Assert that the response is a server error.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -609,6 +609,38 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertBadRequest()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertBadRequest();
+    }
+
+    public function testAssertRequestTimeout()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertRequestTimeout();
+    }
+
     public function testAssertServerError()
     {
         $statusCode = 500;


### PR DESCRIPTION
This is adding two new assert methods for the response:

```php
$this->assertBadRequest(); // Checks if status code is 400

$this->assertRequestTimeout(); // Checks if status code is 408
```