### PR TITLE
[9.x] Add whenHas and whenHasAny() methods to Collections.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -595,6 +595,32 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Execute the given callback if an item exists in the collection by key.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return Collection
+     */
+    public function whenHas($key, $callback, $default = null)
+    {
+        return $this->when($this->has($key), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if any of the keys exist in the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return Collection
+     */
+    public function whenHasAny($key, $callback, $default = null)
+    {
+        return $this->when($this->hasAny($key), $callback, $default);
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  callable|string  $value

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -600,7 +600,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  TKey|array<array-key, TKey>  $key
      * @param  callable  $callback
      * @param  callable|null  $default
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     public function whenHas($key, $callback, $default = null)
     {
@@ -613,7 +613,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  TKey|array<array-key, TKey>  $key
      * @param  callable  $callback
      * @param  callable|null  $default
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     public function whenHasAny($key, $callback, $default = null)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -615,7 +615,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  TKey|array<array-key, TKey>  $key
      * @param  callable  $callback
      * @param  callable|null  $default
-     * @return Collection
+     * @return LazyCollection
      */
     public function whenHas($key, $callback, $default = null)
     {
@@ -628,7 +628,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  TKey|array<array-key, TKey>  $key
      * @param  callable  $callback
      * @param  callable|null  $default
-     * @return Collection
+     * @return LazyCollection
      */
     public function whenHasAny($key, $callback, $default = null)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -615,7 +615,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  TKey|array<array-key, TKey>  $key
      * @param  callable  $callback
      * @param  callable|null  $default
-     * @return LazyCollection
+     * @return \Illuminate\Support\LazyCollection
      */
     public function whenHas($key, $callback, $default = null)
     {
@@ -628,7 +628,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  TKey|array<array-key, TKey>  $key
      * @param  callable  $callback
      * @param  callable|null  $default
-     * @return LazyCollection
+     * @return \Illuminate\Support\LazyCollection
      */
     public function whenHasAny($key, $callback, $default = null)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -610,6 +610,32 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Execute the given callback if an item exists in the collection by key.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return Collection
+     */
+    public function whenHas($key, $callback, $default = null)
+    {
+        return $this->when($this->has($key), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if any of the keys exist in the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return Collection
+     */
+    public function whenHasAny($key, $callback, $default = null)
+    {
+        return $this->when($this->hasAny($key), $callback, $default);
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  callable|string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2299,6 +2299,40 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenHas($collection)
+    {
+        $data = new $collection(['account_id' => 1, 'product' => 'Desk']);
+
+        $data = $data->whenHas('product', fn ($c) => $c->merge('test'));
+        $this->assertEquals(['account_id' => 1, 'product' => 'Desk', 'test'], $data->all());
+
+        $data = $data->whenHas(['foo', 'amount'], fn ($c) => $c->merge('foo'), fn ($c) => $c->merge('bar'));
+        $this->assertEquals(['account_id' => 1, 'product' => 'Desk', 'test', 'bar'], $data->all());
+
+        $data = $data->whenHas('foo', fn ($c) => $c->merge('test'), fn ($c) => $c->merge('foo'));
+        $this->assertEquals(['account_id' => 1, 'product' => 'Desk', 'test', 'bar', 'foo'], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenHasAny($collection)
+    {
+        $data = new $collection(['product' => 'Desk', 'amount' => 5]);
+
+        $data = $data->whenHasAny(['product', 'amount'], fn ($c) => $c->merge('account'));
+        $this->assertEquals(['product' => 'Desk', 'amount' => 5, 'account'], $data->all());
+
+        $data = $data->whenHasAny(['foo', 'amount'], fn ($c) => $c->merge('foo'));
+        $this->assertEquals(['product' => 'Desk', 'amount' => 5, 'account', 'foo'], $data->all());
+
+        $data = $data->whenHasAny(['bar', 'baz'], fn ($c) => $c->merge('test'), fn ($c) => $c->merge('baz'));
+        $this->assertEquals(['product' => 'Desk', 'amount' => 5, 'account', 'foo', 'baz'], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -490,6 +490,32 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testWhenHasIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->whenHas(4, fn ($c) => $c);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->whenHas('non-existent', fn ($c) => $c);
+        });
+    }
+
+    public function testWhenHasAnyIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->whenHasAny(4, fn ($c) => $c);
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->whenHasAny([1, 4], fn ($c) => $c);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->whenHasAny(['non', 'existent'], fn ($c) => $c);
+        });
+    }
+
     public function testImplodeEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
This PR adds support for whenHas and whenHasAny() method to collections. If I did something wrong let me know

``` php
    collect(['foo', 'bar', 'baz'])->whenHas('bar', function ($collection) {
       // do something 
    });

    collect(['foo', 'bar', 'baz'])->whenHasAny(['foo', 'bar'], function ($collection) {
        // do something 
    });
```