### PR TITLE
fix: migration stub  method  type key as static  added

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create('{{ table }}', static function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', static function (Blueprint $table) {
             //
         });
     }
@@ -25,7 +25,7 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', static function (Blueprint $table) {
             //
         });
     }


### PR DESCRIPTION
fix: migration stub method type key as ```static``` added 
