### PR TITLE
[9.x] Fix blade tag issue with nested calls 🔧

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -523,6 +523,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
                    ! $this->hasEvenNumberOfParentheses($match[0])) {
                 $rest = Str::before(Str::after($template, $match[0]), ')');
 
+                if (isset($matches[0][$i + 1]) && Str::contains($rest.')', $matches[0][$i + 1])) {
+                    unset($matches[0][$i + 1]);
+                    $i++;
+                }
+
                 $match[0] = $match[0].$rest.')';
                 $match[3] = $match[3].$rest.')';
                 $match[4] = $match[4].$rest;

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -141,4 +141,35 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testNestedTagCalls()
+    {
+        $string = "<span @class(['k' => @empty(\$v)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['k))' => @empty(\$v)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k))\' => @empty($v)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1), 'r' => @empty(\$v2)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['k' => @empty(\$v), 't))' => @empty(\$v1), 'r' => @empty(\$v2)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t))\' => @empty($v1), \'r\' => @empty($v2)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['k' => @empty(\$v), 't' => @empty(\$v1), 'r' => @empty(\$v2), 'l' => 'l'])></span><span @class(['k' => @empty(\$v)])></span>";
+        $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2), \'l\' => \'l\']) ?>"></span><span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]) ?>"></span>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
Fixes the reported bug introduced in https://github.com/laravel/framework/pull/45490#issuecomment-1399482841

- It seems that having multiple calls to other blade tags in between the parenthesis of another call can create problem.
- The added tests also pass with the logic we had before the fix. #45490 