### PR TITLE
[9.x] Add missing tests for destroy method

### DIFF
--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -143,6 +143,17 @@ class EloquentDeleteTest extends DatabaseTestCase
         // Total of 3 queries.
         $this->assertCount(3, $logs);
 
+        // It can accept an array models
+        PostStringyKey::query()->delete();
+        $model1 = PostStringyKey::query()->create([]);
+        $model2 = PostStringyKey::query()->create([]);
+
+        $this->assertEquals(2, PostStringyKey::count());
+        $count = PostStringyKey::destroy([$model1, $model2]);
+        $this->assertEquals(0, $count);
+        // nothing is deleted
+        $this->assertEquals(2, PostStringyKey::count());
+
         PostStringyKey::reguard();
         unset($_SERVER['destroy']);
         Schema::drop('my_posts');


### PR DESCRIPTION
I think the reported backward incompatibility here: https://github.com/laravel/framework/pull/45709#issuecomment-1412345778 is not really a valid one.

## Why:
The reported example is passing an array of eloquent models into the destroy method, which has never been supported or documented.

The added test shows that if we pass an array of models into the destroy method (the implementation after the revert), depending on the driver either nothing gets deleted (in MySQL, Maria) or an error will be thrown (in Postgres or SQL server).