### PR TITLE
[9.x] Set return type of MailManager::createMailgunTransport to be TransportInterface

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -271,7 +271,7 @@ class MailManager implements FactoryContract
      * Create an instance of the Symfony Mailgun Transport driver.
      *
      * @param  array  $config
-     * @return \Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunApiTransport
+     * @return \Symfony\Component\Mailer\Transport\TransportInterface
      */
     protected function createMailgunTransport(array $config)
     {


### PR DESCRIPTION
In #41255 the default transport was changed to be the `MailgunHttpsTransport`, then in #41309 this was changed to allow any of the possible transports created by `MailgunTransportFactory`. Given that the factory lists `TransportInterface` as return type on the `create` method instead of explicitly listing the possible options (see https://github.com/symfony/mailgun-mailer/blob/6.2/Transport/MailgunTransportFactory.php#L24), I think this would be the best fit here as well.
