### PR TITLE
[10.x] Remove unnecessary `if` statement in `Str::length`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -473,11 +473,7 @@ class Str
      */
     public static function length($value, $encoding = null)
     {
-        if ($encoding) {
-            return mb_strlen($value, $encoding);
-        }
-
-        return mb_strlen($value);
+        return mb_strlen($value, $encoding);
     }
 
     /**


### PR DESCRIPTION
Since PHP 8, the default value of `encoding` parameter of `mb_strlen` function is `null`, therefore the `if` statement here is not needed anymore.

Reference:
https://www.php.net/manual/en/function.mb-strlen.php