### PR TITLE
[10.x] Allow Artisan commands to be aliased with a class property

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -61,6 +61,13 @@ class Command extends SymfonyCommand
     protected $hidden = false;
 
     /**
+     * The console command name aliases.
+     *
+     * @var array
+     */
+    protected $aliases;
+
+    /**
      * Create a new console command instance.
      *
      * @return void
@@ -88,6 +95,10 @@ class Command extends SymfonyCommand
         $this->setHelp((string) $this->help);
 
         $this->setHidden($this->isHidden());
+
+        if (isset($this->aliases)) {
+            $this->setAliases((array) $this->aliases);
+        }
 
         if (! isset($this->signature)) {
             $this->specifyParameters();

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -177,6 +177,18 @@ class CommandTest extends TestCase
         $this->assertFalse($command->parentIsHidden());
     }
 
+    public function testAliasesProperty()
+    {
+        $command = new class extends Command
+        {
+            protected $name = 'foo:bar';
+
+            protected $aliases = ['bar:baz', 'baz:qux'];
+        };
+
+        $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
+    }
+
     public function testChoiceIsSingleSelectByDefault()
     {
         $output = m::mock(OutputStyle::class);


### PR DESCRIPTION
I originally opened [a PR for this](https://github.com/laravel/framework/pull/45697) on 9.x, but it's a breaking change, so this is a resubmission for 10.x. Thanks.