### PR TITLE
[10.x] Adds `date_json` validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -576,6 +576,24 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute matches a JSON date format.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateDateJson($attribute, $value, $parameters)
+    {
+        return $this->validateDateFormat($attribute, $value, [
+            'Y-m-d\TH:i:s.vp', 'Y-m-d\TH:i:s.v',
+            'Y-m-d\TH:i:s.up', 'Y-m-d\TH:i:s.u',
+            'Y-m-d\TH:i:s', 'Y-m-d\TH:i:sp',
+            'c'
+        ]);
+    }
+
+    /**
      * Validate that an attribute has a given number of decimal places.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -580,10 +580,9 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
      * @return bool
      */
-    public function validateDateJson($attribute, $value, $parameters)
+    public function validateDateJson($attribute, $value)
     {
         return $this->validateDateFormat($attribute, $value, ['Y-m-d\TH:i:s.vp', 'Y-m-d\TH:i:s.up']);
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -585,12 +585,7 @@ trait ValidatesAttributes
      */
     public function validateDateJson($attribute, $value, $parameters)
     {
-        return $this->validateDateFormat($attribute, $value, [
-            'Y-m-d\TH:i:s.vp', 'Y-m-d\TH:i:s.v',
-            'Y-m-d\TH:i:s.up', 'Y-m-d\TH:i:s.u',
-            'Y-m-d\TH:i:s', 'Y-m-d\TH:i:sp',
-            'c'
-        ]);
+        return $this->validateDateFormat($attribute, $value, ['Y-m-d\TH:i:s.vp', 'Y-m-d\TH:i:s.up']);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4910,10 +4910,6 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         Carbon::setTestNow(new Carbon('2018-01-01'));
 
-        // With microseconds only
-        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000000'], ['x' => 'date_json']);
-        $this->assertTrue($v->passes());
-
         // With microseconds and timezone UTC
         $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000000Z'], ['x' => 'date_json']);
         $this->assertTrue($v->passes());
@@ -4922,28 +4918,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000000+03:00'], ['x' => 'date_json']);
         $this->assertTrue($v->passes());
 
-        // With milliseconds only
-        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000'], ['x' => 'date_json']);
-        $this->assertTrue($v->passes());
-
         // With milliseconds and timezone UTC
         $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000Z'], ['x' => 'date_json']);
         $this->assertTrue($v->passes());
 
         // With milliseconds and custom timezone
         $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000+03:00'], ['x' => 'date_json']);
-        $this->assertTrue($v->passes());
-
-        // Without microseconds
-        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51'], ['x' => 'date_json']);
-        $this->assertTrue($v->passes());
-
-        // Without microseconds and timezone UTC
-        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51Z'], ['x' => 'date_json']);
-        $this->assertTrue($v->passes());
-
-        // Without microseconds and custom timezone
-        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51+03:00'], ['x' => 'date_json']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4904,6 +4904,49 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testDateJson()
+    {
+        date_default_timezone_set('UTC');
+        $trans = $this->getIlluminateArrayTranslator();
+        Carbon::setTestNow(new Carbon('2018-01-01'));
+
+        // With microseconds only
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000000'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // With microseconds and timezone UTC
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000000Z'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // With microseconds and custom timezone
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000000+03:00'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // With milliseconds only
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // With milliseconds and timezone UTC
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000Z'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // With milliseconds and custom timezone
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51.000+03:00'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // Without microseconds
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // Without microseconds and timezone UTC
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51Z'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+
+        // Without microseconds and custom timezone
+        $v = new Validator($trans, ['x' => '2018-01-01T19:30:51+03:00'], ['x' => 'date_json']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testDateEqualsRespectsCarbonTestNowWhenParameterIsRelative()
     {
         date_default_timezone_set('UTC');


### PR DESCRIPTION
# What?

Adds the `date_json` validation rule, which checks if the given date is one of ISO 8601 formats that Javascript or a Model JSON serialization generates by default.

```php
use Illuminate\Support\Facades\Validator;

// Before
Validator::make(['x' => '2020-01-01T19:30:51.321Z'], ['x' => 'date_format:Y-m-d\TH:i:s.vp,Y-m-d\TH:i:s.up']);

// Now
Validator::make(['x' => '2020-01-01T19:30:51.321Z'], ['x' => 'date_json']);
```

The main purpose of this is to validate ISO 8601 dates that come up from Javascript itself (milliseconds + timezone), or from an Model datetime (microsedons + timezone) that goes back to the application, without having to write the a cryptic PHP date format for a Vue/React/Angular/Livewire app.

* `1234-05-06T07:08:09.012Z`
* `1234-05-06T07:08:09.012Z+03:00`
* `1234-05-06T07:08:09.012345Z`
* `1234-05-06T07:08:09.012345+07:00`