### PR TITLE
[10.x] Make `transform` helper generic

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -382,7 +382,7 @@ if (! function_exists('transform')) {
      *
      * @param  TValue  $value
      * @param  callable(TValue): TReturn  $callback
-     * @param  null|TDefault|callable(TValue): TDefault  $default
+     * @param  TDefault|callable(TValue): TDefault|null  $default
      * @return ($value is empty ? ($default is null ? null : TDefault) : TReturn)
      */
     function transform($value, callable $callback, $default = null)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -376,10 +376,14 @@ if (! function_exists('transform')) {
     /**
      * Transform the given value if it is present.
      *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  mixed  $default
-     * @return mixed|null
+     * @template TValue of mixed
+     * @template TReturn of mixed
+     * @template TDefault of mixed
+     *
+     * @param TValue $value
+     * @param callable(TValue): TReturn $callback
+     * @param null|TDefault|callable(TValue): TDefault $default
+     * @return ($value is empty ? ($default is null ? null : TDefault) : TReturn)
      */
     function transform($value, callable $callback, $default = null)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -380,9 +380,9 @@ if (! function_exists('transform')) {
      * @template TReturn of mixed
      * @template TDefault of mixed
      *
-     * @param TValue $value
-     * @param callable(TValue): TReturn $callback
-     * @param null|TDefault|callable(TValue): TDefault $default
+     * @param  TValue  $value
+     * @param  callable(TValue): TReturn  $callback
+     * @param  null|TDefault|callable(TValue): TDefault  $default
      * @return ($value is empty ? ($default is null ? null : TDefault) : TReturn)
      */
     function transform($value, callable $callback, $default = null)

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -38,3 +38,18 @@ assertType('mixed', with(new User(), function ($user) {
 assertType('User', with(new User(), function ($user): User {
     return $user;
 }));
+
+// falls back to default if provided
+assertType('int|null', transform(optional(), fn () => 1));
+// default as callable
+assertType('int|string', transform(optional(), fn () => 1, fn () => 'string'));
+
+// non empty values
+assertType('int', transform('filled', fn () => 1));
+assertType('int', transform(['filled'], fn () => 1));
+assertType('int', transform(new User(), fn () => 1));
+
+// "empty" values
+assertType('null', transform(null, fn () => 1));
+assertType('null', transform('', fn () => 1));
+assertType('null', transform([], fn () => 1));


### PR DESCRIPTION
This PR gives the `transform` helper function generic types. This ensures that the return types can be determined during type analysis instead of always returning `mixed`.