### PR TITLE
[9.x] Fixes constructable migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -521,6 +521,10 @@ class Migrator
         $migration = static::$requiredPathCache[$path] ??= $this->files->getRequire($path);
 
         if (is_object($migration)) {
+            if (method_exists($migration, '__construct')) {
+                return $this->files->getRequire($path);
+            }
+
             return clone $migration;
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -521,11 +521,9 @@ class Migrator
         $migration = static::$requiredPathCache[$path] ??= $this->files->getRequire($path);
 
         if (is_object($migration)) {
-            if (method_exists($migration, '__construct')) {
-                return $this->files->getRequire($path);
-            }
-
-            return clone $migration;
+            return method_exists($migration, '__construct')
+                    ? $this->files->getRequire($path)
+                    : clone $migration;
         }
 
         return new $class;


### PR DESCRIPTION
This pull request addresses two issues. Firstly, it ensures that constructable migrations (migrations with `__construct` methods) are properly instantiated when a `__construct` is present, and if not, it simply reuses the previously created instance for performance and memory reasons. Secondly, it resolves an issue with telescope migrations that were holding a reference to the PDO Sqlite memory connection and preventing it from being dropped after each test.

This PR fixes the following: https://github.com/laravel/framework/issues/46205, https://github.com/laravel/passport/pull/1639.

@driesvints This fix needs to ported to 10.x