### PR TITLE
test.sh Use docker compose v2 syntax as default. Use docker-compose v1 syntax as fallback.

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -13,7 +13,7 @@ while true; do
 done
 
 if $down; then
-    docker-compose down -t 0
+    docker compose down -t 0 || docker-compose down -t 0
 
     exit 0
 fi
@@ -27,7 +27,7 @@ fi
 
 echo "Ensuring services are running"
 
-docker-compose up -d
+docker compose up -d || docker-compose up -d
 
 if docker run -it --rm "registry.gitlab.com/grahamcampbell/php:$php-base" -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=docker.for.mac.localhost;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"; then
     echo "Running tests"
@@ -45,6 +45,6 @@ if docker run -it --rm "registry.gitlab.com/grahamcampbell/php:$php-base" -r "\$
         exit 1
     fi
 else
-    docker-compose logs
+    docker compose logs || docker-compose logs
     exit 1
 fi


### PR DESCRIPTION
v1 syntax: `docker-compose ...`
v2 syntax: `docker compose ...`

The `test.sh` file is currently using the docker compose v1 syntax. I noticed this because I tried to run the tests before working on another unrelated PR. When I tried to run the tests, I got an error because I don't have the v1 version of docker-compose installed.

I think it is an appropriate time to switch over the `test.sh` script to favor the v2 syntax, as Docker Inc. will soon be phasing out v1 as seen here. https://docs.docker.com/compose/compose-v2/
![image](https://user-images.githubusercontent.com/84747244/215895442-11f0a3a9-7527-4be3-b408-0d8d9931f2c0.png)

V2 is a drop-in replacement for v1, so the same commands work fine. I think it ultimately benefits us because new contributors should not run into an error for having the recommended version of docker compose installed. The v1 syntax is still used as a fallback if the contributor only has docker compose v1 installed.