### PR TITLE
[9.x] Fix DocBlock type hintings for the Auth module

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -17,7 +17,7 @@ class AuthManager implements FactoryContract
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application|\Illuminate\Container\Container
      */
     protected $app;
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -86,7 +86,7 @@ class EloquentUserProvider implements UserProvider
     /**
      * Update the "remember me" token for the given user in storage.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Illuminate\Database\Eloquent\Model $user
      * @param  string  $token
      * @return void
      */

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -86,7 +86,7 @@ class EloquentUserProvider implements UserProvider
     /**
      * Update the "remember me" token for the given user in storage.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Illuminate\Database\Eloquent\Model $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Illuminate\Database\Eloquent\Model  $user
      * @param  string  $token
      * @return void
      */

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -136,7 +136,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Get the currently authenticated user.
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|\Illuminate\Database\Eloquent\Model|null
      */
     public function user()
     {
@@ -845,7 +845,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Get the cookie creator instance used by the guard.
      *
-     * @return \Illuminate\Contracts\Cookie\QueueingFactory
+     * @return \Illuminate\Contracts\Cookie\QueueingFactory|\Illuminate\Cookie\CookieJar
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Contracts/Auth/Factory.php
+++ b/src/Illuminate/Contracts/Auth/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a guard instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard|\Illuminate\Contracts\Auth\SupportsBasicAuth
      */
     public function guard($name = null);
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -15,7 +15,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application|\Illuminate\Container\Container
      */
     protected $app;
 


### PR DESCRIPTION
Fix DocBlock type hintings in these files:

Undefined method 'rebinding' in `src\Illuminate\Auth\AuthServiceProvider.php`

Undefined method 'refresh' in `src\Illuminate\Auth\AuthManager.php`

Undefined method 'save' in `src\Illuminate\Auth\EloquentUserProvider.php` and `src\Illuminate\Auth\SessionGuard.php`

Undefined method 'hasQueued' in `src\Illuminate\Auth\SessionGuard.php`

Undefined method 'basic' in `src\Illuminate\Auth\Middleware\AuthenticateWithBasicAuth.php`

Run test commands with:
`.\vendor\bin\phpunit .\tests\Auth\`
`.\vendor\bin\phpunit .\tests\Support\`

My platform: Windows 10, PHP 8.1.12 from XAMPP
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
