### PR TITLE
Language paths

### DIFF
--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -40,7 +40,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
     protected function registerLoader()
     {
         $this->app->singleton('translation.loader', function ($app) {
-            return new FileLoader($app['files'], $app['path.lang']);
+            return new FileLoader($app['files'], [$app['path.lang']]);
         });
     }
 

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -40,7 +40,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
     protected function registerLoader()
     {
         $this->app->singleton('translation.loader', function ($app) {
-            return new FileLoader($app['files'], [$app['path.lang']]);
+            return new FileLoader($app['files'], [__DIR__.'/lang', $app['path.lang']]);
         });
     }
 


### PR DESCRIPTION
This updates the File translation loader to support arrays of paths. This feature could potentially prove useful for making the `lang` directory an optional part of the skeleton directory structure, while still providing our default set of translations.