### PR TITLE
[9.x] Fixes for console input prompts

### DIFF
--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -35,6 +35,7 @@ trait PromptsForMissingInput
     {
         $prompted = collect($this->getDefinition()->getArguments())
             ->filter(fn ($argument) => $argument->isRequired() && is_null($input->getArgument($argument->getName())))
+            ->filter(fn ($argument) => $argument->getName() !== 'command')
             ->each(fn ($argument) => $input->setArgument(
                 $argument->getName(),
                 $this->askPersistently(

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -86,7 +86,7 @@ class ConsoleApplicationTest extends TestCase
             'testing'
         );
 
-        $app->resolveCommands([FakeCommandWithInputPrompting::class]);
+        $app->addCommands([new FakeCommandWithInputPrompting(false)]);
 
         $statusCode = $app->call('fake-command-for-testing', [
             'name' => 'foo',

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -75,6 +76,23 @@ class ConsoleApplicationTest extends TestCase
 
         $this->assertSame($codeOfCallingArrayInput, $codeOfCallingStringInput);
         $this->assertSame($outputOfCallingArrayInput, $outputOfCallingStringInput);
+    }
+
+    public function testCommandInputPromptingWorksCorrectly()
+    {
+        $app = new Application(
+            $app = new \Illuminate\Foundation\Application(__DIR__),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $app->resolveCommands([FakeCommandWithInputPrompting::class]);
+
+        $statusCode = $app->call('fake-command-for-testing', [
+            'name' => 'foo',
+        ]);
+
+        $this->assertSame(0, $statusCode);
     }
 
     protected function getMockConsole(array $methods)

--- a/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
@@ -2,17 +2,34 @@
 
 namespace Illuminate\Tests\Console\Fixtures;
 
+use BadMethodCallException;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 
 class FakeCommandWithInputPrompting extends Command implements PromptsForMissingInput
 {
-    use \Illuminate\Console\Concerns\PromptsForMissingInput;
+    use \Illuminate\Console\Concerns\PromptsForMissingInput {
+        askPersistently as traitAskPersistently;
+    }
 
     protected $signature = 'fake-command-for-testing {name : An argument}';
+
+    public function __construct(private $expectToRequestInput = true)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
         return self::SUCCESS;
+    }
+
+    private function askPersistently($question)
+    {
+        if (! $this->expectToRequestInput) {
+            throw new BadMethodCallException("No prompts for input were expected, but a question was asked.");
+        }
+
+        return $this->traitAskPersistently($question);
     }
 }

--- a/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
@@ -27,7 +27,7 @@ class FakeCommandWithInputPrompting extends Command implements PromptsForMissing
     private function askPersistently($question)
     {
         if (! $this->expectToRequestInput) {
-            throw new BadMethodCallException("No prompts for input were expected, but a question was asked.");
+            throw new BadMethodCallException('No prompts for input were expected, but a question was asked.');
         }
 
         return $this->traitAskPersistently($question);

--- a/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+
+class FakeCommandWithInputPrompting extends Command implements PromptsForMissingInput
+{
+    use \Illuminate\Console\Concerns\PromptsForMissingInput;
+
+    protected $signature = 'fake-command-for-testing {name : An argument}';
+
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
Hey there!

I discovered this bug whilst updating packages ready for Laravel 10. 

## Replicating

The easiest way to replicate the bug is via a `GeneratorCommand`, which implements the `PromptsForMissingInput` contract and trait from https://github.com/laravel/framework/pull/45629. Execute the command and you'll see the question.

## The cause

This problem is caused because of the order of execution for Symfony commands and how the `PromptsForMissingInput` trait works.

Laravel passes command arguments to Symfony as `[0 => 'command-name', 'argument' => 'foo', '--option' => 'bar']`. This is fine, because vendor/symfony/console/Command/Command.php:303 takes care of this for us by adding a `command` option based on the Command name.

However, `PromptsForMissingInput` performs its magic in the `initialize` method, which is called earlier in command execution (vendor/symfony/console/Command/Command.php:278). As such, the trait *infers* that the 'command' argument has not been provided and is a required argument, so it will ask the user for all eternity for its value. 

## The fix

To fix this, I've simply updated the trait to filter out the `command` argument name when searching for required input. I've added a test for this that uses a fake command to check that no questions are asked when all arguments other than `command` are provided.

Thanks for all the hard work!

Kind Regards,
Luke