### PR TITLE
[10.x] Prevent stray requests by default

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -60,7 +60,7 @@ class Factory
      *
      * @var bool
      */
-    protected $preventStrayRequests = false;
+    protected $preventStrayRequests = true;
 
     /**
      * Create a new factory instance.

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -60,7 +60,7 @@ class Factory
      *
      * @var bool
      */
-    protected $preventStrayRequests = true;
+    protected $preventStrayRequests = false;
 
     /**
      * Create a new factory instance.

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -136,6 +136,8 @@ class Http extends Facade
      * Indicate that an exception should be thrown if any request is not faked.
      *
      * @return \Illuminate\Http\Client\Factory
+     *
+     * @deprecated
      */
     public static function preventStrayRequests()
     {

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -139,8 +139,6 @@ class Http extends Facade
      * Indicate that an exception should be thrown if any request is not faked.
      *
      * @return \Illuminate\Http\Client\Factory
-     *
-     * @deprecated
      */
     public static function preventStrayRequests()
     {

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Client\Factory;
 /**
  * @method static \GuzzleHttp\Promise\PromiseInterface response(array|string|null $body = null, int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\Client\ResponseSequence sequence(array $responses = [])
- * @method static \Illuminate\Http\Client\Factory allowStrayRequests()
  * @method static void recordRequestResponsePair(\Illuminate\Http\Client\Request $request, \Illuminate\Http\Client\Response $response)
  * @method static void assertSent(callable $callback)
  * @method static void assertSentInOrder(array $callbacks)
@@ -119,6 +118,18 @@ class Http extends Facade
         });
 
         return $fake->fakeSequence($urlPattern);
+    }
+
+    /**
+     * Indicate that an exception should not be thrown if a request is not faked.
+     *
+     * @return \Illuminate\Http\Client\Factory
+     */
+    public static function allowStrayRequests()
+    {
+        return tap(static::getFacadeRoot(), function ($fake) {
+            static::swap($fake->allowStrayRequests());
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -82,6 +82,8 @@ use Illuminate\Http\Client\Factory;
  */
 class Http extends Facade
 {
+    protected static $preventStrayRequests = true;
+
     /**
      * Get the registered name of the component.
      *
@@ -101,7 +103,7 @@ class Http extends Facade
     public static function fake($callback = null)
     {
         return tap(static::getFacadeRoot(), function ($fake) use ($callback) {
-            static::swap($fake->preventStrayRequests()->fake($callback));
+            static::swap($fake->preventStrayRequests(static::$preventStrayRequests)->fake($callback));
         });
     }
 
@@ -114,7 +116,7 @@ class Http extends Facade
     public static function fakeSequence(string $urlPattern = '*')
     {
         $fake = tap(static::getFacadeRoot(), function ($fake) {
-            static::swap($fake->preventStrayRequests());
+            static::swap($fake->preventStrayRequests(static::$preventStrayRequests));
         });
 
         return $fake->fakeSequence($urlPattern);
@@ -128,6 +130,7 @@ class Http extends Facade
     public static function allowStrayRequests()
     {
         return tap(static::getFacadeRoot(), function ($fake) {
+            static::$preventStrayRequests = false;
             static::swap($fake->allowStrayRequests());
         });
     }
@@ -142,6 +145,7 @@ class Http extends Facade
     public static function preventStrayRequests()
     {
         return tap(static::getFacadeRoot(), function ($fake) {
+            static::$preventStrayRequests = true;
             static::swap($fake->preventStrayRequests());
         });
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -101,7 +101,7 @@ class Http extends Facade
     public static function fake($callback = null)
     {
         return tap(static::getFacadeRoot(), function ($fake) use ($callback) {
-            static::swap($fake->fake($callback));
+            static::swap($fake->preventStrayRequests()->fake($callback));
         });
     }
 
@@ -114,7 +114,7 @@ class Http extends Facade
     public static function fakeSequence(string $urlPattern = '*')
     {
         $fake = tap(static::getFacadeRoot(), function ($fake) {
-            static::swap($fake);
+            static::swap($fake->preventStrayRequests());
         });
 
         return $fake->fakeSequence($urlPattern);

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -29,7 +29,7 @@ class FoundationDocsCommandTest extends TestCase
     {
         parent::setUp();
 
-        Http::preventStrayRequests()->fake([
+        Http::fake([
             'https://laravel.com/docs/8.x/index.json' => Http::response(file_get_contents(__DIR__.'/fixtures/docs.json')),
         ]);
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1878,6 +1878,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($hitThrowCallback);
     }
 
+
     public function testRequestExceptionIsThrownIfStatusCodeIsSatisfied()
     {
         $this->factory->fake([
@@ -2095,9 +2096,8 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
-    public function testItCanEnforceFaking()
+    public function testItEnforcesFakingByDefault()
     {
-        $this->factory->preventStrayRequests();
         $this->factory->fake(['https://vapor.laravel.com' => Factory::response('ok', 200)]);
         $this->factory->fake(['https://forge.laravel.com' => Factory::response('ok', 200)]);
 
@@ -2108,6 +2108,20 @@ class HttpClientTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Attempted request to [https://laravel.com] without a matching fake.');
+
+        $this->factory->get('https://laravel.com');
+    }
+
+    public function testAllowsSendingStrayRequests()
+    {
+        $this->factory->allowStrayRequests();
+        $this->factory->fake(['https://vapor.laravel.com' => Factory::response('ok', 200)]);
+        $this->factory->fake(['https://forge.laravel.com' => Factory::response('ok', 200)]);
+
+        $responses = [];
+        $responses[] = $this->factory->get('https://vapor.laravel.com')->body();
+        $responses[] = $this->factory->get('https://forge.laravel.com')->body();
+        $this->assertSame(['ok', 'ok'], $responses);
 
         $this->factory->get('https://laravel.com');
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1878,7 +1878,6 @@ class HttpClientTest extends TestCase
         $this->assertFalse($hitThrowCallback);
     }
 
-
     public function testRequestExceptionIsThrownIfStatusCodeIsSatisfied()
     {
         $this->factory->fake([
@@ -2096,8 +2095,9 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
-    public function testItEnforcesFakingByDefault()
+    public function testItEnforcesFaking()
     {
+        $this->factory->preventStrayRequests();
         $this->factory->fake(['https://vapor.laravel.com' => Factory::response('ok', 200)]);
         $this->factory->fake(['https://forge.laravel.com' => Factory::response('ok', 200)]);
 

--- a/tests/Support/SupportFacadesHttpTest.php
+++ b/tests/Support/SupportFacadesHttpTest.php
@@ -55,4 +55,11 @@ class SupportFacadesHttpTest extends TestCase
 
         $this->assertSame($client, $this->app->make(Factory::class));
     }
+
+    public function testFacadeRootIsSharedWhenAllowingStrayRequests(): void
+    {
+        $client = Http::allowStrayRequests();
+
+        $this->assertSame($client, $this->app->make(Factory::class));
+    }
 }


### PR DESCRIPTION
This makes `preventStrayRequests` the default behavior in Laravel 10. Having **strong** tests is always a good default. Many newcomers to Laravel (or testing) may not be aware of `preventStrayRequests` and as such write tests which allow _real_ HTTP requests.

While this is a breaking change, it is targeted at Laravel 10. In addition, I added a top-level `Http::allowStrayRequests()` method which apps with an extensive test suite could quickly add to their test case `setUp` method to avoid changing each `Http::fake()` call. With that said, it's also a pretty easy search and replace.
