### PR TITLE
[9.x] Adds ability to compiles new http verbs directives 🚦

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -57,7 +57,7 @@ trait CompilesHelpers
      */
     protected function compilePut($arguments)
     {
-        if ($arguments === '()') {
+        if ($arguments === null) {
             return $this->compileMethod("('PUT')");
         }
 
@@ -72,7 +72,7 @@ trait CompilesHelpers
      */
     protected function compilePatch($arguments)
     {
-        if ($arguments === '()') {
+        if ($arguments === null) {
             return $this->compileMethod("('PATCH')");
         }
 
@@ -87,7 +87,7 @@ trait CompilesHelpers
      */
     protected function compileDelete($arguments)
     {
-        if ($arguments === '()') {
+        if ($arguments === null) {
             return $this->compileMethod("('DELETE')");
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -50,6 +50,36 @@ trait CompilesHelpers
     }
 
     /**
+     * Compile the patch method statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compilePatch()
+    {
+        return $this->compileMethod("('PATCH')");
+    }
+
+    /**
+     * Compile the put method statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compilePut()
+    {
+        return $this->compileMethod("('PUT')");
+    }
+
+    /**
+     * Compile the delete method statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileDelete()
+    {
+        return $this->compileMethod("('DELETE')");
+    }
+
+    /**
      * Compile the "vite" statements into valid PHP.
      *
      * @param  string|null  $arguments

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -52,7 +52,7 @@ trait CompilesHelpers
     /**
      * Compile the PUT method statements into valid PHP.
      *
-     * @param  string  $arguments
+     * @param  string|null  $arguments
      * @return string
      */
     protected function compilePut($arguments)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -52,31 +52,46 @@ trait CompilesHelpers
     /**
      * Compile the PUT method statements into valid PHP.
      *
+     * @param  string  $arguments
      * @return string
      */
-    protected function compilePut()
+    protected function compilePut($arguments)
     {
-        return $this->compileMethod("('PUT')");
+        if ($arguments === '()') {
+            return $this->compileMethod("('PUT')");
+        }
+
+        return 'method="POST" action="<?php echo Illuminate\\Support\\Str::of'.$arguments.'->whenContains("?", fn ($url) => $url->append("&_method=PUT"), fn ($url) => $url->append("?_method=PUT"))->toString(); ?>"';
     }
 
     /**
      * Compile the PATCH method statements into valid PHP.
      *
+     * @param  string  $arguments
      * @return string
      */
-    protected function compilePatch()
+    protected function compilePatch($arguments)
     {
-        return $this->compileMethod("('PATCH')");
+        if ($arguments === '()') {
+            return $this->compileMethod("('PATCH')");
+        }
+
+        return 'method="POST" action="<?php echo Illuminate\\Support\\Str::of'.$arguments.'->whenContains("?", fn ($url) => $url->append("&_method=PATCH"), fn ($url) => $url->append("?_method=PATCH"))->toString(); ?>"';
     }
 
     /**
      * Compile the DELETE method statements into valid PHP.
      *
+     * @param  string  $arguments
      * @return string
      */
-    protected function compileDelete()
+    protected function compileDelete($arguments)
     {
-        return $this->compileMethod("('DELETE')");
+        if ($arguments === '()') {
+            return $this->compileMethod("('DELETE')");
+        }
+
+        return 'method="POST" action="<?php echo Illuminate\\Support\\Str::of'.$arguments.'->whenContains("?", fn ($url) => $url->append("&_method=DELETE"), fn ($url) => $url->append("?_method=DELETE"))->toString(); ?>"';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -50,17 +50,7 @@ trait CompilesHelpers
     }
 
     /**
-     * Compile the patch method statements into valid PHP.
-     *
-     * @return string
-     */
-    protected function compilePatch()
-    {
-        return $this->compileMethod("('PATCH')");
-    }
-
-    /**
-     * Compile the put method statements into valid PHP.
+     * Compile the PUT method statements into valid PHP.
      *
      * @return string
      */
@@ -70,7 +60,17 @@ trait CompilesHelpers
     }
 
     /**
-     * Compile the delete method statements into valid PHP.
+     * Compile the PATCH method statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compilePatch()
+    {
+        return $this->compileMethod("('PATCH')");
+    }
+
+    /**
+     * Compile the DELETE method statements into valid PHP.
      *
      * @return string
      */

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -57,7 +57,7 @@ trait CompilesHelpers
      */
     protected function compilePut($arguments)
     {
-        if ($arguments === null) {
+        if ($arguments === null || $arguments === '()') {
             return $this->compileMethod("('PUT')");
         }
 
@@ -67,12 +67,12 @@ trait CompilesHelpers
     /**
      * Compile the PATCH method statements into valid PHP.
      *
-     * @param  string  $arguments
+     * @param  string|null  $arguments
      * @return string
      */
     protected function compilePatch($arguments)
     {
-        if ($arguments === null) {
+        if ($arguments === null || $arguments === '()') {
             return $this->compileMethod("('PATCH')");
         }
 
@@ -82,12 +82,12 @@ trait CompilesHelpers
     /**
      * Compile the DELETE method statements into valid PHP.
      *
-     * @param  string  $arguments
+     * @param  string|null  $arguments
      * @return string
      */
     protected function compileDelete($arguments)
     {
-        if ($arguments === null) {
+        if ($arguments === null || $arguments === '()') {
             return $this->compileMethod("('DELETE')");
         }
 

--- a/tests/View/Blade/BladeMethodTest.php
+++ b/tests/View/Blade/BladeMethodTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+use Illuminate\Support\Str;
+
+class BladeMethodTest extends AbstractBladeTestCase
+{
+    public function testPatch()
+    {
+        $string = '@patch()';
+        $expected = "<?php echo method_field('PATCH'); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPut()
+    {
+        $string = '@put()';
+        $expected = "<?php echo method_field('PUT'); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testDelete()
+    {
+        $string = '@delete()';
+        $expected = "<?php echo method_field('DELETE'); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPatchWithUrl()
+    {
+        $string = '@patch("/foo")';
+        $expected = 'method="POST" action="<?php echo Illuminate\Support\Str::of("/foo")->whenContains("?", fn ($url) => $url->append("&_method=PATCH"), fn ($url) => $url->append("?_method=PATCH"))->toString(); ?>"';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPutWithUrl()
+    {
+        $string = '@put("/foo")';
+        $expected = 'method="POST" action="<?php echo Illuminate\Support\Str::of("/foo")->whenContains("?", fn ($url) => $url->append("&_method=PUT"), fn ($url) => $url->append("?_method=PUT"))->toString(); ?>"';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testDeleteWithUrl()
+    {
+        $string = '@delete("/foo")';
+        $expected = 'method="POST" action="<?php echo Illuminate\Support\Str::of("/foo")->whenContains("?", fn ($url) => $url->append("&_method=DELETE"), fn ($url) => $url->append("?_method=DELETE"))->toString(); ?>"';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}
+

--- a/tests/View/Blade/BladeMethodTest.php
+++ b/tests/View/Blade/BladeMethodTest.php
@@ -9,6 +9,10 @@ class BladeMethodTest extends AbstractBladeTestCase
         $string = '@patch';
         $expected = "<?php echo method_field('PATCH'); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@patch()';
+        $expected = "<?php echo method_field('PATCH'); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testPut()
@@ -16,11 +20,19 @@ class BladeMethodTest extends AbstractBladeTestCase
         $string = '@put';
         $expected = "<?php echo method_field('PUT'); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@put()';
+        $expected = "<?php echo method_field('PUT'); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testDelete()
     {
         $string = '@delete';
+        $expected = "<?php echo method_field('DELETE'); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@delete()';
         $expected = "<?php echo method_field('DELETE'); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeMethodTest.php
+++ b/tests/View/Blade/BladeMethodTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\View\Blade;
 
-use Illuminate\Support\Str;
-
 class BladeMethodTest extends AbstractBladeTestCase
 {
     public function testPatch()
@@ -48,4 +46,3 @@ class BladeMethodTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }
-

--- a/tests/View/Blade/BladeMethodTest.php
+++ b/tests/View/Blade/BladeMethodTest.php
@@ -6,21 +6,21 @@ class BladeMethodTest extends AbstractBladeTestCase
 {
     public function testPatch()
     {
-        $string = '@patch()';
+        $string = '@patch';
         $expected = "<?php echo method_field('PATCH'); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testPut()
     {
-        $string = '@put()';
+        $string = '@put';
         $expected = "<?php echo method_field('PUT'); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testDelete()
     {
-        $string = '@delete()';
+        $string = '@delete';
         $expected = "<?php echo method_field('DELETE'); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }


### PR DESCRIPTION
This PR allows us to use the new short directives instead `@method` directive, let's examine the next code for more illumination.

## BEFORE

```BLADE
<form method="post" action="/users/{{ $user->id }}">
    @csrf
    @method('PATCH')
</form>
```

But after this PR gets merged, the code will be like so 🎉

## AFTER

```BLADE
<form method="post" action="/users/{{ $user->id }}">
    @csrf
    @patch
</form>
```