### PR TITLE
Fix phpdoc return type of Illuminate\Database\Eloquent\Collection::find

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -24,7 +24,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  mixed  $key
      * @param  TFindDefault  $default
-     * @return static<TKey|TModel>|TModel|TFindDefault
+     * @return static<TKey, TModel>|TModel|TFindDefault
      */
     public function find($key, $default = null)
     {


### PR DESCRIPTION
Fixes errors with static analysis tools, example message from psalm:
```
WEAK WARNING psalm:: InvalidTemplateParam: Extended template param TKey of Illuminate\Database\Eloquent\Collection<App\User|int>&static expects type array‑key, type App\User|int given
WEAK WARNING psalm:: MissingTemplateParam: Illuminate\Database\Eloquent\Collection has missing template params, expecting 2
```

### Testing

`types/Database/Eloquent/Collection.php` already has the correct assertions
`vendor/bin/phpstan --configuration=phpstan.types.neon.dist` completes without errors