### PR TITLE
feat: new method withHas added to QueriesRelationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -67,18 +67,7 @@ trait QueriesRelationships
     }
 
 
-    /**
-     *  * Add a relationship count / exists condition to the query with where clauses.
-     *
-     * Also load the relationship with same condition.
-     *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
-     * @param string $operator
-     * @param int $count
-     * @param string $boolean
-     * @param Closure|NULL $callback
-     * @return Builder
-     */
+   
       public  function  withHas($relation,  $operator = '>=', int $count = 1,  $boolean = 'and', Closure $callback = NULL): Builder
     {
         return $this->has(Str::before($relation, ':'), $operator, $count, $boolean, $callback)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -66,6 +66,27 @@ trait QueriesRelationships
         );
     }
 
+
+    /**
+     *  * Add a relationship count / exists condition to the query with where clauses.
+     *
+     * Also load the relationship with same condition.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param Closure|NULL $callback
+     * @return Builder
+     */
+      public  function  withHas($relation,  $operator = '>=', int $count = 1,  $boolean = 'and', Closure $callback = NULL): Builder
+    {
+        return $this->has(Str::before($relation, ':'), $operator, $count, $boolean, $callback)
+             ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+
+    }
+
+
     /**
      * Add nested relationship count / exists conditions to the query.
      *


### PR DESCRIPTION
This PR help to load the relationship with has Query  
for example 
before this we used to do 
```
Post::with('tags')->has('tags')->get();
```
now we can achieve this by 
```
 return  Post::withHas('tags')->get();
```
its response

```
{
    "id": 35,
    "name": "Makayla Sanford",
    "created_at": "2023-02-08T11:51:25.000000Z",
    "updated_at": "2023-02-08T11:51:25.000000Z",
    "tags": [
        {
            "id": 16,
            "slug": "abner-marvin",
            "name": "Abner Marvin",
            "created_at": "2023-02-08T11:51:25.000000Z",
            "updated_at": "2023-02-08T11:51:25.000000Z",
            "pivot": {
                "post_id": 35,
                "tag_id": 16
            }
        },
        {
            "id": 17,
            "slug": "clotilde-lubowitz",
            "name": "Clotilde Lubowitz",
            "created_at": "2023-02-08T11:51:25.000000Z",
            "updated_at": "2023-02-08T11:51:25.000000Z",
            "pivot": {
                "post_id": 35,
                "tag_id": 17
            }
        }
       
    ]
}
```

