### PR TITLE
[9.x] Remove database dependency on symfony/console

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,8 +22,7 @@
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
-        "illuminate/support": "^9.0",
-        "symfony/console": "^6.0.9"
+        "illuminate/support": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Placing a requirement on `symfony/console` makes it hard to use the database subpackage with any framework that has its own `symfony/*` requirements.

Dependency is only used by database commands, so removing this dependency does not break anything for use case of not using database commands.

To use database commands, one must install `illuminate/console` which will in turn require `symfony/console`, so use case of using database commands will still get the correct dependencies.

(The existence of this dependency has forced us to use the very old 6.x release with our Drupal installation.)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
