### PR TITLE
[9.x] Use ```shouldAllowMockingProtectedMethods``` for mocking in FilesystemAdapterTest

### DIFF
--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -91,6 +91,7 @@ class FilesystemAdapterTest extends TestCase
         $files = m::mock(FilesystemAdapter::class, [$this->filesystem, $this->adapter])
             ->shouldAllowMockingProtectedMethods()
             ->makePartial();
+        $files->shouldAllowMockingProtectedMethods();
         $files->shouldReceive('fallbackName')->never();
 
         $files->response('file.txt', null, [


### PR DESCRIPTION
Need to use this method because protected methods cannot be mocked without calling ```Mock.shouldAllowMockingProtectedMethods```