### PR TITLE
[10.x] Add ```get``` method to HTTP Client Response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -274,6 +274,17 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Get key from http response.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function get($key)
+    {
+        return data_get($this->object(), $key);
+    }
+
+    /**
      * Throw an exception if a server or client error occurred.
      *
      * @param  \Closure|null  $callback


### PR DESCRIPTION
When you want to get data from response, They didn't method to get a specific field.

Now you can use a specific field easy:
```php
$response = Http::get('https://jsonplaceholder.typicode.com/todos/1');
$response->get('title');
```

It is not over yet, You can access to value of associative array in response like this 🔥:
```php
$response = Http::get('https://jsonplaceholder.typicode.com/users/1');
$response->get('company.name');
```



