### PR TITLE
Built in Auth Notification classes implement ShouldQueue interface and Queueable trait

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Auth\Notifications;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Lang;
 
-class ResetPassword extends Notification
+class ResetPassword extends Notification implements ShouldQueue
 {
+    use Queueable;
     /**
      * The password reset token.
      *

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Auth\Notifications;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Carbon;
@@ -9,8 +11,9 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\URL;
 
-class VerifyEmail extends Notification
+class VerifyEmail extends Notification implements ShouldQueue
 {
+    use Queueable;
     /**
      * The callback that should be used to create the verify email URL.
      *


### PR DESCRIPTION
I think the `ResetPassword` and `VerifyEmail` notifications should implement the `ShouldQueue` interface and `Queueable` trait by default. This does not effect the current default behavior because the default queue driver is set to `sync` in the `.env`. 

This benefits the end users because it maintains the current functionality, and also allows the user to seamlessly utilize a queue driver for the `ResetPassword` and `VerifyEmail` notifications.

I recently needed to use a background queue to send these notifications, and I had to dig inside the `vendor` directory to find these base classes, create new classes that extend these and manually add the `ShouldQueue` interface + `Queueable` trait. I think that friction is avoidable and it would simply be better to have that done in the core.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
