### PR TITLE
fix: allow SMTP TLS to be set for all ports

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -172,7 +172,7 @@ class MailManager implements FactoryContract
         $factory = new EsmtpTransportFactory;
 
         $transport = $factory->create(new Dsn(
-            ! empty($config['encryption']) && $config['encryption'] === 'tls' ? (($config['port'] == 465) ? 'smtps' : 'smtp') : '',
+            ! empty($config['encryption']) && $config['encryption'] === 'tls' ? 'smtps' : '',
             $config['host'],
             $config['username'] ?? null,
             $config['password'] ?? null,


### PR DESCRIPTION
This reverts PR #40943
This resolves #45899

Basically, this allows for setting TLS settings on ports other than 465. If someone wants to use STARTTLS, they should set `MAIL_ENCRYPTION` to `null` and Symfony Mailer will automatically upgrade the connection if STARTTLS is available. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
