### PR TITLE
[10.x] Use PSR Container in Pipeline component

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -3,15 +3,15 @@
 namespace Illuminate\Pipeline;
 
 use Closure;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Hub as HubContract;
+use Psr\Container\ContainerInterface;
 
 class Hub implements HubContract
 {
     /**
      * The container implementation.
      *
-     * @var \Illuminate\Contracts\Container\Container|null
+     * @var \Psr\Container\ContainerInterface|null
      */
     protected $container;
 
@@ -25,10 +25,10 @@ class Hub implements HubContract
     /**
      * Create a new Hub instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container|null  $container
+     * @param  \Psr\Container\ContainerInterface|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(ContainerInterface $container = null)
     {
         $this->container = $container;
     }
@@ -75,7 +75,7 @@ class Hub implements HubContract
     /**
      * Get the container instance used by the hub.
      *
-     * @return \Illuminate\Contracts\Container\Container
+     * @return \Psr\Container\ContainerInterface
      */
     public function getContainer()
     {
@@ -85,10 +85,10 @@ class Hub implements HubContract
     /**
      * Set the container instance used by the hub.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Psr\Container\ContainerInterface  $container
      * @return $this
      */
-    public function setContainer(Container $container)
+    public function setContainer(ContainerInterface $container)
     {
         $this->container = $container;
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Pipeline;
 
 use Closure;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
+use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Throwable;
 
@@ -13,7 +13,7 @@ class Pipeline implements PipelineContract
     /**
      * The container implementation.
      *
-     * @var \Illuminate\Contracts\Container\Container|null
+     * @var \Psr\Container\ContainerInterface|null
      */
     protected $container;
 
@@ -41,10 +41,10 @@ class Pipeline implements PipelineContract
     /**
      * Create a new class instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container|null  $container
+     * @param  \Psr\Container\ContainerInterface|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(ContainerInterface $container = null)
     {
         $this->container = $container;
     }
@@ -166,7 +166,7 @@ class Pipeline implements PipelineContract
                         // If the pipe is a string we will parse the string and resolve the class out
                         // of the dependency injection container. We can then build a callable and
                         // execute the pipe function giving in the parameters that are required.
-                        $pipe = $this->getContainer()->make($name);
+                        $pipe = $this->getContainer()->get($name);
 
                         $parameters = array_merge([$passable, $stack], $parameters);
                     } else {
@@ -218,7 +218,7 @@ class Pipeline implements PipelineContract
     /**
      * Get the container instance.
      *
-     * @return \Illuminate\Contracts\Container\Container
+     * @return \Psr\Container\ContainerInterface
      *
      * @throws \RuntimeException
      */
@@ -234,10 +234,10 @@ class Pipeline implements PipelineContract
     /**
      * Set the container instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Psr\Container\ContainerInterface  $container
      * @return $this
      */
-    public function setContainer(Container $container)
+    public function setContainer(ContainerInterface $container)
     {
         $this->container = $container;
 

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0",
-        "illuminate/support": "^10.0"
+        "illuminate/support": "^10.0",
+        "psr/container": "^1.1.1|^2.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -24,7 +24,7 @@ class Pipeline extends BasePipeline
     protected function handleCarry($carry)
     {
         return $carry instanceof Responsable
-            ? $carry->toResponse($this->getContainer()->make(Request::class))
+            ? $carry->toResponse($this->getContainer()->get(Request::class))
             : $carry;
     }
 
@@ -39,12 +39,12 @@ class Pipeline extends BasePipeline
      */
     protected function handleException($passable, Throwable $e)
     {
-        if (! $this->container->bound(ExceptionHandler::class) ||
+        if (! $this->getContainer()->has(ExceptionHandler::class) ||
             ! $passable instanceof Request) {
             throw $e;
         }
 
-        $handler = $this->container->make(ExceptionHandler::class);
+        $handler = $this->getContainer()->get(ExceptionHandler::class);
 
         $handler->report($e);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR makes the Pipeline component to depend on the PSR Container instead of Illuminate container.

This allows the Pipeline component to be used with another container implementation in projects that do not require the full Laravel framework, and already use a PSR Container implementation.
