### PR TITLE
[10.x] Test mailable sent

### DIFF
--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 
 class SupportMailTest extends TestCase
 {
-    public function testItRegisterAndCallMacros(): void
+    public function testItRegisterAndCallMacros()
     {
         Mail::macro('test', fn (string $str) => $str === 'foo'
             ? 'it works!'
@@ -18,7 +18,7 @@ class SupportMailTest extends TestCase
         $this->assertEquals('it works!', Mail::test('foo'));
     }
 
-    public function testItRegisterAndCallMacrosWhenFaked(): void
+    public function testItRegisterAndCallMacrosWhenFaked()
     {
         Mail::macro('test', fn (string $str) => $str === 'foo'
             ? 'it works!'
@@ -30,7 +30,7 @@ class SupportMailTest extends TestCase
         $this->assertEquals('it works!', Mail::test('foo'));
     }
 
-    public function testEmailSent(): void
+    public function testEmailSent()
     {
         Mail::fake();
         Mail::assertNothingSent();
@@ -44,7 +44,12 @@ class SupportMailTest extends TestCase
 
 class TestMail extends Mailable
 {
-    public function build(): self
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
     {
         return $this->view('view');
     }

--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -41,7 +41,6 @@ class SupportMailTest extends TestCase
     }
 }
 
-
 class TestMail extends Mailable
 {
     /**

--- a/tests/Support/SupportMailTest.php
+++ b/tests/Support/SupportMailTest.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;
 use Orchestra\Testbench\TestCase;
 
 class SupportMailTest extends TestCase
 {
-    public function testItRegisterAndCallMacros()
+    public function testItRegisterAndCallMacros(): void
     {
         Mail::macro('test', fn (string $str) => $str === 'foo'
             ? 'it works!'
@@ -17,7 +18,7 @@ class SupportMailTest extends TestCase
         $this->assertEquals('it works!', Mail::test('foo'));
     }
 
-    public function testItRegisterAndCallMacrosWhenFaked()
+    public function testItRegisterAndCallMacrosWhenFaked(): void
     {
         Mail::macro('test', fn (string $str) => $str === 'foo'
             ? 'it works!'
@@ -27,5 +28,24 @@ class SupportMailTest extends TestCase
         Mail::fake();
 
         $this->assertEquals('it works!', Mail::test('foo'));
+    }
+
+    public function testEmailSent(): void
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        Mail::to('hello@laravel.com')->send(new TestMail());
+
+        Mail::assertSent(TestMail::class);
+    }
+}
+
+
+class TestMail extends Mailable
+{
+    public function build(): self
+    {
+        return $this->view('view');
     }
 }


### PR DESCRIPTION
This PR adds a test case to cover the sending of mailables when using `Mail::fake()`