### PR TITLE
[9.x] Fixed `missing_with` and `missing_with_all` validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1592,7 +1592,11 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'missing_with');
 
-        return ! Arr::hasAny($this->data, $parameters);
+        if (Arr::hasAny($this->data, $parameters)) {
+            return $this->validateMissing($attribute, $value, $parameters);
+        }
+
+        return true;
     }
 
     /**
@@ -1607,7 +1611,11 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'missing_with');
 
-        return ! Arr::has($this->data, $parameters);
+        if (Arr::has($this->data, $parameters)) {
+            return $this->validateMissing($attribute, $value, $parameters);
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2361,6 +2361,9 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.missing_with' => 'The :attribute field must be missing when :values is present.'], 'en');
 
+        $v = new Validator($trans, ['bar' => '2'], ['foo' => 'missing_with:baz,bar']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => 'yes', 'bar' => '2'], ['foo' => 'missing_with:baz,bar']);
         $this->assertFalse($v->passes());
         $this->assertSame('The foo field must be missing when baz / bar is present.', $v->errors()->first('foo'));
@@ -2399,6 +2402,9 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.missing_with_all' => 'The :attribute field must be missing when :values are present.'], 'en');
+
+        $v = new Validator($trans, ['bar' => '2', 'baz' => '2'], ['foo' => 'missing_with_all:baz,bar']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'yes', 'bar' => '2', 'baz' => '2'], ['foo' => 'missing_with_all:baz,bar']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
The `missing_with` and `missing_with_all` rules are failing validation whether or not the specified field is in the data array.  This brings the logic in line with the other missing validators to match the documentation.

Reproduction steps:

```
$ composer create-project laravel/laravel test-app
$ cd test-app/
$ php artisan tinker
Psy Shell v0.11.12 (PHP 8.1.2-1ubuntu2.9 — cli) by Justin Hileman
> Validator::make(['baz' => '1'], ['foo' => 'missing_with:baz'])->errors()->toArray()
= [
    "foo" => [
      "The foo field must be missing when baz is present.",
    ],
  ]

> Validator::make(['bar' => '1', 'baz' => '1'], ['foo' => 'missing_with_all:bar,baz'])->errors()->toArray()
= [
    "foo" => [
      "The foo field must be missing when bar / baz are present.",
    ],
  ]
```