### PR TITLE
[9.x] Backed enum support for @js

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use BackedEnum;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -67,6 +68,10 @@ class Js implements Htmlable
     {
         if ($data instanceof self) {
             return $data->toHtml();
+        }
+
+        if ($data instanceof BackedEnum) {
+            $data = $data->value;
         }
 
         $json = $this->jsonEncode($data, $flags, $depth);

--- a/tests/Support/Fixtures/IntBackedEnum.php
+++ b/tests/Support/Fixtures/IntBackedEnum.php
@@ -5,4 +5,5 @@ namespace Illuminate\Tests\Support\Fixtures;
 enum IntBackedEnum: int
 {
     case ROLE_ADMIN = 1;
+    case TWO = 2;
 }

--- a/tests/Support/Fixtures/StringBackedEnum.php
+++ b/tests/Support/Fixtures/StringBackedEnum.php
@@ -5,4 +5,5 @@ namespace Illuminate\Tests\Support\Fixtures;
 enum StringBackedEnum: string
 {
     case ADMIN_LABEL = 'I am \'admin\'';
+    case HELLO_WORLD = 'Hello world';
 }

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -16,6 +16,7 @@ class SupportJsTest extends TestCase
         $this->assertSame('true', (string) Js::from(true));
         $this->assertSame('1', (string) Js::from(1));
         $this->assertSame('1.1', (string) Js::from(1.1));
+        $this->assertSame("'Hello world'", (string) Js::from('Hello world'));
         $this->assertEquals(
             "'\\u003Cdiv class=\\u0022foo\\u0022\\u003E\\u0027quoted html\\u0027\\u003C\\/div\\u003E'",
             (string) Js::from('<div class="foo">\'quoted html\'</div>')

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Js;
+use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
+use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
@@ -121,5 +123,14 @@ class SupportJsTest extends TestCase
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testBackedEnums()
+    {
+        $this->assertSame('2', (string) Js::from(IntBackedEnum::TWO));
+        $this->assertSame("'Hello world'", (string) Js::from(StringBackedEnum::HELLO_WORLD));
     }
 }


### PR DESCRIPTION
### Current state of `enum` in `@js`

Given we have an defined enum:
```php
enum Thing: string
{
    case SIMPLE = 'simple';
    //...
}
```

and pass it into `@js`
```blade
@js(Thing::SIMPLE)
```

Will output:
```js
JSON.parse('\u0022simple\u0022')
```

### After this PR
```js
'simple'
```