### PR TITLE
[10.x] - Adding prepared Controller Resource stub as an alternative

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -621,6 +621,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Dump the request items and not end the script.
+     *
+     * @param  mixed  ...$keys
+     * @return never
+     */
+    public function ndd(...$keys)
+    {
+        $this->dump(...$keys);
+    }
+
+    /**
      * Dump the items.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Routing/Console/stubs/controller.model-prepared.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model-prepared.stub
@@ -1,0 +1,116 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use {{ namespacedRequests }}
+
+// Route::get('{{ modelVariable }}s', [App\Http\Controllers\{{ modelVariable }}Controller::class, 'index'])->name('{{ modelVariable }}.index');
+// Route::resource('{{ modelVariable }}s', {{ modelVariable }}Controller::class);
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        ${{ modelVariable }}s = {{ model }}::paginate(25);
+        return view('{{ modelVariable }}s.index', collect('{{ modelVariable }}s'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('{{ modelVariable }}s.index');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \{{ namespacedStoreRequest }}  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store({{ storeRequest }} $request)
+    {
+        $request->validate([
+            'put_your_key_name' => 'required|max:255',
+        ]);
+
+         ${{ modelVariable }} = {{ model }}::create([
+            // Put your data here...
+         ]);
+
+        return redirect()
+            ->back()
+            //->route('{{ modelVariable }}s.index')
+            //->route('{{ modelVariable }}s.show', ${{ modelVariable }})
+            ->with(__('success','{{ model }} created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function show({{ model }} ${{ modelVariable }})
+    {
+        return view('{{ modelVariable }}s.show', collect('{{ modelVariable }}'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function edit({{ model }} ${{ modelVariable }})
+    {
+         return view('{{ modelVariable }}s.edit', collect('{{ modelVariable }}'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \{{ namespacedUpdateRequest }}  $request
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
+    {
+         $request->validate([
+            'put_your_key_name' => 'required|max:255',
+         ]);
+
+         ${{ modelVariable }}->user_id = auth()->id() ?? null;
+         ${{ modelVariable }}->save();
+
+
+          return redirect()
+                    ->back()
+                    //->route('{{ modelVariable }}s.index')
+                    //->route('{{ modelVariable }}s.show', ${{ modelVariable }})
+                    ->with(__('success','{{ model }} updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy({{ model }} ${{ modelVariable }})
+    {
+        ${{ modelVariable }}->delete();
+
+        return redirect()->route('{{ modelVariable }}s.index')->with(__('success','{{ model }} updated successfully.');
+    }
+}

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1126,6 +1126,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Dump the string and not end the script.
+     *
+     * @return never
+     */
+    public function ndd()
+    {
+        $this->dump();
+    }
+
+    /**
      * Get the underlying string value.
      *
      * @return string

--- a/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
@@ -29,6 +29,19 @@ trait Debugging
     }
 
     /**
+     * Dumps the given props and not exit.
+     *
+     * @param  string|null  $prop
+     * @return $this
+     */
+    public function ndd(string $prop = null): self
+    {
+        dump($this->prop($prop));
+
+        return $this;
+    }
+
+    /**
      * Retrieve a prop within the current scope using "dot" notation.
      *
      * @param  string|null  $key


### PR DESCRIPTION
When you add a prepared resource controller stub, it helps you to quickly set up a basic CRUD (Create, Read, Update, Delete) functionality for a resource. This can save you time and effort as you don't have to write the basic logic and routes for each action yourself.