### PR TITLE
[9.x] Tests for Multi byte string in blade files 🔍

### DIFF
--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -22,11 +22,13 @@ class BladeEscapedTest extends AbstractBladeTestCase
         $template = '
 @foreach($cols as $col)
     @@foreach($issues as $issue_45915)
+        👋 سلام 👋
     @@endforeach
 @endforeach';
         $compiled = '
 <?php $__currentLoopData = $cols; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $col): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>
     @foreach($issues as $issue_45915)
+        👋 سلام 👋
     @endforeach
 <?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
         $this->assertSame($compiled, $this->compiler->compileString($template));


### PR DESCRIPTION
- If you change the `strpos` to `mb_strpos`, the functionality will break for blade files containing multi-byte strings, but no tests will fail. So it is safer to have some of those characters in those blade files.

- It also removes some extra code originally copied/pasted from illuminate/Str class.
Here we never can have an int or an empty string passed into this method.

![image](https://user-images.githubusercontent.com/6961695/220388263-74385bea-19e4-490d-b8c1-9431c7e29280.png)
