### PR TITLE
[10.x] Check reportCallbacks before dontReport

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -243,6 +243,12 @@ class Handler implements ExceptionHandlerContract
     {
         $e = $this->mapException($e);
 
+        foreach ($this->reportCallbacks as $reportCallback) {
+            if ($reportCallback->handles($e) && $reportCallback($e) === false) {
+                return;
+            }
+        }
+
         if ($this->shouldntReport($e)) {
             return;
         }
@@ -250,12 +256,6 @@ class Handler implements ExceptionHandlerContract
         if (Reflector::isCallable($reportCallable = [$e, 'report']) &&
             $this->container->call($reportCallable) !== false) {
             return;
-        }
-
-        foreach ($this->reportCallbacks as $reportCallback) {
-            if ($reportCallback->handles($e) && $reportCallback($e) === false) {
-                return;
-            }
         }
 
         try {


### PR DESCRIPTION
This is a bit opinionated, but it seems natural to expect that explicitly registered listeners will work:

```php
// App\Exceptions\Handler
public function register()
{
    $this->reportable(fn(ModelNotFoundException $e) => $this->log404s($e));
}
```

Currently this callback would only be called if the developer overrides `$internalDontReport` or `shouldntReport()` neither of which is documented (which would be fine IMO).

The proposed change would make `$internalDontReport` only suppress the default reporting, but additional callbacks would work as documented.