### PR TITLE
[10.x] Fixes missing `getExitCode` on recent version of ParaTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "pda/pheanstalk": "^4.0",
         "phpstan/phpdoc-parser": "^1.15",
         "phpstan/phpstan": "^1.4.7",
-        "phpunit/phpunit": "^9.6.0 || ^10.0.1",
+        "phpunit/phpunit": "^9.6.0 || ^10.0.7",
         "predis/predis": "^2.0.2",
         "symfony/cache": "^6.2",
         "symfony/http-client": "^6.2.4"

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -125,7 +125,7 @@ trait RunsInParallel
 
         return $potentialExitCode === null
             ? $this->getExitCode()
-            : $potentiallyExitCode;
+            : $potentialExitCode;
     }
 
     /**

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -116,14 +116,16 @@ trait RunsInParallel
         });
 
         try {
-            $this->runner->run();
+            $potentialExitCode = $this->runner->run();
         } finally {
             $this->forEachProcess(function () {
                 ParallelTesting::callTearDownProcessCallbacks();
             });
         }
 
-        return $this->getExitCode();
+        return $potentialExitCode === null
+            ? $this->getExitCode()
+            : $potentiallyExitCode;
     }
 
     /**


### PR DESCRIPTION
This pull request was developed in collaboration with @lukeraymonddowning, and we've found ParaTest removed a public method that we relying on.