### PR TITLE
[10.x] Fix calling `response()` helper without args

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -273,4 +273,14 @@ class ResponseFactory implements FactoryContract
     {
         return $this->redirector->intended($default, $status, $headers, $secure);
     }
+
+    /**
+     * Get the string representation of the factory.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
The `response()` helper as its first argument accepts `$content` which defaults to an empty string. Also, it could be called without providing any arguments, so we are able to easily return JSON from the endpoint (`response()->json(['foo' => 'bar'])`).

The problem occurs when the helper is called without args and we are not calling any `ReponseFactory`'s method (like `json()` from the previous example).

**Sure, there is a workaround by passing an empty string as a first argument, but since calling without args is allowed, it should be handled properly.**

Currently, it throws `Symfony\Component\HttpFoundation\Response::setContent(): Argument #1 ($content) must be of type ?string, Illuminate\Routing\ResponseFactory given` error.

In older versions: `Object of class Illuminate\Routing\ResponseFactory could not be converted to string`

I couldn't find a better solution that won't be a breaking change. It's not perfect but it's simple.

See: #18498 #32198