### PR TITLE
change column default name from uuid to ulid in ulid blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1285,7 +1285,7 @@ class Blueprint
      * @param  int|null  $length
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function ulid($column = 'uuid', $length = 26)
+    public function ulid($column = 'ulid', $length = 26)
     {
         return $this->char($column, $length);
     }


### PR DESCRIPTION
When using 
$table->ulid();
in migrator, the default column name is "uuid", it should be "ulid".