### PR TITLE
[10.x] Ensures connections only listen for their own events

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -108,7 +108,7 @@ class Connection implements ConnectionInterface
     /**
      * The event dispatcher instance.
      *
-     * @var \Illuminate\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected $events;
 
@@ -965,7 +965,11 @@ class Connection implements ConnectionInterface
      */
     public function listen(Closure $callback)
     {
-        $this->events?->listen(Events\QueryExecuted::class, $callback);
+        $this->events?->listen(Events\QueryExecuted::class, function ($event) use ($callback) {
+            if ($event->connection === $this) {
+                $callback($event);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
The `Connection::listen()` method currently listens to queries on any connection.

```php
DB::connection('mysql')->listen(function () {
    dump('mysql query run');
});

DB::connection('sqlite')->listen(function () {
    dump('sqlite query run');
});

DB::connection('sqlite')->table('foo')->select('*');

// output:
// "mysql query run"
// "sqlite query run"
```

This is a bug and unexpected behaviour that is potentially problematic. It also impacts other framework behaviour that depends on adding listeners to the specific connection, e.g. the query duration handlers.