### PR TITLE
[9.x] Make sure the lock_connection is used for schedule's withoutOverlapping()

### DIFF
--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -41,10 +41,9 @@ class CacheEventMutex implements EventMutex, CacheAware
     public function create(Event $event)
     {
         if ($this->cache->store($this->store)->getStore() instanceof LockProvider) {
-            $lock = $this->cache->store($this->store)->getStore()
-                ->lock($event->mutexName(), $event->expiresAt * 60);
-
-            return $lock->acquire();
+            return $this->cache->store($this->store)->getStore()
+                ->lock($event->mutexName(), $event->expiresAt * 60)
+                ->acquire();
         }
 
         return $this->cache->store($this->store)->add(
@@ -61,10 +60,9 @@ class CacheEventMutex implements EventMutex, CacheAware
     public function exists(Event $event)
     {
         if ($this->cache->store($this->store)->getStore() instanceof LockProvider) {
-            $lock = $this->cache->store($this->store)->getStore()
-                ->lock($event->mutexName(), $event->expiresAt * 60);
-
-            return ! $lock->get(fn () => true);
+            return ! $this->cache->store($this->store)->getStore()
+                ->lock($event->mutexName(), $event->expiresAt * 60)
+                ->get(fn () => true);
         }
 
         return $this->cache->store($this->store)->has($event->mutexName());
@@ -79,10 +77,9 @@ class CacheEventMutex implements EventMutex, CacheAware
     public function forget(Event $event)
     {
         if ($this->cache->store($this->store)->getStore() instanceof LockProvider) {
-            $lock = $this->cache->store($this->store)->getStore()
-                ->lock($event->mutexName(), $event->expiresAt * 60);
-
-            $lock->forceRelease();
+            $this->cache->store($this->store)->getStore()
+                ->lock($event->mutexName(), $event->expiresAt * 60)
+                ->forceRelease();
 
             return;
         }

--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -64,7 +64,7 @@ class CacheEventMutex implements EventMutex, CacheAware
             $lock = $this->cache->store($this->store)->getStore()
                 ->lock($event->mutexName(), $event->expiresAt * 60);
 
-            return ! $lock->get(fn () : bool => true);
+            return ! $lock->get(fn () => true);
         }
 
         return $this->cache->store($this->store)->has($event->mutexName());


### PR DESCRIPTION
**Background**

PR https://github.com/laravel/framework/pull/35621 added a separate `lock_connection` so that locks would not be cleared when `cache:clear` was run, but this improvement was never implemented for the [withoutOverlapping()](https://laravel.com/docs/9.x/scheduling#preventing-task-overlaps) used for task scheduling.

**This PR**

This PR aims to remedy this, care have been taken to still support cache drivers that doesn't support locking, so the old behaviour is preserved as a fallback.

With this PR we will remove the risk of overlapping tasks whenever `cache:clear` is run, as long as the cache driver implements `LockProvider` and that a separate `lock_connection` is configured.

For users that either uses a cache driver that doesn't support locking, or haven't configured the `lock_connection`, the previous behaviour will be used.

**Tests**

I had to modify the current tests so that they would bypass this new logic and still test the old logic, i did this by mocking the return value of `getStore()` and return anything that didn't implement `LockProvider` (i chose `\stdClass`), this will make sure that the old tests tests the old/fallback behaviour.

I also added 5 new tests that tests the same scenarios as the old tests but instead tests the new logic, i used the `ArrayStore` for this (since it implements `LockProvider`).