### PR TITLE
[9.x] Add pending has-many-through and has-one-through builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -338,21 +338,6 @@ trait HasRelationships
     }
 
     /**
-     * Create a pending has-many-through or has-one-through relationship.
-     *
-     * @param  string|\Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne  $relationship
-     * @return \Illuminate\Database\Eloquent\PendingHasThroughRelationship
-     */
-    public function through($relationship)
-    {
-        if (is_string($relationship)) {
-            $relationship = $this->{$relationship}();
-        }
-
-        return new PendingHasThroughRelationship($this, $relationship);
-    }
-
-    /**
      * Retrieve the actual class name for a given morph class.
      *
      * @param  string  $class
@@ -373,6 +358,21 @@ trait HasRelationships
         [$one, $two, $caller] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
 
         return $caller['function'];
+    }
+
+    /**
+     * Create a pending has-many-through or has-one-through relationship.
+     *
+     * @param  string|\Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne  $relationship
+     * @return \Illuminate\Database\Eloquent\PendingHasThroughRelationship
+     */
+    public function through($relationship)
+    {
+        if (is_string($relationship)) {
+            $relationship = $this->{$relationship}();
+        }
+
+        return new PendingHasThroughRelationship($this, $relationship);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -7,6 +7,7 @@ use Illuminate\Database\ClassMorphViolationException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\PendingHasThroughRelationship;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -334,6 +335,17 @@ trait HasRelationships
     protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
     {
         return new MorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation);
+    }
+
+    /**
+     * Create a pending has-many-through or has-one-through relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne  $localRelationship
+     * @return \Illuminate\Database\Eloquent\PendingHasThroughRelationship
+     */
+    public function through($localRelationship)
+    {
+        return new PendingHasThroughRelationship($this, $localRelationship);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -340,12 +340,16 @@ trait HasRelationships
     /**
      * Create a pending has-many-through or has-one-through relationship.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne  $localRelationship
+     * @param  string|\Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne  $relationship
      * @return \Illuminate\Database\Eloquent\PendingHasThroughRelationship
      */
-    public function through($localRelationship)
+    public function through($relationship)
     {
-        return new PendingHasThroughRelationship($this, $localRelationship);
+        if (is_string($relationship)) {
+            $relationship = $this->{$relationship}();
+        }
+
+        return new PendingHasThroughRelationship($this, $relationship);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2310,7 +2310,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $resolver($this);
         }
 
-        if (Str::startsWith($method, 'through') && method_exists($this, $relationMethod = Str::of($method)->after('through')->lcfirst()->toString())) {
+        if (Str::startsWith($method, 'through') &&
+            method_exists($this, $relationMethod = Str::of($method)->after('through')->lcfirst()->toString())) {
             return $this->through($relationMethod);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2310,6 +2310,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $resolver($this);
         }
 
+        if (Str::startsWith($method, 'through') && method_exists($this, $relationMethod = Str::of($method)->after('through')->lcfirst()->toString())) {
+            return $this->through($relationMethod);
+        }
+
         return $this->forwardCallTo($this->newQuery(), $method, $parameters);
     }
 

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PendingHasThroughRelationship
+{
+    /**
+     * The root model that the relationship exists on.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $rootModel;
+
+    /**
+     * The local relationship.
+     *
+     * @var \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    protected $localRelationship;
+
+    /**
+     * Create a pending has-many-through or has-one-through relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $rootModel
+     * @param  \Illuminate\Database\Eloquent\Relations\HasMany|\Illuminate\Database\Eloquent\Relations\HasOne  $localRelationship
+     */
+    public function __construct($rootModel, $localRelationship)
+    {
+        $this->rootModel = $rootModel;
+
+        $this->localRelationship = $localRelationship;
+    }
+
+    /**
+     * Define the distant relationship that this model has.
+     *
+     * @param  (callable(\Illuminate\Database\Eloquent\Model): (\Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\HasMany))  $callback
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough|\Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function has($callback)
+    {
+        $distantRelation = $callback($this->localRelationship->getRelated());
+
+        if ($distantRelation instanceof HasMany) {
+            return $this->rootModel->hasManyThrough(
+                $distantRelation->getRelated()::class,
+                $this->localRelationship->getRelated()::class,
+                $this->localRelationship->getForeignKeyName(),
+                $distantRelation->getForeignKeyName(),
+                $this->localRelationship->getLocalKeyName(),
+                $distantRelation->getLocalKeyName(),
+            );
+        }
+
+        return $this->rootModel->hasOneThrough(
+            $distantRelation->getRelated()::class,
+            $this->localRelationship->getRelated()::class,
+            $this->localRelationship->getForeignKeyName(),
+            $distantRelation->getForeignKeyName(),
+            $this->localRelationship->getLocalKeyName(),
+            $distantRelation->getLocalKeyName(),
+        );
+    }
+}

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use BadMethodCallException;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 class PendingHasThroughRelationship
 {
@@ -66,5 +68,23 @@ class PendingHasThroughRelationship
             $this->localRelationship->getLocalKeyName(),
             $distantRelation->getLocalKeyName(),
         );
+    }
+
+    /**
+     * Handle dynamic method calls into the model.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (Str::startsWith($method, 'has')) {
+            return $this->has(Str::of($method)->after('has')->lcfirst()->toString());
+        }
+
+        throw new BadMethodCallException(sprintf(
+            'Call to undefined method %s::%s()', static::class, $method
+        ));
     }
 }

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -36,11 +36,15 @@ class PendingHasThroughRelationship
     /**
      * Define the distant relationship that this model has.
      *
-     * @param  (callable(\Illuminate\Database\Eloquent\Model): (\Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\HasMany))  $callback
+     * @param  string|(callable(\Illuminate\Database\Eloquent\Model): (\Illuminate\Database\Eloquent\Relations\HasOne|\Illuminate\Database\Eloquent\Relations\HasMany))  $callback
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough|\Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
     public function has($callback)
     {
+        if (is_string($callback)) {
+            $callback = fn () => $this->localRelationship->getRelated()->{$callback}();
+        }
+
         $distantRelation = $callback($this->localRelationship->getRelated());
 
         if ($distantRelation instanceof HasMany) {

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -2,15 +2,9 @@
 
 namespace Illuminate\Tests\Database\EloquentRelationshipsTest;
 
-use Illuminate\Database\Query\Grammars\Grammar;
-use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Connection;
-use Mockery as m;
-use Illuminate\Database\Query\Builder as BaseBuilder;
-use Illuminate\Database\ConnectionResolver;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\PendingHasThroughRelationship;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -21,7 +15,10 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Support\Fluent;
+use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentRelationshipsTest extends TestCase

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -122,7 +122,8 @@ class DatabaseEloquentRelationshipsTest extends TestCase
     public function testStringyHasThroughApi()
     {
         $fluent = (new FluentMechanic())->owner();
-        $stringy = (new class extends FluentMechanic {
+        $stringy = (new class extends FluentMechanic
+        {
             public function owner()
             {
                 return $this->through('car')->has('owner');
@@ -150,7 +151,8 @@ class DatabaseEloquentRelationshipsTest extends TestCase
         $this->assertSame('cars.mechanic_id', $fluent->getQualifiedFirstKeyName());
 
         $fluent = (new FluentProject())->deployments();
-        $stringy = (new class extends FluentProject {
+        $stringy = (new class extends FluentProject
+        {
             public function deployments()
             {
                 return $this->through('environments')->has('deployments');
@@ -181,7 +183,8 @@ class DatabaseEloquentRelationshipsTest extends TestCase
     public function testHigherOrderHasThroughApi()
     {
         $fluent = (new FluentMechanic())->owner();
-        $higher = (new class extends FluentMechanic {
+        $higher = (new class extends FluentMechanic
+        {
             public function owner()
             {
                 return $this->throughCar()->hasOwner();
@@ -209,8 +212,8 @@ class DatabaseEloquentRelationshipsTest extends TestCase
         $this->assertSame('cars.mechanic_id', $fluent->getQualifiedFirstKeyName());
 
         $fluent = (new FluentProject())->deployments();
-        $higher = (new class extends FluentProject {
-
+        $higher = (new class extends FluentProject
+        {
             public function deployments()
             {
                 return $this->through($this->environments())->has(fn ($env) => $env->deployments());

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -2,8 +2,15 @@
 
 namespace Illuminate\Tests\Database\EloquentRelationshipsTest;
 
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Connection;
+use Mockery as m;
+use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\ConnectionResolver;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\PendingHasThroughRelationship;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -14,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Fluent;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentRelationshipsTest extends TestCase
@@ -73,6 +81,27 @@ class DatabaseEloquentRelationshipsTest extends TestCase
 
         // we must unset relation even if attributes are clean
         $this->assertFalse($post->relationLoaded('author'));
+    }
+
+    public function testPendingHasThroughRelationship()
+    {
+        $classic = (new FluentMechanic())->owner();
+        $fluent = (new ClassicMechanic())->owner();
+
+        $this->assertInstanceOf(HasOneThrough::class, $fluent);
+        $this->assertInstanceOf(HasOneThrough::class, $classic);
+        $this->assertSame('m_id', $fluent->getLocalKeyName());
+        $this->assertSame('m_id', $classic->getLocalKeyName());
+        $this->assertSame('c_id', $fluent->getSecondLocalKeyName());
+        $this->assertSame('c_id', $classic->getSecondLocalKeyName());
+        $this->assertSame('mechanic_id', $fluent->getFirstKeyName());
+        $this->assertSame('mechanic_id', $classic->getFirstKeyName());
+        $this->assertSame('car_id', $fluent->getForeignKeyName());
+        $this->assertSame('car_id', $classic->getForeignKeyName());
+        $this->assertSame('classic_mechanics.m_id', $fluent->getQualifiedLocalKeyName());
+        $this->assertSame('fluent_mechanics.m_id', $classic->getQualifiedLocalKeyName());
+        $this->assertSame('cars.mechanic_id', $classic->getQualifiedFirstKeyName());
+        $this->assertSame('cars.mechanic_id', $fluent->getQualifiedFirstKeyName());
     }
 }
 
@@ -240,4 +269,93 @@ class CustomMorphToMany extends MorphToMany
 class CustomMorphTo extends MorphTo
 {
     //
+}
+
+class Car extends Model
+{
+    public function owner()
+    {
+        return $this->hasOne(Owner::class, 'car_id', 'c_id');
+    }
+
+    public function getConnection()
+    {
+        $mock = m::mock(Connection::class);
+        $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
+        $grammar->shouldReceive('getBitwiseOperators')->andReturn([]);
+        $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
+        $mock->shouldReceive('getName')->andReturn('name');
+        $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {
+            return new BaseBuilder($mock, $grammar, $processor);
+        });
+
+        return $mock;
+    }
+}
+
+class Owner extends Model
+{
+    public function getConnection()
+    {
+        $mock = m::mock(Connection::class);
+        $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
+        $grammar->shouldReceive('getBitwiseOperators')->andReturn([]);
+        $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
+        $mock->shouldReceive('getName')->andReturn('name');
+        $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {
+            return new BaseBuilder($mock, $grammar, $processor);
+        });
+
+        return $mock;
+    }
+}
+
+class FluentMechanic extends Model
+{
+    public function owner()
+    {
+        return $this->through($this->car())
+            ->has(fn (Car $car) => $car->owner());
+    }
+
+    public function car()
+    {
+        return $this->hasOne(Car::class, 'mechanic_id', 'm_id');
+    }
+
+    public function getConnection()
+    {
+        $mock = m::mock(Connection::class);
+        $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
+        $grammar->shouldReceive('getBitwiseOperators')->andReturn([]);
+        $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
+        $mock->shouldReceive('getName')->andReturn('name');
+        $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {
+            return new BaseBuilder($mock, $grammar, $processor);
+        });
+
+        return $mock;
+    }
+}
+
+class ClassicMechanic extends Model
+{
+    public function owner()
+    {
+        return $this->hasOneThrough(Owner::class, Car::class, 'mechanic_id', 'car_id', 'm_id', 'c_id');
+    }
+
+    public function getConnection()
+    {
+        $mock = m::mock(Connection::class);
+        $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
+        $grammar->shouldReceive('getBitwiseOperators')->andReturn([]);
+        $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
+        $mock->shouldReceive('getName')->andReturn('name');
+        $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {
+            return new BaseBuilder($mock, $grammar, $processor);
+        });
+
+        return $mock;
+    }
 }

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -82,40 +82,99 @@ class DatabaseEloquentRelationshipsTest extends TestCase
 
     public function testPendingHasThroughRelationship()
     {
-        $classic = (new FluentMechanic())->owner();
-        $fluent = (new ClassicMechanic())->owner();
+        $fluent = (new FluentMechanic())->owner();
+        $classic = (new ClassicMechanic())->owner();
+
+        $this->assertInstanceOf(HasOneThrough::class, $classic);
+        $this->assertInstanceOf(HasOneThrough::class, $fluent);
+        $this->assertSame('m_id', $classic->getLocalKeyName());
+        $this->assertSame('m_id', $fluent->getLocalKeyName());
+        $this->assertSame('c_id', $classic->getSecondLocalKeyName());
+        $this->assertSame('c_id', $fluent->getSecondLocalKeyName());
+        $this->assertSame('mechanic_id', $classic->getFirstKeyName());
+        $this->assertSame('mechanic_id', $fluent->getFirstKeyName());
+        $this->assertSame('car_id', $classic->getForeignKeyName());
+        $this->assertSame('car_id', $fluent->getForeignKeyName());
+        $this->assertSame('classic_mechanics.m_id', $classic->getQualifiedLocalKeyName());
+        $this->assertSame('fluent_mechanics.m_id', $fluent->getQualifiedLocalKeyName());
+        $this->assertSame('cars.mechanic_id', $fluent->getQualifiedFirstKeyName());
+        $this->assertSame('cars.mechanic_id', $classic->getQualifiedFirstKeyName());
+
+        $fluent = (new FluentProject())->deployments();
+        $classic = (new ClassicProject())->deployments();
+
+        $this->assertInstanceOf(HasManyThrough::class, $classic);
+        $this->assertInstanceOf(HasManyThrough::class, $fluent);
+        $this->assertSame('p_id', $classic->getLocalKeyName());
+        $this->assertSame('p_id', $fluent->getLocalKeyName());
+        $this->assertSame('e_id', $classic->getSecondLocalKeyName());
+        $this->assertSame('e_id', $fluent->getSecondLocalKeyName());
+        $this->assertSame('pro_id', $classic->getFirstKeyName());
+        $this->assertSame('pro_id', $fluent->getFirstKeyName());
+        $this->assertSame('env_id', $classic->getForeignKeyName());
+        $this->assertSame('env_id', $fluent->getForeignKeyName());
+        $this->assertSame('classic_projects.p_id', $classic->getQualifiedLocalKeyName());
+        $this->assertSame('fluent_projects.p_id', $fluent->getQualifiedLocalKeyName());
+        $this->assertSame('environments.pro_id', $fluent->getQualifiedFirstKeyName());
+        $this->assertSame('environments.pro_id', $classic->getQualifiedFirstKeyName());
+    }
+
+    public function testStringyHasThroughApi()
+    {
+        $fluent = (new FluentMechanic())->owner();
+        $stringy = (new class extends FluentMechanic {
+            public function owner()
+            {
+                return $this->through('car')->has('owner');
+            }
+
+            public function getTable()
+            {
+                return 'stringy_mechanics';
+            }
+        })->owner();
 
         $this->assertInstanceOf(HasOneThrough::class, $fluent);
-        $this->assertInstanceOf(HasOneThrough::class, $classic);
+        $this->assertInstanceOf(HasOneThrough::class, $stringy);
         $this->assertSame('m_id', $fluent->getLocalKeyName());
-        $this->assertSame('m_id', $classic->getLocalKeyName());
+        $this->assertSame('m_id', $stringy->getLocalKeyName());
         $this->assertSame('c_id', $fluent->getSecondLocalKeyName());
-        $this->assertSame('c_id', $classic->getSecondLocalKeyName());
+        $this->assertSame('c_id', $stringy->getSecondLocalKeyName());
         $this->assertSame('mechanic_id', $fluent->getFirstKeyName());
-        $this->assertSame('mechanic_id', $classic->getFirstKeyName());
+        $this->assertSame('mechanic_id', $stringy->getFirstKeyName());
         $this->assertSame('car_id', $fluent->getForeignKeyName());
-        $this->assertSame('car_id', $classic->getForeignKeyName());
-        $this->assertSame('classic_mechanics.m_id', $fluent->getQualifiedLocalKeyName());
-        $this->assertSame('fluent_mechanics.m_id', $classic->getQualifiedLocalKeyName());
-        $this->assertSame('cars.mechanic_id', $classic->getQualifiedFirstKeyName());
+        $this->assertSame('car_id', $stringy->getForeignKeyName());
+        $this->assertSame('fluent_mechanics.m_id', $fluent->getQualifiedLocalKeyName());
+        $this->assertSame('stringy_mechanics.m_id', $stringy->getQualifiedLocalKeyName());
+        $this->assertSame('cars.mechanic_id', $stringy->getQualifiedFirstKeyName());
         $this->assertSame('cars.mechanic_id', $fluent->getQualifiedFirstKeyName());
 
-        $classic = (new FluentProject())->deployments();
-        $fluent = (new ClassicProject())->deployments();
+        $fluent = (new FluentProject())->deployments();
+        $stringy = (new class extends FluentProject {
+            public function deployments()
+            {
+                return $this->through('environments')->has('deployments');
+            }
+
+            public function getTable()
+            {
+                return 'stringy_projects';
+            }
+        })->deployments();
 
         $this->assertInstanceOf(HasManyThrough::class, $fluent);
-        $this->assertInstanceOf(HasManyThrough::class, $classic);
+        $this->assertInstanceOf(HasManyThrough::class, $stringy);
         $this->assertSame('p_id', $fluent->getLocalKeyName());
-        $this->assertSame('p_id', $classic->getLocalKeyName());
+        $this->assertSame('p_id', $stringy->getLocalKeyName());
         $this->assertSame('e_id', $fluent->getSecondLocalKeyName());
-        $this->assertSame('e_id', $classic->getSecondLocalKeyName());
+        $this->assertSame('e_id', $stringy->getSecondLocalKeyName());
         $this->assertSame('pro_id', $fluent->getFirstKeyName());
-        $this->assertSame('pro_id', $classic->getFirstKeyName());
+        $this->assertSame('pro_id', $stringy->getFirstKeyName());
         $this->assertSame('env_id', $fluent->getForeignKeyName());
-        $this->assertSame('env_id', $classic->getForeignKeyName());
-        $this->assertSame('classic_projects.p_id', $fluent->getQualifiedLocalKeyName());
-        $this->assertSame('fluent_projects.p_id', $classic->getQualifiedLocalKeyName());
-        $this->assertSame('environments.pro_id', $classic->getQualifiedFirstKeyName());
+        $this->assertSame('env_id', $stringy->getForeignKeyName());
+        $this->assertSame('fluent_projects.p_id', $fluent->getQualifiedLocalKeyName());
+        $this->assertSame('stringy_projects.p_id', $stringy->getQualifiedLocalKeyName());
+        $this->assertSame('environments.pro_id', $stringy->getQualifiedFirstKeyName());
         $this->assertSame('environments.pro_id', $fluent->getQualifiedFirstKeyName());
     }
 }


### PR DESCRIPTION
Alternative to and inspired by https://github.com/laravel/framework/pull/45826

This PR takes a slightly different approach. Everything is just using standard `HasMany` or `HasOne` relationships with standard key ordering. Essentially there is no new concept to learn.

I also feel by starting the chain with "through" it personally helps my mental model of what is happening.


_"From A through B give me C"_

```php
$a->through($a->b())->has(fn ($b) => $b->c());
```

# HasManyThrough

Using the examples from the docs, and assuming we have the relationships already defined...

```php
class Project extends Model
{
    public function environments()
    {
        return $this->hasMany(Environment::class);
    }
}

class Environment extends Model
{
    public function deployments()
    {
        return $this->hasMany(Deployment::class);
    }
}

class Deployment extends Model
{
    //
}
```


This allows us to use those relationships to define our has-many-through relationship on the `Project`:

```php
class Project extends Model
{
    public function deployments()
    {
        return $this->through($this->environments())
            ->has(fn (Environment $env) => $env->deployments());
    }

    public function environments()
    {
        return $this->hasMany(Environment::class);
    }
}
```

The closure passed to the `has()` method receives an instance of the `Environment` model.

# HasOneThrough

There is not a new API for this method. Using the example from the docs...


```php
class Mechanic extends Model
{
    public function car()
    {
         return $this->hasOne(Car::class);
    }
}


class Car extends Model
{
    public function owner()
    {
         return $this->hasOne(Owner::class);
    }
}

class Owner extends Model
{
    //
}
```

We may use these existing relationships to create a hasOneThrough relationship.

```php
class Mechanic extends Model
{
    public function owner()
    {
        return $this->through($this->car())
            ->has(fn (Car $car) => $car->owner());
    }

    public function car()
    {
         return $this->hasOne(Car::class);
    }
}
```

# Creating relationships on the fly

These examples have all shown usage of exiting model relationships, but it is also possible to use this when relationships that you create on the fly. The additional keys are not required here, they are just there for illustration...

```php
class Project extends Model
{
    public function deployments()
    {
        return $this->through($this->hasMany(Project::class, 'project_id', 'id'))
            ->has(fn (Environment $env) => $env->hasMany(Deployment::class, 'environment_id'));
    }
}
```

```php
class Mechanic extends Model
{
    public function owner()
    {
        return $this->through($this->hasOne(Car::class, 'mechanic_id', 'id'))
            ->has(fn (Car $car) => $car->hasOne(Owner::class, 'car_id', 'id'));
    }
}
```

This means that the ordering or has many through disappears and all a developer needs to know is the standard parameters of `HasMany` and `HasOne`.

## String / Higher order API

The following APIs are all equivalent. 

```php

public function deployments()
{
    // explicit...
    return $this->through($this->environments())->has(fn ($env) => $env->deployments());

    // stringy...
    return $this->through('environments')->has('deployments');

    // magic...
    return $this->throughEnvironments()->hasDeployments();
}
```