### PR TITLE
[10.x] Config path customization

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -118,18 +118,18 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $appPath;
 
     /**
+     * The custom configuration path defined by the developer.
+     *
+     * @var string
+     */
+    protected $configPath;
+
+    /**
      * The custom database path defined by the developer.
      *
      * @var string
      */
     protected $databasePath;
-
-    /**
-     * The custom config path defined by the developer.
-     *
-     * @var string
-     */
-    protected $configPath;
 
     /**
      * The custom language file path defined by the developer.
@@ -364,9 +364,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function path($path = '')
     {
-        $appPath = $this->appPath ?: $this->basePath('app');
-
-        return $this->joinPaths($appPath, $path);
+        return $this->joinPaths($this->appPath ?: $this->basePath('app'), $path);
     }
 
     /**
@@ -429,13 +427,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function configPath($path = '')
     {
-        $configPath = $this->configPath ?: $this->basePath('config');
-
-        return $this->joinPaths($configPath, $path);
+        return $this->joinPaths($this->configPath ?: $this->basePath('config'), $path);
     }
 
     /**
-     * Set the config directory.
+     * Set the configuration directory.
      *
      * @param  string  $path
      * @return $this
@@ -457,9 +453,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function databasePath($path = '')
     {
-        $databasePath = $this->databasePath ?: $this->basePath('database');
-
-        return $this->joinPaths($databasePath, $path);
+        return $this->joinPaths($this->databasePath ?: $this->basePath('database'), $path);
     }
 
     /**
@@ -511,9 +505,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function publicPath($path = '')
     {
-        $publicPath = $this->publicPath ?: $this->basePath('public');
-
-        return $this->joinPaths($publicPath, $path);
+        return $this->joinPaths($this->publicPath ?: $this->basePath('public'), $path);
     }
 
     /**
@@ -539,9 +531,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        $storagePath = $this->storagePath ?: $this->basePath('storage');
-
-        return $this->joinPaths($storagePath, $path);
+        return $this->joinPaths($this->storagePath ?: $this->basePath('storage'), $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -125,6 +125,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $databasePath;
 
     /**
+     * The custom config path defined by the developer.
+     *
+     * @var string
+     */
+    protected $configPath;
+
+    /**
      * The custom language file path defined by the developer.
      *
      * @var string
@@ -422,7 +429,24 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function configPath($path = '')
     {
-        return $this->joinPaths($this->basePath('config'), $path);
+        $configPath = $this->configPath ?: $this->basePath('config');
+
+        return $this->joinPaths($this->basePath($configPath), $path);
+    }
+
+    /**
+     * Set the config directory.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useConfigPath($path)
+    {
+        $this->configPath = $path;
+
+        $this->instance('path.config', $path);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -431,7 +431,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $configPath = $this->configPath ?: $this->basePath('config');
 
-        return $this->joinPaths($this->basePath($configPath), $path);
+        return $this->joinPaths($configPath, $path);
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -516,6 +516,16 @@ class FoundationApplicationTest extends TestCase
 
         $this->assertFalse($app->foo());
     }
+
+    /** @test */
+    public function testUseConfigPath(): void
+    {
+        $app = new Application;
+        $app->useConfigPath(__DIR__ . '/fixtures/config');
+        $app->bootstrapWith([\Illuminate\Foundation\Bootstrap\LoadConfiguration::class]);
+
+        $this->assertSame('bar', $app->make('config')->get('app.foo'));
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -521,7 +521,7 @@ class FoundationApplicationTest extends TestCase
     public function testUseConfigPath(): void
     {
         $app = new Application;
-        $app->useConfigPath(__DIR__ . '/fixtures/config');
+        $app->useConfigPath(__DIR__.'/fixtures/config');
         $app->bootstrapWith([\Illuminate\Foundation\Bootstrap\LoadConfiguration::class]);
 
         $this->assertSame('bar', $app->make('config')->get('app.foo'));

--- a/tests/Foundation/fixtures/config/app.php
+++ b/tests/Foundation/fixtures/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'foo' => 'bar',
+];


### PR DESCRIPTION
This PR adds the ability to customize the config path on `Illuminate\Foundation\Application` via the `useConfigPath` method that works the same way as other customization path methods like `useDatabasePath` or `useLangPath`, among others.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
