### PR TITLE
[9.x] Adds `assertJsonIsArray` and `assertJsonIsObject` for TestResponse 

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -967,6 +967,48 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the key that holding the data must be a json array
+     *
+     * @param $key
+     *
+     * @return $this
+     */
+    public function assertJsonIsArray($key = null)
+    {
+        $data = $this->json($key);
+        $encodedData = json_encode($data);
+
+        PHPUnit::assertTrue(
+            is_array($data)
+            && str_starts_with($encodedData, '[')
+            && str_ends_with($encodedData, ']')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the key that holding the data must be a json object
+     *
+     * @param $key
+     *
+     * @return $this
+     */
+    public function assertJsonIsObject($key = null)
+    {
+        $data = $this->json($key);
+        $encodedData = json_encode($data);
+
+        PHPUnit::assertTrue(
+            is_array($data)
+            && str_starts_with($encodedData, '{')
+            && str_ends_with($encodedData, '}')
+        );
+
+        return $this;
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @return \Illuminate\Testing\AssertableJsonString

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -967,7 +967,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the key that holding the data must be a json array.
+     * Assert that the given key is a JSON array.
      *
      * @param $key
      * @return $this
@@ -975,6 +975,7 @@ class TestResponse implements ArrayAccess
     public function assertJsonIsArray($key = null)
     {
         $data = $this->json($key);
+
         $encodedData = json_encode($data);
 
         PHPUnit::assertTrue(
@@ -987,7 +988,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the key that holding the data must be a json object.
+     * Assert that the given key is a JSON object.
      *
      * @param $key
      * @return $this
@@ -995,6 +996,7 @@ class TestResponse implements ArrayAccess
     public function assertJsonIsObject($key = null)
     {
         $data = $this->json($key);
+
         $encodedData = json_encode($data);
 
         PHPUnit::assertTrue(

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -967,10 +967,9 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the key that holding the data must be a json array
+     * Assert that the key that holding the data must be a json array.
      *
      * @param $key
-     *
      * @return $this
      */
     public function assertJsonIsArray($key = null)
@@ -988,10 +987,9 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the key that holding the data must be a json object
+     * Assert that the key that holding the data must be a json object.
      *
      * @param $key
-     *
      * @return $this
      */
     public function assertJsonIsObject($key = null)

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1530,6 +1530,38 @@ class TestResponseTest extends TestCase
         $testResponse->assertJsonMissingValidationErrors('bar', 'data.errors');
     }
 
+    public function testAssertJsonIsArray()
+    {
+        $responseArray = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+        $responseArray->assertJsonIsArray();
+    }
+
+    public function testAssertJsonIsNotArray()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $responseObject = TestResponse::fromBaseResponse(new Response([
+            'foo' => 'bar',
+        ]));
+        $responseObject->assertJsonIsArray();
+    }
+
+    public function testAssertJsonIsObject()
+    {
+        $responseObject = TestResponse::fromBaseResponse(new Response([
+            'foo' => 'bar',
+        ]));
+        $responseObject->assertJsonIsObject();
+    }
+
+    public function testAssertJsonIsNotObject()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $responseArray = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+        $responseArray->assertJsonIsObject();
+    }
+
     public function testAssertDownloadOffered()
     {
         $files = new Filesystem;


### PR DESCRIPTION
Hi team,

When interacting with Collection, after several actions (like `sort` or `filter`,...), the array won't be an indexed array like before (I think most of us here would probably encounter this at least once). 

And if we return the Collection immediately, it will result in a JS Object `{ ... }`. For listing endpoints, it would be wrong and result in **an error** from the **API consumers** (frontend, mobile,...) 

So to ensure we won't return the wrong data structure to the consumers, I added 2 assert methods to validate the data:

- `assertJsonIsArray`
- `assertJsonIsObject`

FYA: from `10.x` we can use `array_is_list` (PHP 8.1) to check against the data since it requires PHP 8.2 and above. 

## Usage
```php
$this->json('GET', 'countries')
    ->assertOk()
    ->assertJsonIsArray(); // [ {..}, {...}, ....]

$this->json('GET', 'users')
    ->assertOk()
    ->assertJsonIsArray('data'); // {'data': [...]}

$this->json('GET', 'countries/US')
    ->assertOk()
    ->assertJsonIsObject(); // {id: '...', name: '..'}

$this->json('GET', 'users/1')
    ->assertOk()
    ->assertJsonIsObject('data'); // {'data': {id: '..', name: '...'}}
```

## PR Information
- Implemented the methods
- Added tests and cover all cases
- No **breaking changes** - only introduces new methods

## Additional information
`assertJsonStructure` won't help us to validate that (check `TestResponseTest@testAssertJsonStructure`)

The wildcard `*` only validates the repeating structure. It doesn't care whether our data is a JS array or JS object.

<img width="528" alt="Screenshot 2023-01-20 at 10 14 01" src="https://user-images.githubusercontent.com/23478115/213611240-79cef8b2-4960-4266-b955-378331d4e354.png">

`assertJson` or `assertExactJson` might be a good alternative, but for listing endpoints, preparing a big list of data to assert would not so fun, right?

Thanks all!