### PR TITLE
Add localization to throttle exception

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -196,7 +196,7 @@ class ThrottleRequests
 
         return is_callable($responseCallback)
                     ? new HttpResponseException($responseCallback($request, $headers))
-                    : new ThrottleRequestsException('Too Many Attempts.', null, $headers);
+                    : new ThrottleRequestsException(__('passwords.throttled'), null, $headers);
     }
 
     /**


### PR DESCRIPTION
Add localization to throttle exception.

Laravel returns English-only response on throttle middleware, which is not the correct thing for localized projects.

it doesn't break anything as it is just a localization. (unless someone matches the string of the response, which doesn't make sense :D)
