### PR TITLE
Adding Not Die and Dump option - ndd()

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -214,7 +214,7 @@ class PendingRequest
     /**
      * Create a new HTTP Client instance.
      *
-     * @param  \Illuminate\Http\Client\Factory|null  $factory
+     * @param \Illuminate\Http\Client\Factory|null $factory
      * @return void
      */
     public function __construct(Factory $factory = null)
@@ -241,7 +241,7 @@ class PendingRequest
     /**
      * Set the base URL for the pending request.
      *
-     * @param  string  $url
+     * @param string $url
      * @return $this
      */
     public function baseUrl(string $url)
@@ -254,8 +254,8 @@ class PendingRequest
     /**
      * Attach a raw body to the request.
      *
-     * @param  string  $content
-     * @param  string  $contentType
+     * @param string $content
+     * @param string $contentType
      * @return $this
      */
     public function withBody($content, $contentType)
@@ -292,10 +292,10 @@ class PendingRequest
     /**
      * Attach a file to the request.
      *
-     * @param  string|array  $name
-     * @param  string|resource  $contents
-     * @param  string|null  $filename
-     * @param  array  $headers
+     * @param string|array $name
+     * @param string|resource $contents
+     * @param string|null $filename
+     * @param array $headers
      * @return $this
      */
     public function attach($name, $contents = '', $filename = null, array $headers = [])
@@ -333,7 +333,7 @@ class PendingRequest
     /**
      * Specify the body format of the request.
      *
-     * @param  string  $format
+     * @param string $format
      * @return $this
      */
     public function bodyFormat(string $format)
@@ -346,7 +346,7 @@ class PendingRequest
     /**
      * Specify the request's content type.
      *
-     * @param  string  $contentType
+     * @param string $contentType
      * @return $this
      */
     public function contentType(string $contentType)
@@ -369,7 +369,7 @@ class PendingRequest
     /**
      * Indicate the type of content that should be returned by the server.
      *
-     * @param  string  $contentType
+     * @param string $contentType
      * @return $this
      */
     public function accept($contentType)
@@ -380,7 +380,7 @@ class PendingRequest
     /**
      * Add the given headers to the request.
      *
-     * @param  array  $headers
+     * @param array $headers
      * @return $this
      */
     public function withHeaders(array $headers)
@@ -395,8 +395,8 @@ class PendingRequest
     /**
      * Specify the basic authentication username and password for the request.
      *
-     * @param  string  $username
-     * @param  string  $password
+     * @param string $username
+     * @param string $password
      * @return $this
      */
     public function withBasicAuth(string $username, string $password)
@@ -409,8 +409,8 @@ class PendingRequest
     /**
      * Specify the digest authentication username and password for the request.
      *
-     * @param  string  $username
-     * @param  string  $password
+     * @param string $username
+     * @param string $password
      * @return $this
      */
     public function withDigestAuth($username, $password)
@@ -423,21 +423,21 @@ class PendingRequest
     /**
      * Specify an authorization token for the request.
      *
-     * @param  string  $token
-     * @param  string  $type
+     * @param string $token
+     * @param string $type
      * @return $this
      */
     public function withToken($token, $type = 'Bearer')
     {
         return tap($this, function () use ($token, $type) {
-            $this->options['headers']['Authorization'] = trim($type.' '.$token);
+            $this->options['headers']['Authorization'] = trim($type . ' ' . $token);
         });
     }
 
     /**
      * Specify the user agent for the request.
      *
-     * @param  string  $userAgent
+     * @param string $userAgent
      * @return $this
      */
     public function withUserAgent($userAgent)
@@ -450,7 +450,7 @@ class PendingRequest
     /**
      * Specify the URL parameters that can be substituted into the request URL.
      *
-     * @param  array  $parameters
+     * @param array $parameters
      * @return $this
      */
     public function withUrlParameters(array $parameters = [])
@@ -463,8 +463,8 @@ class PendingRequest
     /**
      * Specify the cookies that should be included with the request.
      *
-     * @param  array  $cookies
-     * @param  string  $domain
+     * @param array $cookies
+     * @param string $domain
      * @return $this
      */
     public function withCookies(array $cookies, string $domain)
@@ -479,7 +479,7 @@ class PendingRequest
     /**
      * Specify the maximum number of redirects to allow.
      *
-     * @param  int  $max
+     * @param int $max
      * @return $this
      */
     public function maxRedirects(int $max)
@@ -516,7 +516,7 @@ class PendingRequest
     /**
      * Specify the path where the body of the response should be stored.
      *
-     * @param  string|resource  $to
+     * @param string|resource $to
      * @return $this
      */
     public function sink($to)
@@ -529,7 +529,7 @@ class PendingRequest
     /**
      * Specify the timeout (in seconds) for the request.
      *
-     * @param  int  $seconds
+     * @param int $seconds
      * @return $this
      */
     public function timeout(int $seconds)
@@ -542,7 +542,7 @@ class PendingRequest
     /**
      * Specify the connect timeout (in seconds) for the request.
      *
-     * @param  int  $seconds
+     * @param int $seconds
      * @return $this
      */
     public function connectTimeout(int $seconds)
@@ -555,10 +555,10 @@ class PendingRequest
     /**
      * Specify the number of times the request should be attempted.
      *
-     * @param  int  $times
-     * @param  int  $sleepMilliseconds
-     * @param  callable|null  $when
-     * @param  bool  $throw
+     * @param int $times
+     * @param int $sleepMilliseconds
+     * @param callable|null $when
+     * @param bool $throw
      * @return $this
      */
     public function retry(int $times, int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
@@ -574,7 +574,7 @@ class PendingRequest
     /**
      * Replace the specified options on the request.
      *
-     * @param  array  $options
+     * @param array $options
      * @return $this
      */
     public function withOptions(array $options)
@@ -590,7 +590,7 @@ class PendingRequest
     /**
      * Add new middleware the client handler stack.
      *
-     * @param  callable  $middleware
+     * @param callable $middleware
      * @return $this
      */
     public function withMiddleware(callable $middleware)
@@ -603,7 +603,7 @@ class PendingRequest
     /**
      * Add a new "before sending" callback to the request.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return $this
      */
     public function beforeSending($callback)
@@ -616,12 +616,12 @@ class PendingRequest
     /**
      * Throw an exception if a server or client error occurs.
      *
-     * @param  callable|null  $callback
+     * @param callable|null $callback
      * @return $this
      */
     public function throw(callable $callback = null)
     {
-        $this->throwCallback = $callback ?: fn () => null;
+        $this->throwCallback = $callback ?: fn() => null;
 
         return $this;
     }
@@ -629,8 +629,8 @@ class PendingRequest
     /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
-     * @param  callable|bool  $condition
-     * @param  callable|null  $throwCallback
+     * @param callable|bool $condition
+     * @param callable|null $throwCallback
      * @return $this
      */
     public function throwIf($condition)
@@ -645,12 +645,12 @@ class PendingRequest
     /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to false.
      *
-     * @param  bool  $condition
+     * @param bool $condition
      * @return $this
      */
     public function throwUnless($condition)
     {
-        return $this->throwIf(! $condition);
+        return $this->throwIf(!$condition);
     }
 
     /**
@@ -692,26 +692,24 @@ class PendingRequest
      *
      * @return $this
      */
-    public function dd(bool $exit = true)
+    public function dd()
     {
         $values = func_get_args();
 
-        return $this->beforeSending(function (Request $request, array $options) use ($values, $exit) {
+        return $this->beforeSending(function (Request $request, array $options) use ($values) {
             foreach (array_merge($values, [$request, $options]) as $value) {
                 VarDumper::dump($value);
             }
 
-            if ($exit == true) {
-                exit(1);
-            }
+            exit(1);
         });
     }
 
     /**
      * Issue a GET request to the given URL.
      *
-     * @param  string  $url
-     * @param  array|string|null  $query
+     * @param string $url
+     * @param array|string|null $query
      * @return \Illuminate\Http\Client\Response
      */
     public function get(string $url, $query = null)
@@ -724,8 +722,8 @@ class PendingRequest
     /**
      * Issue a HEAD request to the given URL.
      *
-     * @param  string  $url
-     * @param  array|string|null  $query
+     * @param string $url
+     * @param array|string|null $query
      * @return \Illuminate\Http\Client\Response
      */
     public function head(string $url, $query = null)
@@ -738,8 +736,8 @@ class PendingRequest
     /**
      * Issue a POST request to the given URL.
      *
-     * @param  string  $url
-     * @param  array  $data
+     * @param string $url
+     * @param array $data
      * @return \Illuminate\Http\Client\Response
      */
     public function post(string $url, $data = [])
@@ -752,8 +750,8 @@ class PendingRequest
     /**
      * Issue a PATCH request to the given URL.
      *
-     * @param  string  $url
-     * @param  array  $data
+     * @param string $url
+     * @param array $data
      * @return \Illuminate\Http\Client\Response
      */
     public function patch(string $url, $data = [])
@@ -766,8 +764,8 @@ class PendingRequest
     /**
      * Issue a PUT request to the given URL.
      *
-     * @param  string  $url
-     * @param  array  $data
+     * @param string $url
+     * @param array $data
      * @return \Illuminate\Http\Client\Response
      */
     public function put(string $url, $data = [])
@@ -780,8 +778,8 @@ class PendingRequest
     /**
      * Issue a DELETE request to the given URL.
      *
-     * @param  string  $url
-     * @param  array  $data
+     * @param string $url
+     * @param array $data
      * @return \Illuminate\Http\Client\Response
      */
     public function delete(string $url, $data = [])
@@ -794,7 +792,7 @@ class PendingRequest
     /**
      * Send a pool of asynchronous requests concurrently.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return array
      */
     public function pool(callable $callback)
@@ -813,17 +811,17 @@ class PendingRequest
     /**
      * Send the request to the given URL.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array  $options
+     * @param string $method
+     * @param string $url
+     * @param array $options
      * @return \Illuminate\Http\Client\Response
      *
      * @throws \Exception
      */
     public function send(string $method, string $url, array $options = [])
     {
-        if (! Str::startsWith($url, ['http://', 'https://'])) {
-            $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
+        if (!Str::startsWith($url, ['http://', 'https://'])) {
+            $url = ltrim(rtrim($this->baseUrl, '/') . '/' . ltrim($url, '/'), '/');
         }
 
         $url = $this->expandUrlParameters($url);
@@ -845,7 +843,7 @@ class PendingRequest
 
                     $this->dispatchResponseReceivedEvent($response);
 
-                    if (! $response->successful()) {
+                    if (!$response->successful()) {
                         try {
                             $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this) : true;
                         } catch (Exception $exception) {
@@ -886,7 +884,7 @@ class PendingRequest
     /**
      * Substitute the URL parameters in the given URL.
      *
-     * @param  string  $url
+     * @param string $url
      * @return string
      */
     protected function expandUrlParameters(string $url)
@@ -897,7 +895,7 @@ class PendingRequest
     /**
      * Parse the given HTTP options and set the appropriate additional options.
      *
-     * @param  array  $options
+     * @param array $options
      * @return array
      */
     protected function parseHttpOptions(array $options)
@@ -930,7 +928,7 @@ class PendingRequest
     /**
      * Parse multi-part form data.
      *
-     * @param  array  $data
+     * @param array $data
      * @return array|array[]
      */
     protected function parseMultipartBodyFormat(array $data)
@@ -943,9 +941,9 @@ class PendingRequest
     /**
      * Send an asynchronous request to the given URL.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array  $options
+     * @param string $method
+     * @param string $url
+     * @param array $options
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
     protected function makePromise(string $method, string $url, array $options = [])
@@ -965,9 +963,9 @@ class PendingRequest
     /**
      * Send a request either synchronously or asynchronously.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array  $options
+     * @param string $method
+     * @param string $url
+     * @param array $options
      * @return \Psr\Http\Message\MessageInterface|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Exception
@@ -989,9 +987,9 @@ class PendingRequest
     /**
      * Get the request data as an array so that we can attach it to the request for convenient assertions.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array  $options
+     * @param string $method
+     * @param string $url
+     * @param array $options
      * @return array
      */
     protected function parseRequestData($method, $url, array $options)
@@ -1005,7 +1003,7 @@ class PendingRequest
         $urlString = Str::of($url);
 
         if (empty($laravelData) && $method === 'GET' && $urlString->contains('?')) {
-            $laravelData = (string) $urlString->after('?');
+            $laravelData = (string)$urlString->after('?');
         }
 
         if (is_string($laravelData)) {
@@ -1024,7 +1022,7 @@ class PendingRequest
     /**
      * Populate the given response with additional data.
      *
-     * @param  \Illuminate\Http\Client\Response  $response
+     * @param \Illuminate\Http\Client\Response $response
      * @return \Illuminate\Http\Client\Response
      */
     protected function populateResponse(Response $response)
@@ -1053,7 +1051,7 @@ class PendingRequest
      */
     protected function requestsReusableClient()
     {
-        return ! is_null($this->client) || $this->async;
+        return !is_null($this->client) || $this->async;
     }
 
     /**
@@ -1069,7 +1067,7 @@ class PendingRequest
     /**
      * Create new Guzzle client.
      *
-     * @param  \GuzzleHttp\HandlerStack  $handlerStack
+     * @param \GuzzleHttp\HandlerStack $handlerStack
      * @return \GuzzleHttp\Client
      */
     public function createClient($handlerStack)
@@ -1093,7 +1091,7 @@ class PendingRequest
     /**
      * Add the necessary handlers to the given handler stack.
      *
-     * @param  \GuzzleHttp\HandlerStack  $handlerStack
+     * @param \GuzzleHttp\HandlerStack $handlerStack
      * @return \GuzzleHttp\HandlerStack
      */
     public function pushHandlers($handlerStack)
@@ -1157,14 +1155,14 @@ class PendingRequest
         return function ($handler) {
             return function ($request, $options) use ($handler) {
                 $response = ($this->stubCallbacks ?? collect())
-                     ->map
-                     ->__invoke((new Request($request))->withData($options['laravel_data']), $options)
-                     ->filter()
-                     ->first();
+                    ->map
+                    ->__invoke((new Request($request))->withData($options['laravel_data']), $options)
+                    ->filter()
+                    ->first();
 
                 if (is_null($response)) {
                     if ($this->preventStrayRequests) {
-                        throw new RuntimeException('Attempted request to ['.(string) $request->getUri().'] without a matching fake.');
+                        throw new RuntimeException('Attempted request to [' . (string)$request->getUri() . '] without a matching fake.');
                     }
 
                     return $handler($request, $options);
@@ -1186,7 +1184,7 @@ class PendingRequest
     /**
      * Get the sink stub handler callback.
      *
-     * @param  string  $sink
+     * @param string $sink
      * @return \Closure
      */
     protected function sinkStubHandler($sink)
@@ -1208,8 +1206,8 @@ class PendingRequest
     /**
      * Execute the "before sending" callbacks.
      *
-     * @param  \GuzzleHttp\Psr7\RequestInterface  $request
-     * @param  array  $options
+     * @param \GuzzleHttp\Psr7\RequestInterface $request
+     * @param array $options
      * @return \GuzzleHttp\Psr7\RequestInterface
      */
     public function runBeforeSendingCallbacks($request, array $options)
@@ -1232,7 +1230,7 @@ class PendingRequest
     /**
      * Replace the given options with the current request options.
      *
-     * @param  array  ...$options
+     * @param array ...$options
      * @return array
      */
     public function mergeOptions(...$options)
@@ -1246,7 +1244,7 @@ class PendingRequest
     /**
      * Register a stub callable that will intercept requests and be able to return stub responses.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return $this
      */
     public function stub($callback)
@@ -1259,7 +1257,7 @@ class PendingRequest
     /**
      * Indicate that an exception should be thrown if any request is not faked.
      *
-     * @param  bool  $prevent
+     * @param bool $prevent
      * @return $this
      */
     public function preventStrayRequests($prevent = true)
@@ -1272,7 +1270,7 @@ class PendingRequest
     /**
      * Toggle asynchronicity in requests.
      *
-     * @param  bool  $async
+     * @param bool $async
      * @return $this
      */
     public function async(bool $async = true)
@@ -1307,13 +1305,13 @@ class PendingRequest
     /**
      * Dispatch the ResponseReceived event if a dispatcher is available.
      *
-     * @param  \Illuminate\Http\Client\Response  $response
+     * @param \Illuminate\Http\Client\Response $response
      * @return void
      */
     protected function dispatchResponseReceivedEvent(Response $response)
     {
-        if (! ($dispatcher = $this->factory?->getDispatcher()) ||
-            ! $this->request) {
+        if (!($dispatcher = $this->factory?->getDispatcher()) ||
+            !$this->request) {
             return;
         }
 
@@ -1335,7 +1333,7 @@ class PendingRequest
     /**
      * Set the client instance.
      *
-     * @param  \GuzzleHttp\Client  $client
+     * @param \GuzzleHttp\Client $client
      * @return $this
      */
     public function setClient(Client $client)
@@ -1348,7 +1346,7 @@ class PendingRequest
     /**
      * Create a new client instance using the given handler.
      *
-     * @param  callable  $handler
+     * @param callable $handler
      * @return $this
      */
     public function setHandler($handler)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -226,8 +226,8 @@ class PendingRequest
 
         $this->options = [
             'connect_timeout' => 10,
-            'http_errors' => false,
-            'timeout' => 30,
+            'http_errors'     => false,
+            'timeout'         => 30,
         ];
 
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $pendingRequest) {
@@ -311,9 +311,9 @@ class PendingRequest
         $this->asMultipart();
 
         $this->pendingFiles[] = array_filter([
-            'name' => $name,
+            'name'     => $name,
             'contents' => $contents,
-            'headers' => $headers,
+            'headers'  => $headers,
             'filename' => $filename,
         ]);
 
@@ -670,11 +670,11 @@ class PendingRequest
     }
 
     /**
-     * Dump the request before sending and end the script.
+     * Dump the request before sending.
      *
      * @return $this
      */
-    public function dd()
+    public function ndd()
     {
         $values = func_get_args();
 
@@ -682,8 +682,28 @@ class PendingRequest
             foreach (array_merge($values, [$request, $options]) as $value) {
                 VarDumper::dump($value);
             }
+        });
+    }
 
-            exit(1);
+    /**
+     * Dump the request before sending and end the script.
+     *
+     * @param  bool $exit
+     *
+     * @return $this
+     */
+    public function dd(bool $exit = true)
+    {
+        $values = func_get_args();
+
+        return $this->beforeSending(function (Request $request, array $options) use ($values, $exit) {
+            foreach (array_merge($values, [$request, $options]) as $value) {
+                VarDumper::dump($value);
+            }
+
+            if ($exit == true) {
+                exit(1);
+            }
         });
     }
 
@@ -836,7 +856,7 @@ class PendingRequest
 
                         if ($this->throwCallback &&
                             ($this->throwIfCallback === null ||
-                             call_user_func($this->throwIfCallback, $response))) {
+                                call_user_func($this->throwIfCallback, $response))) {
                             $response->throw($this->throwCallback);
                         }
 
@@ -960,7 +980,7 @@ class PendingRequest
 
         return $this->buildClient()->$clientMethod($method, $url, $this->mergeOptions([
             'laravel_data' => $laravelData,
-            'on_stats' => function ($transferStats) {
+            'on_stats'     => function ($transferStats) {
                 $this->transferStats = $transferStats;
             },
         ], $options));

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -621,6 +621,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Dump the request items and continue the script.
+     *
+     * @param  mixed  ...$keys
+     * @return never
+     */
+    public function ndd(...$keys)
+    {
+        $this->dump(...$keys);
+    }
+
+    /**
      * Dump the items.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -54,6 +54,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()
+ * @method static \Illuminate\Http\Client\PendingRequest ndd()
  * @method static \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response head(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response post(string $url, array $data = [])

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1436,6 +1436,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the content from the response and continue the script.
+     *
+     * @return never
+     */
+    public function ndd()
+    {
+        $this->dump();
+    }
+
+    /**
      * Dump the headers from the response and end the script.
      *
      * @return never

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -9,9 +9,7 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
-        $this->assertSame('<?php ndd($var1); ?>', $this->compiler->compileString('@ndd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
-        $this->assertSame('<?php ndd($var1, $var2); ?>', $this->compiler->compileString('@ndd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite()'));

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -9,7 +9,9 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
+        $this->assertSame('<?php ndd($var1); ?>', $this->compiler->compileString('@ndd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
+        $this->assertSame('<?php ndd($var1, $var2); ?>', $this->compiler->compileString('@ndd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite()'));


### PR DESCRIPTION
Sometimes you may want to inspect the value of a variable in your code, but you don't want the script execution to stop immediately after. In such cases, you can use a new alias ndd (for "no die") which is a shorthand for the dump function in Laravel.

For example:
```php
$variable = [1, 2, 3];
ndd($variable);
```
This will output the contents of $variable ([1, 2, 3]) to the browser, but the script execution will continue.

Using an alias for dd or dump allows you to quickly switch between them depending on your debugging needs, without having to change the code each time.