### PR TITLE
[9.x] Cover session store test on setExists method

### DIFF
--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -670,6 +670,7 @@ class SessionStoreTest extends TestCase
     public function getMocks($serialization = 'json', $mockHandler = null)
     {
         $mockHandler ??= m::mock(SessionHandlerInterface::class);
+
         return [
             $this->getSessionName(),
             $mockHandler,


### PR DESCRIPTION
the session store test does not cover test for public method ```setExists``` therefore I added
thanks