### PR TITLE
[10.x] Support int backed enums in QueryBuilder::whereIntegerInRaw

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
+use ReflectionEnum;
 use RuntimeException;
 
 class Builder implements BuilderContract
@@ -1152,7 +1153,11 @@ class Builder implements BuilderContract
         $values = Arr::flatten($values);
 
         foreach ($values as &$value) {
-            $value = (int) $value;
+            if ($value instanceof BackedEnum && (string) (new ReflectionEnum($value))->getBackingType() === 'int') {
+                $value = $value->value;
+            } else {
+                $value = (int) $value;
+            }
         }
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1035,6 +1035,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntegerInRaw('id', IntegerStatus::cases());
+        $this->assertSame('select * from "users" where "id" in (0, 1, 2)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', [
             ['id' => '1a'],
             ['id' => 2],


### PR DESCRIPTION
When using backed enum cases in `\Illuminate\Database\Query\Builder::whereIntegerInRaw`, we get the error:
```
ErrorException : Object of class App\Enums\EnumClass could not be converted to int
```

This PR fixes this by identifying when is an int backed enum and uses its raw value. When is a string backed enum, or even is not a backed enum, the behavior remains the same.