### PR TITLE
[9.x] Fix expectsDatabaseQueryCount() $connection parameter

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -178,17 +178,21 @@ trait InteractsWithDatabase
      */
     public function expectsDatabaseQueryCount($expected, $connection = null)
     {
-        with($this->getConnection($connection), function ($connectionObj) use ($expected, $connection) {
+        with($this->getConnection($connection), function ($connectionInstance) use ($expected, $connection) {
             $actual = 0;
 
-            $connectionObj->listen(function (QueryExecuted $event) use (&$actual, $connection) {
-                if ($connection === null || $event->connection->getName() === $connection) {
+            $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
+                if (is_null($connection) || $connectionInstance === $event->connection) {
                     $actual++;
                 }
             });
 
-            $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connectionObj) {
-                $this->assertSame($actual, $expected, "Expected {$expected} database queries on the [{$connectionObj->getName()}] connection. {$actual} occurred.");
+            $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connectionInstance) {
+                $this->assertSame(
+                    $actual,
+                    $expected,
+                    "Expected {$expected} database queries on the [{$connectionInstance->getName()}] connection. {$actual} occurred."
+                );
             });
         });
 


### PR DESCRIPTION
The listen() function was assuming that the event was being dispatched for just that connection, rather than globally.

Instead, we now check the connection name matches if it was provided.

Fixes #45932