### PR TITLE
[10.x] Remove unused catch exception variable

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -480,7 +480,7 @@ class Gate implements GateContract
             $reflection = new ReflectionClass($class);
 
             $method = $reflection->getMethod($method);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -64,7 +64,7 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -130,7 +130,7 @@ class DatabaseStore implements LockProvider, Store
 
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $result = $this->table()->where('key', $key)->update(compact('value', 'expiration'));
 
             return $result > 0;
@@ -153,7 +153,7 @@ class DatabaseStore implements LockProvider, Store
 
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             return $this->table()
                 ->where('key', $key)
                 ->where('expiration', '<=', $this->getTime())

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -102,7 +102,7 @@ class FileStore implements Store, LockProvider
 
         try {
             $file->getExclusiveLock();
-        } catch (LockTimeoutException $e) {
+        } catch (LockTimeoutException) {
             $file->close();
 
             return false;
@@ -279,7 +279,7 @@ class FileStore implements Store, LockProvider
             $expire = substr(
                 $contents = $this->files->get($path, true), 0, 10
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $this->emptyPayload();
         }
 
@@ -294,7 +294,7 @@ class FileStore implements Store, LockProvider
 
         try {
             $data = unserialize(substr($contents, 10));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->forget($key);
 
             return $this->emptyPayload();

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -84,7 +84,7 @@ class EncryptCookies
                 $value = $this->decryptCookie($key, $cookie);
 
                 $request->cookies->set($key, $this->validateValue($key, $value));
-            } catch (DecryptException $e) {
+            } catch (DecryptException) {
                 $request->cookies->set($key, null);
             }
         }

--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -158,7 +158,7 @@ abstract class DatabaseInspectionCommand extends Command
             ]);
 
             return Arr::wrap((array) $result)['size'];
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             return null;
         }
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -492,7 +492,7 @@ class Dispatcher implements DispatcherContract
             return (new ReflectionClass($class))->implementsInterface(
                 ShouldQueue::class
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -295,7 +295,7 @@ class Filesystem
                 } else {
                     $success = false;
                 }
-            } catch (ErrorException $e) {
+            } catch (ErrorException) {
                 $success = false;
             }
         }

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -56,7 +56,7 @@ class DiscoverEvents
                 $listener = new ReflectionClass(
                     static::classFromFile($listener, $basePath)
                 );
-            } catch (ReflectionException $e) {
+            } catch (ReflectionException) {
                 continue;
             }
 

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -42,7 +42,7 @@ class EncryptedStore extends Store
     {
         try {
             return $this->encrypter->decrypt($data);
-        } catch (DecryptException $e) {
+        } catch (DecryptException) {
             return $this->serialization === 'json' ? json_encode([]) : serialize([]);
         }
     }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -284,7 +284,7 @@ class Factory implements FactoryContract
     {
         try {
             $this->finder->find($view);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return false;
         }
 


### PR DESCRIPTION
in php8.0 introduced Non-capturing catches

With non-capturing catches, we can omit the variable, I have clean up some catch statement remove unuse exception variable

```
try {
    // Something goes wrong
} catch (lException) {
    return false;
}
```

before php8.0 , we must keep the exception variable
```
try {
    // Something goes wrong
} catch (lException $e) {
    return false;
}
```

https://wiki.php.net/rfc/non-capturing_catches