### PR TITLE
[9.x] Add mergeIfMissing method to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -846,7 +846,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Merge the collection with the given items only if the items are missing.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @return static
      */
     public function mergeIfMissing($items)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -844,6 +844,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Merge the collection with the given items only if the items are missing.
+     *
+     * @param \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @return static
+     */
+    public function mergeIfMissing($items)
+    {
+        return new static(
+            $this->merge(collect($items)->filter(fn ($value, $key) => ! $this->has($key)))
+        );
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -846,7 +846,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Merge the collection with the given items only if the items are missing.
      *
-     * @param \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
      * @return static
      */
     public function mergeIfMissing($items)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -706,6 +706,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function merge($items);
 
     /**
+     * Merge the collection with the given items only if the items are missing.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static
+     */
+    public function mergeIfMissing($items);
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -841,6 +841,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Merge the collection with the given items only if the items are missing.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static
+     */
+    public function mergeIfMissing($items)
+    {
+        return $this->passthru('mergeIfMissing', func_get_args());
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1333,6 +1333,33 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMergeIfMissingArray($collection)
+    {
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $c->mergeIfMissing(['foo'])->all());
+
+        $c = new $collection(['role' => 'admin']);
+        $this->assertEquals(['role' => 'admin', 'id' => 1], $c->mergeIfMissing(['id' => 1])->all());
+
+        $c = new $collection(['role' => 'admin', 'id' => 1]);
+        $this->assertEquals(['role' => 'admin', 'id' => 1], $c->mergeIfMissing(['id' => 2])->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeIfMissingCollection($collection)
+    {
+        $c = new $collection(['role' => 'admin']);
+        $this->assertEquals(['role' => 'admin', 'id' => 1], $c->mergeIfMissing(new $collection(['id' => 1]))->all());
+
+        $c = new $collection(['role' => 'admin', 'id' => 1]);
+        $this->assertEquals(['role' => 'admin', 'id' => 1], $c->mergeIfMissing(new $collection(['id' => 2]))->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMergeRecursiveNull($collection)
     {
         $c = new $collection(['name' => 'Hello']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -740,6 +740,17 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testMergeIfMissingIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->mergeIfMissing([1, 2, 3]);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->mergeIfMissing([1, 2, 3])->all();
+        });
+    }
+
     public function testMergeRecursiveIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
This method allows you to merge two collections, but only if the elements in the second collection do not already exist in the first collection. This is useful when you want to add new items to a collection, but do not want to overwrite existing items.