### PR TITLE
Easy getter and setter methods for Json columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
+++ b/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
@@ -80,8 +80,7 @@ trait InteractsWithJsonColumn
 
         return parent::__call($method, $arguments);
     }
-
-
+    
     /**
      * Convert the given value to an array.
      *

--- a/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
+++ b/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
@@ -14,7 +14,7 @@ trait InteractsWithJsonColumn
      *
      * @return void
      */
-    protected static function bootInteractsWithJson()
+    protected static function bootInteractsWithJsonColumn()
     {
         static::retrieved(function ($model) {
             $model->registerJsonColumnMethods();
@@ -36,13 +36,11 @@ trait InteractsWithJsonColumn
                 continue;
             }
 
-            $jsonColumn = $column;
+            $getter = 'get'.Str::studly($column);
+            $setter = 'set'.Str::studly($column);
 
-            $getter = 'get'.Str::studly($jsonColumn);
-            $setter = 'set'.Str::studly($jsonColumn);
-
-            $this->dynamicMethods[$getter] = function ($key = null, $default = null) use ($jsonColumn) {
-                $data = $this->asArray($jsonColumn);
+            $this->dynamicMethods[$getter] = function ($key = null, $default = null) use ($column) {
+                $data = $this->asArray($column);
                 if (! $key) {
                     return $data;
                 }
@@ -53,14 +51,14 @@ trait InteractsWithJsonColumn
                 return Arr::get($data, $key, $default);
             };
 
-            $this->dynamicMethods[$setter] = function ($key, $value) use ($jsonColumn) {
+            $this->dynamicMethods[$setter] = function ($key, $value) use ($column) {
                 if (Str::contains($key, '->')) {
-                    return $this->update([$jsonColumn.'->'.$key => $value]);
+                    return $this->update([$column.'->'.$key => $value]);
                 }
-                $data = $this->asArray($jsonColumn);
+                $data = $this->asArray($column);
                 $data[$key] = $value;
 
-                return $this->update([$jsonColumn => $data]);
+                return $this->update([$column => $data]);
             };
         }
     }

--- a/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
+++ b/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+trait InteractsWithJsonColumn
+{
+    protected array $dynamicMethods = [];
+
+    /**
+     * Boot the trait for the model.
+     *
+     * @return void
+     */
+    protected static function bootInteractsWithJson()
+    {
+        static::retrieved(function ($model) {
+            $model->registerJsonColumnMethods();
+        });
+    }
+
+    /**
+     * Register dynamic methods for JSON columns.
+     *
+     * @return void
+     */
+    protected function registerJsonColumnMethods(): void
+    {
+        $table = $this->getTable();
+        $columns = $this->getConnection()->getSchemaBuilder()->getColumnListing($table);
+
+        foreach ($columns as $column) {
+
+            if ($this->getConnection()->getSchemaBuilder()->getColumnType($table, $column) !== 'json') {
+                continue;
+            }
+
+            $jsonColumn = $column;
+
+            $getter = 'get'.Str::studly($jsonColumn);
+            $setter = 'set'.Str::studly($jsonColumn);
+
+            $this->dynamicMethods[$getter] = function ($key = null, $default = null) use ($jsonColumn) {
+                $data = $this->asArray($jsonColumn);
+                if (!$key) {
+                    return $data;
+                }
+                if (Str::contains($key, '->')) {
+                    $key = str_replace('->', '.', $key);
+                }
+                return Arr::get($data, $key, $default);
+            };
+
+            $this->dynamicMethods[$setter] = function ($key, $value) use ($jsonColumn) {
+                if (Str::contains($key, '->')) {
+                    return $this->update([$jsonColumn.'->'.$key => $value]);
+                }
+                $data = $this->asArray($jsonColumn);
+                $data[$key] = $value;
+                return $this->update([$jsonColumn => $data]);
+            };
+        }
+    }
+
+    /**
+     * Handle dynamic method calls into the method.
+     *
+     * @param  string  $method
+     * @param  array  $arguments
+     * @return mixed
+     */
+
+    public function __call($method, $arguments): mixed
+    {
+        if (array_key_exists($method, $this->dynamicMethods)) {
+            return call_user_func_array($this->dynamicMethods[$method], $arguments);
+        }
+        return parent::__call($method, $arguments);
+    }
+
+
+    /**
+     * Convert the given value to an array.
+     *
+     * @param  string  $column
+     *
+     * @return array
+     */
+    private function asArray($column)
+    {
+        $data = $this->$column;
+        if ($data === null) {
+            return [];
+        }
+        if (!is_array($data)) {
+            $data = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+        }
+        return $data;
+    }
+
+
+}
+

--- a/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
+++ b/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
@@ -32,7 +32,6 @@ trait InteractsWithJsonColumn
         $columns = $this->getConnection()->getSchemaBuilder()->getColumnListing($table);
 
         foreach ($columns as $column) {
-
             if ($this->getConnection()->getSchemaBuilder()->getColumnType($table, $column) !== 'json') {
                 continue;
             }
@@ -44,12 +43,13 @@ trait InteractsWithJsonColumn
 
             $this->dynamicMethods[$getter] = function ($key = null, $default = null) use ($jsonColumn) {
                 $data = $this->asArray($jsonColumn);
-                if (!$key) {
+                if (! $key) {
                     return $data;
                 }
                 if (Str::contains($key, '->')) {
                     $key = str_replace('->', '.', $key);
                 }
+
                 return Arr::get($data, $key, $default);
             };
 
@@ -59,6 +59,7 @@ trait InteractsWithJsonColumn
                 }
                 $data = $this->asArray($jsonColumn);
                 $data[$key] = $value;
+
                 return $this->update([$jsonColumn => $data]);
             };
         }
@@ -71,12 +72,12 @@ trait InteractsWithJsonColumn
      * @param  array  $arguments
      * @return mixed
      */
-
     public function __call($method, $arguments): mixed
     {
         if (array_key_exists($method, $this->dynamicMethods)) {
             return call_user_func_array($this->dynamicMethods[$method], $arguments);
         }
+
         return parent::__call($method, $arguments);
     }
 
@@ -85,7 +86,6 @@ trait InteractsWithJsonColumn
      * Convert the given value to an array.
      *
      * @param  string  $column
-     *
      * @return array
      */
     private function asArray($column)
@@ -94,12 +94,10 @@ trait InteractsWithJsonColumn
         if ($data === null) {
             return [];
         }
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             $data = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
         }
+
         return $data;
     }
-
-
 }
-

--- a/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
+++ b/src/Illuminate/Database/Eloquent/InteractsWithJsonColumn.php
@@ -80,7 +80,7 @@ trait InteractsWithJsonColumn
 
         return parent::__call($method, $arguments);
     }
-    
+
     /**
      * Convert the given value to an array.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -32,7 +32,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
-        ForwardsCalls;
+        ForwardsCalls,
+        InteractsWithJsonColumn;
 
     /**
      * The connection name for the model.


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Already laravel is giving enough flexibility on getting and setting values on JSON columns, gues we have a JSON column named `meta` like this
` $table->json('meta')->nullable();`

Currently, we can interact with it like this,

We need to cast this column as in model

```
    protected $casts = [
        'meta' => 'json',
    ];
```

then we can get the value as 
`Arr::get($this->meta, $key, $default)`

Also, set the value as

```
$this->update([
            'meta->something' => $value
        ]);
```


What if we can use it directly as `getMeta('key')` and `setMeta('key')`

This PR is all about adding a setter and getter for JSON column which is helpful to interact with!

thanks for looking into this PR, any feedback/suggestion is highly appreciated

![image](https://user-images.githubusercontent.com/16163521/216455182-898158b3-a50a-4b26-a58b-ca9badb6046c.png)
