### PR TITLE
[10.x] fix: doc block for Strinagle->append method

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -57,7 +57,7 @@ class Stringable implements JsonSerializable
     /**
      * Append the given values to the string.
      *
-     * @param  string|array  ...$values
+     * @param  array|string  ...$values
      * @return static
      */
     public function append(...$values)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -57,7 +57,7 @@ class Stringable implements JsonSerializable
     /**
      * Append the given values to the string.
      *
-     * @param  string  ...$values
+     * @param  string|array  ...$values
      * @return static
      */
     public function append(...$values)


### PR DESCRIPTION

```php
Str::of($name)
            ->append(['one', 'two'])   // array
            ->append('three')        // string
            ->value();
```