### PR TITLE
[10.x] Fix type of `Http::withUserAgent()` to also accept false

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -437,7 +437,7 @@ class PendingRequest
     /**
      * Specify the user agent for the request.
      *
-     * @param  string  $userAgent
+     * @param  string|bool  $userAgent
      * @return $this
      */
     public function withUserAgent($userAgent)


### PR DESCRIPTION
I have to make a Http request without the `User-Agent` header present. If it is present (even when empty), I get redirected to a consent screen which stops me from scraping the webpage. If the header isn't present at all, I don't get redirected and I can go on with my business.

Guzzle adds a user-agent by default, but it can be removed by setting it to `false`. If you set it to an empty string or null, the header will still be included. Setting it to false completely omits it.

This PR prevents PHPStorm from showing this error:

<img width="443" alt="image" src="https://user-images.githubusercontent.com/7202674/219649390-a0e77f9a-a4c0-4df9-ae7f-09aadd786f39.png">
