### PR TITLE
[9.x] use an instead of a

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -842,7 +842,7 @@ if (! function_exists('secure_asset')) {
 
 if (! function_exists('secure_url')) {
     /**
-     * Generate a HTTPS url for the application.
+     * Generate an HTTPS url for the application.
      *
      * @param  string  $path
      * @param  mixed  $parameters


### PR DESCRIPTION
Since the abbreviation HTTP begins with a vowel sound, it takes the article "an".