### PR TITLE
[10.x] remove handles authorization

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -2,13 +2,10 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Auth\Access\HandlesAuthorization;
 use {{ namespacedUserModel }};
 
 class {{ class }}
 {
-    use HandlesAuthorization;
-
     /**
      * Create a new policy instance.
      */

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,15 +2,12 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
 use {{ namespacedModel }};
 use {{ namespacedUserModel }};
 
 class {{ class }}
 {
-    use HandlesAuthorization;
-
     /**
      * Determine whether the user can view any models.
      */


### PR DESCRIPTION
Resubmitting to "master". Wasn't sure if you were gonna do this or wanted me to, so I figured I'd just help out.

the function in these traits are for the most part proxies to static methods on the `Response` class.

Even the [documentation](https://github.com/laravel/docs/commit/0682ca014e5e1768066ef93b4269a83d82978a70) doesn't use them, and instead goes directly to the `Response` class, so I think it would be best to remove them from the stubs.
