### PR TITLE
[10.x] `offsetExists` fetches attribute and not only checks

### DIFF
--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -342,7 +342,7 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 
         $this->assertTrue(isset($model['incrementing']));
 
-        $this->assertEquals(1, $model['incrementing']);
+        $this->assertEquals(2, $model['incrementing']);
     }
 
     public function testOffsetCheckOnNull()

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -335,6 +335,23 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $this->assertNotSame($previous, $previous = $model->virtualDateTimeWithoutCachingFluent);
         }
     }
+
+    public function testOffsetCheckDoesNotGetAttribute()
+    {
+        $model = New TestEloquentModelWithAttributeCast;
+
+        $this->assertTrue(isset($model['incrementing']));
+
+        $this->assertEquals(1, $model['incrementing']);
+    }
+
+    public function testOffsetCheckOnNull()
+    {
+        $model = New TestEloquentModelWithAttributeCast;
+
+        $this->assertFalse(isset($model['null']));
+        $this->assertNull($model['null']);
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -510,6 +527,23 @@ class TestEloquentModelWithAttributeCast extends Model
         return Attribute::get(function () {
             return Date::now()->addSeconds(mt_rand(0, 10000));
         })->withoutObjectCaching();
+    }
+
+
+    public int $timesCalled = 0;
+
+    public function incrementing(): Attribute
+    {
+        return Attribute::get(function () {
+            return ++$this->timesCalled;
+        });
+    }
+
+    public function null(): Attribute
+    {
+        return Attribute::get(function () {
+            return null;
+        });
     }
 }
 

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -127,6 +127,23 @@ class EloquentBelongsToTest extends DatabaseTestCase
         $this->assertFalse($child->parent()->is($parent));
         $this->assertTrue($child->parent()->isNot($parent));
     }
+
+    public function testOffsetRelation()
+    {
+        $user = User::has('parent')->first();
+
+        $this->assertTrue(isset($user['parent']));
+        $this->assertFalse($user->relationLoaded('parent'));
+    }
+
+    public function testOffsetDynamicRelation()
+    {
+        $user = User::first();
+        $user->setRelation('newRelation', collect());
+
+        $this->assertTrue(isset($user['newRelation']));
+        $this->assertTrue($user->relationLoaded('newRelation'));
+    }
 }
 
 class User extends Model

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -94,6 +94,22 @@ class EloquentModelTest extends DatabaseTestCase
         $user->save();
         $this->assertFalse($user->wasChanged());
     }
+
+    public function testOffsetAttribute()
+    {
+        $user = new TestModel2;
+        $user->name = 'works';
+
+        $this->assertTrue(isset($user['name']));
+    }
+
+    public function testOffsetAttributeOnNull()
+    {
+        $user = new TestModel2;
+        $user->name = null;
+
+        $this->assertFalse(isset($user['name']));
+    }
 }
 
 class TestModel1 extends Model


### PR DESCRIPTION
## Problem
When calling `offsetExists` on a model, it will call the underlying attribute and actually get the value. In the case where the getter is a bit more heavy this can result in unexpected extra load. `offsetGet` should be the method that actually fetches the attribute. 

```php
$model = new Model();

if(isset($model['name']) {
    return $model['name'];
}
```
The following code will result in two calls to the underlying attribute getter.  
This is mostly a problem when utilizing third party packages which accepts an `ArrayAccess` object and relies on `isset` logic. These packages now need custom logic for handling Laravel (for better performance), instead of just relying on the expected behaviour of `ArrayAccess`. 