### PR TITLE
[9.x] Helper - Set tag on object based on instanceof

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1076,7 +1076,7 @@ if (! function_exists('tag_instance_of')) {
         $cachedFile = app()->bootstrapPath('cache/tagged-instance-of-services.php');
         $taggedServices = [];
         if ($useCachedServices && $fileManager->isFile($cachedFile)) {
-            $taggedServices = $fileManager->getRequire()();
+            $taggedServices = $fileManager->getRequire($cachedFile);
         }
 
         if (isset($taggedServices[$tags][$instancesOfFQCN])) {
@@ -1091,7 +1091,7 @@ if (! function_exists('tag_instance_of')) {
             $classmap = [];
 
             $classmapFile = app()->basePath('vendor/composer/autoload_classmap.php');
-            $classmapValues = $fileManager->getRequire($classmapFile)();
+            $classmapValues = $fileManager->getRequire($classmapFile);
 
             foreach ($classmapValues as $class => $value) {
                 if (! is_string($class)) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1044,9 +1044,11 @@ if (! function_exists('tag_instance_of')) {
      * @param  array|string  $instancesOfFQCN
      * @param  array|string  $tags
      * @return void
+     *
      * @throws ReflectionException
      */
-    function tag_instance_of(array|string $instancesOfFQCN, array|string $tags): void {
+    function tag_instance_of(array|string $instancesOfFQCN, array|string $tags)
+    {
         if (is_array($instancesOfFQCN)) {
             foreach ($instancesOfFQCN as $instance) {
                 tag_instance_of($instance, $tags);
@@ -1085,7 +1087,7 @@ if (! function_exists('tag_instance_of')) {
 
         // Define the classmap that should be used
         $classmap = config('app.instance_of.classmap', null);
-        if (!isset($classmap)) {
+        if (! isset($classmap)) {
             $classmap = [];
 
             $classmapFile = app()->basePath('vendor/composer/autoload_classmap.php');


### PR DESCRIPTION
**Purpose**

Allow tagging an object based on its parent(s), interface(s) or its own FQCN.

This enables a developer to tag multiple objects dynamically at once without having to manually add new objects when they are added and extend a certain interface or parent.

Dynamically tagging can be an useful addition when you use a strategy pattern in your code and want, for example, register a new handler.

**How is it used**

Its usage would result in line with the following sample code.

```php
tag_instance_of(BaseServiceTypeInterface::class, 'my-tag');

$this->app
    ->when(MyDynamicHandlerService::class)
    ->needs(BaseServiceTypeInterface::class)
    ->giveTagged('my-tag');

// ...

class MyDynamicHandlerService
{
    public function __construct(BaseServiceTypeInterface ...$handlers)
    {
        $this->handlers = $handlers;
    }

    public function handle(string $type, array $config)
    {
        foreach ($this->handlers as $handler) {
            if (! $handler->supports($type)) {
                continue;
            }

            return $handler->handle($config);
        }

        throw new \LogicException('Missing handler for type '.$type);
    }
}
```

**Configuration options**

The developer can influence certain parts by configuration:

* `app.instance_of.cache (bool)` - Wether or not to cache the result of the tagging. This can be used in non-development environments to speed-up the proces.
* `app.instance_of.namespaces.include (string[])` - The class namespaces that should be considered to be tagged. By default this is only done for `App\`.
* `app.instance_of.namespaces.exclude (string[])` - The class namespaces that should be ignored to be tagged. By default this one is empty.
* `app.instance_of.classmap (array<string, string[]>` - A custom created classmap. By default a classmap and the classes and interfaces it implements/extends are created based on the Composer classmap.

**Based on**
This MR is a rework of https://github.com/laravel/framework/pull/44164. In this MR the functionality has been moved to a user land function and the codebase has been updated to boost its performance (the result of running it in production environments).

This update has been inspired by the Symfony methology to tag services through an instanceof provided value. @see https://symfony.com/doc/current/service_container/tags.html#autoconfiguring-tags

Resolves #42499

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
