### PR TITLE
[10.x] fix `Expression` string casting

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -113,7 +113,7 @@ class HasInDatabase extends Constraint
     public function toString($options = 0): string
     {
         foreach ($this->data as $key => $data) {
-            $output[$key] = $data instanceof Expression ? (string) $data : $data;
+            $output[$key] = $data instanceof Expression ? $data->getValue($this->database->getQueryGrammar()) : $data;
         }
 
         return json_encode($output ?? [], $options);


### PR DESCRIPTION
The `Expression` class no longer provides a `__toString()` method, so we cannot cast it to a string here.

We'll now use the `->getValue()` method and pass the current database connection's query grammar.

#44784

strangely enough, the `HasInDatabase::toString()` method is only called to get the failure description, but I was getting the unavailable string casting error even without a test failure. this leads me to believe PHPUnit is (sometimes) calling the `failureDescription()` method even without a failure? Not sure on this.