### PR TITLE
Gate ability registration

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -231,7 +231,7 @@ class Gate implements GateContract
     }
 
     /**
-     * Register abilities for a class.
+     * Register abilities from a class.
      *
      * @param  string  $name
      * @param  string  $class

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -253,7 +253,7 @@ class Gate implements GateContract
             ->reject(fn ($item) => in_array($item->name, $traitMethods->toArray()));
 
         foreach ($abilities as $ability) {
-            $this->define($name . '.' . $ability->name, $class . '@' . $ability->name);
+            $this->define($name.'.'.$ability->name, $class.'@'.$ability->name);
         }
 
         return $this;

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -221,6 +221,21 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('test.ability2'));
     }
 
+    public function testClassGatesCanBeRegistered()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->register('test', ClassGateTest::class);
+
+        $this->assertTrue($gate->has(''));
+        $this->assertTrue($gate->has(''));
+        $this->assertTrue($gate->has(''));
+        $this->assertTrue($gate->has(''));
+        $this->assertTrue($gate->has(''));
+        $this->assertFalse($gate->has(''));
+        $this->assertFalse($gate->has(''));
+    }
+
     public function testBeforeCallbacksCanOverrideResultIfNecessary()
     {
         $gate = $this->getBasicGate();

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -225,15 +225,17 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->register('test', ClassGateTest::class);
+        $gate->register('test', AccessGateTestAutoRegistersMethods::class);
 
-        $this->assertTrue($gate->has(''));
-        $this->assertTrue($gate->has(''));
-        $this->assertTrue($gate->has(''));
-        $this->assertTrue($gate->has(''));
-        $this->assertTrue($gate->has(''));
-        $this->assertFalse($gate->has(''));
-        $this->assertFalse($gate->has(''));
+        $this->assertTrue($gate->has('test.gate1'));
+        $this->assertTrue($gate->has('test.gate2'));
+        $this->assertFalse($gate->has('test.__construct'));
+        $this->assertFalse($gate->has('test.parent1'));
+        $this->assertFalse($gate->has('test.parent2'));
+        $this->assertFalse($gate->has('test.trait1'));
+        $this->assertFalse($gate->has('test.trait2'));
+        $this->assertFalse($gate->has('test.trait3'));
+        $this->assertFalse($gate->has('test.trait4'));
     }
 
     public function testBeforeCallbacksCanOverrideResultIfNecessary()
@@ -1410,4 +1412,31 @@ class AccessGateTestPolicyThrowingAuthorizationException
     {
         throw new AuthorizationException('Not allowed.', 'some_code');
     }
+}
+
+class AccessGateTestAutoRegistersMethodsParent
+{
+    public function parent1() {}
+    public function parent2() {}
+}
+
+trait AccessGateTestAutoRegistersMethodsTraitOne
+{
+    public function trait1() {}
+    public function trait2() {}
+}
+
+trait AccessGateTestAutoRegistersMethodsTraitTwo
+{
+    public function trait3() {}
+    public function trait4() {}
+}
+
+class AccessGateTestAutoRegistersMethods extends AccessGateTestAutoRegistersMethodsParent
+{
+    use AccessGateTestAutoRegistersMethodsTraitOne, AccessGateTestAutoRegistersMethodsTraitTwo;
+
+    public function __construct(){}
+    public function gate1() {}
+    public function gate2() {}
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1416,27 +1416,50 @@ class AccessGateTestPolicyThrowingAuthorizationException
 
 class AccessGateTestAutoRegistersMethodsParent
 {
-    public function parent1() {}
-    public function parent2() {}
+    public function parent1()
+    {
+    }
+
+    public function parent2()
+    {
+    }
 }
 
 trait AccessGateTestAutoRegistersMethodsTraitOne
 {
-    public function trait1() {}
-    public function trait2() {}
+    public function trait1()
+    {
+    }
+
+    public function trait2()
+    {
+    }
 }
 
 trait AccessGateTestAutoRegistersMethodsTraitTwo
 {
-    public function trait3() {}
-    public function trait4() {}
+    public function trait3()
+    {
+    }
+
+    public function trait4()
+    {
+    }
 }
 
 class AccessGateTestAutoRegistersMethods extends AccessGateTestAutoRegistersMethodsParent
 {
     use AccessGateTestAutoRegistersMethodsTraitOne, AccessGateTestAutoRegistersMethodsTraitTwo;
 
-    public function __construct(){}
-    public function gate1() {}
-    public function gate2() {}
+    public function __construct()
+    {
+    }
+
+    public function gate1()
+    {
+    }
+
+    public function gate2()
+    {
+    }
 }


### PR DESCRIPTION
Currently to register a group of authorization abilities, we can use the `resource()` method, which defines our standard CRUD options. This is fine in a lot of cases, but if you want to adjust those basic options, you now need to pass a clunky third parameter in the `resource()` method to get the desired abilities.

With this PR we now have the ability to *auto-register* any methods defined in a class as a Gate ability! It uses the convention of the method name being the same as the ability name.

Imagine we have a class of gates:

```php
class UserPolicy
{
    public function viewAny(User $user): bool {}
    public function view(User $user, User $model): bool {}
    public function create(User $user): bool {}
    public function update(User $user, User $model): bool {}
    public function delete(User $user, User $model): bool {}
    public function restore(User $user, User $model): bool {}
    public function forceDelete(User $user, User $model): bool {}
}
```

To register this in our `AuthServiceProvider` we can now use:

```php
$gate->register('users', \App\Policies\UserPolicy::class);
```

and all 7 of our methods will be defined with the following ability names:

```
users.viewAny
users.view
users.create
users.update
users.delete
users.restore
users.forceDelete
```

---

Some people will probably be thinking, why not just use actual Laravel Policies?  I've talked previously (#19124) about why I prefer defined gates vs policies, but it boils down to the fact policies will auto resolve the authorization rule based on the first Model it receives, and this isn't always desirable. Defined gates work more similarly to Routes, and allow you to be explicit about which authorization rule is called.

---

The one thing I'm not really sure about with this PR is if there are performance concerns when dealing with Reflection. I wasn't seeing any issues in my testing, but if anyone has any knowledge on this, would love to hear it.