### PR TITLE
[10.x] Add a "channel:list" command

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -97,6 +97,16 @@ abstract class Broadcaster implements BroadcasterContract
     }
 
     /**
+     * Return a Collection of registered private channels.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getChannels()
+    {
+        return collect($this->channels);
+    }
+
+    /**
      * Authenticate the incoming request for a given channel.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -97,16 +97,6 @@ abstract class Broadcaster implements BroadcasterContract
     }
 
     /**
-     * Return a Collection of registered private channels.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function getChannels()
-    {
-        return collect($this->channels);
-    }
-
-    /**
      * Authenticate the incoming request for a given channel.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -382,5 +372,15 @@ abstract class Broadcaster implements BroadcasterContract
     protected function channelNameMatchesPattern($channel, $pattern)
     {
         return preg_match('/^'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
+    }
+
+    /**
+     * Get all of the registered channels.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getChannels()
+    {
+        return collect($this->channels);
     }
 }

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Support\Collection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Terminal;
+
+#[AsCommand(name: 'channel:list')]
+class ChannelListCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'channel:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all registered private broadcasting channels';
+
+    /**
+     * The broadcaster instance.
+     *
+     * @var \Illuminate\Contracts\Broadcasting\Broadcaster
+     */
+    protected $broadcaster;
+
+    /**
+     * The terminal width resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $terminalWidthResolver;
+
+    /**
+     * Create a new channel list command instance.
+     *
+     * @param  \Illuminate\Contracts\Broadcasting\Broadcaster  $broadcaster
+     * @return void
+     */
+    public function __construct(Broadcaster $broadcaster)
+    {
+        parent::__construct();
+
+        $this->broadcaster = $broadcaster;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $channels = $this->broadcaster->getChannels();
+
+        if (! $this->laravel->providerIsLoaded('App\Providers\BroadcastServiceProvider')) {
+            $this->components->warn('The [App\Providers\BroadcastServiceProvider] has not been loaded. Your private channels may not be loaded.');
+        }
+
+        if (! $channels->count()) {
+            return $this->components->error("Your application doesn't have any private broadcasting channels.");
+        }
+
+        $this->displayChannels($channels);
+    }
+
+    /**
+     * Display the channel information on the console.
+     *
+     * @param  Collection  $channels
+     * @return void
+     */
+    protected function displayChannels($channels)
+    {
+        $this->output->writeln($this->forCli($channels));
+    }
+
+    /**
+     * Convert the given channels to regular CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $channels
+     * @return array
+     */
+    protected function forCli($channels)
+    {
+        $maxChannelName = $channels->keys()->max(function ($channelName) {
+            return mb_strlen($channelName);
+        });
+
+        $terminalWidth = $this->getTerminalWidth();
+
+        $channelCount = $this->determineChannelCountOutput($channels, $terminalWidth);
+
+        return $channels->map(function ($channel, $channelName) use ($maxChannelName, $terminalWidth) {
+            $resolver = $channel instanceof Closure ? 'Closure' : $channel;
+
+            $spaces = str_repeat(' ', max($maxChannelName + 6 - mb_strlen($channelName), 0));
+
+            $dots = str_repeat('.', max(
+                $terminalWidth - mb_strlen($channelName.$spaces.$resolver) - 6, 0
+            ));
+
+            $dots = empty($dots) ? $dots : " $dots";
+
+            return sprintf(
+                '  <fg=blue;options=bold>%s</> %s<fg=white>%s</><fg=#6C7280>%s</>',
+                $channelName,
+                $spaces,
+                $resolver,
+                $dots,
+            );
+        })
+            ->filter()
+            ->sort()
+            ->prepend('')
+            ->push('')->push($channelCount)->push('')
+            ->toArray();
+    }
+
+    /**
+     * Determine and return the output for displaying the number of registered chanels in the CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $channels
+     * @param  int  $terminalWidth
+     * @return string
+     */
+    protected function determineChannelCountOutput($channels, $terminalWidth)
+    {
+        $channelCountText = 'Showing ['.$channels->count().'] private channels';
+
+        $offset = $terminalWidth - mb_strlen($channelCountText) - 2;
+
+        $spaces = str_repeat(' ', $offset);
+
+        return $spaces.'<fg=blue;options=bold>Showing ['.$channels->count().'] private channels</>';
+    }
+
+    /**
+     * Get the terminal width.
+     *
+     * @return int
+     */
+    public static function getTerminalWidth()
+    {
+        return is_null(static::$terminalWidthResolver)
+            ? (new Terminal)->getWidth()
+            : call_user_func(static::$terminalWidthResolver);
+    }
+
+    /**
+     * Set a callback that should be used when resolving the terminal width.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveTerminalWidthUsing($resolver)
+    {
+        static::$terminalWidthResolver = $resolver;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -24,14 +24,7 @@ class ChannelListCommand extends Command
      *
      * @var string
      */
-    protected $description = 'List all registered private broadcasting channels';
-
-    /**
-     * The broadcaster instance.
-     *
-     * @var \Illuminate\Contracts\Broadcasting\Broadcaster
-     */
-    protected $broadcaster;
+    protected $description = 'List all registered private broadcast channels';
 
     /**
      * The terminal width resolver callback.
@@ -41,28 +34,17 @@ class ChannelListCommand extends Command
     protected static $terminalWidthResolver;
 
     /**
-     * Create a new channel list command instance.
-     *
-     * @param  \Illuminate\Contracts\Broadcasting\Broadcaster  $broadcaster
-     * @return void
-     */
-    public function __construct(Broadcaster $broadcaster)
-    {
-        parent::__construct();
-
-        $this->broadcaster = $broadcaster;
-    }
-
-    /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Contracts\Broadcasting\Broadcaster
      * @return void
      */
-    public function handle()
+    public function handle(Broadcaster $broadcaster)
     {
-        $channels = $this->broadcaster->getChannels();
+        $channels = $broadcaster->getChannels();
 
-        if (! $this->laravel->providerIsLoaded('App\Providers\BroadcastServiceProvider')) {
+        if (! $this->laravel->providerIsLoaded('App\Providers\BroadcastServiceProvider') &&
+            file_exists($this->laravel->path('Providers/BroadcastServiceProvider.php'))) {
             $this->components->warn('The [App\Providers\BroadcastServiceProvider] has not been loaded. Your private channels may not be loaded.');
         }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
+use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ComponentMakeCommand;
@@ -165,6 +166,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected $devCommands = [
         'CacheTable' => CacheTableCommand::class,
         'CastMake' => CastMakeCommand::class,
+        'ChannelList' => ChannelListCommand::class,
         'ChannelMake' => ChannelMakeCommand::class,
         'ComponentMake' => ComponentMakeCommand::class,
         'ConsoleMake' => ConsoleMakeCommand::class,


### PR DESCRIPTION
Hey!

This PR proposes a new `php artisan channel:list` Artisan command that can be used to list the registered broadcasting channels in your app.

## What is it?

My idea behind this is that I find the `route:list` command really useful. I sometimes end up working on projects that have a big-ish number of channels registered in the `routes/channels.php` file. So I tried to mimic the concept of the `route:list` command for broadcasting channels.

I think this command could possibly make it easier to get a quick overview of which private channels are registered in the application (in alphabetical order).

One thing I also like about the command is that I've added a warning message that lets you know if you've not uncommented the `BroadcastServiceProvider` in your `config/app.php` file. I don't know about other people, but this is something I tend to forget to do quite often when adding WebSockets to my applications haha! I then spend quite a while trying to figure out why I keep getting a 404 when trying to authorise a private channel using Echo. I'd like to think that this would reduce the chance of that happening.

So far, I've only done a limited amount of testing, so there may be some things I've missed. I've also not written any tests for it just yet, just in case it wasn't something you thought would be worth merging. If it's something you think might be worthwhile, I'll be happy to put some tests together.

## Future and limitations

At the moment, the command is relatively basic and just outputs the name of the channel and the channel class or closure that is used to resolve the authorisation logic.

I think this command could be extended in the future to have things like filtering (similar to the `route:list` command).

It could maybe also list the parameters that are expected by the closure/class (e.g. - an `App\Models\Chat` model).

I'm a little biased, but I think this command could be a handy little tool to improve the DX when working with broadcasting. I think it has potential to be extended with useful features.

One limitation I'm aware of is that it doesn't list the public channels because they're not listed in the `routes/channels.php` file. I don't know if it's possible to extend the command in the future to also detect other public channels that are being used in the event classes?

I also guessed at the design for the command and used the same approach as the `route:list` command. But I'm wondering if it would be better to make it more like (with the dots separating and the "resolver" being on the right side of the terminal):

```text
channel name ............ resolver
channel name ............ resolver
channel name ............ resolver
```

## Example screenshots

This screenshot shows what happens if there aren't private channels registered in the app:

<img width="1134" alt="Screenshot 2023-02-23 at 17 53 29" src="https://user-images.githubusercontent.com/39652331/220989946-c6e82c44-0d8d-4478-90f3-82cf162124de.png">

This screenshot shows what happens if the provider isn't registered and there are no private channels registered:

<img width="1127" alt="Screenshot 2023-02-23 at 17 53 54" src="https://user-images.githubusercontent.com/39652331/220989952-20aeb7cd-27a3-45aa-9df0-b0a7f161ccb6.png">

This screenshot shows what happens if there are 4 channels registered:

<img width="1135" alt="Screenshot 2023-02-23 at 17 53 06" src="https://user-images.githubusercontent.com/39652331/220989931-fc3002a5-38a2-4aa1-9ff9-07f564e475b1.png">

If this might be something you'd be interested in accepting, please let me know if there's anything you'd like changing. Thanks! 😄