### PR TITLE
[10.x] Rework Application public path methods

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -132,6 +132,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $langPath;
 
     /**
+     * The custom public / web path defined by the developer.
+     *
+     * @var string
+     */
+    protected $publicPath;
+
+    /**
      * The custom storage path defined by the developer.
      *
      * @var string
@@ -481,9 +488,24 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function publicPath($path = '')
     {
-        $publicPath = $this->bound('path.public') ? $this->make('path.public') : $this->basePath('public');
+        $publicPath = $this->publicPath ?: $this->basePath('public');
 
         return $this->joinPaths($publicPath, $path);
+    }
+
+    /**
+     * Set the public / web directory.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function usePublicPath($path)
+    {
+        $this->publicPath = $path;
+
+        $this->instance('path.public', $path);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -331,11 +331,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->instance('path', $this->path());
         $this->instance('path.base', $this->basePath());
         $this->instance('path.config', $this->configPath());
-        $this->instance('path.public', $this->publicPath());
-        $this->instance('path.storage', $this->storagePath());
         $this->instance('path.database', $this->databasePath());
+        $this->instance('path.public', $this->publicPath());
         $this->instance('path.resources', $this->resourcePath());
-        $this->instance('path.bootstrap', $this->bootstrapPath());
+        $this->instance('path.storage', $this->storagePath());
 
         $this->useBootstrapPath(value(function () {
             return is_dir($directory = $this->basePath('.laravel'))

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -205,9 +205,7 @@ class FoundationHelpersTest extends TestCase
 
     protected function makeHotModuleReloadFile($url, $directory = '')
     {
-        app()->singleton('path.public', function () {
-            return __DIR__;
-        });
+        app()->usePublicPath(__DIR__);
 
         $path = public_path(Str::finish($directory, '/').'hot');
 
@@ -220,9 +218,7 @@ class FoundationHelpersTest extends TestCase
 
     protected function makeManifest($directory = '')
     {
-        app()->singleton('path.public', function () {
-            return __DIR__;
-        });
+        app()->usePublicPath(__DIR__);
 
         $path = public_path(Str::finish($directory, '/').'mix-manifest.json');
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1108,7 +1108,7 @@ class FoundationViteTest extends TestCase
     public function testItCanConfigureTheManifestFilename()
     {
         $buildDir = Str::random();
-        app()->singleton('path.public', fn () => __DIR__);
+        app()->usePublicPath(__DIR__);
         if (! file_exists(public_path($buildDir))) {
             mkdir(public_path($buildDir));
         }
@@ -1186,7 +1186,7 @@ class FoundationViteTest extends TestCase
 
     protected function makeViteManifest($contents = null, $path = 'build')
     {
-        app()->singleton('path.public', fn () => __DIR__);
+        app()->usePublicPath(__DIR__);
 
         if (! file_exists(public_path($path))) {
             mkdir(public_path($path));
@@ -1247,7 +1247,7 @@ class FoundationViteTest extends TestCase
 
     protected function makeViteHotFile($path = null)
     {
-        app()->singleton('path.public', fn () => __DIR__);
+        app()->usePublicPath(__DIR__);
 
         $path ??= public_path('hot');
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -117,9 +117,7 @@ class FoundationHelpersTest extends TestCase
 
     protected function makeManifest($directory = '')
     {
-        $this->app->singleton('path.public', function () {
-            return __DIR__;
-        });
+        app()->usePublicPath(__DIR__);
 
         $path = public_path(Str::finish($directory, '/').'mix-manifest.json');
 


### PR DESCRIPTION
Follow up to #45968 and #45969.

This MR adds a `setPublicPath` helper to allow overriding the public directory for an `Application` instance.

This does break the previous method of achieving this, namely overriding the `public.path` instance on the `Application` instance. On the plus side, it is more consistent with the other path overrides, like the paths for storage and bootstrap, and probably easier to find and understand for developers trying to achieve this.