### PR TITLE
bump symfony/http-kernel min requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/error-handler": "^6.0",
         "symfony/finder": "^6.0",
         "symfony/http-foundation": "^6.0",
-        "symfony/http-kernel": "^6.0",
+        "symfony/http-kernel": "^6.2.6",
         "symfony/mailer": "^6.0",
         "symfony/mime": "^6.0",
         "symfony/process": "^6.0",


### PR DESCRIPTION
This PR bumps the minimum version of `symfony/http-kernel` to 6.2.6 to address a security vulnerability identified in [this PR](https://github.com/symfony/http-kernel/commit/f7822a7c63681e6ad4cadb8f8c2943c9bc2d3e9a) which prevents caching of private headers via HttpCache.

PHP Insights flagged the security concern in one of our repo's:

![Screenshot 2023-02-01 at 10 44 07](https://user-images.githubusercontent.com/7163152/216021647-e7c4dfca-6bcc-47ce-aedb-fbdfa0537406.png)