### PR TITLE
[9.x] Fixes memory leak on anonymous migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -67,6 +67,13 @@ class Migrator
     protected $paths = [];
 
     /**
+     * The paths that have already been required.
+     *
+     * @var array<string, \Illuminate\Database\Migrations\Migration|null>
+     */
+    protected static $pathsAlreadyRequired = [];
+
+    /**
      * The output interface implementation.
      *
      * @var \Symfony\Component\Console\Output\OutputInterface
@@ -511,9 +518,13 @@ class Migrator
             return new $class;
         }
 
-        $migration = $this->files->getRequire($path);
+        $migration = static::$pathsAlreadyRequired[$path] ??= $this->files->getRequire($path);
 
-        return is_object($migration) ? $migration : new $class;
+        if (is_object($migration)) {
+            return clone $migration;
+        }
+
+        return new $class;
     }
 
     /**


### PR DESCRIPTION
This pull request resolves an issue with memory leaks in Laravel test suites that utilize anonymous migrations. The leak is a result of an internal memory issue within PHP when anonymous classes are utilized. It is important to note that this fix will only be noticeable if the user uses the `RefreshDatabase` trait, and **in-memory databases**.

```
// Use case 1: 702 feature tests

// Before:
Time: 00:23.628, Memory: 324.00 MB
// After
Time: 00:21.393, Memory: 40.00 MB

---
// Use case 2: 233 feature tests

// Before:
Time: 01:03.643, Memory: 147.00 MB
// After
Time: 01:01.898, Memory: 82.50 MB
```

Fixes https://github.com/laravel/framework/issues/46029.