### PR TITLE
[10.x] Default spaces=false when generating passwords

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -731,7 +731,7 @@ class Str
      * @param  bool  $spaces
      * @return string
      */
-    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = true)
+    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {
         $characters = [];
 


### PR DESCRIPTION
I'd recommend defaulting to `$spaces = false` when generating passwords to avoid the situation where the password begins/ends with a space. 
Having a space at the start or end could be easily missed when a user copies the generated password from the page.

Having a `.` at the end can be confusing in some situations too, but that's less of an issue than space character and can be solved through formatting the password display.