### PR TITLE
Allow Belongs to many relationship to sync id's with distinct pivot values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -141,23 +141,33 @@ trait InteractsWithPivotTable
         }), $detaching);
     }
     
-     /**
-     * Sync the intermediate tables with a list of IDs or collection of models with the given pivot values associatively.
-     *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
-     * @param  array  $values
-     * @param  bool  $detaching
-     * @return array
-     */
-    public function syncWithAssocPivotValues($ids, array $values, bool $detaching = true)
-    {
-      array_splice($ids,count($values));
+      /**
+       * Sync the intermediate tables with a list of IDs or collection of models with the given pivot values associatively.
+       *
+       * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+       * @param  array  $values
+       * @param  bool  $detaching
+       * @return array
+       */
+      public function syncWithAssocPivotValues($ids, array $values, bool $detaching = true)
+      {
+
+        if ($ids instanceof \Illuminate\Support\Collection) {
+          $ids = $ids->toArray();
+        }
+
+        //$ids are paired with $values in the same position in their array eg. $ids[0] => $values[0]
+        //If $ids length is less than that of the $values the remaining $ids with no value pair are
+        //ignored while syncing to pivot table, meaning all $ids must have a pair to be synced
+
+        array_splice($ids, count($values));
+
         return $this->sync(collect($this->parseIds($ids))->mapWithKeys(function ($value, $key) use ($values) {
           return [
             $value => $values[$key]
           ];
         }), $detaching);
-    }
+      }
 
     /**
      * Format the sync / toggle record list so that it is keyed by ID.

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -140,6 +140,24 @@ trait InteractsWithPivotTable
             return [$id => $values];
         }), $detaching);
     }
+    
+     /**
+     * Sync the intermediate tables with a list of IDs or collection of models with the given pivot values associatively.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  array  $values
+     * @param  bool  $detaching
+     * @return array
+     */
+    public function syncWithAssocPivotValues($ids, array $values, bool $detaching = true)
+    {
+      array_splice($ids,count($values));
+        return $this->sync(collect($this->parseIds($ids))->mapWithKeys(function ($value, $key) use ($values) {
+          return [
+            $value => $values[$key]
+          ];
+        }), $detaching);
+    }
 
     /**
      * Format the sync / toggle record list so that it is keyed by ID.

--- a/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
+++ b/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseConcernsInteractsWithPivotTableTest extends TestCase
+{
+  protected function setUp(): void
+  {
+    $db = new Manager;
+
+    $db->addConnection([
+      'driver' => 'sqlite',
+      'database' => ':memory:',
+  ]);
+
+    $db->bootEloquent();
+    $db->setAsGlobal();
+
+    $this->createSchema();
+  }
+
+  /**
+   * Setup the database schema.
+   *
+   * @return void
+   */
+  public function createSchema()
+  {
+    $this->schema()->create('users', function ($table) {
+      $table->increments('id');
+      $table->string('name');
+    });
+
+    $this->schema()->create('roles', function ($table) {
+      $table->increments('id');
+      $table->string('name');
+    });
+
+    $this->schema()->create('role_user', function ($table) {
+      $table->integer('role_id')->unsigned();
+      $table->foreign('role_id')->references('id')->on('roles');
+      $table->integer('user_id')->unsigned();
+      $table->foreign('user_id')->references('id')->on('users');
+      $table->string('office')->nullable();
+    });
+  }
+
+  /**
+   * Get a schema builder instance.
+   *
+   * @return \Illuminate\Database\Schema\Builder
+   */
+  protected function schema()
+  {
+    return $this->connection()->getSchemaBuilder();
+  }
+
+
+  protected function connection(): mixed
+  {
+    return Model::getConnectionResolver()->connection();
+  }
+
+  public function seed()
+  {
+    $user = PivotInteractionUser::create(['id' => 1, 'name' => 'Chibuike']);
+    PivotInteractionRoles::insert([
+      ['id' => 1, 'name' => 'Eater'],
+      ['id' => 2, 'name' => 'Sleeper'],
+      ['id' => 3, 'name' => 'Skier'],
+    ]);
+
+    $user->roles()->attach(PivotInteractionRoles::first());
+  }
+
+  public function testCanSyncPivotInAnAssociativeWay()
+  {
+    $this->seed();
+    $user = PivotInteractionUser::first();
+    $roles = PivotInteractionRoles::all();
+
+    $user->roles()->syncWithAssocPivotValues($roles->pluck('id'), [
+      ['office' => 'Dinning'],
+      ['office' => 'Bedroom'],
+      ['office' => 'Innsbruck'],
+    ]);
+
+    $this->assertEquals(3, $user->roles()->count());
+    $this->assertEquals('Bedroom', $user->roles()->where('name', 'Sleeper')->first()->pivot->office);
+  }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('roles');
+        $this->schema()->drop('role_user');
+    }
+}
+
+/**
+ * User model
+ */
+class PivotInteractionUser extends Model
+{
+  protected $fillable = ['name'];
+  protected $table = 'users';
+  public $timestamps = false;
+  public function roles()
+  {
+    return $this->belongsToMany(PivotInteractionRoles::class,'role_user','user_id','role_id')->withPivot('office');
+  }
+}
+
+/**
+ * Role model
+ */
+
+class PivotInteractionRoles extends Model
+{
+  public $timestamps = false;
+  protected $fillable = ['name'];
+  protected $table = 'roles';
+
+  public function users()
+  {
+    return $this->belongsToMany(PivotInteractionUser::class,'role_user','role_id','user_id');
+  }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The behavior of the method syncWithPivotValues() is to sync  all entered id's with a particular set of value(s) to pivot column(s)

Example
```php
$user->roles()->syncWithPivotValues([1,2,3],[ 'status' => 'active' ]);
//will produce this array after mapping
array(
  '1' => [ 'status' => 'active'],
  '2' => [ 'status' => 'active'],
  '3' => [ 'status' => 'active'],
)
```

But what I wanted was the ability to have different pivot column values for each role_id. More like so:

```php
//notice the different values for each role_id
array(
  '1' => [ 'status' => 'active'],
  '2' => [ 'status' => 'inactive'],
  '3' => [ 'status' => 'pending'],
)
```
Now for the user's roles to all have a different status in one short at syncing; This can be possible with a new method syncWithAssocPivotValues()

```php
$user->roles()->syncWithAssocPivotValues([1,2,3],[
           ['status' => 'active'],
           ['status' => 'inactive'],
           ['status' => 'pending'],
        ];

```

