### PR TITLE
[Breaking Change] Refactor validation rules: alpha, alpha_dash, alpha_num

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -334,7 +334,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute contains only alphabetic characters.
+     * Validate that an attribute contains only ascii alphabetic characters.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -342,11 +342,11 @@ trait ValidatesAttributes
      */
     public function validateAlpha($attribute, $value)
     {
-        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
+        return is_string($value) && preg_match('/^[a-zA-Z]+$/u', $value) > 0;
     }
 
     /**
-     * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
+     * Validate that an attribute contains only ascii alpha-numeric characters, dashes, and underscores.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -358,11 +358,11 @@ trait ValidatesAttributes
             return false;
         }
 
-        return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
+        return preg_match('/^[a-zA-Z0-9_-]+$/u', $value) > 0;
     }
 
     /**
-     * Validate that an attribute contains only alpha-numeric characters.
+     * Validate that an attribute contains only ascii alpha-numeric characters.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -374,7 +374,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
+        return preg_match('/^[a-zA-Z0-9]+$/u', $value) > 0;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -378,6 +378,50 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute contains only multibyte alphabetic characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAlphaMb($attribute, $value)
+    {
+        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute contains only multibyte alpha-numeric characters, dashes, and underscores.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAlphaDashMb($attribute, $value)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute contains only multibyte alpha-numeric characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAlphaNumMb($attribute, $value)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
+    }
+
+    /**
      * Validate that an attribute is an array.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4145,7 +4145,7 @@ class ValidationValidatorTest extends TestCase
     public function testValidateAlpha()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'alpha']);
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
@@ -4153,75 +4153,173 @@ class ValidationValidatorTest extends TestCase
             'x' => 'aslsdlks
 1
 1',
-        ], ['x' => 'Alpha']);
+        ], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'Alpha']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'ユニコード を基盤技術と'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'Alpha']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'आपका स्वागत है'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'ユニコード を基盤技術と'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'Continuación'], ['x' => 'Alpha']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'ofreció su dimisión'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '❤'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'आपका स्वागत है'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '123'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'Continuación'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 123], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => 'ofreció su dimisión'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => '❤'], ['x' => 'alpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '123'], ['x' => 'alpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'alpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'alpha']);
         $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaNum()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AlphaNum']);
+        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'alpha_num']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'AlphaNum']);
+        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'alpha_num']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AlphaNum']); // numbers in Hindi
-        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'alpha_num']);
+        $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaNum']); // eastern arabic numerals
-        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と123'], ['x' => 'alpha_num']);
+        $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNum']);
-        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'alpha_num']); // numbers in Hindi
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'alpha_num']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'alpha_num']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaDash()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AlphaDash']);
+        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'alpha_dash']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'AlphaDash']);
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'alpha_dash']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'AlphaDash']);
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と-_123'], ['x' => 'alpha_dash']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'alpha_dash']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'alpha_dash']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAlphaMb()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'alpha_mb']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaDash']); // eastern arabic numerals
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'x' => 'aslsdlks
+1
+1',
+        ], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'alpha_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコード を基盤技術と'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'alpha_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'आपका स्वागत है'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'Continuación'], ['x' => 'alpha_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ofreció su dimisión'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '❤'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '123'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'alpha_mb']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAlphaNumMb()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'alpha_num_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'alpha_num_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と123'], ['x' => 'alpha_num_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'alpha_num_mb']); // numbers in Hindi
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'alpha_num_mb']); // eastern arabic numerals
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'alpha_num_mb']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidateAlphaDashMb()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'alpha_dash_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'alpha_dash_mb']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と-_123'], ['x' => 'alpha_dash_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'alpha_dash_mb']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'alpha_dash_mb']); // eastern arabic numerals
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
This PR is a redo of #45609

## Reason for re-submitting PR
The reason why I refactored this again is discussed at #45660 . Please see.
In the previous PR, we received a comment that custom rules should be defined individually by the developer.
However, as described below, there is a problem that the definition of "alphabet" is implemented differently from what is generally known, which is not good for a Web framework widely used in the world.
Also, since we received a lot of support in the above Discussion, we thought it would be better to address this issue as a framework rather than as individual developers.

## What is this?
The validation rules: alpha, alpha_dash, alpha_num have a problem.
The common definition of "alphabet" or "alphabetic characters" is the 26 types of characters [a-zA-Z] (52 types of uppercase and lowercase characters combined).
However, Laravel's validation rules for verifying whether an input character is an alphabetic character actually allowed characters that went well beyond the definition of an alphabetic character.

This is the actual "alpha" rule code
```php
public function validateAlpha($attribute, $value)
{
    return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value) > 0;
}
```

The following is the meaning of the properties included in this regular expression （from https://www.php.net/manual/en/regexp.reference.unicode.php）
![スクリーンショット 2023-01-23 13 37 25](https://user-images.githubusercontent.com/52437973/213966826-1be5f82c-63ec-44e8-ac6b-81407544e799.png)

That's why, I believe the following code is the more correct one
```php
public function validateAlpha($attribute, $value)
{
    return is_string($value) && preg_match('/^[a-zA-Z]+$/u', $value) > 0;
}
```

This overly broad definition is contrary to the developers' intentions in a language area such as Japan, where multibyte characters are used on a daily basis.
I shared this opinion in the discussion above and got over 30 Upvodes. This is the second most Upvodes of any discussion topic in the Laravel project.

## Changes
- Refactored existing rule logic (alpha, alpha_num, alpha_dash) 4441ec3ace6576a3a7c7ebedb9947dd14b8672c7
  - Changed the rule to not allow multibyte characters according to the original definition of "alpha".
- Renamed existing definitions 59c39e6707c2a952b0ad76192bf379a7c72eb89e
  - The rule originally defined as "alpha" has been renamed to indicate that it "contains multibytes".
- Wrote the test. fa7c923a84ef15e157d46c30f4db10aef6275fd2

## What you get from this change
- Correct validation rules based on the original definition
- Clear separation of validation rules when multibyte is allowed and when it is not
- Preventing the use of validation rules contrary to the developer's intentions