### PR TITLE
[9.x] Update array generic types to match laravel/laravel skeleton implementations

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -22,7 +22,7 @@ class EncryptCookies
     /**
      * The names of the cookies that should not be encrypted.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [];
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -51,21 +51,21 @@ class Kernel implements KernelContract
     /**
      * The application's middleware stack.
      *
-     * @var array
+     * @var array<int, class-string|string>
      */
     protected $middleware = [];
 
     /**
      * The application's route middleware groups.
      *
-     * @var array
+     * @var array<string, array<int, class-string|string>>
      */
     protected $middlewareGroups = [];
 
     /**
      * The application's route middleware.
      *
-     * @var array
+     * @var array<string, class-string|string>
      */
     protected $routeMiddleware = [];
 

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -19,7 +19,7 @@ class PreventRequestsDuringMaintenance
     /**
      * The URIs that should be accessible while maintenance mode is enabled.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [];
 

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -16,7 +16,7 @@ class TrimStrings extends TransformsRequest
     /**
      * The attributes that should not be trimmed.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [
         //

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -34,7 +34,7 @@ class VerifyCsrfToken
     /**
      * The URIs that should be excluded from CSRF verification.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [];
 

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -11,7 +11,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The event handler mappings for the application.
      *
-     * @var array
+     * @var array<string, array<int, string>>
      */
     protected $listen = [];
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -10,7 +10,7 @@ class TrustProxies
     /**
      * The trusted proxies for the application.
      *
-     * @var array|string|null
+     * @var array<int, string>|string|null
      */
     protected $proxies;
 


### PR DESCRIPTION
When using [PHPStan](https://phpstan.org/) Strict Rules in conjunction with [Larastan](https://github.com/nunomaduro/larastan), there are a few errors with a default install of 9.x. Most of these can easily be fixed in the app code if you want, but some of the default implementations have docblock typehints that are incompatible with the vendor classes they extend. There is no nice way to ignore those in PHPStan other than creating stubs.

An example:

````
------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Http/Kernel.php
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  16     PHPDoc type array<int, string> of property App\Http\Kernel::$middleware is not the same as PHPDoc type array of overridden property Illuminate\Foundation\Http\Kernel::$middleware.
         💡 You can fix 3rd party PHPDoc types with stub files:
            https://phpstan.org/user-guide/stub-files
            This error can be turned off by setting
            reportMaybesInPropertyPhpDocTypes: false in your phpstan.neon.
````

I did see that @nunomaduro already made some [improvements to the skeleton code in this PR](https://github.com/laravel/laravel/pull/5740), so it stands to reason the actually classes being extended should be updated too?

I have only updated the properties that are actually overwritten by the app in a default install
