### PR TITLE
[9.x] Add as() helper method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -455,6 +455,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Set the as table which the query is targeting.
+     *
+     * @param  string  $as
+     * @return $this
+     */
+    public function as($as)
+    {
+        $this->from($this->from, $as);
+
+        return $this;
+    }
+
+    /**
      * Add a join clause to the query.
      *
      * @param  string  $table

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5343,6 +5343,12 @@ SQL;
         $this->assertSame('select * from (select * from "users") as "u"', $builder->toSql());
     }
 
+    public function testAsChris()
+    {
+        $builder = $this->getBuilder()->from('users')->as('u');
+        $this->assertSame('select * from "users" as "u"', $builder->toSql());
+    }
+
     public function testFromSub()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5343,7 +5343,7 @@ SQL;
         $this->assertSame('select * from (select * from "users") as "u"', $builder->toSql());
     }
 
-    public function testAsChris()
+    public function testAs()
     {
         $builder = $this->getBuilder()->from('users')->as('u');
         $this->assertSame('select * from "users" as "u"', $builder->toSql());


### PR DESCRIPTION
This PR makes a developer quality of life improvement to the Eloquent builder by reducing the need for duplicating the model table name throughout your code.  Previously if you wanted to specify a table alias you had to use the `from()` method and ensure you specified the table name, which has already been set on the model.

This PR adds a new `as()` method which gets the table name for you and calls the existing `from()`.  By doing this the code becomes more explicitly readable.

Previously - 

```php
Account::from('accounts', 'a')->select('a.name')....

// or

Account::from('accounts AS a')->select('a.name')....
```

Now - 

```php
Account::as('a')->select('a.name')....
```

