### PR TITLE
[9.x] Add valueOr method to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -652,6 +652,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single column's value from the first result of a query or call a callback.
+     *
+     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @return mixed
+     */
+    public function valueOr($column, Closure $callback)
+    {
+        if (! is_null($result = $this->value($column))) {
+            return $result;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Get a single column's value from the first result of a query if it's the sole matching record.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -345,7 +345,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueOrMethodWithModelNotFound()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('first')->with(['name'])->andReturn(null);
 
         $this->assertSame('callback result', $builder->valueOr('name', fn () => 'callback result'));
@@ -357,7 +357,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueOrMethodWithModelFound()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $mockModel = new stdClass;
         $mockModel->name = 'foo';
         $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -343,6 +343,28 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertNull($builder->value('name'));
     }
 
+    public function testValueOrMethodWithModelNotFound()
+    {
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('first')->with(['name'])->andReturn(null);
+
+        $this->assertSame('callback result', $builder->valueOr('name', fn () => 'callback result'));
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $builder->valueOr('name', fn () => throw new ModelNotFoundException());
+    }
+
+    public function testValueOrMethodWithModelFound()
+    {
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $mockModel = new stdClass;
+        $mockModel->name = 'foo';
+        $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
+
+        $this->assertSame('foo', $builder->valueOr('name', fn () => 'callback result'));
+    }
+
     public function testValueOrFailMethodWithModelFound()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
This PR adds a valueOr() method to the Eloquent Builder

Example usage:

```php
Task::where('completed')->valueOr('title', fn () => abort(403));
Task::where('completed')->valueOr('title', fn () => 'return something');
Task::where('completed')->valueOr('title', fn () => '...');
```