### PR TITLE
[9.x] Check for empty array in request body

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -724,7 +724,7 @@ class PendingRequest
      */
     public function post(string $url, $data = [])
     {
-        return $this->send('POST', $url, [
+        return $this->send('POST', $url, empty($data) ? [] : [
             $this->bodyFormat => $data,
         ]);
     }
@@ -738,7 +738,7 @@ class PendingRequest
      */
     public function patch(string $url, $data = [])
     {
-        return $this->send('PATCH', $url, [
+        return $this->send('PATCH', $url, empty($data) ? [] : [
             $this->bodyFormat => $data,
         ]);
     }
@@ -752,7 +752,7 @@ class PendingRequest
      */
     public function put(string $url, $data = [])
     {
-        return $this->send('PUT', $url, [
+        return $this->send('PUT', $url, empty($data) ? [] : [
             $this->bodyFormat => $data,
         ]);
     }


### PR DESCRIPTION
In _Http/Client/PendingRequest_ the helpers of `post`, `patch` and `put` don't check for empty array as request body and this PR will implement same solution that is used on `delete` method.

Related issue: https://github.com/laravel/framework/issues/46085