### PR TITLE
[10.x] Use unsigned closures for route caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "dragonmantank/cron-expression": "^3.3.2",
         "egulias/email-validator": "^3.2.1|^4.0",
         "fruitcake/php-cors": "^1.2",
-        "laravel/serializable-closure": "^1.2.2",
+        "laravel/serializable-closure": "dev-fix/unsigned-serializable-closures as 1.2.2",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",
         "monolog/monolog": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "dragonmantank/cron-expression": "^3.3.2",
         "egulias/email-validator": "^3.2.1|^4.0",
         "fruitcake/php-cors": "^1.2",
-        "laravel/serializable-closure": "dev-fix/unsigned-serializable-closures as 1.2.2",
+        "laravel/serializable-closure": "^1.3",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",
         "monolog/monolog": "^3.0",

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -213,10 +213,7 @@ class RouteListCommand extends Command
             $path = (new ReflectionFunction($route->action['uses']))
                                 ->getFileName();
         } elseif (is_string($route->action['uses']) &&
-                  Str::contains($route->action['uses'], [
-                      'SerializableClosure',
-                      'UnsignedSerializableClosure',
-                  ])) {
+                  str_contains($route->action['uses'], 'SerializableClosure')) {
             return false;
         } elseif (is_string($route->action['uses'])) {
             if ($this->isFrameworkController($route)) {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -213,7 +213,10 @@ class RouteListCommand extends Command
             $path = (new ReflectionFunction($route->action['uses']))
                                 ->getFileName();
         } elseif (is_string($route->action['uses']) &&
-                  str_contains($route->action['uses'], 'SerializableClosure')) {
+                  Str::contains($route->action['uses'], [
+                    'SerializableClosure',
+                    'UnsignedSerializableClosure',
+                ])) {
             return false;
         } elseif (is_string($route->action['uses'])) {
             if ($this->isFrameworkController($route)) {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -214,9 +214,9 @@ class RouteListCommand extends Command
                                 ->getFileName();
         } elseif (is_string($route->action['uses']) &&
                   Str::contains($route->action['uses'], [
-                    'SerializableClosure',
-                    'UnsignedSerializableClosure',
-                ])) {
+                      'SerializableClosure',
+                      'UnsignedSerializableClosure',
+                  ])) {
             return false;
         } elseif (is_string($route->action['uses'])) {
             if ($this->isFrameworkController($route)) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -997,6 +997,7 @@ class Route
         return is_string($missing) &&
             Str::startsWith($missing, [
                 'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
+                'O:55:"Laravel\\SerializableClosure\\UnsignedSerializableClosure',
             ]) ? unserialize($missing) : $missing;
     }
 
@@ -1340,13 +1341,13 @@ class Route
     {
         if ($this->action['uses'] instanceof Closure) {
             $this->action['uses'] = serialize(
-                new SerializableClosure($this->action['uses'])
+                SerializableClosure::unsigned($this->action['uses'])
             );
         }
 
         if (isset($this->action['missing']) && $this->action['missing'] instanceof Closure) {
             $this->action['missing'] = serialize(
-                new SerializableClosure($this->action['missing'])
+                SerializableClosure::unsigned($this->action['missing'])
             );
         }
 

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -105,6 +105,7 @@ class RouteAction
     {
         return is_string($action['uses']) && Str::startsWith($action['uses'], [
             'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
+            'O:55:"Laravel\\SerializableClosure\\UnsignedSerializableClosure',
         ]) !== false;
     }
 }


### PR DESCRIPTION
This pull request uses unsigned routes - for Laravel 10 - as discussed https://github.com/laravel/serializable-closure/pull/62. We need a release of https://github.com/laravel/serializable-closure/pull/64, to bump `composer.json`.