### PR TITLE
[9.x] Avoid mutating the `$expectedLitener` between loops on `Event::assertListening`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -85,24 +85,23 @@ class EventFake implements Dispatcher
             $actualListener = (new ReflectionFunction($listenerClosure))
                         ->getStaticVariables()['listener'];
 
-            // If both the actual and expected listeners are Class[@]method
-            // callback strings, we need to normalize them to the same format.
-            $expectedListenerNormalized = $expectedListener;
+            $normalizedListener = $expectedListener;
+
             if (is_string($actualListener) && Str::contains($actualListener, '@')) {
                 $actualListener = Str::parseCallback($actualListener);
 
                 if (is_string($expectedListener)) {
                     if (Str::contains($expectedListener, '@')) {
-                        $expectedListenerNormalized = Str::parseCallback($expectedListener);
+                        $normalizedListener = Str::parseCallback($expectedListener);
                     } else {
-                        $expectedListenerNormalized = [$expectedListener, 'handle'];
+                        $normalizedListener = [$expectedListener, 'handle'];
                     }
                 }
             }
 
-            if ($actualListener === $expectedListenerNormalized ||
+            if ($actualListener === $normalizedListener ||
                 ($actualListener instanceof Closure &&
-                $expectedListenerNormalized === Closure::class)) {
+                $normalizedListener === Closure::class)) {
                 PHPUnit::assertTrue(true);
 
                 return;

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -85,21 +85,24 @@ class EventFake implements Dispatcher
             $actualListener = (new ReflectionFunction($listenerClosure))
                         ->getStaticVariables()['listener'];
 
+            // If both the actual and expected listeners are Class[@]method
+            // callback strings, we need to normalize them to the same format.
+            $expectedListenerNormalized = $expectedListener;
             if (is_string($actualListener) && Str::contains($actualListener, '@')) {
                 $actualListener = Str::parseCallback($actualListener);
 
                 if (is_string($expectedListener)) {
                     if (Str::contains($expectedListener, '@')) {
-                        $expectedListener = Str::parseCallback($expectedListener);
+                        $expectedListenerNormalized = Str::parseCallback($expectedListener);
                     } else {
-                        $expectedListener = [$expectedListener, 'handle'];
+                        $expectedListenerNormalized = [$expectedListener, 'handle'];
                     }
                 }
             }
 
-            if ($actualListener === $expectedListener ||
+            if ($actualListener === $expectedListenerNormalized ||
                 ($actualListener instanceof Closure &&
-                $expectedListener === Closure::class)) {
+                $expectedListenerNormalized === Closure::class)) {
                 PHPUnit::assertTrue(true);
 
                 return;

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Events;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase;
@@ -140,11 +141,20 @@ class EventFakeTest extends TestCase
     public function testAssertListening()
     {
         Event::fake();
-        Event::listen('event', 'listener');
-        Event::listen('event', PostEventSubscriber::class);
-        Event::listen('event', 'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle');
-        Event::listen('event', [PostEventSubscriber::class, 'foo']);
+
+        $listenersOfSameEventInRandomOrder = Arr::shuffle([
+            'listener',
+            'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle',
+            PostEventSubscriber::class,
+            [PostEventSubscriber::class, 'foo'],
+        ]);
+
+        foreach ($listenersOfSameEventInRandomOrder as $listener) {
+            Event::listen('event', $listener);
+        }
+
         Event::subscribe(PostEventSubscriber::class);
+
         Event::listen(function (NonImportantEvent $event) {
             // do something
         });


### PR DESCRIPTION
After upgrading from Laravel `8.x `to `9.x`, some of the assertions for the `assertListening` failed randomly. 

I observed that when iteration over the listeners for a given event, if a `Class[@]method` callback (`PostAutoEventSubscriber::class . '@handle'`) string is evaluated before any class-based listener (`PostAutoEventSubscriber::class`), it causes the assertion to fail wrongfully.

This happens because after the callback string is evaluated, the `$expectedListener` is normalized for the comparison. It causes the subsequent iteration to compare the `$actualListener` with the changed `$expectedListener` from the previous one.

You can attest that by changing the order in which the listeners are bound in the `tests/Integration/Events/EventFakeTest.php` from:

```php
Event::listen('event', PostEventSubscriber::class);
Event::listen('event', 'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle');
```

To: 
```php
Event::listen('event', 'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle');
Event::listen('event', PostEventSubscriber::class);
```

To solve the issue, we're just "caching" the normalized form of the expected listeners to avoid mutability between the iteration loops.
