### PR TITLE
[9.x] Removes duplicate returns in tests for pending has-many-through

### DIFF
--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -216,10 +216,6 @@ class DatabaseEloquentRelationshipsTest extends TestCase
         {
             public function deployments()
             {
-                return $this->through($this->environments())->has(fn ($env) => $env->deployments());
-
-                return $this->through('environments')->has('deployments');
-
                 return $this->throughEnvironments()->hasDeployments();
             }
 


### PR DESCRIPTION
Coming from #45894

There are multiple returns, and based on the test name and the co-tested method on line 190, I believe this was the intended behavior.