### PR TITLE
[9.x] Ensure subsiquent calls to `Mailable->to()` overwrite previous entries

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -695,7 +695,9 @@ class Mailable implements MailableContract, Renderable
         }
 
         $this->{$property} = collect($this->{$property})
+            ->reverse()
             ->unique('address')
+            ->reverse()
             ->values()
             ->all();
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -30,9 +30,8 @@ class MailMailableTest extends TestCase
         $mailable->to('taylor@laravel.com', 'Taylor Otwell');
 
         // Add the same recipient again, but with a different name. This should set the name correctly.
-        $this->assertTrue($mailable->hasTo('taylor@laravel.com','Taylor Otwell'));
+        $this->assertTrue($mailable->hasTo('taylor@laravel.com', 'Taylor Otwell'));
         $mailable->assertHasTo('taylor@laravel.com', 'Taylor Otwell');
-
 
         $mailable = new WelcomeMailableStub;
         $mailable->to('taylor@laravel.com', 'Taylor Otwell');

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -27,6 +27,12 @@ class MailMailableTest extends TestCase
         $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->to);
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
         $mailable->assertHasTo('taylor@laravel.com');
+        $mailable->to('taylor@laravel.com', 'Taylor Otwell');
+
+        // Add the same recipient again, but with a different name. This should set the name correctly.
+        $this->assertTrue($mailable->hasTo('taylor@laravel.com','Taylor Otwell'));
+        $mailable->assertHasTo('taylor@laravel.com', 'Taylor Otwell');
+
 
         $mailable = new WelcomeMailableStub;
         $mailable->to('taylor@laravel.com', 'Taylor Otwell');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes a bug introduced by #45119 where subsequent calls to `->to()` with a different name will not take effect.
We do this by reversing the collection before the call to `unique` and then reversing it back.

A test for this functionality has been added to `MailMailableTest::testMailableSetsRecipientsCorrectly()`

More context - https://github.com/laravel/framework/pull/45119#issuecomment-1410285596