### PR TITLE
[10.x] Change how UUID/ULID is set when perform an Insert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1034,7 +1034,7 @@ class Builder implements BuilderContract
         }
 
         return $this->toBase()->upsert(
-            $this->addTimestampsToUpsertValues($values),
+            $this->addTimestampsToUpsertValues($this->addUniqueIdsToUpsertValues($values)),
             $uniqueBy,
             $this->addUpdatedAtToUpsertColumns($update)
         );
@@ -1146,6 +1146,29 @@ class Builder implements BuilderContract
         foreach ($columns as $column) {
             foreach ($values as &$row) {
                 $row = array_merge([$column => $timestamp], $row);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Add Unique IDs to the inserted values.
+     *
+     * @param  array  $values
+     * @return array
+     */
+    protected function addUniqueIdsToUpsertValues(array $values)
+    {
+        if (! $this->model->usesUniqueIds()) {
+            return $values;
+        }
+
+        foreach ($this->model->uniqueIds() as $column) {
+            foreach ($values as &$row) {
+                if (empty($row[$column])) {
+                    $row = array_merge([$column => $this->model->newUniqueId()], $row);
+                }
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -8,19 +8,13 @@ use Illuminate\Support\Str;
 trait HasUlids
 {
     /**
-     * Boot the trait.
+     * Initialize the trait.
      *
      * @return void
      */
-    public static function bootHasUlids()
+    public function initializeHasUlids()
     {
-        static::creating(function (self $model) {
-            foreach ($model->uniqueIds() as $column) {
-                if (empty($model->{$column})) {
-                    $model->{$column} = $model->newUniqueId();
-                }
-            }
-        });
+        $this->uniqueIds = true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueIds.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait HasUniqueIds
+{
+    /**
+     * Indicates if the model uses unique ids.
+     *
+     * @var bool
+     */
+    public $uniqueIds = false;
+
+    /**
+     * Determine if the model uses unique ids.
+     *
+     * @return bool
+     */
+    public function usesUniqueIds()
+    {
+        return $this->uniqueIds;
+    }
+
+    /**
+     * Generate a unique keys for model
+     *
+     * @return void
+     */
+    public function setUniqueIds() {
+        foreach ($this->uniqueIds() as $column) {
+            if (empty($this->{$column})) {
+                $this->{$column} = $this->newUniqueId();
+            }
+        }
+    }
+
+    /**
+     * Generate a new key for the model.
+     *
+     * @return string
+     */
+    public function newUniqueId()
+    {
+        return null;
+    }
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array
+     */
+    public function uniqueIds()
+    {
+        return [];
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueIds.php
@@ -22,11 +22,12 @@ trait HasUniqueIds
     }
 
     /**
-     * Generate a unique keys for model
+     * Generate a unique keys for model.
      *
      * @return void
      */
-    public function setUniqueIds() {
+    public function setUniqueIds()
+    {
         foreach ($this->uniqueIds() as $column) {
             if (empty($this->{$column})) {
                 $this->{$column} = $this->newUniqueId();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -8,19 +8,13 @@ use Illuminate\Support\Str;
 trait HasUuids
 {
     /**
-     * Generate a primary UUID for the model.
+     * Initialize the trait.
      *
      * @return void
      */
-    public static function bootHasUuids()
+    public function initializeHasUuids()
     {
-        static::creating(function (self $model) {
-            foreach ($model->uniqueIds() as $column) {
-                if (empty($model->{$column})) {
-                    $model->{$column} = $model->newUniqueId();
-                }
-            }
-        });
+        $this->uniqueIds = true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -30,6 +30,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasGlobalScopes,
         Concerns\HasRelationships,
         Concerns\HasTimestamps,
+        Concerns\HasUniqueIds,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
         ForwardsCalls;
@@ -1284,6 +1285,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // convenience. After, we will just continue saving these model instances.
         if ($this->usesTimestamps()) {
             $this->updateTimestamps();
+        }
+
+        // Set the Unique IDs
+        if ($this->usesUniqueIds()) {
+            $this->setUniqueIds();
         }
 
         // If the model has an incrementing key, we can use the "insertGetId" method on

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -126,9 +126,9 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
     public function testUpsertWithUuidPrimaryKey()
     {
         ModelUpsertWithUuidPrimaryKey::create(['email' => 'foo', 'name' => 'bar']);
-        ModelUpsertWithUuidPrimaryKey::create(['name' => 'bar1', 'email' => 'foo2']);
+        ModelUpsertWithUuidPrimaryKey::create(['name' => 'bar2', 'email' => 'foo2']);
 
-        $result = ModelUpsertWithUuidPrimaryKey::upsert([['email' => 'foo3', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
+        $result = ModelUpsertWithUuidPrimaryKey::upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
 
         $this->assertEquals(2, $result);
     }

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -126,11 +126,11 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
     public function testUpsertWithUuidPrimaryKey()
     {
         ModelUpsertWithUuidPrimaryKey::create(['email' => 'foo', 'name' => 'bar']);
-        ModelUpsertWithUuidPrimaryKey::create(['name' => 'bar2', 'email' => 'foo2']);
+        ModelUpsertWithUuidPrimaryKey::create(['name' => 'bar1', 'email' => 'foo2']);
 
-        $result = ModelUpsertWithUuidPrimaryKey::upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
+        ModelUpsertWithUuidPrimaryKey::upsert([['email' => 'foo3', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
 
-        $this->assertEquals(2, $result);
+        $this->assertEquals(3, ModelUpsertWithUuidPrimaryKey::count());
     }
 }
 

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -73,6 +73,48 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
 
         $this->assertTrue(Str::isUuid($user->uuid));
     }
+
+    public function testModelWithUuidPrimaryKeyCanBeCreatedQuietly()
+    {
+        $user = new ModelWithUuidPrimaryKey();
+
+        $user->saveQuietly();
+
+        $this->assertTrue(Str::isUuid($user->id));
+        $this->assertTrue(Str::isUuid($user->foo));
+        $this->assertTrue(Str::isUuid($user->bar));
+    }
+
+    public function testModelWithUlidPrimaryKeyCanBeCreatedQuietly()
+    {
+        $user = new ModelWithUlidPrimaryKey();
+
+        $user->saveQuietly();
+
+        $this->assertTrue(Str::isUlid($user->id));
+        $this->assertTrue(Str::isUlid($user->foo));
+        $this->assertTrue(Str::isUlid($user->bar));
+    }
+
+    public function testModelWithoutUuidPrimaryKeyCanBeCreatedQuietly()
+    {
+        $user = new ModelWithoutUuidPrimaryKey();
+
+        $user->saveQuietly();
+
+        $this->assertTrue(is_int($user->id));
+        $this->assertTrue(Str::isUuid($user->foo));
+        $this->assertTrue(Str::isUuid($user->bar));
+    }
+
+    public function testModelWithCustomUuidPrimaryKeyNameCanBeCreatedQuietly()
+    {
+        $user = new ModelWithCustomUuidPrimaryKeyName();
+
+        $user->saveQuietly();
+
+        $this->assertTrue(Str::isUuid($user->uuid));
+    }
 }
 
 class ModelWithUuidPrimaryKey extends Eloquent

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -20,6 +20,13 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
             $table->timestamps();
         });
 
+        Schema::create('foo', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('email')->unique();
+            $table->string('name');
+            $table->timestamps();
+        });
+
         Schema::create('posts', function (Blueprint $table) {
             $table->ulid('id')->primary();
             $table->ulid('foo');
@@ -115,6 +122,16 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
 
         $this->assertTrue(Str::isUuid($user->uuid));
     }
+
+    public function testUpsertWithUuidPrimaryKey()
+    {
+        ModelUpsertWithUuidPrimaryKey::create(['email' => 'foo', 'name' => 'bar']);
+        ModelUpsertWithUuidPrimaryKey::create(['name' => 'bar1', 'email' => 'foo2']);
+
+        $result = ModelUpsertWithUuidPrimaryKey::upsert([['email' => 'foo3', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
+
+        $this->assertEquals(2, $result);
+    }
 }
 
 class ModelWithUuidPrimaryKey extends Eloquent
@@ -128,6 +145,20 @@ class ModelWithUuidPrimaryKey extends Eloquent
     public function uniqueIds()
     {
         return [$this->getKeyName(), 'foo', 'bar'];
+    }
+}
+
+class ModelUpsertWithUuidPrimaryKey extends Eloquent
+{
+    use HasUuids;
+
+    protected $table = 'foo';
+
+    protected $guarded = [];
+
+    public function uniqueIds()
+    {
+        return [$this->getKeyName()];
     }
 }
 


### PR DESCRIPTION
This PR change the way that unique IDs are defined.

This fixes the saveQuietly and upsert methods.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
