### PR TITLE
[10.x] Adds `--parallel` support to Laravel 10

### DIFF
--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Illuminate\Testing\Concerns;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Testing\ParallelConsoleOutput;
+use RuntimeException;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait RunsInParallel
+{
+    /**
+     * The application resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $applicationResolver;
+
+    /**
+     * The runner resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $runnerResolver;
+
+    /**
+     * The original test runner options.
+     *
+     * @var \ParaTest\Runners\PHPUnit\Options|\ParaTest\Options
+     */
+    protected $options;
+
+    /**
+     * The output instance.
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+
+    /**
+     * The original test runner.
+     *
+     * @var \ParaTest\Runners\PHPUnit\RunnerInterface|\ParaTest\RunnerInterface
+     */
+    protected $runner;
+
+    /**
+     * Creates a new test runner instance.
+     *
+     * @param  \ParaTest\Runners\PHPUnit\Options|\ParaTest\Options  $options
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function __construct($options, OutputInterface $output)
+    {
+        $this->options = $options;
+
+        if ($output instanceof ConsoleOutput) {
+            $output = new ParallelConsoleOutput($output);
+        }
+
+        $runnerResolver = static::$runnerResolver ?: function ($options, OutputInterface $output) {
+            $wrapperRunnerClass = class_exists(\ParaTest\WrapperRunner\WrapperRunner::class)
+                ? \ParaTest\WrapperRunner\WrapperRunner::class
+                : \ParaTest\Runners\PHPUnit\WrapperRunner::class;
+
+            return new $wrapperRunnerClass($options, $output);
+        };
+
+        $this->runner = $runnerResolver($options, $output);
+    }
+
+    /**
+     * Set the application resolver callback.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveApplicationUsing($resolver)
+    {
+        static::$applicationResolver = $resolver;
+    }
+
+    /**
+     * Set the runner resolver callback.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveRunnerUsing($resolver)
+    {
+        static::$runnerResolver = $resolver;
+    }
+
+    /**
+     * Runs the test suite.
+     *
+     * @return int
+     */
+    public function execute(): int
+    {
+        $phpHandlerClass = class_exists(\PHPUnit\TextUI\Configuration\PhpHandler::class)
+            ? \PHPUnit\TextUI\Configuration\PhpHandler::class
+            : \PHPUnit\TextUI\XmlConfiguration\PhpHandler::class;
+
+        $configuration = $this->options instanceof \ParaTest\Options
+            ? $this->options->configuration
+            : $this->options->configuration();
+
+        (new $phpHandlerClass)->handle($configuration->php());
+
+        $this->forEachProcess(function () {
+            ParallelTesting::callSetUpProcessCallbacks();
+        });
+
+        try {
+            $this->runner->run();
+        } finally {
+            $this->forEachProcess(function () {
+                ParallelTesting::callTearDownProcessCallbacks();
+            });
+        }
+
+        return $this->getExitCode();
+    }
+
+    /**
+     * Returns the highest exit code encountered throughout the course of test execution.
+     *
+     * @return int
+     */
+    public function getExitCode(): int
+    {
+        return $this->runner->getExitCode();
+    }
+
+    /**
+     * Apply the given callback for each process.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function forEachProcess($callback)
+    {
+        $processes = $this->options instanceof \ParaTest\Options
+            ? $this->options->processes
+            : $this->options->processes();
+
+        collect(range(1, $processes))->each(function ($token) use ($callback) {
+            tap($this->createApplication(), function ($app) use ($callback, $token) {
+                ParallelTesting::resolveTokenUsing(fn () => $token);
+
+                $callback($app);
+            })->flush();
+        });
+    }
+
+    /**
+     * Creates the application.
+     *
+     * @return \Illuminate\Contracts\Foundation\Application
+     *
+     * @throws \RuntimeException
+     */
+    protected function createApplication()
+    {
+        $applicationResolver = static::$applicationResolver ?: function () {
+            if (trait_exists(\Tests\CreatesApplication::class)) {
+                $applicationCreator = new class
+                {
+                    use \Tests\CreatesApplication;
+                };
+
+                return $applicationCreator->createApplication();
+            } elseif (file_exists($path = getcwd().'/bootstrap/app.php') ||
+                      file_exists($path = getcwd().'/.laravel/app.php')) {
+                $app = require $path;
+
+                $app->make(Kernel::class)->bootstrap();
+
+                return $app;
+            }
+
+            throw new RuntimeException('Parallel Runner unable to resolve application.');
+        };
+
+        return $applicationResolver();
+    }
+}

--- a/src/Illuminate/Testing/ParallelRunner.php
+++ b/src/Illuminate/Testing/ParallelRunner.php
@@ -2,175 +2,36 @@
 
 namespace Illuminate\Testing;
 
-use Illuminate\Contracts\Console\Kernel;
-use Illuminate\Support\Facades\ParallelTesting;
-use ParaTest\Runners\PHPUnit\Options;
-use ParaTest\Runners\PHPUnit\RunnerInterface;
-use ParaTest\Runners\PHPUnit\WrapperRunner;
-use PHPUnit\TextUI\XmlConfiguration\PhpHandler;
-use RuntimeException;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\OutputInterface;
+use Illuminate\Testing\Concerns\RunsInParallel;
 
-class ParallelRunner implements RunnerInterface
-{
-    /**
-     * The application resolver callback.
-     *
-     * @var \Closure|null
-     */
-    protected static $applicationResolver;
-
-    /**
-     * The runner resolver callback.
-     *
-     * @var \Closure|null
-     */
-    protected static $runnerResolver;
-
-    /**
-     * The original test runner options.
-     *
-     * @var \ParaTest\Runners\PHPUnit\Options
-     */
-    protected $options;
-
-    /**
-     * The output instance.
-     *
-     * @var \Symfony\Component\Console\Output\OutputInterface
-     */
-    protected $output;
-
-    /**
-     * The original test runner.
-     *
-     * @var \ParaTest\Runners\PHPUnit\RunnerInterface
-     */
-    protected $runner;
-
-    /**
-     * Creates a new test runner instance.
-     *
-     * @param  \ParaTest\Runners\PHPUnit\Options  $options
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
-     */
-    public function __construct(Options $options, OutputInterface $output)
+if (interface_exists(\ParaTest\RunnerInterface::class)) {
+    class ParallelRunner implements \ParaTest\RunnerInterface
     {
-        $this->options = $options;
+        use RunsInParallel;
 
-        if ($output instanceof ConsoleOutput) {
-            $output = new ParallelConsoleOutput($output);
-        }
-
-        $runnerResolver = static::$runnerResolver ?: function (Options $options, OutputInterface $output) {
-            return new WrapperRunner($options, $output);
-        };
-
-        $this->runner = $runnerResolver($options, $output);
-    }
-
-    /**
-     * Set the application resolver callback.
-     *
-     * @param  \Closure|null  $resolver
-     * @return void
-     */
-    public static function resolveApplicationUsing($resolver)
-    {
-        static::$applicationResolver = $resolver;
-    }
-
-    /**
-     * Set the runner resolver callback.
-     *
-     * @param  \Closure|null  $resolver
-     * @return void
-     */
-    public static function resolveRunnerUsing($resolver)
-    {
-        static::$runnerResolver = $resolver;
-    }
-
-    /**
-     * Runs the test suite.
-     *
-     * @return void
-     */
-    public function run(): void
-    {
-        (new PhpHandler)->handle($this->options->configuration()->php());
-
-        $this->forEachProcess(function () {
-            ParallelTesting::callSetUpProcessCallbacks();
-        });
-
-        try {
-            $this->runner->run();
-        } finally {
-            $this->forEachProcess(function () {
-                ParallelTesting::callTearDownProcessCallbacks();
-            });
+        /**
+         * Runs the test suite.
+         *
+         * @return int
+         */
+        public function run(): int
+        {
+            return $this->execute();
         }
     }
-
-    /**
-     * Returns the highest exit code encountered throughout the course of test execution.
-     *
-     * @return int
-     */
-    public function getExitCode(): int
+} else {
+    class ParallelRunner implements \ParaTest\Runners\PHPUnit\RunnerInterface
     {
-        return $this->runner->getExitCode();
-    }
+        use RunsInParallel;
 
-    /**
-     * Apply the given callback for each process.
-     *
-     * @param  callable  $callback
-     * @return void
-     */
-    protected function forEachProcess($callback)
-    {
-        collect(range(1, $this->options->processes()))->each(function ($token) use ($callback) {
-            tap($this->createApplication(), function ($app) use ($callback, $token) {
-                ParallelTesting::resolveTokenUsing(fn () => $token);
-
-                $callback($app);
-            })->flush();
-        });
-    }
-
-    /**
-     * Creates the application.
-     *
-     * @return \Illuminate\Contracts\Foundation\Application
-     *
-     * @throws \RuntimeException
-     */
-    protected function createApplication()
-    {
-        $applicationResolver = static::$applicationResolver ?: function () {
-            if (trait_exists(\Tests\CreatesApplication::class)) {
-                $applicationCreator = new class
-                {
-                    use \Tests\CreatesApplication;
-                };
-
-                return $applicationCreator->createApplication();
-            } elseif (file_exists($path = getcwd().'/bootstrap/app.php') ||
-                      file_exists($path = getcwd().'/.laravel/app.php')) {
-                $app = require $path;
-
-                $app->make(Kernel::class)->bootstrap();
-
-                return $app;
-            }
-
-            throw new RuntimeException('Parallel Runner unable to resolve application.');
-        };
-
-        return $applicationResolver();
+        /**
+         * Runs the test suite.
+         *
+         * @return void
+         */
+        public function run(): void
+        {
+            $this->execute();
+        }
     }
 }


### PR DESCRIPTION
This pull request adds `--parallel` support to Laravel 10, on what concerns the Laravel side. Note that, we are supporting both ParaTest 6 (PHPUnit 9 and Pest 1) and ParaTest 7 (PHPUnit 10 and Pest 2) once this pull request gets merged.

So, here is the current state of things:

- PHPUnit 9 with `--parallel` via `php artisan test --parallel`. ✅
- Pest v1 with `--parallel` via `php artisan test --parallel`. ✅
- PHPUnit 10 with `--parallel` via `php artisan test --parallel`. ✅
- Pest v2 with `--parallel` via `php artisan test --parallel`. ⚠️ (work in progress)