### PR TITLE
Fail jobs on OOM errors

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -141,10 +141,10 @@ class Worker
 
         register_shutdown_function(function () use (&$job) {
             $e = error_get_last();
-            if (!$job instanceof Job) {
+            if (! $job instanceof Job) {
                 return;
             }
-            if (!str_contains($e['message'], 'memory size')) {
+            if (! str_contains($e['message'], 'memory size')) {
                 return;
             }
             $this->failJob($job, new FatalError($e['message'], 0, $e));


### PR DESCRIPTION
Right now, creating a dummy job that just consumes memory, the job fails with an OOM error, but it stays on the queue forever. It's never marked as failed and never released.

This adds a shutdown handler that will mark the job as failed on OOM errors.

Without this, jobs that fail because of high memory usage all stay on the queue and accumulate there. If enough of them have accumulated, the workers keep spinning on jobs that can never go through preventing any other jobs from being worked on.

This now works similarly to what would happen on job timeouts.

This isn't the final PR, but I wanted to gauge interest in adding this before making a more complete PR.