### PR TITLE
[10.x] Allow JIT named data based attachables

### DIFF
--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Support\Traits\Macroable;
+use RuntimeException;
 
 class Attachment
 {
@@ -58,10 +59,10 @@ class Attachment
      * Create a mail attachment from in-memory data.
      *
      * @param  \Closure  $data
-     * @param  string  $name
+     * @param  string|null  $name
      * @return static
      */
-    public static function fromData(Closure $data, $name)
+    public static function fromData(Closure $data, $name = null)
     {
         return (new static(
             fn ($attachment, $pathStrategy, $dataStrategy) => $dataStrategy($data, $attachment)
@@ -104,7 +105,7 @@ class Attachment
     /**
      * Set the attached file's filename.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return $this
      */
     public function as($name)
@@ -143,13 +144,28 @@ class Attachment
      * Attach the attachment to a built-in mail type.
      *
      * @param  \Illuminate\Mail\Mailable|\Illuminate\Mail\Message|\Illuminate\Notifications\Messages\MailMessage  $mail
+     * @param  array  $options
      * @return mixed
      */
-    public function attachTo($mail)
+    public function attachTo($mail, $options = [])
     {
         return $this->attachWith(
-            fn ($path) => $mail->attach($path, ['as' => $this->as, 'mime' => $this->mime]),
-            fn ($data) => $mail->attachData($data(), $this->as, ['mime' => $this->mime])
+            fn ($path) => $mail->attach($path, [
+                'as' => $options['as'] ?? $this->as,
+                'mime' => $options['mime'] ?? $this->mime,
+            ]),
+            function ($data) use ($mail, $options) {
+                $options = [
+                    'as' => $options['as'] ?? $this->as,
+                    'mime' => $options['mime'] ?? $this->mime,
+                ];
+
+                if ($options['as'] === null) {
+                    throw new RuntimeException('Attachment requires a filename to be specified.');
+                }
+
+                return $mail->attachData($data(), $options['as'], ['mime' => $options['mime']]);
+            }
         );
     }
 
@@ -157,16 +173,20 @@ class Attachment
      * Determine if the given attachment is equivalent to this attachment.
      *
      * @param  \Illuminate\Mail\Attachment  $attachment
+     * @param  array  $options
      * @return bool
      */
-    public function isEquivalent(Attachment $attachment)
+    public function isEquivalent(Attachment $attachment, $options = [])
     {
-        return $this->attachWith(
+        return with([
+            'as' => $options['as'] ?? $attachment->as,
+            'mime' => $options['mime'] ?? $attachment->mime,
+        ], fn ($options) => $this->attachWith(
             fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
             fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
         ) === $attachment->attachWith(
-            fn ($path) => [$path, ['as' => $attachment->as, 'mime' => $attachment->mime]],
-            fn ($data) => [$data(), ['as' => $attachment->as, 'mime' => $attachment->mime]],
-        );
+            fn ($path) => [$path, $options],
+            fn ($data) => [$data(), $options],
+        ));
     }
 }


### PR DESCRIPTION
Data based attachables currently require a name at the point of instantiation.

```php
class MyModel extends Model implements Attachable
{
    public function toMailAttachment()
    {
        return Attachment::fromData(fn () => '👻', 'Ghosty.emoji');
    }
}
```

This is restricting. It is now possible to create "fromData" based attachables with a name.

```php
class MyModel extends Model implements Attachable
{
    public function toMailAttachment()
    {
        return Attachment::fromData(fn () => '👻');
    }
}
```

The name must be provided later or an exception is thrown.

This allows attachable objects / attachments that knows their data, but the name of the attachment is decided Just In Time.
```php
public function build()
{
    $this->attach(new MyPdf(/* ... */), ['as' => 'Ghosty.emoji']);
}
```

This really only serves the older build API and not the envelope API, however I still find it useful. Lots of build APIs out there that may never refactor to the new API.

The envelope API would likely need:

```php
public function attachments()
{
    return [
        (new MyPdf())->toMailAttachment()->as('Ghosty.emoji'),
    ];
}
```

We could look at using the key as the name to make this nicer...

```php
public function attachments()
{
    return [
        'foo.jpg' => new MyPdf(),
    ];
}
```

but that is another PR.

Targeting 10.x due to the signature changes.