### PR TITLE
[9.x] Don't expose model full path in model not found exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -36,6 +36,7 @@ class ModelNotFoundException extends RecordsNotFoundException
         $this->model = $model;
         $this->ids = Arr::wrap($ids);
 
+        $model = class_basename($model);
         $this->message = "No query results for model [{$model}]";
 
         if (count($this->ids) > 0) {

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -170,7 +170,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFirstOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
+        $this->expectExceptionMessage('No query results for model [HasManyThroughTestPost].');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
             ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -181,7 +181,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
+        $this->expectExceptionMessage('No query results for model [HasManyThroughTestPost] 1');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
@@ -192,7 +192,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrFailWithManyThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
+        $this->expectExceptionMessage('No query results for model [HasManyThroughTestPost] 1, 2');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
@@ -204,7 +204,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFindOrFailWithManyUsingCollectionThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1, 2');
+        $this->expectExceptionMessage('No query results for model [HasManyThroughTestPost] 1, 2');
 
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -131,7 +131,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
     public function testFirstOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
+        $this->expectExceptionMessage('No query results for model [HasOneThroughTestContract].');
 
         HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -678,7 +678,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1');
+        $this->expectExceptionMessage('No query results for model [EloquentTestUser] 1');
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [1]),
         );
@@ -689,7 +689,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionMessage('No query results for model [EloquentTestUser] 2, 3');
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
         );
@@ -701,7 +701,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithMultipleIdsUsingCollectionThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionMessage('No query results for model [EloquentTestUser] 2, 3');
         $this->expectExceptionObject(
             (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
         );

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -407,7 +407,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function testFindOrFailMethod()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10');
+        $this->expectExceptionMessage('No query results for model [Tag] 10');
 
         $post = Post::create(['title' => Str::random()]);
 
@@ -421,7 +421,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function testFindOrFailMethodWithMany()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+        $this->expectExceptionMessage('No query results for model [Tag] 10, 11');
 
         $post = Post::create(['title' => Str::random()]);
 
@@ -435,7 +435,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     public function testFindOrFailMethodWithManyUsingCollection()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+        $this->expectExceptionMessage('No query results for model [Tag] 10, 11');
 
         $post = Post::create(['title' => Str::random()]);
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1029,7 +1029,7 @@ class RoutingRouteTest extends TestCase
     public function testModelBindingWithNullReturn()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
+        $this->expectExceptionMessage('No query results for model [RouteModelBindingNullStub].');
 
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {


### PR DESCRIPTION
When The ModelNotFoundException class prepares for the exception message does not check for app.debug level so if we are in APP_DEBUG set to false (meaning in production) we still expose the model full path as the json response. 

example:
```
{
    "message": "No query results for model [App\\Models\\Video] 99"
}
```

which is not good. We are exposing our model path.
I propose just give the model short class name as the message, as below no matter what env

```
{
    "message": "No query results for model [Video] 99"
}
```

Thank you

:zzz: :zzz: :zzz: :zzz:

