### PR TITLE
Use mixed return type on controller stubs

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -10,7 +10,7 @@ class {{ class }} extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(): mixed
+    public function index()
     {
         //
     }
@@ -18,7 +18,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): mixed
+    public function store(Request $request)
     {
         //
     }
@@ -26,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id): mixed
+    public function show(string $id)
     {
         //
     }
@@ -34,7 +34,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id): mixed
+    public function update(Request $request, string $id)
     {
         //
     }
@@ -42,7 +42,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id): mixed
+    public function destroy(string $id)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -4,14 +4,13 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(): Response
+    public function index(): mixed
     {
         //
     }
@@ -19,7 +18,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): Response
+    public function store(Request $request): mixed
     {
         //
     }
@@ -27,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id): Response
+    public function show(string $id): mixed
     {
         //
     }
@@ -35,7 +34,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id): Response
+    public function update(Request $request, string $id): mixed
     {
         //
     }
@@ -43,7 +42,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id): Response
+    public function destroy(string $id): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -4,14 +4,13 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Handle the incoming request.
      */
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -10,7 +10,7 @@ class {{ class }} extends Controller
     /**
      * Handle the incoming request.
      */
-    public function __invoke(Request $request): mixed
+    public function __invoke(Request $request)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -11,7 +11,7 @@ class {{ class }} extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(): mixed
+    public function index()
     {
         //
     }
@@ -19,7 +19,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store({{ storeRequest }} $request): mixed
+    public function store({{ storeRequest }} $request)
     {
         //
     }
@@ -27,7 +27,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ model }} ${{ modelVariable }}): mixed
+    public function show({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -35,7 +35,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }}): mixed
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -43,7 +43,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ model }} ${{ modelVariable }}): mixed
+    public function destroy({{ model }} ${{ modelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -5,14 +5,13 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedRequests }}
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(): Response
+    public function index(): mixed
     {
         //
     }
@@ -20,7 +19,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store({{ storeRequest }} $request): Response
+    public function store({{ storeRequest }} $request): mixed
     {
         //
     }
@@ -28,7 +27,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ model }} ${{ modelVariable }}): Response
+    public function show({{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -36,7 +35,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }}): Response
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -44,7 +43,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ model }} ${{ modelVariable }}): Response
+    public function destroy({{ model }} ${{ modelVariable }}): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -5,15 +5,13 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedRequests }}
-use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(): Response
+    public function index(): mixed
     {
         //
     }
@@ -21,7 +19,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create(): Response
+    public function create(): mixed
     {
         //
     }
@@ -29,7 +27,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store({{ storeRequest }} $request): RedirectResponse
+    public function store({{ storeRequest }} $request): mixed
     {
         //
     }
@@ -37,7 +35,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ model }} ${{ modelVariable }}): Response
+    public function show({{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -45,7 +43,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit({{ model }} ${{ modelVariable }}): Response
+    public function edit({{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -53,7 +51,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }}): RedirectResponse
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -61,7 +59,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ model }} ${{ modelVariable }}): RedirectResponse
+    public function destroy({{ model }} ${{ modelVariable }}): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -11,7 +11,7 @@ class {{ class }} extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(): mixed
+    public function index()
     {
         //
     }
@@ -19,7 +19,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create(): mixed
+    public function create()
     {
         //
     }
@@ -27,7 +27,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store({{ storeRequest }} $request): mixed
+    public function store({{ storeRequest }} $request)
     {
         //
     }
@@ -35,7 +35,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ model }} ${{ modelVariable }}): mixed
+    public function show({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -43,7 +43,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit({{ model }} ${{ modelVariable }}): mixed
+    public function edit({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -51,7 +51,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }}): mixed
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -59,7 +59,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ model }} ${{ modelVariable }}): mixed
+    public function destroy({{ model }} ${{ modelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -6,14 +6,13 @@ use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedParentModel }};
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index({{ parentModel }} ${{ parentModelVariable }}): Response
+    public function index({{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -21,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): Response
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -29,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): Response
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -37,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): Response
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -45,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): Response
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -12,7 +12,7 @@ class {{ class }} extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index({{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function index({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -20,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -28,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -36,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -44,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.api.stub
@@ -20,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function show({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -28,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.api.stub
@@ -5,7 +5,6 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use {{ namespacedParentModel }};
 
 class {{ class }} extends Controller
@@ -21,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}): Response
+    public function show({{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -29,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}): Response
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.stub
@@ -4,9 +4,7 @@ namespace {{ namespace }};
 
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use {{ namespacedParentModel }};
 
 class {{ class }} extends Controller
@@ -30,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}): Response
+    public function show({{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -38,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the resource.
      */
-    public function edit({{ parentModel }} ${{ parentModelVariable }}): Response
+    public function edit({{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -46,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}): RedirectResponse
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.stub
@@ -28,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function show({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -36,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the resource.
      */
-    public function edit({{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function edit({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -44,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -5,16 +5,14 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedParentModel }};
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index({{ parentModel }} ${{ parentModelVariable }}): Response
+    public function index({{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -22,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create({{ parentModel }} ${{ parentModelVariable }}): Response
+    public function create({{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -30,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): RedirectResponse
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
     {
         //
     }
@@ -38,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): Response
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -46,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): Response
+    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -54,7 +52,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): RedirectResponse
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }
@@ -62,7 +60,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): RedirectResponse
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -12,7 +12,7 @@ class {{ class }} extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index({{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function index({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -20,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create({{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function create({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -28,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): mixed
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
@@ -36,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -44,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -52,7 +52,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -60,7 +60,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}): mixed
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
@@ -18,7 +18,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show(): mixed
+    public function show()
     {
         //
     }
@@ -26,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request): mixed
+    public function update(Request $request)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
@@ -4,7 +4,6 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
@@ -19,7 +18,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show(): Response
+    public function show(): mixed
     {
         //
     }
@@ -27,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request): Response
+    public function update(Request $request): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
@@ -26,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show(): mixed
+    public function show()
     {
         //
     }
@@ -34,7 +34,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the resource.
      */
-    public function edit(): mixed
+    public function edit()
     {
         //
     }
@@ -42,7 +42,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request): mixed
+    public function update(Request $request)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
@@ -3,9 +3,7 @@
 namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
@@ -28,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show(): Response
+    public function show(): mixed
     {
         //
     }
@@ -36,7 +34,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the resource.
      */
-    public function edit(): Response
+    public function edit(): mixed
     {
         //
     }
@@ -44,7 +42,7 @@ class {{ class }} extends Controller
     /**
      * Update the resource in storage.
      */
-    public function update(Request $request): RedirectResponse
+    public function update(Request $request): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -3,16 +3,14 @@
 namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(): Response
+    public function index(): mixed
     {
         //
     }
@@ -20,7 +18,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create(): Response
+    public function create(): mixed
     {
         //
     }
@@ -28,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request): mixed
     {
         //
     }
@@ -36,7 +34,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id): Response
+    public function show(string $id): mixed
     {
         //
     }
@@ -44,7 +42,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id): Response
+    public function edit(string $id): mixed
     {
         //
     }
@@ -52,7 +50,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id): RedirectResponse
+    public function update(Request $request, string $id): mixed
     {
         //
     }
@@ -60,7 +58,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id): RedirectResponse
+    public function destroy(string $id): mixed
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -10,7 +10,7 @@ class {{ class }} extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(): mixed
+    public function index()
     {
         //
     }
@@ -18,7 +18,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create(): mixed
+    public function create()
     {
         //
     }
@@ -26,7 +26,7 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): mixed
+    public function store(Request $request)
     {
         //
     }
@@ -34,7 +34,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id): mixed
+    public function show(string $id)
     {
         //
     }
@@ -42,7 +42,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id): mixed
+    public function edit(string $id)
     {
         //
     }
@@ -50,7 +50,7 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id): mixed
+    public function update(Request $request, string $id)
     {
         //
     }
@@ -58,7 +58,7 @@ class {{ class }} extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id): mixed
+    public function destroy(string $id)
     {
         //
     }


### PR DESCRIPTION
This pull request updates the controller stubs to use a `mixed` return type to accommodate the various types of return values a controller can return in Laravel.

This allows developers to return anything they want without an error by default, but they can easily tighten up the types as they decide which each controller endpoint will actually return.