### PR TITLE
[10.x] Add optional parameter for name

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -155,7 +155,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Begin the process of mailing a mailable class instance.
      *
      * @param  mixed  $users
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Mail\PendingMail
      */
     public function to($users, $name = null)
@@ -171,10 +171,15 @@ class Mailer implements MailerContract, MailQueueContract
      * Begin the process of mailing a mailable class instance.
      *
      * @param  mixed  $users
+     * @param  string|null  $name
      * @return \Illuminate\Mail\PendingMail
      */
-    public function cc($users)
+    public function cc($users, $name = null)
     {
+        if (! is_null($name) && is_string($users)) {
+            $users = new Address($users, $name);
+        }
+
         return (new PendingMail($this))->cc($users);
     }
 
@@ -182,10 +187,15 @@ class Mailer implements MailerContract, MailQueueContract
      * Begin the process of mailing a mailable class instance.
      *
      * @param  mixed  $users
+     * @param  string|null  $name
      * @return \Illuminate\Mail\PendingMail
      */
-    public function bcc($users)
+    public function bcc($users, $name = null)
     {
+        if (! is_null($name) && is_string($users)) {
+            $users = new Address($users, $name);
+        }
+
         return (new PendingMail($this))->bcc($users);
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Mail\Mailables\Address;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -154,10 +155,15 @@ class Mailer implements MailerContract, MailQueueContract
      * Begin the process of mailing a mailable class instance.
      *
      * @param  mixed  $users
+     * @param  string $name
      * @return \Illuminate\Mail\PendingMail
      */
-    public function to($users)
+    public function to($users, $name = null)
     {
+        if (!is_null($name) && is_string($users)) {
+            $users = new Address($users, $name);
+        }
+
         return (new PendingMail($this))->to($users);
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -155,12 +155,12 @@ class Mailer implements MailerContract, MailQueueContract
      * Begin the process of mailing a mailable class instance.
      *
      * @param  mixed  $users
-     * @param  string $name
+     * @param  string  $name
      * @return \Illuminate\Mail\PendingMail
      */
     public function to($users, $name = null)
     {
-        if (!is_null($name) && is_string($users)) {
+        if (! is_null($name) && is_string($users)) {
             $users = new Address($users, $name);
         }
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -159,6 +159,21 @@ class MailMailerTest extends TestCase
         $this->assertStringContainsString($expected, $sentMessage->toString());
     }
 
+    public function testToAllowsEmailAndName()
+    {
+        $view = m::mock(Factory::class);
+        $view->shouldReceive('make')->once()->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn('rendered.view');
+        $mailer = new Mailer('array', $view, new ArrayTransport);
+
+        $sentMessage = $mailer->to('taylor@laravel.com', 'Taylor Otwell')->send(new TestMail());
+
+        $recipients = $sentMessage->getEnvelope()->getRecipients();
+        $this->assertCount(1, $recipients);
+        $this->assertSame('taylor@laravel.com', $recipients[0]->getAddress());
+        $this->assertSame('Taylor Otwell', $recipients[0]->getName());
+    }
+
     public function testGlobalFromIsRespectedOnAllMessages()
     {
         $view = m::mock(Factory::class);
@@ -265,5 +280,14 @@ class MailMailerTest extends TestCase
         $this->assertSame(
             'bar', $mailer->foo()
         );
+    }
+}
+
+class TestMail extends \Illuminate\Mail\Mailable
+{
+    public function build()
+    {
+        return $this->view('view')
+            ->from('hello@laravel.com');
     }
 }


### PR DESCRIPTION
I constantly find myself trying to remember the correct syntax for sending a mail to a raw email/name combination. Digging in the framework shows you may pass an array with a key/value pair. However, you also have to remember to pass this as a nested array.

This PR adds an optional second parameter for name, to allow conveniently sending mail to a email/name.

**Before:**
```php
Mail::to([['email' => 'jmac@example.com', 'name' => 'JMac']])->send($mailable);
```

**After:**
```php
Mail::to('jmac@example.com', 'JMac')->send($mailable);
```

Note, this parameter is only used when set and the first parameter is a `string`.