### PR TITLE
[10.x] Fixing issue where 0 is discarded as a valid timestamp

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -249,7 +249,7 @@ trait ValidatesAttributes
             return $this->checkDateTimeOrder($format, $value, $parameters[0], $operator);
         }
 
-        if (! $date = $this->getDateTimestamp($parameters[0])) {
+        if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
             $date = $this->getDateTimestamp($this->getValue($parameters[0]));
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5028,6 +5028,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '17:44'], ['x' => 'After:17:44:00']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '0001-01-01T00:00'], ['x' => 'before:1970-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '0001-01-01T00:00'], ['x' => 'after:1970-01-01']);
+        $this->assertTrue($v->fails());
     }
 
     public function testBeforeAndAfterWithFormat()


### PR DESCRIPTION
This fixes the issue as described in #46150 by checking explicitly checking for `null`. This ensures a valid value of `0` is used as is.