### PR TITLE
[10.x] Remove database dependency on symfony/console

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,8 +22,7 @@
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
-        "illuminate/support": "^10.0",
-        "symfony/console": "^6.2"
+        "illuminate/support": "^10.0"
     },
     "autoload": {
         "psr-4": {
@@ -42,6 +41,7 @@
         "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
         "illuminate/filesystem": "Required to use the migrations (^10.0).",
         "illuminate/pagination": "Required to paginate the result set (^10.0).",
+        "symfony/console": "Required to use the migrations (^6.2).",
         "symfony/finder": "Required to use Eloquent model factories (^6.2)."
     },
     "config": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -41,7 +41,7 @@
         "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
         "illuminate/filesystem": "Required to use the migrations (^10.0).",
         "illuminate/pagination": "Required to paginate the result set (^10.0).",
-        "symfony/console": "Required to use the migrations (^6.2).",
+        "symfony/console": "Required to use database console commands (^6.2).",
         "symfony/finder": "Required to use Eloquent model factories (^6.2)."
     },
     "config": {


### PR DESCRIPTION
Placing a requirement on `symfony/console` makes it hard to use the database subpackage with any framework that has its own `symfony/*` requirements.

See #45788