### PR TITLE
[9.x] Fixing spelling mistake "mulitple_of"

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1652,7 +1652,7 @@ trait ValidatesAttributes
 
             return $numerator->remainder($denominator)->isZero();
         } catch (BrickMathException $e) {
-            throw new MathException('An error occurred while handling the mulitple_of input values.', previous: $e);
+            throw new MathException('An error occurred while handling the multiple_of input values.', previous: $e);
         }
     }
 


### PR DESCRIPTION
Just fixing a spelling mistake in an exception message: `mulitple_of` instead of `multiple_of`.
