### PR TITLE
add ddFinalQuery() function

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3800,14 +3800,14 @@ class Builder implements BuilderContract
         dd($this->toSql(), $this->getBindings());
     }
     
-     /**
+    /**
      * Die and dump the final SQL query with replaced bindings.
      *
      * @return never
      */
     public function ddFinalQuery()
     {
-        dd(vsprintf(str_replace(array('?'), array('\'%s\''), $this->toSql()), $this->getBindings()));
+        dd(vsprintf(str_replace(['?'], ['\'%s\''], $this->toSql()), $this->getBindings()));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3799,7 +3799,7 @@ class Builder implements BuilderContract
     {
         dd($this->toSql(), $this->getBindings());
     }
-    
+
     /**
      * Die and dump the final SQL query with replaced bindings.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3799,6 +3799,16 @@ class Builder implements BuilderContract
     {
         dd($this->toSql(), $this->getBindings());
     }
+    
+     /**
+     * Die and dump the final SQL query with replaced bindings.
+     *
+     * @return never
+     */
+    public function ddFinalQuery()
+    {
+        dd(vsprintf(str_replace(array('?'), array('\'%s\''), $this->toSql()), $this->getBindings()));
+    }
 
     /**
      * Handle dynamic method calls into the method.


### PR DESCRIPTION
This function replace bind bindings in to query and die and dump final query. when you debugging complicated queries, you need to get final query without complexity.

if you do like bellow :
```php
User::where('name','farshid')->dd(); 
```
For example you will get bellow result:
```
"SELECT * FROM users WHERE name=?;",
[
  0 => "farshid"
]
```

But if you calling
```php
User::where('name','farshid')->ddFinalQuery(); 
```
You will get bellow result:
```
"SELECT * FROM users WHERE name='farshid';"
```

