### PR TITLE
Added @mixin annotation to the Model class for improved autocompletion for IDEs eg. PhpStorm.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -23,6 +23,9 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
+/**
+ * @mixin Builder
+ */
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,


### PR DESCRIPTION
## Introduction
[DocBlocks](https://en.wikipedia.org/wiki/PHPDoc) can be used by IDEs like PhpStorm, to improve autocomplete suggestions.

## Problem
When using IDE like PhpStorm some of methods on model are note autocompleted and are sometimes underlined as errors (Method not found in model). Example:
<pre>
$user = User::where('id', 1)->first();
</pre>
The `where` method on user is considered as not available on the model.

## Work-around
I normally add the @mixin to all of my models during development so that my autocompletes work perfectly and I get rid of lint errors. 
<pre>
namespace App\Models;

use Illuminate\Database\Eloquent\Builder;
use Illuminate\Foundation\Auth\User as Authenticatable;

/**
 * @mixin Builder
 */
class User extends Authenticatable
{
    // User methods
}
</pre>
The above solves the issue for the model.

## Suggestion
I Would like to see this set by default for all models. 
I Hope this is a the appropriate way to do it. Otherwise I would like to have it implemented the correct way.

## Benefits
With this fix, the IDE would render all Builder autosuggestions on models during their usage. This gives the developer more confidence and speeds up development.

## Breaking 
This change doesn't break anything as it is only an annotation and doe not modify any part of the existing code.
> Note: I could not write any test because this change does not alter any operation or function.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
