### PR TITLE
[10.x] Fix missing `pid` method

### DIFF
--- a/src/Illuminate/Contracts/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Process/InvokedProcess.php
@@ -9,7 +9,7 @@ interface InvokedProcess
      *
      * @return int|null
      */
-    public function id();
+    public function pid();
 
     /**
      * Send a signal to the process.

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -72,13 +72,24 @@ class FakeInvokedProcess implements InvokedProcessContract
     /**
      * Get the process ID if the process is still running.
      *
+     * @alias id
      * @return int|null
      */
-    public function id()
+    public function pid()
     {
         $this->invokeOutputHandlerWithNextLineOfOutput();
 
         return $this->process->processId;
+    }
+
+    /**
+     * Get the process ID if the process is still running.
+     *
+     * @return int|null
+     */
+    public function id()
+    {
+        return $this->pid();
     }
 
     /**

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -19,7 +19,7 @@ class InvokedProcess implements InvokedProcessContract
     /**
      * Create a new invoked process instance.
      *
-     * @param  \Symfony\Component\Process\Process  $process
+     * @param  \Symfony\Component\Process\Process $process
      * @return void
      */
     public function __construct(Process $process)
@@ -38,9 +38,19 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Get the process ID if the process is still running.
+     * @alias pid
+     * @return int|null
+     */
+    public function pid()
+    {
+        return $this->process->getPid();
+    }
+
+    /**
      * Send a signal to the process.
      *
-     * @param  int  $signal
+     * @param  int $signal
      * @return $this
      */
     public function signal(int $signal)
@@ -103,7 +113,7 @@ class InvokedProcess implements InvokedProcessContract
     /**
      * Wait for the process to finish.
      *
-     * @param  callable|null  $output
+     * @param  callable|null $output
      * @return \Illuminate\Process\ProcessResult
      */
     public function wait(callable $output = null)


### PR DESCRIPTION
The [documentation](https://laravel.com/docs/10.x/processes#process-ids-and-signals) says to get the pid of a running process using the `pid` method but that method doesn't exist, it should be `id`.

![Screenshot from 2023-02-22 01-14-54](https://user-images.githubusercontent.com/37969970/220418281-5937db6d-449d-4ce5-a8f9-01fb5c167ee4.png)

But based on the use of a well-known term among developers and sysadmins and also in some well-known software the name is `pid`.

Look at the image below, marked in red

## lsof
![Screenshot from 2023-02-22 01-34-28](https://user-images.githubusercontent.com/37969970/220419094-0320b782-814c-4f26-be84-03196d69428d.png)

## netstat
![Screenshot from 2023-02-22 01-34-37](https://user-images.githubusercontent.com/37969970/220419103-67a6bdee-b7b1-4103-8b3b-cb01125bd563.png)

Based on that, I think the term `pid` is better and `id` can still be used.
