### PR TITLE
[9.x] Add assertLocked() assertion

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -154,6 +154,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 423 "Locked" status code.
+     *
+     * @return $this
+     */
+    public function assertLocked()
+    {
+        return $this->assertStatus(423);
+    }
+
+    /**
      * Assert that the response has a 429 "Too Many Requests" status code.
      *
      * @return $this


### PR DESCRIPTION
Adds a response status assertion for 423 Locked. This status is emitted by the framework itself and I find myself testing for this status code a lot.

https://github.com/laravel/framework/blob/e063e5db66bba2195e5ebd1fb46ad462e159420a/src/Illuminate/Auth/Middleware/RequirePassword.php#L60-L62