### PR TITLE
[10.x] Validate new rules if previous attribute validated

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -49,6 +49,17 @@ interface Validator extends MessageProvider
     public function sometimes($attribute, $rules, callable $callback);
 
     /**
+     * Validate the new rules if the previous attribute have been validated.
+     *
+     * @param  string|array  $attribute
+     * @param  array  $rules
+     * @param  array  $messages
+     * @param  array  $customAttributes
+     * @return $this
+     */
+    public function validateIfPasses($attributes, array $rules, array $messages = [], array $customAttributes = []);
+
+    /**
      * Add an after validation callback.
      *
      * @param  callable|string  $callback

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1201,6 +1201,29 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate the new rules if the previous attribute have been validated.
+     *
+     * @param  string|array  $attribute
+     * @param  array  $rules
+     * @param  array  $messages
+     * @param  array  $customAttributes
+     * @return $this
+     */
+    public function validateIfPasses($attributes, array $rules, array $messages = [], array $customAttributes = [])
+    {
+        $attributes = (array)$attributes;
+
+        $this->after(function ($validator) use ($attributes, $rules, $messages, $customAttributes) {
+            if ($validator->messages()->hasAny($attributes)) {
+                return;
+            }
+            $validator->messages()->merge((new self($this->translator, $this->data, $rules, $messages, $customAttributes))->messages());
+        });
+
+        return $this;
+    }
+
+    /**
      * Instruct the validator to stop validating after the first rule failure.
      *
      * @param  bool  $stopOnFirstFailure


### PR DESCRIPTION
Sometimes we need to add a validation rule if the validation of other attributes is passed.

For example, when I create a custom rule that requires multiple request parameters and requires these parameters to be validated.

With this feature we can:

```php
 $validator->validateIfPasses(['user_id', 'post_id'], [
      'post_type' => [new CustomRule($request->user_id, $request->post_id)]
 ]);
```