### PR TITLE
[10.x] Use common joinPaths function in Application for generating paths

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -545,7 +545,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  string  $path
      * @return string
      */
-    protected function joinPaths($basePath, $path = '')
+    public function joinPaths($basePath, $path = '')
     {
         return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -344,18 +344,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
-     * Join the given paths together.
-     *
-     * @param  string  $basePath
-     * @param  string  $path
-     * @return string
-     */
-    protected function joinPaths($basePath, $path = '')
-    {
-        return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
-    }
-
-    /**
      * Get the path to the application "app" directory.
      *
      * @param  string  $path
@@ -548,6 +536,18 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $viewPath = rtrim($this['config']->get('view.paths')[0], DIRECTORY_SEPARATOR);
 
         return $this->joinPaths($viewPath, $path);
+    }
+
+    /**
+     * Join the given paths together.
+     *
+     * @param  string  $basePath
+     * @param  string  $path
+     * @return string
+     */
+    protected function joinPaths($basePath, $path = '')
+    {
+        return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -344,6 +344,18 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Join the given paths together.
+     *
+     * @param  string  $basePath
+     * @param  string  $path
+     * @return string
+     */
+    protected function joinPaths($basePath, $path = '')
+    {
+        return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
+    }
+
+    /**
      * Get the path to the application "app" directory.
      *
      * @param  string  $path
@@ -351,9 +363,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function path($path = '')
     {
-        $appPath = $this->appPath ?: $this->basePath.DIRECTORY_SEPARATOR.'app';
+        $appPath = $this->appPath ?: $this->basePath('app');
 
-        return $appPath.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($appPath, $path);
     }
 
     /**
@@ -379,7 +391,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function basePath($path = '')
     {
-        return $this->basePath.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($this->basePath, $path);
     }
 
     /**
@@ -390,7 +402,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function bootstrapPath($path = '')
     {
-        return $this->bootstrapPath.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($this->bootstrapPath, $path);
     }
 
     /**
@@ -416,7 +428,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function configPath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'config'.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($this->basePath('config'), $path);
     }
 
     /**
@@ -427,7 +439,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function databasePath($path = '')
     {
-        return ($this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database').($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        $databasePath = $this->databasePath ?: $this->basePath('database');
+
+        return $this->joinPaths($databasePath, $path);
     }
 
     /**
@@ -453,7 +467,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function langPath($path = '')
     {
-        return $this->langPath.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($this->langPath, $path);
     }
 
     /**
@@ -474,11 +488,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Get the path to the public / web directory.
      *
+     * @param  string  $path
      * @return string
      */
-    public function publicPath()
+    public function publicPath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'public';
+        return $this->joinPaths($this->basePath('public'), $path);
     }
 
     /**
@@ -489,8 +504,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        return ($this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage')
-                            .($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        $storagePath = $this->storagePath ?: $this->basePath('storage');
+
+        return $this->joinPaths($storagePath, $path);
     }
 
     /**
@@ -516,7 +532,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function resourcePath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'resources'.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($this->basePath('resources'), $path);
     }
 
     /**
@@ -529,9 +545,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function viewPath($path = '')
     {
-        $basePath = $this['config']->get('view.paths')[0];
+        $viewPath = rtrim($this['config']->get('view.paths')[0], DIRECTORY_SEPARATOR);
 
-        return rtrim($basePath, DIRECTORY_SEPARATOR).($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->joinPaths($viewPath, $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -628,7 +628,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
+        return app()->joinPaths(app()->make('path.public'), $path);
     }
 }
 


### PR DESCRIPTION
This MR creates a common `joinPath` function in the `Application` class, aiming to ensure the various path-related helper functions will behave identical now and in the future.

It also allows the `publicPath` helper to accept an optional argument, similar to how the other helpers work.