### PR TITLE
[10.x] Add support to handle exceptions on Timebox

### DIFF
--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -22,14 +22,23 @@ class Timebox
      */
     public function call(callable $callback, int $microseconds)
     {
+        $exception = null;
         $start = microtime(true);
 
-        $result = $callback($this);
+        try {
+            $result = $callback($this);
+        } catch (\Throwable $caugth) {
+            $exception = $caugth;
+        }
 
         $remainder = intval($microseconds - ((microtime(true) - $start) * 1000000));
 
         if (! $this->earlyReturn && $remainder > 0) {
             $this->usleep($remainder);
+        }
+
+        if ($exception) {
+            throw $exception;
         }
 
         return $result;

--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support;
 
+use Throwable;
+
 class Timebox
 {
     /**
@@ -23,12 +25,13 @@ class Timebox
     public function call(callable $callback, int $microseconds)
     {
         $exception = null;
+
         $start = microtime(true);
 
         try {
             $result = $callback($this);
-        } catch (\Throwable $caugth) {
-            $exception = $caugth;
+        } catch (Throwable $caught) {
+            $exception = $caught;
         }
 
         $remainder = intval($microseconds - ((microtime(true) - $start) * 1000000));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PR #44069 introduced the Timebox class, which "aims to guard against timing attacks at the application".

Unfortunately, if the Timebox callback throws an Exception, the Timebox guard is bypassed, even if the developer handles this exception gracefully somewhere else.

An example: when implementing a custom guard that verifies a remote service, this verification can fail, bypassing the timebox guard entirely.

This PR:

- Adds support to handle exceptions thrown during a Timebox's callback execution
- Adds relevant test cases

