### PR TITLE
[9.x] pass value along to ttl callback

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -394,7 +394,9 @@ class Repository implements ArrayAccess, CacheContract
             return $value;
         }
 
-        $this->put($key, $value = $callback(), value($ttl, $value));
+        $value = $callback();
+
+        $this->put($key, $value, value($ttl, $value));
 
         return $value;
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -394,7 +394,7 @@ class Repository implements ArrayAccess, CacheContract
             return $value;
         }
 
-        $this->put($key, $value = $callback(), value($ttl));
+        $this->put($key, $value = $callback(), value($ttl, $value));
 
         return $value;
     }


### PR DESCRIPTION
When using the `Cache::remember()` method I sometimes have a value that contains data which determines when the value should expire.

When it is relatively costly to determine the value, the functionality of `Cache::remember()` has to be duplicated elsewhere in order to not determine it twice. Providing the value to the ttl callback via the already used `value()` function would eliminate this duplication.