### PR TITLE
[10.x] Simplifies collection customisation

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -78,11 +78,22 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return tap(new AnonymousResourceCollection($resource, static::class), function ($collection) {
+        return tap(static::newCollection($resource), function ($collection) {
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
         });
+    }
+
+    /**
+     * Create a new resource collection instance.
+     *
+     * @param  mixed  $resource
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    protected static function newCollection($resource)
+    {
+        return new AnonymousResourceCollection($resource, static::class);
     }
 
     /**


### PR DESCRIPTION
This makes is much easier to change the collection type of a `JsonResource` while still maintaining the `preserveKeys` functionality.

Classes can now just extend the `newCollection` method and return their own custom implementation.

I've wanted this while building out my JSON:API resource package.