### PR TITLE
[9.x] Add some tests to testIntegerMethod and testFloatMethod (HttpRequestTest.php)

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -618,6 +618,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame(2, $request->integer('underscore_notation'));
         $this->assertSame(123456, $request->integer('unknown_key', 123456));
         $this->assertSame(0, $request->integer('null'));
+        $this->assertSame(0, $request->integer('null', 123456));
     }
 
     public function testFloatMethod()
@@ -643,6 +644,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame(1e3, $request->float('scientific_notation'));
         $this->assertSame(123.456, $request->float('unknown_key', 123.456));
         $this->assertSame(0.0, $request->float('null'));
+        $this->assertSame(0.0, $request->float('null', 123.456));
     }
 
     public function testCollectMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -607,6 +607,7 @@ class HttpRequestTest extends TestCase
             'nan' => 'nan',
             'mixed' => '1ab',
             'underscore_notation' => '2_000',
+            'null' => null,
         ]);
         $this->assertSame(123, $request->integer('int'));
         $this->assertSame(456, $request->integer('raw_int'));
@@ -616,6 +617,8 @@ class HttpRequestTest extends TestCase
         $this->assertSame(1, $request->integer('mixed'));
         $this->assertSame(2, $request->integer('underscore_notation'));
         $this->assertSame(123456, $request->integer('unknown_key', 123456));
+        $this->assertSame(0, $request->integer('null'));
+        $this->assertSame(0, $request->integer('key_doesnt_exist'));
     }
 
     public function testFloatMethod()
@@ -629,6 +632,7 @@ class HttpRequestTest extends TestCase
             'nan' => 'nan',
             'mixed' => '1.ab',
             'scientific_notation' => '1e3',
+            'null' => null,
         ]);
         $this->assertSame(1.23, $request->float('float'));
         $this->assertSame(45.6, $request->float('raw_float'));
@@ -639,6 +643,8 @@ class HttpRequestTest extends TestCase
         $this->assertSame(1.0, $request->float('mixed'));
         $this->assertSame(1e3, $request->float('scientific_notation'));
         $this->assertSame(123.456, $request->float('unknown_key', 123.456));
+        $this->assertSame(0.0, $request->float('null'));
+        $this->assertSame(0.0, $request->float('key_doesnt_exist'));
     }
 
     public function testCollectMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -618,7 +618,6 @@ class HttpRequestTest extends TestCase
         $this->assertSame(2, $request->integer('underscore_notation'));
         $this->assertSame(123456, $request->integer('unknown_key', 123456));
         $this->assertSame(0, $request->integer('null'));
-        $this->assertSame(0, $request->integer('key_doesnt_exist'));
     }
 
     public function testFloatMethod()
@@ -644,7 +643,6 @@ class HttpRequestTest extends TestCase
         $this->assertSame(1e3, $request->float('scientific_notation'));
         $this->assertSame(123.456, $request->float('unknown_key', 123.456));
         $this->assertSame(0.0, $request->float('null'));
-        $this->assertSame(0.0, $request->float('key_doesnt_exist'));
     }
 
     public function testCollectMethod()


### PR DESCRIPTION
Additional tests are assumed that when a key exists and the value is null.