### PR TITLE
[9.x] Remove deprecation warnings in test output

### DIFF
--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -248,7 +248,10 @@ class CacheArrayStoreTest extends TestCase
         $store->put('object', $object, 10);
         $object->bar = true;
 
-        $this->assertObjectNotHasAttribute('bar', $store->get('object'));
+        $retrievedObject = $store->get('object');
+
+        $this->assertTrue($retrievedObject->foo);
+        $this->assertFalse(property_exists($retrievedObject, 'bar'));
     }
 
     public function testValuesAreStoredByReferenceIfSerializationIsDisabled()
@@ -260,7 +263,10 @@ class CacheArrayStoreTest extends TestCase
         $store->put('object', $object, 10);
         $object->bar = true;
 
-        $this->assertObjectHasAttribute('bar', $store->get('object'));
+        $retrievedObject = $store->get('object');
+
+        $this->assertTrue($retrievedObject->foo);
+        $this->assertTrue($retrievedObject->bar);
     }
 
     public function testReleasingLockAfterAlreadyForceReleasedByAnotherOwnerFails()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2024,7 +2024,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testIncrementManyArgumentValidation1()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage('Non-numeric value passed as increment amount for column: \'col\'.');
+        $this->expectExceptionMessage('Non-numeric value passed as increment amount for column: \'col\'.');
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach(['col' => 'a']);
     }
@@ -2032,7 +2032,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testIncrementManyArgumentValidation2()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage('Non-associative array passed to incrementEach method.');
+        $this->expectExceptionMessage('Non-associative array passed to incrementEach method.');
         $builder = $this->getBuilder();
         $builder->from('users')->incrementEach([11 => 11]);
     }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Events;
 
+use Error;
 use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Events\Dispatcher;
@@ -570,6 +571,13 @@ class EventsDispatcherTest extends TestCase
         $d->listen('myEvent', [TestListenerInvokey::class, 'someAbsentMethod']);
         $d->dispatch('myEvent', 'somePayload');
         $this->assertEquals(['__construct', '__invoke_somePayload'], $_SERVER['__event.test']);
+
+        // It throws an "Error" when there is no method to be called.
+        $d = new Dispatcher;
+        $d->listen('myEvent', TestListenerLean::class);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Call to undefined method '.TestListenerLean::class.'::__invoke()');
+        $d->dispatch('myEvent', 'somePayload');
 
         unset($_SERVER['__event.test']);
     }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -571,13 +571,6 @@ class EventsDispatcherTest extends TestCase
         $d->dispatch('myEvent', 'somePayload');
         $this->assertEquals(['__construct', '__invoke_somePayload'], $_SERVER['__event.test']);
 
-        // It throws an "Error" when there is no method to be called.
-        $d = new Dispatcher;
-        $d->listen('myEvent', TestListenerLean::class);
-        $this->expectError();
-        $this->expectErrorMessage('Call to undefined method '.TestListenerLean::class.'::__invoke()');
-        $d->dispatch('myEvent', 'somePayload');
-
         unset($_SERVER['__event.test']);
     }
 }

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -142,14 +142,14 @@ class LotteryTest extends TestCase
         $this->assertSame('winner', $result);
 
         $this->expectException(RuntimeException::class);
-        $this->expectErrorMessage('Missing key in sequence.');
+        $this->expectExceptionMessage('Missing key in sequence.');
         Lottery::odds(1, 10000)->winner(fn () => 'winner')->loser(fn () => 'loser')->choose();
     }
 
     public function testItThrowsForFloatsOverOne()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectErrorMessage('Float must not be greater than 1.');
+        $this->expectExceptionMessage('Float must not be greater than 1.');
 
         new Lottery(1.1);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1651,7 +1651,7 @@ class ValidationValidatorTest extends TestCase
     {
         $emptyCountable = new class implements Countable
         {
-            public function count()
+            public function count(): int
             {
                 return 0;
             }


### PR DESCRIPTION
Right now, with the latest PHPUnit v9 update, we get some deprecation messages in our test output. I've resolved these so the output stays clean.

<img width="865" alt="Screenshot 2023-02-07 at 13 55 02" src="https://user-images.githubusercontent.com/594614/217251792-9f18784b-9f1c-4000-ad5a-8e8af573c9f2.png">
<img width="1736" alt="Screenshot 2023-02-07 at 13 54 58" src="https://user-images.githubusercontent.com/594614/217251797-ee598bd8-42b7-4707-8d0e-de6ab8fdb498.png">
