### PR TITLE
[10.x] use AWS SES v2 Client for `ses` mailer

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Mail;
 
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Closure;
 use Illuminate\Contracts\Mail\Factory as FactoryContract;
 use Illuminate\Log\LogManager;
@@ -230,14 +230,14 @@ class MailManager implements FactoryContract
     {
         $config = array_merge(
             $this->app['config']->get('services.ses', []),
-            ['version' => 'latest', 'service' => 'email'],
+            ['version' => 'latest'],
             $config
         );
 
         $config = Arr::except($config, ['transport']);
 
         return new SesTransport(
-            new SesClient($this->addSesCredentials($config)),
+            new SesV2Client($this->addSesCredentials($config)),
             $config['options'] ?? []
         );
     }

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -57,7 +57,7 @@ class SesTransport extends AbstractTransport
         }
 
         try {
-            $result = $this->ses->sendRawEmail(
+            $result = $this->ses->sendEmail(
                 array_merge(
                     $options, [
                         'ReplyToAddresses' => [$message->getEnvelope()->getSender()->toString()],

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
@@ -58,7 +58,7 @@ class MailSesTransportTest extends TestCase
         $message->bcc('you@example.com');
         $message->getHeaders()->add(new MetadataHeader('FooTag', 'TagValue'));
 
-        $client = m::mock(SesClient::class);
+        $client = m::mock(SesV2Client::class);
         $sesResult = m::mock();
         $sesResult->shouldReceive('get')
             ->with('MessageId')

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -64,10 +64,11 @@ class MailSesTransportTest extends TestCase
             ->with('MessageId')
             ->once()
             ->andReturn('ses-message-id');
-        $client->shouldReceive('sendRawEmail')->once()
+        $client->shouldReceive('sendEmail')->once()
             ->with(m::on(function ($arg) {
-                return $arg['Source'] === 'myself@example.com' &&
-                    $arg['Destinations'] === ['me@example.com', 'you@example.com'] &&
+                return count($arg['ReplyToAddresses']) === 1 &&
+                    $arg['ReplyToAddresses'][0] === 'myself@example.com' &&
+                    $arg['Destination']['ToAddresses'] === ['me@example.com', 'you@example.com'] &&
                     $arg['Tags'] === [['Name' => 'FooTag', 'Value' => 'TagValue']];
             }))
             ->andReturn($sesResult);


### PR DESCRIPTION
Using the AWS SES v2 Client automatically increases the 10 MB outbound and 30 MB inbound message size limit to 40 MB, as further explained in this blogpost: https://aws.amazon.com/de/about-aws/whats-new/2022/04/amazon-ses-v2-supports-email-size-40mb-inbound-outbound-emails-default/

This is quite a huge deal, especially when dealing with email attachments.