### PR TITLE
[11.x] Add initial typings for QueryBuilder and some relationships

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Builder.php
@@ -6,8 +6,8 @@ use Illuminate\Contracts\Database\Query\Builder as BaseContract;
 
 /**
  * This interface is intentionally empty and exists to improve IDE support.
- *
- * @mixin \Illuminate\Database\Eloquent\Builder
+ * @template TResult
+ * @mixin \Illuminate\Database\Eloquent\Builder<TResult>
  */
 interface Builder extends BaseContract
 {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\HigherOrderBuilderProxy;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\RecordsNotFoundException;
@@ -18,6 +19,9 @@ use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use RuntimeException;
 
+/**
+ * @template TResult
+ */
 trait BuildsQueries
 {
     use Conditionable;
@@ -67,7 +71,7 @@ trait BuildsQueries
      *
      * @param  callable  $callback
      * @param  int  $count
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, mixed>
      */
     public function chunkMap(callable $callback, $count = 1000)
     {
@@ -180,7 +184,7 @@ trait BuildsQueries
      * Query lazily, by chunks of the given size.
      *
      * @param  int  $chunkSize
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TResult>
      *
      * @throws \InvalidArgumentException
      */
@@ -215,7 +219,7 @@ trait BuildsQueries
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TResult>
      *
      * @throws \InvalidArgumentException
      */
@@ -230,7 +234,7 @@ trait BuildsQueries
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TResult>
      *
      * @throws \InvalidArgumentException
      */
@@ -246,7 +250,7 @@ trait BuildsQueries
      * @param  string|null  $column
      * @param  string|null  $alias
      * @param  bool  $descending
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TResult>
      *
      * @throws \InvalidArgumentException
      */
@@ -289,7 +293,7 @@ trait BuildsQueries
      * Execute the query and get the first result.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     * @return TResult|null
      */
     public function first($columns = ['*'])
     {
@@ -300,7 +304,7 @@ trait BuildsQueries
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     * @return TResult
      *
      * @throws \Illuminate\Database\RecordsNotFoundException
      * @throws \Illuminate\Database\MultipleRecordsFoundException

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -25,12 +25,12 @@ use ReflectionMethod;
  * @property-read HigherOrderBuilderProxy $whereNot
  * @property-read HigherOrderBuilderProxy $orWhereNot
  * @template TModel of \Illuminate\Database\Eloquent\Model
- * @uses \Illuminate\Database\Concerns\BuildsQueries<TModel>
  * @implements BuilderContract<TModel>
  * @mixin \Illuminate\Database\Query\Builder<TModel>
  */
 class Builder implements BuilderContract
 {
+    /** @use \Illuminate\Database\Concerns\BuildsQueries<TModel> */
     use BuildsQueries, ForwardsCalls, QueriesRelationships {
         BuildsQueries::sole as baseSole;
     }
@@ -38,7 +38,7 @@ class Builder implements BuilderContract
     /**
      * The base query builder instance.
      *
-     * @var \Illuminate\Database\Query\Builder
+     * @var \Illuminate\Database\Query\Builder<array>
      */
     protected $query;
 
@@ -684,7 +684,7 @@ class Builder implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Collection<TModel>
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function get($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -24,8 +24,10 @@ use ReflectionMethod;
  * @property-read HigherOrderBuilderProxy $orWhere
  * @property-read HigherOrderBuilderProxy $whereNot
  * @property-read HigherOrderBuilderProxy $orWhereNot
- *
- * @mixin \Illuminate\Database\Query\Builder
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ * @uses \Illuminate\Database\Concerns\BuildsQueries<TModel>
+ * @implements BuilderContract<TModel>
+ * @mixin \Illuminate\Database\Query\Builder<TModel>
  */
 class Builder implements BuilderContract
 {
@@ -43,7 +45,7 @@ class Builder implements BuilderContract
     /**
      * The model being queried.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var TModel
      */
     protected $model;
 
@@ -146,7 +148,7 @@ class Builder implements BuilderContract
      * Create and return an un-saved model instance.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function make(array $attributes = [])
     {
@@ -306,7 +308,7 @@ class Builder implements BuilderContract
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static|null
+     * @return TModel|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -395,7 +397,7 @@ class Builder implements BuilderContract
      * Create a collection of models from plain arrays.
      *
      * @param  array  $items
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function hydrate(array $items)
     {
@@ -417,7 +419,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $query
      * @param  array  $bindings
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function fromQuery($query, $bindings = [])
     {
@@ -431,7 +433,7 @@ class Builder implements BuilderContract
      *
      * @param  mixed  $id
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
+     * @return TModel|\Illuminate\Database\Eloquent\Collection<int, TModel>|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -447,7 +449,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function findMany($ids, $columns = ['*'])
     {
@@ -465,9 +467,9 @@ class Builder implements BuilderContract
      *
      * @param  mixed  $id
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
+     * @return TModel|\Illuminate\Database\Eloquent\Collection<int, TModel>
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
      */
     public function findOrFail($id, $columns = ['*'])
     {
@@ -499,7 +501,7 @@ class Builder implements BuilderContract
      *
      * @param  mixed  $id
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function findOrNew($id, $columns = ['*'])
     {
@@ -516,7 +518,7 @@ class Builder implements BuilderContract
      * @param  mixed  $id
      * @param  \Closure|array|string  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
+     * @return TModel|\Illuminate\Database\Eloquent\Collection<int, TModel>|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)
     {
@@ -538,7 +540,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
@@ -554,7 +556,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
@@ -572,7 +574,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
@@ -585,9 +587,9 @@ class Builder implements BuilderContract
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
      */
     public function firstOrFail($columns = ['*'])
     {
@@ -603,7 +605,7 @@ class Builder implements BuilderContract
      *
      * @param  \Closure|array|string  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     * @return TModel|mixed
      */
     public function firstOr($columns = ['*'], Closure $callback = null)
     {
@@ -624,9 +626,9 @@ class Builder implements BuilderContract
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TModel
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
      * @throws \Illuminate\Database\MultipleRecordsFoundException
      */
     public function sole($columns = ['*'])
@@ -657,7 +659,7 @@ class Builder implements BuilderContract
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return mixed
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
      * @throws \Illuminate\Database\MultipleRecordsFoundException
      */
     public function soleValue($column)
@@ -671,7 +673,7 @@ class Builder implements BuilderContract
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return mixed
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
      */
     public function valueOrFail($column)
     {
@@ -682,7 +684,7 @@ class Builder implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     * @return \Illuminate\Database\Eloquent\Collection<TModel>
      */
     public function get($columns = ['*'])
     {
@@ -702,7 +704,7 @@ class Builder implements BuilderContract
      * Get the hydrated models without eager loading.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model[]|static[]
+     * @return TModel[]|static[]
      */
     public function getModels($columns = ['*'])
     {
@@ -827,7 +829,7 @@ class Builder implements BuilderContract
     /**
      * Get a lazy collection for the given query.
      *
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TModel>
      */
     public function cursor()
     {
@@ -978,7 +980,7 @@ class Builder implements BuilderContract
      * Save a new model and return the instance.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|$this
+     * @return TModel
      */
     public function create(array $attributes = [])
     {
@@ -991,7 +993,7 @@ class Builder implements BuilderContract
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|$this
+     * @return TModel
      */
     public function forceCreate(array $attributes)
     {
@@ -1178,15 +1180,16 @@ class Builder implements BuilderContract
     /**
      * Delete records from the database.
      *
-     * @return mixed
+     * @param  mixed  $id
+     * @return int
      */
-    public function delete()
+    public function delete($id = null)
     {
         if (isset($this->onDelete)) {
             return call_user_func($this->onDelete, $this);
         }
 
-        return $this->toBase()->delete();
+        return $this->toBase()->delete($id);
     }
 
     /**
@@ -1194,7 +1197,7 @@ class Builder implements BuilderContract
      *
      * Since we do not apply scopes here, the row will actually be deleted.
      *
-     * @return mixed
+     * @return int
      */
     public function forceDelete()
     {
@@ -1448,7 +1451,7 @@ class Builder implements BuilderContract
      * Create a new instance of the model being queried.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function newModelInstance($attributes = [])
     {
@@ -1721,7 +1724,7 @@ class Builder implements BuilderContract
     /**
      * Get the model instance being queried.
      *
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TModel
      */
     public function getModel()
     {
@@ -1731,8 +1734,9 @@ class Builder implements BuilderContract
     /**
      * Set a model instance for the model being queried.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return $this
+     * @template TNewModel of \Illuminate\Database\Eloquent\Model
+     * @param  TNewModel $model
+     * @return self<TNewModel>
      */
     public function setModel(Model $model)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -27,7 +27,7 @@ trait HasRelationships
     /**
      * The loaded relationships for the model.
      *
-     * @var array
+     * @var array<string, \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>|null>
      */
     protected $relations = [];
 
@@ -92,10 +92,11 @@ trait HasRelationships
     /**
      * Define a one-to-one relationship.
      *
-     * @param  string  $related
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TRelated>  $related
      * @param  string|null  $foreignKey
      * @param  string|null  $localKey
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne<TRelated, static>
      */
     public function hasOne($related, $foreignKey = null, $localKey = null)
     {
@@ -111,11 +112,13 @@ trait HasRelationships
     /**
      * Instantiate a new HasOne relationship.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @template TParent of \Illuminate\Database\Eloquent\Model
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TParent  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne<TRelated, TParent>
      */
     protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
     {
@@ -211,7 +214,7 @@ trait HasRelationships
      * @param  string|null  $foreignKey
      * @param  string|null  $ownerKey
      * @param  string|null  $relation
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<TModel, static>
      */
     public function belongsTo($related, $foreignKey = null, $ownerKey = null, $relation = null)
     {
@@ -244,12 +247,14 @@ trait HasRelationships
     /**
      * Instantiate a new BelongsTo relationship.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $child
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @template TChild of \Illuminate\Database\Eloquent\Model
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TChild  $child
      * @param  string  $foreignKey
      * @param  string  $ownerKey
      * @param  string  $relation
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelated, TChild>
      */
     protected function newBelongsTo(Builder $query, Model $child, $foreignKey, $ownerKey, $relation)
     {
@@ -363,10 +368,11 @@ trait HasRelationships
     /**
      * Define a one-to-many relationship.
      *
-     * @param  string  $related
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TRelated>  $related
      * @param  string|null  $foreignKey
      * @param  string|null  $localKey
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<TRelated, static>
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
     {
@@ -384,11 +390,13 @@ trait HasRelationships
     /**
      * Instantiate a new HasMany relationship.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @template TParent of \Illuminate\Database\Eloquent\Model
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TParent  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<TRelated, TParent>
      */
     protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
     {
@@ -486,14 +494,15 @@ trait HasRelationships
     /**
      * Define a many-to-many relationship.
      *
-     * @param  string  $related
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TRelated>  $related
      * @param  string|null  $table
      * @param  string|null  $foreignPivotKey
      * @param  string|null  $relatedPivotKey
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
      * @param  string|null  $relation
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelated, static>
      */
     public function belongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
                                   $parentKey = null, $relatedKey = null, $relation = null)
@@ -531,15 +540,17 @@ trait HasRelationships
     /**
      * Instantiate a new BelongsToMany relationship.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @template TParent of \Illuminate\Database\Eloquent\Model
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TParent  $parent
      * @param  string  $table
      * @param  string  $foreignPivotKey
      * @param  string  $relatedPivotKey
      * @param  string  $parentKey
      * @param  string  $relatedKey
      * @param  string|null  $relationName
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelated, TParent>
      */
     protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey,
                                         $parentKey, $relatedKey, $relationName = null)
@@ -770,8 +781,9 @@ trait HasRelationships
     /**
      * Create a new model instance for a related model.
      *
-     * @param  string  $class
-     * @return mixed
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TModel>  $class
+     * @return TModel
      */
     protected function newRelatedInstance($class)
     {
@@ -785,8 +797,9 @@ trait HasRelationships
     /**
      * Create a new model instance for a related "through" model.
      *
-     * @param  string  $class
-     * @return mixed
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TModel>  $class
+     * @return TModel
      */
     protected function newRelatedThroughInstance($class)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -206,7 +206,8 @@ trait HasRelationships
     /**
      * Define an inverse one-to-one or many relationship.
      *
-     * @param  string  $related
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     * @param  class-string<TModel>  $related
      * @param  string|null  $foreignKey
      * @param  string|null  $ownerKey
      * @param  string|null  $relation

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1454,7 +1454,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Begin querying the model.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<$this>
      */
     public static function query()
     {
@@ -1464,7 +1464,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get a new query builder for the model's table.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQuery()
     {
@@ -1474,7 +1474,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get a new query builder that doesn't have any global scopes or eager loading.
      *
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newModelQuery()
     {
@@ -1486,7 +1486,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get a new query builder with no relationships loaded.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryWithoutRelationships()
     {
@@ -1496,8 +1496,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register the global scopes for this builder instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function registerGlobalScopes($builder)
     {
@@ -1511,7 +1511,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get a new query builder that doesn't have any global scopes.
      *
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryWithoutScopes()
     {
@@ -1524,7 +1524,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Get a new query instance without a given scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryWithoutScope($scope)
     {
@@ -1535,7 +1535,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Get a new query to restore one or more models by their queueable IDs.
      *
      * @param  array|int  $ids
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryForRestoration($ids)
     {
@@ -1546,7 +1546,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newEloquentBuilder($query)
     {
@@ -1567,7 +1567,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Create a new Eloquent Collection instance.
      *
      * @param  array  $models
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<static>
      */
     public function newCollection(array $models = [])
     {
@@ -1661,7 +1661,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function fresh($with = [])
     {
         if (! $this->exists) {
-            return;
+            return null;
         }
 
         return $this->setKeysForSelectQuery($this->newQueryWithoutScopes())

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -9,6 +9,11 @@ use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
+/**
+ * @template TRelated of \Illuminate\Database\Eloquent\Model who we are relating to, what we are querying.
+ * @template TChild of \Illuminate\Database\Eloquent\Model origin of the relationship
+ * @extends Relation<TRelated, TChild>
+ */
 class BelongsTo extends Relation
 {
     use ComparesRelatedModels,
@@ -18,7 +23,7 @@ class BelongsTo extends Relation
     /**
      * The child model instance of the relation.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var TChild
      */
     protected $child;
 
@@ -46,8 +51,8 @@ class BelongsTo extends Relation
     /**
      * Create a new belongs to relationship instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $child
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TChild  $child
      * @param  string  $foreignKey
      * @param  string  $ownerKey
      * @param  string  $relationName
@@ -70,7 +75,7 @@ class BelongsTo extends Relation
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
+     * @return TRelated|null
      */
     public function getResults()
     {
@@ -198,8 +203,8 @@ class BelongsTo extends Relation
     /**
      * Associate the model instance to the given parent.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|int|string|null  $model
-     * @return \Illuminate\Database\Eloquent\Model
+     * @param  TRelated|mixed|null  $model
+     * @return TChild
      */
     public function associate($model)
     {
@@ -219,7 +224,7 @@ class BelongsTo extends Relation
     /**
      * Dissociate previously associated model from the given parent.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TChild
      */
     public function dissociate()
     {
@@ -231,7 +236,7 @@ class BelongsTo extends Relation
     /**
      * Alias of "dissociate" method.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TChild
      */
     public function disassociate()
     {
@@ -293,7 +298,7 @@ class BelongsTo extends Relation
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     protected function newRelatedInstanceFor(Model $parent)
     {
@@ -303,7 +308,7 @@ class BelongsTo extends Relation
     /**
      * Get the child of the relationship.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TChild
      */
     public function getChild()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -14,6 +14,11 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
+/**
+ * @template TRelated of \Illuminate\Database\Eloquent\Model
+ * @template TParent of \Illuminate\Database\Eloquent\Model origin of the relationship
+ * @extends Relation<TRelated, TParent>
+ */
 class BelongsToMany extends Relation
 {
     use InteractsWithDictionary, InteractsWithPivotTable;
@@ -133,8 +138,8 @@ class BelongsToMany extends Relation
     /**
      * Create a new belongs to many relationship instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TParent  $parent
      * @param  string  $table
      * @param  string  $foreignPivotKey
      * @param  string  $relatedPivotKey
@@ -581,7 +586,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+     * @return TRelated|\Illuminate\Database\Eloquent\Collection<int, TRelated>
      */
     public function findOrNew($id, $columns = ['*'])
     {
@@ -597,7 +602,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
@@ -615,7 +620,7 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
@@ -637,7 +642,7 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
@@ -661,7 +666,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
+     * @return TRelated|\Illuminate\Database\Eloquent\Collection<int, TRelated>|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -679,7 +684,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelated>
      */
     public function findMany($ids, $columns = ['*'])
     {
@@ -699,9 +704,9 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return TRelated|\Illuminate\Database\Eloquent\Collection<int, TRelated>
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelated>
      */
     public function findOrFail($id, $columns = ['*'])
     {
@@ -726,7 +731,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $id
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
+     * @return TRelated|\Illuminate\Database\Eloquent\Collection<int, TRelated>|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)
     {
@@ -758,7 +763,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TRelated|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
@@ -769,22 +774,20 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result.
      *
      * @param  array  $columns
-     * @return mixed
+     * @return TRelated|null
      */
     public function first($columns = ['*'])
     {
-        $results = $this->take(1)->get($columns);
-
-        return count($results) > 0 ? $results->first() : null;
+        return $this->take(1)->get($columns)->first();
     }
 
     /**
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return TRelated
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelated>
      */
     public function firstOrFail($columns = ['*'])
     {
@@ -800,7 +803,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     * @return TRelated|mixed
      */
     public function firstOr($columns = ['*'], Closure $callback = null)
     {
@@ -820,7 +823,7 @@ class BelongsToMany extends Relation
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
+     * @return Collection<int, TRelated>
      */
     public function getResults()
     {
@@ -833,7 +836,7 @@ class BelongsToMany extends Relation
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelated>
      */
     public function get($columns = ['*'])
     {
@@ -1009,7 +1012,7 @@ class BelongsToMany extends Relation
      * Query lazily, by chunks of the given size.
      *
      * @param  int  $chunkSize
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TRelated>
      */
     public function lazy($chunkSize = 1000)
     {
@@ -1026,7 +1029,7 @@ class BelongsToMany extends Relation
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TRelated>
      */
     public function lazyById($chunkSize = 1000, $column = null, $alias = null)
     {
@@ -1046,7 +1049,7 @@ class BelongsToMany extends Relation
     /**
      * Get a lazy collection for the given query.
      *
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TRelated>
      */
     public function cursor()
     {
@@ -1060,7 +1063,7 @@ class BelongsToMany extends Relation
     /**
      * Prepare the query builder for query execution.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<TRelated>
      */
     protected function prepareQueryBuilder()
     {
@@ -1181,10 +1184,10 @@ class BelongsToMany extends Relation
     /**
      * Save a new model and attach it to the parent model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  TRelated  $model
      * @param  array  $pivotAttributes
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function save(Model $model, array $pivotAttributes = [], $touch = true)
     {
@@ -1198,10 +1201,10 @@ class BelongsToMany extends Relation
     /**
      * Save a new model without raising any events and attach it to the parent model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  TRelated  $model
      * @param  array  $pivotAttributes
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function saveQuietly(Model $model, array $pivotAttributes = [], $touch = true)
     {
@@ -1213,7 +1216,7 @@ class BelongsToMany extends Relation
     /**
      * Save an array of new models and attach them to the parent model.
      *
-     * @param  \Illuminate\Support\Collection|array  $models
+     * @param  \Illuminate\Support\Collection<TRelated>|iterable<TRelated>  $models
      * @param  array  $pivotAttributes
      * @return array
      */
@@ -1231,7 +1234,7 @@ class BelongsToMany extends Relation
     /**
      * Save an array of new models without raising any events and attach them to the parent model.
      *
-     * @param  \Illuminate\Support\Collection|array  $models
+     * @param  \Illuminate\Support\Collection<TRelated>|iterable<TRelated>  $models
      * @param  array  $pivotAttributes
      * @return array
      */
@@ -1248,7 +1251,7 @@ class BelongsToMany extends Relation
      * @param  array  $attributes
      * @param  array  $joining
      * @param  bool  $touch
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function create(array $attributes = [], array $joining = [], $touch = true)
     {
@@ -1267,9 +1270,9 @@ class BelongsToMany extends Relation
     /**
      * Create an array of new instances of the related models.
      *
-     * @param  iterable  $records
+     * @param  iterable<array>  $records
      * @param  array  $joinings
-     * @return array
+     * @return array<TRelated>
      */
     public function createMany(iterable $records, array $joinings = [])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -4,12 +4,18 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 
+
+/**
+ * @template TRelated of \Illuminate\Database\Eloquent\Model
+ * @template TParent of \Illuminate\Database\Eloquent\Model origin of the relationship
+ * @extends HasOneOrMany<TRelated, TParent>
+ */
 class HasMany extends HasOneOrMany
 {
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
+     * @return Collection<TRelated>
      */
     public function getResults()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -11,6 +11,11 @@ use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use Illuminate\Database\Query\JoinClause;
 
+/**
+ * @template TRelated of \Illuminate\Database\Eloquent\Model
+ * @template TParent of \Illuminate\Database\Eloquent\Model origin of the relationship
+ * @extends HasOneOrMany<TRelated, TParent>
+ */
 class HasOne extends HasOneOrMany implements SupportsPartialRelations
 {
     use ComparesRelatedModels, CanBeOneOfMany, SupportsDefaultModels;
@@ -18,7 +23,7 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
+     * @return TRelated
      */
     public function getResults()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
+/**
+ * @template TRelated of \Illuminate\Database\Eloquent\Model
+ * @template TParent of \Illuminate\Database\Eloquent\Model origin of the relationship
+ * @extends Relation<TRelated, TParent>
+ */
 abstract class HasOneOrMany extends Relation
 {
     use InteractsWithDictionary;
@@ -28,8 +33,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new has one or many relationship instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelated>  $query
+     * @param  TParent  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
      * @return void
@@ -46,7 +51,7 @@ abstract class HasOneOrMany extends Relation
      * Create and return an un-saved instance of the related model.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function make(array $attributes = [])
     {
@@ -59,7 +64,7 @@ abstract class HasOneOrMany extends Relation
      * Create and return an un-saved instance of the related models.
      *
      * @param  iterable  $records
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelated>
      */
     public function makeMany($records)
     {
@@ -178,7 +183,7 @@ abstract class HasOneOrMany extends Relation
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param  \Illuminate\Database\Eloquent\Collection  $results
-     * @return array
+     * @return
      */
     protected function buildDictionary(Collection $results)
     {
@@ -212,7 +217,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
@@ -230,7 +235,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
@@ -246,7 +251,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
@@ -260,8 +265,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Attach a model instance to the parent model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|false
+     * @param  TRelated  $model
+     * @return TRelated|false
      */
     public function save(Model $model)
     {
@@ -273,8 +278,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Attach a model instance without raising any events to the parent model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|false
+     * @param  TRelated  $model
+     * @return TRelated|false
      */
     public function saveQuietly(Model $model)
     {
@@ -286,8 +291,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Attach a collection of models to the parent instance.
      *
-     * @param  iterable  $models
-     * @return iterable
+     * @param  iterable<TRelated>  $models
+     * @return iterable<TRelated>
      */
     public function saveMany($models)
     {
@@ -301,8 +306,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Attach a collection of models to the parent instance without raising any events to the parent model.
      *
-     * @param  iterable  $models
-     * @return iterable
+     * @param  iterable<TRelated>  $models
+     * @return iterable<TRelated>
      */
     public function saveManyQuietly($models)
     {
@@ -315,7 +320,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function create(array $attributes = [])
     {
@@ -330,7 +335,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function forceCreate(array $attributes = [])
     {
@@ -343,7 +348,7 @@ abstract class HasOneOrMany extends Relation
      * Create a Collection of new instances of the related model.
      *
      * @param  iterable  $records
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelated>
      */
     public function createMany(iterable $records)
     {
@@ -359,7 +364,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Set the foreign ID for creating a related model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  TRelated  $model
      * @return void
      */
     protected function setForeignAttributesForCreate(Model $model)

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -13,6 +13,11 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
+/**
+ * @template TRelated of \Illuminate\Database\Eloquent\Model where we are relating to, what we are querying.
+ * @template TParent of \Illuminate\Database\Eloquent\Model origin of the relationship
+ * @implements BuilderContract<TRelated>
+ */
 abstract class Relation implements BuilderContract
 {
     use ForwardsCalls, Macroable {
@@ -29,14 +34,14 @@ abstract class Relation implements BuilderContract
     /**
      * The parent model instance.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var TParent
      */
     protected $parent;
 
     /**
      * The related model instance.
      *
-     * @var \Illuminate\Database\Eloquent\Model
+     * @var TRelated
      */
     protected $related;
 
@@ -78,8 +83,8 @@ abstract class Relation implements BuilderContract
     /**
      * Create a new relation instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  \Illuminate\Database\Eloquent\Builder<TParent>  $query
+     * @param  TParent  $parent
      * @return void
      */
     public function __construct(Builder $query, Model $parent)
@@ -170,9 +175,9 @@ abstract class Relation implements BuilderContract
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelated>
      * @throws \Illuminate\Database\MultipleRecordsFoundException
      */
     public function sole($columns = ['*'])
@@ -196,7 +201,7 @@ abstract class Relation implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<TRelated>
      */
     public function get($columns = ['*'])
     {
@@ -349,7 +354,7 @@ abstract class Relation implements BuilderContract
     /**
      * Get the related model of the relation.
      *
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return TRelated
      */
     public function getRelated()
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -26,6 +26,10 @@ use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 
+/**
+ * @template TResult of array
+ * @uses \Illuminate\Database\Concerns\BuildsQueries<TResult>
+ */
 class Builder implements BuilderContract
 {
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
@@ -2565,7 +2569,7 @@ class Builder implements BuilderContract
      *
      * @param  int|string  $id
      * @param  array|string  $columns
-     * @return mixed|static
+     * @return TResult|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -2642,7 +2646,7 @@ class Builder implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<TResult>
      */
     public function get($columns = ['*'])
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -28,10 +28,10 @@ use RuntimeException;
 
 /**
  * @template TResult of array
- * @uses \Illuminate\Database\Concerns\BuildsQueries<TResult>
  */
 class Builder implements BuilderContract
 {
+    /** @use \Illuminate\Database\Concerns\BuildsQueries<TResult> */
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }


### PR DESCRIPTION
_Added to 'master' as it could be quite a big change for static analyzers such as larastan._

This PR adds generic typings to query builder and some of the relationships (willing to put to work to make it 100% if i get a go, not wanting to waste a days of work if you do not like this idea)..

Benefits:
* Complete type system for queries and relationships (at least for 95% use cases)
* Static analyzers will be able to understand code much better and need less hoops.
* IDE will be happy with the improvements

## Benefits Query builder

Proper typing for Query build model:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/2960938/215260254-e1f3dc3c-d5aa-46e9-aeb2-a299db389c5a.png">


Results:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/2960938/215260776-837a1b53-7ca4-41b3-a0ac-efd0522ee382.png">
<img width="595" alt="image" src="https://user-images.githubusercontent.com/2960938/215260786-b92df093-a06e-417f-b601-f80a0a46748a.png">

Get results as well:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/2960938/215260913-544bb458-3551-4b11-ac93-7e775f0bfdd3.png">



Proper typings for relationships:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/2960938/214947674-2d10ff31-23a5-42ce-a7ef-c01146484eaa.png">

Results
<img width="558" alt="image" src="https://user-images.githubusercontent.com/2960938/214947899-847c875a-6467-470c-9e37-3ff2c8b722e7.png">


### Static analyzers

Larastan and psalm will be able to do much better and in depth analyses of correctness of the code.


### Draw backs

PHPStorm still has some problems with generics, it dies after on second level of generics:
* https://youtrack.jetbrains.com/issue/WI-71011/this-and-static-return-type-do-not-work-as-Generi-in-phpdoc-this
* https://youtrack.jetbrains.com/issue/WI-47158/Generics-support-with-template
* https://youtrack.jetbrains.com/issue/WI-63722


Which means calling the builder from a Model and getting the results without explicit type casts loses type control :-(
this is why I considered putting this on master branch and hope PHPStorm would solve this by the time this lands.

 
<img width="593" alt="image" src="https://user-images.githubusercontent.com/2960938/215261237-7f2836d2-e0f7-4a3a-96ab-cf81eb29cebd.png">

