### PR TITLE
[9.x] Add missing php extensions in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,7 @@
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",
-        "ext-pcntl": "Required to use all features of the queue worker.",
+        "ext-pcntl": "Required to use all features of the queue worker and console signal trapping.",
         "ext-pdo": "Required to use all database features.",
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",

--- a/composer.json
+++ b/composer.json
@@ -142,13 +142,13 @@
         }
     },
     "suggest": {
-        "ext-apcu": "Required to use the APC Cache driver.",
-        "ext-fileinfo": "Required to use the Filesystem.",
+        "ext-apcu": "Required to use the APC cache driver.",
+        "ext-fileinfo": "Required to use the Filesystem class.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",
         "ext-pcntl": "Required to use all features of the queue worker.",
-        "ext-pdo": "Required to use any Database driver.",
+        "ext-pdo": "Required to use all database features.",
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,8 @@
         "illuminate/view": "self.version"
     },
     "require-dev": {
+        "ext-gmp": "*",
+        "ext-bcmath": "*",
         "ably/ably-php": "^1.0",
         "aws/aws-sdk-php": "^3.235.5",
         "doctrine/dbal": "^2.13.3|^3.1.4",
@@ -140,10 +142,13 @@
         }
     },
     "suggest": {
+        "ext-apcu": "Required to use the APC Cache driver.",
+        "ext-fileinfo": "Required to use the Filesystem.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",
         "ext-pcntl": "Required to use all features of the queue worker.",
+        "ext-pdo": "Required to use any Database driver.",
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,13 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-ctype": "*",
+        "ext-filter": "*",
+        "ext-hash": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "ext-session": "*",
+        "ext-tokenizer": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.3.2",

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,6 @@
     },
     "require-dev": {
         "ext-gmp": "*",
-        "ext-bcmath": "*",
         "ably/ably-php": "^1.0",
         "aws/aws-sdk-php": "^3.235.5",
         "doctrine/dbal": "^2.13.3|^3.1.4",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-hash": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/http": "^9.0",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "psr/log": "^1.0|^2.0|^3.0",
         "illuminate/bus": "^9.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-hash": "*",
         "psr/log": "^1.0|^2.0|^3.0",
         "illuminate/bus": "^9.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-hash": "*",
         "psr/log": "^1.0|^2.0|^3.0",
         "illuminate/bus": "^9.0",
         "illuminate/collections": "^9.0",
@@ -35,6 +34,7 @@
         }
     },
     "suggest": {
+        "ext-hash": "Required to use the Ably and Pusher broadcast drivers.",
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0)."
     },

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-filter": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-filter": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
@@ -35,6 +34,7 @@
         }
     },
     "suggest": {
+        "ext-filter": "Required to use the DynamoDb cache driver.",
         "ext-memcached": "Required to use the memcache cache driver.",
         "illuminate/database": "Required to use the database cache driver (^9.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^9.0).",

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -34,6 +34,7 @@
         }
     },
     "suggest": {
+        "ext-apcu": "Required to use the APC cache driver.",
         "ext-filter": "Required to use the DynamoDb cache driver.",
         "ext-memcached": "Required to use the memcache cache driver.",
         "illuminate/database": "Required to use the database cache driver (^9.0).",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-mbstring": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^8.0.2",
         "ext-mbstring": "*",
-        "ext-pcntl": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
@@ -37,6 +36,7 @@
         }
     },
     "suggest": {
+        "ext-pcntl": "Required to use signal trapping.",
         "dragonmantank/cron-expression": "Required to use scheduler (^3.3.2).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^7.5).",
         "illuminate/bus": "Required to use the scheduled job dispatcher (^9.0).",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-mbstring": "*",
+        "ext-pcntl": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-hash": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-PDO": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,8 +17,6 @@
     "require": {
         "php": "^8.0.2",
         "ext-PDO": "*",
-        "ext-filter": "*",
-        "ext-pcntl": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
@@ -38,6 +36,7 @@
         }
     },
     "suggest": {
+        "ext-filter": "Required to use the Postgres database driver.",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.4).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
         "illuminate/console": "Required to use the database commands (^9.0).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-PDO": "*",
+        "ext-pdo": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -18,6 +18,7 @@
         "php": "^8.0.2",
         "ext-PDO": "*",
         "ext-filter": "*",
+        "ext-pcntl": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-PDO": "*",
+        "ext-filter": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-hash": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-hash": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-hash": "*",
+        "ext-fileinfo": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-hash": "*",
         "ext-fileinfo": "*",
+        "ext-hash": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,8 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-fileinfo": "*",
-        "ext-hash": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
@@ -34,7 +32,9 @@
         }
     },
     "suggest": {
+        "ext-fileinfo": "Required to use the Filesystem class.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
+        "ext-hash": "Required to use the Filesystem class.",
         "illuminate/http": "Required for handling uploaded files (^7.0).",
         "league/flysystem": "Required to use the Flysystem local driver (^3.0.16).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.0).",

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "fruitcake/php-cors": "^1.2",
         "illuminate/collections": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-filter": "*",
         "fruitcake/php-cors": "^1.2",
         "illuminate/collections": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/support": "^9.0"

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-filter": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/support": "^9.0"

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -38,7 +38,7 @@
         }
     },
     "suggest": {
-        "ext-PDO": "Required to use the database queue worker.",
+        "ext-pdo": "Required to use the database queue worker.",
         "ext-filter": "Required to use the SQS queue worker.",
         "ext-mbstring": "Required to use the database failed job providers.",
         "ext-pcntl": "Required to use all features of the queue worker.",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-PDO": "*",
         "ext-filter": "*",
         "ext-mbstring": "*",
         "illuminate/collections": "^9.0",
@@ -41,6 +40,7 @@
         }
     },
     "suggest": {
+        "ext-PDO": "Required to use the database queue worker.",
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.235.5).",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-PDO": "*",
+        "ext-mbstring": "*",
         "illuminate/collections": "^9.0",
         "illuminate/console": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-PDO": "*",
+        "ext-filter": "*",
         "ext-mbstring": "*",
         "illuminate/collections": "^9.0",
         "illuminate/console": "^9.0",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,8 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-filter": "*",
-        "ext-mbstring": "*",
         "illuminate/collections": "^9.0",
         "illuminate/console": "^9.0",
         "illuminate/container": "^9.0",
@@ -41,6 +39,8 @@
     },
     "suggest": {
         "ext-PDO": "Required to use the database queue worker.",
+        "ext-filter": "Required to use the SQS queue worker.",
+        "ext-mbstring": "Required to use the database failed job providers.",
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.235.5).",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/console": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-PDO": "*",
         "illuminate/collections": "^9.0",
         "illuminate/console": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-filter": "*",
+        "ext-hash": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-filter": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/filesystem": "^9.0",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-ctype": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/filesystem": "^9.0",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-ctype": "*",
+        "ext-session": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/filesystem": "^9.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-ctype": "*",
+        "ext-filter": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^2.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-ctype": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^2.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^2.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-mbstring": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "egulias/email-validator": "^3.2.1|^4.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-filter": "*",
+        "ext-mbstring": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "egulias/email-validator": "^3.2.1|^4.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-filter": "*",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "egulias/email-validator": "^3.2.1|^4.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "ext-tokenizer": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Brick\Math\BigDecimal;
+use Brick\Math\BigNumber;
 use GMP;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
@@ -398,14 +400,14 @@ class EuroCaster implements CastsAttributes
 
     public function increment($model, $key, string $value, $attributes)
     {
-        $model->$key = new Euro(bcadd($model->$key->value, $value, 2));
+        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->plus($value)->toScale(2));
 
         return $model->$key;
     }
 
     public function decrement($model, $key, string $value, $attributes)
     {
-        $model->$key = new Euro(bcsub($model->$key->value, $value, 2));
+        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->subtract($value)->toScale(2));
 
         return $model->$key;
     }

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use GMP;
 use Illuminate\Contracts\Database\Eloquent\Castable;


### PR DESCRIPTION
Followup: https://github.com/laravel/framework/pull/45848

add missing necessary (for testing) and suggested PHP extensions.