### PR TITLE
[9.x] fix groupBy and keyBy by Enum field

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -507,6 +507,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 $groupKey = match (true) {
                     is_bool($groupKey) => (int) $groupKey,
                     $groupKey instanceof \Stringable => (string) $groupKey,
+                    $groupKey instanceof \UnitEnum => $groupKey->value,
                     default => $groupKey,
                 };
 
@@ -542,9 +543,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         foreach ($this->items as $key => $item) {
             $resolvedKey = $keyBy($item, $key);
 
-            if (is_object($resolvedKey)) {
-                $resolvedKey = (string) $resolvedKey;
-            }
+            $resolvedKey = match (true) {
+                $resolvedKey instanceof \UnitEnum => $resolvedKey->value,
+                is_object($resolvedKey) => (string) $resolvedKey,
+                default => $resolvedKey,
+            };
 
             $results[$resolvedKey] = $item;
         }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -561,9 +561,11 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             foreach ($this as $key => $item) {
                 $resolvedKey = $keyBy($item, $key);
 
-                if (is_object($resolvedKey)) {
-                    $resolvedKey = (string) $resolvedKey;
-                }
+                $resolvedKey = match (true) {
+                    $resolvedKey instanceof \UnitEnum => $resolvedKey->value,
+                    is_object($resolvedKey) => (string) $resolvedKey,
+                    default => $resolvedKey,
+                };
 
                 yield $resolvedKey => $item;
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
 use Illuminate\Support\Str;
+use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
 use InvalidArgumentException;
 use IteratorAggregate;
 use JsonSerializable;
@@ -3310,6 +3311,25 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
+    /**
+     * @requires PHP >= 8.1
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByAttributeWithEnumValue($collection)
+    {
+        $data = new $collection([
+            ['id' => 1, 'label' => StringBackedEnum::ADMIN_LABEL],
+            ['id' => 2, 'label' => StringBackedEnum::HELLO_WORLD],
+        ]);
+
+        $result = $data->groupBy('label');
+
+        $this->assertEquals([
+            'I am \'admin\'' => [['id' => 1, 'label' => StringBackedEnum::ADMIN_LABEL]],
+            'Hello world' => [['id' => 2, 'label' => StringBackedEnum::HELLO_WORLD]],
+        ], $result->toArray());
+    }
+
     public function sortByRating(array $value)
     {
         return $value['rating'];
@@ -3528,6 +3548,24 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([
             '[0,"Taylor","Otwell"]' => ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
             '[1,"Lucas","Michot"]' => ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
+        ], $result->all());
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeyByAttributeWithEnumValue($collection)
+    {
+        $data = new $collection([
+            ['id' => 1, 'label' => StringBackedEnum::ADMIN_LABEL],
+            ['id' => 2, 'label' => StringBackedEnum::HELLO_WORLD],
+        ]);
+
+        $result = $data->keyBy('label');
+        $this->assertEquals([
+            'I am \'admin\'' => ['id' => 1, 'label' => StringBackedEnum::ADMIN_LABEL],
+            'Hello world' => ['id' => 2, 'label' => StringBackedEnum::HELLO_WORLD],
         ], $result->all());
     }
 


### PR DESCRIPTION
REF #42507 (just fixed it like it was said in this PR)

When doing groupBy or keyBy with enum field that casted from a model, it returns an enum instance. It will cause an error 

> array_key_exists(): Argument #1 ($key) must be a valid array offset type.

for example like below
```php
enum CustomerStatus: string
{
    case Bussines = 'bussines';
    case Private = 'private';
}
class Customer  extends Model {
    protected $casts = [
        'status' => CustomerStatus::class,
    ];
}
```
then when we do
`Customer::all()->groupBy('status')`
it will cause an error
>array_key_exists(): Argument #1 ($key) must be a valid array offset type

We need to workaround with enum for example `Customer::all()->groupBy('status.value')` and `Customer::all()->keyBy('status.value')`
This PR will make accessing value of an enum directly like `Customer::all()->groupBy('status')` and `Customer::all()->keyBy('status')`