### PR TITLE
[9.x] Fix duplicated columns on select

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -411,6 +411,10 @@ class Builder implements BuilderContract
 
                 $this->selectSub($column, $as);
             } else {
+                if (is_array($this->columns) && in_array($column, $this->columns, true)) {
+                    continue;
+                }
+
                 $this->columns[] = $column;
             }
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -107,7 +107,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testAddingSelects()
     {
         $builder = $this->getBuilder();
-        $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
+        $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->addSelect('bar')->from('users');
         $this->assertSame('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
     }
 


### PR DESCRIPTION
This PR is based on a previous PR (https://github.com/laravel/framework/pull/37936) that was not merged because there were objections to the proposed fix. This PR resolves those objections.

--- 

Using `$query->addSelect('something')` multiple times introduces duplicated columns, causing `SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'something'.`

# Steps to reproduce

Execute the following query:

```php
// accounts() is a many-to-many relation, with an intermediate Eloquent Model
App\User::find(1)->accounts()->groupBy('accounts.id')->select('accounts.*')->paginate();
```

The resulting problematic SQL query will be:

```
select count(*) as aggregate
from (select `accounts`.*,
             `accounts`.*,
             `membership`.`user_id`    as `pivot_user_id`,
             `membership`.`account_id` as `pivot_account_id`,
             `membership`.`id`         as `pivot_id`,
             `membership`.`created_at` as `pivot_created_at`,
             `membership`.`updated_at` as `pivot_updated_at`
      from `accounts`
               inner join `membership` on `accounts`.`id` = `membership`.`account_id`
      where `membership`.`user_id` = 1
      group by `accounts`.`id`) as `aggregate_table`
```

# Proposed fix

The previous PR was denied because it used `array_unique` on the columns array and may result in a different column order than expected. To prevent this, a strict `in_array` check is used to ensure column orders are not changed. The `is_array` check is there for sanity purposes as columns may not always be an array. This check can be dropped once strict types are introduced.

PR includes updated test to ensure the fix works. Test failed before fix and now passes so all should be fine.

## Related issues
- PR: https://github.com/laravel/framework/pull/37936
- Issue: https://github.com/laravel/framework/issues/34096
- Discussion: https://github.com/laravel/framework/discussions/34097
