### PR TITLE
[9.x] Add support for multiline strings in Str::excerpt method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -301,7 +301,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/iu', (string) $text, $matches);
+        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/ius', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -177,12 +177,8 @@ class SupportStrTest extends TestCase
               ['omission' => '[...]'],
         ));
         $this->assertSame(
-            "...Just like...",
-            Str::excerpt(
-                "This is a multiline text.
-              Just like it could exist in a realworld application.",
-                'Just',
-                ['radius' => 5]
+            '...ext.'.PHP_EOL.'Just like...',
+            Str::excerpt('This is a multiline text.'.PHP_EOL.'Just like it could exist in a realworld application.','Just',['radius' => 5]
             )
         );
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -176,6 +176,15 @@ class SupportStrTest extends TestCase
               Str::excerpt('This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
               ['omission' => '[...]'],
         ));
+        $this->assertSame(
+            "...Just like...",
+            Str::excerpt(
+                "This is a multiline text.
+              Just like it could exist in a realworld application.",
+                'Just',
+                ['radius' => 5]
+            )
+        );
 
         $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
         $this->assertSame('...ayl...', Str::excerpt('taylor', 'Y', ['radius' => 1]));


### PR DESCRIPTION
In my opinion the Str::excerpt method's main use-case is to create excerpts from longer texts including paragraphs aka line-breaks. Therefore, I found myself often wrapping the method with another that replaces new line characters with spaces. 

By adding the DOTALL Regex flag (`s`) to the used expression it will also match on multiline strings.