### PR TITLE
Update false docblock of pluck method in Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -849,7 +849,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get an array with the values of a given column.
+     * Get a collection with the values of a given column.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  string|null  $key


### PR DESCRIPTION
The `pluck` method of `Illuminate/Database/Eloquent/Builder.php` returns a Collection, as documented in the docblock at `@return`. However, the comment right above specifies that the method returns an array, which is false and misleading. This small PR corrects the false comment.