### PR TITLE
[9.x] Use secure randomness in Arr:random and Arr:shuffle

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -646,7 +646,7 @@ class Arr
         $count = count($keys);
         $selected = [];
 
-        for ($i = $count - 1; $i >= $count - $number; --$i) {
+        for ($i = $count - 1; $i >= $count - $number; $i--) {
             $j = random_int(0, $i);
 
             if ($preserveKeys) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -635,28 +635,15 @@ class Arr
         }
 
         if (is_null($number)) {
-            return $array[array_rand($array)];
+            $values = array_values($array);
+            return $values[random_int(0, $count - 1)];
         }
 
         if ((int) $number === 0) {
             return [];
         }
 
-        $keys = array_rand($array, $number);
-
-        $results = [];
-
-        if ($preserveKeys) {
-            foreach ((array) $keys as $key) {
-                $results[$key] = $array[$key];
-            }
-        } else {
-            foreach ((array) $keys as $key) {
-                $results[] = $array[$key];
-            }
-        }
-
-        return $results;
+        return array_slice(static::shuffle($array), 0, $number, $preserveKeys);
     }
 
     /**
@@ -708,15 +695,30 @@ class Arr
      */
     public static function shuffle($array, $seed = null)
     {
-        if (is_null($seed)) {
-            shuffle($array);
-        } else {
+        if (! is_null($seed)) {
             mt_srand($seed);
             shuffle($array);
             mt_srand();
+
+            return $array;
         }
 
-        return $array;
+        $keys = array_keys($array);
+
+        for ($i = count($keys) - 1; $i > 0; $i--) {
+            $j = random_int(0, $i);
+            $temp = $keys[$i];
+            $keys[$i] = $keys[$j];
+            $keys[$j] = $temp;
+        }
+
+        $shuffled = [];
+
+        foreach ($keys as $key) {
+            $shuffled[$key] = $array[$key];
+        }
+
+        return $shuffled;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -718,16 +718,18 @@ class Arr
             return $array;
         }
 
-        $array = array_keys($array);
+        $keys = array_keys($array);
 
-        for ($i = count($array) - 1; $i > 0; $i--) {
+
+        for ($i = count($keys) - 1; $i > 0; $i--) {
             $j = random_int(0, $i);
-            $swap = $array[$i];
-            $array[$i] = $array[$j];
-            $array[$j] = $swap;
+            $shuffled[] = $array[$keys[$j]];
+            $keys[$j] = $keys[$i];
         }
 
-        return $array;
+        $shuffled[] = $array[$keys[0]];
+
+        return $shuffled;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -720,7 +720,6 @@ class Arr
 
         $keys = array_keys($array);
 
-
         for ($i = count($keys) - 1; $i > 0; $i--) {
             $j = random_int(0, $i);
             $shuffled[] = $array[$keys[$j]];

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -642,7 +642,23 @@ class Arr
             return [];
         }
 
-        return array_slice(static::shuffle($array), 0, $number, $preserveKeys);
+        $keys = array_keys($array);
+        $count = count($keys);
+        $selected = [];
+
+        for ($i = 0; $i < $number; $i++) {
+            $j = random_int($i, $count - $i - 1);
+
+            if ($preserveKeys) {
+                $selected[$keys[$j]] = $array[$keys[$j]];
+            } else {
+                $selected[] = $array[$keys[$j]];
+            }
+
+            $keys[$j] = $keys[$i];
+        }
+
+        return $selected;
     }
 
     /**
@@ -702,16 +718,16 @@ class Arr
             return $array;
         }
 
-        $keys = array_keys($array);
-        $shuffled = [];
+        $array = array_keys($array);
 
-        for ($i = count($keys) - 1; $i >= 0; $i--) {
+        for ($i = count($array) - 1; $i > 0; $i--) {
             $j = random_int(0, $i);
-            $shuffled[$keys[$j]] = $array[$keys[$j]];
-            $keys[$j] = $keys[$i];
+            $swap = $array[$i];
+            $array[$i] = $array[$j];
+            $array[$j] = $swap;
         }
 
-        return $shuffled;
+        return $array;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -635,8 +635,7 @@ class Arr
         }
 
         if (is_null($number)) {
-            $values = array_values($array);
-            return $values[random_int(0, $count - 1)];
+            return head(array_slice($array, random_int(0, $count - 1), 1));
         }
 
         if ((int) $number === 0) {
@@ -704,18 +703,12 @@ class Arr
         }
 
         $keys = array_keys($array);
-
-        for ($i = count($keys) - 1; $i > 0; $i--) {
-            $j = random_int(0, $i);
-            $temp = $keys[$i];
-            $keys[$i] = $keys[$j];
-            $keys[$j] = $temp;
-        }
-
         $shuffled = [];
 
-        foreach ($keys as $key) {
-            $shuffled[$key] = $array[$key];
+        for ($i = count($keys) - 1; $i >= 0; $i--) {
+            $j = random_int(0, $i);
+            $shuffled[$keys[$j]] = $array[$keys[$j]];
+            $keys[$j] = $keys[$i];
         }
 
         return $shuffled;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -646,8 +646,8 @@ class Arr
         $count = count($keys);
         $selected = [];
 
-        for ($i = 0; $i < $number; $i++) {
-            $j = random_int($i, $count - $i - 1);
+        for ($i = $count - 1; $i >= $count - $number; --$i) {
+            $j = random_int(0, $i);
 
             if ($preserveKeys) {
                 $selected[$keys[$j]] = $array[$keys[$j]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -750,7 +750,7 @@ class SupportArrTest extends TestCase
         $this->assertContains($random, ['foo', 'bar', 'baz']);
     }
 
-        public function testRandomOnEmptyArray()
+    public function testRandomOnEmptyArray()
     {
         $random = Arr::random([], 0);
         $this->assertIsArray($random);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -838,10 +838,37 @@ class SupportArrTest extends TestCase
 
     public function testShuffle()
     {
+        $this->assertEquals(
+            Arr::shuffle(range(0, 10)),
+            Arr::shuffle(range(0, 10)),
+            'Shuffled array should have the same elements.'
+        );
+
         $this->assertNotSame(
             Arr::shuffle(range(0, 10)),
-            Arr::shuffle(range(0, 10))
+            Arr::shuffle(range(0, 10)),
+            'Shuffled array should not have the same order.'
         );
+    }
+
+    public function testShuffleWithKeys()
+    {
+        $array = ['one' => 'foo', 'two' => 'bar', 'three' => 'baz', 'four' => 'boom'];
+
+        $sameElements = true;
+        $dontMatch = false;
+
+        // Attempt 5x times to prevent random failures
+        for ($i = 0; $i < 5; $i++) {
+            $one = Arr::shuffle($array);
+            $two = Arr::shuffle($array);
+
+            $sameElements = $sameElements && $one == $two;
+            $dontMatch = $dontMatch || $one !== $two;
+        }
+
+        $this->assertTrue($sameElements, 'Shuffled array should always have the same elements.');
+        $this->assertTrue($dontMatch, 'Shuffled array should not have the same order.');
     }
 
     public function testSort()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -830,26 +830,30 @@ class SupportArrTest extends TestCase
 
     public function testShuffleWithSeed()
     {
-        $this->assertEquals(
+        $this->assertSame(
             Arr::shuffle(range(0, 100, 10), 1234),
+            Arr::shuffle(range(0, 100, 10), 1234)
+        );
+
+        $this->assertNotSame(
+            range(0, 100, 10),
             Arr::shuffle(range(0, 100, 10), 1234)
         );
     }
 
     public function testShuffle()
     {
-        $array = range(1, 10);
+        $source = range('a', 'z'); // alphabetic keys to ensure values are returned
 
         $sameElements = true;
         $dontMatch = false;
 
         // Attempt 5x times to prevent random failures
         for ($i = 0; $i < 5; $i++) {
-            $one = Arr::shuffle($array);
-            $two = Arr::shuffle($array);
+            $shuffled = Arr::shuffle($source);
 
-            $dontMatch = $dontMatch || $one !== $two;
-            $sameElements = $sameElements && array_values(Arr::sort($one)) === array_values(Arr::sort($two));
+            $dontMatch = $dontMatch || $source !== $shuffled;
+            $sameElements = $sameElements && $source === array_values(Arr::sort($shuffled));
         }
 
         $this->assertTrue($sameElements, 'Shuffled array should always have the same elements.');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -731,7 +731,26 @@ class SupportArrTest extends TestCase
         $this->assertCount(2, array_intersect_assoc(['one' => 'foo', 'two' => 'bar', 'three' => 'baz'], $random));
     }
 
-    public function testRandomOnEmptyArray()
+    public function testRandomIsActuallyRandom()
+    {
+        $values = [];
+
+        for ($i = 0; $i < 100; $i++) {
+            $values[] = Arr::random(['foo', 'bar', 'baz']);
+        }
+
+        $this->assertContains('foo', $values);
+        $this->assertContains('bar', $values);
+        $this->assertContains('baz', $values);
+    }
+
+    public function testRandomNotIncrementingKeys()
+    {
+        $random = Arr::random(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz']);
+        $this->assertContains($random, ['foo', 'bar', 'baz']);
+    }
+
+        public function testRandomOnEmptyArray()
     {
         $random = Arr::random([], 0);
         $this->assertIsArray($random);
@@ -814,6 +833,14 @@ class SupportArrTest extends TestCase
         $this->assertEquals(
             Arr::shuffle(range(0, 100, 10), 1234),
             Arr::shuffle(range(0, 100, 10), 1234)
+        );
+    }
+
+    public function testShuffle()
+    {
+        $this->assertNotSame(
+            Arr::shuffle(range(0, 10)),
+            Arr::shuffle(range(0, 10))
         );
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -838,22 +838,7 @@ class SupportArrTest extends TestCase
 
     public function testShuffle()
     {
-        $this->assertEquals(
-            Arr::shuffle(range(0, 10)),
-            Arr::shuffle(range(0, 10)),
-            'Shuffled array should have the same elements.'
-        );
-
-        $this->assertNotSame(
-            Arr::shuffle(range(0, 10)),
-            Arr::shuffle(range(0, 10)),
-            'Shuffled array should not have the same order.'
-        );
-    }
-
-    public function testShuffleWithKeys()
-    {
-        $array = ['one' => 'foo', 'two' => 'bar', 'three' => 'baz', 'four' => 'boom'];
+        $array = range(1, 10);
 
         $sameElements = true;
         $dontMatch = false;
@@ -863,8 +848,8 @@ class SupportArrTest extends TestCase
             $one = Arr::shuffle($array);
             $two = Arr::shuffle($array);
 
-            $sameElements = $sameElements && $one == $two;
             $dontMatch = $dontMatch || $one !== $two;
+            $sameElements = $sameElements && array_values(Arr::sort($one)) === array_values(Arr::sort($two));
         }
 
         $this->assertTrue($sameElements, 'Shuffled array should always have the same elements.');


### PR DESCRIPTION
The `Arr::random()` and `Arr:shuffle()` methods relied upon PHP's `array_rand()` and `shuffle()` methods, neither of which were are cryptographically secure algorithms. As such, they were were not safe to use for any secure purposes, yet because they are core Laravel functions, they were being used as such.

To make things simpler for everyone, this changes those methods to use secure implementations. Allowing them to be safely used for secure purposes. I've PR'ed this on 9.x as it's technically a security fix, and I believe that's the oldest supported version?

- Single value randomness uses `random_int()` and `array_slice()` to pull out a random value securely. 
- Multi-value randomness uses the new `shuffle()` method to shuffle the array and then slice off the requested number of items.
- Shuffle uses a slightly modified version of the [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle), to securely shuffle the values. I modified the algorithm to support PHP's magical array keys, since the pure algorithm expects numerical keys only.

I'm pretty confident this can now be considered a secure implementation, but please pick holes in it and check my implementations. It's better to be paranoid than make assumptions.

_Note, I've left the seeded shuffle with the insecure methods for backwards compatibility. I haven't looked into securely seeding shuffles. It's probably something that could be done with the new https://www.php.net/manual/en/class.random-randomizer.php in PHP 8.2._