### PR TITLE
[10.x] make dispatch() behaviour same across the framework

### DIFF
--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Foundation\Bus;
 
-use Illuminate\Contracts\Bus\Dispatcher;
-
 trait DispatchesJobs
 {
     /**
@@ -14,7 +12,7 @@ trait DispatchesJobs
      */
     protected function dispatch($job)
     {
-        return app(Dispatcher::class)->dispatch($job);
+        return dispatch($job);
     }
 
     /**
@@ -27,6 +25,6 @@ trait DispatchesJobs
      */
     public function dispatchSync($job)
     {
-        return app(Dispatcher::class)->dispatchSync($job);
+        return dispatch_sync($job);
     }
 }


### PR DESCRIPTION
Fixes the bug https://github.com/laravel/framework/issues/45781

The dispatch method inside `DispatchesJobs` trait does not check for Unique Jobs.

The global [dispatch](https://github.com/laravel/framework/blob/f801dd731592281a48e592b27960663bfe5fafab/src/Illuminate/Foundation/helpers.php#L386) helper functions does check it here

https://github.com/laravel/framework/blob/f801dd731592281a48e592b27960663bfe5fafab/src/Illuminate/Foundation/Bus/PendingDispatch.php#L163

This PR make these 2 methods act same.