### PR TITLE
[10.x] Fix type hinting for new validation rule interface

### DIFF
--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -61,7 +61,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     /**
      * Create a new implicit or explicit Invokable validation rule.
      *
-     * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
+     * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule  $invokable
      * @return \Illuminate\Contracts\Validation\Rule
      */
     public static function make($invokable)


### PR DESCRIPTION
The constructor allows the new `ValidationRule` class as `$invokable` parameter.

```php
/**
 * Create a new explicit Invokable validation rule.
 *
 * @return void
 */
protected function __construct(ValidationRule|InvokableRule $invokable)
{
    $this->invokable = $invokable;
}
```
See: https://github.com/laravel/framework/blob/10.x/src/Illuminate/Validation/InvokableValidationRule.php#L50-L59

But the `make` function to build this class does not allow it.
```php
/**
 * Create a new implicit or explicit Invokable validation rule.
 *
 * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
 */
public static function make($invokable)
{
    // ...

    return new InvokableValidationRule($invokable);
}
```
See: https://github.com/laravel/framework/blob/10.x/src/Illuminate/Validation/InvokableValidationRule.php#L61-L77

This PR fixes this.