### PR TITLE
[10.x] Fix custom themes not reseting on Markdown renderer

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -324,9 +324,7 @@ class Mailable implements MailableContract, Renderable
     {
         $markdown = Container::getInstance()->make(Markdown::class);
 
-        if (isset($this->theme)) {
-            $markdown->theme($this->theme);
-        }
+        $markdown->theme($this->theme ?? 'default');
 
         $data = $this->buildViewData();
 


### PR DESCRIPTION
This fixes the issue described in #46179. It should reset the theme to `'default'` on the Markdown renderer object if no `$theme` is set on the `Mailable` object. I've also added a test for this. This PR does not introduce any breaking changes.

There's a small inconsistency between `Mailable` and `Markdown` classes, the `Mailable` class has a default `$theme` value of `null` (implicitly the default theme), however `Markdown` has a default theme value of `'default'` ([here](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Mail/Mailable.php#L166) and [here](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Mail/Markdown.php#L28)). But fixing this inconsistency _might_ be a breaking change, so not sure if you'd want to fix it.