### PR TITLE
[10.x] Add public path to application contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -54,6 +54,14 @@ interface Application extends Container
     public function langPath($path = '');
 
     /**
+     * Get the path to the public directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function publicPath($path = '');
+
+    /**
      * Get the path to the resources directory.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -481,7 +481,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function publicPath($path = '')
     {
-        return $this->joinPaths($this->basePath('public'), $path);
+        $publicPath = $this->bound('path.public') ? $this->make('path.public') : $this->basePath('public');
+
+        return $this->joinPaths($publicPath, $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -628,7 +628,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->joinPaths(app()->make('path.public'), $path);
+        return app()->publicPath($path);
     }
 }
 


### PR DESCRIPTION
Requires #45968 to be merged first.

This MR adds the `publicPath` function the the `Application` contract for consistency with other path-related helpers. It also updates the global helper function to use this function.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
