### PR TITLE
[9.x] Add ```sum``` directive in blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -14,7 +14,8 @@ use InvalidArgumentException;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
-    use Concerns\CompilesAuthorizations,
+    use Concerns\CompilesArray,
+        Concerns\CompilesAuthorizations,
         Concerns\CompilesClasses,
         Concerns\CompilesComments,
         Concerns\CompilesComponents,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
@@ -11,8 +11,9 @@ trait CompilesArray
     protected function compileSum($arguments)
     {
         $arguments = str_replace(['[', ']'], '', $arguments);
-        $arguments = explode(',', $arguments);
+        $arguments = explode(', ', $arguments);
+        $sum = array_sum($arguments);
 
-        return "<?php echo array_sum($arguments) ?>";
+        return "<?php echo $sum; ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
@@ -5,6 +5,8 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesArray
 {
     /**
+     *  Compile the "array_sum" statements into valid PHP.
+     *
      * @param  string  $arguments
      * @return string
      */

--- a/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
@@ -10,7 +10,7 @@ trait CompilesArray
      */
     protected function compileSum($arguments)
     {
-        $arguments = str_replace(array('[', ']'), '', $arguments);
+        $arguments = str_replace(['[', ']'], '', $arguments);
         $arguments = explode(',', $arguments);
 
         return "<?php echo array_sum($arguments) ?>";

--- a/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesArray
+{
+
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesArray.php
@@ -4,5 +4,15 @@ namespace Illuminate\View\Compilers\Concerns;
 
 trait CompilesArray
 {
+    /**
+     * @param  string  $arguments
+     * @return string
+     */
+    protected function compileSum($arguments)
+    {
+        $arguments = str_replace(array('[', ']'), '', $arguments);
+        $arguments = explode(',', $arguments);
 
+        return "<?php echo array_sum($arguments) ?>";
+    }
 }


### PR DESCRIPTION
I think is better to add array php methods in blade.
This directive help to sum array in blade like this;
```php
@sum([1, 2, 3, 4]) // 10
OR
@sum(1, 2, 3, 4) // 10
```