### PR TITLE
[11.x] Route redirect with query string

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -39,6 +39,12 @@ class RedirectController extends Controller
             $url = Str::after($url, '/');
         }
 
+        $queryString = $request->getQueryString();
+
+        if (!empty($queryString)) {
+            $url = $url . '?' . $queryString;
+        }
+
         return new RedirectResponse($url, $status);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR changes the `Illuminate/Routing/Router@redirect` method to maintain the query parameters from the source url in the target url. I think it is intuitive to expect the query parameters to be kept in a redirect. Without this, the user would need to use a closure or controller and add the query parameters to the redirect.
