### PR TITLE
Pass resetUrl variable to user's toMail callback function instead of token

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $resetUrl = $this->resetUrl($notifiable);
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $resetUrl);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage($resetUrl);
     }
 
     /**


### PR DESCRIPTION
I noticed, that in `ResetPassword.php` and `VerifyEmail.php` files in the `toMail` function used different parameters for the user's callback function: in the `VerifyEmail.php` file there are used the same variable `$verificationUrl` for both user callback and `buildMailMessage` function but in `ResetPassword.php` file in `toMail` function for user's callback function used token variable instead of URL, but to the `buildMailMessage` function there is passed URL.
I think it's will be better to pass the URL to the user callback function in both files. In this case, we don't need manually generate a URL, based on the passed token, when we use the `toMailUsing` callback.