### PR TITLE
[10.x] Standardise prohibited rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1707,7 +1707,7 @@ trait ValidatesAttributes
         [$values, $other] = $this->parseDependentRuleParameters($parameters);
 
         if (in_array($other, $values, is_bool($other) || is_null($other))) {
-            return ! $this->validateRequired($attribute, $value);
+            return is_string($value) && trim($value) === '';
         }
 
         return true;
@@ -1728,7 +1728,7 @@ trait ValidatesAttributes
         [$values, $other] = $this->parseDependentRuleParameters($parameters);
 
         if (! in_array($other, $values, is_bool($other) || is_null($other))) {
-            return ! $this->validateRequired($attribute, $value);
+            return is_string($value) && trim($value) === '';
         }
 
         return true;
@@ -1744,7 +1744,11 @@ trait ValidatesAttributes
      */
     public function validateProhibits($attribute, $value, $parameters)
     {
-        return ! Arr::hasAny($this->data, $parameters);
+        return collect($parameters)
+            ->filter(fn ($parameter) => Arr::has($this->data, $parameter))
+            ->map(fn ($parameter) => Arr::get($this->data, $parameter))
+            ->reject(fn ($value) => is_string($value) && trim($value) === '')
+            ->isEmpty();
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1599,7 +1599,7 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo', 'emails' => ''], ['email' => 'prohibits:emails']);
-        $this->assertTrue($v->fails());
+        $this->assertFalse($v->fails());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo', 'emails' => null], ['email' => 'prohibits:emails']);
@@ -1671,9 +1671,9 @@ class ValidationValidatorTest extends TestCase
             [['p' => 'prohibited_if:bar,1'], ['bar' => 1], true],
             [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ''], true],
             [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ' '], true],
-            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => null], true],
-            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => []], true],
-            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => $emptyCountable], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => null], false],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => []], false],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => $emptyCountable], false],
             [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => 'foo'], false],
 
             // prohibitedIf...
@@ -1689,9 +1689,9 @@ class ValidationValidatorTest extends TestCase
             [['p' => 'prohibited_unless:bar,1'], ['bar' => 2], true],
             [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ''], true],
             [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ' '], true],
-            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => null], true],
-            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => []], true],
-            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => $emptyCountable], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => null], false],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => []], false],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => $emptyCountable], false],
             [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => 'foo'], false],
 
             // // prohibites, with "p" values...
@@ -1705,8 +1705,8 @@ class ValidationValidatorTest extends TestCase
 
             // prohibites, with "bar" values...
             [['p' => 'prohibits:bar'], ['p' => 'foo'], true],
-            [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ''], false],
-            [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ' '], false],
+            [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ''], true],
+            [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ' '], true],
             [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => null], false],
             [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => []], false],
             [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => $emptyCountable], false],


### PR DESCRIPTION
## Problem

The prohibited rules are inconsistent from an implementation and documentation point of view. Not only does the documented definition of "prohibited" change on a rule by rule basis, sometimes the implementation does not match the intended documented functionality of the rule iteself.

## Definition of present

We need to make sure we are on the same page about how I'm using the word "present". I'm using this only in relation to the key, i.e. present = exist.

## Intended definitions

1. The key must not be present in the payload.
2. The key may be present. If it is present it must be an empty string. An empty string may contain whitespace (tabs / spaces, new lines, etc).

The parts of the docs that back up these definitions are:

> ... may not be present ...
> 
> [prohibited rule](https://laravel.com/docs/9.x/validation#rule-prohibited)

> ... no fields in anotherfield can be present, even if empty ...
> 
> [prohibits rule](https://laravel.com/docs/9.x/validation#rule-prohibits)


> ... must be an empty string or not present ...
> 
> [prohibited_if rule](https://laravel.com/docs/9.x/validation#rule-prohibited-if) + [prohibited_unless rule](https://laravel.com/docs/9.x/validation#rule-prohibited-unless)

## Implemented definitions

To show these definitions via tests, the following currently pass. The first array is are the rules. The second array is the data. The third boolean is if the validation passes:

```php
// prohibited...
[['p' => 'prohibited'], [], true],
[['p' => 'prohibited'], ['p' => ''], true],
[['p' => 'prohibited'], ['p' => ' '], true],
[['p' => 'prohibited'], ['p' => null], false],
[['p' => 'prohibited'], ['p' => []], false],
[['p' => 'prohibited'], ['p' => $emptyCountable], false],
[['p' => 'prohibited'], ['p' => 'foo'], false],

// prohibited_if...
[['p' => 'prohibited_if:bar,1'], ['bar' => 1], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ''], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ' '], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => null], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => []], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => $emptyCountable], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => 'foo'], false],

// prohibitedIf...
[['p' => new ProhibitedIf(true)], [], true],
[['p' => new ProhibitedIf(true)], ['p' => ''], true],
[['p' => new ProhibitedIf(true)], ['p' => ' '], true],
[['p' => new ProhibitedIf(true)], ['p' => null], false],
[['p' => new ProhibitedIf(true)], ['p' => []], false],
[['p' => new ProhibitedIf(true)], ['p' => $emptyCountable], false],
[['p' => new ProhibitedIf(true)], ['p' => 'foo'], false],

// // prohibited_unless...
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ''], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ' '], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => null], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => []], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => $emptyCountable], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => 'foo'], false],

// // prohibites, with "p" values...
[['p' => 'prohibits:bar'], [], true],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => ''], true],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => ' '], true],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => null], false],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => []], false],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => $emptyCountable], false],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => 'foo'], false],

// prohibites, with "bar" values...
[['p' => 'prohibits:bar'], ['p' => 'foo'], true],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ''], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ' '], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => null], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => []], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => $emptyCountable], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => 'foo'], false],
```

These test show the following:

### `"prohibited"`

#### Documented

The field under validation may not be present.

#### Actual

The field under validation may not be present.

✅ Documentation and implementation match
✅ Implementation correct
📌 Baseline for definition of "prohibited"

### `"prohibited_if"`

#### Documented

The field under validation must be an empty string or not present if the _anotherfield_ field is equal to any value.

#### Actual

The field under validation must be an empty string, _**null, an empty array, an empty countable object,**_ or not present if the anotherfield field is equal to any value.

❌ Documentation and implementation do not match
❌ Definition of prohibited does not match `"prohibited"` rule.


### `Rule::prohibited(true)`

#### Documented

_This is a paraphrased version of the docs, to account for the closure resolution:_

The field under validation must be an empty string or not present if the closure / value evaluates to `true`.

#### Actual

The field under validation must be an empty string or not present if the closure / value evaluates to `true`.

✅ Documentation and implementation match
✅ Definition of prohibited does not match `"prohibited"` rule.
❌ Implementation does not match the string based `"prohibited_if"` rule.


### `"prohibited_unless"`

#### Documented

The field under validation must be an empty string or not present unless the anotherfield field is equal to any value.

#### Actual

The field under validation must be an empty string, _**null, an empty array, an empty countable object,**_ or not present unless the anotherfield field is equal to any value.

❌ Documentation and implementation do not match
❌ Definition of prohibited does not match `"prohibited"` rule.

### `"prohibits"`

#### Documented

If the field under validation is present, no fields in anotherfield can be present, even if empty.

#### Actual

If the field under validation is present **_and not an empty string_**, no fields in anotherfield can be present, even if empty.

❌ Documentation and implementation do not match
❌ Definition of prohibited does not match `"prohibited"` rule (because the other key is not allowed to be an empty string).

## Proposed solution

I feel in Laravel `10.x` we should, at a minimum, standardise what being "prohibited" means: _If a field is prohibited, the field must not be present in the payload or its value must be an empty string._

Implemented with https://github.com/laravel/framework/pull/45716/commits/47727dc40311c442fc4a3ef41d595ef809735c75. This results in the following test changes:

```diff
// prohibited...
[['p' => 'prohibited'], [], true],
[['p' => 'prohibited'], ['p' => ''], true],
[['p' => 'prohibited'], ['p' => ' '], true],
[['p' => 'prohibited'], ['p' => null], false],
[['p' => 'prohibited'], ['p' => []], false],
[['p' => 'prohibited'], ['p' => $emptyCountable], false],
[['p' => 'prohibited'], ['p' => 'foo'], false],

// prohibited_if...
[['p' => 'prohibited_if:bar,1'], ['bar' => 1], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ''], true],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ' '], true],
- [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => null], true],
- [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => []], true],
- [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => $emptyCountable], true],
+ [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => null], false],
+ [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => []], false],
+ [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => $emptyCountable], false],
[['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => 'foo'], false],

// prohibitedIf...
[['p' => new ProhibitedIf(true)], [], true],
[['p' => new ProhibitedIf(true)], ['p' => ''], true],
[['p' => new ProhibitedIf(true)], ['p' => ' '], true],
[['p' => new ProhibitedIf(true)], ['p' => null], false],
[['p' => new ProhibitedIf(true)], ['p' => []], false],
[['p' => new ProhibitedIf(true)], ['p' => $emptyCountable], false],
[['p' => new ProhibitedIf(true)], ['p' => 'foo'], false],

// // prohibited_unless...
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ''], true],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ' '], true],
- [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => null], true],
- [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => []], true],
- [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => $emptyCountable], true],
+ [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => null], false],
+ [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => []], false],
+ [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => $emptyCountable], false],
[['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => 'foo'], false],

// // prohibites, with "p" values...
[['p' => 'prohibits:bar'], [], true],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => ''], true],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => ' '], true],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => null], false],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => []], false],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => $emptyCountable], false],
[['p' => 'prohibits:bar'], ['bar' => 2, 'p' => 'foo'], false],

// prohibites, with "bar" values...
[['p' => 'prohibits:bar'], ['p' => 'foo'], true],
- [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ''], false],
- [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ' '], false],
+ [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ''], true],
+ [['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => ' '], true],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => null], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => []], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => $emptyCountable], false],
[['p' => 'prohibits:bar'], ['p' => 'foo', 'bar' => 'foo'], false],
```

These changes are breaking but in my eye they are really bug fixes, but I've targeted 10.x to be cautious.

Related: https://github.com/laravel/framework/pull/45717