### PR TITLE
[10.x] Add a dynamic update method to Eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1021,6 +1021,7 @@ class Builder implements BuilderContract
     protected function performDynamicUpdate(string $method, array $parameters)
     {
         $column = Str::of($method)->after('update')->snake()->value();
+
         return $this->update([$column => $parameters[0]]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1012,6 +1012,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Perform dynamic update.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return int
+     */
+    protected function performDynamicUpdate(string $method, array $parameters)
+    {
+        $column = Str::of($method)->after('update')->snake()->value();
+        return $this->update([$column => $parameters[0]]);
+    }
+
+    /**
      * Insert new records or update the existing ones.
      *
      * @param  array  $values
@@ -1867,6 +1880,10 @@ class Builder implements BuilderContract
 
         if (in_array($method, $this->passthru)) {
             return $this->toBase()->{$method}(...$parameters);
+        }
+
+        if (str_starts_with($method, 'update')) {
+            return $this->performDynamicUpdate($method, $parameters);
         }
 
         $this->forwardCallTo($this->query, $method, $parameters);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2020,6 +2020,22 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testDynamicUpdate()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "user_id" = ?, "table"."updated_at" = ?', [10, $now])->andReturn(1);
+        $result = $builder->updateUserId(10);
+
+        $this->assertEquals(1, $result);
+    }
+
     public function testUpdateWithTimestampValue()
     {
         $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));


### PR DESCRIPTION
often not always we need to perform update on one column of a model only
eg:

```
$user->update([ 'active' => true);
$post->update([ 'archive' => true);
$product->update([ 'cat_id' => 99);
```
would it be nice we have dynamic method calling on the update

```
$user->updateActive(true);
$post->updateArchive(true);
$product->updateCatId(99);
```

by upgrading to mthod not only it reads better than the array syntax, also give you a nicer interface.
