### PR TITLE
[10.x] Add ```setKey``` and ```getKey``` in container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -707,6 +707,18 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Set a key on container.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function setKey(string $key, $value)
+    {
+        return $this[$key] = $value;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return mixed

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -719,6 +719,17 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Get a key from container.
+     *
+     * @param  string  $key
+     * @return mixed|string
+     */
+    public function getKey(string $key)
+    {
+        return $this[$key];
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return mixed

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -216,4 +216,12 @@ interface Container extends ContainerInterface
      * @return mixed
      */
     public function setKey(string $key, $value);
+
+    /**
+     * Get a key from container.
+     *
+     * @param  string  $key
+     * @return mixed|string
+     */
+    public function getKey(string $key);
 }

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -207,4 +207,13 @@ interface Container extends ContainerInterface
      * @return void
      */
     public function afterResolving($abstract, Closure $callback = null);
+
+    /**
+     * Set a key on container.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function setKey(string $key, $value);
 }

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -107,6 +107,8 @@ namespace Illuminate\Support\Facades;
  * @method static mixed call(callable|string $callback, array $parameters = [], string|null $defaultMethod = null)
  * @method static \Closure factory(string $abstract)
  * @method static mixed makeWith(string|callable $abstract, array $parameters = [])
+ * @method static mixed setKey(string $key, mixed $value)
+ * @method static mixed|string getKey(string $key)
  * @method static mixed get(string $id)
  * @method static mixed build(\Closure|string $concrete)
  * @method static void beforeResolving(\Closure|string $abstract, \Closure|null $callback = null)


### PR DESCRIPTION
This PR is related to this PR(https://github.com/laravel/docs/pull/8532)

When you want to set key on container, You may use this:
```php
app()['middleware.disable'] = true;
```

This is a bit ugly, With ```setKey``` method you can set key fluently on container.
```php
app()->setKey('middleware.disable', false);
```

Or maybe you want to catch one key.
```php
app()->getKey('middleware.disable');
```