### PR TITLE
Added min, max, minlength, maxlength and autofocus directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -374,6 +374,19 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a max block into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileMax($expression)
+    {
+        $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
+
+        return "<?php if({$parts[0]}): echo 'max=\'{$parts[1]}\''; endif; ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -381,6 +381,10 @@ trait CompilesConditionals
     {
         $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
 
+        if (count($parts) === 1) {
+            return "<?php echo 'min=\'{$parts[0]}\''; endif; ?>";
+        }
+
         return "<?php if({$parts[0]}): echo 'min=\'{$parts[1]}\''; endif; ?>";
     }
 
@@ -393,6 +397,10 @@ trait CompilesConditionals
     protected function compileMax($expression)
     {
         $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
+
+        if (count($parts) === 1) {
+            return "<?php echo 'max=\'{$parts[0]}\''; endif; ?>";
+        }
 
         return "<?php if({$parts[0]}): echo 'max=\'{$parts[1]}\''; endif; ?>";
     }
@@ -407,6 +415,10 @@ trait CompilesConditionals
     {
         $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
 
+        if (count($parts) === 1) {
+            return "<?php echo 'minlength=\'{$parts[0]}\''; endif; ?>";
+        }
+
         return "<?php if({$parts[0]}): echo 'minlength=\'{$parts[1]}\''; endif; ?>";
     }
 
@@ -419,6 +431,10 @@ trait CompilesConditionals
     protected function compileMaxlength($expression)
     {
         $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
+
+        if (count($parts) === 1) {
+            return "<?php echo 'maxlength=\'{$parts[0]}\''; endif; ?>";
+        }
 
         return "<?php if({$parts[0]}): echo 'maxlength=\'{$parts[1]}\''; endif; ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -387,6 +387,19 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a minlength block into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileMinlength($expression)
+    {
+        $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
+
+        return "<?php if({$parts[0]}): echo 'minlength=\'{$parts[1]}\''; endif; ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -361,6 +361,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile an autofocus block into valid PHP.
+     *
+     * @param  string  $condition
+     * @return string
+     */
+    protected function compileAutofocus($condition)
+    {
+        return "<?php if{$condition}: echo 'autofocus'; endif; ?>";
+    }
+
+    /**
      * Compile a min block into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -361,6 +361,19 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a min block into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileMin($expression)
+    {
+        $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
+
+        return "<?php if({$parts[0]}): echo 'min=\'{$parts[1]}\''; endif; ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -400,6 +400,19 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a maxlength block into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileMaxlength($expression)
+    {
+        $parts = array_map('trim', explode(',', $this->stripParentheses($expression), 2));
+
+        return "<?php if({$parts[0]}): echo 'maxlength=\'{$parts[1]}\''; endif; ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -52,10 +52,26 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testMinStatementsWithoutConditionAreCompiled()
+    {
+        $string = '<input @min(1)/>';
+        $expected = "<input <?php echo 'min=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testMaxStatementsAreCompiled()
     {
         $string = '<input @max(name(foo(bar)), 1)/>';
         $expected = "<input <?php if(name(foo(bar))): echo 'max=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaxStatementsWithoutConditionAreCompiled()
+    {
+        $string = '<input @max(1)/>';
+        $expected = "<input <?php echo 'max=\'1\''; endif; ?>/>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
@@ -68,10 +84,26 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testMinlengthStatementsWithoutConditionAreCompiled()
+    {
+        $string = '<input @minlength(1)/>';
+        $expected = "<input <?php echo 'minlength=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testMaxlengthStatementsAreCompiled()
     {
         $string = '<input @maxlength(name(foo(bar)), 1)/>';
         $expected = "<input <?php if(name(foo(bar))): echo 'maxlength=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaxlengthStatementsWithoutConditionAreCompiled()
+    {
+        $string = '<input @maxlength(1)/>';
+        $expected = "<input <?php echo 'maxlength=\'1\''; endif; ?>/>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -59,4 +59,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testMaxlengthStatementsAreCompiled()
+    {
+        $string = '<input @maxlength(name(foo(bar)), 1)/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'maxlength=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -43,4 +43,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testMaxStatementsAreCompiled()
+    {
+        $string = '<input @max(name(foo(bar)), 1)/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'max=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -36,6 +36,14 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testAutofocusStatementsAreCompiled()
+    {
+        $string = '<input @autofocus(name(foo(bar)))/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'autofocus'; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testMinStatementsAreCompiled()
     {
         $string = '<input @min(name(foo(bar)), 1)/>';

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -51,4 +51,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testMinlengthStatementsAreCompiled()
+    {
+        $string = '<input @minlength(name(foo(bar)), 1)/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'minlength=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -35,4 +35,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testMinStatementsAreCompiled()
+    {
+        $string = '<input @min(name(foo(bar)), 1)/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'min=\'1\''; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR provides the use of `min`, `max`, `minlength`, `maxlength` and `autofocus` HTML directives via Blade directives 💅🏻

This will allow developers to have a better experience when setting these directives in `<input>` tag, while make it more readable.
It will be especially useful in the case of forms generated dynamically using user-defined values.

Example:
Transform this
```blade
<input type="{{$something->type}}"
       @required($something->required)
       {{ $something->primary ? 'autofocus' : '' }}
       {{ $something->min > 0 ? 'min="' . $something->min . '"' : '' }}
       {{ $something->max > 0 ? 'max="' . $something->max . '"' : '' }}
       {{ $something->minlength > 0 ? 'minlength="' . $something->minlength . '"' : '' }}
       {{ $something->maxlength > 0 ? 'maxlength="' . $something->maxlength . '"' : '' }}
>
```

into this
```blade
<input type="{{$something->type}}"
       @required($something->required)
       @autofocus($something->primary)
       @min($something->min > 0, $something->min)
       @max($something->max > 0, $something->max)
       @minlength($something->minlength > 0, $something->minlength)
       @maxlength($something->maxlength > 0, $something->maxlength)
>
```