### PR TITLE
[9.x] Fluent has-x-through definitions.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 class HasMany extends HasOneOrMany
 {
@@ -45,5 +46,31 @@ class HasMany extends HasOneOrMany
     public function match(array $models, Collection $results, $relation)
     {
         return $this->matchMany($models, $results, $relation);
+    }
+
+    /**
+     * Convert this has-many relationship into a has-many-through relationship.
+     *
+     * @param  string  $through
+     * @param  string|null  $foreignKey
+     * @param  string|null  $localKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
+     */
+    public function through($through, $foreignKey = null, $localKey = null): HasManyThrough
+    {
+        $through = new $through;
+
+        $foreignKey = $foreignKey ?: $through->getForeignKey();
+        $localKey = $localKey ?: $through->getKeyName();
+
+        return new HasManyThrough(
+            $this->getRelated()->newQuery(),
+            $this->getParent(),
+            new $through,
+            Str::after($this->foreignKey, '.'),
+            $foreignKey,
+            $this->localKey,
+            $localKey,
+        );
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\CanBeOneOfMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Str;
 
 class HasOne extends HasOneOrMany implements SupportsPartialRelations
 {
@@ -133,5 +134,31 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
     protected function getRelatedKeyFrom(Model $model)
     {
         return $model->getAttribute($this->getForeignKeyName());
+    }
+
+    /**
+     * Convert the this has-one relationship into a has-one-through relationship.
+     *
+     * @param  string  $through
+     * @param  string|null  $foreignKey
+     * @param  string|null  $localKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function through($through, $foreignKey = null, $localKey = null): HasOneThrough
+    {
+        $through = new $through;
+
+        $foreignKey = $foreignKey ?: $through->getForeignKey();
+        $localKey = $localKey ?: $through->getKeyName();
+
+        return new HasOneThrough(
+            $this->getRelated()->newQuery(),
+            $this->getParent(),
+            new $through,
+            Str::after($this->foreignKey, '.'),
+            $foreignKey,
+            $this->localKey,
+            $localKey,
+        );
     }
 }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -75,10 +75,17 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testItLoadsAHasManyThroughRelationWithCustomKeys()
     {
         $this->seedData();
-        $posts = HasManyThroughTestCountry::first()->posts;
+        $model = HasManyThroughTestCountry::first();
+
+        $posts = $model->posts;
 
         $this->assertSame('A title', $posts[0]->title);
         $this->assertCount(2, $posts);
+
+        $postsAlt = $model->postsAlt;
+
+        $this->assertSame('A title', $postsAlt[0]->title);
+        $this->assertCount(2, $postsAlt);
     }
 
     public function testItLoadsADefaultHasManyThroughRelation()
@@ -614,6 +621,13 @@ class HasManyThroughTestCountry extends Eloquent
     public function posts()
     {
         return $this->hasManyThrough(HasManyThroughTestPost::class, HasManyThroughTestUser::class, 'country_id', 'user_id');
+    }
+
+    public function postsAlt()
+    {
+        return $this
+            ->hasMany(HasManyThroughTestPost::class, 'country_id')
+            ->through(HasManyThroughTestUser::class, 'user_id');
     }
 
     public function users()

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -83,9 +83,15 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->migrateDefault();
         $this->seedDefaultData();
 
-        $contract = HasOneThroughDefaultTestPosition::first()->contract;
+        $model = HasOneThroughDefaultTestPosition::first();
+
+        $contract = $model->contract;
         $this->assertSame('A title', $contract->title);
         $this->assertArrayNotHasKey('email', $contract->getAttributes());
+
+        $contractAlt = $model->contractAlt;
+        $this->assertSame('A title', $contractAlt->title);
+        $this->assertArrayNotHasKey('email', $contractAlt->getAttributes());
 
         $this->resetDefault();
     }
@@ -451,6 +457,11 @@ class HasOneThroughDefaultTestPosition extends Eloquent
     public function contract()
     {
         return $this->hasOneThrough(HasOneThroughDefaultTestContract::class, HasOneThroughDefaultTestUser::class);
+    }
+
+    public function contractAlt()
+    {
+        return $this->hasOne(HasOneThroughDefaultTestContract::class)->through(HasOneThroughDefaultTestUser::class);
     }
 
     public function user()


### PR DESCRIPTION
The current `hasOneThrough` and `hasManyThrough` method definitions can be confusing, especially when having to modify the local & foreign keys, and—at least personally—has me reaching for the docs pretty much every time I need to use them.

For (an admittedly contrived) example, let's say I have `photos` and `albums` tables, and in my app I have decided to use `photo_id` and `album_id` as the respective primary keys, I would have to achieve that like so:
```php
class User
{
    public function photos(): HasManyThrough
    {
        return $this->hasManyThrough(Photo::class, Album::class, 'photo_id', 'album_id', 'photo_id', 'album_id');
    }

    public function profilePhoto(): HasOneThrough
    {
        return $this
            ->hasOneThrough(Photo::class, Album::class, 'photo_id', 'album_id', 'photo_id', 'album_id')
            ->where('is_profile', true);
    }
}
```

This isn't super clear on what we're achieving or what any of the final 4 arguments are. Granted, some IDEs might add inlays, or I could use named arguments to clear this up, but the definition doesn't feel obvious from a glance.

I am proposing that we add a `through` method onto the `HasOne` and `HasMany` relation classes. This would allow a more fluent definition of the relationship and is a lot easier to understand what is happening:
```php
class User
{
    public function photos(): HasManyThrough
    {
        return $this
            ->hasMany(Photo::class, 'photo_id', 'photo_id')
            ->through(Album::class, 'album_id', 'album_id');
    }

    public function profilePhoto(): HasOneThrough
    {
        return $this
            ->hasOne(Photo::class, 'photo_id', 'photo_id')
            ->through(Album::class, 'album_id', 'album_id')
            ->where('is_profile', true);
    }
}
```

--

Edit:
* I have only added a couple of tests so far, as I wanted to see what appetite there was for this — if we wanted I can add more tests.
* The old methods (`hasOneThrough`, `hasManyThrough`) remain intact. This is simply an alternative