### PR TITLE
[9.x] Add createManyQuietly to HasOneOrMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -354,6 +354,17 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create a Collection of new instances of the related model without raising any events to the parent model.
+     *
+     * @param  iterable  $records
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function createManyQuietly(iterable $records)
+    {
+        return Model::withoutEvents(fn () => $this->createMany($records));
+    }
+
+    /**
      * Set the foreign ID for creating a related model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model


### PR DESCRIPTION
This method makes it possible to create multiple related models without raising any events to the parent model.