### PR TITLE
[10.x] More expressive validation rule interface

### DIFF
--- a/src/Illuminate/Contracts/Validation/ValidationRule.php
+++ b/src/Illuminate/Contracts/Validation/ValidationRule.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+use Closure;
+
+interface ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void;
+}

--- a/src/Illuminate/Foundation/Console/stubs/rule.implicit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.implicit.stub
@@ -3,9 +3,9 @@
 namespace {{ namespace }};
 
 use Closure;
-use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class {{ class }} implements InvokableRule
+class {{ class }} implements ValidationRule
 {
     /**
      * Indicates whether the rule should be implicit.
@@ -19,7 +19,7 @@ class {{ class }} implements InvokableRule
      *
      * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
-    public function __invoke(string $attribute, mixed $value, Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -3,16 +3,16 @@
 namespace {{ namespace }};
 
 use Closure;
-use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class {{ class }} implements InvokableRule
+class {{ class }} implements ValidationRule
 {
     /**
      * Run the validation rule.
      *
      * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
-    public function __invoke(string $attribute, mixed $value, Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         //
     }

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Translation\PotentiallyTranslatedString;
 
@@ -14,7 +15,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     /**
      * The invokable that validates the attribute.
      *
-     * @var \Illuminate\Contracts\Validation\InvokableRule
+     * @var \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule
      */
     protected $invokable;
 
@@ -49,10 +50,10 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     /**
      * Create a new explicit Invokable validation rule.
      *
-     * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
+     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule  $invokable
      * @return void
      */
-    protected function __construct(InvokableRule $invokable)
+    protected function __construct(ValidationRule|InvokableRule $invokable)
     {
         $this->invokable = $invokable;
     }
@@ -66,8 +67,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule
-            {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
                 //
             };
         }
@@ -94,7 +94,11 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             $this->invokable->setValidator($this->validator);
         }
 
-        $this->invokable->__invoke($attribute, $value, function ($attribute, $message = null) {
+        $method = $this->invokable instanceof ValidationRule
+                        ? 'validate'
+                        : '__invoke';
+
+        $this->invokable->{$method}($attribute, $value, function ($attribute, $message = null) {
             $this->failed = true;
 
             return $this->pendingPotentiallyTranslatedString($attribute, $message);
@@ -106,7 +110,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     /**
      * Get the underlying invokable rule.
      *
-     * @return \Illuminate\Contracts\Validation\InvokableRule
+     * @return \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule
      */
     public function invokable()
     {
@@ -162,8 +166,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             ? fn ($message) => $this->messages[] = $message
             : fn ($message) => $this->messages[$attribute] = $message;
 
-        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor) extends PotentiallyTranslatedString
-        {
+        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor) extends PotentiallyTranslatedString {
             /**
              * The callback to call when the object destructs.
              *

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -67,7 +67,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule
+            {
                 //
             };
         }
@@ -166,7 +167,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             ? fn ($message) => $this->messages[] = $message
             : fn ($message) => $this->messages[$attribute] = $message;
 
-        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor) extends PotentiallyTranslatedString {
+        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor) extends PotentiallyTranslatedString
+        {
             /**
              * The callback to call when the object destructs.
              *

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use Closure;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
@@ -113,7 +114,7 @@ class ValidationRuleParser
             $rule = new ClosureValidationRule($rule);
         }
 
-        if ($rule instanceof InvokableRule) {
+        if ($rule instanceof InvokableRule || $rule instanceof ValidationRule) {
             $rule = InvokableValidationRule::make($rule);
         }
 

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -16,7 +16,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanPass()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 //
@@ -32,7 +33,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanFail()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail("The {$attribute} attribute is not 'foo'. Got '{$value}' instead.");
@@ -52,7 +54,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanReturnMultipleErrorMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('Error message 1.');
@@ -75,7 +78,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'Translated error message.'], 'en');
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('validation.translated-error')->translate();
@@ -96,7 +100,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'attribute: :attribute input: :input position: :position index: :index baz: :baz'], 'en');
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 if ($value !== null) {
@@ -122,7 +127,8 @@ class ValidationInvokableRuleTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'attribute: :attribute'], 'en');
         $trans->addLines(['validation.attributes.foo' => 'email address'], 'en');
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 if ($value !== null) {
@@ -146,7 +152,8 @@ class ValidationInvokableRuleTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'English'], 'en');
         $trans->addLines(['validation.translated-error' => 'French'], 'fr');
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('validation.translated-error')->translate([], 'en');
@@ -168,7 +175,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanAccessDataDuringValidation()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule, DataAwareRule {
+        $rule = new class() implements ValidationRule, DataAwareRule
+        {
             public $data = [];
 
             public function setData($data)
@@ -197,7 +205,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $rule = new class() implements ValidationRule, ValidatorAwareRule {
+        $rule = new class() implements ValidationRule, ValidatorAwareRule
+        {
             public $validator = null;
 
             public function setValidator($validator)
@@ -222,7 +231,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeExplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public $implicit = false;
 
             public function validate($attribute, $value, $fail): void
@@ -240,7 +250,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeImplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public $implicit = true;
 
             public function validate($attribute, $value, $fail): void
@@ -262,7 +273,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItIsExplicitByDefault()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
@@ -278,7 +290,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanSpecifyTheValidationErrorKeyForTheErrorMessage()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('bar.baz', 'Another attribute error.');
@@ -303,7 +316,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'There is one error.|There are many errors.'], 'en');
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('validation.translated-error')->translateChoice(2);
@@ -323,7 +337,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testExplicitRuleCanUseInlineValidationMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public $implicit = false;
 
             public function validate($attribute, $value, $fail): void
@@ -354,7 +369,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testImplicitRuleCanUseInlineValidationMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public $implicit = true;
 
             public function validate($attribute, $value, $fail): void
@@ -384,7 +400,8 @@ class ValidationInvokableRuleTest extends TestCase
 
     public function testItCanReturnInvokableRule()
     {
-        $rule = new class() implements ValidationRule {
+        $rule = new class() implements ValidationRule
+        {
             public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Validation;
 
 use Illuminate\Contracts\Validation\DataAwareRule;
-use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
@@ -16,9 +16,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanPass()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 //
             }
@@ -33,9 +32,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanFail()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail("The {$attribute} attribute is not 'foo'. Got '{$value}' instead.");
             }
@@ -54,9 +52,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanReturnMultipleErrorMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('Error message 1.');
                 $fail('Error message 2.');
@@ -78,9 +75,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'Translated error message.'], 'en');
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('validation.translated-error')->translate();
             }
@@ -100,9 +96,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'attribute: :attribute input: :input position: :position index: :index baz: :baz'], 'en');
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 if ($value !== null) {
                     $fail('validation.translated-error')->translate([
@@ -127,9 +122,8 @@ class ValidationInvokableRuleTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'attribute: :attribute'], 'en');
         $trans->addLines(['validation.attributes.foo' => 'email address'], 'en');
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 if ($value !== null) {
                     $fail('validation.translated-error')->translate();
@@ -152,9 +146,8 @@ class ValidationInvokableRuleTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'English'], 'en');
         $trans->addLines(['validation.translated-error' => 'French'], 'fr');
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('validation.translated-error')->translate([], 'en');
                 $fail('validation.translated-error')->translate([], 'fr');
@@ -175,8 +168,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanAccessDataDuringValidation()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule, DataAwareRule
-        {
+        $rule = new class() implements ValidationRule, DataAwareRule {
             public $data = [];
 
             public function setData($data)
@@ -184,7 +176,7 @@ class ValidationInvokableRuleTest extends TestCase
                 $this->data = $data;
             }
 
-            public function __invoke($attribute, $value, $fail)
+            public function validate($attribute, $value, $fail): void
             {
                 if ($this->data === []) {
                     $fail('xxxx');
@@ -205,8 +197,7 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $rule = new class() implements InvokableRule, ValidatorAwareRule
-        {
+        $rule = new class() implements ValidationRule, ValidatorAwareRule {
             public $validator = null;
 
             public function setValidator($validator)
@@ -214,7 +205,7 @@ class ValidationInvokableRuleTest extends TestCase
                 $this->validator = $validator;
             }
 
-            public function __invoke($attribute, $value, $fail)
+            public function validate($attribute, $value, $fail): void
             {
                 if ($this->validator === null) {
                     $fail('xxxx');
@@ -231,11 +222,10 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeExplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
+        $rule = new class() implements ValidationRule {
             public $implicit = false;
 
-            public function __invoke($attribute, $value, $fail)
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
             }
@@ -250,11 +240,10 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeImplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
+        $rule = new class() implements ValidationRule {
             public $implicit = true;
 
-            public function __invoke($attribute, $value, $fail)
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
             }
@@ -273,9 +262,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItIsExplicitByDefault()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
             }
@@ -290,9 +278,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanSpecifyTheValidationErrorKeyForTheErrorMessage()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('bar.baz', 'Another attribute error.');
                 $fail('This attribute error.');
@@ -316,9 +303,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'There is one error.|There are many errors.'], 'en');
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('validation.translated-error')->translateChoice(2);
             }
@@ -337,11 +323,10 @@ class ValidationInvokableRuleTest extends TestCase
     public function testExplicitRuleCanUseInlineValidationMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
+        $rule = new class() implements ValidationRule {
             public $implicit = false;
 
-            public function __invoke($attribute, $value, $fail)
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
             }
@@ -369,11 +354,10 @@ class ValidationInvokableRuleTest extends TestCase
     public function testImplicitRuleCanUseInlineValidationMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements InvokableRule
-        {
+        $rule = new class() implements ValidationRule {
             public $implicit = true;
 
-            public function __invoke($attribute, $value, $fail)
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
             }
@@ -400,9 +384,8 @@ class ValidationInvokableRuleTest extends TestCase
 
     public function testItCanReturnInvokableRule()
     {
-        $rule = new class() implements InvokableRule
-        {
-            public function __invoke($attribute, $value, $fail)
+        $rule = new class() implements ValidationRule {
+            public function validate($attribute, $value, $fail): void
             {
                 $fail('xxxx');
             }


### PR DESCRIPTION
The default class based validation rules in Laravel 10.x are "invokable" rules. This adds a new interface with a more expressive method name (to be consistent with all other class types in Laravel), but has the same behavior as "invokable" rules.