### PR TITLE
fix: normalize route pipeline exception

### DIFF
--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -54,6 +54,6 @@ class Pipeline extends BasePipeline
             $response->withException($e);
         }
 
-        return $response;
+        return $this->handleCarry($response);
     }
 }


### PR DESCRIPTION
Similar to normal pipeline carry, convert the custom `Responsable` class to the `\Symfony\Component\HttpFoundation\Response` class for the exception result.