### PR TITLE
[9.x] Fix infinite loop in blade compiler

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -526,6 +526,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 }
 
                 $rest = Str::before($after, ')');
+
                 if (isset($matches[0][$i + 1]) && Str::contains($rest.')', $matches[0][$i + 1])) {
                     unset($matches[0][$i + 1]);
                     $i++;

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -521,8 +521,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
             while (isset($match[4]) &&
                    Str::endsWith($match[0], ')') &&
                    ! $this->hasEvenNumberOfParentheses($match[0])) {
-                $rest = Str::before(Str::after($template, $match[0]), ')');
+                if (($after = Str::after($template, $match[0])) === $template) {
+                    break;
+                }
 
+                $rest = Str::before($after, ')');
                 if (isset($matches[0][$i + 1]) && Str::contains($rest.')', $matches[0][$i + 1])) {
                     unset($matches[0][$i + 1]);
                     $i++;

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -172,4 +172,10 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $expected = '<span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v), \'t\' => @empty($v1), \'r\' => @empty($v2), \'l\' => \'l\']) ?>"></span><span class="<?php echo \Illuminate\Support\Arr::toCssClasses([\'k\' => @empty($v)]) ?>"></span>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testItDoesNotCompileInvalidSyntax()
+    {
+        $template = "<a @class(['k\' => ()])></a>";
+        $this->assertEquals($template, $this->compiler->compileString($template));
+    }
 }


### PR DESCRIPTION
During the latest bug fix in the blade compiler, I found that if the user passes invalid PHP syntax to blade tag calls, it will end up in an infinite loop that eventually fills up the memory and crashes.
`php artisan view:cache`

`Str::after` return the whole input if it can not find the `$needle` so we check if it is equal and break.
If you comment out the line: `break;` the added test will result in an infinite loop.

This is what the end user see in case of syntax error in the browser (after this fix):
![image](https://user-images.githubusercontent.com/6961695/214281057-28c4ffc8-fdd5-4f24-8c7a-590602376705.png)
