### PR TITLE
[9.x] Add "addRestoreOrCreate" extension to SoftDeletingScope

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -86,10 +86,6 @@ class SoftDeletingScope implements Scope
             $builder->withTrashed();
 
             return tap($builder->firstOrCreate($attributes, $values), function ($instance) {
-                if ($instance->wasRecentlyCreated) {
-                    return;
-                }
-
                 $instance->restore();
             });
         });

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -86,6 +86,10 @@ class SoftDeletingScope implements Scope
             $builder->withTrashed();
 
             return tap($builder->firstOrCreate($attributes, $values), function($instance) {
+                if($instance->wasRecentlyCreated) {
+                    return;
+                }
+
                 $instance->restore();
             });
         });

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,7 @@ class SoftDeletingScope implements Scope
      *
      * @var string[]
      */
-    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
+    protected $extensions = ['Restore', 'RestoreOrCreate', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -71,6 +71,23 @@ class SoftDeletingScope implements Scope
             $builder->withTrashed();
 
             return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);
+        });
+    }
+
+    /**
+     * Add the restore-or-create extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function addRestoreOrCreate(Builder $builder)
+    {
+        $builder->macro('restoreOrCreate', function(Builder $builder, array $attributes = [], array $values = []) {
+            $builder->withTrashed();
+
+            return tap($builder->firstOrCreate($attributes, $values), function($instance) {
+                $instance->restore();
+            });
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -82,11 +82,11 @@ class SoftDeletingScope implements Scope
      */
     protected function addRestoreOrCreate(Builder $builder)
     {
-        $builder->macro('restoreOrCreate', function(Builder $builder, array $attributes = [], array $values = []) {
+        $builder->macro('restoreOrCreate', function (Builder $builder, array $attributes = [], array $values = []) {
             $builder->withTrashed();
 
-            return tap($builder->firstOrCreate($attributes, $values), function($instance) {
-                if($instance->wasRecentlyCreated) {
+            return tap($builder->firstOrCreate($attributes, $values), function ($instance) {
+                if ($instance->wasRecentlyCreated) {
                     return;
                 }
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -63,8 +63,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $callback = $builder->getMacro('restoreOrCreate');
         $givenBuilder = m::mock(EloquentBuilder::class);
         $givenBuilder->shouldReceive('withTrashed')->once();
-        $attributes = ['name'  => 'foo'];
-        $values     = ['email' => 'bar'];
+        $attributes = ['name' => 'foo'];
+        $values = ['email' => 'bar'];
         $givenBuilder->shouldReceive('firstOrCreate')->once()->with($attributes, $values)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('restore')->once()->andReturn(true);
         $result = $callback($givenBuilder, $attributes, $values);

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -50,6 +50,28 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $callback($givenBuilder);
     }
 
+    public function testRestoreOrCreateExtension()
+    {
+        $builder = new EloquentBuilder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            m::mock(Grammar::class),
+            m::mock(Processor::class)
+        ));
+
+        $scope = new SoftDeletingScope;
+        $scope->extend($builder);
+        $callback = $builder->getMacro('restoreOrCreate');
+        $givenBuilder = m::mock(EloquentBuilder::class);
+        $givenBuilder->shouldReceive('withTrashed')->once();
+        $attributes = ['name'  => 'foo'];
+        $values     = ['email' => 'bar'];
+        $givenBuilder->shouldReceive('firstOrCreate')->once()->with($attributes, $values)->andReturn($model = m::mock(Model::class));
+        $model->shouldReceive('restore')->once()->andReturn(true);
+        $result = $callback($givenBuilder, $attributes, $values);
+
+        $this->assertEquals($model, $result);
+    }
+
     public function testWithTrashedExtension()
     {
         $builder = new EloquentBuilder(new BaseBuilder(


### PR DESCRIPTION
I would like to suggest adding addRestoreOrCreate extenstion to the IlluminateDatabaseEloquentSoftDeletingScope.

Following exampels are assumed that User model use SofteDelete trait.


## before this PR
* We need to check if user exists or not and do restore() or create().

```

$user = User::withTrashed()
    ->where(['email' => 'user@example.com'])
    ->first();

if($user) {
    $user->restore();
} else {
    $user = User::create([
        'email' => 'user@example.com',
        'name' => 'user name',
    ]);
}

```


## after this PR
* We don't have to worry about if user exist or not.
```

$user = User::restoreOrCretae(
    ['email' => 'user@example.com'],
    ['name' => 'user name'],
);
