### PR TITLE
[9.x] Update updateRememberToken method in EloquentUserProvider

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
 
 class EloquentUserProvider implements UserProvider
 {
@@ -94,13 +95,7 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
-        $timestamps = $user->timestamps;
-
-        $user->timestamps = false;
-
-        $user->save();
-
-        $user->timestamps = $timestamps;
+        Model::withoutTimestamps(fn () => $user->save());
     }
 
     /**


### PR DESCRIPTION
Switched to Model::withoutTimestamps method for disabling timestamps instead of manual process