### PR TITLE
[9.x] fix pdo exception when rollbacking without active transaction

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -290,7 +290,11 @@ trait ManagesTransactions
     protected function performRollBack($toLevel)
     {
         if ($toLevel == 0) {
-            $this->getPdo()->rollBack();
+            $pdo = $this->getPdo();
+
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
         } elseif ($this->queryGrammar->supportsSavepoints()) {
             $this->getPdo()->exec(
                 $this->queryGrammar->compileSavepointRollBack('trans'.($toLevel + 1))


### PR DESCRIPTION
This PR prevents an issue when trying to rollback when there is no active database transaction. 

I faced this issue when I converted my tests suites (which uses `LazilyRefreshDatabase` trait) from SQLite (in memory) to MySQL, which seems to behave differently regarding the transaction verification (SQLite is more permissive).
