### PR TITLE
[9.x] Add return null to the getCookie method of test response

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -482,6 +482,8 @@ class TestResponse implements ArrayAccess
                 );
             }
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
This pull request adds a return statement for the case where no matching cookie is found in the getCookie method. 
The method was previously missing a return statement.