### PR TITLE
[9.x] Reverts https://github.com/laravel/framework/pull/45856 tests changes.

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -19,7 +19,7 @@ class FilesystemTest extends TestCase
      */
     public static function setUpTempDir()
     {
-        self::$tempDir = sys_get_temp_dir().'/tmp'.time();
+        self::$tempDir = sys_get_temp_dir().'/tmp';
         mkdir(self::$tempDir);
     }
 
@@ -97,25 +97,14 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($tempFile, 'Hello Taylor');
     }
 
-    public function testFilePermissionRestoredAfterReplace()
-    {
-        $tempFile = self::$tempDir.'/file.txt';
-        $filesystem = new Filesystem;
-        $filesystem->replace($tempFile, 'Hello World');
-        $umaskValue = umask();
-        $permissionValueInDecimal = (int) base_convert('777', 8, 10);
-        $actualPermission = $permissionValueInDecimal - $umaskValue;
-        $this->assertEquals($actualPermission, $this->getFilePermissions($tempFile));
-    }
-
     /**
      * @requires OS Linux|Darwin
      */
     public function testReplaceWhenUnixSymlinkExists()
     {
-        $tempFile = self::$tempDir.'/'.time().'file.txt';
-        $symlinkDir = self::$tempDir.'/'.time().'symlink_dir';
-        $symlink = "{$symlinkDir}/'.time().'symlink.txt";
+        $tempFile = self::$tempDir.'/file.txt';
+        $symlinkDir = self::$tempDir.'/symlink_dir';
+        $symlink = "{$symlinkDir}/symlink.txt";
 
         mkdir($symlinkDir);
         symlink($tempFile, $symlink);


### PR DESCRIPTION
This pull requests reverts some changes introduced by https://github.com/laravel/framework/pull/45856, that are making tests to fail on `9.x`.