### PR TITLE
[10.x] Add contract to Http Kernel Bootstrappers

### DIFF
--- a/src/Illuminate/Contracts/Foundation/IsBootstrapper.php
+++ b/src/Illuminate/Contracts/Foundation/IsBootstrapper.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation;
+
+interface IsBootstrapper
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @param  Application  $app
+     * @return void
+     */
+    public function bootstrap(Application $app);
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -245,7 +245,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
                 $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
             } else {
-                throw new \RuntimeException('The bootstrapper must be implements of IsBootstrapper');
+                throw new \RuntimeException('The' . $bootstrapper . 'must be implements of IsBootstrapper');
             }
         }
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -239,11 +239,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         foreach ($bootstrappers as $bootstrapper) {
             if (new $bootstrapper instanceof IsBootstrapper) {
-                $this['events']->dispatch('bootstrapping: ' . $bootstrapper, [$this]);
+                $this['events']->dispatch('bootstrapping: '.$bootstrapper, [$this]);
 
                 $this->make($bootstrapper)->bootstrap($this);
 
-                $this['events']->dispatch('bootstrapped: ' . $bootstrapper, [$this]);
+                $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
             } else {
                 throw new \RuntimeException('The bootstrapper must be implements of IsBootstrapper');
             }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Contracts\Foundation\CachesRoutes;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Events\EventServiceProvider;
@@ -237,11 +238,15 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->hasBeenBootstrapped = true;
 
         foreach ($bootstrappers as $bootstrapper) {
-            $this['events']->dispatch('bootstrapping: '.$bootstrapper, [$this]);
+            if (new $bootstrapper instanceof IsBootstrapper) {
+                $this['events']->dispatch('bootstrapping: ' . $bootstrapper, [$this]);
 
-            $this->make($bootstrapper)->bootstrap($this);
+                $this->make($bootstrapper)->bootstrap($this);
 
-            $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
+                $this['events']->dispatch('bootstrapped: ' . $bootstrapper, [$this]);
+            } else {
+                throw new \RuntimeException('The bootstrapper must be implements of IsBootstrapper');
+            }
         }
     }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -245,7 +245,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
                 $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
             } else {
-                throw new \RuntimeException('The' . $bootstrapper . 'must be implements of IsBootstrapper');
+                throw new \RuntimeException('The'.$bootstrapper.'must be implements of IsBootstrapper');
             }
         }
     }

--- a/src/Illuminate/Foundation/Bootstrap/BootProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/BootProviders.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 
-class BootProviders
+class BootProviders implements IsBootstrapper
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -6,13 +6,14 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 use Illuminate\Log\LogManager;
 use Monolog\Handler\NullHandler;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Throwable;
 
-class HandleExceptions
+class HandleExceptions implements IsBootstrapper
 {
     /**
      * Reserved memory so that errors can be displayed properly on memory exhaustion.

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -6,10 +6,11 @@ use Exception;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
-class LoadConfiguration
+class LoadConfiguration implements IsBootstrapper
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -5,11 +5,12 @@ namespace Illuminate\Foundation\Bootstrap;
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidFileException;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 use Illuminate\Support\Env;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
-class LoadEnvironmentVariables
+class LoadEnvironmentVariables implements IsBootstrapper
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Facades\Facade;
 
-class RegisterFacades
+class RegisterFacades implements IsBootstrapper
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\IsBootstrapper;
 
-class RegisterProviders
+class RegisterProviders implements IsBootstrapper
 {
     /**
      * Bootstrap the given application.


### PR DESCRIPTION
Laravel has always been known for code style.
In http kernel all bootstraps must be have ```bootstrap``` method, but if some developer modify the method name of bootstrapper or add a new bootstrapper like this:
```php 
    protected $bootstrappers = [
        \Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables::class,
        \Illuminate\Foundation\Bootstrap\LoadConfiguration::class,
        \Illuminate\Foundation\Bootstrap\LoadConfigProject::class, // Add new for test
        \Illuminate\Foundation\Bootstrap\HandleExceptions::class,
        \Illuminate\Foundation\Bootstrap\RegisterFacades::class,
        \Illuminate\Foundation\Bootstrap\RegisterProviders::class,
        \Illuminate\Foundation\Bootstrap\BootProviders::class,
    ];
```
After in browser the message error is:
![2023-02-04_13-01-08](https://user-images.githubusercontent.com/98118400/216759926-624bdd55-d07b-4c67-8c4f-177c4536898d.png)
 
Or Maybe change the ```bootstrapper ``` method name, the error message like this:
![2023-02-04_12-59-20](https://user-images.githubusercontent.com/98118400/216759940-0bea2eb4-9c79-40c4-a8b5-1e64eba5f7b2.png)

----------------------
Here when add contract to bootstrapper, the error message is very pretty:
![2023-02-04_13-04-17](https://user-images.githubusercontent.com/98118400/216760048-69c1b8ee-dd8f-4599-8a96-ceb26a93b647.png)

After implement, There is not error in application.
