### PR TITLE
[10.x] Unifies static constructor

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -60,6 +60,19 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
+     * Create a new resource or anonymous resource collection.
+     *
+     * @param  mixed  $resource
+     * @return static|\Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public static function from($resource)
+    {
+        return is_iterable($resource)
+            ? static::collection($resource)
+            : static::make($resource);
+    }
+
+    /**
      * Create a new resource instance.
      *
      * @param  mixed  ...$parameters

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
 use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MergeValue;
 use Illuminate\Http\Resources\MissingValue;
@@ -45,6 +46,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\Subscription;
 use LogicException;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
+use stdClass;
 
 class ResourceTest extends TestCase
 {
@@ -1640,6 +1642,16 @@ class ResourceTest extends TestCase
             1 => 20,
             'total' => 30,
         ], ['data' => [0 => 10, 1 => 20, 'total' => 30]]);
+    }
+
+    public function testFromMethod()
+    {
+        $this->assertInstanceOf(JsonResource::class, JsonResource::from(new stdClass));
+        $this->assertInstanceOf(JsonResource::class, JsonResource::from('foo'));
+
+        $this->assertInstanceOf(AnonymousResourceCollection::class, JsonResource::from(['foo']));
+        $this->assertInstanceOf(AnonymousResourceCollection::class, JsonResource::from(['foo' => 'bar']));
+        $this->assertInstanceOf(AnonymousResourceCollection::class, JsonResource::from(collect()));
     }
 
     private function assertJsonResourceResponse($data, $expectedJson)

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
 use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Request;
@@ -1648,6 +1649,7 @@ class ResourceTest extends TestCase
     {
         $this->assertInstanceOf(JsonResource::class, JsonResource::from(new stdClass));
         $this->assertInstanceOf(JsonResource::class, JsonResource::from('foo'));
+        $this->assertInstanceOf(JsonResource::class, JsonResource::from(new User()));
 
         $this->assertInstanceOf(AnonymousResourceCollection::class, JsonResource::from(['foo']));
         $this->assertInstanceOf(AnonymousResourceCollection::class, JsonResource::from(['foo' => 'bar']));


### PR DESCRIPTION
this is potentially a bad idea 🤷‍♂️

Simplifies the 90% use-case for `JsonResource` static constructors into a single API. The following:

```php
UserResource::make($user);

// returns UserResource

UserResource::collection($users);

// return AnonymousCollection
```

is unified under a single API:

```php
UserResource::from($user);

// returns UserResource

UserResource::from($users);

// return AnonymousCollection
```

This falls apart for a resource of a hash, but I figure that 99% of the time these are used with Eloquent models and collections of models.

I think we should only merge this if we think it would be the documented way of doing things.