### PR TITLE
[9.x] Add default eager loading of related column aggregates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -84,6 +84,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected $withCount = [];
 
     /**
+     * The relationship aggregates that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withAggregate = [];
+
+    /**
      * Indicates whether lazy loading will be prevented on this model.
      *
      * @var bool
@@ -1525,9 +1532,32 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newQueryWithoutScopes()
     {
-        return $this->newModelQuery()
-            ->with($this->with)
-            ->withCount($this->withCount);
+        return $this->withAggregates(
+            $this->newModelQuery()
+                ->with($this->with)
+                ->withCount($this->withCount)
+        );
+    }
+
+    /**
+     * Add default model aggregates to a query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|static  $query
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    protected function withAggregates(Builder $query)
+    {
+        foreach ($this->withAggregate as $function => $aggregates) {
+            foreach ($aggregates as $aggregate) {
+                [$relations, $column] = explode(':', $aggregate, 2);
+
+                $relations = explode(',', $relations);
+
+                $query->withAggregate($relations, $column, $function);
+            }
+        }
+
+        return $query;
     }
 
     /**

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -19,24 +19,37 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
         Schema::create('two', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
+            $table->float('value');
         });
 
         Schema::create('three', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
+            $table->float('value');
         });
     }
 
     public function testItBasic()
     {
         $one = Model1::create();
-        $one->twos()->create();
-        $one->threes()->create();
+        $one->twos()->create(['value' => 1]);
+        $one->twos()->create(['value' => 2]);
+        $one->threes()->create(['value' => 3]);
+        $one->threes()->create(['value' => 4]);
+        $one->threes()->create(['value' => 5]);
 
         $model = Model1::find($one->id);
 
         $this->assertTrue($model->relationLoaded('twos'));
         $this->assertFalse($model->relationLoaded('threes'));
+        $this->assertEquals(3, $model->twos_sum_value);
+        $this->assertEquals(1.5, $model->twos_avg_value);
+        $this->assertEquals(1, $model->twos_min_value);
+        $this->assertEquals(2, $model->twos_max_value);
+        $this->assertEquals(12, $model->threes_sum_value);
+        $this->assertEquals(4, $model->threes_avg_value);
+        $this->assertEquals(3, $model->threes_min_value);
+        $this->assertEquals(5, $model->threes_max_value);
 
         DB::enableQueryLog();
 
@@ -54,6 +67,27 @@ class Model1 extends Model
     public $timestamps = false;
     protected $guarded = [];
     protected $with = ['twos'];
+    protected $withAggregate = [
+        'sum' => [
+            'twos:value',
+            'threes:value',
+        ],
+
+        'avg' => [
+            'twos:value',
+            'threes:value',
+        ],
+
+        'min' => [
+            'twos:value',
+            'threes:value',
+        ],
+
+        'max' => [
+            'twos:value',
+            'threes:value',
+        ],
+    ];
 
     public function twos()
     {


### PR DESCRIPTION
Building on `$with` and `$withCount`, `$withAggregate` adds the ability to eager load related column aggregate values by default.

```php
class Product extends Model
{
    protected $with = ['orders'];
    protected $withCount = ['orders'];
    protected $withAggregate = [
        'sum' => [
            'orders:amount'
        ],

        'avg' => [
            'orders:amount'
        ],

        'min' => [
            'orders:amount'
        ],

        'max' => [
            'orders:amount'
        ]
    ];

    public function orders()
    {
        return $this->belongsToMany(Order::class);
    }
}
```

```php
foreach (Product::popular()->take(10)->get() as $product) {
    echo $product->orders_sum_amount;
    echo $product->orders_avg_amount;
    echo $product->orders_min_amount;
    echo $product->orders_max_amount;
}
```
