### PR TITLE
[9.x] Restart syscalls for SIGALRM when worker times out a job

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -224,7 +224,7 @@ class Worker
             }
 
             $this->kill(static::EXIT_ERROR, $options);
-        });
+        }, true);
 
         pcntl_alarm(
             max($this->timeoutForJob($job, $options), 0)


### PR DESCRIPTION
As mentioned in #45867 whenever a `SIGALRM` happens during an execution of a query a PDOException gets thrown from the MSSql server. In simpler terms, whenever `SIGALRM` arrives the MSSQL connection gets broken resulting in the query not being to execute itself, hence throwing the error.

Although `restart_syscalls` argument is true by default in `pcntl_signal` this will not work with `SIGALRM` signal due to the backwards compatibility left by Nikita Popov in [this commit](https://github.com/php/php-src/commit/e98e1f92c98b7c8910c55835d8f67d0d9230cc8b).
