### PR TITLE
[10.x] Alternative to the stringy middleware API

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1048,12 +1048,9 @@ class Route
             $middleware = func_get_args();
         }
 
-        foreach ($middleware as $index => $value) {
-            $middleware[$index] = (string) $value;
-        }
-
         $this->action['middleware'] = array_merge(
-            (array) ($this->action['middleware'] ?? []), $middleware
+            (array) ($this->action['middleware'] ?? []),
+            $this->router->parseMiddleware($middleware),
         );
 
         return $this;

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
 use InvalidArgumentException;
 
@@ -111,15 +112,7 @@ class RouteRegistrar
         }
 
         if ($key === 'middleware') {
-            $middleware = [];
-
-            foreach ($value as $k => $v) {
-                $middleware[] = (string) is_string($k)
-                    ? $k.':'.implode(',', $v)
-                    : $v;
-            }
-
-            $value = $middleware;
+            $value = $this->router->parseMiddleware($value);
         }
 
         $attributeKey = Arr::get($this->aliases, $key, $key);

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -111,9 +111,15 @@ class RouteRegistrar
         }
 
         if ($key === 'middleware') {
-            foreach ($value as $index => $middleware) {
-                $value[$index] = (string) $middleware;
+            $middleware = [];
+
+            foreach ($value as $k => $v) {
+                $middleware[] = (string) is_string($k)
+                    ? $k.':'.implode(',', $v)
+                    : $v;
             }
+
+            $value = $middleware;
         }
 
         $attributeKey = Arr::get($this->aliases, $key, $key);

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -5,7 +5,6 @@ namespace Illuminate\Routing;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
 use InvalidArgumentException;
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1437,6 +1437,22 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Parse an array of middleware.
+     *
+     * @param  array  $middleware
+     * @return array
+     */
+    public function parseMiddleware($middleware)
+    {
+        return Collection::make($middleware)
+            ->map(fn ($value, $key) => is_int($key)
+                ? (string) $value
+                : $key.':'.Collection::wrap($value)->implode(','))
+            ->values()
+            ->all();
+    }
+
+    /**
      * Set the container instance used by the router.
      *
      * @param  \Illuminate\Container\Container  $container

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1447,7 +1447,9 @@ class Router implements BindingRegistrar, RegistrarContract
         return Collection::make($middleware)
             ->map(fn ($value, $key) => is_int($key)
                 ? (string) $value
-                : $key.':'.Collection::wrap($value)->implode(','))
+                : $key.':'.Collection::wrap($value)
+                    ->map(fn ($v) => $v === false ? '0' : $v)
+                    ->implode(','))
             ->values()
             ->all();
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use ArrayObject;
+use BackedEnum;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -1449,6 +1450,8 @@ class Router implements BindingRegistrar, RegistrarContract
                 ? (string) $value
                 : $key.':'.Collection::wrap($value)
                     ->map(fn ($v) => $v === false ? '0' : $v)
+                    ->map(fn ($v) => $v instanceof BackedEnum ? $v->value : $v)
+                    ->map(fn ($v) => (string) $v)
                     ->implode(','))
             ->values()
             ->all();

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1449,9 +1449,9 @@ class Router implements BindingRegistrar, RegistrarContract
             ->map(fn ($value, $key) => is_int($key)
                 ? (string) $value
                 : $key.':'.Collection::wrap($value)
-                    ->map(fn ($v) => $v === false ? '0' : $v)
-                    ->map(fn ($v) => $v instanceof BackedEnum ? $v->value : $v)
-                    ->map(fn ($v) => (string) $v)
+                    ->map(fn ($v) => $v instanceof BackedEnum
+                        ? (string) $v->value
+                        : (string) $v)
                     ->implode(','))
             ->values()
             ->all();

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -33,11 +33,42 @@ class RouteRegistrarTest extends TestCase
 
     public function testMiddlewareAsHash()
     {
+        $this->router->middleware(['one:1', 'two' => '2'])->get('users', function () {
+            return 'all-users';
+        });
+        $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(['one:1', 'two' => '2']);
+        $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
+
         $this->router->middleware(['one:1', 'two' => ['2']])->get('users', function () {
             return 'all-users';
         });
-
         $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(['one:1', 'two' => ['2']]);
+        $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
+
+        $this->router->middleware(['one:1', 'two' => ['2', 3, 'four', ' five ']])->get('users', function () {
+            return 'all-users';
+        });
+        $this->assertEquals(['one:1', 'two:2,3,four, five '], $this->getRoute()->middleware());
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(['one:1', 'two' => ['2', 3, 'four', ' five ']]);
+        $this->assertEquals(['one:1', 'two:2,3,four, five '], $this->getRoute()->middleware());
+
+        $this->router->middleware(['one:1', 'two' => []])->get('users', function () {
+            return 'all-users';
+        });
+        $this->assertEquals(['one:1', 'two:'], $this->getRoute()->middleware());
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(['one:1', 'two' => []]);
+        $this->assertEquals(['one:1', 'two:'], $this->getRoute()->middleware());
     }
 
     public function testMiddlewareFluentRegistration()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -31,6 +31,15 @@ class RouteRegistrarTest extends TestCase
         m::close();
     }
 
+    public function testMiddlewareAsHash()
+    {
+        $this->router->middleware(['one:1', 'two' => ['2']])->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
+    }
+
     public function testMiddlewareFluentRegistration()
     {
         $this->router->middleware(['one', 'two'])->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -33,6 +33,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testMiddlewareAsHash()
     {
+        // single value without wrapper...
+
         $this->router->middleware(['one:1', 'two' => '2'])->get('users', function () {
             return 'all-users';
         });
@@ -43,32 +45,53 @@ class RouteRegistrarTest extends TestCase
         })->middleware(['one:1', 'two' => '2']);
         $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
 
+        // single value...
+
         $this->router->middleware(['one:1', 'two' => ['2']])->get('users', function () {
             return 'all-users';
         });
         $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
+
         $this->router->get('users', function () {
             return 'all-users';
         })->middleware(['one:1', 'two' => ['2']]);
         $this->assertEquals(['one:1', 'two:2'], $this->getRoute()->middleware());
 
+        // multiple values...
+
         $this->router->middleware(['one:1', 'two' => ['2', 3, 'four', ' five ']])->get('users', function () {
             return 'all-users';
         });
         $this->assertEquals(['one:1', 'two:2,3,four, five '], $this->getRoute()->middleware());
+
         $this->router->get('users', function () {
             return 'all-users';
         })->middleware(['one:1', 'two' => ['2', 3, 'four', ' five ']]);
         $this->assertEquals(['one:1', 'two:2,3,four, five '], $this->getRoute()->middleware());
 
+        // empty array...
+
         $this->router->middleware(['one:1', 'two' => []])->get('users', function () {
             return 'all-users';
         });
         $this->assertEquals(['one:1', 'two:'], $this->getRoute()->middleware());
+
         $this->router->get('users', function () {
             return 'all-users';
         })->middleware(['one:1', 'two' => []]);
         $this->assertEquals(['one:1', 'two:'], $this->getRoute()->middleware());
+
+        // boolean casting
+
+        $this->router->middleware(['foo' => [true, false, true]])->get('users', function () {
+            return 'all-users';
+        });
+        $this->assertEquals(['foo:1,0,1'], $this->getRoute()->middleware());
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(['foo' => [true, false, true]]);
+        $this->assertEquals(['foo:1,0,1'], $this->getRoute()->middleware());
     }
 
     public function testMiddlewareFluentRegistration()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -86,12 +86,12 @@ class RouteRegistrarTest extends TestCase
         $this->router->middleware(['foo' => [true, false, true]])->get('users', function () {
             return 'all-users';
         });
-        $this->assertEquals(['foo:1,0,1'], $this->getRoute()->middleware());
+        $this->assertEquals(['foo:1,,1'], $this->getRoute()->middleware());
 
         $this->router->get('users', function () {
             return 'all-users';
         })->middleware(['foo' => [true, false, true]]);
-        $this->assertEquals(['foo:1,0,1'], $this->getRoute()->middleware());
+        $this->assertEquals(['foo:1,,1'], $this->getRoute()->middleware());
 
         // backed enum handling...
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -81,7 +81,7 @@ class RouteRegistrarTest extends TestCase
         })->middleware(['one:1', 'two' => []]);
         $this->assertEquals(['one:1', 'two:'], $this->getRoute()->middleware());
 
-        // boolean casting
+        // boolean casting...
 
         $this->router->middleware(['foo' => [true, false, true]])->get('users', function () {
             return 'all-users';
@@ -92,6 +92,18 @@ class RouteRegistrarTest extends TestCase
             return 'all-users';
         })->middleware(['foo' => [true, false, true]]);
         $this->assertEquals(['foo:1,0,1'], $this->getRoute()->middleware());
+
+        // backed enum handling...
+
+        $this->router->middleware(['foo' => [Suit::Diamonds, Suit::Clubs]])->get('users', function () {
+            return 'all-users';
+        });
+        $this->assertEquals(['foo:first,second'], $this->getRoute()->middleware());
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(['foo' => [Suit::Diamonds, Suit::Clubs]]);
+        $this->assertEquals(['foo:first,second'], $this->getRoute()->middleware());
     }
 
     public function testMiddlewareFluentRegistration()
@@ -1210,7 +1222,8 @@ class InvokableRouteRegistrarControllerStub
     }
 }
 
-class RouteRegistrarMiddlewareStub
+enum Suit: string
 {
-    //
+    case Diamonds = 'first';
+    case Clubs = 'second';
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2126,7 +2126,11 @@ class RoutingRouteTest extends TestCase
 
     public function testRouteCanMiddlewareCanBeAssigned()
     {
+        $container = new Container;
+        $router = new Router(new Dispatcher, $container);
         $route = new Route(['GET'], '/', []);
+        $route->setRouter($router);
+
         $route->middleware(['foo'])->can('create', Route::class);
 
         $this->assertEquals([
@@ -2134,7 +2138,10 @@ class RoutingRouteTest extends TestCase
             'can:create,Illuminate\Routing\Route',
         ], $route->middleware());
 
+        $container = new Container;
+        $router = new Router(new Dispatcher, $container);
         $route = new Route(['GET'], '/', []);
+        $route->setRouter($router);
         $route->can('create');
 
         $this->assertEquals([


### PR DESCRIPTION
This is simplified and framework first implementation of my [HasParameters](https://github.com/timacdonald/has-parameters/) package.

Removes the need to use string concatenation when specifying middleware. No need for middleware classes to extend a base class or use a trait. The framework just handles things.

> **Note** This is just a wrapper around the stringy API. The middleware classes still receive the string representation of the value.

## Using a middleware class

```php
// before

Route::etc()->middleware([
    MyMiddleware::class.':'.implode(',', [Foo::ONE, Foo::TWO]),
]);

// after

Route::etc()->middleware([
    MyMiddleware::class => [Foo::ONE, Foo::TWO],
]);
```

## Using a middleware alias

```php
// before

Route::etc()->middleware([
    'myAlias:'.implode(',', [Foo::ONE, Foo::TWO]),
]);

// after

Route::etc()->middleware([
    'myAlias' => [Foo::ONE, Foo::TWO],
]);
```

## Optional single value API

You may omit the array if it is a single value.

```php
// before

Route::etc()->middleware([
   'alias:'.Foo::ONE,
]);

// after

Route::etc()->middleware([
    'alias' => Foo::ONE,
]);
```

## Handles backed enums

Remember that all values are still cast to a string. The middleware does not receive the enum.

```php
// before

Route::etc()->middleware([
   'alias:'.Suit::Diamonds->value,
]);

// after

Route::etc()->middleware([
    'alias' => Suit::Diamonds,
]);
```