### PR TITLE
[9.x] feat: add support for database custom init commands

### DIFF
--- a/src/Illuminate/Database/Concerns/ConfiguresCustomInitCommands.php
+++ b/src/Illuminate/Database/Concerns/ConfiguresCustomInitCommands.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+trait ConfiguresCustomInitCommands
+{
+    /**
+     * Configure custom database init commands.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function configureCustomInitCommands($connection, array $config)
+    {
+        if (isset($config['init']) && is_array($config['init'])) {
+            foreach ($config['init'] as $command) {
+                $connection->prepare($command)->execute();
+            }
+        }
+    }
+}

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Connectors;
 
 use Doctrine\DBAL\Driver\PDOConnection;
 use Exception;
+use Illuminate\Database\Concerns\ConfiguresCustomInitCommands;
 use Illuminate\Database\DetectsLostConnections;
 use PDO;
 use Throwable;
@@ -11,6 +12,7 @@ use Throwable;
 class Connector
 {
     use DetectsLostConnections;
+    use ConfiguresCustomInitCommands;
 
     /**
      * The default PDO connection options.

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -38,6 +38,8 @@ class MySqlConnector extends Connector implements ConnectorInterface
 
         $this->setModes($connection, $config);
 
+        $this->configureCustomInitCommands($connection, $config);
+
         return $connection;
     }
 

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -54,6 +54,8 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
         $this->configureSynchronousCommit($connection, $config);
 
+        $this->configureCustomInitCommands($connection, $config);
+
         return $connection;
     }
 

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -22,7 +22,11 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         // connection does. These are useful for tests or for short lifetime store
         // querying. In-memory databases may only have a single open connection.
         if ($config['database'] === ':memory:') {
-            return $this->createConnection('sqlite::memory:', $config, $options);
+            $connection = $this->createConnection('sqlite::memory:', $config, $options);
+
+            $this->configureCustomInitCommands($connection, $config);
+
+            return $connection;
         }
 
         $path = realpath($config['database']);
@@ -34,6 +38,10 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             throw new SQLiteDatabaseDoesNotExistException($config['database']);
         }
 
-        return $this->createConnection("sqlite:{$path}", $config, $options);
+        $connection = $this->createConnection("sqlite:{$path}", $config, $options);
+
+        $this->configureCustomInitCommands($connection, $config);
+
+        return $connection;
     }
 }

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -33,6 +33,8 @@ class SqlServerConnector extends Connector implements ConnectorInterface
 
         $this->configureIsolationLevel($connection, $config);
 
+        $this->configureCustomInitCommands($connection, $config);
+
         return $connection;
     }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -73,6 +73,24 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testMySqlConnectCallsCreateConnectionWithCustomInit()
+    {
+        $dsn = 'mysql:host=foo;dbname=bar';
+        $config = ['host' => 'foo', 'database' => 'bar', 'init' => ['baz']];
+
+        $connector = $this->getMockBuilder(MySqlConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->once()->with('baz')->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresConnectCallsCreateConnectionWithProperArguments()
     {
         $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';
@@ -232,6 +250,23 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresConnectCallsCreateConnectionWithCustomInit()
+    {
+        $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';
+        $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'init' => ['baz']];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(PDO::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->once()->with('baz')->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresConnectorReadsIsolationLevelFromConfig()
     {
         $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';
@@ -275,6 +310,40 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testSQLiteMemoryDatabasesMayBeConnectedToWithCustomInit()
+    {
+        $dsn = 'sqlite::memory:';
+        $config = ['database' => ':memory:', 'init' => ['baz']];
+        $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(stdClass::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->once()->with('baz')->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testSQLiteFileDatabasesMayBeConnectedToWithCustomInit()
+    {
+        $dsn = 'sqlite:'.__DIR__;
+        $config = ['database' => __DIR__, 'init' => ['baz']];
+        $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(stdClass::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->once()->with('baz')->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testSqlServerConnectCallsCreateConnectionWithProperArguments()
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111];
@@ -312,6 +381,23 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
+    public function testSqlServerConnectCallsCreateConnectionWithCustomInit()
+    {
+        $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'init' => ['baz']];
+        $dsn = $this->getDsn($config);
+        $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(stdClass::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->once()->with('baz')->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->zeroOrMoreTimes();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);


### PR DESCRIPTION
We currently ran into the situation where we need to set the max_execution_time for the current session in our MySql Database.

We implemented it (using a Provider with DB::unprepared and didn't like it) and thought maybe it makes sense to bring that into laravel core, as laravel currently lacks that possibility.

We currently configure it in database.php
```
return [
    'connections' => [
          'default' => [
                ...
               'host' => env('DB_HOST'),
               ...
               'init' => ['set session max_execution_time = 20000'],
              ....
            ]
      ]
];
```

We use the MySql connector and so I am following the same concept for the other connectors.

If approved, I can make the appropriate PR for the docs too.