### PR TITLE
[9.x] Update `afterPromptingForMissingArguments` method

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -137,7 +137,7 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -245,7 +245,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -162,7 +162,7 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -221,7 +221,7 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -132,7 +132,7 @@ class TestMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 


### PR DESCRIPTION
This pull request allows users to check if the argument name is a reserved word in the PHP language before proceeding to the next step.

Why go to the next step if the input is invalid?

## before

![Screenshot_20230209_011901](https://user-images.githubusercontent.com/70023120/217791093-c357e045-119d-4533-99d9-d90dd09f657a.png)

## after

![Screenshot_20230209_011957](https://user-images.githubusercontent.com/70023120/217791185-d30159d1-c453-4d17-9fb9-da636cd76cde.png)
