### PR TITLE
[9.x] fix: docblock of GuardHelpers::$user

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -13,7 +13,7 @@ trait GuardHelpers
     /**
      * The currently authenticated user.
      *
-     * @var \Illuminate\Contracts\Auth\Authenticatable
+     * @var \Illuminate\Contracts\Auth\Authenticatable|null
      */
     protected $user;
 


### PR DESCRIPTION
In `GuardHelpers`, the `$user` property may be *null*.
Since the related docblock indicates otherwise, it causes false positives with PHPStan.