### PR TITLE
[9.x] Ability to attach multiple in-memory data in MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -278,6 +278,21 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
+     * Attach multiple in-memory data as an attachments.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function attachManyData(array $data)
+    {
+        foreach ($data as $item) {
+            $this->attachData(...$item);
+        }
+
+        return $this;
+    }
+    
+    /**
      * Add a tag header to the message when supported by the underlying transport.
      *
      * @param  string  $value


### PR DESCRIPTION
If we have an unknown number of elements to be attached, we have to do a foreach loop, which looks nasty.

The `attachManyData()` method is much cleaner.

```php
    return (new MailMessage())
           ->attachManyData([
                [
                    $first_file,
                    'filename.pdf',
                    ['mime' => 'application/pdf']
                ],
                [
                    $second_file,
                    'filename.jpeg',
                    ['mime' => 'image/jpg']
                ],
            ]);
````