### PR TITLE
[9.x] Add S3 `temporaryUploadUrl` method to AwsS3V3Adapter

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -96,6 +96,35 @@ class AwsS3V3Adapter extends FilesystemAdapter
     }
 
     /**
+     * Get a temporary upload URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
+     * @return string
+     */
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    {
+        $command = $this->client->getCommand('PutObject', array_merge([
+            'Bucket' => $this->config['bucket'],
+            'Key' => $this->prefixer->prefixPath($path),
+        ], $options));
+
+        $uri = $this->client->createPresignedRequest(
+            $command, $expiration, $options
+        )->getUri();
+
+        // If an explicit base URL has been set on the disk configuration then we will use
+        // it as the base URL instead of the default path. This allows the developer to
+        // have full control over the base path for this filesystem's generated URLs.
+        if (isset($this->config['temporary_url'])) {
+            $uri = $this->replaceBaseUrl($uri, $this->config['temporary_url']);
+        }
+
+        return (string) $uri;
+    }
+
+    /**
      * Get the underlying S3 client.
      *
      * @return \Aws\S3\S3Client

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -101,24 +101,34 @@ class AwsS3V3Adapter extends FilesystemAdapter
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
-     * @return string
+     * @param  bool  $requiredHeaders
+     * @return string|array
      */
-    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    public function temporaryUploadUrl($path, $expiration, array $options = [], bool $requiredHeaders = false)
     {
         $command = $this->client->getCommand('PutObject', array_merge([
             'Bucket' => $this->config['bucket'],
             'Key' => $this->prefixer->prefixPath($path),
         ], $options));
 
-        $uri = $this->client->createPresignedRequest(
+        $signedRequest = $this->client->createPresignedRequest(
             $command, $expiration, $options
-        )->getUri();
+        );
+
+        $uri = $signedRequest->getUri();
 
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
         if (isset($this->config['temporary_url'])) {
             $uri = $this->replaceBaseUrl($uri, $this->config['temporary_url']);
+        }
+
+        if($requiredHeaders) {
+            return [
+                'url' => (string) $uri,
+                'headers' => $signedRequest->getHeaders(),
+            ];
         }
 
         return (string) $uri;

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -101,10 +101,9 @@ class AwsS3V3Adapter extends FilesystemAdapter
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
-     * @param  bool  $requiredHeaders
-     * @return string|array
+     * @return array
      */
-    public function temporaryUploadUrl($path, $expiration, array $options = [], bool $requiredHeaders = false)
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
     {
         $command = $this->client->getCommand('PutObject', array_merge([
             'Bucket' => $this->config['bucket'],
@@ -124,14 +123,10 @@ class AwsS3V3Adapter extends FilesystemAdapter
             $uri = $this->replaceBaseUrl($uri, $this->config['temporary_url']);
         }
 
-        if($requiredHeaders) {
-            return [
-                'url' => (string) $uri,
-                'headers' => $signedRequest->getHeaders(),
-            ];
-        }
-
-        return (string) $uri;
+        return [
+            'url' => (string) $uri,
+            'headers' => $signedRequest->getHeaders(),
+        ];
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -734,6 +734,25 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Get a temporary upload URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    {
+        if (method_exists($this->adapter, 'temporaryUploadUrl')) {
+            return $this->adapter->temporaryUploadUrl($path, $expiration, $options);
+        }
+
+        throw new RuntimeException('This driver does not support creating temporary upload URLs.');
+    }
+
+    /**
      * Concatenate a path to a URL.
      *
      * @param  string  $url

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -739,15 +739,14 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
-     * @param  bool  $requiredHeaders
-     * @return string|array
+     * @return array
      *
      * @throws \RuntimeException
      */
-    public function temporaryUploadUrl($path, $expiration, array $options = [], bool $requiredHeaders = false)
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
     {
         if (method_exists($this->adapter, 'temporaryUploadUrl')) {
-            return $this->adapter->temporaryUploadUrl($path, $expiration, $options, $requiredHeaders);
+            return $this->adapter->temporaryUploadUrl($path, $expiration, $options);
         }
 
         throw new RuntimeException('This driver does not support creating temporary upload URLs.');

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -739,14 +739,15 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
-     * @return string
+     * @param  bool  $requiredHeaders
+     * @return string|array
      *
      * @throws \RuntimeException
      */
-    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    public function temporaryUploadUrl($path, $expiration, array $options = [], bool $requiredHeaders = false)
     {
         if (method_exists($this->adapter, 'temporaryUploadUrl')) {
-            return $this->adapter->temporaryUploadUrl($path, $expiration, $options);
+            return $this->adapter->temporaryUploadUrl($path, $expiration, $options, $requiredHeaders);
         }
 
         throw new RuntimeException('This driver does not support creating temporary upload URLs.');

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -59,7 +59,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string url(string $path)
  * @method static bool providesTemporaryUrls()
  * @method static string temporaryUrl(string $path, \DateTimeInterface $expiration, array $options = [])
- * @method static string|array temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [], bool $requiredHeaders = false)
+ * @method static array temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [])
  * @method static \League\Flysystem\FilesystemOperator getDriver()
  * @method static \League\Flysystem\FilesystemAdapter getAdapter()
  * @method static array getConfig()

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -59,7 +59,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string url(string $path)
  * @method static bool providesTemporaryUrls()
  * @method static string temporaryUrl(string $path, \DateTimeInterface $expiration, array $options = [])
- * @method static string temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [])
+ * @method static string|array temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [], bool $requiredHeaders = false)
  * @method static \League\Flysystem\FilesystemOperator getDriver()
  * @method static \League\Flysystem\FilesystemAdapter getAdapter()
  * @method static array getConfig()

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -59,6 +59,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string url(string $path)
  * @method static bool providesTemporaryUrls()
  * @method static string temporaryUrl(string $path, \DateTimeInterface $expiration, array $options = [])
+ * @method static string temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [])
  * @method static \League\Flysystem\FilesystemOperator getDriver()
  * @method static \League\Flysystem\FilesystemAdapter getAdapter()
  * @method static array getConfig()


### PR DESCRIPTION
Hi,

This method `temporaryUploadUrl` is helpful for getting presign upload URL from S3 for upload. useful for js uploaders e.g `filepond`etc. so they can upload to this URL directly.

we just have to replace the `GetObject` command with `PutObject`.

Usage:

```php
Storage:disk('s3')->temporaryUploadUrl('path/to/file.pdf', now()->addMinutes(5));
```

