### PR TITLE
[9.x] Added savepoints release

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -207,7 +207,6 @@ trait ManagesTransactions
      * Perform a commit within the database.
      *
      * @return void
-     *
      */
     protected function performCommit()
     {
@@ -228,7 +227,7 @@ trait ManagesTransactions
     {
         return $this->transactions == 0 ||
             ($this->transactionsManager &&
-                $this->transactionsManager->callbackApplicableTransactions()->count() === 1);
+            $this->transactionsManager->callbackApplicableTransactions()->count() === 1);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -218,6 +218,7 @@ trait ManagesTransactions
             );
         }
     }
+
     /**
      * Determine if after commit callbacks should be executed.
      *

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1259,6 +1259,16 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Determine if the grammar supports savepoints release.
+     *
+     * @return bool
+     */
+    public function supportsSavepointsRelease()
+    {
+        return true;
+    }
+
+    /**
      * Compile the SQL statement to define a savepoint.
      *
      * @param  string  $name
@@ -1267,6 +1277,17 @@ class Grammar extends BaseGrammar
     public function compileSavepoint($name)
     {
         return 'SAVEPOINT '.$name;
+    }
+
+    /**
+     * Compile the SQL statement to execute a savepoint release.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function compileSavepointRelease($name)
+    {
+        return 'RELEASE '.$name;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1287,7 +1287,7 @@ class Grammar extends BaseGrammar
      */
     public function compileSavepointRelease($name)
     {
-        return 'RELEASE '.$name;
+        return 'RELEASE SAVEPOINT '.$name;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -536,6 +536,14 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * @inheritdoc
+     */
+    public function supportsSavepointsRelease()
+    {
+        return false;
+    }
+
+    /**
      * Compile the SQL statement to define a savepoint.
      *
      * @param  string  $name

--- a/tests/Integration/Database/DatabaseTransactionTest.php
+++ b/tests/Integration/Database/DatabaseTransactionTest.php
@@ -12,7 +12,7 @@ class DatabaseTransactionTest extends DatabaseTestCase
     protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
+            $table->unsignedInteger('id');
         });
     }
 

--- a/tests/Integration/Database/DatabaseTransactionTest.php
+++ b/tests/Integration/Database/DatabaseTransactionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DatabaseTransactionTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+    }
+
+    public function testDatabaseTransactionCommit()
+    {
+        $connection = $this->getConnection();
+
+        $connection->beginTransaction();
+
+        $this->assertEquals(1, $connection->transactionLevel());
+
+        $connection->table('users')->insert(['id' => 1]);
+        $connection->commit();
+
+        $this->assertEquals(0, $connection->transactionLevel());
+        $this->assertDatabaseHas('users', ['id' => 1]);
+    }
+
+    public function testDatabaseTransactionRollback()
+    {
+        $connection = $this->getConnection();
+
+        $connection->beginTransaction();
+
+        $this->assertEquals(1, $connection->transactionLevel());
+
+        $connection->table('users')->insert(['id' => 2]);
+        $connection->rollBack();
+
+        $this->assertEquals(0, $connection->transactionLevel());
+        $this->assertDatabaseMissing('users', ['id' => 2]);
+    }
+
+    public function testDatabaseNestedTransactionCommmit()
+    {
+        $connection = $nestedConnection = $this->getConnection();
+
+        $connection->beginTransaction();
+        $connection->table('users')->insert(['id' => 1]);
+
+        $this->assertEquals(1, $connection->transactionLevel());
+
+        $nestedConnection->beginTransaction();
+
+        $this->assertEquals(2, $connection->transactionLevel());
+
+        $nestedConnection->table('users')->insert(['id' => 2]);
+        $nestedConnection->commit();
+
+        $this->assertEquals(1, $connection->transactionLevel());
+
+        $connection->commit();
+
+        $this->assertEquals(0, $connection->transactionLevel());
+        $this->assertDatabaseHas('users', ['id' => 1]);
+        $this->assertDatabaseHas('users', ['id' => 2]);
+    }
+
+    public function testDatabaseNestedTransactionRollback()
+    {
+        $connection = $nestedConnection = $this->getConnection();
+
+        $connection->beginTransaction();
+        $connection->table('users')->insert(['id' => 1]);
+
+        $this->assertEquals(1, $connection->transactionLevel());
+
+        $nestedConnection->beginTransaction();
+
+        $this->assertEquals(2, $connection->transactionLevel());
+
+        $nestedConnection->table('users')->insert(['id' => 2]);
+
+        $nestedConnection->rollBack();
+
+        $this->assertEquals(1, $connection->transactionLevel());
+
+        $connection->commit();
+
+        $this->assertEquals(0, $connection->transactionLevel());
+        $this->assertDatabaseHas('users', ['id' => 1]);
+        $this->assertDatabaseMissing('users', ['id' => 2]);
+    }
+}


### PR DESCRIPTION
Based on issue [#46040](https://github.com/laravel/framework/issues/46040)

In this PR, I've added release savepoints for nested transactions. I also wrote some simple integration tests for commit and rollback transactions.

**SQLServer** does not support release savepoint and I have disabled them in the [SqlServerGrammar](https://github.com/laravel/framework/compare/9.x...korkoshko:framework:savepoints-release?expand=1#diff-145e760491e9e32a7285c4bd520a832f5867d3e35068770197c8327381b68ce1) class.

**Change in behavior**:  [TransactionCommitting](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Events/TransactionCommitting.php) is now also dispatch when a nested transaction commits.

