### PR TITLE
[11.x] Change order of composite morphable index members

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1475,7 +1475,7 @@ class Blueprint
 
         $this->unsignedBigInteger("{$name}_id");
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
     }
 
     /**
@@ -1491,7 +1491,7 @@ class Blueprint
 
         $this->unsignedBigInteger("{$name}_id")->nullable();
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
     }
 
     /**
@@ -1507,7 +1507,7 @@ class Blueprint
 
         $this->uuid("{$name}_id");
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
     }
 
     /**
@@ -1523,7 +1523,7 @@ class Blueprint
 
         $this->uuid("{$name}_id")->nullable();
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
     }
 
     /**
@@ -1539,7 +1539,7 @@ class Blueprint
 
         $this->ulid("{$name}_id");
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
     }
 
     /**
@@ -1555,7 +1555,7 @@ class Blueprint
 
         $this->ulid("{$name}_id")->nullable();
 
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
     }
 
     /**

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -134,7 +134,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         });
 
         Schema::table('comments', function (Blueprint $table) {
-            $table->dropIndex('comments_commentable_type_commentable_id_index');
+            $table->dropIndex('comments_commentable_id_commentable_type_index');
         });
 
         Schema::table('comments', function (Blueprint $table) {


### PR DESCRIPTION
Morphable columns are built with a composite index on (`morphable_type`, `morphable_id`) which is fine if queries most commonly target the type OR if there are more types than there are unique IDs.

However, in my experience, it's more common that applications query for items that belong to a specific model. From what I understand about database indexing, a composite index is most useful if the first member has a lower cardinality than the next member.