### PR TITLE
[9.x] Add title tag in mail template

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+<title>{{ config('app.name') }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<title>{{ config('app.name') }}</title>
 <meta name="color-scheme" content="light">
 <meta name="supported-color-schemes" content="light">
 <style>

--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -3,6 +3,7 @@
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>{{ config('app.name') }}</title>
 <meta name="color-scheme" content="light">
 <meta name="supported-color-schemes" content="light">
 <style>


### PR DESCRIPTION
Hi,

When rendering the email directly in [browser](https://laravel.com/docs/9.x/mail#previewing-mailables-in-the-browser), the browser tab does not have a title.

There is no side effect adding a title tag to mail template.
