### PR TITLE
Add softDeletesDatetime() to Blueprint class for consistency

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1244,7 +1244,7 @@ class Blueprint
      * Add a "deleted at" datetime column to the table.
      *
      * @param  int|null  $precision
-     * @return void
+     * @return \Illuminate\Database\Schema\ColumnDefinition
      */
     public function softDeletesDatetime($precision = 0)
     {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1243,12 +1243,13 @@ class Blueprint
     /**
      * Add a "deleted at" datetime column to the table.
      *
+     * @param  string  $column
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletesDatetime($precision = 0)
+    public function softDeletesDatetime($column = 'deleted_at', $precision = 0)
     {
-        return $this->datetime('deleted_at', $precision)->nullable();
+        return $this->datetime($column, $precision)->nullable();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1248,7 +1248,7 @@ class Blueprint
      */
     public function softDeletesDatetime($precision = 0)
     {
-        $this->datetime('deleted_at', $precision)->nullable();
+        return $this->datetime('deleted_at', $precision)->nullable();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1239,6 +1239,17 @@ class Blueprint
     {
         return $this->timestampTz($column, $precision)->nullable();
     }
+    
+    /**
+     * Add a "deleted at" datetime column to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function softDeletesDatetime($precision = 0)
+    {
+        $this->datetime('deleted_at', $precision)->nullable();
+    }
 
     /**
      * Create a new year column on the table.


### PR DESCRIPTION
Well you all merged this PR yesterday to for a method to make created_at and updated_at to be datetimes

https://github.com/laravel/framework/pull/45947

So i make this PR to apply the same too for deleted_at for consistency

Should i make it return? I notice some methods does it while some don't

Update: I made it return in the end since some people might want to call ->index() afterwards.