### PR TITLE
add `gone` method to http client response

### DIFF
--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -154,4 +154,14 @@ trait DeterminesStatusCode
     {
         return $this->status() === 429;
     }
+
+    /**
+     * Determine if the response was a 410 "Gone" response.
+     *
+     * @return bool
+     */
+    public function gone()
+    {
+        return $this->status() === 410;
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -245,6 +245,17 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->notFound());
     }
 
+    public function testGoneResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 410),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+
+        $this->assertTrue($response->gone());
+    }
+
     public function testResponseBodyCasting()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR adds new functionality to the Http Client Response class. It provides a way to check if a response was 410 Gone.

Previously, to check if a response was 410 Gone, we had to write code like this:

```
$response = Http::get('https://laravel.com/');

if ($response->status() === 410) {
    doSomething();
}
```

With this PR you can do this:

```
$response = Http::get('https://laravel.com/');

if ($response->gone()) {
    doSomething();
}
```

The HTTP 410 Gone status code indicates that the requested resource is no longer available and will not be available again. This status code is typically used in situations where the resource has been intentionally deleted or has become unavailable for some other reason.