### PR TITLE
[10.x] Updated Eloquent\Collection callable docblocks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -52,7 +52,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function load($relations)
@@ -73,7 +73,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of aggregations over relationship's column onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @param  string|null  $function
      * @return $this
@@ -110,7 +110,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship counts onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function loadCount($relations)
@@ -121,7 +121,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's max column values onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -133,7 +133,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's min column values onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -145,7 +145,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's column summations onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -157,7 +157,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's average column values onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -169,7 +169,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of related existences onto the collection.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function loadExists($relations)
@@ -180,7 +180,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection if they are not already eager loaded.
      *
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function loadMissing($relations)
@@ -254,7 +254,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of relationships onto the mixed relationship collection.
      *
      * @param  string  $relation
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string> $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string> $relations
      * @return $this
      */
     public function loadMorph($relation, $relations)
@@ -275,7 +275,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of relationship counts onto the mixed relationship collection.
      *
      * @param  string  $relation
-     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string> $relations
+     * @param  array<array-key, (callable(\Illuminate\Contracts\Database\Eloquent\Builder): mixed)|string> $relations
      * @return $this
      */
     public function loadMorphCount($relation, $relations)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

So while using `->load()` I got a PHPStan (Larastan) error. For example with something like this:

```php
<?php

use Illuminate\Database\Eloquent\Relations\HasMany;

$eloquentCollection->load([
    'relationOne' => static function (HasMany $q): void {
        $q->where('foobar', 1);
        $q->with(['relationTwo' => static function (HasMany $q2): void {
            $q2->limit(100);
        }]);
    },
    'anotherRelation',
]);
```

I get:

> Parameter #1 $relations of method Illuminate\Database\Eloquent\Collection<(int|string),App\Models\Eloquent\SomeEloquentModel>::load() expects array<(callable(Illuminate\Database\Eloquent\Builder): mixed)|string>|string, array{relationOne: Closure(Illuminate\Database\Query\Builder): void, 0: 'anotherRelation'} given.

This is because `HasMany` does not extend `Illuminate\Database\Eloquent\Builder`, but it does implement the contract `Illuminate\Contracts\Database\Eloquent\Builder`.

I replaced all Builder implementation with the contract within `Eloquent\Collection`, but I am not sure if this is correct. 