### PR TITLE
[9.x] Add configurable timezone support for WorkCommand output timestamps

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -207,7 +207,7 @@ class WorkCommand extends Command
     {
         $this->output->write(sprintf(
             '  <fg=gray>%s</> %s%s',
-            Carbon::now()->format('Y-m-d H:i:s'),
+            $this->getCurrentTimestamp()->format('Y-m-d H:i:s'),
             $job->resolveName(),
             $this->output->isVerbose()
                 ? sprintf(' <fg=gray>%s</>', $job->getJobId())
@@ -240,6 +240,20 @@ class WorkCommand extends Command
             'released_after_exception' => ' <fg=yellow;options=bold>FAIL</>',
             default => ' <fg=red;options=bold>FAIL</>',
         });
+    }
+
+    protected function getCurrentTimestamp(): Carbon
+    {
+        $appTimezone = $this->laravel['config']->get('app.timezone');
+        $queueLogTimezone = $this->laravel['config']->get('queue.log_timezone');
+
+        $timestamp = Carbon::now();
+
+        if ($queueLogTimezone && $queueLogTimezone !== $appTimezone) {
+            $timestamp->setTimezone($queueLogTimezone);
+        }
+
+        return $timestamp;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -207,7 +207,7 @@ class WorkCommand extends Command
     {
         $this->output->write(sprintf(
             '  <fg=gray>%s</> %s%s',
-            $this->getCurrentTimestamp()->format('Y-m-d H:i:s'),
+            $this->now()->format('Y-m-d H:i:s'),
             $job->resolveName(),
             $this->output->isVerbose()
                 ? sprintf(' <fg=gray>%s</>', $job->getJobId())
@@ -242,18 +242,21 @@ class WorkCommand extends Command
         });
     }
 
-    protected function getCurrentTimestamp(): Carbon
+    /**
+     * Get the current date / time.
+     *
+     * @return \Illuminate\Support\Carbon
+     */
+    protected function now()
     {
-        $appTimezone = $this->laravel['config']->get('app.timezone');
-        $queueLogTimezone = $this->laravel['config']->get('queue.log_timezone');
+        $queueTimezone = $this->laravel['config']->get('queue.output_timezone');
 
-        $timestamp = Carbon::now();
-
-        if ($queueLogTimezone && $queueLogTimezone !== $appTimezone) {
-            $timestamp->setTimezone($queueLogTimezone);
+        if ($queueTimezone &&
+            $queueTimezone !== $this->laravel['config']->get('app.timezone')) {
+            return Carbon::now()->setTimezone($queueTimezone);
         }
 
-        return $timestamp;
+        return Carbon::now();
     }
 
     /**

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -55,7 +55,7 @@ class WorkCommandTest extends TestCase
 
     public function testRunTimestampOutputWithDefaultAppTimezone()
     {
-        // queue.log_timezone not set at all
+        // queue.output_tiemzone not set at all
         $this->travelTo(Carbon::create(2023, 1, 18, 10, 10, 11));
         Queue::connection('database')->push(new FirstJob);
 
@@ -69,7 +69,7 @@ class WorkCommandTest extends TestCase
 
     public function testRunTimestampOutputWithDifferentLogTimezone()
     {
-        $this->app['config']->set('queue.log_timezone', 'Europe/Helsinki');
+        $this->app['config']->set('queue.output_timezone', 'Europe/Helsinki');
 
         $this->travelTo(Carbon::create(2023, 1, 18, 10, 10, 11));
         Queue::connection('database')->push(new FirstJob);
@@ -84,7 +84,7 @@ class WorkCommandTest extends TestCase
 
     public function testRunTimestampOutputWithSameAppDefaultAndQueueLogDefault()
     {
-        $this->app['config']->set('queue.log_timezone', 'UTC');
+        $this->app['config']->set('queue.output_timezone', 'UTC');
 
         $this->travelTo(Carbon::create(2023, 1, 18, 10, 10, 11));
         Queue::connection('database')->push(new FirstJob);

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Queue;
 
@@ -50,6 +51,50 @@ class WorkCommandTest extends TestCase
         $this->assertSame(1, Queue::connection('database')->size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
+    }
+
+    public function testRunTimestampOutputWithDefaultAppTimezone()
+    {
+        // queue.log_timezone not set at all
+        $this->travelTo(Carbon::create(2023, 1, 18, 10, 10, 11));
+        Queue::connection('database')->push(new FirstJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--once' => true,
+            '--memory' => 1024,
+        ])->expectsOutputToContain('2023-01-18 10:10:11')
+            ->assertExitCode(0);
+    }
+
+    public function testRunTimestampOutputWithDifferentLogTimezone()
+    {
+        $this->app['config']->set('queue.log_timezone', 'Europe/Helsinki');
+
+        $this->travelTo(Carbon::create(2023, 1, 18, 10, 10, 11));
+        Queue::connection('database')->push(new FirstJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--once' => true,
+            '--memory' => 1024,
+        ])->expectsOutputToContain('2023-01-18 12:10:11')
+            ->assertExitCode(0);
+    }
+
+    public function testRunTimestampOutputWithSameAppDefaultAndQueueLogDefault()
+    {
+        $this->app['config']->set('queue.log_timezone', 'UTC');
+
+        $this->travelTo(Carbon::create(2023, 1, 18, 10, 10, 11));
+        Queue::connection('database')->push(new FirstJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--once' => true,
+            '--memory' => 1024,
+        ])->expectsOutputToContain('2023-01-18 10:10:11')
+            ->assertExitCode(0);
     }
 
     public function testDaemon()


### PR DESCRIPTION
Introduces a new configuration option `queue.log_timezone`, so that the `php artisan queue:work` command can output the timestamps in a different timezone than the in application default `app.timezone`. 

The rationale for this addition is that this is already doable for log files made through Log facade with `Log::setTimezone` but the WorkCommand is not using the Logging subsystem but Console\OutputStyle to write directly back to the stdout and stderr. 

When we're pushing the logs from the `php artisan queue:work` to a logging service like AWS Cloudwatch, it expects the timestamps to be in UTC but the previously used application default timezone can be something else leading to discrepancy between Log::'ed log files and console command output. In this specific case Cloudwatch isn't too happy about timestamps happening in the future.

The configuration has been added as optional. If it has not been defined, the code uses the current application timezone. 