### PR TITLE
[10.x] Add the ability to re-resolve cache drivers

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -91,7 +91,7 @@ class CacheManager implements FactoryContract
      *
      * @throws \InvalidArgumentException
      */
-    protected function resolve($name)
+    public function resolve($name)
     {
         $config = $this->getConfig($name);
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -589,7 +589,7 @@ class Repository implements ArrayAccess, CacheContract
      * Set the cache store implementation.
      *
      * @param \Illuminate\Contracts\Cache\Store
-     * @return Repository
+     * @return static
      */
     public function setStore($store)
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -586,6 +586,19 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Set the cache store implementation.
+     *
+     * @param \Illuminate\Contracts\Cache\Store
+     * @return Repository
+     */
+    public function setStore($store)
+    {
+        $this->store = $store;
+
+        return $this;
+    }
+
+    /**
      * Fire an event for this cache instance.
      *
      * @param  object|string  $event

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -113,4 +113,11 @@ interface Repository extends CacheInterface
      * @return \Illuminate\Contracts\Cache\Store
      */
     public function getStore();
+
+    /**
+     * Set the cache store implementation.
+     *
+     * @return static
+     */
+    public function setStore();
 }

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -117,7 +117,8 @@ interface Repository extends CacheInterface
     /**
      * Set the cache store implementation.
      *
+     * @param \Illuminate\Contracts\Cache\Store
      * @return static
      */
-    public function setStore();
+    public function setStore($store);
 }

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -113,12 +113,4 @@ interface Repository extends CacheInterface
      * @return \Illuminate\Contracts\Cache\Store
      */
     public function getStore();
-
-    /**
-     * Set the cache store implementation.
-     *
-     * @param \Illuminate\Contracts\Cache\Store
-     * @return static
-     */
-    public function setStore($store);
 }


### PR DESCRIPTION
We're working on improving our cache tenancy support in [Tenancy for Laravel](https://github.com/archtechx/tenancy) and one of the things we'd need would be the ability to re-resolve the drivers for cache stores.

Currently (in v3), we only support Redis since we use cache tags to scope cache for tenants.

In v4, we'd like to have driver-agnostic cache tenancy using prefixes. We already have all of the code written (and tested with a laravel/framework fork that includes the changes from this PR) so we'd only need this added in Laravel.

We experimented with several different implementations and this is the one that requires the least changes to Laravel. It essentially only makes one method public and adds a setter to `Illuminate\Cache\Repository`.

The changes here could _in theory_ be breaking if:
1. someone overrode the `resolve()` method in `Illuminate\Cache\Manager` and kept it `protected`
2. someone had a custom `setStore()` in `Illuminate\Cache\Repository`. We tried to avoid this being a problem by making the method as predictable as possible, so it's a setter that does exactly what its name implies.

I think both of these changes are very low-risk and easily fixable if anyone overrode these methods. We also avoided touching any contracts and only changed the default classes that implement them.

(Please squash when merging)