### PR TITLE
[9.x] Fixes blade escaped tags issue

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -507,6 +507,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         preg_match_all('/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( [\S\s]*? ) \))?/x', $template, $matches);
 
+        $offset = 0;
         for ($i = 0; isset($matches[0][$i]); $i++) {
             $match = [
                 $matches[0][$i],
@@ -538,10 +539,32 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 $match[4] = $match[4].$rest;
             }
 
-            $template = Str::replaceFirst($match[0], $this->compileStatement($match), $template);
+            [$template, $offset] = $this->replaceFirst(
+                $match[0],
+                $this->compileStatement($match),
+                $template,
+                $offset
+            );
         }
 
         return $template;
+    }
+
+    public function replaceFirst($search, $replace, $subject, $offset)
+    {
+        $search = (string) $search;
+
+        if ($search === '') {
+            return $subject;
+        }
+
+        $position = strpos($subject, $search, $offset);
+
+        if ($position !== false) {
+            return [substr_replace($subject, $replace, $position, strlen($search)), $position + strlen($replace)];
+        }
+
+        return [$subject, 0];
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -508,6 +508,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         preg_match_all('/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( [\S\s]*? ) \))?/x', $template, $matches);
 
         $offset = 0;
+
         for ($i = 0; isset($matches[0][$i]); $i++) {
             $match = [
                 $matches[0][$i],
@@ -539,7 +540,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 $match[4] = $match[4].$rest;
             }
 
-            [$template, $offset] = $this->replaceFirst(
+            [$template, $offset] = $this->replaceFirstStatement(
                 $match[0],
                 $this->compileStatement($match),
                 $template,
@@ -550,7 +551,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
         return $template;
     }
 
-    public function replaceFirst($search, $replace, $subject, $offset)
+    /**
+     * Replace the first match for a statement compilation operation.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
+     * @param  int  $offset
+     * @return array
+     */
+    protected function replaceFirstStatement($search, $replace, $subject, $offset)
     {
         $search = (string) $search;
 
@@ -561,7 +571,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $position = strpos($subject, $search, $offset);
 
         if ($position !== false) {
-            return [substr_replace($subject, $replace, $position, strlen($search)), $position + strlen($replace)];
+            return [
+                substr_replace($subject, $replace, $position, strlen($search)),
+                $position + strlen($replace)
+            ];
         }
 
         return [$subject, 0];

--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -16,4 +16,19 @@ class BladeEscapedTest extends AbstractBladeTestCase
             $i as $x
         )'));
     }
+
+    public function testNestedEscapes()
+    {
+        $template = '
+@foreach($cols as $col)
+    @@foreach($issues as $issue_45915)
+    @@endforeach
+@endforeach';
+        $compiled = '
+<?php $__currentLoopData = $cols; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $col): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
+    @foreach($issues as $issue_45915)
+    @endforeach
+<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
+        $this->assertSame($compiled, $this->compiler->compileString($template));
+    }
 }


### PR DESCRIPTION
This fixes #45915

In the added test there are 4 matches, in the second replacement `@@endforeach` with `@endforeach` in the second replacement.

Then the final replacement searches for `@endforeach` to replace it with the compiled version, but it finds what was produced by the previously escaped tag because it starts the search from the beginning of the string.

### Solution:
Logically when replacing the matches found by REGEX one after the other using `Str::replaceFirst`, we have to continue from where we last left off.