### PR TITLE
[10.x] docs: `getAllTables` return type form `void` to `array`

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -364,7 +364,7 @@ class Builder
     /**
      * Get all of the table names for the database.
      *
-     * @return void
+     * @return array
      *
      * @throws \LogicException
      */

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -25,7 +25,7 @@ namespace Illuminate\Support\Facades;
  * @method static void dropAllTables()
  * @method static void dropAllViews()
  * @method static void dropAllTypes()
- * @method static void getAllTables()
+ * @method static array getAllTables()
  * @method static void rename(string $from, string $to)
  * @method static bool enableForeignKeyConstraints()
  * @method static bool disableForeignKeyConstraints()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PhpStan fails to understand `getAllTables` return type, as the Facade's and Builder docblock points  void  
![image](https://user-images.githubusercontent.com/22406063/220150671-9d6df6b6-e988-4c5a-b4dc-700b1274b51a.png)
