### PR TITLE
[9.x] Add `conflict` method to http client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -215,6 +215,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response was a 409 "Conflict" response.
+     *
+     * @return bool
+     */
+    public function conflict()
+    {
+        return $this->status() === 409;
+    }
+
+    /**
      * Determine if the response indicates a client or server error occurred.
      *
      * @return bool

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -89,6 +89,17 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->notFound());
     }
 
+    public function testConflictResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 409),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+
+        $this->assertTrue($response->conflict());
+    }
+
     public function testResponseBodyCasting()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR adds a convenient method to check if a HTTP request resulted in a conflict (HTTP Status 409).

So instead of checking the status code manually, you can use this new method:

```php
// Before
$response = Http::post('https://www.laravel.com', []);

if ($response->status() === 409) {
    doStuff();
}

// After
$response = Http::post('https://www.laravel.com', []);

if ($response->conflict()) {
    doStuff();
}
```