### PR TITLE
[9.x] Update `afterPromptingForMissingArguments` method

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -457,7 +457,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      *
      * @return bool
      */
-    protected function isReservedAOrExistenceName()
+    protected function isReservedOrExistingName()
     {
         if ($this->isReservedName($this->getNameInput())) {
             return true;

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -453,6 +453,24 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     }
 
     /**
+     * Checks whether the given class name is reserved or already exists.
+     *
+     * @return bool
+     */
+    protected function isReservedAOrExistenceName()
+    {
+        if ($this->isReservedName($this->getNameInput())) {
+            return true;
+        }
+
+        if ($this->alreadyExists($this->getNameInput())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Get the first view directory path from the application configuration.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -137,7 +137,7 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -245,7 +245,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -245,7 +245,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
+        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -245,7 +245,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
+        if ($this->isReservedOrExistingName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -162,7 +162,7 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -162,7 +162,7 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
+        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -162,7 +162,7 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
+        if ($this->isReservedOrExistingName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -221,7 +221,7 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -221,7 +221,7 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
+        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -221,7 +221,7 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
+        if ($this->isReservedOrExistingName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -132,7 +132,7 @@ class TestMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -132,7 +132,7 @@ class TestMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
+        if ($this->isReservedOrExistingName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -132,7 +132,7 @@ class TestMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedName($this->getNameInput()) || $this->didReceiveOptions($input)) {
+        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -309,7 +309,7 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->didReceiveOptions($input)) {
+        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
             return;
         }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -309,7 +309,7 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
     {
-        if ($this->isReservedAOrExistenceName() || $this->didReceiveOptions($input)) {
+        if ($this->isReservedOrExistingName() || $this->didReceiveOptions($input)) {
             return;
         }
 


### PR DESCRIPTION
This PR continuation of this https://github.com/laravel/framework/pull/46052

## Before

![Screenshot_20230210_010627](https://user-images.githubusercontent.com/70023120/218051797-00ca21e3-3add-4876-8260-b4b331fdd9c2.png)

## After

![Screenshot_20230210_010706](https://user-images.githubusercontent.com/70023120/218051900-d638e135-3534-4cfb-9f7a-9bbf64f709f8.png)
