### PR TITLE
Adds more `Regular Expression` methods 🔎

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -40,6 +40,30 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters must equals the given length.
+     *
+     * @param  array|string  $parameters
+     * @param  int  $length
+     * @return $this
+     */
+    public function whereLength($parameters, int $length)
+    {
+        return $this->assignExpressionToParameters($parameters, '[0-9]{'.$length.'}');
+    }
+
+    /**
+     * Specify that the given route parameters must equals the given value.
+     *
+     * @param  array|string  $parameters
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereEquals($parameters, $value)
+    {
+        return $this->assignExpressionToParameters($parameters, '('.$value.')');
+    }
+
+    /**
      * Specify that the given route parameters must be ULIDs.
      *
      * @param  array|string  $parameters

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -83,6 +83,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar whereAlpha(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereAlphaNumeric(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereNumber(array|string $parameters)
+ * @method static \Illuminate\Routing\RouteRegistrar whereLength(array|string $parameters, int $length)
+ * @method static \Illuminate\Routing\RouteRegistrar whereEquals(array|string $parameters, mixed $value)
  * @method static \Illuminate\Routing\RouteRegistrar whereUlid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUuid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereIn(array|string $parameters, array $values)


### PR DESCRIPTION
This PR adds more useful `Regular Expression Route` methods that save many of lines code. Let's see the next scenario for more illustration 👀.

## BEFORE accepting the PR

```PHP
/**
 * Display the given integer value.
 *
 * @param  int  $id
 * @return int
 */
public function show($id)
{
    // Checking if the length of `$id` is 1
    if (strlen($id) != 1) {
        abort(404);
    }

    // Checking if the `$id` value equals 1
    if ($id != 1) {
        abort(404);
    }

    return $id;
}
```

Let's see the magic of the new two methods 🎉

## AFTER accepting the PR

```PHP
Route::get('users/{user}', function ($user) {
    return $user;
})
    ->whereLength('user', 1)
    ->whereEquals('user', 1);
```