### PR TITLE
[10.x] Register policies automatically to the gate

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
@@ -22,9 +22,29 @@ class AuthServiceProvider extends ServiceProvider
     public function register()
     {
         $this->booting(function () {
-            foreach ($this->policies as $model => $policy) {
-                Gate::policy($model, $policy);
-            }
+            $this->registerPolicies();
         });
     }
+
+    /**
+     * Register the application's policies.
+     *
+     * @return void
+     */
+    public function registerPolicies()
+    {
+        foreach ($this->policies() as $model => $policy) {
+             Gate::policy($model, $policy);
+         }
+    }
+
+    /**
+      * Get the policies defined on the provider.
+      *
+      * @return array<class-string, class-string>
+      */
+     public function policies()
+     {
+         return $this->policies;
+     }
 }

--- a/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
@@ -34,17 +34,17 @@ class AuthServiceProvider extends ServiceProvider
     public function registerPolicies()
     {
         foreach ($this->policies() as $model => $policy) {
-             Gate::policy($model, $policy);
-         }
+            Gate::policy($model, $policy);
+        }
     }
 
     /**
-      * Get the policies defined on the provider.
-      *
-      * @return array<class-string, class-string>
-      */
-     public function policies()
-     {
-         return $this->policies;
-     }
+     * Get the policies defined on the provider.
+     *
+     * @return array<class-string, class-string>
+     */
+    public function policies()
+    {
+        return $this->policies;
+    }
 }

--- a/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
@@ -19,20 +19,12 @@ class AuthServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function registerPolicies()
+    public function register()
     {
-        foreach ($this->policies() as $model => $policy) {
-            Gate::policy($model, $policy);
-        }
-    }
-
-    /**
-     * Get the policies defined on the provider.
-     *
-     * @return array<class-string, class-string>
-     */
-    public function policies()
-    {
-        return $this->policies;
+        $this->booting(function () {
+            foreach ($this->policies as $model => $policy) {
+                Gate::policy($model, $policy);
+            }
+        });
     }
 }


### PR DESCRIPTION
This PR aims to enhance eventual consistency between parts of the framework.

Unlike the other features of the framework (observers, listeners, etc.), policies don't get automatically registered while AuthServiceProvider is booting. It is required to call the `registerPolicies` method. 

And I think this is redundant.

Logic preserves its natural behavior. It doesn't affect auto-discovery, defined with the `Gate::guessPolicyNamesUsing` method.

I also create a PR in the skeleton repo to remove redundant calling of the `registerPolicies` method.