### PR TITLE
[10.x] Added possibility to globally set timeout setting via env variable

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -227,7 +227,7 @@ class PendingRequest
         $this->options = [
             'connect_timeout' => 10,
             'http_errors' => false,
-            'timeout' => 30,
+            'timeout' => env('HTTP_CLIENT_TIMEOUT', 30)
         ];
 
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $pendingRequest) {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -227,7 +227,7 @@ class PendingRequest
         $this->options = [
             'connect_timeout' => 10,
             'http_errors' => false,
-            'timeout' => env('HTTP_CLIENT_TIMEOUT', 30)
+            'timeout' => env('HTTP_CLIENT_TIMEOUT', 30),
         ];
 
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $pendingRequest) {


### PR DESCRIPTION
Having third-party libraries that depends on the HTTP Client, we found the need to be able to globally set a higher timeout threshold. 

This leaves the standard timeout as 30 seconds. 