### PR TITLE
[10.x] Facade Fake Awareness

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -60,9 +60,11 @@ class Bus extends Facade
      */
     public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)
     {
-        static::swap($fake = new BusFake(static::getFacadeRoot(), $jobsToFake, $batchRepository));
-
-        return $fake;
+        return tap(new BusFake(static::getFacadeRoot(), $jobsToFake, $batchRepository), function ($fake) {
+            if (! static::isFake()) {
+                static::swap($fake);
+            }
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -47,12 +47,14 @@ class Event extends Facade
      */
     public static function fake($eventsToFake = [])
     {
-        static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
+        return tap(new EventFake(static::getFacadeRoot(), $eventsToFake), function ($fake) {
+            if (! static::isFake()) {
+                static::swap($fake);
 
-        Model::setEventDispatcher($fake);
-        Cache::refreshEventDispatcher();
-
-        return $fake;
+                Model::setEventDispatcher($fake);
+                Cache::refreshEventDispatcher();
+            }
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -173,10 +173,9 @@ abstract class Facade
      * Hotswap the underlying instance behind the facade.
      *
      * @param  mixed  $instance
-     * @paramm  bool  $fake
      * @return void
      */
-    public static function swap($instance, $fake = false)
+    public static function swap($instance)
     {
 
         static::$resolvedInstance[static::getFacadeAccessor()] = $instance;

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -177,7 +177,6 @@ abstract class Facade
      */
     public static function swap($instance)
     {
-
         static::$resolvedInstance[static::getFacadeAccessor()] = $instance;
 
         if (isset(static::$app)) {

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -212,7 +212,7 @@ abstract class Facade
      *
      * @return string
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     protected static function getFacadeAccessor()
     {

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -3,17 +3,13 @@
 namespace Illuminate\Support\Facades;
 
 use Closure;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\Fake;
 use Mockery;
-use Mockery\Expectation;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use RuntimeException;
 
 abstract class Facade
@@ -21,7 +17,7 @@ abstract class Facade
     /**
      * The application instance being facaded.
      *
-     * @var Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected static $app;
 
@@ -42,7 +38,7 @@ abstract class Facade
     /**
      * Run a Closure when the facade has been resolved.
      *
-     * @param  Closure  $callback
+     * @param  \Closure  $callback
      * @return void
      */
     public static function resolved(Closure $callback)
@@ -61,7 +57,7 @@ abstract class Facade
     /**
      * Convert the facade into a Mockery spy.
      *
-     * @return MockInterface
+     * @return \Mockery\MockInterface
      */
     public static function spy()
     {
@@ -77,7 +73,7 @@ abstract class Facade
     /**
      * Initiate a partial mock on the facade.
      *
-     * @return MockInterface
+     * @return \Mockery\MockInterface
      */
     public static function partialMock()
     {
@@ -93,7 +89,7 @@ abstract class Facade
     /**
      * Initiate a mock expectation on the facade.
      *
-     * @return Expectation
+     * @return \Mockery\Expectation
      */
     public static function shouldReceive()
     {
@@ -109,7 +105,7 @@ abstract class Facade
     /**
      * Initiate a mock expectation on the facade.
      *
-     * @return Expectation
+     * @return \Mockery\Expectation
      */
     public static function expects()
     {
@@ -125,7 +121,7 @@ abstract class Facade
     /**
      * Create a fresh mock instance for the given class.
      *
-     * @return MockInterface
+     * @return \Mockery\MockInterface
      */
     protected static function createFreshMockInstance()
     {
@@ -139,7 +135,7 @@ abstract class Facade
     /**
      * Create a fresh mock instance for the given class.
      *
-     * @return MockInterface
+     * @return \Mockery\MockInterface
      */
     protected static function createMock()
     {
@@ -270,7 +266,7 @@ abstract class Facade
     /**
      * Get the application default aliases.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     public static function defaultAliases()
     {
@@ -321,7 +317,7 @@ abstract class Facade
     /**
      * Get the application instance behind the facade.
      *
-     * @return Application
+     * @return \Illuminate\Contracts\Foundation\Application
      */
     public static function getFacadeApplication()
     {
@@ -331,7 +327,7 @@ abstract class Facade
     /**
      * Set the application instance.
      *
-     * @param  Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public static function setFacadeApplication($app)
@@ -346,7 +342,7 @@ abstract class Facade
      * @param  array  $args
      * @return mixed
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public static function __callStatic($method, $args)
     {

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -3,12 +3,17 @@
 namespace Illuminate\Support\Facades;
 
 use Closure;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Js;
 use Illuminate\Support\Str;
+use Illuminate\Support\Testing\Fakes\Fake;
 use Mockery;
+use Mockery\Expectation;
 use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use RuntimeException;
 
 abstract class Facade
@@ -16,7 +21,7 @@ abstract class Facade
     /**
      * The application instance being facaded.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var Application
      */
     protected static $app;
 
@@ -37,7 +42,7 @@ abstract class Facade
     /**
      * Run a Closure when the facade has been resolved.
      *
-     * @param  \Closure  $callback
+     * @param  Closure  $callback
      * @return void
      */
     public static function resolved(Closure $callback)
@@ -56,7 +61,7 @@ abstract class Facade
     /**
      * Convert the facade into a Mockery spy.
      *
-     * @return \Mockery\MockInterface
+     * @return MockInterface
      */
     public static function spy()
     {
@@ -72,7 +77,7 @@ abstract class Facade
     /**
      * Initiate a partial mock on the facade.
      *
-     * @return \Mockery\MockInterface
+     * @return MockInterface
      */
     public static function partialMock()
     {
@@ -88,7 +93,7 @@ abstract class Facade
     /**
      * Initiate a mock expectation on the facade.
      *
-     * @return \Mockery\Expectation
+     * @return Expectation
      */
     public static function shouldReceive()
     {
@@ -104,7 +109,7 @@ abstract class Facade
     /**
      * Initiate a mock expectation on the facade.
      *
-     * @return \Mockery\Expectation
+     * @return Expectation
      */
     public static function expects()
     {
@@ -120,7 +125,7 @@ abstract class Facade
     /**
      * Create a fresh mock instance for the given class.
      *
-     * @return \Mockery\MockInterface
+     * @return MockInterface
      */
     protected static function createFreshMockInstance()
     {
@@ -134,7 +139,7 @@ abstract class Facade
     /**
      * Create a fresh mock instance for the given class.
      *
-     * @return \Mockery\MockInterface
+     * @return MockInterface
      */
     protected static function createMock()
     {
@@ -172,15 +177,30 @@ abstract class Facade
      * Hotswap the underlying instance behind the facade.
      *
      * @param  mixed  $instance
+     * @paramm  bool  $fake
      * @return void
      */
-    public static function swap($instance)
+    public static function swap($instance, $fake = false)
     {
+
         static::$resolvedInstance[static::getFacadeAccessor()] = $instance;
 
         if (isset(static::$app)) {
             static::$app->instance(static::getFacadeAccessor(), $instance);
         }
+    }
+
+    /**
+     * Determines whether a "fake" is set as the instance of the facade.
+     *
+     * @return bool
+     */
+    protected static function isFake(): bool
+    {
+        $name = static::getFacadeAccessor();
+
+        return isset(static::$resolvedInstance[$name]) &&
+            static::$resolvedInstance[$name] instanceof Fake;
     }
 
     /**
@@ -198,7 +218,7 @@ abstract class Facade
      *
      * @return string
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     protected static function getFacadeAccessor()
     {
@@ -250,7 +270,7 @@ abstract class Facade
     /**
      * Get the application default aliases.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public static function defaultAliases()
     {
@@ -301,7 +321,7 @@ abstract class Facade
     /**
      * Get the application instance behind the facade.
      *
-     * @return \Illuminate\Contracts\Foundation\Application
+     * @return Application
      */
     public static function getFacadeApplication()
     {
@@ -311,7 +331,7 @@ abstract class Facade
     /**
      * Set the application instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  Application  $app
      * @return void
      */
     public static function setFacadeApplication($app)
@@ -326,7 +346,7 @@ abstract class Facade
      * @param  array  $args
      * @return mixed
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public static function __callStatic($method, $args)
     {

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -185,16 +185,16 @@ abstract class Facade
     }
 
     /**
-     * Determines whether a "fake" is set as the instance of the facade.
+     * Determines whether a "fake" has been set as the facade instance.
      *
      * @return bool
      */
-    protected static function isFake(): bool
+    protected static function isFake()
     {
         $name = static::getFacadeAccessor();
 
         return isset(static::$resolvedInstance[$name]) &&
-            static::$resolvedInstance[$name] instanceof Fake;
+               static::$resolvedInstance[$name] instanceof Fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -65,9 +65,11 @@ class Mail extends Facade
      */
     public static function fake()
     {
-        static::swap($fake = new MailFake(static::getFacadeRoot()));
-
-        return $fake;
+        return tap(new MailFake(static::getFacadeRoot()), function ($fake) {
+            if (! static::isFake()) {
+                static::swap($fake);
+            }
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -49,9 +49,11 @@ class Notification extends Facade
      */
     public static function fake()
     {
-        static::swap($fake = new NotificationFake);
-
-        return $fake;
+        return tap(new NotificationFake(), function ($fake) {
+            if (! static::isFake()) {
+                static::swap($fake);
+            }
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -76,9 +76,12 @@ class Queue extends Facade
      */
     public static function fake($jobsToFake = [])
     {
-        static::swap($fake = new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()));
+        tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()), function ($fake) {
+            if (! static::isFake()) {
+                static::swap($fake);
+            }
+        });
 
-        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -81,7 +81,6 @@ class Queue extends Facade
                 static::swap($fake);
             }
         });
-
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class BusFake implements QueueingDispatcher
+class BusFake implements Fake, QueueingDispatcher
 {
     use ReflectsClosures;
 

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionFunction;
 
-class EventFake implements Dispatcher
+class EventFake implements Dispatcher, Fake
 {
     use ForwardsCalls, ReflectsClosures;
 

--- a/src/Illuminate/Support/Testing/Fakes/Fake.php
+++ b/src/Illuminate/Support/Testing/Fakes/Fake.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+interface Fake
+{
+    //
+}

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class MailFake implements Factory, Mailer, MailQueue
+class MailFake implements Factory, Fake, Mailer, MailQueue
 {
     use ForwardsCalls, ReflectsClosures;
 

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class NotificationFake implements NotificationDispatcher, NotificationFactory
+class NotificationFake implements Fake, NotificationDispatcher, NotificationFactory
 {
     use Macroable, ReflectsClosures;
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class QueueFake extends QueueManager implements Queue
+class QueueFake extends QueueManager implements Fake, Queue
 {
     use ReflectsClosures;
 

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -48,9 +48,9 @@ class UniqueJobTest extends TestCase
             $this->app->get(Cache::class)->lock($this->getLockKey(UniqueTestJob::class), 10)->get()
         );
 
-        Bus::fake();
+        Bus::assertDispatchedTimes(UniqueTestJob::class);
         UniqueTestJob::dispatch();
-        Bus::assertNotDispatched(UniqueTestJob::class);
+        Bus::assertDispatchedTimes(UniqueTestJob::class);
 
         $this->assertFalse(
             $this->app->get(Cache::class)->lock($this->getLockKey(UniqueTestJob::class), 10)->get()


### PR DESCRIPTION
## Description

This PR attempts to address a [slight issue](https://github.com/laravel/framework/issues/46180) with Facade fakes. Currently, if a facade fake requires an instance of the root as a constructor argument. (e.g. `MailFake::__construct()` or `BusFake::__construct()`), then calling `fake()` more than once can cause tests to fail in userland.

Let's consider the following scenario that currently passes in 9.x:

```php
<?php

namespace Tests

use Illuminate\Support\Facades\Mail;
use Tests\TestCase;

class ExampleTest extends TestCase
{
    public function setUp(): void
    {
        // ...
        Mail::fake();
        // ...
    }

    // ...


    public function testItWorks(): void
    {
        Mail::fake();

        // ...
    }
}
```

This test case runs perfectly fine on Laravel < 10.0.0, but due to the merge of #45988 and #46055 will fail in Laravel >= 10.0.0. This is because we end up with a small loop:

`Mail::fake()` loads `Mail::getFacadeRoot()` (also resolvable as `app('mail.manager')`) as a constructor argument of `MailFake`. On the first attempt, this call resolves to the correct `MailManager`. However on the second pass, the binding to `mail.manager` has been swapped out with the new `MailFake` instance in the container. Causing errors like this one:

```bash
Illuminate\Support\Testing\Fakes\MailFake::__construct(): Argument #1 ($manager) must be of type 
Illuminate\Mail\MailManager, Illuminate\Support\Testing\Fakes\MailFake given, called in 
/var/www/vendor/laravel/framework/src/Illuminate/Support/Facades/Mail.php on line 68
```

---

## Solution

To solve this issue, I've created a new `\Illuminate\Support\Testing\Fakes\Fake` interface that is used to determine if the current facade root is being "faked". If that's the case, then in the facade itself I skip the call to `static::swap(...)`.

I've then taken inspiration from `isMock()` used for determining if the facade is a mockery instance during for testing and added a new `protected function isFake()` which is checked inside the `fake()`:

```php
$fake = // ...

return tap($fake, function ($fake) {
    if (!static::isFake()) {
        static::swap($fake);

        // ...
    }
});
```


### Facades updated

| Facade | Done |
| ---  | --- |
| Bus | ✅  |
| Event | ✅ |
| Mail  | ✅ |
| Notification  | ✅ |
| Queue  | ✅ |