### PR TITLE
[9.x] Update Mail phpdoc

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -315,7 +315,7 @@ class Message
     /**
      * Attach in-memory data as an attachment.
      *
-     * @param  string  $data
+     * @param  string|resource  $data
      * @param  string  $name
      * @param  array  $options
      * @return $this
@@ -366,7 +366,7 @@ class Message
     /**
      * Embed in-memory data in the message and get the CID.
      *
-     * @param  string  $data
+     * @param  string|resource  $data
      * @param  string  $name
      * @param  string|null  $contentType
      * @return string


### PR DESCRIPTION
`symfony/mailer` allows passing a stream (`resource`) to `embed()` and `attach()`, see:
* `embed` - https://github.com/symfony/symfony/blob/b101b71ddacfa664485bb09ec6272971e458f49f/src/Symfony/Component/Mime/Email.php#L351
* `attach` - https://github.com/symfony/symfony/blob/b101b71ddacfa664485bb09ec6272971e458f49f/src/Symfony/Component/Mime/Email.php#L323

PHPStan throws an error at the moment if a resource is provided to these methods.