### PR TITLE
[9.x] Added ability to assert that event Listeners were pushed to Queue

### DIFF
--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -29,11 +29,64 @@ class QueuedListenersTest extends TestCase
             return $job->class == QueuedListenersTestListenerShouldNotQueue::class;
         });
     }
+
+    public function testAssertListenerPushed()
+    {
+        Queue::fake();
+
+        Event::listen(QueuedListenersTestEvent::class, QueuedListenersTestListenerShouldQueue::class);
+
+        Event::dispatch(
+            new QueuedListenersTestEvent
+        );
+
+        Queue::assertListenerPushed(QueuedListenersTestListenerShouldQueue::class);
+    }
+
+    public function testAssertListenerPushedTimes()
+    {
+        Queue::fake();
+
+        Event::listen(QueuedListenersTestEvent::class, QueuedListenersTestListenerShouldQueue::class);
+        Event::listen(QueuedListenersTestEvent::class, QueuedListenersTestListenerShouldQueue::class);
+        Event::listen(QueuedListenersTestEvent::class, QueuedListenersTestListenerShouldQueue::class);
+
+        Event::dispatch(
+            new QueuedListenersTestEvent
+        );
+
+        Queue::assertListenerPushed(QueuedListenersTestListenerShouldQueue::class, 3);
+    }
+
+    public function testAssertListenerPushedWithCallback()
+    {
+        Queue::fake();
+
+        Event::listen(QueuedListenersTestEventWithAttributes::class, QueuedListenersTestListenerShouldQueue::class);
+
+        Event::dispatch(
+            new QueuedListenersTestEventWithAttributes
+        );
+
+        Queue::assertListenerPushed(QueuedListenersTestListenerShouldQueue::class, function ($job) {
+            $this->assertTrue($job instanceof QueuedListenersTestEventWithAttributes);
+            $this->assertSame('first', $job->firstAttribute);
+            $this->assertSame('second', $job->secondAttribute);
+
+            return true;
+        });
+    }
 }
 
 class QueuedListenersTestEvent
 {
     //
+}
+
+class QueuedListenersTestEventWithAttributes
+{
+    public $firstAttribute = 'first';
+    public $secondAttribute = 'second';
 }
 
 class QueuedListenersTestListenerShouldQueue implements ShouldQueue


### PR DESCRIPTION
## Summary

This PR allows asserting that event listeners are pushed into the queue. Currently, `Event::assertListening()` exists for this but this allows the developer to ensure that the listener was pushed into the queue.

`Queue::assertListenerPushed` allows asserting if listener was pushed, if it was pushed X times, and even accepts a truth-test callback similar to `Queue::assertPushed`
