### PR TITLE
[9.x] Adds `redirectName` method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -253,6 +253,22 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Create a redirect from one route name to another.
+     *
+     * @param  string  $name
+     * @param  string  $destinationRouteName
+     * @param  int  $status
+     * @return \Illuminate\Routing\Route
+     */
+    public function redirectName($name, $destinationRouteName, $status = 302)
+    {
+        $uri = Str::after(route($name), request()->root());
+        $destination = Str::after(route($destinationRouteName), request()->root());
+
+        return $this->redirect($uri, $destination, $status);
+    }
+
+    /**
      * Create a permanent redirect from one URI to another.
      *
      * @param  string  $uri

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -12,6 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route any(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route fallback(array|string|callable|null $action)
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
+ * @method static \Illuminate\Routing\Route redirectName(string $name, string $destinationRouteName, int $status = 302)
  * @method static \Illuminate\Routing\Route permanentRedirect(string $uri, string $destination)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
  * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, array|string|callable|null $action = null)

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -12,7 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route any(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route fallback(array|string|callable|null $action)
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
- * @method static \Illuminate\Routing\Route redirectName(string $name, string $destinationRouteName, int $status = 302)
+ * @method static \Illuminate\Routing\Route redirectName(string $fromRoute, string $toRoute, int $status = 302)
  * @method static \Illuminate\Routing\Route permanentRedirect(string $uri, string $destination)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
  * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, array|string|callable|null $action = null)


### PR DESCRIPTION
This PR allows us to use a new awesome form of the `redirect` method by passing the route name source and route name destination instead using URI, let's examine the next scenario for more illumination.

## BEFORE this PR gets merged

```PHP
Route::get('users', [UserController::class, 'index']);
Route::get('posts', [PostController::class, 'index']);

Route::redirect('/users', '/posts');
```

But, what if the URI was too long, it will be difficult to write and remember, so let's say hello to the new redirect method 🎉

## AFTER this PR gets merged

```PHP
Route::get('users', [UserController::class, 'index'])->name('users.index');
Route::get('posts', [PostController::class, 'index'])->name('posts.index');

Route::redirectName('users.index', 'posts.index');
```
