### PR TITLE
[10.x] Standard Input can be applied to PendingProcess

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -77,6 +77,8 @@ class PendingProcess
 
 
     /**
+     * The standard input data piped into the command
+     *
      * @var string|int|float|bool|resource|\Traversable|null
      */
     public $input;

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -75,14 +75,12 @@ class PendingProcess
      */
     public $options = [];
 
-
     /**
      * The standard input data piped into the command
      *
      * @var string|int|float|bool|resource|\Traversable|null
      */
     public $input;
-
 
     /**
      * The registered fake handler callbacks.

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -218,7 +218,7 @@ class PendingProcess
     /**
      * Set the standard input that should be used when invoking the process.
      *
-     * @param string|int|float|bool|resource|\Traversable|null $input
+     * @param  string|int|float|bool|resource|\Traversable|null $input
      * @return PendingProcess
      */
     public function input($input)

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -55,6 +55,13 @@ class PendingProcess
     public $environment = [];
 
     /**
+     * The standard input data that should be piped into the command.
+     *
+     * @var string|int|float|bool|resource|\Traversable|null
+     */
+    public $input;
+
+    /**
      * Indicates whether output should be disabled for the process.
      *
      * @var bool
@@ -74,13 +81,6 @@ class PendingProcess
      * @var array
      */
     public $options = [];
-
-    /**
-     * The standard input data piped into the command.
-     *
-     * @var string|int|float|bool|resource|\Traversable|null
-     */
-    public $input;
 
     /**
      * The registered fake handler callbacks.
@@ -178,6 +178,19 @@ class PendingProcess
     }
 
     /**
+     * Set the standard input that should be provided when invoking the process.
+     *
+     * @param  \Traversable|resource|string|int|float|bool|null  $input
+     * @return $this
+     */
+    public function input($input)
+    {
+        $this->input = $input;
+
+        return $this;
+    }
+
+    /**
      * Disable output for the process.
      *
      * @return $this
@@ -211,19 +224,6 @@ class PendingProcess
     public function options(array $options)
     {
         $this->options = $options;
-
-        return $this;
-    }
-
-    /**
-     * Set the standard input that should be used when invoking the process.
-     *
-     * @param  string|int|float|bool|resource|\Traversable|null  $input
-     * @return PendingProcess
-     */
-    public function input($input)
-    {
-        $this->input = $input;
 
         return $this;
     }
@@ -301,6 +301,10 @@ class PendingProcess
             $process->setIdleTimeout($this->idleTimeout);
         }
 
+        if ($this->input) {
+            $process->setInput($this->input);
+        }
+
         if ($this->quietly) {
             $process->disableOutput();
         }
@@ -313,7 +317,7 @@ class PendingProcess
             $process->setOptions($this->options);
         }
 
-        return $process->setInput($this->input);
+        return $process;
     }
 
     /**

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -75,6 +75,13 @@ class PendingProcess
      */
     public $options = [];
 
+
+    /**
+     * @var string|int|float|bool|resource|\Traversable|null
+     */
+    public $input;
+
+
     /**
      * The registered fake handler callbacks.
      *
@@ -209,6 +216,19 @@ class PendingProcess
     }
 
     /**
+     * Set the standard input that should be used when invoking the process.
+     *
+     * @param string|int|float|bool|resource|\Traversable|null $input
+     * @return PendingProcess
+     */
+    public function input($input)
+    {
+        $this->input = $input;
+
+        return $this;
+    }
+
+    /**
      * Run the process.
      *
      * @param  array<array-key, string>|string|null  $command
@@ -293,7 +313,7 @@ class PendingProcess
             $process->setOptions($this->options);
         }
 
-        return $process;
+        return $process->setInput($this->input);
     }
 
     /**

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -76,7 +76,7 @@ class PendingProcess
     public $options = [];
 
     /**
-     * The standard input data piped into the command
+     * The standard input data piped into the command.
      *
      * @var string|int|float|bool|resource|\Traversable|null
      */
@@ -218,7 +218,7 @@ class PendingProcess
     /**
      * Set the standard input that should be used when invoking the process.
      *
-     * @param  string|int|float|bool|resource|\Traversable|null $input
+     * @param  string|int|float|bool|resource|\Traversable|null  $input
      * @return PendingProcess
      */
     public function input($input)

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -15,6 +15,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\PendingProcess quietly()
  * @method static \Illuminate\Process\PendingProcess tty(bool $tty = true)
  * @method static \Illuminate\Process\PendingProcess options(array $options)
+ * @method static \Illuminate\Process\PendingProcess input(string|int|float|bool|resource|\Traversable|null $input)
  * @method static \Illuminate\Contracts\Process\ProcessResult run(array|string|null $command = null, callable|null $output = null)
  * @method static \Illuminate\Process\InvokedProcess start(array|string|null $command = null, callable $output = null)
  * @method static \Illuminate\Process\PendingProcess withFakeHandlers(array $fakeHandlers)

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -15,7 +15,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\PendingProcess quietly()
  * @method static \Illuminate\Process\PendingProcess tty(bool $tty = true)
  * @method static \Illuminate\Process\PendingProcess options(array $options)
- * @method static \Illuminate\Process\PendingProcess input(string|int|float|bool|resource|\Traversable|null $input)
+ * @method static \Illuminate\Process\PendingProcess input(\Traversable|resource|string|int|float|bool|null $input)
  * @method static \Illuminate\Contracts\Process\ProcessResult run(array|string|null $command = null, callable|null $output = null)
  * @method static \Illuminate\Process\InvokedProcess start(array|string|null $command = null, callable $output = null)
  * @method static \Illuminate\Process\PendingProcess withFakeHandlers(array $fakeHandlers)

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
-use Illuminate\Process\PendingProcess;
 use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -477,8 +477,8 @@ class ProcessTest extends TestCase
             $this->markTestSkipped('Requires Linux.');
         }
 
-        $pendingProcess = new PendingProcess(new Factory());
-        $result = $pendingProcess->input('foobar')->run('cat');
+        $factory = new Factory();
+        $result = $factory->input('foobar')->run('cat');
 
         $this->assertSame('foobar', $result->output());
     }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Process\Factory;
+use Illuminate\Process\PendingProcess;
 use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
@@ -468,6 +469,18 @@ class ProcessTest extends TestCase
         $result->throwIf(false);
 
         $this->assertTrue(true);
+    }
+
+    public function testRealProcessesCanUseStandardInput()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $pendingProcess = new PendingProcess(new Factory());
+        $result = $pendingProcess->input('foobar')->run('cat');
+
+        $this->assertSame('foobar', $result->output());
     }
 
     public function testFakeInvokedProcessOutputWithLatestOutput()


### PR DESCRIPTION
Currently, the PendingProcess class doesn't allow for standard input to be passed to the Symfony command created by the Process wrapper.

This change would allow for

```php
Process::input('hello world')->run('pbcopy');
```

This would result in the text `hello world` would be made into a standard input for the `pbcopy` command.

[Documentation for Symfony](https://symfony.com/blog/new-in-symfony-3-1-input-and-output-stream-for-processes#input-streaming)