### PR TITLE
[9.x] Add methods for error handling and throwing exceptions in HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -220,6 +220,36 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Execute the given callback if there was a client error.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onClientError(callable $callback)
+    {
+        if ($this->clientError()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if there was a server error.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onServerError(callable $callback)
+    {
+        if ($this->serverError()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the response cookies.
      *
      * @return \GuzzleHttp\Cookie\CookieJar

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -327,6 +327,52 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Throw an exception if a client error occurred.
+     *
+     * @param  \Closure|null  $callback
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwOnClientError()
+    {
+        $callback = func_get_args()[0] ?? null;
+
+        if ($this->clientError()) {
+            throw tap($this->toException(), function ($exception) use ($callback) {
+                if ($callback && is_callable($callback)) {
+                    $callback($this, $exception);
+                }
+            });
+        }
+
+        return $this;
+    }
+
+    /**
+     * Throw an exception if a server error occurred.
+     *
+     * @param  \Closure|null  $callback
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwOnServerError()
+    {
+        $callback = func_get_args()[0] ?? null;
+
+        if ($this->serverError()) {
+            throw tap($this->toException(), function ($exception) use ($callback) {
+                if ($callback && is_callable($callback)) {
+                    $callback($this, $exception);
+                }
+            });
+        }
+
+        return $this;
+    }
+
+    /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
      * @param  \Closure|bool  $condition

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1957,6 +1957,219 @@ class HttpClientTest extends TestCase
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
     }
 
+    public function testRequestExceptionIfTheRequestClientError()
+    {
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnClientError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertTrue($flag);
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionIfTheRequestNotClientError()
+    {
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 101),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnClientError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnClientError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 301),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnClientError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 501),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnClientError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+    }
+    public function testRequestExceptionServerIfTheRequestServerError()
+    {
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 501),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnServerError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertTrue($flag);
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionServerIfTheRequestNotServerError()
+    {
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 101),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnServerError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnServerError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 301),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnServerError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+
+        $exception = null;
+        $flag = false;
+
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        try {
+            $client->get('laravel.com')
+                ->throwOnServerError(function ($response, $e) use (&$flag, &$exception) {
+                    $flag = true;
+                    $exception = $e;
+                });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertFalse($flag);
+        $this->assertNull($exception);
+    }
+
     public function testRequestExceptionIsThrowIfConditionIsSatisfied()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1000,6 +1000,166 @@ class HttpClientTest extends TestCase
         $this->assertSame(501, $response->status());
     }
 
+    public function testOnClientErrorDoesntCallClosureOnInformational()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 101),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onServerError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(101, $response->status());
+    }
+
+    public function testOnClientErrorDoesntCallClosureOnSuccess()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onClientError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(201, $response->status());
+    }
+
+    public function testOnClientErrorDoesntCallClosureOnRedirection()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 301),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onClientError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(301, $response->status());
+    }
+
+    public function testOnClientErrorDoesCallClosureOnClientError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onClientError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(401, $status);
+        $this->assertSame(401, $response->status());
+    }
+
+    public function testOnClientErrorDoesntCallClosureOnServer()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 501),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onClientError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(501, $response->status());
+    }
+
+    public function testOnServerErrorDoesntCallClosureOnInformational()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 101),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onServerError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(101, $response->status());
+    }
+
+    public function testOnServerErrorDoesntCallClosureOnSuccess()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onServerError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(201, $response->status());
+    }
+
+    public function testOnServerErrorDoesntCallClosureOnRedirection()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 301),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onServerError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(301, $response->status());
+    }
+
+    public function testOnServerErrorDoesntCallClosureOnClientError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onServerError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(401, $response->status());
+    }
+
+    public function testOnServerErrorDoesCallClosureOnServer()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 501),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onServerError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(501, $status);
+        $this->assertSame(501, $response->status());
+    }
+
     public function testSinkToFile()
     {
         $this->factory->fakeSequence()->push('abc123');

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2063,6 +2063,7 @@ class HttpClientTest extends TestCase
         $this->assertFalse($flag);
         $this->assertNull($exception);
     }
+
     public function testRequestExceptionServerIfTheRequestServerError()
     {
         $exception = null;


### PR DESCRIPTION
1- Add new Methods `onClientError()` and `onServerError()` that allow handling custom callback when the response is a client error or server error rather than `onError()` for both client and server.
 
```php 
   Http::get(/* ... */)
    ->onClientError(function () {
        // execute a callback when the response is a client error
    })
    ->onServerError(function () {
        // execute a callback when the response is a server error
    });
```

2- Add new Methods `throwOnClientError()` and `throwOnServerError()` that allow throwing a custom exception or request exception when the response is a client error or server error rather than `throw()` for both client and server.

```php
   Http::get(/* ... */)
    ->throwOnClientError(function ($response, $e) {
          // throw custom exception for client error
    })
    ->throwOnServerError(function ($response, $e) {
         // throw custom exception for server error
    });
```


## Expmale :

```php
  Http::get('laravel.com')
        ->throw(function ($response, $exception) {
            $response->serverError() 
                ? APIException::serverError(/*...*/) 
                : APIException::clientError(/*...*/);
        });

    // to
    
    Http::get('laravel.com')
        ->throwOnClient(function ($response, $exception) {
            APIException::clientError(/*...*/);
        })
        ->throwOnServer(function ($response, $exception) {
            APIException::clientError(/*...*/);
        });

```
```php
    Http::get('laravel.com')
        ->throwIfServerError()
        ->throw(function ($response, $exception) {
            APIException::clientError(/*...*/);
        });

    // to
    
    Http::get('laravel.com')
        ->throwOnClient(function ($response, $exception) {
            APIException::clientError(/*...*/);
        });
```












