### PR TITLE
[9.x] Add validation rule options: alpha:ascii, alpha_num:ascii, alpha_dash:ascii

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -338,7 +338,7 @@ trait ValidatesAttributes
 
     /**
      * Validate that an attribute contains only alphabetic characters.
-     * If the 'ascii' option is passed, validate that an attribute contains only ascii alphabetic characters
+     * If the 'ascii' option is passed, validate that an attribute contains only ascii alphabetic characters.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -381,6 +381,50 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute contains only ASCII alphabetic characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAsciiAlpha($attribute, $value)
+    {
+        return is_string($value) && preg_match('/^[a-zA-Z]+$/u', $value);
+    }
+
+    /**
+     * Validate that an attribute contains only ASCII alpha-numeric characters, dashes, and underscores.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAsciiAlphaDash($attribute, $value)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return preg_match('/^[a-zA-Z0-9_-]+$/u', $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute contains only ASCII alpha-numeric characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAsciiAlphaNum($attribute, $value)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return preg_match('/^[a-zA-Z0-9]+$/u', $value) > 0;
+    }
+
+    /**
      * Validate that an attribute is an array.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -338,27 +338,38 @@ trait ValidatesAttributes
 
     /**
      * Validate that an attribute contains only alphabetic characters.
+     * If the 'ascii' option is passed, validate that an attribute contains only ascii alphabetic characters
      *
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */
-    public function validateAlpha($attribute, $value)
+    public function validateAlpha($attribute, $value, $parameters)
     {
+        if (isset($parameters[0]) && $parameters[0] === 'ascii') {
+            return is_string($value) && preg_match('/^[a-zA-Z]+$/u', $value);
+        }
+
         return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
     }
 
     /**
      * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
+     * If the 'ascii' option is passed, validate that an attribute contains only ascii alpha-numeric characters,
+     * dashes, and underscores.
      *
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */
-    public function validateAlphaDash($attribute, $value)
+    public function validateAlphaDash($attribute, $value, $parameters)
     {
         if (! is_string($value) && ! is_numeric($value)) {
             return false;
+        }
+
+        if (isset($parameters[0]) && $parameters[0] === 'ascii') {
+            return preg_match('/^[a-zA-Z0-9_-]+$/u', $value) > 0;
         }
 
         return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
@@ -366,62 +377,23 @@ trait ValidatesAttributes
 
     /**
      * Validate that an attribute contains only alpha-numeric characters.
+     * If the 'ascii' option is passed, validate that an attribute contains only ascii alpha-numeric characters.
      *
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */
-    public function validateAlphaNum($attribute, $value)
+    public function validateAlphaNum($attribute, $value, $parameters)
     {
         if (! is_string($value) && ! is_numeric($value)) {
             return false;
+        }
+
+        if (isset($parameters[0]) && $parameters[0] === 'ascii') {
+            return preg_match('/^[a-zA-Z0-9]+$/u', $value) > 0;
         }
 
         return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
-    }
-
-    /**
-     * Validate that an attribute contains only ASCII alphabetic characters.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function validateAsciiAlpha($attribute, $value)
-    {
-        return is_string($value) && preg_match('/^[a-zA-Z]+$/u', $value);
-    }
-
-    /**
-     * Validate that an attribute contains only ASCII alpha-numeric characters, dashes, and underscores.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function validateAsciiAlphaDash($attribute, $value)
-    {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        return preg_match('/^[a-zA-Z0-9_-]+$/u', $value) > 0;
-    }
-
-    /**
-     * Validate that an attribute contains only ASCII alpha-numeric characters.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function validateAsciiAlphaNum($attribute, $value)
-    {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        return preg_match('/^[a-zA-Z0-9]+$/u', $value) > 0;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4497,6 +4497,95 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateAsciiAlpha()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'AsciiAlpha']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'x' => 'aslsdlks
+1
+1',
+        ], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコード を基盤技術と'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'आपका स्वागत है'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'Continuación'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ofreció su dimisión'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '❤'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '123'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'AsciiAlpha']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAsciiAlphaNum()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AsciiAlphaNum']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'AsciiAlphaNum']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と123'], ['x' => 'AsciiAlphaNum']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AsciiAlphaNum']); // numbers in Hindi
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AsciiAlphaNum']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AsciiAlphaNum']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAsciiAlphaDash()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AsciiAlphaDash']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'AsciiAlphaDash']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と-_123'], ['x' => 'AsciiAlphaDash']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'AsciiAlphaDash']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AsciiAlphaDash']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateTimezone()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4497,10 +4497,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateAsciiAlpha()
+    public function testValidateAlphaWithAsciiOption()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Alpha:ascii']);
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
@@ -4508,81 +4508,81 @@ class ValidationValidatorTest extends TestCase
             'x' => 'aslsdlks
 1
 1',
-        ], ['x' => 'Alpha']);
+        ], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'ユニコード を基盤技術と'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'ユニコード を基盤技術と'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'आपका स्वागत है'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'आपका स्वागत है'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'Continuación'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'Continuación'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'ofreció su dimisión'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 'ofreció su dimisión'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '❤'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => '❤'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '123'], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => '123'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 123], ['x' => 'AsciiAlpha']);
+        $v = new Validator($trans, ['x' => 123], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'AsciiAlpha']);
-        $this->assertFalse($v->passes());
-    }
-
-    public function testValidateAsciiAlphaNum()
-    {
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AsciiAlphaNum']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'AsciiAlphaNum']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と123'], ['x' => 'AsciiAlphaNum']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AsciiAlphaNum']); // numbers in Hindi
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AsciiAlphaNum']); // eastern arabic numerals
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AsciiAlphaNum']);
+        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateAsciiAlphaDash()
+    public function testValidateAlphaNumWithAsciiOption()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AsciiAlphaDash']);
+        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AlphaNum:ascii']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'AsciiAlphaDash']);
+        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'AlphaNum:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と-_123'], ['x' => 'AsciiAlphaDash']);
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と123'], ['x' => 'AlphaNum:ascii']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'AsciiAlphaDash']);
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AlphaNum:ascii']); // numbers in Hindi
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AsciiAlphaDash']); // eastern arabic numerals
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaNum:ascii']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNum:ascii']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAlphaDashWithAsciiOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AlphaDash:ascii']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'AlphaDash:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と-_123'], ['x' => 'AlphaDash:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'AlphaDash:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaDash:ascii']); // eastern arabic numerals
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
This PR is a redo of https://github.com/laravel/framework/pull/45767

## Reason for re-submitting PR
The previous PR was closed because it made too many breaking changes to the existing variation rules.
This PR is a new implementation of the validation rules, with no changes to the existing implementation.