### PR TITLE
[9.x] Add dropForeignWithIndex method in Blueprint class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1826,4 +1826,16 @@ class Blueprint
                         : [$column->name => null];
         })->filter()->all();
     }
+
+    /**
+     * Indicate that the given foreign key index should be dropped with their index.
+     *
+     * @param array|string $index
+     */
+    public function dropForeignWithIndex(array|string $index): void
+    {
+        $this->dropForeign($index);
+
+        $this->dropIndex($index);
+    }
 }


### PR DESCRIPTION
This PR will add a new method in the `Blueprint` class with this method clients are able to drop a foreign key with the related index in their migrations

- example
```
Schema::table('users', function (Blueprint $table) {
  $table->dropForeignWithIndex('users_office_id_foreign');
});
```