### PR TITLE
[9.x] Adds magic status methods and assertions

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -484,7 +484,7 @@ class Response implements ArrayAccess
             return $this->macroCall($method, $parameters);
         }
 
-        $statusConstant = HttpResponse::class.'::HTTP_'.Str::of($method)->after('assert')->snake()->upper();
+        $statusConstant = HttpResponse::class.'::HTTP_'.Str::of($method)->snake()->upper();
 
         if (defined($statusConstant) && array_key_exists($status = constant($statusConstant), HttpResponse::$statusTexts)) {
             return $this->status() === $status;

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -484,9 +484,12 @@ class Response implements ArrayAccess
             return $this->macroCall($method, $parameters);
         }
 
-        $statusConstant = HttpResponse::class.'::HTTP_'.Str::of($method)->snake()->upper();
+        $status = collect(HttpResponse::$statusTexts)
+            ->map(fn ($status) => (string) Str::of($status)->slug()->camel())
+            ->flip()
+            ->get($method);
 
-        if (defined($statusConstant) && array_key_exists($status = constant($statusConstant), HttpResponse::$statusTexts)) {
+        if ($status !== null) {
             return $this->status() === $status;
         }
 

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -15,10 +15,6 @@ use Throwable;
 
 class ResponseFactory implements FactoryContract
 {
-    use Macroable {
-        __call as macroCall;
-    }
-
     /**
      * The view factory instance.
      *

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -15,6 +15,8 @@ use Throwable;
 
 class ResponseFactory implements FactoryContract
 {
+    use Macroable;
+
     /**
      * The view factory instance.
      *

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -275,28 +275,4 @@ class ResponseFactory implements FactoryContract
     {
         return $this->redirector->intended($default, $status, $headers, $secure);
     }
-
-    /**
-     * Dynamically proxy other methods to the underlying response.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        if (static::hasMacro($method)) {
-            return $this->macroCall($method, $parameters);
-        }
-
-        // WIP
-
-        // $statusConstant = Response::class.'::HTTP_'.Str::of($method)->snake()->upper();
-
-        // if (defined($statusConstant) && array_key_exists($status = constant($statusConstant), HttpResponse::$statusTexts)) {
-        //     return $this->status() === $status;
-        // }
-
-        // throw exception
-    }
 }

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -15,7 +15,9 @@ use Throwable;
 
 class ResponseFactory implements FactoryContract
 {
-    use Macroable;
+    use Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The view factory instance.
@@ -273,4 +275,29 @@ class ResponseFactory implements FactoryContract
     {
         return $this->redirector->intended($default, $status, $headers, $secure);
     }
+
+    /**
+     * Dynamically proxy other methods to the underlying response.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        // WIP
+
+        // $statusConstant = Response::class.'::HTTP_'.Str::of($method)->snake()->upper();
+
+        // if (defined($statusConstant) && array_key_exists($status = constant($statusConstant), HttpResponse::$statusTexts)) {
+        //     return $this->status() === $status;
+        // }
+
+        // throw exception
+    }
+
 }

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -299,5 +299,4 @@ class ResponseFactory implements FactoryContract
 
         // throw exception
     }
-
 }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -1786,6 +1787,14 @@ class TestResponse implements ArrayAccess
     {
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $args);
+        }
+
+        if (Str::startsWith($method, 'assert')) {
+            $httpStatusCodeConstant = Response::class.'::HTTP_'.Str::of($method)->after('assert')->snake()->upper();
+
+            if (defined($httpStatusCodeConstant) && array_key_exists($status = constant($httpStatusCodeConstant), Response::$statusTexts)) {
+                return $this->assertStatus($status);
+            }
         }
 
         return $this->baseResponse->{$method}(...$args);

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1790,9 +1790,12 @@ class TestResponse implements ArrayAccess
         }
 
         if (Str::startsWith($method, 'assert')) {
-            $statusConstant = Response::class.'::HTTP_'.Str::of($method)->after('assert')->snake()->upper();
+            $status = collect(Response::$statusTexts)
+                ->map(fn ($status) => (string) Str::of($status)->slug()->studly())
+                ->flip()
+                ->get(Str::after($method, 'assert'));
 
-            if (defined($statusConstant) && array_key_exists($status = constant($statusConstant), Response::$statusTexts)) {
+            if ($status !== null) {
                 return $this->assertStatus($status);
             }
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1790,9 +1790,9 @@ class TestResponse implements ArrayAccess
         }
 
         if (Str::startsWith($method, 'assert')) {
-            $httpStatusCodeConstant = Response::class.'::HTTP_'.Str::of($method)->after('assert')->snake()->upper();
+            $statusConstant = Response::class.'::HTTP_'.Str::of($method)->after('assert')->snake()->upper();
 
-            if (defined($httpStatusCodeConstant) && array_key_exists($status = constant($httpStatusCodeConstant), Response::$statusTexts)) {
+            if (defined($statusConstant) && array_key_exists($status = constant($statusConstant), Response::$statusTexts)) {
                 return $this->assertStatus($status);
             }
         }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -107,11 +107,7 @@ class HttpClientTest extends TestCase
         foreach (HttpResponse::$statusTexts as $code => $name) {
             $response = $this->factory->get("http://{$code}.example.com");
 
-            $method = match($code) {
-                226 => 'imUsed',
-                414 => 'uriTooLong',
-                default => (string) Str::of($name)->slug('_', dictionary: [])->camel($name),
-            };
+            $method = (string) Str::of($name)->slug(dictionary: [])->camel($name);
 
             $this->assertTrue($response->{$method}());
         }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -17,6 +17,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
@@ -87,6 +88,22 @@ class HttpClientTest extends TestCase
         $response = $this->factory->post('http://laravel.com');
 
         $this->assertTrue($response->notFound());
+    }
+
+    public function testMagicStatusMethods()
+    {
+        $this->factory->fake([
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_UNAVAILABLE_FOR_LEGAL_REASONS),
+            'laravel.com' => $this->factory::response('', HttpResponse::HTTP_I_AM_A_TEAPOT),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+        $this->assertTrue($response->iAmATeapot());
+        $this->assertFalse($response->unavailableForLegalReasons());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertTrue($response->unavailableForLegalReasons());
+        $this->assertFalse($response->iAmATeapot());
     }
 
     public function testResponseBodyCasting()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -94,6 +94,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake(collect(HttpResponse::$statusTexts)
             ->mapWithKeys(fn ($status, $code) => ["{$code}.example.com" => $this->factory::response('', $code)])
+            ->merge(['99.example.com' => $this->factory::response('', 199)])
             ->all());
 
         $response = $this->factory->get('http://418.example.com');
@@ -105,10 +106,12 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->imATeapot());
 
         foreach (HttpResponse::$statusTexts as $code => $name) {
-            $response = $this->factory->get("http://{$code}.example.com");
-
             $method = (string) Str::of($name)->slug(dictionary: [])->camel($name);
 
+            $response = $this->factory->get("http://199.example.com");
+            $this->assertFalse($response->{$method}());
+
+            $response = $this->factory->get("http://{$code}.example.com");
             $this->assertTrue($response->{$method}());
         }
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -609,6 +609,27 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertMagicStatusCodes()
+    {
+        $response = TestResponse::fromBaseResponse((new Response)->setStatusCode(Response::HTTP_I_AM_A_TEAPOT));
+        $response->assertIAmATeapot();
+        try {
+            $response->assertUnavailableForLegalReasons();
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Failed asserting that 451 is identical to 418.', $e->getMessage());
+        }
+
+        $response = TestResponse::fromBaseResponse((new Response)->setStatusCode(Response::HTTP_UNAVAILABLE_FOR_LEGAL_REASONS));
+        $response->assertUnavailableForLegalReasons();
+        try {
+            $response->assertIAmATeapot();
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Failed asserting that 418 is identical to 451.', $e->getMessage());
+        }
+    }
+
     public function testAssertServerError()
     {
         $statusCode = 500;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -631,9 +631,18 @@ class TestResponseTest extends TestCase
         }
 
         foreach (Response::$statusTexts as $code => $name) {
-            $response = TestResponse::fromBaseResponse((new Response)->setStatusCode($code));
-
             $method = 'assert'.Str::of($name)->slug(dictionary: [])->studly($name);
+
+            $response = TestResponse::fromBaseResponse((new Response)->setStatusCode(199));
+
+            try {
+                $response->{$method}();
+                $this->fail();
+            } catch (AssertionFailedError $e) {
+                $this->assertStringContainsString("Failed asserting that {$code} is identical to 199.", $e->getMessage());
+            }
+
+            $response = TestResponse::fromBaseResponse((new Response)->setStatusCode($code));
 
             $this->assertSame(
                 $response,

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -632,19 +632,17 @@ class TestResponseTest extends TestCase
 
         foreach (Response::$statusTexts as $code => $name) {
             $response = TestResponse::fromBaseResponse((new Response)->setStatusCode($code));
-            $method = 'assert'.match($code) {
+
+            $prefix = match($code) {
                 226 => 'ImUsed',
                 414 => 'UriTooLong',
                 default => Str::of($name)->slug('_', dictionary: [])->studly($name),
             };
 
-            $response->{$method}();
-            try {
-                $response->assertStatus(0);
-                $this->fail();
-            } catch (AssertionFailedError $e) {
-                $this->assertStringContainsString("Failed asserting that 0 is identical to {$code}.", $e->getMessage());
-            }
+            $this->assertSame(
+                $response,
+                $response->{'assert'.$prefix}()
+            );
         }
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -633,15 +633,11 @@ class TestResponseTest extends TestCase
         foreach (Response::$statusTexts as $code => $name) {
             $response = TestResponse::fromBaseResponse((new Response)->setStatusCode($code));
 
-            $prefix = match($code) {
-                226 => 'ImUsed',
-                414 => 'UriTooLong',
-                default => Str::of($name)->slug('_', dictionary: [])->studly($name),
-            };
+            $method = 'assert'.Str::of($name)->slug(dictionary: [])->studly($name);
 
             $this->assertSame(
                 $response,
-                $response->{'assert'.$prefix}()
+                $response->{$method}()
             );
         }
     }


### PR DESCRIPTION
As seen with may recent PRs, there is a thirst from the community to be able to have named status code methods.

This PR aims to bring named methods to all possible places without the need for a gazillion individual methods.

## Test response

```php
$response = $this->get(/* ... */);

$response->assertConflict(); // ✅|❌
```

## Http client response

```php
$response = Http::get(/* ... */);

if ($response->paymentRequired()) {
    //
}
```

Recent attempts to add a variety of named methods:

- https://github.com/laravel/framework/pull/45718
- https://github.com/laravel/framework/pull/45701
- https://github.com/laravel/framework/pull/45698
- https://github.com/laravel/framework/pull/45681
- https://github.com/laravel/framework/pull/44658
- etc.

Edit: I've removed the ability to use named methods on the response factory, as we would have to handle standard responses, JSON responses, streamed responses, etc.,  and that feels like a lot.