### PR TITLE
[10.x] Add option to transform result in validation framework (for future type safety)

### DIFF
--- a/src/Illuminate/Contracts/Validation/TransformsResultRule.php
+++ b/src/Illuminate/Contracts/Validation/TransformsResultRule.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Validation;
+
+interface TransformsResultRule
+{
+    /**
+     * @param string $attribute the name of the attribute we are validating.
+     * @param mixed $value The value the attribute currently has
+     * @param array $context data context we are validating in (all other values), which will be updated as validation rules being applied.
+     * @return mixed The value we want to set for the attribute
+     */
+    public function transform(string $attribute, mixed $value, array $context): mixed;
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use BadMethodCallException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Contracts\Validation\TransformsResultRule;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
@@ -833,6 +834,11 @@ class Validator implements ValidatorContract
                 $this->messages->add($key, $this->makeReplacements(
                     $message, $key, $ruleClass, []
                 ));
+            }
+        } elseif($rule instanceof TransformsResultRule){
+            $newValue = $rule->transform($attribute, $value, $this->data);
+            if($newValue !== $value){
+                Arr::set($this->data,  $attribute, $newValue);
             }
         }
     }

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -11,6 +11,7 @@ use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\DatabasePresenceVerifier;
 use Illuminate\Validation\Validator;
+use Orchestra\Testbench\TestCase;
 
 class ValidatorTest extends DatabaseTestCase
 {

--- a/tests/Integration/Validation/ValidatorTransformsResultTest.php
+++ b/tests/Integration/Validation/ValidatorTransformsResultTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Validation;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\TransformsResultRule;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\DatabasePresenceVerifier;
+use Illuminate\Validation\Validator;
+use Orchestra\Testbench\TestCase;
+
+class ValidatorTransformsResultTest extends TestCase
+{
+    public function testRuleTransformsResult()
+    {
+        $validator = $this->getValidator(['value' => '1'], ['value' => new ValidFloat()]);
+        $data = $validator->validate();
+        $this->assertIsFloat($data['value']);
+        $this->assertSame(1.0, $data['value']);
+    }
+
+    public function testRuleWithoutTransformIsNotCalledTransformsResult()
+    {
+        $rule = \Mockery::mock(Rule::class);
+        $rule->shouldReceive('passes')->andReturn(true);
+        $validator = $this->getValidator(['value' => '1'], ['value' => $rule]);
+        $data = $validator->validate();
+        $this->assertIsString($data['value']);
+    }
+
+    public function testTransformIsNotCalledOnFailure()
+    {
+        $rule = \Mockery::mock(Rule::class, TransformsResultRule::class);
+        $rule->shouldReceive('passes')->andReturn(false);
+        $rule->shouldReceive('message')->andReturn('tset');
+        $rule->shouldNotReceive('transform');
+        $validator = $this->getValidator(['value' => '1'], ['value' => $rule]);
+        $this->assertTrue($validator->fails());
+    }
+
+    public function testSecondRuleGetsTransformedValueFromFirstRule()
+    {
+        $rule = \Mockery::mock(Rule::class);
+        $rule->shouldReceive('passes')->with('value', 1.0)->andReturn(true);
+        $rule->shouldNotReceive('transform');
+        $validator = $this->getValidator(['value' => '1'], ['value' => [new ValidFloat(), $rule]]);
+        $this->assertTrue($validator->passes());
+    }
+
+    protected function getValidator(array $data, array $rules): Validator
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $validator = new Validator($translator, $data, $rules);
+        $validator->setPresenceVerifier(new DatabasePresenceVerifier($this->app['db']));
+
+        return $validator;
+    }
+}
+
+
+class ValidFloatBase implements Rule {
+    public function passes($attribute, $value)
+    {
+        return true;
+    }
+
+    public function message()
+    {
+        return 'float';
+    }
+}
+
+
+class ValidFloat extends ValidFloatBase implements TransformsResultRule {
+    public function transform(string $attribute, mixed $value, array $context): mixed
+    {
+        return ((float) $value);
+    }
+}


### PR DESCRIPTION
Note: This an MVP, im willing to work out some more kinks.

Our biggest problem with the validation framework at the moment is that it does not restrict the types in the result, for example:

### Example old situation

```php
$validator = $this->getValidator(['input' => '1'], ['input' => 'required|int']);
$data = $validator->validate();
$data['input']; // = string '1';
```

Result: creating a lot of bugs in our code projects which could have been solved if the validation (as expected by any new developer to Laravel) is cast to an int type during the validation, which it is not.

You write your TestCases using integers but an external api developer might put integers or floats in strings, and thus breaking your code.

### New situation

With this RFC you can now make rules that also provide type safety, by making your own rules (I will be willing to make a library for all default types).

 for float for example:

```php
class ValidFloat implements Rules, TransformsResultRule {
    // removed passes() and message() function for readability.

    public function transform(string $attribute, mixed $value, array $context): mixed
    {
        return ((float) $value);
    }
}


$validator = $this->getValidator(['input' => '1'], ['input' => new ValidFloat()]);
$data = $validator->validate();
$data['input']; // = float 1.0;
```

### Other benefits

Rules can be changed and don't constantly have to cast values, especially usefull for date rules:

```php 
$this->validate($data, [
    'date' => [new ValidCarbonDate(), new MustBeInTheFuture()]
])
```

now `MustBeInTheFuture` in the `passes()` function can expect to always get a Carbon instance instead of a string which it will have to cast again, and the developer also has to cast again later in controller code.

### Considerations.

Does not work yet with `ValidationRule` but im willing to add support for this if necessary. shouldn't be too complicated.