### PR TITLE
[9.x] Fix `Collection::wrap()` docblock typing

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -54,7 +54,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TWrapKey of array-key
      * @template TWrapValue
      *
-     * @param  iterable<TWrapKey, TWrapValue>  $value
+     * @param  iterable<TWrapKey, TWrapValue>|mixed<TWrapValue>  $value
      * @return static<TWrapKey, TWrapValue>
      */
     public static function wrap($value);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -117,7 +117,7 @@ trait EnumeratesValues
      * @template TWrapKey of array-key
      * @template TWrapValue
      *
-     * @param  iterable<TWrapKey, TWrapValue>  $value
+     * @param  iterable<TWrapKey, TWrapValue>|mixed<TWrapValue>  $value
      * @return static<TWrapKey, TWrapValue>
      */
     public static function wrap($value)

--- a/vendor 2
+++ b/vendor 2
@@ -1,1 +1,0 @@
-/Users/ralphjsmit/Library/Mobile Documents/com~apple~CloudDocs/Work/Development/Sites/framework/vendor.nosync

--- a/vendor 2
+++ b/vendor 2
@@ -1,0 +1,1 @@
+/Users/ralphjsmit/Library/Mobile Documents/com~apple~CloudDocs/Work/Development/Sites/framework/vendor.nosync


### PR DESCRIPTION
The `Arr::wrap()` and `Collection::wrap()` are very useful to wrap an item in an array/collection or, if it is already an array collection, don't apply a wrap.

I noticed that my IDE was complaining about the type of `Collection::wrap()`, because currently the typehint would only support iterables. That's weird, because the `wrap()` was specifically designed to accept anything (and wrap that anything into an array/collection):

<img width="674" alt="Scherm­afbeelding 2023-02-03 om 18 59 57" src="https://user-images.githubusercontent.com/59207045/216674495-abd970cc-e531-4f63-ba59-d0f1b6e9a2b7.png">

The interesting thing is that `Arr::wrap()` already has the correct type, it's only an issue in `Collection::wrap()`:

<img width="674" alt="Scherm­afbeelding 2023-02-03 om 19 02 19" src="https://user-images.githubusercontent.com/59207045/216674976-1690a6e0-e5bf-46c1-82e5-bf076b7a59fb.png">

Not sure if this counts as a bug fix 😜 Thanks!
