### PR TITLE
[9.x] Add uuidPrimary and ulidPrimary methods to Blueprint class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1265,6 +1265,17 @@ class Blueprint
     }
 
     /**
+     * Create a new UUID primary column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function uuidPrimary($column = 'uuid')
+    {
+        return $this->uuid($column)->primary();
+    }
+
+    /**
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
@@ -1288,6 +1299,18 @@ class Blueprint
     public function ulid($column = 'uuid', $length = 26)
     {
         return $this->char($column, $length);
+    }
+
+    /**
+     * Create a new ULID primary column on the table.
+     *
+     * @param  string  $column
+     * @param  int|null  $length
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function ulidPrimary($column = 'uuid', $length = 26)
+    {
+        return $this->ulid($column, $length)->primary();
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1057,6 +1057,50 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `uuid` char(36) not null', $statements[0]);
     }
 
+    public function testAddingUlidPrimary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `foo` char(26) not null', $statements[0]);
+        $this->assertSame('alter table `users` add primary key (`foo`)', $statements[1]);
+    }
+
+    public function testAddingUlidPrimaryWithLength()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary('foo', 36);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
+        $this->assertSame('alter table `users` add primary key (`foo`)', $statements[1]);
+    }
+
+    public function testAddingUlidPrimaryDefaultsColumnName()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `uuid` char(26) not null', $statements[0]);
+        $this->assertSame('alter table `users` add primary key (`uuid`)', $statements[1]);
+    }
+
+    public function testAddingUlidPrimaryDefaultsColumnNameWithLength()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary(length: 36);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `uuid` char(36) not null', $statements[0]);
+        $this->assertSame('alter table `users` add primary key (`uuid`)', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This PR adds uuidPrimary and ulidPrimary methods to the `Blueprint` class. It makes it possible to create UUID or ULID field as the primary key with one method call.

Examples.
```
Schema::create('user', function (Blueprint $table) {
    $table->uuidPrimary('id');
});
```
```
Schema::create('user', function (Blueprint $table) {
    $table->ulidPrimary('id');
});
```