### PR TITLE
[9.x] Random function doesn't generate evenly distributed random chars

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -735,7 +735,9 @@ class Str
             while (($len = strlen($string)) < $length) {
                 $size = $length - $len;
 
-                $bytes = random_bytes($size);
+                $bytesSize = (int) ceil(($size) / 3) * 3;
+
+                $bytes = random_bytes($bytesSize);
 
                 $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
             }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -492,7 +492,6 @@ class SupportStrTest extends TestCase
         $results = [];
         // take 6.200.000 samples, because there are 62 different characters
         for ($i = 0; $i < 6200000; $i++) {
-
             $random = Str::random(1);
             $results[$random] = ($results[$random] ?? 0) + 1;
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -487,22 +487,21 @@ class SupportStrTest extends TestCase
     }
 
     /** @test */
-    public function TestWhetherTheNumberOfGeneratedCharactersIsEquallyDistributed() {
+    public function TestWhetherTheNumberOfGeneratedCharactersIsEquallyDistributed()
+    {
         $results = [];
         // take 6.200.000 samples, because there are 62 different characters
         for ($i = 0; $i < 6200000; $i++) {
 
             $random = Str::random(1);
-            $results[$random] = ($results[$random] ?? 0)  + 1;
+            $results[$random] = ($results[$random] ?? 0) + 1;
         }
 
-        // Each character should occur 100,000 times with a variance of 2%.
+        // each character should occur 100.000 times with a variance of 2%.
         foreach ($results as $result) {
             $this->assertEqualsWithDelta(100000, $result, 2000);
         }
     }
-
-
 
     public function testRandomStringFactoryCanBeSet()
     {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -491,14 +491,14 @@ class SupportStrTest extends TestCase
     {
         $results = [];
         // take 6.200.000 samples, because there are 62 different characters
-        for ($i = 0; $i < 6200000; $i++) {
+        for ($i = 0; $i < 620000; $i++) {
             $random = Str::random(1);
             $results[$random] = ($results[$random] ?? 0) + 1;
         }
 
         // each character should occur 100.000 times with a variance of 2%.
         foreach ($results as $result) {
-            $this->assertEqualsWithDelta(100000, $result, 2000);
+            $this->assertEqualsWithDelta(10000, $result, 2000);
         }
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -486,6 +486,24 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
+    /** @test */
+    public function TestWhetherTheNumberOfGeneratedCharactersIsEquallyDistributed() {
+        $results = [];
+        // take 6.200.000 samples, because there are 62 different characters
+        for ($i = 0; $i < 6200000; $i++) {
+
+            $random = Str::random(1);
+            $results[$random] = ($results[$random] ?? 0)  + 1;
+        }
+
+        // Each character should occur 100,000 times with a variance of 2%.
+        foreach ($results as $result) {
+            $this->assertEqualsWithDelta(100000, $result, 2000);
+        }
+    }
+
+
+
     public function testRandomStringFactoryCanBeSet()
     {
         Str::createRandomStringsUsing(fn ($length) => 'length:'.$length);


### PR DESCRIPTION
The random function does not generate evenly distributed random characters particularly for short strings (<12 chars). For example, if exactly 1 character is generated, the letters A, Q, g and w are significantly overrepresented.

This is due to the conversion of the randomly generated bytes using the base64 function. If the number of bytes is not divisible by three, zeros are added at the end in the algorithm (see [https://en.wikipedia.org/wiki/Base64](https://en.wikipedia.org/wiki/Base64)).

This leads to the increased frequency of A (000000), Q (010000), g (100000) and w (110000).

Evenly distributed random characters are obtained if it is ensured that the number of generated random bytes modulo 3 is equal to 0:

```jsx
$bytesSize = (int) ceil(($size) / 3) * 3;
```