### PR TITLE
[9.x] Fix docblock issue from #45749

### DIFF
--- a/src/Illuminate/Contracts/Cookie/QueueingFactory.php
+++ b/src/Illuminate/Contracts/Cookie/QueueingFactory.php
@@ -7,7 +7,7 @@ interface QueueingFactory extends Factory
     /**
      * Queue a cookie to send with the next response.
      *
-     * @param  array  ...$parameters
+     * @param  mixed  ...$parameters
      * @return void
      */
     public function queue(...$parameters);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -525,7 +525,7 @@ abstract class Factory
     /**
      * Add a new sequenced state transformation to the model definition.
      *
-     * @param  array  ...$sequence
+     * @param  mixed  ...$sequence
      * @return static
      */
     public function sequence(...$sequence)

--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -30,7 +30,7 @@ class Sequence implements Countable
     /**
      * Create a new sequence instance.
      *
-     * @param  array  ...$sequence
+     * @param  mixed  ...$sequence
      * @return void
      */
     public function __construct(...$sequence)

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -86,7 +86,7 @@ abstract class SchemaState
     /**
      * Create a new process instance.
      *
-     * @param  array  ...$arguments
+     * @param  mixed  ...$arguments
      * @return \Symfony\Component\Process\Process
      */
     public function makeProcess(...$arguments)

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -27,7 +27,7 @@ class ViewController extends Controller
     /**
      * Invoke the controller method.
      *
-     * @param  array  ...$args
+     * @param  mixed  ...$args
      * @return \Illuminate\Http\Response
      */
     public function __invoke(...$args)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -721,7 +721,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * Check the result of a condition.
      *
      * @param  string  $name
-     * @param  array  ...$parameters
+     * @param  mixed  ...$parameters
      * @return bool
      */
     public function check($name, ...$parameters)


### PR DESCRIPTION
Bladecompiler check accepts mixed parameters for user func Schemastate makeProcess accepts mixed parameters for user func

Viewcontroller invoke accepts mixed args(eg status is int and data an array)

(Factory)Sequence accepts mixed values

QueueingFactory que accepts mixed params

the docblock should be `@param type ...$values` instead of the result of $values(array) in order to be correct

otherwise IDE would mark an error
