### PR TITLE
[9.x] Adds support for flattening associative arrays

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -252,6 +252,26 @@ class Arr
 
         return $result;
     }
+    
+    /**
+     * Flatten a multi-dimensional associative array into a single level.
+     *
+     * @param  array  $array
+     * @param  int  $depth
+     * @return array
+     */
+    public static function flattenAssoc($array, $depth = INF)
+    {
+        return array_reduce(array_keys($array), function ($result, $key) use ($array, $depth) {
+            $value = $array[$key] instanceof Collection ? $array[$key]->all() : $array[$key];
+            if (is_array($value) && $depth > 0) {
+                $result = array_merge($result, static::flattenAssoc($value, $depth - 1));
+            } else {
+                $result[$key] = $value;
+            }
+            return $result;
+        }, []);
+    }
 
     /**
      * Remove one or many array items from a given array using "dot" notation.


### PR DESCRIPTION
Added a new helper method called `Arr::flattenAssoc()`, similar to existing `Arr::flatten()`, but works for multi-level associative arrays. 
Receives the array to flatten and an optional depth (defaults is infinity).
Uses PHP's built-in `array_reduce()` and returns a single-level associative  array.

Can transforms this:
```
['a' => 1, 'b' => 2, 'c' => [
    'd' => 3, 'e' => 4, 'f' => [
        'g' => 5, 'h' => 6
        ], 'i' => 7
    ], 'j' => 8
];
```
into this:
```
[
  "a" => 1
  "b" => 2
  "d" => 3
  "e" => 4
  "g" => 5
  "h" => 6
  "i" => 7
  "j" => 8
]
```
Works great on results of an eloquent query (after ...get()-> toArray()):
```
[
  "name" => "Caroline Casanova"
  "email" => "livia.mendonca@example.net"
  "primary_address" => [
    "postal_code" => "07550-778"
    "address" => "Avenida Inácio"
    "number" => "156"
    "complement" => "Apto 5895"
    "province" => "do Norte"
    "state" => "Maranhão"
    "country" => "Palaos"
    "primary_address" => 1
  ]
]
```
```
[
  "name" => "Caroline Casanova"
  "email" => "livia.mendonca@example.net"
  "postal_code" => "07550-778"
  "address" => "Avenida Inácio"
  "number" => "156"
  "complement" => "Apto 5895"
  "province" => "do Norte"
  "state" => "Maranhão"
  "country" => "Palaos"
  "primary_address" => 1
]
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
