### PR TITLE
[9.x] - Command Input Validation

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console;
 
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
+use Illuminate\Contracts\Console\Validatable;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +18,7 @@ class Command extends SymfonyCommand
         Concerns\InteractsWithIO,
         Concerns\InteractsWithSignals,
         Concerns\PromptsForMissingInput,
+        Concerns\ValidatesInput,
         Macroable;
 
     /**
@@ -178,6 +180,16 @@ class Command extends SymfonyCommand
         }
 
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
+
+        if ($this instanceof Validatable) {
+            try {
+                $this->validateInput();
+            } catch (ValidationException $e) {
+                $this->displayFailedValidationErrors($e->getValidator());
+
+                return 1;
+            }
+        }
 
         try {
             return (int) $this->laravel->call([$this, $method]);

--- a/src/Illuminate/Console/Concerns/ValidatesInput.php
+++ b/src/Illuminate/Console/Concerns/ValidatesInput.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Console\ValidationException;
+use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
+
+trait ValidatesInput
+{
+    /**
+     * The rules to use for input validation.
+     *
+     * @return array
+     */
+    protected function rules()
+    {
+        return [];
+    }
+
+    /**
+     * The custom error messages to use for input validation.
+     *
+     * @return array
+     */
+    protected function messages()
+    {
+        return [];
+    }
+
+    /**
+     * The custom attribute names for input validation.
+     *
+     * @return array
+     */
+    protected function attributes()
+    {
+        return [];
+    }
+
+    /**
+     * Validate the input as defined by the command.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Console\ValidationException
+     */
+    protected function validateInput()
+    {
+        if (empty($rules = $this->rules())) {
+            return;
+        }
+
+        $validator = $this->laravel->make(ValidatorFactory::class)->make(
+            array_merge($this->arguments(), $this->options()),
+            $rules,
+            $this->messages(),
+            $this->attributes()
+        );
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * Display the failed validation errors for the given validator.
+     *
+     * @param  \Illuminate\Console\ValidationException  $validator
+     * @return void
+     */
+    protected function displayFailedValidationErrors($validator)
+    {
+        foreach ($validator->errors()->all() as $error) {
+            $this->components->error($error);
+        }
+    }
+}

--- a/src/Illuminate/Console/ValidationException.php
+++ b/src/Illuminate/Console/ValidationException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Exception;
+
+class ValidationException extends Exception
+{
+    /**
+     * The validator instance.
+     *
+     * @var \Illuminate\Contracts\Validation\Validator
+     */
+    public $validator;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return void
+     */
+    public function __construct($validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * Return the validator instance.
+     *
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    public function getValidator()
+    {
+        return $this->validator;
+    }
+}

--- a/src/Illuminate/Contracts/Console/Validatable.php
+++ b/src/Illuminate/Contracts/Console/Validatable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Console;
+
+interface Validatable
+{
+    //
+}


### PR DESCRIPTION
I attempted to add this feature (https://github.com/laravel/framework/pull/29976) a while ago and I believe Taylor had some interest to explore, but he changed his mind for some reason. I'm happy to close if this is truly not a desired feature for the framework, but I wanted to try once again as I still believe it would be really useful for artisan commands to have the ability to utilize the framework's validation features without manual implementation per command. This allows the developer to not worry about validating the input for their commands manually and allows for the command to be clean of validation logic. 

Using the example of a sending a password reset command:

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Contracts\Console\Validatable;

class SendPasswordResetCommand extends Command implements Validatable
{

    protected $signature = 'password:send-reset {email}{--expires-date=}';

    protected $description = 'Send a password reset link to the given email.';

    public function rules()
    {
        return [
            'email'=>'email|max:75',
            'expires-date'=>'bail|required|date|after:today'
        ];
    }

    public function handle()
    {
         // send email logic
    }
}

```

The following command call:

`php artisan password:send-reset notanemail  --expires-date="not a date"`

Would result with an exit and with the following errors displayed:

![image](https://user-images.githubusercontent.com/12025002/217442062-a1a302f6-94fc-45b8-a16b-524c59392e60.png)

