### PR TITLE
[9.x] Add index hinting support to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -103,7 +103,7 @@ class Builder implements BuilderContract
     /**
      * The index hint for the query.
      *
-     * @var IndexHint
+     * @var \Illuminate\Database\Query\IndexHint
      */
     public $indexHint;
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -101,6 +101,13 @@ class Builder implements BuilderContract
     public $from;
 
     /**
+     * The index hint for the query.
+     *
+     * @var IndexHint
+     */
+    public $indexHint;
+
+    /**
      * The table joins for the query.
      *
      * @var array
@@ -454,6 +461,45 @@ class Builder implements BuilderContract
         }
 
         $this->from = $as ? "{$table} as {$as}" : $table;
+
+        return $this;
+    }
+
+    /**
+     * Add an index hint to suggest a query index.
+     *
+     * @param  string  $index
+     * @return $this
+     */
+    public function useIndex($index)
+    {
+        $this->indexHint = new IndexHint('hint', $index);
+
+        return $this;
+    }
+
+    /**
+     * Add an index hint to force a query index.
+     *
+     * @param  string  $index
+     * @return $this
+     */
+    public function forceIndex($index)
+    {
+        $this->indexHint = new IndexHint('force', $index);
+
+        return $this;
+    }
+
+    /**
+     * Add an index hint to ignore a query index.
+     *
+     * @param  string  $index
+     * @return $this
+     */
+    public function ignoreIndex($index)
+    {
+        $this->indexHint = new IndexHint('ignore', $index);
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -36,6 +36,7 @@ class Grammar extends BaseGrammar
         'aggregate',
         'columns',
         'from',
+        'indexHint',
         'joins',
         'wheres',
         'groups',

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -76,6 +76,22 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the index hints for the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Query\IndexHint  $indexHint
+     * @return string
+     */
+    protected function compileIndexHint(Builder $query, $indexHint)
+    {
+        return match ($indexHint->type) {
+            'hint' => "use index ({$indexHint->index})",
+            'force' => "force index ({$indexHint->index})",
+            default => "ignore index ({$indexHint->index})",
+        };
+    }
+
+    /**
      * Compile an insert ignore statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -299,26 +315,6 @@ class MySqlGrammar extends Grammar
         })->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);
-    }
-
-    /**
-     * Compile the index hints of the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  IndexHint  $indexHint
-     * @return string
-     */
-    protected function compileIndexHint(Builder $query, $indexHint)
-    {
-        if ($indexHint->type === 'hint') {
-            return "use index ({$indexHint->index})";
-        }
-
-        if ($indexHint->type === 'force') {
-            return "force index ({$indexHint->index})";
-        }
-
-        return "ignore index ({$indexHint->index})";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\IndexHint;
 use Illuminate\Support\Str;
 
 class MySqlGrammar extends Grammar
@@ -298,6 +299,26 @@ class MySqlGrammar extends Grammar
         })->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);
+    }
+
+    /**
+     * Compile the index hints of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  IndexHint  $indexHint
+     * @return string
+     */
+    protected function compileIndexHint(Builder $query, $indexHint)
+    {
+        if ($indexHint->type === 'hint') {
+            return "use index ({$indexHint->index})";
+        }
+
+        if ($indexHint->type === 'force') {
+            return "force index ({$indexHint->index})";
+        }
+
+        return "ignore index ({$indexHint->index})";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -119,6 +119,20 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the index hints for the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Query\IndexHint  $indexHint
+     * @return string
+     */
+    protected function compileIndexHint(Builder $query, $indexHint)
+    {
+        return $indexHint->type === 'force'
+                ? "indexed by {$indexHint->index}"
+                : '';
+    }
+
+    /**
      * Compile a "JSON length" statement into SQL.
      *
      * @param  string  $column
@@ -339,22 +353,6 @@ class SQLiteGrammar extends Grammar
             'delete from sqlite_sequence where name = ?' => [$query->from],
             'delete from '.$this->wrapTable($query->from) => [],
         ];
-    }
-
-    /**
-     * Compile the index hints of the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  IndexHint  $indexHint
-     * @return string
-     */
-    protected function compileIndexHint(Builder $query, $indexHint)
-    {
-        if ($indexHint->type === 'force') {
-            return "indexed by {$indexHint->index}";
-        }
-
-        return '';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\IndexHint;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -338,6 +339,22 @@ class SQLiteGrammar extends Grammar
             'delete from sqlite_sequence where name = ?' => [$query->from],
             'delete from '.$this->wrapTable($query->from) => [],
         ];
+    }
+
+    /**
+     * Compile the index hints of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  IndexHint  $indexHint
+     * @return string
+     */
+    protected function compileIndexHint(Builder $query, $indexHint)
+    {
+        if ($indexHint->type === 'force') {
+            return "indexed by {$indexHint->index}";
+        }
+
+        return '';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\IndexHint;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -601,6 +602,22 @@ class SqlServerGrammar extends Grammar
         }
 
         return $this->getValue($table);
+    }
+
+    /**
+     * Compile the index hints of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  IndexHint  $indexHint
+     * @return string
+     */
+    protected function compileIndexHint(Builder $query, $indexHint)
+    {
+        if ($indexHint->type === 'force') {
+            return "with (index({$indexHint->index}))";
+        }
+
+        return '';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -98,6 +98,20 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the index hints for the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Query\IndexHint  $indexHint
+     * @return string
+     */
+    protected function compileIndexHint(Builder $query, $indexHint)
+    {
+        return $indexHint->type === 'force'
+                    ? "with (index({$indexHint->index}))"
+                    : '';
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -602,22 +616,6 @@ class SqlServerGrammar extends Grammar
         }
 
         return $this->getValue($table);
-    }
-
-    /**
-     * Compile the index hints of the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  IndexHint  $indexHint
-     * @return string
-     */
-    protected function compileIndexHint(Builder $query, $indexHint)
-    {
-        if ($indexHint->type === 'force') {
-            return "with (index({$indexHint->index}))";
-        }
-
-        return '';
     }
 
     /**

--- a/src/Illuminate/Database/Query/IndexHint.php
+++ b/src/Illuminate/Database/Query/IndexHint.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+class IndexHint
+{
+    /**
+     * The type of query hint.
+     *
+     * @var string
+     */
+    public $type;
+
+    /**
+     * The name of the index.
+     *
+     * @var string
+     */
+    public $index;
+
+    /**
+     * Create a new index hint instance.
+     *
+     * @param  string  $type
+     * @param  string  $index
+     * @return void
+     */
+    public function __construct($type, $index)
+    {
+        $this->type = $type;
+        $this->index = $index;
+    }
+}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5418,6 +5418,69 @@ SQL;
         $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
+    public function testUseIndexMySql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('foo')->from('users')->useIndex('test_index');
+        $this->assertSame('select `foo` from `users` use index (test_index)', $builder->toSql());
+    }
+
+    public function testForceIndexMySql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('foo')->from('users')->forceIndex('test_index');
+        $this->assertSame('select `foo` from `users` force index (test_index)', $builder->toSql());
+    }
+
+    public function testIgnoreIndexMySql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('foo')->from('users')->ignoreIndex('test_index');
+        $this->assertSame('select `foo` from `users` ignore index (test_index)', $builder->toSql());
+    }
+
+    public function testUseIndexSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('foo')->from('users')->useIndex('test_index');
+        $this->assertSame('select "foo" from "users"', $builder->toSql());
+    }
+
+    public function testForceIndexSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('foo')->from('users')->forceIndex('test_index');
+        $this->assertSame('select "foo" from "users" indexed by test_index', $builder->toSql());
+    }
+
+    public function testIgnoreIndexSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('foo')->from('users')->ignoreIndex('test_index');
+        $this->assertSame('select "foo" from "users"', $builder->toSql());
+    }
+
+    public function testUseIndexSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('foo')->from('users')->useIndex('test_index');
+        $this->assertSame('select [foo] from [users]', $builder->toSql());
+    }
+
+    public function testForceIndexSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('foo')->from('users')->forceIndex('test_index');
+        $this->assertSame('select [foo] from [users] with (index(test_index))', $builder->toSql());
+    }
+
+    public function testIgnoreIndexSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('foo')->from('users')->ignoreIndex('test_index');
+        $this->assertSame('select [foo] from [users]', $builder->toSql());
+    }
+
     public function testClone()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR adds `useIndex()`, `forceIndex()` and `ignoreIndex()` methods to the query builder, to help MySQL's (and others) query planner use the indexes I want for a query. I've had to do this in the past to optimize slow queries where the planner didn't choose to use an index even though it was dramatically more performant, and today I came across @assertchris [doing the same thing](https://twitter.com/assertchris/status/1623730973534744578), so I thought it might be worth adding to the ORM for other people to use.

Support across engines is spotty, with only MySQL supporting all three hinting modes. Based on my research this seems to be the support:

| Database  | Index hinting | Index forcing | Index ignoring
| ---------- | ---------- | ---------- | ---------- |
| MySQL | ✅ Supported | ✅ Supported | ✅ Supported |
| SQLite | ❌ Not supported | ✅ Supported | ❌ Not supported (can only ignore all indexes) |
| PostgreSQL | ❌ Not supported | ❌ Not supported | ❌ Not supported |
| SQL Server | ❌ Not supported | ✅ Supported | ❌ Not supported (can only ignore all indexes) |

I have only implemented these where supported, for engines without support the query will be unchanged by the `useIndex()`, `forceIndex()` and `ignoreIndex()` methods.

I have also only added support for hinting one index. MySQL supports the use of multiple `USE INDEX` hints, and a combination of `USE INDEX` hints with `IGNORE INDEX` hints, but I have left that unimplemented for simplicity and to test the water on if this change is wanted. If we want to add support for hinting multiple indexes, I can add that functionality.

A 4th method called `ignoreIndexes()` could be added to support SQLite and SQL Server's ability to ignore all indexes and do full table scans, but I struggle to think of why you'd actually want to do that in a real environment.