### PR TITLE
[10.x] Add `fragment*` signatures to view interface

### DIFF
--- a/src/Illuminate/Contracts/View/View.php
+++ b/src/Illuminate/Contracts/View/View.php
@@ -28,4 +28,38 @@ interface View extends Renderable
      * @return array
      */
     public function getData();
+
+    /**
+     * Get the evaluated contents of a given fragment.
+     *
+     * @param  string  $fragment
+     * @return string
+     */
+    public function fragment($fragment);
+
+    /**
+     * Get the evaluated contents for a given array of fragments.
+     *
+     * @param  array  $fragments
+     * @return string
+     */
+    public function fragments(array $fragments);
+
+    /**
+     * Get the evaluated contents of a given fragment if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  string  $fragment
+     * @return string
+     */
+    public function fragmentIf($boolean, $fragment);
+
+    /**
+     * Get the evaluated contents for a given array of fragments if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  array  $fragments
+     * @return string
+     */
+    public function fragmentsIf($boolean, array $fragments);
 }


### PR DESCRIPTION
### Description

While working on a Blade & HTMX project, I've noticed my editor not being aware of the `fragment*` methods on the `view()` helper. The helper returns interfaces that does not implement the method signature for said methods.

During this PR I've noticed several public methods are not on the interface, I am unsure if this is by choice however, so I've left them out (for now).

If this is indeed a breaking change, perhaps another solution could be raised.

### Solution

Added signatures for all `fragment*` methods on `Illuminate\Contracts\View\View`.

### Benefit

Editor/IDE & end users aware of method being available.