### PR TITLE
[9.x] Add equals methods to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -302,6 +302,81 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the items equal the given items.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @return bool
+     */
+    public function equals($items)
+    {
+        return $this->diff($items)->isEmpty()
+            && (new static($items))->diff($this->items)->isEmpty();
+    }
+
+    /**
+     * Determine if the items equal the given items, using the callback.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @param  callable(TValue, TValue): int  $callback
+     * @return bool
+     */
+    public function equalsUsing($items, callable $callback)
+    {
+        return $this->diffUsing($items, $callback)->isEmpty()
+            && (new static($items))->diffUsing($this->items, $callback)->isEmpty();
+    }
+
+    /**
+     * Determine if the items equal the given items by comparing both keys and values.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return bool
+     */
+    public function equalsAssoc($items)
+    {
+        return $this->diffAssoc($items)->isEmpty()
+            && (new static($items))->diffAssoc($this->items)->isEmpty();
+    }
+
+    /**
+     * Determine if the items equal the given items by comparing both keys and values, using the callback.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @param  callable(TValue, TValue): int  $callback
+     * @return bool
+     */
+    public function equalsAssocUsing($items, callable $callback)
+    {
+        return $this->diffAssocUsing($items, $callback)->isEmpty()
+            && (new static($items))->diffAssocUsing($this->items, $callback)->isEmpty();
+    }
+
+    /**
+     * Determine if the items equal the given items by comparing keys.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return bool
+     */
+    public function equalsKeys($items)
+    {
+        return $this->diffKeys($items)->isEmpty()
+            && (new static($items))->diffKeys($this->items)->isEmpty();
+    }
+
+    /**
+     * Determine if the items equal the given items by comparing keys, using the callback.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @param  callable(TValue, TValue): int  $callback
+     * @return bool
+     */
+    public function equalsKeysUsing($items, callable $callback)
+    {
+        return $this->diffKeysUsing($items, $callback)->isEmpty()
+            && (new static($items))->diffKeysUsing($this->items, $callback)->isEmpty();
+    }
+
+    /**
      * Retrieve duplicate items from the collection.
      *
      * @param  (callable(TValue): bool)|string|null  $callback

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -321,6 +321,25 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(new Collection([$one]), $c1->diff($c2));
     }
 
+    public function testCollectionEqualsWithGivenCollection()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturn(3);
+
+        $c1 = new Collection([$one, $two]);
+        $c2 = new Collection([$two, $three]);
+        $c3 = new Collection([$two, $one]);
+
+        $this->assertFalse($c1->equals($c2));
+        $this->assertTrue($c1->equals($c3));
+    }
+
     public function testCollectionReturnsDuplicateBasedOnlyOnKeys()
     {
         $one = new TestEloquentCollectionModel;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1553,6 +1553,55 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssocUsing($c2, 'strcasecmp')->all());
     }
 
+    public function testEqualsCollection()
+    {
+        $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $this->assertTrue($c->equals(['Hello', 1]));
+        $this->assertFalse($c->equals([1, 'Hello', false]));
+    }
+
+    public function testEqualsUsingWithCollection()
+    {
+        $c = new Collection(['fr', 'HR']);
+        // demonstrate that equals won't support case insensitivity
+        $this->assertFalse($c->equals(new Collection(['fr', 'hr'])));
+        // allow for case insensitive comparison
+        $this->assertTrue($c->equalsUsing(new Collection(['fr', 'hr']), 'strcasecmp'));
+    }
+
+    public function testEqualsAssoc()
+    {
+        $c = new Collection(['id' => 1]);
+        $this->assertTrue($c->equalsAssoc(['id' => 1]));
+        $this->assertFalse($c->equalsAssoc(['id' => 2]));
+        $this->assertFalse($c->equalsAssoc(['key' => 1]));
+    }
+
+    public function testEqualsAssocUsing()
+    {
+        $c = new Collection(['foo' => 'bar']);
+        // demonstrate that equalsAssoc won't support case insensitivity
+        $this->assertFalse($c->equalsAssoc(new Collection(['FOO' => 'bar'])));
+        // allow for case insensitive comparison
+        $this->assertTrue($c->equalsAssocUsing(new Collection(['FOO' => 'bar']), 'strcasecmp'));
+    }
+
+    public function testEqualsKeys()
+    {
+        $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $this->assertTrue($c->equalsKeys(['first_word' => 'foo', 'id' => 33]));
+        $this->assertFalse($c->equalsKeys(['key' => 1, 'second_word' => 'Hello']));
+    }
+
+    public function testEqualsKeysUsing()
+    {
+        $c = new Collection(['foo' => 'bar']);
+        // demonstrate that equalsAssoc won't support case insensitivity
+        $this->assertFalse($c->equalsKeys(new Collection(['FOO' => 123])));
+        // allow for case insensitive comparison
+        $this->assertTrue($c->equalsKeysUsing(new Collection(['FOO' => 123]), 'strcasecmp'));
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
I've created some helper methods for comparing Collections using the already present diff methods.

It's basically a short-hand for converting this...
```php
if (
    $collectionA->diff($collectionB)->isEmpty()
    && $collectionB->diff($collectionA)->isEmpty()
) {
    // do something if both collections contain the same values
}
```

...into this.
```php
if ($collectionA->equals($collectionB)) {
    // do something if both collections contain the same values
}
```
