### PR TITLE
[10.x] Update password generator to use `range()` and avoid `array_merge()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -736,31 +736,34 @@ class Str
         $characters = [];
 
         if ($letters) {
-            $characters = array_merge($characters, [
-                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-                'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-                'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
-                'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-            ]);
+            $characters = [
+                ...$characters,
+                ...range('a', 'z'),
+                ...range('A', 'Z'),
+            ];
         }
 
         if ($numbers) {
-            $characters = array_merge($characters, [
+            $characters = [
+                ...$characters,
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            ]);
+            ];
         }
 
         if ($symbols) {
-            $characters = array_merge($characters, [
+            $characters = [
+                ...$characters,
                 '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
                 '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
                 ']', '|', ':', ';',
-            ]);
+            ];
         }
 
         if ($spaces) {
-            $characters = array_merge($characters, [' ']);
+            $characters = [
+                ...$characters,
+                ' ',
+            ];
         }
 
         $password = '';


### PR DESCRIPTION
- rather than listing out all the alphabet characters, we can use `range()` to make this more succinct
- by using array unpacking, we can avoid the overhead of the `array_merge()` function call

https://wiki.php.net/rfc/spread_operator_for_array#advantages_over_array_merge