### PR TITLE
Support responsable on more objects

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -4,12 +4,13 @@ namespace Illuminate\Http;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\JsonResponse as BaseJsonResponse;
 
-class JsonResponse extends BaseJsonResponse
+class JsonResponse extends BaseJsonResponse implements Responsable
 {
     use ResponseTrait, Macroable {
         Macroable::__call as macroCall;
@@ -135,5 +136,16 @@ class JsonResponse extends BaseJsonResponse
     public function hasEncodingOption($option)
     {
         return (bool) ($this->encodingOptions & $option);
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $this;
     }
 }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http;
 
 use Illuminate\Contracts\Support\MessageProvider;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -12,7 +13,7 @@ use Illuminate\Support\ViewErrorBag;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
-class RedirectResponse extends BaseRedirectResponse
+class RedirectResponse extends BaseRedirectResponse implements Responsable
 {
     use ForwardsCalls, ResponseTrait, Macroable {
         Macroable::__call as macroCall;
@@ -232,6 +233,17 @@ class RedirectResponse extends BaseRedirectResponse
     public function setSession(SessionStore $session)
     {
         $this->session = $session;
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -6,13 +6,14 @@ use ArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-class Response extends SymfonyResponse
+class Response extends SymfonyResponse implements Responsable
 {
     use ResponseTrait, Macroable {
         Macroable::__call as macroCall;
@@ -104,5 +105,16 @@ class Response extends SymfonyResponse
         }
 
         return json_encode($content);
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $this;
     }
 }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -8,15 +8,17 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Http\Response;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
 use Throwable;
 
-class View implements ArrayAccess, Htmlable, ViewContract
+class View implements ArrayAccess, Htmlable, Responsable, ViewContract
 {
     use Macroable {
         __call as macroCall;
@@ -478,6 +480,17 @@ class View implements ArrayAccess, Htmlable, ViewContract
     public function toHtml()
     {
         return $this->render();
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return new Response($this->toHtml());
     }
 
     /**

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -21,6 +21,7 @@
         "illuminate/contracts": "^10.0",
         "illuminate/events": "^10.0",
         "illuminate/filesystem": "^10.0",
+        "illuminate/http": "^10.0",
         "illuminate/macroable": "^10.0",
         "illuminate/support": "^10.0"
     },


### PR DESCRIPTION
Support `Responsable` on all response types + views so that the contract could potentially be used as an alternative to `Response` or `mixed` on controller stubs.

Reference: https://github.com/laravel/framework/pull/46166