### PR TITLE
[10.x] Accept time when generating ULID

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1380,7 +1380,11 @@ class Str
      */
     public static function ulid($time = null)
     {
-        return Ulid::generate($time);
+        if ($time === null) {
+            return new Ulid();
+        }
+
+        return new Ulid(Ulid::generate($time));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1375,11 +1375,12 @@ class Str
     /**
      * Generate a ULID.
      *
+     * @param  \DateTimeInterface|null  $time
      * @return \Symfony\Component\Uid\Ulid
      */
-    public static function ulid()
+    public static function ulid($time = null)
     {
-        return new Ulid();
+        return Ulid::generate($time);
     }
 
     /**


### PR DESCRIPTION
Currently `Str::ulid()` doesn't accept a time, although the underlying Symfony class does have a `generate` method that does accept it.

When migrating models from integer IDs to ULIDs, it's nice if you can keep the creation timestamp in the ULID.
This PR enables that.

Not sure what laravel/framework uses for type declarations, so let me know if anything needs changing.