### PR TITLE
[9.x] Generic `CastsAttributes` docs

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Castable.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Castable.php
@@ -8,8 +8,7 @@ interface Castable
      * Get the name of the caster class to use when casting from / to this cast target.
      *
      * @param  array  $arguments
-     * @return string
-     * @return string|\Illuminate\Contracts\Database\Eloquent\CastsAttributes|\Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes
+     * @return class-string<CastsAttributes|CastsInboundAttributes>|CastsAttributes|CastsInboundAttributes
      */
     public static function castUsing(array $arguments);
 }

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -2,6 +2,10 @@
 
 namespace Illuminate\Contracts\Database\Eloquent;
 
+/**
+ * @template TGet
+ * @template TSet
+ */
 interface CastsAttributes
 {
     /**
@@ -11,7 +15,7 @@ interface CastsAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @return mixed
+     * @return TGet|null
      */
     public function get($model, string $key, $value, array $attributes);
 
@@ -20,7 +24,7 @@ interface CastsAttributes
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
-     * @param  mixed  $value
+     * @param  TSet|null  $value
      * @param  array  $attributes
      * @return mixed
      */

--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
@@ -6,6 +6,11 @@ use ArrayObject as BaseArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 
+/**
+ * @template TKey of array-key
+ * @template TItem
+ * @extends  \ArrayObject<TKey, TItem>
+ */
 class ArrayObject extends BaseArrayObject implements Arrayable, JsonSerializable
 {
     /**

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -10,8 +10,7 @@ class AsArrayObject implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @return CastsAttributes<ArrayObject<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -10,6 +10,7 @@ class AsArrayObject implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
+     * @param  array  $arguments
      * @return CastsAttributes<ArrayObject<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -11,6 +11,7 @@ class AsCollection implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
+     * @param  array  $arguments
      * @return CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -11,8 +11,7 @@ class AsCollection implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @return CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -11,6 +11,7 @@ class AsEncryptedArrayObject implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
+     * @param  array  $arguments
      * @return CastsAttributes<ArrayObject<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -11,8 +11,7 @@ class AsEncryptedArrayObject implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @return CastsAttributes<ArrayObject<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -12,8 +12,7 @@ class AsEncryptedCollection implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @return CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -12,6 +12,7 @@ class AsEncryptedCollection implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
+     * @param  array  $arguments
      * @return CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -13,8 +13,9 @@ class AsEnumArrayObject implements Castable
      * Get the caster class to use when casting from / to this cast target.
      *
      * @template TEnum
+     *
      * @param    array{class-string<TEnum>} $arguments
-     * @return   CastsAttributes<ArrayObject<array-key, TEnum>, iterable<TEnum>>
+     * @return CastsAttributes<ArrayObject<array-key, TEnum>, iterable<TEnum>>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -12,8 +12,9 @@ class AsEnumArrayObject implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @template TEnum
+     * @param    array{class-string<TEnum>} $arguments
+     * @return   CastsAttributes<ArrayObject<array-key, TEnum>, iterable<TEnum>>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -14,7 +14,7 @@ class AsEnumArrayObject implements Castable
      *
      * @template TEnum
      *
-     * @param    array{class-string<TEnum>} $arguments
+     * @param  array{class-string<TEnum>}  $arguments
      * @return CastsAttributes<ArrayObject<array-key, TEnum>, iterable<TEnum>>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -14,7 +14,7 @@ class AsEnumCollection implements Castable
      *
      * @template TEnum of \UnitEnum|\BackedEnum
      *
-     * @param    array{class-string<TEnum>}  $arguments
+     * @param  array{class-string<TEnum>}  $arguments
      * @return CastsAttributes<Collection<array-key, TEnum>, iterable<TEnum>>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -12,8 +12,9 @@ class AsEnumCollection implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @template TEnum of \UnitEnum|\BackedEnum
+     * @param    array{class-string<TEnum>}  $arguments
+     * @return   CastsAttributes<Collection<array-key, TEnum>, iterable<TEnum>>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -13,8 +13,9 @@ class AsEnumCollection implements Castable
      * Get the caster class to use when casting from / to this cast target.
      *
      * @template TEnum of \UnitEnum|\BackedEnum
+     *
      * @param    array{class-string<TEnum>}  $arguments
-     * @return   CastsAttributes<Collection<array-key, TEnum>, iterable<TEnum>>
+     * @return CastsAttributes<Collection<array-key, TEnum>, iterable<TEnum>>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
@@ -11,8 +11,7 @@ class AsStringable implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
-     * @return object|string
+     * @return CastsAttributes<\Illuminate\Support\Stringable, string|\Stringable>
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsStringable.php
@@ -11,6 +11,7 @@ class AsStringable implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
+     * @param  array  $arguments
      * @return CastsAttributes<\Illuminate\Support\Stringable, string|\Stringable>
      */
     public static function castUsing(array $arguments)

--- a/types/Autoload.php
+++ b/types/Autoload.php
@@ -8,6 +8,6 @@ class User extends Authenticatable
     use HasFactory;
 }
 
-enum UserType {
-
+enum UserType
+{
 }

--- a/types/Autoload.php
+++ b/types/Autoload.php
@@ -7,3 +7,7 @@ class User extends Authenticatable
 {
     use HasFactory;
 }
+
+enum UserType {
+
+}

--- a/types/Database/Eloquent/Casts/Castable.php
+++ b/types/Database/Eloquent/Casts/Castable.php
@@ -1,0 +1,38 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Database\Eloquent\Casts\ArrayObject<(int|string), mixed>, iterable>',
+    \Illuminate\Database\Eloquent\Casts\AsArrayObject::castUsing([]),
+);
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), mixed>, iterable>',
+    \Illuminate\Database\Eloquent\Casts\AsCollection::castUsing([]),
+);
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Database\Eloquent\Casts\ArrayObject<(int|string), mixed>, iterable>',
+    \Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject::castUsing([]),
+);
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), mixed>, iterable>',
+    \Illuminate\Database\Eloquent\Casts\AsEncryptedCollection::castUsing([]),
+);
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Database\Eloquent\Casts\ArrayObject<(int|string), UserType>, iterable<UserType>>',
+    \Illuminate\Database\Eloquent\Casts\AsEnumArrayObject::castUsing([\UserType::class]),
+);
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), UserType>, iterable<UserType>>',
+    \Illuminate\Database\Eloquent\Casts\AsEnumCollection::castUsing([\UserType::class]),
+);
+
+assertType(
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Stringable, string|Stringable>',
+    \Illuminate\Database\Eloquent\Casts\AsStringable::castUsing([]),
+);

--- a/types/Database/Eloquent/Casts/CastsAttributes.php
+++ b/types/Database/Eloquent/Casts/CastsAttributes.php
@@ -4,7 +4,6 @@ use function PHPStan\Testing\assertType;
 
 /** @var User $user */
 /** @var \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Stringable, string|\Stringable> $cast */
-
 assertType('Illuminate\Support\Stringable|null', $cast->get($user, 'email', 'taylor@laravel.com', $user->getAttributes()));
 
 $cast->set($user, 'email', 'taylor@laravel.com', $user->getAttributes()); // This works.

--- a/types/Database/Eloquent/Casts/CastsAttributes.php
+++ b/types/Database/Eloquent/Casts/CastsAttributes.php
@@ -1,0 +1,12 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+/** @var User $user */
+/** @var \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Stringable, string|\Stringable> $cast */
+
+assertType('Illuminate\Support\Stringable|null', $cast->get($user, 'email', 'taylor@laravel.com', $user->getAttributes()));
+
+$cast->set($user, 'email', 'taylor@laravel.com', $user->getAttributes()); // This works.
+$cast->set($user, 'email', \Illuminate\Support\Str::of('taylor@laravel.com'), $user->getAttributes()); // This also works!
+$cast->set($user, 'email', null, $user->getAttributes()); // Also valid.


### PR DESCRIPTION
Happy Laracon EU! 🇵🇹🇪🇺 

While working on some improvements in [Larastan](https://github.com/nunomaduro/larastan/pull/1529), I had to take some shortcuts in order to get the types for the included class-based attribute casters.

This PR adds the generic types already included in Larastan to the framework core and adds correct types for the included `Castable` classes. Naturally, I've made sure to include some tests.

There shouldn't be any breaking changes, as this only affects static analysis.