### PR TITLE
[10.x] Show queue connection in MonitorCommand

### DIFF
--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -43,13 +43,6 @@ class MonitorCommand extends Command
     protected $events;
 
     /**
-     * The table headers for the command.
-     *
-     * @var string[]
-     */
-    protected $headers = ['Connection', 'Queue', 'Size', 'Status'];
-
-    /**
      * Create a new queue monitor command.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $manager

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -116,9 +116,10 @@ class MonitorCommand extends Command
         $this->components->twoColumnDetail('<fg=gray>Queue name</>', '<fg=gray>Size / Status</>');
 
         $queues->each(function ($queue) {
+            $name = '['.$queue['connection'].'] '.$queue['queue'];
             $status = '['.$queue['size'].'] '.$queue['status'];
 
-            $this->components->twoColumnDetail($queue['queue'], $status);
+            $this->components->twoColumnDetail($name, $status);
         });
 
         $this->newLine();


### PR DESCRIPTION
Currently, the MonitorCommand command does not display the queue connection in question, only its name and size.

This change will allow the user who uses more than one connection to display multiple connections in the same command.

Ex: php artisan queue:monitor redis:events,database:events

Outuput: the command will display both queues and their connections in the listing.