### PR TITLE
[9.x] Fix docblock issue

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -57,7 +57,7 @@ class Stringable implements JsonSerializable
     /**
      * Append the given values to the string.
      *
-     * @param  array  ...$values
+     * @param  string  ...$values
      * @return static
      */
     public function append(...$values)
@@ -545,7 +545,7 @@ class Stringable implements JsonSerializable
     /**
      * Prepend the given values to the string.
      *
-     * @param  array  ...$values
+     * @param  string  ...$values
      * @return static
      */
     public function prepend(...$values)


### PR DESCRIPTION
See #45749

`append` and `prepend` methods accept a variadic list of `string`s 

the docblock changed in #45749 should be `@param string ...$values` in order to be correct

otherwise IDE would mark an error like this one:

![image](https://user-images.githubusercontent.com/8792274/216599647-38731300-b414-46e8-b0c2-829d244d5365.png)


**note** this should be fixed also in 10.x, will open a new PR as soon as this is approved
