### PR TITLE
[10.x] Remove symfony/console from suggest

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -41,7 +41,6 @@
         "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
         "illuminate/filesystem": "Required to use the migrations (^10.0).",
         "illuminate/pagination": "Required to paginate the result set (^10.0).",
-        "symfony/console": "Required to use database console commands (^6.2).",
         "symfony/finder": "Required to use Eloquent model factories (^6.2)."
     },
     "config": {


### PR DESCRIPTION
This was added in https://github.com/laravel/framework/pull/45838 when the dependency was removed for the database component but in fact isn't needed as there's already a suggest for `illuminate/console` which is enough.