### PR TITLE
[10.x] Use `MailManager` as underlying passthru object for `MailFake`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\MailManager;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -19,9 +20,9 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * The mailer instance.
      *
-     * @var Mailer
+     * @var MailManager
      */
-    protected $mailer;
+    protected $manager;
 
     /**
      * The mailer currently being used to send a message.
@@ -47,12 +48,12 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Create a new mail fake.
      *
-     * @param  Mailer  $mailer
+     * @param  MailManager  $manager
      * @return void
      */
-    public function __construct(Mailer $mailer)
+    public function __construct(MailManager $manager)
     {
-        $this->mailer = $mailer;
+        $this->manager = $manager;
     }
 
     /**
@@ -460,6 +461,6 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function __call($method, $parameters)
     {
-        return $this->forwardCallTo($this->mailer, $method, $parameters);
+        return $this->forwardCallTo($this->manager, $method, $parameters);
     }
 }

--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -16,4 +16,16 @@ class SupportMailTest extends TestCase
 
         $this->assertEquals('it works!', Mail::test('foo'));
     }
+
+    public function testItRegisterAndCallMacrosWhenFaked()
+    {
+        Mail::macro('test', fn (string $str) => $str === 'foo'
+            ? 'it works!'
+            : 'it failed.',
+        );
+
+        Mail::fake();
+
+        $this->assertEquals('it works!', Mail::test('foo'));
+    }
 }

--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Facades\Mail;
+use Orchestra\Testbench\TestCase;
+
+class SupportMailTest extends TestCase
+{
+    public function testItRegisterAndCallMacros()
+    {
+        Mail::macro('test', fn (string $str) => $str === 'foo'
+            ? 'it works!'
+            : 'it failed.',
+        );
+
+        $this->assertEquals('it works!', Mail::test('foo'));
+    }
+}

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Mail\Mailable;
-use Illuminate\Mail\Mailer;
+use Illuminate\Mail\MailManager;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use Mockery as m;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -16,7 +16,7 @@ class SupportTestingMailFakeTest extends TestCase
     /**
      * @var \Mockery
      */
-    private $mailer;
+    private $mailManager;
 
     /**
      * @var \Illuminate\Support\Testing\Fakes\MailFake
@@ -31,8 +31,8 @@ class SupportTestingMailFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mailer = m::mock(Mailer::class);
-        $this->fake = new MailFake($this->mailer);
+        $this->mailManager = m::mock(MailManager::class);
+        $this->fake = new MailFake($this->mailManager);
         $this->mailable = new MailableStub;
     }
 
@@ -224,7 +224,7 @@ class SupportTestingMailFakeTest extends TestCase
 
     public function testMissingMethodsAreForwarded()
     {
-        $this->mailer->shouldReceive('foo')->andReturn('bar');
+        $this->mailManager->shouldReceive('foo')->andReturn('bar');
 
         $this->assertEquals('bar', $this->fake->foo());
     }


### PR DESCRIPTION
This PR fixes a bug introduced in #45988 where calling `Mail::fake()` throws the following `TypeError`:

```
TypeError: Illuminate\Support\Testing\Fakes\MailFake::__construct(): Argument #1 ($mailer) must be of type Illuminate\Contracts\Mail\Mailer, Illuminate\Mail\MailManager given, called in /home/runner/work/jetstream/jetstream/vendor/laravel/framework/src/Illuminate/Support/Facades/Mail.php on line 68

/home/runner/work/jetstream/jetstream/vendor/laravel/framework/src/Illuminate/Support/Testing/Fakes/MailFake.php:53
/home/runner/work/jetstream/jetstream/vendor/laravel/framework/src/Illuminate/Support/Facades/Mail.php:68
```

I've added two new test cases to ensure the intended functionality for the original PR remains – please let me know if you want these moved to a better suited directory.