### PR TITLE
[10.x] use array unpacking for Collection merging

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -840,7 +840,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function merge($items)
     {
-        return new static(array_merge($this->items, $this->getArrayableItems($items)));
+        return new static([
+            ...$this->items,
+            ...$this->getArrayableItems($items),
+        ]);
     }
 
     /**


### PR DESCRIPTION
array unpacking should have better performance from avoiding the overhead of a method call, and apparently there are some runtime optimizations as well.

https://wiki.php.net/rfc/spread_operator_for_array https://www.php.net/releases/8.1/en.php#array_unpacking_support_for_string_keyed_arrays https://www.php.net/manual/en/migration56.new-features.php https://php.watch/versions/8.1/spread-operator-string-array-keys
