### PR TITLE
[10.x] Add hasDebugModeEnabled to Application Contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -100,6 +100,13 @@ interface Application extends Container
     public function runningUnitTests();
 
     /**
+     * Determine if the application is running with debug mode enabled.
+     *
+     * @return bool
+     */
+    public function hasDebugModeEnabled();
+
+    /**
      * Get an instance of the maintenance mode manager implementation.
      *
      * @return \Illuminate\Contracts\Foundation\MaintenanceMode


### PR DESCRIPTION
Currently, `hasDebugModeEnabled` is not included in `Illuminate\Contracts\Foundation\Application` and will not give type hints in the IDE when I type `app()->`. Adding this would allow IDE to type hint this method.

This would make development slightly easier.
