### PR TITLE
[10.x] Passthru missing methods on `EventFake` & `MailFake` for macro accessibility

### DIFF
--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -65,7 +65,7 @@ class Mail extends Facade
      */
     public static function fake()
     {
-        static::swap($fake = new MailFake);
+        static::swap($fake = new MailFake(static::getFacadeRoot()));
 
         return $fake;
     }

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -65,7 +65,7 @@ class Mail extends Facade
      */
     public static function fake()
     {
-        static::swap($fake = new MailFake(static::getFacadeRoot()));
+        static::swap($fake = new MailFake);
 
         return $fake;
     }

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -13,8 +13,7 @@ use ReflectionFunction;
 
 class EventFake implements Dispatcher
 {
-    use ForwardsCalls;
-    use ReflectsClosures;
+    use ForwardsCalls, ReflectsClosures;
 
     /**
      * The original event dispatcher.
@@ -56,18 +55,6 @@ class EventFake implements Dispatcher
         $this->dispatcher = $dispatcher;
 
         $this->eventsToFake = Arr::wrap($eventsToFake);
-    }
-
-    /**
-     * Handle dynamic method calls to the dispatcher.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->forwardCallTo($this->dispatcher, $method, $parameters);
     }
 
     /**
@@ -390,5 +377,17 @@ class EventFake implements Dispatcher
     public function until($event, $payload = [])
     {
         return $this->dispatch($event, $payload, true);
+    }
+
+    /**
+     * Handle dynamic method calls to the dispatcher.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->dispatcher, $method, $parameters);
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -6,12 +6,14 @@ use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionFunction;
 
 class EventFake implements Dispatcher
 {
+    use ForwardsCalls;
     use ReflectsClosures;
 
     /**
@@ -54,6 +56,18 @@ class EventFake implements Dispatcher
         $this->dispatcher = $dispatcher;
 
         $this->eventsToFake = Arr::wrap($eventsToFake);
+    }
+
+    /**
+     * Handle dynamic method calls to the dispatcher.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->dispatcher, $method, $parameters);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -8,12 +8,21 @@ use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
+    use ForwardsCalls;
     use ReflectsClosures;
+
+    /**
+     * The mailer instance.
+     *
+     * @var Mailer
+     */
+    protected $mailer;
 
     /**
      * The mailer currently being used to send a message.
@@ -35,6 +44,29 @@ class MailFake implements Factory, Mailer, MailQueue
      * @var array
      */
     protected $queuedMailables = [];
+
+    /**
+     * Create a new mail fake.
+     *
+     * @param Mailer $mailer
+     * @return void
+     */
+    public function __construct(Mailer $mailer)
+    {
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * Handle dynamic method calls to the mailer.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->mailer, $method, $parameters);
+    }
 
     /**
      * Assert if a mailable was sent based on a truth-test callback.

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -14,8 +14,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
-    use ForwardsCalls;
-    use ReflectsClosures;
+    use ForwardsCalls, ReflectsClosures;
 
     /**
      * The mailer instance.
@@ -54,18 +53,6 @@ class MailFake implements Factory, Mailer, MailQueue
     public function __construct(Mailer $mailer)
     {
         $this->mailer = $mailer;
-    }
-
-    /**
-     * Handle dynamic method calls to the mailer.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->forwardCallTo($this->mailer, $method, $parameters);
     }
 
     /**
@@ -462,5 +449,17 @@ class MailFake implements Factory, Mailer, MailQueue
         $this->currentMailer = null;
 
         return $this;
+    }
+
+    /**
+     * Handle dynamic method calls to the mailer.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->mailer, $method, $parameters);
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -8,12 +8,21 @@ use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
+    use ForwardsCalls;
     use ReflectsClosures;
+
+    /**
+     * The mailer instance.
+     *
+     * @var Mailer
+     */
+    protected $mailer;
 
     /**
      * The mailer currently being used to send a message.
@@ -35,6 +44,29 @@ class MailFake implements Factory, Mailer, MailQueue
      * @var array
      */
     protected $queuedMailables = [];
+
+    /**
+     * Create a new mail fake.
+     *
+     * @param Mailer $mailer
+     * @return void
+     */
+    public function __construct(Mailer $mailer)
+    {
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * Handle dynamic method calls to the mailer.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this, $method, $parameters);
+    }
 
     /**
      * Assert if a mailable was sent based on a truth-test callback.

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -8,21 +8,12 @@ use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
-    use ForwardsCalls;
     use ReflectsClosures;
-
-    /**
-     * The mailer instance.
-     *
-     * @var Mailer
-     */
-    protected $mailer;
 
     /**
      * The mailer currently being used to send a message.
@@ -44,29 +35,6 @@ class MailFake implements Factory, Mailer, MailQueue
      * @var array
      */
     protected $queuedMailables = [];
-
-    /**
-     * Create a new mail fake.
-     *
-     * @param Mailer $mailer
-     * @return void
-     */
-    public function __construct(Mailer $mailer)
-    {
-        $this->mailer = $mailer;
-    }
-
-    /**
-     * Handle dynamic method calls to the mailer.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->forwardCallTo($this, $method, $parameters);
-    }
 
     /**
      * Assert if a mailable was sent based on a truth-test callback.

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -48,7 +48,7 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Create a new mail fake.
      *
-     * @param Mailer $mailer
+     * @param  Mailer  $mailer
      * @return void
      */
     public function __construct(Mailer $mailer)

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -164,7 +164,7 @@ class EventFakeTest extends TestCase
         Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
     }
 
-    public function testMacrosCanBeCalled()
+    public function testMissingMethodsAreForwarded()
     {
         Event::macro('foo', fn () => 'bar');
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -151,7 +151,7 @@ class EventFakeTest extends TestCase
 
         Post::observe(new PostObserver);
 
-        ($post = new Post)->save();
+        (new Post)->save();
 
         Event::assertListening('event', 'listener');
         Event::assertListening('event', PostEventSubscriber::class);
@@ -162,6 +162,13 @@ class EventFakeTest extends TestCase
         Event::assertListening(NonImportantEvent::class, Closure::class);
         Event::assertListening('eloquent.saving: '.Post::class, PostObserver::class.'@saving');
         Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
+    }
+
+    public function testMacrosCanBeCalled()
+    {
+        Event::macro('foo', fn () => 'bar');
+
+        $this->assertEquals('bar', Event::fake()->foo());
     }
 }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Support;
 
-use Mockery as m;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Support\Testing\Fakes\MailFake;
+use Mockery as m;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -2,15 +2,22 @@
 
 namespace Illuminate\Tests\Support;
 
+use Mockery as m;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailer;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
 class SupportTestingMailFakeTest extends TestCase
 {
+    /**
+     * @var \Mockery
+     */
+    private $mailer;
+
     /**
      * @var \Illuminate\Support\Testing\Fakes\MailFake
      */
@@ -24,7 +31,8 @@ class SupportTestingMailFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->fake = new MailFake;
+        $this->mailer = m::mock(Mailer::class);
+        $this->fake = new MailFake($this->mailer);
         $this->mailable = new MailableStub;
     }
 
@@ -212,6 +220,13 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->assertSent(function (MailableStub $mail) use ($user) {
             return $mail->hasTo($user);
         });
+    }
+
+    public function testMissingMethodsAreForwarded()
+    {
+        $this->mailer->shouldReceive('foo')->andReturn('bar');
+
+        $this->assertEquals('bar', $this->fake->foo());
     }
 }
 


### PR DESCRIPTION
Closes #45986

This PR implements `ForwardsCalls` trait onto the `EventFake` and `MailFake` classes  so that macro'd methods are still accessible after calling `Event::fake()` or `Mail::fake()`.

Below are the list of facades that have the capability of being faked, along with their status of their underlying implementations supporting macro calls:

| Facade | Supports `macro`'s on fakes |
| --- | --- |
| `Illuminate\Support\Facades\Event` | ✅ (in this PR) |
| `Illuminate\Support\Facades\Http` | ✅  |
| `Illuminate\Support\Facades\Mail` | ✅ (in this PR)  |
| `Illuminate\Support\Facades\Storage` | ✅ |

Let me know your thoughts about this, and thanks so much for your time! ❤️ 