### PR TITLE
add 410 gone exception view

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/410.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/410.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::minimal')
+
+@section('title', __('Gone'))
+@section('code', '410')
+@section('message', __('Gone'))


### PR DESCRIPTION
No error page exists for exceptions with an HTTP status code of 410 Gone.

I propose adding a default error view for this status code in the project provide an indication to the user that the resource they are trying to access is no longer available.