### PR TITLE
[9.x] Add ```get_enum_values``` function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.1",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -428,18 +428,20 @@ if (! function_exists('get_enum_values')) {
     /**
      * Get all values of enum class.
      *
-     * @param string $enum
+     * @param  string  $enum
      * @return array
+     *
+     * @throws \RuntimeException
      */
     function get_enum_values(string $enum)
     {
         $values = [];
 
         if ((float) PHP_VERSION <= 8.1) {
-            throw new \RuntimeException("PHP version must be equal or more than 8.1");
+            throw new RuntimeException("PHP version must be equal or more than 8.1");
         }
         if (! enum_exists($enum)) {
-            throw new \RuntimeException("Enum class is not valid.");
+            throw new RuntimeException("Enum class is not valid.");
         }
 
         foreach ($enum::cases() as $val) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -435,7 +435,7 @@ if (! function_exists('get_enum_values')) {
     {
         $values = [];
 
-        if ((float) PHP_VERSION <= 8.0) {
+        if ((float) PHP_VERSION <= 8.1) {
             throw new \RuntimeException("PHP version must be equal or more than 8.1");
         }
         if (! enum_exists($enum)) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -438,10 +438,10 @@ if (! function_exists('get_enum_values')) {
         $values = [];
 
         if ((float) PHP_VERSION <= 8.1) {
-            throw new RuntimeException("PHP version must be equal or more than 8.1");
+            throw new RuntimeException('PHP version must be equal or more than 8.1');
         }
         if (! enum_exists($enum)) {
-            throw new RuntimeException("Enum class is not valid.");
+            throw new RuntimeException('Enum class is not valid');
         }
 
         foreach ($enum::cases() as $val) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -435,6 +435,13 @@ if (! function_exists('get_enum_values')) {
     {
         $values = [];
 
+        if ((float) PHP_VERSION <= 8.0) {
+            throw new \RuntimeException("PHP version must be equal or more than 8.1");
+        }
+        if (! enum_exists($enum)) {
+            throw new \RuntimeException("Enum class is not valid.");
+        }
+
         foreach ($enum::cases() as $val) {
             $values[] = $val->value;
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -423,3 +423,15 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('get_enum_values')) {
+    function get_enum_values(string $enum) {
+        $values = [];
+
+        foreach ($enum::cases() as $val) {
+            $values[] = $val->value;
+        }
+
+        return $values;
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -425,7 +425,14 @@ if (! function_exists('with')) {
 }
 
 if (! function_exists('get_enum_values')) {
-    function get_enum_values(string $enum) {
+    /**
+     * Get all values of enum class.
+     *
+     * @param string $enum
+     * @return array
+     */
+    function get_enum_values(string $enum)
+    {
         $values = [];
 
         foreach ($enum::cases() as $val) {


### PR DESCRIPTION
Most of the time work with enums is hard.
If you want to take all values of one enum, you may have to do a series of operations, for example:

1.Get enum with cases method.
2.Loop the enums and move values to variable.
3. ....

But you can use this method to give all enum values, for example:
```php
<?php

namespace App;

enum ProductStatusEnum:string
{
    case ACTIVE = "active";
    case IN_PROGRESS = "in-progress";
    case INACTIVE = "inactive";
}
```
When need to take values:
```php
$enums = get_enum_values(ProductStatusEnum::class);
dd($enums);
```
The result is:
![2023-01-25_23-27-43](https://user-images.githubusercontent.com/98118400/214675906-b2c65949-d71e-4daf-84ba-c0fe491ed627.png)

🟢 Now you can do anything :)
