### PR TITLE
[10.x] Fixes memory leak on PHPUnit v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "pda/pheanstalk": "^4.0",
         "phpstan/phpdoc-parser": "^1.15",
         "phpstan/phpstan": "^1.4.7",
-        "phpunit/phpunit": "^9.5.8 || ^10.0.1",
+        "phpunit/phpunit": "^9.6.0 || ^10.0.1",
         "predis/predis": "^2.0.2",
         "symfony/cache": "^6.2",
         "symfony/http-client": "^6.2.4"

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -260,10 +260,10 @@ abstract class TestCase extends BaseTestCase
     {
         static::$latestResponse = null;
 
-        foreach([
+        foreach ([
             \PHPUnit\Util\Annotation\Registry::class,
             \PHPUnit\Metadata\Annotation\Parser\Registry::class,
-            ] as $class) {
+        ] as $class) {
             if (class_exists($class)) {
                 (function () {
                     $this->classDocBlocks = [];

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -15,7 +15,6 @@ use Illuminate\View\Component;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use PHPUnit\Util\Annotation\Registry;
 use Throwable;
 
 abstract class TestCase extends BaseTestCase
@@ -261,11 +260,16 @@ abstract class TestCase extends BaseTestCase
     {
         static::$latestResponse = null;
 
-        if (class_exists(Registry::class)) {
-            (function () {
-                $this->classDocBlocks = [];
-                $this->methodDocBlocks = [];
-            })->call(Registry::getInstance());
+        foreach([
+            \PHPUnit\Util\Annotation\Registry::class,
+            \PHPUnit\Metadata\Annotation\Parser\Registry::class,
+            ] as $class) {
+            if (class_exists($class)) {
+                (function () {
+                    $this->classDocBlocks = [];
+                    $this->methodDocBlocks = [];
+                })->call($class::getInstance());
+            }
         }
     }
 


### PR DESCRIPTION
This pull request adds one missing piece while adding support for PHPUnit 10, where we also need to clean the registry of annotations.