### PR TITLE
[9.x] Extract status methods to traits

### DIFF
--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -144,4 +144,14 @@ trait DeterminesStatusCode
     {
         return $this->status() === 422;
     }
+
+    /**
+     * Determine if the response was a "Too Many Requests".
+     *
+     * @return bool
+     */
+    public function tooManyRequests()
+    {
+        return $this->status() === 429;
+    }
 }

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -5,7 +5,7 @@ namespace Illuminate\Http\Client\Concerns;
 trait DeterminesStatusCode
 {
     /**
-     * Determine if the response code was "OK".
+     * Determine if the response code was 200 "OK" response.
      *
      * @return bool
      */
@@ -15,7 +15,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response code was "created".
+     * Determine if the response code was 201 "Created" response.
      *
      * @return bool
      */
@@ -25,7 +25,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response code was "accepted".
+     * Determine if the response code was 202 "Accepted" response.
      *
      * @return bool
      */
@@ -35,7 +35,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response code was "no content".
+     * Determine if the response code was the given status code and the body has no content.
      *
      * @param  int  $status
      * @return bool
@@ -46,7 +46,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response code was "moved permanently".
+     * Determine if the response code was a 301 "Moved Permanently".
      *
      * @return bool
      */
@@ -56,7 +56,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response code was "found".
+     * Determine if the response code was a 302 "Found" response.
      *
      * @return bool
      */
@@ -66,7 +66,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a "bad request".
+     * Determine if the response was a 400 "Bad Request" response.
      *
      * @return bool
      */
@@ -86,7 +86,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a "payment required".
+     * Determine if the response was a 402 "Payment Required" response.
      *
      * @return bool
      */
@@ -116,7 +116,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a "Request Timeout".
+     * Determine if the response was a 408 "Request Timeout" response.
      *
      * @return bool
      */
@@ -126,7 +126,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a "Conflict".
+     * Determine if the response was a 409 "Conflict" response.
      *
      * @return bool
      */
@@ -136,7 +136,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a "Unprocessable Entity".
+     * Determine if the response was a 422 "Unprocessable Entity" response.
      *
      * @return bool
      */
@@ -146,7 +146,7 @@ trait DeterminesStatusCode
     }
 
     /**
-     * Determine if the response was a "Too Many Requests".
+     * Determine if the response was a 429 "Too Many Requests" response.
      *
      * @return bool
      */

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -134,4 +134,14 @@ trait DeterminesStatusCode
     {
         return $this->status() === 409;
     }
+
+    /**
+     * Determine if the response was a "Unprocessable Entity".
+     *
+     * @return bool
+     */
+    public function unprocessableEntity()
+    {
+        return $this->status() === 422;
+    }
 }

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -15,6 +15,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response code was "created".
+     *
+     * @return bool
+     */
+    public function created()
+    {
+        return $this->status() === 201;
+    }
+
+    /**
      * Determine if the response was a 401 "Unauthorized" response.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Http\Client\Concerns;
+
+trait DeterminesStatusCode
+{
+    /**
+     * Determine if the response code was "OK".
+     *
+     * @return bool
+     */
+    public function ok()
+    {
+        return $this->status() === 200;
+    }
+
+    /**
+     * Determine if the response was a 401 "Unauthorized" response.
+     *
+     * @return bool
+     */
+    public function unauthorized()
+    {
+        return $this->status() === 401;
+    }
+
+    /**
+     * Determine if the response was a 403 "Forbidden" response.
+     *
+     * @return bool
+     */
+    public function forbidden()
+    {
+        return $this->status() === 403;
+    }
+
+    /**
+     * Determine if the response was a 404 "Not Found" response.
+     *
+     * @return bool
+     */
+    public function notFound()
+    {
+        return $this->status() === 404;
+    }
+}

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -56,6 +56,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response code was "found".
+     *
+     * @return bool
+     */
+    public function found()
+    {
+        return $this->status() === 302;
+    }
+
+    /**
      * Determine if the response was a 401 "Unauthorized" response.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -124,4 +124,14 @@ trait DeterminesStatusCode
     {
         return $this->status() === 408;
     }
+
+    /**
+     * Determine if the response was a "Conflict".
+     *
+     * @return bool
+     */
+    public function conflict()
+    {
+        return $this->status() === 409;
+    }
 }

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -25,6 +25,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response code was "accepted".
+     *
+     * @return bool
+     */
+    public function accepted()
+    {
+        return $this->status() === 202;
+    }
+
+    /**
      * Determine if the response was a 401 "Unauthorized" response.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -66,6 +66,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response was a "bad request".
+     *
+     * @return bool
+     */
+    public function badRequest()
+    {
+        return $this->status() === 400;
+    }
+
+    /**
      * Determine if the response was a 401 "Unauthorized" response.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -86,6 +86,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response was a "payment required".
+     *
+     * @return bool
+     */
+    public function paymentRequired()
+    {
+        return $this->status() === 402;
+    }
+
+    /**
      * Determine if the response was a 403 "Forbidden" response.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -35,6 +35,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response code was "no content".
+     *
+     * @return bool
+     */
+    public function noContent($status = 204)
+    {
+        return $this->status() === $status && $this->body() === '';
+    }
+
+    /**
      * Determine if the response was a 401 "Unauthorized" response.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -37,11 +37,22 @@ trait DeterminesStatusCode
     /**
      * Determine if the response code was "no content".
      *
+     * @param  int  $status
      * @return bool
      */
     public function noContent($status = 204)
     {
         return $this->status() === $status && $this->body() === '';
+    }
+
+    /**
+     * Determine if the response code was "moved permanently".
+     *
+     * @return bool
+     */
+    public function movedPermanently()
+    {
+        return $this->status() === 301;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -114,4 +114,14 @@ trait DeterminesStatusCode
     {
         return $this->status() === 404;
     }
+
+    /**
+     * Determine if the response was a "Request Timeout".
+     *
+     * @return bool
+     */
+    public function requestTimeout()
+    {
+        return $this->status() === 408;
+    }
 }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -9,7 +9,7 @@ use LogicException;
 
 class Response implements ArrayAccess
 {
-    use Macroable {
+    use Concerns\DeterminesStatusCode, Macroable {
         __call as macroCall;
     }
 
@@ -165,16 +165,6 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Determine if the response code was "OK".
-     *
-     * @return bool
-     */
-    public function ok()
-    {
-        return $this->status() === 200;
-    }
-
-    /**
      * Determine if the response was a redirect.
      *
      * @return bool
@@ -182,36 +172,6 @@ class Response implements ArrayAccess
     public function redirect()
     {
         return $this->status() >= 300 && $this->status() < 400;
-    }
-
-    /**
-     * Determine if the response was a 401 "Unauthorized" response.
-     *
-     * @return bool
-     */
-    public function unauthorized()
-    {
-        return $this->status() === 401;
-    }
-
-    /**
-     * Determine if the response was a 403 "Forbidden" response.
-     *
-     * @return bool
-     */
-    public function forbidden()
-    {
-        return $this->status() === 403;
-    }
-
-    /**
-     * Determine if the response was a 404 "Not Found" response.
-     *
-     * @return bool
-     */
-    public function notFound()
-    {
-        return $this->status() === 404;
     }
 
     /**

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -63,6 +63,17 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a found status code.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    public function assertFound()
+    {
+        return $this->assertStatus(302);
+    }
+
+    /**
      * Assert that the response has a bad request status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -152,4 +152,14 @@ trait AssertsStatusCodes
     {
         return $this->assertStatus(422);
     }
+
+    /**
+     * Assert that the response has a too many requests status code.
+     *
+     * @return $this
+     */
+    public function assertTooManyRequests()
+    {
+        return $this->assertStatus(429);
+    }
 }

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -27,6 +27,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has an accepted status code.
+     *
+     * @return $this
+     */
+    public function assertAccepted()
+    {
+        return $this->assertStatus(202);
+    }
+
+    /**
      * Assert that the response has the given status code and no content.
      *
      * @param  int  $status

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -82,6 +82,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a request timeout status code.
+     *
+     * @return $this
+     */
+    public function assertRequestTimeout()
+    {
+        return $this->assertStatus(408);
+    }
+
+    /**
      * Assert that the response has a 422 status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Testing\Concerns;
+
+use Illuminate\Testing\Assert as PHPUnit;
+
+trait AssertsStatusCodes
+{
+    /**
+     * Assert that the response has a 200 status code.
+     *
+     * @return $this
+     */
+    public function assertOk()
+    {
+        return $this->assertStatus(200);
+    }
+
+    /**
+     * Assert that the response has a 201 status code.
+     *
+     * @return $this
+     */
+    public function assertCreated()
+    {
+        return $this->assertStatus(201);
+    }
+
+    /**
+     * Assert that the response has the given status code and no content.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    public function assertNoContent($status = 204)
+    {
+        $this->assertStatus($status);
+
+        PHPUnit::assertEmpty($this->getContent(), 'Response content is not empty.');
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response has an unauthorized status code.
+     *
+     * @return $this
+     */
+    public function assertUnauthorized()
+    {
+        return $this->assertStatus(401);
+    }
+
+    /**
+     * Assert that the response has a forbidden status code.
+     *
+     * @return $this
+     */
+    public function assertForbidden()
+    {
+        return $this->assertStatus(403);
+    }
+
+    /**
+     * Assert that the response has a not found status code.
+     *
+     * @return $this
+     */
+    public function assertNotFound()
+    {
+        return $this->assertStatus(404);
+    }
+
+    /**
+     * Assert that the response has a 422 status code.
+     *
+     * @return $this
+     */
+    public function assertUnprocessable()
+    {
+        return $this->assertStatus(422);
+    }
+}

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -62,6 +62,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a payment required status code.
+     *
+     * @return $this
+     */
+    public function assertPaymentRequired()
+    {
+        return $this->assertStatus(402);
+    }
+
+    /**
      * Assert that the response has a forbidden status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -52,6 +52,17 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a moved permanently status code.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    public function assertMovedPermanently()
+    {
+        return $this->assertStatus(301);
+    }
+
+    /**
      * Assert that the response has a bad request status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -134,6 +134,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a conflict status code.
+     *
+     * @return $this
+     */
+    public function assertConflict()
+    {
+        return $this->assertStatus(409);
+    }
+
+    /**
      * Assert that the response has a 422 status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -42,6 +42,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a bad request status code.
+     *
+     * @return $this
+     */
+    public function assertBadRequest()
+    {
+        return $this->assertStatus(400);
+    }
+
+    /**
      * Assert that the response has an unauthorized status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -7,7 +7,7 @@ use Illuminate\Testing\Assert as PHPUnit;
 trait AssertsStatusCodes
 {
     /**
-     * Assert that the response has a 200 status code.
+     * Assert that the response has a 200 "OK" status code.
      *
      * @return $this
      */
@@ -17,7 +17,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a 201 status code.
+     * Assert that the response has a 201 "Created" status code.
      *
      * @return $this
      */
@@ -27,7 +27,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has an accepted status code.
+     * Assert that the response has a 202 "Accepted" status code.
      *
      * @return $this
      */
@@ -52,7 +52,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a moved permanently status code.
+     * Assert that the response has a 301 "Moved Permanently" status code.
      *
      * @param  int  $status
      * @return $this
@@ -63,7 +63,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a found status code.
+     * Assert that the response has a 302 "Found" status code.
      *
      * @param  int  $status
      * @return $this
@@ -74,7 +74,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a bad request status code.
+     * Assert that the response has a 400 "Bad Request" status code.
      *
      * @return $this
      */
@@ -84,7 +84,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has an unauthorized status code.
+     * Assert that the response has a 402 "Unauthorized" status code.
      *
      * @return $this
      */
@@ -94,7 +94,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a payment required status code.
+     * Assert that the response has a 402 "Payment Required" status code.
      *
      * @return $this
      */
@@ -104,7 +104,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a forbidden status code.
+     * Assert that the response has a 403 "Forbidden" status code.
      *
      * @return $this
      */
@@ -114,7 +114,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a not found status code.
+     * Assert that the response has a 404 "Not Found" status code.
      *
      * @return $this
      */
@@ -124,7 +124,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a request timeout status code.
+     * Assert that the response has a 408 "Request Timeout" status code.
      *
      * @return $this
      */
@@ -134,7 +134,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a conflict status code.
+     * Assert that the response has a 409 "Conflict" status code.
      *
      * @return $this
      */
@@ -144,7 +144,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a 422 status code.
+     * Assert that the response has a 422 "Unprocessable Entity" status code.
      *
      * @return $this
      */
@@ -154,7 +154,7 @@ trait AssertsStatusCodes
     }
 
     /**
-     * Assert that the response has a too many requests status code.
+     * Assert that the response has a 429 "Too Many Requests" status code.
      *
      * @return $this
      */

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class TestResponse implements ArrayAccess
 {
-    use Tappable, Macroable {
+    use Concerns\AssertsStatusCodes, Tappable, Macroable {
         __call as macroCall;
     }
 
@@ -93,81 +93,6 @@ class TestResponse implements ArrayAccess
         );
 
         return $this;
-    }
-
-    /**
-     * Assert that the response has a 200 status code.
-     *
-     * @return $this
-     */
-    public function assertOk()
-    {
-        return $this->assertStatus(200);
-    }
-
-    /**
-     * Assert that the response has a 201 status code.
-     *
-     * @return $this
-     */
-    public function assertCreated()
-    {
-        return $this->assertStatus(201);
-    }
-
-    /**
-     * Assert that the response has the given status code and no content.
-     *
-     * @param  int  $status
-     * @return $this
-     */
-    public function assertNoContent($status = 204)
-    {
-        $this->assertStatus($status);
-
-        PHPUnit::assertEmpty($this->getContent(), 'Response content is not empty.');
-
-        return $this;
-    }
-
-    /**
-     * Assert that the response has a not found status code.
-     *
-     * @return $this
-     */
-    public function assertNotFound()
-    {
-        return $this->assertStatus(404);
-    }
-
-    /**
-     * Assert that the response has a forbidden status code.
-     *
-     * @return $this
-     */
-    public function assertForbidden()
-    {
-        return $this->assertStatus(403);
-    }
-
-    /**
-     * Assert that the response has an unauthorized status code.
-     *
-     * @return $this
-     */
-    public function assertUnauthorized()
-    {
-        return $this->assertStatus(401);
-    }
-
-    /**
-     * Assert that the response has a 422 status code.
-     *
-     * @return $this
-     */
-    public function assertUnprocessable()
-    {
-        return $this->assertStatus(422);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -141,6 +141,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->badRequest());
     }
 
+    public function testPaymentRequiredTest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_PAYMENT_REQUIRED),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->paymentRequired());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->paymentRequired());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -127,6 +127,19 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->found());
     }
 
+    public function testBadRequestRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_BAD_REQUEST),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->badRequest());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->badRequest());
+    }
 
     public function testUnauthorizedRequest()
     {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -88,18 +88,28 @@ class HttpClientTest extends TestCase
     public function testNoContentRequest()
     {
         $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_MOVED_PERMANENTLY),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->movedPermanently());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->movedPermanently());
+    }
+
+    public function testMovedPermanentlyRequest()
+    {
+        $this->factory->fake([
             'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_NO_CONTENT),
             'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
-            'basecamp.laravel.com' => $this->factory::response('foo', HttpResponse::HTTP_NO_CONTENT),
         ]);
 
         $response = $this->factory->post('http://vapor.laravel.com');
         $this->assertTrue($response->noContent());
 
         $response = $this->factory->post('http://forge.laravel.com');
-        $this->assertFalse($response->noContent());
-
-        $response = $this->factory->post('http://basecamp.laravel.com');
         $this->assertFalse($response->noContent());
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -205,6 +205,20 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->forbidden());
     }
 
+    public function testUnprocessableEntityRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_UNPROCESSABLE_ENTITY),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->unprocessableEntity());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->unprocessableEntity());
+    }
+
     public function testNotFoundResponse()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -113,6 +113,21 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->noContent());
     }
 
+    public function testFoundRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_FOUND),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->found());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->found());
+    }
+
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -169,6 +169,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->requestTimeout());
     }
 
+    public function testConflictResponseTest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_CONFLICT),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->conflict());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->conflict());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -71,6 +71,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->created());
     }
 
+    public function testAcceptedRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_ACCEPTED),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->accepted());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->accepted());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -85,6 +85,24 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->accepted());
     }
 
+    public function testNoContentRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_NO_CONTENT),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+            'basecamp.laravel.com' => $this->factory::response('foo', HttpResponse::HTTP_NO_CONTENT),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->noContent());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->noContent());
+
+        $response = $this->factory->post('http://basecamp.laravel.com');
+        $this->assertFalse($response->noContent());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -155,6 +155,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->paymentRequired());
     }
 
+    public function testRequestTimeoutTest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_REQUEST_TIMEOUT),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->requestTimeout());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->requestTimeout());
+    }
+
     public function testUnauthorizedRequest()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -85,7 +85,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->accepted());
     }
 
-    public function testNoContentRequest()
+    public function testMovedPermanentlyRequest()
     {
         $this->factory->fake([
             'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_MOVED_PERMANENTLY),
@@ -99,7 +99,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->movedPermanently());
     }
 
-    public function testMovedPermanentlyRequest()
+    public function testNoContentRequest()
     {
         $this->factory->fake([
             'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_NO_CONTENT),
@@ -197,6 +197,19 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->unprocessableEntity());
     }
 
+    public function testTooManyRequestsRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_TOO_MANY_REQUESTS),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->tooManyRequests());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->tooManyRequests());
+    }
 
     public function testUnauthorizedRequest()
     {
@@ -218,20 +231,6 @@ class HttpClientTest extends TestCase
         $response = $this->factory->post('http://laravel.com');
 
         $this->assertTrue($response->forbidden());
-    }
-
-    public function testTooManyRequestsRequest()
-    {
-        $this->factory->fake([
-            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_TOO_MANY_REQUESTS),
-            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
-        ]);
-
-        $response = $this->factory->post('http://vapor.laravel.com');
-        $this->assertTrue($response->tooManyRequests());
-
-        $response = $this->factory->post('http://forge.laravel.com');
-        $this->assertFalse($response->tooManyRequests());
     }
 
     public function testNotFoundResponse()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -141,7 +141,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->badRequest());
     }
 
-    public function testPaymentRequiredTest()
+    public function testPaymentRequiredRequest()
     {
         $this->factory->fake([
             'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_PAYMENT_REQUIRED),
@@ -155,7 +155,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->paymentRequired());
     }
 
-    public function testRequestTimeoutTest()
+    public function testRequestTimeoutRequest()
     {
         $this->factory->fake([
             'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_REQUEST_TIMEOUT),
@@ -169,7 +169,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->requestTimeout());
     }
 
-    public function testConflictResponseTest()
+    public function testConflictResponseRequest()
     {
         $this->factory->fake([
             'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_CONFLICT),
@@ -182,6 +182,21 @@ class HttpClientTest extends TestCase
         $response = $this->factory->post('http://forge.laravel.com');
         $this->assertFalse($response->conflict());
     }
+
+    public function testUnprocessableEntityRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_UNPROCESSABLE_ENTITY),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->unprocessableEntity());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->unprocessableEntity());
+    }
+
 
     public function testUnauthorizedRequest()
     {
@@ -203,20 +218,6 @@ class HttpClientTest extends TestCase
         $response = $this->factory->post('http://laravel.com');
 
         $this->assertTrue($response->forbidden());
-    }
-
-    public function testUnprocessableEntityRequest()
-    {
-        $this->factory->fake([
-            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_UNPROCESSABLE_ENTITY),
-            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
-        ]);
-
-        $response = $this->factory->post('http://vapor.laravel.com');
-        $this->assertTrue($response->unprocessableEntity());
-
-        $response = $this->factory->post('http://forge.laravel.com');
-        $this->assertFalse($response->unprocessableEntity());
     }
 
     public function testTooManyRequestsRequest()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -17,6 +17,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
@@ -54,6 +55,20 @@ class HttpClientTest extends TestCase
         $response = $this->factory->post('http://laravel.com/test-missing-page');
 
         $this->assertTrue($response->ok());
+    }
+
+    public function testCreatedRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_CREATED),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->created());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->created());
     }
 
     public function testUnauthorizedRequest()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -219,6 +219,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse($response->unprocessableEntity());
     }
 
+    public function testTooManyRequestsRequest()
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_TOO_MANY_REQUESTS),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('http://vapor.laravel.com');
+        $this->assertTrue($response->tooManyRequests());
+
+        $response = $this->factory->post('http://forge.laravel.com');
+        $this->assertFalse($response->tooManyRequests());
+    }
+
     public function testNotFoundResponse()
     {
         $this->factory->fake([

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -612,6 +612,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertRequestTimeout()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_REQUEST_TIMEOUT)
+        );
+
+        $response->assertRequestTimeout();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [408] but received 200.\nFailed asserting that 408 is identical to 200.");
+
+        $response->assertRequestTimeout();
+        $this->fail();
+    }
+
     public function testAssertUnprocessable()
     {
         $statusCode = 500;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -688,6 +688,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertConflict()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_CONFLICT)
+        );
+
+        $response->assertConflict();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [409] but received 200.\nFailed asserting that 409 is identical to 200.");
+
+        $response->assertConflict();
+        $this->fail();
+    }
+
     public function testAssertAccepted()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -650,6 +650,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertMovedPermanently()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_MOVED_PERMANENTLY)
+        );
+
+        $response->assertMovedPermanently();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [301] but received 200.\nFailed asserting that 301 is identical to 200.");
+
+        $response->assertMovedPermanently();
+        $this->fail();
+    }
+
     public function testAssertAccepted()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -593,6 +593,25 @@ class TestResponseTest extends TestCase
         $response->assertUnauthorized();
     }
 
+    public function testAssertBadRequest()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_BAD_REQUEST)
+        );
+
+        $response->assertBadRequest();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [400] but received 200.\nFailed asserting that 400 is identical to 200.");
+
+        $response->assertBadRequest();
+        $this->fail();
+    }
+
     public function testAssertUnprocessable()
     {
         $statusCode = 500;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -650,6 +650,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertAccepted()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_ACCEPTED)
+        );
+
+        $response->assertAccepted();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [202] but received 200.\nFailed asserting that 202 is identical to 200.");
+
+        $response->assertAccepted();
+        $this->fail();
+    }
+
     public function testAssertUnprocessable()
     {
         $statusCode = 500;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -707,6 +707,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertTooManyRequests()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_TOO_MANY_REQUESTS)
+        );
+
+        $response->assertTooManyRequests();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [429] but received 200.\nFailed asserting that 429 is identical to 200.");
+
+        $response->assertTooManyRequests();
+        $this->fail();
+    }
+
     public function testAssertAccepted()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -631,7 +631,7 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
-    public function testAssertPaymetRequired()
+    public function testAssertPaymentRequired()
     {
         $response = TestResponse::fromBaseResponse(
             (new Response)->setStatusCode(Response::HTTP_PAYMENT_REQUIRED)

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -669,6 +669,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertFound()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_FOUND)
+        );
+
+        $response->assertFound();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [302] but received 200.\nFailed asserting that 302 is identical to 200.");
+
+        $response->assertFound();
+        $this->fail();
+    }
+
     public function testAssertAccepted()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -631,6 +631,25 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertPaymetRequired()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_PAYMENT_REQUIRED)
+        );
+
+        $response->assertPaymentRequired();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [402] but received 200.\nFailed asserting that 402 is identical to 200.");
+
+        $response->assertPaymentRequired();
+        $this->fail();
+    }
+
     public function testAssertUnprocessable()
     {
         $statusCode = 500;


### PR DESCRIPTION
Another proposal for https://github.com/laravel/framework/pull/45734 with concrete methods extracted to traits.

Only pure `$status === {int}` checks and assertions have been extracted to the traits.

I've added some additional status checks for those that the community have previously attempted  and others I see as regularly used, to anticipate future PRs and give the "I wonder if this is just there" feel.