### PR TITLE
[9.x] - 45782: Solve data to be dumped for separate schemes

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -94,7 +94,7 @@ class DumpCommand extends Command
      */
     protected function path(Connection $connection)
     {
-        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.dump'), function ($path) {
+        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.sql'), function ($path) {
             (new Filesystem)->ensureDirectoryExists(dirname($path));
         });
     }

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -16,8 +16,8 @@ class PostgresSchemaState extends SchemaState
     public function dump(Connection $connection, $path)
     {
         $commands = collect([
-            $this->baseDumpCommand() . ' --schema-only > ' . $path,
-            $this->baseDumpCommand() . ' -t '. $this->migrationTable .' --data-only >> ' . $path,
+            $this->baseDumpCommand().' --schema-only > '.$path,
+            $this->baseDumpCommand().' -t '.$this->migrationTable.' --data-only >> '.$path,
         ]);
 
         $commands->map(function ($command, $path) {

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -15,16 +15,8 @@ class PostgresSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
-        $excludedTables = collect($connection->getSchemaBuilder()->getAllTables())
-                        ->map->tablename
-                        ->reject(function ($table) {
-                            return $table === $this->migrationTable;
-                        })->map(function ($table) {
-                            return '--exclude-table-data="*.'.$table.'"';
-                        })->implode(' ');
-
         $this->makeProcess(
-            $this->baseDumpCommand().' --file="${:LARAVEL_LOAD_PATH}" '.$excludedTables
+            $this->baseDumpCommand().' --file="${:LARAVEL_LOAD_PATH}" '
         )->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));
@@ -58,7 +50,7 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        return 'pg_dump --no-owner --no-acl -Fc --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
+        return 'pg_dump -s -T '.$this->migrationTable.' --no-owner --no-acl -Fc --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**


### PR DESCRIPTION
This issue refers to:
https://github.com/laravel/framework/issues/45782

---

For MySQL a schema is defined as:

Conceptually, a schema is a set of interrelated database objects, such as tables, table columns, data types, indexes and so on. In MySQL a schema is synonymous with a database: you can swap out the words schema and database.

For PostgreSQL a schema is defined as:

A schema is a namespace for SQL objects, which all reside in the same database. Each SQL object must reside in exactly one schema.

More generically, the term schema is used to mean all data descriptions.

A schema can be used to organize database objects, or even allow having one database identical tables for different schemas. If you have a database named 'laravel', with schema 'symfony' and schema 'laravel', this database can have two tables named users in a PostgreSQL database.

In a MySQL database, you would simply have a database named laravel and symfony.

PostgreSQL has a default public schema, but for consistency sake I would recommend exporting all schemas for one database, so the artisan dump command simply dumps out all tables.

What we would like to achieve is that we want to get all schemas, without any data, excluding the migrations table.

This would look like something like:

pg_dump [connection_options] -s -T 'migrations' [db_name]

**Why not the current approach?**

The current approach will dump all database objects, excluding the table data defined in the public scheme. As we have no way of knowing what schemes a user might be using, and we shouldn't want to know for the dump command, it could be a more general solution to simply dump all sql objects, exclude data, for all schemes.

Another approach would be to only dump out all data under the default public scheme, but this would make a dump useless for companies that have a logical grouping the database.