### PR TITLE
[9.x] Added --pending option to migrate:status

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -124,12 +124,9 @@ class StatusCommand extends BaseCommand
     {
         return [
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
-
+            ['pending', null, InputOption::VALUE_NONE, 'Only list pending migrations'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
-
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
-
-            ['pending', null, InputOption::VALUE_NONE, 'Get only pending migrations'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -65,9 +65,13 @@ class StatusCommand extends BaseCommand
 
                 $this->components->twoColumnDetail('<fg=gray>Migration name</>', '<fg=gray>Batch / Status</>');
 
-                $migrations->each(
-                    fn ($migration) => $this->components->twoColumnDetail($migration[0], $migration[1])
-                );
+                $migrations
+                    ->when($this->option('pending'), fn ($collection) => $collection->filter(function ($migration) {
+                        return str($migration[1])->contains('Pending');
+                    }))
+                    ->each(
+                        fn ($migration) => $this->components->twoColumnDetail($migration[0], $migration[1])
+                    );
 
                 $this->newLine();
             } else {
@@ -124,6 +128,8 @@ class StatusCommand extends BaseCommand
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to use'],
 
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+
+            ['pending', null, InputOption::VALUE_NONE, 'Get only pending migrations'],
         ];
     }
 }


### PR DESCRIPTION
This PR add --pending option to migrate:status command to obtain only pending migrations.

File :  Illuminate\Database\Console\Migrations\StatusCommand.php

```sh
php artisan migrate:status --pending
```