### PR TITLE
[9.x] Migrator strict mode

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -51,6 +51,11 @@ class RollbackCommand extends BaseCommand
      */
     public function handle()
     {
+        if ($this->migrator->preventsRollback()) {
+            $this->components->warn('Rollback was prevented.');
+            return 1;
+        }
+
         if (! $this->confirmToProceed()) {
             return 1;
         }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -53,6 +53,7 @@ class RollbackCommand extends BaseCommand
     {
         if ($this->migrator->preventsRollback()) {
             $this->components->warn('Rollback was prevented.');
+
             return 1;
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -74,7 +74,7 @@ class Migrator
     protected $output;
 
     /**
-     * Indicates whether migrator should prevent rollback. 
+     * Indicates whether migrator should prevent rollback.
      */
     protected static $shouldPreventRollback = false;
 
@@ -765,7 +765,7 @@ class Migrator
 
     /**
      * Indicates that migrator should prevent rollback.
-     * 
+     *
      * @param  bool  $shouldBeStrict
      * @return void
      */
@@ -776,7 +776,7 @@ class Migrator
 
     /**
      * Prevent migrator from rollback.
-     * 
+     *
      * @param  bool  $value
      * @return void
      */
@@ -787,7 +787,7 @@ class Migrator
 
     /**
      * Indicates if rollback is disabled.
-     * 
+     *
      * @return bool
      */
     public function preventsRollback()

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -74,6 +74,11 @@ class Migrator
     protected $output;
 
     /**
+     * Indicates whether migrator should prevent rollback. 
+     */
+    protected static $shouldPreventRollback = false;
+
+    /**
      * Create a new migrator instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
@@ -756,5 +761,37 @@ class Migrator
         if ($this->events) {
             $this->events->dispatch($event);
         }
+    }
+
+    /**
+     * Indicates that migrator should prevent rollback.
+     * 
+     * @param  bool  $shouldBeStrict
+     * @return void
+     */
+    public static function shouldBeStrict(bool $shouldBeStrict = true)
+    {
+        static::preventRollback($shouldBeStrict);
+    }
+
+    /**
+     * Prevent migrator from rollback.
+     * 
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventRollback(bool $value = true)
+    {
+        static::$shouldPreventRollback = $value;
+    }
+
+    /**
+     * Indicates if rollback is disabled.
+     * 
+     * @return bool
+     */
+    public function preventsRollback()
+    {
+        return static::$shouldPreventRollback;
     }
 }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -23,6 +23,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
+        $migrator->shouldReceive('preventsRollback')->once()->andReturn(false);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
@@ -39,6 +40,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
+        $migrator->shouldReceive('preventsRollback')->once()->andReturn(false);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
@@ -55,6 +57,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
+        $migrator->shouldReceive('preventsRollback')->once()->andReturn(false);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
@@ -71,12 +74,28 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
+        $migrator->shouldReceive('preventsRollback')->once()->andReturn(false);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2]);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
+    }
+
+    public function testPreventRollback()
+    {
+        $command = new RollbackCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('preventsRollback')->once()->andReturn(true);
+        $migrator->shouldReceive('paths')->never();
+        $migrator->shouldReceive('usingConnection')->never();
+        $migrator->shouldReceive('setOutput')->never();
+        $migrator->shouldReceive('rollback')->never();
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -282,4 +282,26 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->reset([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->assertSame('default', $this->migrator->getConnection());
     }
+
+    public function testStrictMode()
+    {
+        $this->assertSame(false, $this->migrator->preventsRollback());
+
+        $this->migrator->shouldBeStrict(true);
+        $this->assertSame(true, $this->migrator->preventsRollback());
+
+        $this->migrator->shouldBeStrict(false);
+        $this->assertSame(false, $this->migrator->preventsRollback());
+    }
+
+    public function testPreventsRollback()
+    {
+        $this->assertSame(false, $this->migrator->preventsRollback());
+
+        $this->migrator->shouldBeStrict(true);
+        $this->assertSame(true, $this->migrator->preventsRollback());
+
+        $this->migrator->shouldBeStrict(false);
+        $this->assertSame(false, $this->migrator->preventsRollback());
+    }
 }


### PR DESCRIPTION
This PR introduces `Migrator::preventRollback($bool)` and `Migrator::shouldBeStrict($bool)`.

Both methods prevent database rollback for now, we can add more preventions into `shouldBeStrict` (Open to any preventions that will help) and you can specify the condition when you want the `rollback` to be prevented.

To activate `strict mode` you just need to call it in the `boot()` method in a registered service provider.

```php
Migrator::shouldBeStrict(App::environment('production'));
```

To prevent only the rollback you can use
```php
Migrator::preventRollback(App::environment('production'));
```

If `strict mode` is activated and you trying to rollback a `WARNING` will show up on your console without rolling back the last migration.

![Screenshot 2023-01-18 171227](https://user-images.githubusercontent.com/60013703/213230014-f93e050f-d998-44f6-a533-fe34dabf8853.png)

