### PR TITLE
add AddQueuedCookiesToResponse to middlewarePriority so it is handled in the right place

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -102,6 +102,7 @@ class Kernel implements KernelContract
     protected $middlewarePriority = [
         \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         \Illuminate\Cookie\Middleware\EncryptCookies::class,
+        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -31,6 +31,7 @@ class KernelTest extends TestCase
         $this->assertEquals([
             \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
             \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,


### PR DESCRIPTION
Hi there, I was trying to set `session storage` to `cookie`, but the cookies with session data were not set at all. After a bit of search, this came up: https://github.com/laravel/framework/issues/43693 and that is a perfect match, the queued cookies (https://github.com/laravel/framework/blob/10.x/src/Illuminate/Session/CookieSessionHandler.php#L101) never got sent back to the browser, because the middleware was handled in the wrong "place"

adding the middleware to the list so it is always in correct order seems to resolve this issue (and fixes #43693)
targets both 9.x and 10.x versions
