### PR TITLE
[9.x] Allow use of brick/math 0.9.3 to enable compatibility with Nova 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.0.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "brick/math": "^0.10.2|^0.11",
+        "brick/math": "^0.9.3|^0.10.2|^0.11",
         "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^3.3.2",
         "egulias/email-validator": "^3.2.1|^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
-        "brick/math": "^0.10.2|^0.11",
+        "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
-        "brick/math": "^0.10.2|^0.11",
+        "brick/math": "^0.9.3|^0.10.2|^0.11",
         "egulias/email-validator": "^3.2.1|^4.0",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

9.48 broke compatibility with Nova 3.32 due to the introduction of brick/math in #45602 - trying to update to 9.48 gives the following problem:

    Problem 1
    - laravel/framework v9.48.0 requires brick/math ^0.10.2 -> satisfiable by brick/math[0.10.2].
    - Conclusion: don't install brick/math 0.10.2 (conflict analysis result)
    - Root composer.json requires laravel/nova * -> satisfiable by laravel/nova[3.32.0].
    - Root composer.json requires laravel/framework ^9.48 -> satisfiable by laravel/framework[v9.48.0, 9.x-dev].
    - laravel/nova 3.32.0 requires brick/money ^0.5.0 -> satisfiable by brick/money[0.5.0, 0.5.1, 0.5.2, 0.5.3].
    - brick/money[0.5.0, ..., 0.5.3] require brick/math ~0.7.3 || ~0.8.0 || ~0.9.0 -> satisfiable by brick/math[0.7.3, ..., 0.9.3].
    - You can only install one version of a package, so only one of these can be installed: brick/math[0.7.3, ..., v0.11.x-dev].
    - laravel/framework 9.x-dev requires brick/math ^0.10.2|^0.11 -> satisfiable by brick/math[0.10.2, 0.11.0, v0.11.x-dev].
    - Conclusion: don't install brick/math 0.11.0 (conflict analysis result)

The requirement for brick/math was extended to allow 0.11 in #45762. This PR relaxes the requirement further to allow 0.9.3.

None of the changes from 0.9.3 to 0.10.2 in brick/math affect its use in Laravel. The changes between versions of brick/math are minimal.