### PR TITLE
[9.x] Fix typos

### DIFF
--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -28,7 +28,7 @@ class MiddlewareNameResolver
         }
 
         // If the middleware is the name of a middleware group, we will return the array
-        // of middlewares that belong to the group. This allows developers to group a
+        // of middleware that belong to the group. This allows developers to group a
         // set of middleware under single keys that can be conveniently referenced.
         if (isset($middlewareGroups[$name])) {
             return static::parseMiddlewareGroup($name, $map, $middlewareGroups);
@@ -57,7 +57,7 @@ class MiddlewareNameResolver
         foreach ($middlewareGroups[$name] as $middleware) {
             // If the middleware is another middleware group we will pull in the group and
             // merge its middleware into the results. This allows groups to conveniently
-            // reference other groups without needing to repeat all their middlewares.
+            // reference other groups without needing to repeat all their middleware.
             if (isset($middlewareGroups[$middleware])) {
                 $results = array_merge($results, static::parseMiddlewareGroup(
                     $middleware, $map, $middlewareGroups

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1032,7 +1032,7 @@ class Route
     }
 
     /**
-     * Get or set the middlewares attached to the route.
+     * Get or set the middleware attached to the route.
      *
      * @param  array|string|null  $middleware
      * @return $this|array

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -74,7 +74,7 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $currentRequest;
 
     /**
-     * All of the short-hand keys for middlewares.
+     * All of the short-hand keys for middleware.
      *
      * @var array
      */

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -23,7 +23,7 @@ class SortedMiddleware extends Collection
     }
 
     /**
-     * Sort the middlewares by the given priority map.
+     * Sort the middleware by the given priority map.
      *
      * Each call to this method makes one discrete middleware movement if necessary.
      *


### PR DESCRIPTION
[Since we use `middleware` as plural.](https://english.stackexchange.com/questions/257120/middleware-vs-middlewares)
Left some variable names unchanged, although we might want to change them from `$middlewares` to `$middleware`. 