### PR TITLE
fix: support previous timezones

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2276,7 +2276,7 @@ trait ValidatesAttributes
      */
     public function validateTimezone($attribute, $value)
     {
-        return in_array($value, timezone_identifiers_list(), true);
+        return in_array($value, iterator_to_array(IntlTimeZone::createTimeZoneIDEnumeration(IntlTimeZone::TYPE_CANONICAL_LOCATION)), true);
     }
 
     /**


### PR DESCRIPTION
Support timezones like `America/Buenos_Aires` which are often sent by browsers in validation.

`timezone_identifiers_list()` currently does not contain backward compatible timezone links (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), while the Intl extension plugin does support those when choosing `TYPE_CANONICAL_LOCATION`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
