### PR TITLE
[10.x] Requires Composer `^2.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-openssl": "*",
         "ext-session": "*",
         "ext-tokenizer": "*",
-        "composer-runtime-api": "^2.0",
+        "composer-runtime-api": "^2.2",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.3.2",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "ext-openssl": "*",
         "ext-session": "*",
         "ext-tokenizer": "*",
+        "composer-runtime-api": "^2.0",
         "brick/math": "^0.9.3|^0.10.2|^0.11",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.3.2",


### PR DESCRIPTION
Composer 1 has been [officially deprecated](https://blog.packagist.com/deprecating-composer-1-support/) for several months and is no longer compatible with PHP 8.2. In order to provide a solid foundation for Laravel 10 projects, this pull request proposes (at least) the usage of Composer 2.2, which has Long-Term Support, in new Laravel 10 projects. This version ensures that critical bugs and security concerns will be addressed until at least the end of 2023.

Note that the `"composer-runtime-api": "^2.2"` is a virtual package which is provided by Composer and will make sure people have to use Composer `^2.2` to use Laravel 10.

Once this pull request is accepted, I will update the upgrade guide to include instructions on upgrading to Composer `^2.2`.

Upgrade guide pull request: https://github.com/laravel/docs/pull/8564.