### PR TITLE
[9.x] Removes dependency on bcmath

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,6 @@
         }
     },
     "suggest": {
-        "ext-bcmath": "Required to use the multiple_of validation rule.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Validation\Concerns;
 
+use Brick\Math\BigDecimal;
+use Brick\Math\Exception\MathException as BrickMathException;
 use DateTime;
 use DateTimeInterface;
 use Egulias\EmailValidator\EmailValidator;
@@ -13,6 +15,7 @@ use Egulias\EmailValidator\Validation\RFCValidation;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
@@ -1520,11 +1523,26 @@ trait ValidatesAttributes
             return false;
         }
 
-        if ((float) $parameters[0] === 0.0) {
-            return false;
-        }
+        try {
+            $numerator = BigDecimal::of($value);
+            $denominator = BigDecimal::of($parameters[0]);
 
-        return bcmod($value, $parameters[0], 16) === '0.0000000000000000';
+            if ($numerator->isZero() && $denominator->isZero()) {
+                return false;
+            }
+
+            if ($numerator->isZero()) {
+                return true;
+            }
+
+            if ($denominator->isZero()) {
+                return false;
+            }
+
+            return $numerator->remainder($denominator)->isZero();
+        } catch (BrickMathException $e) {
+            throw new MathException('An error occurred while handling the mulitple_of input values.', previous: $e);
+        }
     }
 
     /**

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -37,7 +37,6 @@
         }
     },
     "suggest": {
-        "ext-bcmath": "Required to use the multiple_of validation rule.",
         "illuminate/database": "Required to use the database presence verifier (^9.0)."
     },
     "config": {


### PR DESCRIPTION
All the existing tests pass, which has some tricky floating point math in it. I was unable to get it to fail with any additional testing. Seems to be a good replacement to me so we can ditch the bcmath requirement.

Documentation: https://github.com/laravel/docs/pull/8467