### PR TITLE
[9.x] Add whereNotInstanceOf method to Collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -467,6 +467,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whereInstanceOf($type);
 
     /**
+     * Filter the items, removing any items that don't match the given type(s).
+     *
+     * @template TWhereInstanceOf
+     *
+     * @param  class-string<TWhereInstanceOf>|array<array-key, class-string<TWhereInstanceOf>>  $type
+     * @return static<TKey, TWhereInstanceOf>
+     */
+    public function whereNotInstanceOf($type);
+
+    /**
      * Get the first item from the enumerable passing the given truth test.
      *
      * @template TFirstDefault

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -679,6 +679,31 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter the items, removing any items that match the given type(s).
+     *
+     * @template TWhereNotInstanceOf
+     *
+     * @param  class-string<TWhereNotInstanceOf>|array<array-key, class-string<TWhereNotInstanceOf>>  $type
+     * @return static<TKey, TWhereNotInstanceOf>
+     */
+    public function whereNotInstanceOf($type)
+    {
+        return $this->filter(function ($value) use ($type) {
+            if (is_array($type)) {
+                foreach ($type as $classType) {
+                    if ($value instanceof $classType) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return ! ($value instanceof $type);
+        });
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @template TPipeReturnType

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1133,6 +1133,17 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhereNotInstanceOf($collection)
+    {
+        $c = new $collection([new stdClass, new stdClass, new $collection, new stdClass, new Str]);
+        $this->assertCount(2, $c->whereNotInstanceOf(stdClass::class));
+
+        $this->assertCount(1, $c->whereNotInstanceOf([stdClass::class, Str::class]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhereIn($collection)
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
This PR introduces a new method whereNotInstanceOf for Laravel Collections. The method filters the items in the collection and removes any items that match the given type(s), providing a convenient way to exclude certain types from a collection. This method is the inverse of the existing whereInstanceOf method in Laravel.

## Example

``` php
$collection = collect([
    new User,
    new User,
    new Post,
    new Comment
]);

$filtered = $collection->whereNotInstanceOf(User::class);

dd($filtered->all());

// [App\Models\Post, App\Models\Comment]

```