### PR TITLE
Add fullUrlOnlyWithQuery request method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -155,6 +155,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get the full URL for the request only with the given query string parameters.
+     *
+     * @param  array|string  $keys
+     * @return string
+     */
+    public function fullUrlOnlyWithQuery($keys)
+    {
+        $query = Arr::only($this->query(), $keys);
+
+        $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
+
+        return count($query) > 0
+            ? $this->url().$question.Arr::query($query)
+            : $this->url();
+    }
+
+    /**
      * Get the current path info for the request.
      *
      * @return string

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static string fullUrl()
  * @method static string fullUrlWithQuery(array $query)
  * @method static string fullUrlWithoutQuery(array|string $keys)
+ * @method static string fullUrlOnlyWithQuery(array|string $keys)
  * @method static string path()
  * @method static string decodedPath()
  * @method static string|null segment(int $index, string|null $default = null)

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -158,6 +158,22 @@ class HttpRequestTest extends TestCase
 
         $request = Request::create('https://foo.com');
         $this->assertSame('https://foo.com/?key=value%20with%20spaces', $request->fullUrlWithQuery(['key' => 'value with spaces']));
+
+        $request = Request::create('https://foo.com');
+        $this->assertSame('https://foo.com', $request->fullUrlOnlyWithQuery(['page']));
+
+        $request = Request::create('https://foo.com?page=1');
+        $this->assertSame('https://foo.com?page=1', $request->fullUrlOnlyWithQuery(['page']));
+
+        $request = Request::create('https://foo.com?name=taylor&page=1');
+        $this->assertSame('https://foo.com?page=1', $request->fullUrlOnlyWithQuery(['page']));
+
+        $request = Request::create('http://foo.com/foo/bar?name=taylor&page=1');
+        $this->assertSame('http://foo.com/foo/bar?page=1', $request->fullUrlOnlyWithQuery(['page']));
+
+        $request = Request::create('https://foo.com?name=taylor&key=value%20with%20spaces');
+        $this->assertSame('https://foo.com?key=value%20with%20spaces', $request->fullUrlOnlyWithQuery(['key']));
+
     }
 
     public function testIsMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -163,16 +163,16 @@ class HttpRequestTest extends TestCase
         $this->assertSame('https://foo.com', $request->fullUrlOnlyWithQuery(['page']));
 
         $request = Request::create('https://foo.com?page=1');
-        $this->assertSame('https://foo.com?page=1', $request->fullUrlOnlyWithQuery(['page']));
+        $this->assertSame('https://foo.com/?page=1', $request->fullUrlOnlyWithQuery(['page']));
 
         $request = Request::create('https://foo.com?name=taylor&page=1');
-        $this->assertSame('https://foo.com?page=1', $request->fullUrlOnlyWithQuery(['page']));
+        $this->assertSame('https://foo.com/?page=1', $request->fullUrlOnlyWithQuery(['page']));
 
         $request = Request::create('http://foo.com/foo/bar?name=taylor&page=1');
-        $this->assertSame('http://foo.com/foo/bar?page=1', $request->fullUrlOnlyWithQuery(['page']));
+        $this->assertSame('http://foo.com/foo/bar/?page=1', $request->fullUrlOnlyWithQuery(['page']));
 
         $request = Request::create('https://foo.com?name=taylor&key=value%20with%20spaces');
-        $this->assertSame('https://foo.com?key=value%20with%20spaces', $request->fullUrlOnlyWithQuery(['key']));
+        $this->assertSame('https://foo.com/?key=value%20with%20spaces', $request->fullUrlOnlyWithQuery(['key']));
 
     }
 


### PR DESCRIPTION
Add another variant of the request fullUrl method. It helps to get the full URL for the request ONLY with the given query string parameters.
For example, it helped me to get the canonical URL of the page with only allowed query parameters.