### PR TITLE
[9.x] Replace array_search with in_array in Kernel.php

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -328,7 +328,7 @@ class Kernel implements KernelContract
      */
     public function prependMiddleware($middleware)
     {
-        if (array_search($middleware, $this->middleware) === false) {
+        if (! in_array($middleware, $this->middleware)) {
             array_unshift($this->middleware, $middleware);
         }
 
@@ -343,7 +343,7 @@ class Kernel implements KernelContract
      */
     public function pushMiddleware($middleware)
     {
-        if (array_search($middleware, $this->middleware) === false) {
+        if (! in_array($middleware, $this->middleware)) {
             $this->middleware[] = $middleware;
         }
 
@@ -365,7 +365,7 @@ class Kernel implements KernelContract
             throw new InvalidArgumentException("The [{$group}] middleware group has not been defined.");
         }
 
-        if (array_search($middleware, $this->middlewareGroups[$group]) === false) {
+        if (! in_array($middleware, $this->middlewareGroups[$group])) {
             array_unshift($this->middlewareGroups[$group], $middleware);
         }
 
@@ -389,7 +389,7 @@ class Kernel implements KernelContract
             throw new InvalidArgumentException("The [{$group}] middleware group has not been defined.");
         }
 
-        if (array_search($middleware, $this->middlewareGroups[$group]) === false) {
+        if (! in_array($middleware, $this->middlewareGroups[$group])) {
             $this->middlewareGroups[$group][] = $middleware;
         }
 


### PR DESCRIPTION
The original code used `array_search` to check if the middleware already exists in the stack, but this has been replaced with the `in_array` function for simplicity and improved readability.

This change does not affect the functionality of the code but results in improved code quality and readability.
