### PR TITLE
[9.x] Support an array of models as input for destroy method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1340,6 +1340,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $ids = is_array($ids) ? $ids : func_get_args();
 
+        $ids = array_map(fn ($id) => $id instanceof Model ? $id->getKey() : $id, $ids);
+
         if (count($ids) === 0) {
             return 0;
         }


### PR DESCRIPTION
Currently, if we pass an array of models into the destroy method it either ignores (for Mysql driver) or errors (Postgres or SqlServer) with this PR the models get retrieved and delete. https://github.com/laravel/framework/pull/45904#issuecomment-1412860121

- But someone may complain that their app is broken because the models are now really deleted.

- This implementation mimics when we pass an eloquent collection to the destroy, another way was to only loop through the array and call the delete method on all the instances. So that the select query does not get run redundantly and the passed models exist property gets updated.

- It also adds back the removed tests during a recent revert.
