### PR TITLE
[10.x] Allow expressions in query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3094,7 +3094,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the "count" result of the query.
      *
-     * @param  string  $columns
+     * @param  string|ExpressionContract  $columns
      * @return int
      */
     public function count($columns = '*')
@@ -3105,7 +3105,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the minimum value of a given column.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @return mixed
      */
     public function min($column)
@@ -3116,7 +3116,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the maximum value of a given column.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @return mixed
      */
     public function max($column)
@@ -3127,7 +3127,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the sum of the values of a given column.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @return mixed
      */
     public function sum($column)
@@ -3140,7 +3140,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the average of the values of a given column.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @return mixed
      */
     public function avg($column)
@@ -3151,7 +3151,7 @@ class Builder implements BuilderContract
     /**
      * Alias for the "avg" method.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @return mixed
      */
     public function average($column)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -745,7 +745,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array|ExpressionContract  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -924,7 +924,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|string|array|ExpressionContract  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -941,7 +941,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic "where not" clause to the query.
      *
-     * @param  \Closure|string|array|ExpressionContract  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -961,7 +961,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  \Closure|string|array|ExpressionContract  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -1053,7 +1053,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where in" clause to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1098,7 +1098,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where in" clause to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $values
      * @return $this
      */
@@ -1110,7 +1110,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where not in" clause to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @return $this
@@ -1123,7 +1123,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not in" clause to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $values
      * @return $this
      */
@@ -1200,7 +1200,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where null" clause to the query.
      *
-     * @param  string|array|ExpressionContract  $columns
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -1219,7 +1219,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where null" clause to the query.
      *
-     * @param  string|array|ExpressionContract  $column
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return $this
      */
     public function orWhereNull($column)
@@ -1230,7 +1230,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where not null" clause to the query.
      *
-     * @param  string|array|ExpressionContract  $columns
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @param  string  $boolean
      * @return $this
      */
@@ -1242,7 +1242,7 @@ class Builder implements BuilderContract
     /**
      * Add a where between statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  iterable  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1266,7 +1266,7 @@ class Builder implements BuilderContract
     /**
      * Add a where between statement using columns to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  array  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1284,7 +1284,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where between statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  iterable  $values
      * @return $this
      */
@@ -1296,7 +1296,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where between statement using columns to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  array  $values
      * @return $this
      */
@@ -1308,7 +1308,7 @@ class Builder implements BuilderContract
     /**
      * Add a where not between statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  iterable  $values
      * @param  string  $boolean
      * @return $this
@@ -1321,7 +1321,7 @@ class Builder implements BuilderContract
     /**
      * Add a where not between statement using columns to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  array  $values
      * @param  string  $boolean
      * @return $this
@@ -1334,7 +1334,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where not between statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  iterable  $values
      * @return $this
      */
@@ -1346,7 +1346,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where not between statement using columns to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  array  $values
      * @return $this
      */
@@ -1358,7 +1358,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not null" clause to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return $this
      */
     public function orWhereNotNull($column)
@@ -1369,7 +1369,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where date" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
@@ -1393,7 +1393,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where date" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @return $this
@@ -1410,7 +1410,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where time" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
@@ -1434,7 +1434,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where time" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @return $this
@@ -1451,7 +1451,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where day" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
@@ -1479,7 +1479,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where day" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
@@ -1496,7 +1496,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where month" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
@@ -1524,7 +1524,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where month" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
@@ -1541,7 +1541,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where year" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
@@ -1565,7 +1565,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where year" statement to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
@@ -1583,7 +1583,7 @@ class Builder implements BuilderContract
      * Add a date based (year, month, day, time) statement to the query.
      *
      * @param  string  $type
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -1647,7 +1647,7 @@ class Builder implements BuilderContract
     /**
      * Add a full sub-select to the query.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $operator
      * @param  \Closure  $callback
      * @param  string  $boolean
@@ -2039,7 +2039,7 @@ class Builder implements BuilderContract
     /**
      * Add a "group by" clause to the query.
      *
-     * @param  array|string|ExpressionContract  ...$groups
+     * @param  array|string|\Illuminate\Contracts\Database\Query\Expression  ...$groups
      * @return $this
      */
     public function groupBy(...$groups)
@@ -2276,7 +2276,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|ExpressionContract|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -2309,7 +2309,7 @@ class Builder implements BuilderContract
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|ExpressionContract|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function orderByDesc($column)
@@ -2320,7 +2320,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|ExpressionContract|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function latest($column = 'created_at')
@@ -2331,7 +2331,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|ExpressionContract|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function oldest($column = 'created_at')
@@ -2477,7 +2477,7 @@ class Builder implements BuilderContract
     /**
      * Remove all existing orders and optionally add a new order.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|ExpressionContract|string|null  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|null  $column
      * @param  string  $direction
      * @return $this
      */
@@ -2917,7 +2917,7 @@ class Builder implements BuilderContract
     /**
      * Get a collection instance containing the values of a given column.
      *
-     * @param  ExpressionContract|string  $column
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */
@@ -3094,7 +3094,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the "count" result of the query.
      *
-     * @param  string|ExpressionContract  $columns
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @return int
      */
     public function count($columns = '*')
@@ -3105,7 +3105,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the minimum value of a given column.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      */
     public function min($column)
@@ -3116,7 +3116,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the maximum value of a given column.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      */
     public function max($column)
@@ -3127,7 +3127,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the sum of the values of a given column.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      */
     public function sum($column)
@@ -3140,7 +3140,7 @@ class Builder implements BuilderContract
     /**
      * Retrieve the average of the values of a given column.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      */
     public function avg($column)
@@ -3151,7 +3151,7 @@ class Builder implements BuilderContract
     /**
      * Alias for the "avg" method.
      *
-     * @param  string|ExpressionContract  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      */
     public function average($column)
@@ -3621,7 +3621,7 @@ class Builder implements BuilderContract
      * Create a raw database expression.
      *
      * @param  mixed  $value
-     * @return ExpressionContract
+     * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1053,7 +1053,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where in" clause to the query.
      *
-     * @param  string|ExpressionContract $column
+     * @param  string|ExpressionContract  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1242,7 +1242,7 @@ class Builder implements BuilderContract
     /**
      * Add a where between statement to the query.
      *
-     * @param  string|ExpressionContract $column
+     * @param  string|ExpressionContract  $column
      * @param  iterable  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -2039,7 +2039,7 @@ class Builder implements BuilderContract
     /**
      * Add a "group by" clause to the query.
      *
-     * @param  array|string|ExpressionContract ...$groups
+     * @param  array|string|ExpressionContract  ...$groups
      * @return $this
      */
     public function groupBy(...$groups)
@@ -2917,7 +2917,7 @@ class Builder implements BuilderContract
     /**
      * Get a collection instance containing the values of a given column.
      *
-     * @param ExpressionContract|string  $column
+     * @param  ExpressionContract|string  $column
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -508,7 +508,7 @@ class Builder implements BuilderContract
     /**
      * Add a join clause to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
@@ -548,7 +548,7 @@ class Builder implements BuilderContract
     /**
      * Add a "join where" clause to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string  $first
      * @param  string  $operator
      * @param  string  $second
@@ -588,7 +588,7 @@ class Builder implements BuilderContract
     /**
      * Add a left join to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
@@ -602,7 +602,7 @@ class Builder implements BuilderContract
     /**
      * Add a "join where" clause to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string  $first
      * @param  string  $operator
      * @param  string  $second
@@ -631,7 +631,7 @@ class Builder implements BuilderContract
     /**
      * Add a right join to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
@@ -645,7 +645,7 @@ class Builder implements BuilderContract
     /**
      * Add a "right join where" clause to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string  $first
      * @param  string  $operator
      * @param  string  $second
@@ -674,7 +674,7 @@ class Builder implements BuilderContract
     /**
      * Add a "cross join" clause to the query.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $table
      * @param  \Closure|string|null  $first
      * @param  string|null  $operator
      * @param  string|null  $second

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -745,7 +745,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array  $column
+     * @param  \Closure|string|array|ExpressionContract  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -924,7 +924,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|string|array  $column
+     * @param  \Closure|string|array|ExpressionContract  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -941,7 +941,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic "where not" clause to the query.
      *
-     * @param  \Closure|string|array  $column
+     * @param  \Closure|string|array|ExpressionContract  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -961,7 +961,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  \Closure|string|array  $column
+     * @param  \Closure|string|array|ExpressionContract  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -1053,7 +1053,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1098,7 +1098,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  mixed  $values
      * @return $this
      */
@@ -1110,7 +1110,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where not in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @return $this
@@ -1123,7 +1123,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  mixed  $values
      * @return $this
      */
@@ -1200,7 +1200,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where null" clause to the query.
      *
-     * @param  string|array  $columns
+     * @param  string|array|ExpressionContract  $columns
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -1219,7 +1219,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where null" clause to the query.
      *
-     * @param  string|array  $column
+     * @param  string|array|ExpressionContract  $column
      * @return $this
      */
     public function orWhereNull($column)
@@ -1230,7 +1230,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where not null" clause to the query.
      *
-     * @param  string|array  $columns
+     * @param  string|array|ExpressionContract  $columns
      * @param  string  $boolean
      * @return $this
      */
@@ -1242,7 +1242,7 @@ class Builder implements BuilderContract
     /**
      * Add a where between statement to the query.
      *
-     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string|ExpressionContract $column
      * @param  iterable  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1266,7 +1266,7 @@ class Builder implements BuilderContract
     /**
      * Add a where between statement using columns to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  array  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -1284,7 +1284,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where between statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  iterable  $values
      * @return $this
      */
@@ -1296,7 +1296,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where between statement using columns to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  array  $values
      * @return $this
      */
@@ -1308,7 +1308,7 @@ class Builder implements BuilderContract
     /**
      * Add a where not between statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  iterable  $values
      * @param  string  $boolean
      * @return $this
@@ -1321,7 +1321,7 @@ class Builder implements BuilderContract
     /**
      * Add a where not between statement using columns to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  array  $values
      * @param  string  $boolean
      * @return $this
@@ -1334,7 +1334,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where not between statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  iterable  $values
      * @return $this
      */
@@ -1346,7 +1346,7 @@ class Builder implements BuilderContract
     /**
      * Add an or where not between statement using columns to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  array  $values
      * @return $this
      */
@@ -1358,7 +1358,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not null" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @return $this
      */
     public function orWhereNotNull($column)
@@ -1369,7 +1369,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where date" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
@@ -1393,7 +1393,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where date" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @return $this
@@ -1410,7 +1410,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where time" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
@@ -1434,7 +1434,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where time" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @return $this
@@ -1451,7 +1451,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where day" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
@@ -1479,7 +1479,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where day" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
@@ -1496,7 +1496,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where month" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
@@ -1524,7 +1524,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where month" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
@@ -1541,7 +1541,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where year" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
@@ -1565,7 +1565,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where year" statement to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
@@ -1583,7 +1583,7 @@ class Builder implements BuilderContract
      * Add a date based (year, month, day, time) statement to the query.
      *
      * @param  string  $type
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -1647,7 +1647,7 @@ class Builder implements BuilderContract
     /**
      * Add a full sub-select to the query.
      *
-     * @param  string  $column
+     * @param  string|ExpressionContract  $column
      * @param  string  $operator
      * @param  \Closure  $callback
      * @param  string  $boolean
@@ -2039,7 +2039,7 @@ class Builder implements BuilderContract
     /**
      * Add a "group by" clause to the query.
      *
-     * @param  array|string|\Illuminate\Contracts\Database\Query\Expression  ...$groups
+     * @param  array|string|ExpressionContract ...$groups
      * @return $this
      */
     public function groupBy(...$groups)
@@ -2276,7 +2276,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|ExpressionContract|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -2309,7 +2309,7 @@ class Builder implements BuilderContract
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|ExpressionContract|string  $column
      * @return $this
      */
     public function orderByDesc($column)
@@ -2320,7 +2320,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|ExpressionContract|string  $column
      * @return $this
      */
     public function latest($column = 'created_at')
@@ -2331,7 +2331,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|ExpressionContract|string  $column
      * @return $this
      */
     public function oldest($column = 'created_at')
@@ -2477,7 +2477,7 @@ class Builder implements BuilderContract
     /**
      * Remove all existing orders and optionally add a new order.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|null  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|ExpressionContract|string|null  $column
      * @param  string  $direction
      * @return $this
      */
@@ -2917,7 +2917,7 @@ class Builder implements BuilderContract
     /**
      * Get a collection instance containing the values of a given column.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param ExpressionContract|string  $column
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */
@@ -3621,7 +3621,7 @@ class Builder implements BuilderContract
      * Create a raw database expression.
      *
      * @param  mixed  $value
-     * @return \Illuminate\Contracts\Database\Query\Expression
+     * @return ExpressionContract
      */
     public function raw($value)
     {


### PR DESCRIPTION
With the types being added, the query builder no longer allows expressions for _where_ and _aggregate_ functions. This now generates errors with phpstan or other similar tools, but works just fine.

This PR adds `ExpressionContract` typehint for these functions.

## Example
This allows using `DB::raw()` expressions for these functions

```php
Product::query()->whereIn(DB::raw('TRIM(LEADING \'0\' FROM upc)'), ['12345678', '87654321'])->get();
```
```php
Product::query()->where('category', 'toys')->avg(DB::raw('price / 100'));
```
