### PR TITLE
[9.x] Use `ResponseSequence::isEmpty()` to keep the implementation in one place.

### DIFF
--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -143,11 +143,11 @@ class ResponseSequence
      */
     public function __invoke()
     {
-        if ($this->failWhenEmpty && count($this->responses) === 0) {
+        if ($this->failWhenEmpty && $this->isEmpty()) {
             throw new OutOfBoundsException('A request was made, but the response sequence is empty.');
         }
 
-        if (! $this->failWhenEmpty && count($this->responses) === 0) {
+        if (! $this->failWhenEmpty && $this->isEmpty()) {
             return value($this->emptyResponse ?? Factory::response());
         }
 


### PR DESCRIPTION
The class offers a `isEmpty()` method to check if the client has no responses anymore. Use that method instead reimplement the logic several times throughout the class.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
