### PR TITLE
[10.x] Restore return on Queue facade

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -76,7 +76,7 @@ class Queue extends Facade
      */
     public static function fake($jobsToFake = [])
     {
-        tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()), function ($fake) {
+        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()), function ($fake) {
             if (! static::isFake()) {
                 static::swap($fake);
             }


### PR DESCRIPTION
I think this return was accidentally removed in https://github.com/laravel/framework/pull/46188
