### PR TITLE
[9.x] Add mailer name to data for SentMessage and MessageSending events

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -281,6 +281,8 @@ class Mailer implements MailerContract, MailQueueContract
         // its recipients. We will then fire the sent event for the sent message.
         $symfonyMessage = $message->getSymfonyMessage();
 
+        $data['mailer'] = $this->name;
+
         if ($this->shouldSendMessage($symfonyMessage, $data)) {
             $symfonySentMessage = $this->sendSymfonyMessage($symfonyMessage);
 


### PR DESCRIPTION
This PR adds the mailer name to data for the `MessageSending` and `SentMessage` events.

It is impossible to detect through which mailer a mailable is sent when listening to the `MessageSending` and `SentMessage` event.

There are some use cases where this is a benefit:

1. Stop sending the email depending on the mailer.

2. Storing every outgoing mail with its mailer

When using different mailers and a custom failover logic, it is important to know from which mailer a message was sent. Especially when using a package and the only way to intercept mails are the events.


Accessing the mailer from event data looks like this:
```php
Event::listen(MessageSending::class, function(MessageSending $event){
    $mailer = $event->data['mailer'];
});
```
