### PR TITLE
[9.x] Fix Illuminate Filesystem replace() leaves file executable

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -207,7 +207,7 @@ class Filesystem
         $tempPath = tempnam(dirname($path), basename($path));
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
-        chmod($tempPath, 0756 - umask());
+        chmod($tempPath, 0776 - umask());
 
         file_put_contents($tempPath, $content);
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -207,7 +207,7 @@ class Filesystem
         $tempPath = tempnam(dirname($path), basename($path));
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
-        chmod($tempPath, 0776 - umask());
+        chmod($tempPath, 0756 - umask());
 
         file_put_contents($tempPath, $content);
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -207,7 +207,7 @@ class Filesystem
         $tempPath = tempnam(dirname($path), basename($path));
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
-        chmod($tempPath, 0776 - umask());
+        chmod($tempPath, 0666 - umask());
 
         file_put_contents($tempPath, $content);
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -207,7 +207,7 @@ class Filesystem
         $tempPath = tempnam(dirname($path), basename($path));
 
         // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
-        chmod($tempPath, 0777 - umask());
+        chmod($tempPath, 0776 - umask());
 
         file_put_contents($tempPath, $content);
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -98,8 +98,8 @@ class FilesystemTest extends TestCase
     }
 
     public function testFilePermissionRestoredAfterReplace(){
-        // For validation since getFilePermissions returns value in decimal, passing 774 after subtracting 2 for umask() i.e 0776 - 2 = 774
-        $permissionValueInDecimal = base_convert("774",8,10);
+        // For validation since getFilePermissions returns value in decimal, passing 754 after subtracting 2 for umask() i.e 0756 - 2 = 754
+        $permissionValueInDecimal = base_convert("754",8,10);
         $tempFile = self::$tempDir.'/file.txt';
         $filesystem = new Filesystem;
         $filesystem->replace($tempFile, 'Hello World');
@@ -130,22 +130,22 @@ class FilesystemTest extends TestCase
         // Test replacing non-existent file.
         $filesystem->replace($tempFile, 'Hello World');
         $this->assertStringEqualsFile($tempFile, 'Hello World');
-        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0756 - $this->getFilePermissions($tempFile));
 
         // Test replacing existing file.
         $filesystem->replace($tempFile, 'Something Else');
         $this->assertStringEqualsFile($tempFile, 'Something Else');
-        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0756 - $this->getFilePermissions($tempFile));
 
         // Test replacing symlinked file.
         $filesystem->replace($symlink, 'Yet Something Else Again');
         $this->assertStringEqualsFile($tempFile, 'Yet Something Else Again');
-        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0756 - $this->getFilePermissions($tempFile));
 
         umask($originalUmask);
 
         // Reset changes to symlink_dir
-        chmod($symlinkDir, 0776 - $originalUmask);
+        chmod($symlinkDir, 0756 - $originalUmask);
     }
 
     public function testSetChmod()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -102,7 +102,7 @@ class FilesystemTest extends TestCase
         $filesystem = new Filesystem;
         $filesystem->replace($tempFile, 'Hello World');
         $umaskValue = umask();
-        $permissionValueInDecimal = (int) base_convert("776",8,10);
+        $permissionValueInDecimal = (int) base_convert("666",8,10);
         $actualPermission = $permissionValueInDecimal - $umaskValue;
         $this->assertEquals($actualPermission, $this->getFilePermissions($tempFile));
     }
@@ -131,22 +131,22 @@ class FilesystemTest extends TestCase
         // Test replacing non-existent file.
         $filesystem->replace($tempFile, 'Hello World');
         $this->assertStringEqualsFile($tempFile, 'Hello World');
-        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0666 - $this->getFilePermissions($tempFile));
 
         // Test replacing existing file.
         $filesystem->replace($tempFile, 'Something Else');
         $this->assertStringEqualsFile($tempFile, 'Something Else');
-        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0666 - $this->getFilePermissions($tempFile));
 
         // Test replacing symlinked file.
         $filesystem->replace($symlink, 'Yet Something Else Again');
         $this->assertStringEqualsFile($tempFile, 'Yet Something Else Again');
-        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0666 - $this->getFilePermissions($tempFile));
 
         umask($originalUmask);
 
         // Reset changes to symlink_dir
-        chmod($symlinkDir, 0776 - $originalUmask);
+        chmod($symlinkDir, 0666 - $originalUmask);
     }
 
     public function testSetChmod()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -98,7 +98,7 @@ class FilesystemTest extends TestCase
     }
 
     public function testFilePermissionRestoredAfterReplace(){
-        // For validation since getFilePermissions returns value in decimal
+        // For validation since getFilePermissions returns value in decimal, passing 774 after subtracting 2 for umask() i.e 0776 - 2 = 774
         $permissionValueInDecimal = base_convert(774,8,10);
         $tempFile = self::$tempDir.'/file.txt';
         $filesystem = new Filesystem;

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -112,9 +112,9 @@ class FilesystemTest extends TestCase
      */
     public function testReplaceWhenUnixSymlinkExists()
     {
-        $tempFile = self::$tempDir.'/file.txt';
-        $symlinkDir = self::$tempDir.'/symlink_dir';
-        $symlink = "{$symlinkDir}/symlink.txt";
+        $tempFile = self::$tempDir.'/'.time().'file.txt';
+        $symlinkDir = self::$tempDir.'/'.time().'symlink_dir';
+        $symlink = "{$symlinkDir}/'.time().'symlink.txt";
 
         mkdir($symlinkDir);
         symlink($tempFile, $symlink);
@@ -123,7 +123,7 @@ class FilesystemTest extends TestCase
         chmod($symlinkDir, 0555);
 
         // Test with a weird non-standard umask.
-        $umask = 0131;
+        $umask = 0031;
         $originalUmask = umask($umask);
 
         $filesystem = new Filesystem;

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -98,12 +98,13 @@ class FilesystemTest extends TestCase
     }
 
     public function testFilePermissionRestoredAfterReplace(){
-        // For validation since getFilePermissions returns value in decimal, passing 754 after subtracting 2 for umask() i.e 0756 - 2 = 754
-        $permissionValueInDecimal = base_convert("754",8,10);
         $tempFile = self::$tempDir.'/file.txt';
         $filesystem = new Filesystem;
         $filesystem->replace($tempFile, 'Hello World');
-        $this->assertEquals($permissionValueInDecimal, $this->getFilePermissions($tempFile));
+        $umaskValue = umask();
+        $permissionValueInDecimal = (int) base_convert("776",8,10);
+        $actualPermission = $permissionValueInDecimal - $umaskValue;
+        $this->assertEquals($actualPermission, $this->getFilePermissions($tempFile));
     }
 
     /**
@@ -130,22 +131,22 @@ class FilesystemTest extends TestCase
         // Test replacing non-existent file.
         $filesystem->replace($tempFile, 'Hello World');
         $this->assertStringEqualsFile($tempFile, 'Hello World');
-        $this->assertEquals($umask, 0756 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
 
         // Test replacing existing file.
         $filesystem->replace($tempFile, 'Something Else');
         $this->assertStringEqualsFile($tempFile, 'Something Else');
-        $this->assertEquals($umask, 0756 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
 
         // Test replacing symlinked file.
         $filesystem->replace($symlink, 'Yet Something Else Again');
         $this->assertStringEqualsFile($tempFile, 'Yet Something Else Again');
-        $this->assertEquals($umask, 0756 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
 
         umask($originalUmask);
 
         // Reset changes to symlink_dir
-        chmod($symlinkDir, 0756 - $originalUmask);
+        chmod($symlinkDir, 0776 - $originalUmask);
     }
 
     public function testSetChmod()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -99,7 +99,7 @@ class FilesystemTest extends TestCase
 
     public function testFilePermissionRestoredAfterReplace(){
         // For validation since getFilePermissions returns value in decimal, passing 774 after subtracting 2 for umask() i.e 0776 - 2 = 774
-        $permissionValueInDecimal = base_convert(774,8,10);
+        $permissionValueInDecimal = base_convert("774",8,10);
         $tempFile = self::$tempDir.'/file.txt';
         $filesystem = new Filesystem;
         $filesystem->replace($tempFile, 'Hello World');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -97,6 +97,15 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($tempFile, 'Hello Taylor');
     }
 
+    public function testFilePermissionRestoredAfterReplace(){
+        // For validation since getFilePermissions returns value in decimal
+        $permissionValueInDecimal = base_convert(774,8,10);
+        $tempFile = self::$tempDir.'/file.txt';
+        $filesystem = new Filesystem;
+        $filesystem->replace($tempFile, 'Hello World');
+        $this->assertEquals($permissionValueInDecimal, $this->getFilePermissions($tempFile));
+    }
+
     /**
      * @requires OS Linux|Darwin
      */
@@ -121,22 +130,22 @@ class FilesystemTest extends TestCase
         // Test replacing non-existent file.
         $filesystem->replace($tempFile, 'Hello World');
         $this->assertStringEqualsFile($tempFile, 'Hello World');
-        $this->assertEquals($umask, 0777 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
 
         // Test replacing existing file.
         $filesystem->replace($tempFile, 'Something Else');
         $this->assertStringEqualsFile($tempFile, 'Something Else');
-        $this->assertEquals($umask, 0777 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
 
         // Test replacing symlinked file.
         $filesystem->replace($symlink, 'Yet Something Else Again');
         $this->assertStringEqualsFile($tempFile, 'Yet Something Else Again');
-        $this->assertEquals($umask, 0777 - $this->getFilePermissions($tempFile));
+        $this->assertEquals($umask, 0776 - $this->getFilePermissions($tempFile));
 
         umask($originalUmask);
 
         // Reset changes to symlink_dir
-        chmod($symlinkDir, 0777 - $originalUmask);
+        chmod($symlinkDir, 0776 - $originalUmask);
     }
 
     public function testSetChmod()


### PR DESCRIPTION
The issue #45779 is because of changing the permission of file stored in `/tmp` directory giving `0775` permission via `chmod()` method call with `umask()` subtraction. 

`chmod($tempPath, 0777 - umask());`

Here we are subtracting the umask() value from 0777 
i.e ` 0777 - 002 = 0775` which in permission is `rwxrwxr-x` i.e **others** is getting read and execute permission

if we change the permission given to `chmod($tempPath, 0776 - umask());` file will have permission
of  ` 0776 - 002 = 0774` which in permission is `rwxrwxr--` i.e other is getting read only permission

passing values in test is a bit confusing for me but I tried doing my best :

in `testFilePermissionRestoredAfterReplace line 100` I have converted 774 into decimal which is after subtracting 2 of umask() from 776, I had to do the assertion with decimal value since  `$this->getFilePermissions($tempFile)` returns permission value in decimal. **( I think this function name should be getFilePermissionsInDecimal to avoid confusion)**.

After that I updated the permission value in `testReplaceWhenUnixSymlinkExists()` test.




