### PR TITLE
[9.x] Allow choosing tables to truncate

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -80,7 +80,11 @@ trait DatabaseTruncation
         $connection->unsetEventDispatcher();
 
         collect(static::$allTables[$name] ??= $connection->getDoctrineSchemaManager()->listTableNames())
-            ->diff($this->exceptTables($name))
+            ->when(
+                property_exists($this, 'tablesToTruncate'),
+                fn ($tables) => $tables->intersect($this->tablesToTruncate),
+                fn ($tables) => $tables->diff($this->exceptTables($name))
+            )
             ->filter(fn ($table) => $connection->table($table)->exists())
             ->each(fn ($table) => $connection->table($table)->truncate());
 


### PR DESCRIPTION
Currently when using `DatabaseTruncation` trait, there is no option to choose which tables should be truncated, I can either exclude all other tables in the `$exceptTables` array or it will go through all tables and attempt to truncate (which can be slow for databases with a lot of tables).

With this PR we can choose the tables for truncation by defining a `$tablesToTruncate` property.

```php
class AuthenticationTest extends DuskTestCase
{
    use DatabaseTruncation;

    /**
     * Indicates which tables should be truncated.
     *
     * @var array
     */
    protected $tablesToTruncate = ['users'];

    //...
}
```