### PR TITLE
[9.x] Allow brick/math 0.11 also

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.0.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "brick/math": "^0.10.2",
+        "brick/math": "^0.10.2|^0.11",
         "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^3.3.2",
         "egulias/email-validator": "^3.2.1|^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
+        "brick/math": "^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
+        "brick/math": "^0.10.2|^0.11",
         "egulias/email-validator": "^3.2.1|^4.0",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",


### PR DESCRIPTION
Allows brick/math version 0.11 besides version 0.10

See https://github.com/brick/math/releases/tag/0.11.0
Doesn't seem to contain breaking changes for Laravel.

0.10 is required for uuid, but will also allow 0.11 later: https://github.com/ramsey/uuid/pull/488 (if merged)
