### PR TITLE
[9.x] Add noActionOnDelete method

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -73,14 +73,4 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->onDelete('no action');
     }
-
-    /**
-     * Indicate that updates should set no action.
-     *
-     * @return $this
-     */
-    public function noActionOnUpdate()
-    {
-        return $this->onUpdate('no action');
-    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -65,7 +65,7 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
-     * Indicate that deletes should set no action.
+     * Indicate that deletes should have "no action".
      *
      * @return $this
      */

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -63,4 +63,24 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->onDelete('set null');
     }
+
+    /**
+     * Indicate that deletes should set no action.
+     *
+     * @return $this
+     */
+    public function noActionOnDelete()
+    {
+        return $this->onDelete('no action');
+    }
+
+    /**
+     * Indicate that updates should set no action.
+     *
+     * @return $this
+     */
+    public function noActionOnUpdate()
+    {
+        return $this->onUpdate('no action');
+    }
 }


### PR DESCRIPTION
This PR will add a new method in the `ForeignKeyDefinition` class with this method clients are able to create a foreign key in their migrations with the `no action` property/option.

- example
`$table->foreign('user_id')->references('id')->on('users')->noActionOnDelete();`