### PR TITLE
[9.x] Fix race condition in locks issued by the file cache driver

### DIFF
--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -34,7 +34,9 @@ class CacheLock extends Lock
      */
     public function acquire()
     {
-        if (method_exists($this->store, 'add') && $this->seconds > 0) {
+        if ($this->store instanceof FileStore
+            || (method_exists($this->store, 'add') && $this->seconds > 0)
+        ) {
             return $this->store->add(
                 $this->name, $this->owner, $this->seconds
             );

--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -34,9 +34,7 @@ class CacheLock extends Lock
      */
     public function acquire()
     {
-        if ($this->store instanceof FileStore
-            || (method_exists($this->store, 'add') && $this->seconds > 0)
-        ) {
+        if (method_exists($this->store, 'add') && $this->seconds > 0) {
             return $this->store->add(
                 $this->name, $this->owner, $this->seconds
             );

--- a/src/Illuminate/Cache/FileLock.php
+++ b/src/Illuminate/Cache/FileLock.php
@@ -5,29 +5,6 @@ namespace Illuminate\Cache;
 class FileLock extends CacheLock
 {
     /**
-     * The cache store implementation.
-     *
-     * @var FileStore
-     */
-    protected $store;
-
-    /**
-     * Create a new lock instance.
-     *
-     * @param  FileStore  $store
-     * @param  string  $name
-     * @param  int  $seconds
-     * @param  string|null  $owner
-     * @return void
-     */
-    public function __construct(FileStore $store, $name, $seconds, $owner = null)
-    {
-        parent::__construct($name, $seconds, $owner);
-
-        $this->store = $store;
-    }
-
-    /**
      * Attempt to acquire the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/FileLock.php
+++ b/src/Illuminate/Cache/FileLock.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Cache;
+
+class FileLock extends CacheLock
+{
+    /**
+     * The cache store implementation.
+     *
+     * @var FileStore
+     */
+    protected $store;
+
+    /**
+     * Create a new lock instance.
+     *
+     * @param  FileStore  $store
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return void
+     */
+    public function __construct(FileStore $store, $name, $seconds, $owner = null)
+    {
+        parent::__construct($name, $seconds, $owner);
+
+        $this->store = $store;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        return $this->store->add($this->name, $this->owner, $this->seconds);
+    }
+}

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -12,7 +12,7 @@ use Illuminate\Support\InteractsWithTime;
 
 class FileStore implements Store, LockProvider
 {
-    use InteractsWithTime, HasCacheLock, RetrievesMultipleKeys;
+    use InteractsWithTime, RetrievesMultipleKeys;
 
     /**
      * The Illuminate Filesystem instance.
@@ -198,6 +198,31 @@ class FileStore implements Store, LockProvider
     public function forever($key, $value)
     {
         return $this->put($key, $value, 0);
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new FileLock($this, $name, $seconds, $owner);
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/43627

Before:

```bash
root@fa0e2058d0ad:/app# php artisan app:test-locks --workers=2 --iterations=1000 --cache-driver=file
Running 1000 iterations with 2 workers using the cache driver 'file' for locking.
Process 1/2 started.
Process 2/2 started.
Process 1/2 finished.
Process 2/2 finished.
Process 1/2 started at 0 and ended at 1938.
Process 2/2 started at 0 and ended at 1932.
Counted only to 1938 instead of the expected 2000.
```

After:

```bash
root@fa0e2058d0ad:/app# php artisan app:test-locks --workers=2 --iterations=1000 --cache-driver=file
Running 1000 iterations with 2 workers using the cache driver 'file' for locking.
Process 1/2 started.
Process 2/2 started.
Process 1/2 finished.
Process 2/2 finished.
Process 1/2 started at 0 and ended at 1922.
Process 2/2 started at 26 and ended at 2000.
Successfully counted to 2000.

```