### PR TITLE
[9.x] Lottery: prevent second parameter when using float as first

### DIFF
--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -50,8 +50,13 @@ class Lottery
      */
     public function __construct($chances, $outOf = null)
     {
-        if ($outOf === null && is_float($chances) && $chances > 1) {
-            throw new RuntimeException('Float must not be greater than 1.');
+        if (is_float($chances)) {
+            if ($outOf !== null) {
+                throw new RuntimeException('The second parameter cannot be used when the first parameter is a float.');
+            }
+            if ($chances > 1) {
+                throw new RuntimeException('Float must not be greater than 1.');
+            }
         }
 
         $this->chances = $chances;

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -63,7 +63,7 @@ class LotteryTest extends TestCase
 
     public function testItCanBePassedAsCallable()
     {
-        // Exmaple...
+        // Example...
         // DB::whenQueryingForLongerThan(Interval::seconds(5), Lottery::odds(1, 5)->winner(function ($connection) {
         //     Alert the team
         // }));
@@ -180,5 +180,11 @@ class LotteryTest extends TestCase
 
         $this->assertFalse($wins);
         $this->assertTrue($loses);
+    }
+
+    public function testFloatProhibitsSecondParameter()
+    {
+        $this->expectException(RuntimeException::class);
+        Lottery::odds(0.4, 2);
     }
 }


### PR DESCRIPTION
An improvement for https://github.com/laravel/framework/pull/45741.

Using the second parameter for the lottery has undefined behaviour when the first parameter uses a float (which assumes scientific probability notation, e.g. `0.0-1.0` maps to `0-100`).