### PR TITLE
[9.x] Adds database query count test expectation helper

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -169,6 +169,30 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Specify the number of database queries that should occur throughout the test.
+     *
+     * @param  int  $expected
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function expectsDatabaseQueryCount($expected, $connection = null)
+    {
+        with($this->getConnection($connection), function ($connection) use ($expected) {
+            $actual = 0;
+
+            $connection->listen(function () use (&$actual) {
+                $actual++;
+            });
+
+            $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connection) {
+                $this->assertSame($actual, $expected, "Expected {$expected} database queries on the [{$connection->getName()}] connection. {$actual} occurred.");
+            });
+        });
+
+        return $this;
+    }
+
+    /**
      * Determine if the argument is a soft deletable model.
      *
      * @param  mixed  $model
@@ -261,30 +285,6 @@ trait InteractsWithDatabase
         foreach (Arr::wrap($class) as $class) {
             $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
         }
-
-        return $this;
-    }
-
-    /**
-     * Specify the number of database queries that should occur throughout the test.
-     *
-     * @param  int  $expected
-     * @param  string|null  $connection
-     * @return $this
-     */
-    public function expectsDatabaseQueryCount($expected, $connection = null)
-    {
-        with($this->getConnection($connection), function ($connection) use ($expected) {
-            $actual = 0;
-
-            $connection->listen(function () use (&$actual) {
-                $actual++;
-            });
-
-            $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connection) {
-                $this->assertSame($actual, $expected, "Expected {$expected} database queries on the [{$connection->getName()}] connection. {$actual} occurred.");
-            });
-        });
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -264,4 +264,28 @@ trait InteractsWithDatabase
 
         return $this;
     }
+
+    /**
+     * Specify the number of database queries that should occur throughout the test.
+     *
+     * @param  int  $expected
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function expectsDatabaseQueryCount($expected, $connection = null)
+    {
+        with($this->getConnection($connection), function ($connection) use ($expected) {
+            $actual = 0;
+
+            $connection->listen(function () use (&$actual) {
+                $actual++;
+            });
+
+            $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connection) {
+                $this->assertSame($actual, $expected, "Expected {$expected} database queries on the [{$connection->getName()}] connection. {$actual} occurred.");
+            });
+        });
+
+        return $this;
+    }
 }


### PR DESCRIPTION
New testing helper. Useful when you want to ensure the code doesn't inadvertantly introduce new database queries.

```php
public function testItWorksEfficiently()
{
    $this->expectsDatabaseQueryCount(5);

    // do stuff...

    // throws an exception on tearDown if more than 5 queries have run
    // since the expectation was created.
}
```