### PR TITLE
[9.x] Command schedule:work minor features: schedule:run output file & environment specific verbosity

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -17,7 +17,7 @@ class ScheduleWorkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schedule:work {--run-output-file=}';
+    protected $signature = 'schedule:work {--run-output-file= : The file to direct <info>schedule:run</info> output to}';
 
     /**
      * The name of the console command.

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -51,7 +51,7 @@ class ScheduleWorkCommand extends Command
 
         [$lastExecutionStartedAt, $executions] = [null, []];
 
-        $command = implode(' ', array_map(ProcessUtils::escapeArgument(...), [
+        $command = implode(' ', array_map(fn ($arg) => ProcessUtils::escapeArgument($arg), [
             PHP_BINARY,
             defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
             'schedule:run',

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -45,7 +45,7 @@ class ScheduleWorkCommand extends Command
     public function handle()
     {
         $this->components->info(
-            'Running schedule tasks every minute.',
+            'Running scheduled tasks every minute.',
             $this->getLaravel()->isLocal() ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -4,18 +4,20 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 #[AsCommand(name: 'schedule:work')]
 class ScheduleWorkCommand extends Command
 {
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'schedule:work';
+    protected $signature = 'schedule:work {--run-output-file=}';
 
     /**
      * The name of the console command.
@@ -42,20 +44,29 @@ class ScheduleWorkCommand extends Command
      */
     public function handle()
     {
-        $this->components->info('Running schedule tasks every minute.');
+        $this->components->info(
+            'Running schedule tasks every minute.',
+            $this->getLaravel()->isLocal() ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
+        );
 
         [$lastExecutionStartedAt, $executions] = [null, []];
+
+        $command = implode(' ', array_map(ProcessUtils::escapeArgument(...), [
+            PHP_BINARY,
+            defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+            'schedule:run',
+        ]));
+
+        if ($this->option('run-output-file')) {
+            $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';
+        }
 
         while (true) {
             usleep(100 * 1000);
 
             if (Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
-                $executions[] = $execution = new Process([
-                    PHP_BINARY,
-                    defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
-                    'schedule:run',
-                ]);
+                $executions[] = $execution = Process::fromShellCommandline($command);
 
                 $execution->start();
 
@@ -64,7 +75,7 @@ class ScheduleWorkCommand extends Command
 
             foreach ($executions as $key => $execution) {
                 $output = $execution->getIncrementalOutput().
-                          $execution->getIncrementalErrorOutput();
+                    $execution->getIncrementalErrorOutput();
 
                 $this->output->write(ltrim($output, "\n"));
 


### PR DESCRIPTION
Minor features to make `schedule:work` less chatty in certain environments:

`schedule:work` command to accept option `--run-output-file=` to redirect schedule:run output. This would allow someone using `schedule:work` to have it run similar to [directions for cron](https://laravel.com/docs/9.x/scheduling#running-the-scheduler), this is intended to be used like `artisan schedule:work --run-output-file=/dev/null` which would result in run being called like in this process list:

```
php /app/artisan schedule:work --run-output-file=/dev/null
  sh -c '/usr/bin/php8.1' 'artisan' 'schedule:run' >> '/dev/null' 2>&1
```

Additionally, different default verbosity levels for this command depending on the environment: local normal) vs. production = verbose (`-v`)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
