### PR TITLE
[9.x] Fix: prevent duplicated content-type on HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -343,11 +343,7 @@ class PendingRequest
      */
     public function contentType(string $contentType)
     {
-        $currentContentTypes = Arr::wrap(Arr::get($this->options, 'headers.Content-Type'));
-
-        if (! in_array($contentType, $currentContentTypes)) {
-            $this->withHeaders(['Content-Type' => $contentType]);
-        }
+        $this->options['headers']['Content-Type'] = $contentType;
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -343,7 +343,13 @@ class PendingRequest
      */
     public function contentType(string $contentType)
     {
-        return $this->withHeaders(['Content-Type' => $contentType]);
+        $currentContentTypes = Arr::wrap(Arr::get($this->options, 'headers.Content-Type'));
+
+        if (! in_array($contentType, $currentContentTypes)) {
+            $this->withHeaders(['Content-Type' => $contentType]);
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2159,6 +2159,6 @@ class HttpClientTest extends TestCase
 
         $client->contentType('foo');
 
-        $this->assertSame(['application/json', 'foo'], Arr::get($client->getOptions(), 'headers.Content-Type'));
+        $this->assertSame('foo', Arr::get($client->getOptions(), 'headers.Content-Type'));
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -18,6 +18,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Http\Response as HttpResponse;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
@@ -2143,5 +2144,21 @@ class HttpClientTest extends TestCase
         $request = $request->maxRedirects(10);
 
         $this->assertSame(['connect_timeout' => 10, 'http_errors' => false, 'timeout' => 30, 'allow_redirects' => ['max' => 10]], $request->getOptions());
+    }
+
+    public function testPreventDuplicatedContentType(): void
+    {
+        $client = $this->factory->asJson();
+
+        $this->assertSame('application/json', Arr::get($client->getOptions(), 'headers.Content-Type'));
+
+        $client->asJson();
+        $client->asJson();
+
+        $this->assertSame('application/json', Arr::get($client->getOptions(), 'headers.Content-Type'));
+
+        $client->contentType('foo');
+
+        $this->assertSame(['application/json', 'foo'], Arr::get($client->getOptions(), 'headers.Content-Type'));
     }
 }


### PR DESCRIPTION
The PR fixes a weird behaviour where calling multiple times a method that sets a content type (or manually) will append the same content type duplicated, eventually causing issues with external APIs (especially with Express middlewares etc.).

**Sample to reproduce the old behaviour**:

```php
use Illuminate\Support\Facades\Http;

$client = Illuminate\Support\Facades\Http::asJson();

$client->asJson();
$client->asJson();
dd($client->getOptions()['headers']['Content-Type']);
```

**Output**

![image](https://user-images.githubusercontent.com/6277291/216766593-f9c6e036-c887-4fc6-93ea-05d1d5b59796.png)
