### PR TITLE
[9.x] Fix LazyCollection::makeIterator() to accept non Generator Function

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1636,7 +1636,14 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             return new ArrayIterator($source);
         }
 
-        return $source();
+        if (is_callable($source)) {
+            $maybeTraversable = $source();
+            return $maybeTraversable instanceof Traversable
+                ? $maybeTraversable
+                : new ArrayIterator((array)$maybeTraversable);
+        }
+
+        return new ArrayIterator((array)$source);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -7,12 +7,13 @@ use Closure;
 use DateTimeInterface;
 use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use IteratorAggregate;
-use stdClass;
 use Traversable;
+use stdClass;
 
 /**
  * @template TKey of array-key
@@ -1641,7 +1642,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
             return $maybeTraversable instanceof Traversable
                 ? $maybeTraversable
-                : new ArrayIterator((array) $maybeTraversable);
+                : new ArrayIterator(Arr::wrap($maybeTraversable));
         }
 
         return new ArrayIterator((array) $source);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1640,10 +1640,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $maybeTraversable = $source();
             return $maybeTraversable instanceof Traversable
                 ? $maybeTraversable
-                : new ArrayIterator((array)$maybeTraversable);
+                : new ArrayIterator((array) $maybeTraversable);
         }
 
-        return new ArrayIterator((array)$source);
+        return new ArrayIterator((array) $source);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1638,6 +1638,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
         if (is_callable($source)) {
             $maybeTraversable = $source();
+
             return $maybeTraversable instanceof Traversable
                 ? $maybeTraversable
                 : new ArrayIterator((array) $maybeTraversable);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -19,7 +19,7 @@ class FilesystemTest extends TestCase
      */
     public static function setUpTempDir()
     {
-        self::$tempDir = sys_get_temp_dir().'/tmp';
+        self::$tempDir = sys_get_temp_dir().'/tmp'.time();
         mkdir(self::$tempDir);
     }
 

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -73,10 +73,10 @@ class SupportLazyCollectionTest extends TestCase
     public function testCanCreateCollectionFromNonGeneratorFunction()
     {
         $data = LazyCollection::make(function () {
-            return "laravel";
+            return 'laravel';
         });
 
-        $this->assertSame(["laravel"], $data->all());
+        $this->assertSame(['laravel'], $data->all());
     }
 
     public function testDoesNotCreateCollectionFromGenerator()

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -47,7 +47,7 @@ class SupportLazyCollectionTest extends TestCase
         $this->assertSame($array, $data->all());
     }
 
-    public function testCanCreateCollectionFromClosure()
+    public function testCanCreateCollectionFromGeneratorFunction()
     {
         $data = LazyCollection::make(function () {
             yield 1;
@@ -68,6 +68,15 @@ class SupportLazyCollectionTest extends TestCase
             'b' => 2,
             'c' => 3,
         ], $data->all());
+    }
+
+    public function testCanCreateCollectionFromNonGeneratorFunction()
+    {
+        $data = LazyCollection::make(function () {
+            return "laravel";
+        });
+
+        $this->assertSame(["laravel"], $data->all());
     }
 
     public function testDoesNotCreateCollectionFromGenerator()


### PR DESCRIPTION
# Introduction
LazyCollection accepts a generator function instead of a Generator in its constructor so that it can be called many times.
However, there is no logic implemented to check at runtime whether a received closure is really a generator function.
So, for example, if you pass the following Closure to LazyCollection::make()

```php
$lazy = LazyCollection::make(fn (): string => "foo");
```

Calling LazyCollection::getIterator() will result in the following error
> Illuminate\Support\LazyCollection::getIterator(): Return value must be of type Traversable, string returned

This is because LazyCollection::makeIterator() called in LazyCollection::getIterator() returns the result of executing the function even if it is not a generator function.

# What changed?
The original code looked like this

```php
protected function makeIterator($source)
{
    if ($source instanceof IteratorAggregate) {
        return $source->getIterator();
    }

    if (is_array($source)) {
        return new ArrayIterator($source);
    }

    return $source();
}
```

It is not known if $source is callable in the first place, and even if it is, it is not known if it returns Traversable or not.
Therefore, the following modifications have been made

```php
protected function makeIterator($source)
{
    if ($source instanceof IteratorAggregate) {
        return $source->getIterator();
    }

    if (is_array($source)) {
        return new ArrayIterator($source);
    }

    if (is_callable($source)) {
        $maybeTraversable = $source();
        return $maybeTraversable instanceof Traversable
            ? $maybeTraversable
            : new ArrayIterator((array)$maybeTraversable);
    }

    return new ArrayIterator((array)$source);
}
```

I considered throwing an exception if $source was not a generator function, but seeing that LazyCollection::getArrayableItems() converts $item to an array of any value, I decided that makeIterator should do the same I decided that makeIterator should do the same.

# Why wasn't this done in the constructor?
If you want to achieve the above in the constructor, use
- Use ReflectionFunction::isGenerator(), etc.
- Actually execute the function and check the return type.

However, I wanted to avoid the overhead of using Reflection as much as possible, and I also wanted to avoid wasting data in memory when a closure is executed in the constructor and an Iterator is returned.

thank you.