### PR TITLE
[10.x] Lockable Model Route Bindings

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -102,4 +102,12 @@ interface Registrar
      * @return void
      */
     public function substituteImplicitBindings($route);
+
+    /**
+     * Substitute the route bindings that were passed as a closure to allow for delayed execution.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     */
+    public function substituteClosureBindings($route);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -119,6 +119,20 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected $escapeWhenCastingToString = false;
 
     /**
+     * Determines if route bindings should resolve trashed models as well.
+     *
+     * @var bool
+     */
+    public $resolveWithTrashed;
+
+    /**
+     * Determines if route bindings should resolve with a row-level lock.
+     *
+     * @var bool
+     */
+    public $resolveWithLock;
+
+    /**
      * The connection resolver instance.
      *
      * @var \Illuminate\Database\ConnectionResolverInterface
@@ -2027,32 +2041,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveRouteBinding($value, $field = null)
     {
-        return $this->resolveRouteBindingQuery($this, $value, $field)->first();
-    }
-
-    /**
-     * Retrieve the model for a bound value with a row-level lock.
-     *
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @param  bool  $lock
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveLockRouteBinding($value, $field = null, $lock = true)
-    {
-        return $this->resolveRouteBindingQuery($this, $value, $field)->lock($lock)->first();
-    }
-
-    /**
-     * Retrieve the model for a bound value.
-     *
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveSoftDeletableRouteBinding($value, $field = null)
-    {
-        return $this->resolveRouteBindingQuery($this, $value, $field)->withTrashed()->first();
+        return $this->resolveRouteBindingQuery($this, $value, $field)
+            ->when($this->resolveWithTrashed, fn ($query) => $query->withTrashed())
+            ->when($this->resolveWithLock, fn ($query) => $query->lock($this->resolveWithLock))
+            ->first();
     }
 
     /**
@@ -2065,34 +2057,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveChildRouteBinding($childType, $value, $field)
     {
-        return $this->resolveChildRouteBindingQuery($childType, $value, $field)->first();
-    }
-
-    /**
-     * Retrieve the child model for a bound value with a row-level lock.
-     *
-     * @param  string  $childType
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @param  bool  $lock
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveLockChildRouteBinding($childType, $value, $field, $lock = true)
-    {
-        return $this->resolveChildRouteBindingQuery($childType, $value, $field)->lock($lock)->first();
-    }
-
-    /**
-     * Retrieve the child model for a bound value.
-     *
-     * @param  string  $childType
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveSoftDeletableChildRouteBinding($childType, $value, $field)
-    {
-        return $this->resolveChildRouteBindingQuery($childType, $value, $field)->withTrashed()->first();
+        return $this->resolveChildRouteBindingQuery($childType, $value, $field)
+            ->when($this->resolveWithTrashed, fn ($query) => $query->withTrashed())
+            ->when($this->resolveWithLock, fn ($query) => $query->lock($this->resolveWithLock))
+            ->first();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2031,6 +2031,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Retrieve the model for a bound value with a row-level lock.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @param  bool  $lock
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveLockRouteBinding($value, $field = null, $lock = true)
+    {
+        return $this->resolveRouteBindingQuery($this, $value, $field)->lock($lock)->first();
+    }
+
+    /**
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $value
@@ -2053,6 +2066,20 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function resolveChildRouteBinding($childType, $value, $field)
     {
         return $this->resolveChildRouteBindingQuery($childType, $value, $field)->first();
+    }
+
+    /**
+     * Retrieve the child model for a bound value with a row-level lock.
+     *
+     * @param  string  $childType
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @param  bool  $lock
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveLockChildRouteBinding($childType, $value, $field, $lock = true)
+    {
+        return $this->resolveChildRouteBindingQuery($childType, $value, $field)->lock($lock)->first();
     }
 
     /**

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
-use Illuminate\Tests\Integration\Routing\ImplicitBindingUser;
 
 class ImplicitRouteBinding
 {
@@ -72,7 +71,6 @@ class ImplicitRouteBinding
             if ($parent instanceof UrlRoutable &&
                 ! $route->preventsScopedBindings() &&
                 ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
-
                 $model = static::resolveChildRouteBinding($route, $instance, $parent, $parameterName, $parameterValue);
             } else {
                 $model = static::resolveRouteBinding($route, $instance, $parameterName, $parameterValue);

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -95,6 +95,7 @@ class ImplicitRouteBinding
 
         if ($route->requiresLockBindings()) {
             $instance->resolveWithLock = true;
+
             return new RouteClosureBinding($parameterName, fn () => $instance->resolveRouteBinding(
                 $parameterValue, $route->bindingFieldFor($parameterName)
             ));
@@ -123,6 +124,7 @@ class ImplicitRouteBinding
 
         if ($route->requiresLockBindings()) {
             $instance->resolveWithLock = true;
+
             return new RouteClosureBinding($parameterName, fn () => $parent->resolveChildRouteBinding(
                 $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
             ));

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -51,6 +51,7 @@ class SubstituteBindings
         if ($route->requiresLockBindings()) {
             return DB::transaction(function () use ($next, $request, $route) {
                 $this->router->substituteClosureBindings($route);
+
                 return $next($request);
             });
         }

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -48,7 +48,7 @@ class SubstituteBindings
             throw $exception;
         }
 
-        if ($route->usesLockBindings()) {
+        if ($route->requiresLockBindings()) {
             return DB::transaction(function () use ($next, $request, $route) {
                 $this->router->substituteClosureBindings($route);
                 return $next($request);

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing\Middleware;
 use Closure;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\DB;
 
 class SubstituteBindings
 {
@@ -45,6 +46,13 @@ class SubstituteBindings
             }
 
             throw $exception;
+        }
+
+        if ($route->usesLockBindings()) {
+            return DB::transaction(function () use ($next, $request, $route) {
+                $this->router->substituteClosureBindings($route);
+                return $next($request);
+            });
         }
 
         return $next($request);

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -102,6 +102,14 @@ class Route
     protected $withTrashedBindings = false;
 
     /**
+     * Determines whether Eloquent model route bindings should be retrieved with a lock. A boolean value
+     * indicates a singular lock (true) or a shared lock (false). `null` indicates no lock.
+     *
+     * @var bool|null
+     */
+    protected $withLockBindings = null;
+
+    /**
      * Indicates the maximum number of seconds the route should acquire a session lock for.
      *
      * @var int|null
@@ -156,14 +164,6 @@ class Route
      * @var callable[]
      */
     protected $lockSubstitutions = [];
-
-    /**
-     * Determines whether Eloquent model route bindings should be retrieved with a lock. A boolean value
-     * indicates a singular lock (true) or a shared lock (false). `null` indicates no lock.
-     *
-     * @var bool|null
-     */
-    protected $withLockBindings;
 
     /**
      * The validators used by the routes.
@@ -614,21 +614,37 @@ class Route
         return $this;
     }
 
-    public function withLockBindings($lock = true)
+    /**
+     * Require models to be retrieved with a row-level lock.
+     *
+     * @param  bool  $lock
+     * @return $this
+     */
+    public function withLocks($lock = true)
     {
         $this->withLockBindings = $lock;
 
         return $this;
     }
 
-    public function withoutLockBindings()
+    /**
+     * Retrieve models without row-level locks.
+     *
+     * @return $this
+     */
+    public function withoutLocks()
     {
         $this->withLockBindings = null;
 
         return $this;
     }
 
-    public function usesLockBindings()
+    /**
+     * Determines if the route requires models to be retrieved with a row-level lock.
+     *
+     * @return bool
+     */
+    public function requiresLockBindings()
     {
         return is_bool($this->withLockBindings);
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1122,16 +1122,6 @@ class Route
                     : $this->middleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);
     }
 
-    public function hasLockSubstitutions()
-    {
-        return ! empty($this->lockSubstitutions);
-    }
-
-    public function getLockSubstitutions()
-    {
-        return $this->lockSubstitutions;
-    }
-
     /**
      * Get the middleware for the route's controller.
      *

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -159,13 +159,6 @@ class Route
     protected $bindingFields = [];
 
     /**
-     * The list of callables that retrieve Eloquent model substitutions that contain a row-level lock.
-     *
-     * @var callable[]
-     */
-    protected $lockSubstitutions = [];
-
-    /**
      * The validators used by the routes.
      *
      * @var array

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -151,6 +151,21 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * The list of callables that retrieve Eloquent model substitutions that contain a row-level lock.
+     *
+     * @var callable[]
+     */
+    protected $lockSubstitutions = [];
+
+    /**
+     * Determines whether Eloquent model route bindings should be retrieved with a lock. A boolean value
+     * indicates a singular lock (true) or a shared lock (false). `null` indicates no lock.
+     *
+     * @var bool|null
+     */
+    protected $withLockBindings;
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -522,7 +537,7 @@ class Route
      * Get the parameters that are listed in the route / controller signature.
      *
      * @param  array  $conditions
-     * @return array
+     * @return array|\ReflectionParameter[]
      */
     public function signatureParameters($conditions = [])
     {
@@ -597,6 +612,25 @@ class Route
         $this->withTrashedBindings = $withTrashed;
 
         return $this;
+    }
+
+    public function withLockBindings($lock = true)
+    {
+        $this->withLockBindings = $lock;
+
+        return $this;
+    }
+
+    public function withoutLockBindings()
+    {
+        $this->withLockBindings = null;
+
+        return $this;
+    }
+
+    public function usesLockBindings()
+    {
+        return is_bool($this->withLockBindings);
     }
 
     /**
@@ -1070,6 +1104,16 @@ class Route
         return empty($models)
                     ? $this->middleware(['can:'.$ability])
                     : $this->middleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);
+    }
+
+    public function hasLockSubstitutions()
+    {
+        return ! empty($this->lockSubstitutions);
+    }
+
+    public function getLockSubstitutions()
+    {
+        return $this->lockSubstitutions;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteClosureBinding.php
+++ b/src/Illuminate/Routing/RouteClosureBinding.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Routing;
+
+class RouteClosureBinding
+{
+    /**
+     * The name of the route parameter.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The callback to execute to obtain the route parameter.
+     *
+     * @var \Closure
+     */
+    protected $callback;
+
+    /**
+     * @param  string  $name
+     * @param  \Closure  $callback
+     */
+    public function __construct($name, callable $callback)
+    {
+        $this->name = $name;
+        $this->callback = $callback;
+    }
+
+    public function resolveForRoute(Route $route)
+    {
+        $route->setParameter($this->name, ($this->callback)());
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -917,7 +917,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * Substitute the route bindings onto the route.
      *
      * @param  \Illuminate\Routing\Route  $route
-     * @return \Illuminate\Routing\Route
+     * @return void
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
      * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
@@ -929,8 +929,6 @@ class Router implements BindingRegistrar, RegistrarContract
                 $route->setParameter($key, $this->performBinding($key, $value, $route));
             }
         }
-
-        return $route;
     }
 
     /**
@@ -945,6 +943,19 @@ class Router implements BindingRegistrar, RegistrarContract
     public function substituteImplicitBindings($route)
     {
         ImplicitRouteBinding::resolveForRoute($this->container, $route);
+    }
+
+    /**
+     * Substitute the route bindings that were passed as a closure to allow for delayed execution.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     */
+    public function substituteClosureBindings($route)
+    {
+        ImplicitRouteBinding::resolveClosureBindingsForRoute($this->container, $route);
     }
 
     /**

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -152,7 +152,7 @@ PHP);
         Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             $this->assertEquals(1, DB::connection()->transactionLevel());
             return $user;
-        })->middleware(['web'])->withLockBindings();
+        })->middleware(['web'])->withLocks();
 
         $response = $this->postJson("/user/{$user->id}");
 
@@ -173,7 +173,7 @@ PHP);
         Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             $this->assertEquals(1, DB::connection()->transactionLevel());
             return $user;
-        })->middleware(['web'])->withLockBindings()->withTrashed();
+        })->middleware(['web'])->withLocks()->withTrashed();
 
         $response = $this->postJson("/user/{$user->id}");
 

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
@@ -151,6 +150,7 @@ PHP);
 
         Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             $this->assertEquals(1, DB::connection()->transactionLevel());
+
             return $user;
         })->middleware(['web'])->withLocks();
 
@@ -172,6 +172,7 @@ PHP);
 
         Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             $this->assertEquals(1, DB::connection()->transactionLevel());
+
             return $user;
         })->middleware(['web'])->withLocks()->withTrashed();
 

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -90,6 +90,8 @@ class ImplicitRouteBindingTest extends TestCase
 
         ImplicitRouteBinding::resolveForRoute($container, $route);
     }
+
+
 }
 
 class ImplicitRouteBindingUser extends Model

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -90,8 +90,6 @@ class ImplicitRouteBindingTest extends TestCase
 
         ImplicitRouteBinding::resolveForRoute($container, $route);
     }
-
-
 }
 
 class ImplicitRouteBindingUser extends Model


### PR DESCRIPTION
### Problem Explanation
This feature allows developers to apply a lock on implicitly resolved models. Consider the following example:

```php
Route::post('/user/{user}', function (ImplicitBindingModel $user) {
    if ($user->paid) {
        throw ValidationException::withMessages([...]);
    }

    // Pay user ...
    $user->update(['paid' => true]);

    return $user;
});
```

Since the controller action requires a read to `$user->paid` (some property indicating the user has been paid which must only happen once), there is a potential exploit by calling this function twice in quick succession. Since both calls happen at the same time, they retrieve `$user->paid === false` for both occasions, causing the code to be executed in both occasions as well. This requires a transaction in order to run it correctly.

### Solution: Route `withLocks()`
By using the `withLocks()` option on your route (requiring the `SubstituteBindings` middleware), you can now make sure that models are retrieved with a read-lock using Eloquent's `lockForUpdate()`, using:

```php
// New example
Route::post('/user/{user}', function (ImplicitBindingModel $user) {
    // Pay user etc.
})->middleware(['web'])->withLocks();
```

The controller action is now automatically wrapped in a transaction, with read-locks applied to all implicitly bound models. This also works with `withTrashed()` (this enables retrieval of soft-deleted models) so `->withLocks()->withTrashed()` will work as expected too.

### Old situation: `DB::transaction(...)` and manually retrieving models
An explicit way to do this currently (showing the current limitation) is:

```php
// Old example
Route::post('/user/{user}', function ($userId)
{
    return DB::transaction(function () {
        $user = User::query()->lockForUpdate()->findOrFail($userId);

        if ($user->paid) {
            throw ValidationException::withMessages([...]);
        }

        // Pay user...

    });
});
```
Implicit model bounding cannot take place in the old situation, since the model would have been retrieved before the transaction commenced.