### PR TITLE
[10.x] Use fallback when previous URL is the same as the current

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -160,8 +160,8 @@ class UrlGenerator implements UrlGeneratorContract
 
         if ($url && rtrim($url, '/') !== $this->request->fullUrl()) {
             return $url;
-        } elseif ($fallback && rtrim($fallback = $this->to($fallback), '/') !== $this->request->fullUrl()) {
-            return $fallback;
+        } elseif ($fallback) {
+            return $this->to($fallback);
         }
 
         return $this->to('/');

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -158,10 +158,10 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
 
-        if ($url) {
+        if ($url && rtrim($url, '/') !== $this->request->fullUrl()) {
             return $url;
-        } elseif ($fallback) {
-            return $this->to($fallback);
+        } elseif ($fallback && rtrim($fallback = $this->to($fallback), '/') !== $this->request->fullUrl()) {
+            return $fallback;
         }
 
         return $this->to('/');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -734,6 +734,44 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/bar', $url->previousPath('/bar'));
     }
 
+    public function testWhenPreviousIsEqualToCurrent()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/');
+        $this->assertSame('http://www.foo.com', $url->previous());
+        $this->assertSame('http://www.foo.com', $url->previous('/'));
+        $this->assertSame('http://www.foo.com', $url->previous('http://www.foo.com/'));
+        $this->assertSame('http://www.foo.com/bar', $url->previous('/bar'));
+
+        $url->setRequest(Request::create('http://www.foo.com/bar'));
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar');
+        $this->assertSame('http://www.foo.com', $url->previous());
+        $this->assertSame('http://www.foo.com', $url->previous('/'));
+        $this->assertSame('http://www.foo.com/', $url->previous('http://www.foo.com/'));
+        $this->assertSame('http://www.foo.com', $url->previous('/bar'));
+
+        $url->setRequest(Request::create('http://www.foo.com/bar?page=2'));
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?page=2');
+        $this->assertSame('http://www.foo.com', $url->previous());
+        $this->assertSame('http://www.foo.com', $url->previous('/'));
+        $this->assertSame('http://www.foo.com/', $url->previous('http://www.foo.com/'));
+        $this->assertSame('http://www.foo.com/bar', $url->previous('/bar'));
+
+        $url->setRequest(Request::create('http://www.foo.com/bar?page=3'));
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?page=2');
+        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous());
+        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('/'));
+        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('http://www.foo.com/'));
+        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('/bar'));
+    }
+
     public function testRouteNotDefinedException()
     {
         $this->expectException(RouteNotFoundException::class);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -743,33 +743,21 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/');
         $this->assertSame('http://www.foo.com', $url->previous());
-        $this->assertSame('http://www.foo.com', $url->previous('/'));
-        $this->assertSame('http://www.foo.com', $url->previous('http://www.foo.com/'));
         $this->assertSame('http://www.foo.com/bar', $url->previous('/bar'));
 
         $url->setRequest(Request::create('http://www.foo.com/bar'));
 
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar');
         $this->assertSame('http://www.foo.com', $url->previous());
-        $this->assertSame('http://www.foo.com', $url->previous('/'));
-        $this->assertSame('http://www.foo.com/', $url->previous('http://www.foo.com/'));
-        $this->assertSame('http://www.foo.com', $url->previous('/bar'));
+        $this->assertSame('http://www.foo.com/bar', $url->previous('/bar'));
+        $this->assertSame('http://www.foo.com/baz', $url->previous('/baz'));
 
         $url->setRequest(Request::create('http://www.foo.com/bar?page=2'));
 
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?page=2');
         $this->assertSame('http://www.foo.com', $url->previous());
-        $this->assertSame('http://www.foo.com', $url->previous('/'));
-        $this->assertSame('http://www.foo.com/', $url->previous('http://www.foo.com/'));
         $this->assertSame('http://www.foo.com/bar', $url->previous('/bar'));
-
-        $url->setRequest(Request::create('http://www.foo.com/bar?page=3'));
-
-        $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?page=2');
-        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous());
-        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('/'));
-        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('http://www.foo.com/'));
-        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('/bar'));
+        $this->assertSame('http://www.foo.com/bar?page=2', $url->previous('/bar?page=2'));
     }
 
     public function testRouteNotDefinedException()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

closes #46134 

As highlighted in issue #46134, when the previous URL stored in session is equals to the current one, a user would expect the `UrlGenerator@previous` to use the fallback URL instead of returning the current one.

One can easily reproduce the current behavior with these steps

1. create a new Laravel project
2. add this single route: `Route::get('/', fn () => url()->previous('/foo'));`
3. serve application
4. On first load, the previous URL displayed is http://127.0.0.1:8000/foo, using the default fallback as expected
5. Reload the page
6. Now, the previous URL displayed is http://127.0.0.1:8000, which is just the same as the current page

This happens as, in the first load, the current URL is stored into the session. 

As in the first load there is nothing in the request's session, nor a referrer header, the `UrlGenerator@previous` returns the fallback.

When reloading, the same page, now there is a URL stored into the request's session. So `UrlGenerator@previous` does not default to the fallback URL and returns the current URL instead.

This is particularly annoying when the `url()->previous()` helper is used in back buttons. On a page that auto-refreshes in an interval, such as a live report page, after the first reload this button would not work.

I have used a custom helper to work around this behavior on past projects.

This PR

- Changes `UrlGenerator@previous` to verify if the previous URL is different from the current one, if so it defaults to the fallback
- Add relevant tests

Notes:

I compared to `$this->request->fullUrl()`, as the `Request@fullUrl` method is used to store the previous URL on the `StartSession@storeCurrentUrl` middleware method.

Using the `UrlGenerator@current` could lead to false positives, for example, when using pagination, as it doesn't account for query parameters.

Another small issue is that `UrlGenerator@to` does not trim a trailing forward slash when its parameter is already a valid URL.

I used `rtrim(..., '/')` when comparing to `Request@fullUrl`, as `Request@fullUrl` never has a trailing forward slash, due to being constructed from its path.

I thought on changing `UrlGenerator@to` to trim the trailing forward slash in those cases, or at least make `Url@Generator@previous` to trim the ones it uses, but refrained to do so for the following reasons:

- As this would be a behavior change, it is possible many test cases on userland rely on current behavior
- It would widen the scope of this PR
- I believe this change should be discussed, if not already discussed in the past

This is why the added test case has similar assertions, to account for the trailing forward slash, which could be present when a Request has a referrer header.
