### PR TITLE
[9.x] Add getModelChanges to HasAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2024,6 +2024,37 @@ trait HasAttributes
     }
 
     /**
+     * Retrieve the changed properties of the model according to the "all", "only" or "except" strategy.
+     *
+     * @param  string|null $strategy
+     * @param  null        $fields
+     * @return array
+     */
+    public function getModelChanges(string $strategy = null, array $fields = null)
+    {
+        $changes = [];
+
+        foreach ($this->getChanges() as $fieldName => $newVal) {
+            if ($strategy === 'only') {
+                if (!in_array($fieldName, $fields)) {
+                    continue;
+                }
+            }
+            if ($strategy === 'except') {
+                if (in_array($fieldName, $fields)) {
+                    continue;
+                }
+            }
+            $changes[$fieldName] = [
+                'old' => $this->getOriginal($fieldName),
+                'new' => $newVal,
+            ];
+        }
+
+        return $changes;
+    }
+
+    /**
      * Determine if the new and old values for a given key are equivalent.
      *
      * @param  string  $key


### PR DESCRIPTION
Our team constantly uses the same piece of code to get a list of changes in the model. We log these changes to a log file or a special database table. This allows you to keep track of the changes that have been made.

Example:

```
$model->getModelChanges();
```

Result:

```
array:2 [
  "name" => array:2 [
    "old" => "Otwell Taylor"
    "new" => "Taylor Otwell"
  ],
  "email" => array:2 [
    "old" => "taylor@laravel.org"
    "new" => "taylor@laravel.com"
  ]
]
```