### PR TITLE
Default content type to JSON

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -250,7 +250,7 @@ class PendingRequest
      * @param  string  $contentType
      * @return $this
      */
-    public function withBody($content, $contentType)
+    public function withBody($content, $contentType = 'application/json')
     {
         $this->bodyFormat('body');
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -23,7 +23,7 @@ use Illuminate\Http\Client\Factory;
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
  * @method static \Illuminate\Http\Client\PendingRequest baseUrl(string $url)
- * @method static \Illuminate\Http\Client\PendingRequest withBody(string $content, string $contentType)
+ * @method static \Illuminate\Http\Client\PendingRequest withBody(string $content, string $contentType = 'application/json')
  * @method static \Illuminate\Http\Client\PendingRequest asJson()
  * @method static \Illuminate\Http\Client\PendingRequest asForm()
  * @method static \Illuminate\Http\Client\PendingRequest attach(string|array $name, string|resource $contents = '', string|null $filename = null, array $headers = [])

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -303,7 +303,7 @@ class HttpClientTest extends TestCase
         $this->assertEquals(collect(), $response->collect('missing_key'));
     }
 
-    public function testSendRequestBody()
+    public function testSendRequestBodyAsJsonByDefault()
     {
         $body = '{"test":"phpunit"}';
 
@@ -316,7 +316,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->fake($fakeRequest);
 
-        $this->factory->withBody($body, 'application/json')->send('get', 'http://foo.com/api');
+        $this->factory->withBody($body)->send('get', 'http://foo.com/api');
     }
 
     public function testSendRequestBodyWithManyAmpersands()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -309,6 +309,7 @@ class HttpClientTest extends TestCase
 
         $fakeRequest = function (Request $request) use ($body) {
             self::assertSame($body, $request->body());
+            self::assertContains('application/json', $request->header('Content-Type'));
 
             return ['my' => 'response'];
         };
@@ -324,6 +325,7 @@ class HttpClientTest extends TestCase
 
         $fakeRequest = function (Request $request) use ($body) {
             self::assertSame($body, $request->body());
+            self::assertContains('text/plain', $request->header('Content-Type'));
 
             return ['my' => 'response'];
         };


### PR DESCRIPTION
This addresses a paper cut of having to set the content type when sending raw JSON bodies via the `Http` client. Since the `Http` client sends data as JSON by default, it'd find it more intuitive if the `withBody` did so as well.

**Before**
```php
Http::withBody('{"foo": "bar"}', 'application/json')->post('https://example.com');
```

**After**
```php
Http::withBody('{"foo": "bar"}')->post('https://example.com');
```

I'm targeting Laravel 10 since this changes the signature of a `public` method.