### PR TITLE
[10.x] Adds Servers to HTTP Client Factory

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -403,7 +403,6 @@ class Factory
         return $this->dispatcher;
     }
 
-
     /**
      * Execute a method against a new pending request instance.
      *

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
-use RuntimeException;
 
 /**
  * @mixin \Illuminate\Http\Client\PendingRequest

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -107,7 +107,7 @@ class Factory
         $server = $this->servers[$name] ?? $this->servers[Str::camel($name)];
 
         return $server
-            ? tap(new $server($this, $parameters))
+            ? new $server($this, $parameters)
             : throw new RuntimeException("The server \"$name\" is not defined.");
     }
 
@@ -418,7 +418,7 @@ class Factory
         }
 
         if (isset($this->servers[$method])) {
-            return tap(new $this->servers[$method]($this, $parameters));
+            return new $this->servers[$method]($this, $parameters);
         }
 
         return tap($this->newPendingRequest(), function ($request) {

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -29,13 +29,6 @@ class Factory
     protected $dispatcher;
 
     /**
-     * The registered servers.
-     *
-     * @var \Illuminate\Support\Collection<\Illuminate\Http\Client\Server>
-     */
-    protected $servers;
-
-    /**
      * The stub callables that will handle requests.
      *
      * @var \Illuminate\Support\Collection
@@ -84,31 +77,15 @@ class Factory
     }
 
     /**
-     * Defines a new server to build requests.
-     *
-     * @param  string|class-string  $class
-     * @return void
-     */
-    public function define($class, $name = null)
-    {
-        $name ??= Str::lcfirst(class_basename($class));
-
-        $this->servers[$name] = $class;
-    }
-
-    /**
      * Returns a previously saved server.
      *
-     * @param  string  $name
+     * @param  string|class-string  $server
+     * @param  array  $parameters
      * @return \Illuminate\Http\Client\Server
      */
-    public function server($name, $parameters = [])
+    public function server($server, $parameters = [])
     {
-        $server = $this->servers[$name] ?? $this->servers[Str::camel($name)];
-
-        return $server
-            ? new $server($this, $parameters)
-            : throw new RuntimeException("The server \"$name\" is not defined.");
+        return new $server($this, $parameters);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -79,6 +79,18 @@ class Pool
     }
 
     /**
+     * Returns a previously saved server.
+     *
+     * @param  string  $name
+     * @param  array  $parameters
+     * @return \Illuminate\Http\Client\Server
+     */
+    public function server($name, $parameters = [])
+    {
+        return $this->pool[] = $this->factory->server($name, $parameters)->setHandler($this->handler)->async();
+    }
+
+    /**
      * Add a request to the pool with a numeric index.
      *
      * @param  string  $method

--- a/src/Illuminate/Http/Client/Server.php
+++ b/src/Illuminate/Http/Client/Server.php
@@ -12,9 +12,9 @@ abstract class Server
     use ForwardsCalls;
 
     /**
-     * The quick actions for this server.
+     * The actions for this server.
      *
-     * @var array{string,string}
+     * @var array{string:string}
      */
     protected $actions = [];
 

--- a/src/Illuminate/Http/Client/Server.php
+++ b/src/Illuminate/Http/Client/Server.php
@@ -99,6 +99,17 @@ abstract class Server
     }
 
     /**
+     * Redirects the wait procedure to the underlying request promise.
+     *
+     * @param  bool  $unwrap
+     * @return mixed
+     */
+    public function wait($unwrap = true)
+    {
+        return $this->getPromise()->wait($unwrap);
+    }
+
+    /**
      * Dynamically handle calls to the underlying request.
      *
      * @param  string  $method

--- a/src/Illuminate/Http/Client/Server.php
+++ b/src/Illuminate/Http/Client/Server.php
@@ -86,7 +86,7 @@ abstract class Server
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */
-    protected function request()
+    protected function buildRequest()
     {
         return $this->request ??= tap(
             $this->factory
@@ -125,9 +125,24 @@ abstract class Server
                 ? explode(':', $this->actions[$method], 2)
                 : ['get', $this->actions[$method]];
 
-            return $this->request()->{$verb}($path, ...$parameters);
+            return $this->buildRequest()->{$verb}($path, ...$parameters);
         }
 
-        return $this->forwardDecoratedCallTo($this->request(), $method, $parameters);
+        return $this->forwardDecoratedCallTo($this->buildRequest(), $method, $parameters);
+    }
+
+    /**
+     * Creates a new server instance.
+     *
+     * @param  array  $parameters
+     * @return static
+     */
+    public static function request($parameters = [])
+    {
+        $factory = class_exists('Illuminate\Container\Container')
+            ? \Illuminate\Container\Container::getInstance()->make(Factory::class)
+            : new Factory();
+
+        return $factory->server(static::class, $parameters);
     }
 }

--- a/src/Illuminate/Http/Client/Server.php
+++ b/src/Illuminate/Http/Client/Server.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
@@ -105,6 +104,7 @@ abstract class Server
      * @param  string  $method
      * @param  array  $parameters
      * @return $this|object
+     *
      * @throws \Exception
      */
     public function __call(string $method, array $parameters)

--- a/src/Illuminate/Http/Client/Server.php
+++ b/src/Illuminate/Http/Client/Server.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * @mixin \Illuminate\Http\Client\PendingRequest
+ */
+abstract class Server
+{
+    use ForwardsCalls;
+
+    /**
+     * The quick actions for this server.
+     *
+     * @var array{string,string}
+     */
+    protected $actions = [];
+
+    /**
+     * The base URL of this server.
+     *
+     * @var string
+     */
+    protected $baseUrl = '';
+
+    /**
+     * The headers to include in the server requests.
+     *
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
+     * The bearer token to use as authentication mechanism.
+     *
+     * @var string
+     */
+    protected $authToken;
+
+    /**
+     * The request to be sent, once built.
+     *
+     * @var \Illuminate\Http\Client\PendingRequest
+     */
+    protected $request;
+
+    /**
+     * Create a new Server instance.
+     *
+     * @param  \Illuminate\Http\Client\Factory  $factory
+     * @param  array  $urlParameters
+     */
+    public function __construct(protected $factory, protected $urlParameters = [])
+    {
+        //
+    }
+
+    /**
+     * Customize the request created for this server.
+     *
+     * @param  \Illuminate\Http\Client\PendingRequest  $request
+     * @return \Illuminate\Http\Client\PendingRequest|void
+     */
+    protected function build($request)
+    {
+        //
+    }
+
+    /**
+     * Sets the query parameters for the URI.
+     *
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function parameters(array $parameters)
+    {
+        $this->urlParameters = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * Builds a request based on the server configuration.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    protected function request()
+    {
+        return $this->request ??= tap(
+            $this->factory
+                ->baseUrl($this->baseUrl)
+                ->when($this->authToken)->withToken($this->authToken)
+                ->when($this->headers)->withHeaders($this->headers)
+                ->when($this->urlParameters)->withUrlParameters($this->urlParameters),
+            $this->build(...)
+        );
+    }
+
+    /**
+     * Dynamically handle calls to the underlying request.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return $this|object
+     * @throws \Exception
+     */
+    public function __call(string $method, array $parameters)
+    {
+        if (isset($this->actions[$method])) {
+            [$verb, $path] = str_contains($this->actions[$method], ':')
+                ? explode(':', $this->actions[$method], 2)
+                : ['get', $this->actions[$method]];
+
+            return $this->request()->{$verb}($path, ...$parameters);
+        }
+
+        return $this->forwardDecoratedCallTo($this->request(), $method, $parameters);
+    }
+}

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2336,6 +2336,24 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testItChainsMultipleCustomActions(): void
+    {
+        $this->factory->fake();
+
+        $this->factory->define(TestActionsApp::class);
+
+        $server = $this->factory->server('test actions app');
+
+        $server->noReply()->chirp('hello world');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'https://chirper.app/api/new'
+                && $request->method() === 'POST'
+                && $request->hasHeader('X-Reply', ['false'])
+                && $request->body() === '{"message":"hello world"}';
+        });
+    }
+
     public function testItExecutesBuilder(): void
     {
         $this->factory->fake();
@@ -2383,7 +2401,12 @@ class TestActionsApp extends Server
 
     public function chirp($message)
     {
-        return $this->request()->post('new', ['message' => $message]);
+        return $this->post('new', ['message' => $message]);
+    }
+
+    public function noReply()
+    {
+        return $this->withHeaders(['X-Reply' => 'false']);
     }
 }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2181,25 +2181,12 @@ class HttpClientTest extends TestCase
         });
     }
 
-    public function testItThrowsWhenServerDoesNotExist(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The server "fail" is not defined.');
-
-        $this->factory->define(TestApp::class);
-
-        $this->factory->server('fail');
-    }
 
     public function testItRetrievesDefinedServer(): void
     {
         $this->factory->fake();
 
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->server('test app');
-
-        $server->get('test');
+        $this->factory->server(TestApp::class)->get('test');
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'https://chirper.app/api/test';
@@ -2210,11 +2197,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->server('test app');
-
-        $server->get('test');
+        $this->factory->server(TestApp::class)->get('test');
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'https://chirper.app/api/test'
@@ -2228,11 +2211,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestComplexApp::class);
-
-        $server = $this->factory->server('test complex app');
-
-        $server->get('test');
+        $this->factory->server(TestComplexApp::class)->get('test');
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'https://chirper.app/api/test'
@@ -2242,28 +2221,11 @@ class HttpClientTest extends TestCase
         });
     }
 
-    public function testItRetrievesDefinedServerDynamically(): void
-    {
-        $this->factory->fake();
-
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->testApp();
-
-        $server->get('test');
-
-        $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'https://chirper.app/api/test';
-        });
-    }
-
     public function testItSetsParameters(): void
     {
         $this->factory->fake();
 
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->server('test app');
+        $server = $this->factory->server(TestApp::class);
 
         $server->parameters(['id' => 10])->view();
 
@@ -2276,9 +2238,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->server('test app', ['id' => 10]);
+        $server = $this->factory->server(TestApp::class, ['id' => 10]);
 
         $server->view();
 
@@ -2291,9 +2251,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->server('test app');
+        $server = $this->factory->server(TestApp::class);
 
         $server->latest();
 
@@ -2306,9 +2264,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestApp::class);
-
-        $server = $this->factory->server('test app');
+        $server = $this->factory->server(TestApp::class);
 
         $server->chirp(['message' => 'hello world']);
 
@@ -2323,9 +2279,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestActionsApp::class);
-
-        $server = $this->factory->server('test actions app');
+        $server = $this->factory->server(TestActionsApp::class);
 
         $server->chirp('hello world');
 
@@ -2340,9 +2294,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestActionsApp::class);
-
-        $server = $this->factory->server('test actions app');
+        $server = $this->factory->server(TestActionsApp::class);
 
         $server->noReply()->chirp('hello world');
 
@@ -2358,9 +2310,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->define(TestBuilderApp::class);
-
-        $server = $this->factory->server('test builder app');
+        $server = $this->factory->server(TestBuilderApp::class);
 
         $server->chirp(['message' => 'hello world']);
 
@@ -2380,19 +2330,22 @@ class HttpClientTest extends TestCase
             'https://chirper.app/api/500' => $this->factory::response('', 500),
         ]);
 
-        $this->factory->define(TestBuilderApp::class);
-
         $responses = $this->factory->pool(function (Pool $pool) {
             return [
-                $pool->server('test builder app')->get('200'),
-                $pool->server('test builder app')->get('400'),
-                $pool->server('test builder app')->get('500'),
+                $pool->server(TestBuilderApp::class)->get('200'),
+                $pool->server(TestBuilderApp::class)->get('400'),
+                $pool->server(TestBuilderApp::class)->get('500'),
             ];
         });
 
         $this->assertSame(200, $responses[0]->status());
         $this->assertSame(400, $responses[1]->status());
         $this->assertSame(500, $responses[2]->status());
+    }
+
+    public function testItCreatesServerFromClass(): void
+    {
+        $this->assertInstanceOf(TestApp::class, TestApp::request());
     }
 }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2181,7 +2181,6 @@ class HttpClientTest extends TestCase
         });
     }
 
-
     public function testItRetrievesDefinedServer(): void
     {
         $this->factory->fake();


### PR DESCRIPTION
# HTTP Servers

This PR is meant to help on two scenarios

1) Having more than one HTTP API servers. For example, posting something to multiple social networks at the same time.
2) Having multiple verbose URIs for a given server, scattered through the app.

Let's start with the first problem. 

> Note, this PR doesn't uses  the Container because it's not a dependency for `Illuminate/Http`. Bummer :(

* **Problem 1: Multiple Servers**

Instead of creating raw HTTP Clients around controllers, we can move that logic into a single class that extends the `Server` class.

```php
namespace App\Http\Servers;

use Illuminate\Http\Client\Server;

class Chirper extends Server
{
    protected $baseUrl = 'https://chirper.app/api';
    protected $authToken = 'my-chirper-secret';
}
```

We can use that server with the HTTP Factory with  `server()` and the class name. A new instance will be created by gathering the server attributes.

```php
// With the server syntax.
$latest = Chirper::request()->get('/timeline')

// Same as:
$latest = Http::withToken('my-chirper-secret')->get('https://chirper.app/api/timeline')
```

* **Problem 2: Too many URIs**

The second problem is having multiple URIs for different things. For example, if we have multiple actions over one resource, the URIs to define can become hectic and scattered across the application. 

We can simplify this by defining "actions" for a server on the class with an array of action names that contain the HTTP Verb and the route. If no verb is prepended, `get` is inferred.

```php
class Chirper extends Server
{
    protected $actions = [
        'latest' => 'timeline', // sane as "get:timeline"
        'chirp'  => 'post:new',
        'delete' => 'delete:chirp/{id}'
    ];
};

// Arguments are passed down magically to the request.
Chirper::request()->chirp(['message' => 'This is awesome!']);

// You can set the URL parameters when invoking the server too.
Chirper::request(['id' => 46578])->delete();
```

Of course, you can also create a method that makes the request to the server directly with optional arguments. With some `_call()` magic, we can build upon the same request and chain multiple actions.

```php
class Chirper extends Server
{
    public function noReply()
    {
        return $this->header(['X-Reply' => false]);
    }

    public function chirp($message)
    {
        return $this->post('/new', [
            'message' => $message,
        ]);
    }
};

Chirper::request()->chirp('This is awesome!');

Chirper::request()->noReply()->chirp('You can not reply to this');
```

## Overriding

All methods not present in the class are forwarded to the underlying `PendingRequest`. You can override anything as usual since the build step happens on server invoke, and the last step is the action.

```php
$newChirp = Chirper::request()->withToken('user-secret')->chirp("You're awesome");
```

## Async (Concurrent)

When doing concurrent requests to a single or different servers, the `server()`  method must be used on the pool request rather than outside.

```php
Http::pool(fn ($pool) => [
    $pool->server(Chirper::class)->latest(),
    $pool->server(Facebook::class)->get('latest'),
]);
```

## Macros

If the Factory contains Macros, these will take precedence over the dynamic server name. The purpose of using `server()` is to avoid these collisions.

## Testing

Since the Servers defined use the HTTP Factory behind the scenes, there is no need to refactor tests that already exists.