### PR TITLE
[9.x] invalid json method extra parameter

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -515,7 +515,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function invalidJson($request, ValidationException $exception)
     {
-        return response()->json([
+        return $request->json([
             'message' => $exception->getMessage(),
             'errors' => $exception->errors(),
         ], $exception->status);


### PR DESCRIPTION
there is an extra parameter in this method. 
we can delete that parameter or just use the $request instead of the request method.

I replaced the request() with the $request parameter throughout the method to avoid any confusion.
