### PR TITLE
[10.x] Refactor existing code to include function for dropping columns if th…

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -5,6 +5,8 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Fluent;
 use RuntimeException;
 
@@ -375,8 +377,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
-        $columns = $this->prefixArray('drop', $this->wrapArray($command->columns));
-
+        $columns = $this->prefixArray('drop column if exists', $this->wrapArray($command->columns));
         return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -5,8 +5,6 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Fluent;
 use RuntimeException;
 
@@ -378,6 +376,7 @@ class MySqlGrammar extends Grammar
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
         $columns = $this->prefixArray('drop column if exists', $this->wrapArray($command->columns));
+
         return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -413,7 +413,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
-        $columns = $this->prefixArray('drop column', $this->wrapArray($command->columns));
+        $columns = $this->prefixArray('drop column if exists', $this->wrapArray($command->columns));
 
         return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
     }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -207,21 +207,21 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` drop `foo`', $statements[0]);
+        $this->assertSame('alter table `users` drop column if exists `foo`', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn(['foo', 'bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+        $this->assertSame('alter table `users` drop column if exists `foo`, drop column if exists `bar`', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo', 'bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+        $this->assertSame('alter table `users` drop column if exists `foo`, drop column if exists `bar`', $statements[0]);
     }
 
     public function testDropPrimary()
@@ -281,7 +281,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+        $this->assertSame('alter table `users` drop column if exists `created_at`, drop column if exists `updated_at`', $statements[0]);
     }
 
     public function testDropTimestampsTz()
@@ -291,7 +291,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+        $this->assertSame('alter table `users` drop column if exists `created_at`, drop column if exists `updated_at`', $statements[0]);
     }
 
     public function testDropMorphs()
@@ -302,7 +302,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $this->assertSame('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
-        $this->assertSame('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
+        $this->assertSame('alter table `photos` drop column if exists `imageable_type`, drop column if exists `imageable_id`', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -120,21 +120,21 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop column "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop column if exists "foo"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn(['foo', 'bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
+        $this->assertSame('alter table "users" drop column if exists "foo", drop column if exists "bar"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo', 'bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
+        $this->assertSame('alter table "users" drop column if exists "foo", drop column if exists "bar"', $statements[0]);
     }
 
     public function testDropPrimary()
@@ -194,7 +194,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
+        $this->assertSame('alter table "users" drop column if exists "created_at", drop column if exists "updated_at"', $statements[0]);
     }
 
     public function testDropTimestampsTz()
@@ -204,7 +204,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
+        $this->assertSame('alter table "users" drop column if exists "created_at", drop column if exists "updated_at"', $statements[0]);
     }
 
     public function testDropMorphs()
@@ -215,7 +215,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $this->assertSame('drop index "photos_imageable_type_imageable_id_index"', $statements[0]);
-        $this->assertSame('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[1]);
+        $this->assertSame('alter table "photos" drop column if exists "imageable_type", drop column if exists "imageable_id"', $statements[1]);
     }
 
     public function testRenameTable()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -205,10 +205,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection->shouldReceive('usingNativeSchemaOperations')->andReturn(true);
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` drop `foo`'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` drop column if exists `foo`'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" drop column "foo"'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" drop column if exists "foo"'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" drop column "foo"'], $blueprint->toSql($connection, new SQLiteGrammar));
@@ -416,7 +416,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` drop foreign key `posts_user_id_foreign`',
-            'alter table `posts` drop `user_id`',
+            'alter table `posts` drop column if exists `user_id`',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -434,7 +434,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` drop foreign key `posts_eloquent_model_uuid_stub_id_foreign`',
-            'alter table `posts` drop `eloquent_model_uuid_stub_id`',
+            'alter table `posts` drop column if exists `eloquent_model_uuid_stub_id`',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 


### PR DESCRIPTION
For MySql and Postgres drivers, The dropColumn method will work like the dropIfExists method, if the column exists it will be deleted, if not it will not throw any errors. 