### PR TITLE
Fix ValidationValidator not to accept terminating newline

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -348,10 +348,10 @@ trait ValidatesAttributes
     public function validateAlpha($attribute, $value, $parameters)
     {
         if (isset($parameters[0]) && $parameters[0] === 'ascii') {
-            return is_string($value) && preg_match('/^[a-zA-Z]+$/u', $value);
+            return is_string($value) && preg_match('/\A[a-zA-Z]+\z/u', $value);
         }
 
-        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
+        return is_string($value) && preg_match('/\A[\pL\pM]+\z/u', $value);
     }
 
     /**
@@ -370,10 +370,10 @@ trait ValidatesAttributes
         }
 
         if (isset($parameters[0]) && $parameters[0] === 'ascii') {
-            return preg_match('/^[a-zA-Z0-9_-]+$/u', $value) > 0;
+            return preg_match('/\A[a-zA-Z0-9_-]+\z/u', $value) > 0;
         }
 
-        return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
+        return preg_match('/\A[\pL\pM\pN_-]+\z/u', $value) > 0;
     }
 
     /**
@@ -391,10 +391,10 @@ trait ValidatesAttributes
         }
 
         if (isset($parameters[0]) && $parameters[0] === 'ascii') {
-            return preg_match('/^[a-zA-Z0-9]+$/u', $value) > 0;
+            return preg_match('/\A[a-zA-Z0-9]+\z/u', $value) > 0;
         }
 
-        return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
+        return preg_match('/\A[\pL\pM\pN]+\z/u', $value) > 0;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4547,6 +4547,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'Alpha']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha']); // ends with newline
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaNum()
@@ -4566,6 +4569,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNum']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaNum']); // ends with newline
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaDash()
@@ -4582,6 +4588,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaDash']); // eastern arabic numerals
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDash']); // ends with newline
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaWithAsciiOption()
@@ -4630,6 +4639,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'Alpha:ascii']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha:ascii']); // ends with newline
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaNumWithAsciiOption()
@@ -4652,6 +4664,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNum:ascii']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaNum:ascii']); // ends with newline
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaDashWithAsciiOption()
@@ -4670,6 +4685,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaDash:ascii']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDash:ascii']); // ends with newline
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
I've seen https://github.com/laravel/framework/pull/45769 merged and realize that these methods are probably accept unintended newlines.


The manual ([PHP: Meta-characters](https://www.php.net/manual/en/regexp.reference.meta.php)) says that `$` matches not only the end of the string, but also the terminating newline.
The `\A` and `\z` pairs are safe because they always match leading and trailing ends regardless of mode.

[PHP: Escape sequences - Manual](https://www.php.net/manual/en/regexp.reference.escape.php)

> The `\A`, `\Z`, and `\z` assertions differ from the traditional circumflex and dollar (described in [anchors](https://www.php.net/manual/en/regexp.reference.anchors.php) ) in that they only ever match at the very start and end of the subject string, whatever options are set. They are not affected by the [PCRE_MULTILINE](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php) or [PCRE_DOLLAR_ENDONLY](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php) options. The difference between `\Z` and `\z` is that `\Z` matches before a newline that is the last character of the string as well as at the end of the string, whereas `\z` matches only at the end.

------

I'm not a Laravel user, so I'm not too concerned with this issue. If more work is needed for compatibility, please close this PR and have someone else work on it again. thank you!