### PR TITLE
[10.x] Added JobPopping and JobPopped events

### DIFF
--- a/src/Illuminate/Queue/Events/JobPopped.php
+++ b/src/Illuminate/Queue/Events/JobPopped.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobPopped
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job|null
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->connectionName = $connectionName;
+        $this->job = $job;
+    }
+}

--- a/src/Illuminate/Queue/Events/JobPopping.php
+++ b/src/Illuminate/Queue/Events/JobPopping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobPopping
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @return void
+     */
+    public function __construct($connectionName)
+    {
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -611,7 +611,7 @@ class Worker
     }
 
     /**
-     * Raise the after job has been popped.
+     * Raise the before job has been popped.
      *
      * @param  string  $connectionName
      * @return void

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -350,12 +350,14 @@ class Worker
             if (isset(static::$popCallbacks[$this->name])) {
                 $job = (static::$popCallbacks[$this->name])($popJobCallback, $queue);
                 $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
+
                 return $job;
             }
 
             foreach (explode(',', $queue) as $queue) {
                 if (! is_null($job = $popJobCallback($queue))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
+
                     return $job;
                 }
             }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobPopped;
+use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
@@ -342,13 +344,18 @@ class Worker
             return $connection->pop($queue);
         };
 
+        $this->raiseBeforeJobPopEvent($connection->getConnectionName());
+
         try {
             if (isset(static::$popCallbacks[$this->name])) {
-                return (static::$popCallbacks[$this->name])($popJobCallback, $queue);
+                $job = (static::$popCallbacks[$this->name])($popJobCallback, $queue);
+                $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
+                return $job;
             }
 
             foreach (explode(',', $queue) as $queue) {
                 if (! is_null($job = $popJobCallback($queue))) {
+                    $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
                     return $job;
                 }
             }
@@ -599,6 +606,31 @@ class Worker
         );
 
         return (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
+    }
+
+    /**
+     * Raise the after job has been popped.
+     *
+     * @param  string  $connectionName
+     * @return void
+     */
+    protected function raiseBeforeJobPopEvent($connectionName)
+    {
+        $this->events->dispatch(new JobPopping($connectionName));
+    }
+
+    /**
+     * Raise the after job has been popped.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
+     * @return void
+     */
+    protected function raiseAfterJobPopEvent($connectionName, $job)
+    {
+        $this->events->dispatch(new JobPopped(
+            $connectionName, $job
+        ));
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -348,10 +348,10 @@ class Worker
 
         try {
             if (isset(static::$popCallbacks[$this->name])) {
-                $job = (static::$popCallbacks[$this->name])($popJobCallback, $queue);
-                $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
-
-                return $job;
+                return tap(
+                    (static::$popCallbacks[$this->name])($popJobCallback, $queue),
+                    fn ($job) => $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job)
+                );
             }
 
             foreach (explode(',', $queue) as $queue) {


### PR DESCRIPTION
Added two new events to monitor `queue:work`-process.

With these events is easy to make a listener which, for example, can update some file (or any other storage) on every pop-event with current timestamp. That particularly useful for k8s liveness probe.
Existing events `JobProcessing` and `JobProcessed` are useless in case when a queue is rarely pushed cause they raised only if some job has been popped.