### PR TITLE
[9.x] Lottery chances float odds percentage

### DIFF
--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -50,13 +50,45 @@ class Lottery
      */
     public function __construct($chances, $outOf = null)
     {
-        if ($outOf === null && is_float($chances) && $chances > 1) {
-            throw new RuntimeException('Float must not be greater than 1.');
-        }
+        [$chances, $outOf] = $this->parseChancesAndOutOf($chances, $outOf);
 
         $this->chances = $chances;
 
         $this->outOf = $outOf;
+    }
+
+    /**
+     * parse and validate chances and outOf
+     *
+     * @param  int|float  $chances
+     * @param  int|null  $outOf
+     * @return array
+     */
+    public function parseChancesAndOutOf($chances, $outOf)
+    {
+        if ($outOf === null && is_float($chances) && $chances > 1) {
+            throw new RuntimeException('Float must not be greater than 1.');
+        }
+
+        if (! is_null($outOf) && is_float($chances)) {
+            $multipleBy = $this->getMultiplyValue($chances);
+            $chances *= $multipleBy;
+            $outOf *= $multipleBy;
+        }
+
+        return [$chances, $outOf];
+    }
+
+    /**
+     * get the multiple value by a float value.
+     *
+     * @param  float  $value
+     * @return string
+     */
+    protected function getMultiplyValue($value)
+    {
+        $decimalsCount = strlen(explode('.', $value)[1]);
+        return '1'.str_repeat(0, $decimalsCount);
     }
 
     /**

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -63,7 +63,7 @@ class LotteryTest extends TestCase
 
     public function testItCanBePassedAsCallable()
     {
-        // Exmaple...
+        // Example...
         // DB::whenQueryingForLongerThan(Interval::seconds(5), Lottery::odds(1, 5)->winner(function ($connection) {
         //     Alert the team
         // }));
@@ -180,5 +180,33 @@ class LotteryTest extends TestCase
 
         $this->assertFalse($wins);
         $this->assertTrue($loses);
+    }
+
+    public function testItCanSetFloatProperly()
+    {
+        $lottery1 = new FakeLottery(5.8, 10);
+        $lottery2 = new FakeLottery(3.88, 9);
+        $lottery3 = new FakeLottery(4.100, 10);
+
+        $this->assertEquals(58, $lottery1->getChances());
+        $this->assertEquals(100, $lottery1->getOutOf());
+        $this->assertEquals(388, $lottery2->getChances());
+        $this->assertEquals(900, $lottery2->getOutOf());
+        $this->assertEquals(41, $lottery3->getChances());
+        $this->assertEquals(100, $lottery3->getOutOf());
+    }
+}
+
+class FakeLottery extends Lottery
+{
+
+    public function getChances()
+    {
+       return $this->chances;
+    }
+
+    public function getOutOf()
+    {
+        return $this->outOf;
     }
 }


### PR DESCRIPTION
In the lottery class , we can pass float to the constructor like this

```
Lottery::odds(5.8,, 10);
```

In the above example users expect a _true_ 58% odds percentage, but in our current calculation it is only 50% always.
because this is how we determine the winning

```
random_int(1, $outOf) <= $chances
```

the random_int always returns the integer so in this case it always gets one of numbers between 1 to 10.
That means it only has a 50% chance of winning.

**propose**
to solve this simply multiply the chances and outOf value
eg

```
Lottery::odds(5.8,, 10);
//become
Lottery::odds(58,, 100);

Lottery::odds(3.15,, 9);
//become
Lottery::odds(315,, 900);
``

@timacdonald what do you think? 
Do you think we need to take care of the float odds calculation or this is an edge case just ask users to pass a non-float number if they want accurate odds.
