### PR TITLE
[9.x]Execute a callback over each attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1771,6 +1771,23 @@ trait HasAttributes
     }
 
     /**
+     * Execute a callback over each attribute.
+     *
+     * @param  callable(TValue, TKey): mixed  $callback
+     * @return $this
+     */
+    public function each(callable $callback)
+    {
+        foreach ($this->getAttributes() as $key => $item) {
+            if ($callback($item, $key) === false) {
+                break;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Get all of the current attributes on the model for an insert operation.
      *
      * @return array


### PR DESCRIPTION
While working through a project, I accidentally called `each()` on a model. This somehow resulted in a series of selects as follows from offset `1000..292000` in increments of 1000 (292 queries in total)

```
[2023-02-09 21:17:32] local.INFO: select * from `ordhdr` where `ordhdr`.`ordID` = ? limit 1 [294694] 
[2023-02-09 21:17:32] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 0  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 1000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 2000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 3000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 4000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 5000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 6000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 7000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 8000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 9000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 10000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 11000  
[2023-02-09 21:17:40] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 12000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 13000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 14000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 15000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 16000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 17000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 18000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 19000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 20000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 21000  
[2023-02-09 21:17:41] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 22000  
[2023-02-09 21:17:42] local.INFO: select * from `ordhdr` order by `ordhdr`.`ordID` asc limit 1000 offset 23000  
```

I was thinking it might actually be a good small feature to instead iterate over the models attributes.
