### PR TITLE
[9.x] Add orderByField query builder method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2338,6 +2338,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Put the query's results in field order.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function orderByField($column, $values)
+    {
+        return $this->orderByRaw($this->grammar->compileOrderField($column, $values));
+    }
+
+    /**
      * Add a raw "order by" clause to the query.
      *
      * @param  string  $sql

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -887,6 +887,18 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the order by field statement into SQL.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return string
+     */
+    public function compileOrderField($column, $values)
+    {
+        throw new RuntimeException('This database engine does not support ordering by field.');
+    }
+
+    /**
      * Compile the "limit" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -166,6 +166,11 @@ class MySqlGrammar extends Grammar
         return 'RAND('.$seed.')';
     }
 
+    public function compileOrderField($column, $values)
+    {
+        return 'field('.$this->wrap($column).', '.implode(', ', $values).')';
+    }
+
     /**
      * Compile the lock into SQL.
      *

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1572,6 +1572,27 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from [users] order by NEWID()', $builder->toSql());
     }
 
+    public function testFieldOrderMySql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->orderByField('id', [42, 1, 1000]);
+        $this->assertSame('select * from `users` order by field(`id`, 42, 1, 1000)', $builder->toSql());
+    }
+
+    public function testFieldOrderPostgres()
+    {
+        $this->expectException(RuntimeException::class);
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->orderByField('id', [42, 1, 1000]);
+    }
+
+    public function testFieldOrderSqlServer()
+    {
+        $this->expectException(RuntimeException::class);
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderByField('id', [42, 1, 1000]);
+    }
+
     public function testOrderBysSqlServer()
     {
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR add a `orderByField` query builder method that is only supporter by MySQL grammar.

```php
$keys = [42, 1, 1000];

$models = Users::query()
    ->whereKey($keys)
    ->orderByField('id', $keys)
    ->get();
```