### PR TITLE
- Adding Not Die and Dump option

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -226,8 +226,8 @@ class PendingRequest
 
         $this->options = [
             'connect_timeout' => 10,
-            'http_errors' => false,
-            'timeout' => 30,
+            'http_errors'     => false,
+            'timeout'         => 30,
         ];
 
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $pendingRequest) {
@@ -311,9 +311,9 @@ class PendingRequest
         $this->asMultipart();
 
         $this->pendingFiles[] = array_filter([
-            'name' => $name,
+            'name'     => $name,
             'contents' => $contents,
-            'headers' => $headers,
+            'headers'  => $headers,
             'filename' => $filename,
         ]);
 
@@ -670,11 +670,11 @@ class PendingRequest
     }
 
     /**
-     * Dump the request before sending and end the script.
+     * Dump the request before sending.
      *
      * @return $this
      */
-    public function dd()
+    public function ndd()
     {
         $values = func_get_args();
 
@@ -682,8 +682,28 @@ class PendingRequest
             foreach (array_merge($values, [$request, $options]) as $value) {
                 VarDumper::dump($value);
             }
+        });
+    }
 
-            exit(1);
+    /**
+     * Dump the request before sending and end the script.
+     *
+     * @param  bool $exit
+     *
+     * @return $this
+     */
+    public function dd(bool $exit = true)
+    {
+        $values = func_get_args();
+
+        return $this->beforeSending(function (Request $request, array $options) use ($values, $exit) {
+            foreach (array_merge($values, [$request, $options]) as $value) {
+                VarDumper::dump($value);
+            }
+
+            if ($exit == true) {
+                exit(1);
+            }
         });
     }
 
@@ -836,7 +856,7 @@ class PendingRequest
 
                         if ($this->throwCallback &&
                             ($this->throwIfCallback === null ||
-                             call_user_func($this->throwIfCallback, $response))) {
+                                call_user_func($this->throwIfCallback, $response))) {
                             $response->throw($this->throwCallback);
                         }
 
@@ -960,7 +980,7 @@ class PendingRequest
 
         return $this->buildClient()->$clientMethod($method, $url, $this->mergeOptions([
             'laravel_data' => $laravelData,
-            'on_stats' => function ($transferStats) {
+            'on_stats'     => function ($transferStats) {
                 $this->transferStats = $transferStats;
             },
         ], $options));

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -621,6 +621,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Dump the request items and continue the script.
+     *
+     * @param  mixed  ...$keys
+     * @return never
+     */
+    public function ndd(...$keys)
+    {
+        $this->dump(...$keys);
+    }
+
+    /**
      * Dump the items.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -54,6 +54,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()
+ * @method static \Illuminate\Http\Client\PendingRequest ndd()
  * @method static \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response head(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response post(string $url, array $data = [])

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1436,6 +1436,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the content from the response and continue the script.
+     *
+     * @return never
+     */
+    public function ndd()
+    {
+        $this->dump();
+    }
+
+    /**
      * Dump the headers from the response and end the script.
      *
      * @return never

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -9,9 +9,7 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
-        $this->assertSame('<?php ndd($var1); ?>', $this->compiler->compileString('@ndd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
-        $this->assertSame('<?php ndd($var1, $var2); ?>', $this->compiler->compileString('@ndd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite()'));

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -9,7 +9,9 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
+        $this->assertSame('<?php ndd($var1); ?>', $this->compiler->compileString('@ndd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
+        $this->assertSame('<?php ndd($var1, $var2); ?>', $this->compiler->compileString('@ndd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite()'));


### PR DESCRIPTION
Sometimes you may want to inspect the value of a variable in your code, but you don't want the script execution to stop immediately after. In such cases, you can use a new alias ndd (for "no die") which is a shorthand for the dump function in Laravel.

For example:

```php
$variable = [1, 2, 3];
ndd($variable);
```

This will output the contents of $variable ([1, 2, 3]) to the browser, but the script execution will continue.

Using an alias for dd or dump allows you to quickly switch between them depending on your debugging needs, without having to change the code each time.
