### PR TITLE
[10.x] Improve `Collection::getOrPut()` return type

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -456,9 +456,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get an item from the collection by key or add it to collection if it does not exist.
      *
+     * @template TGetOrPutValue
+     *
      * @param  mixed  $key
-     * @param  mixed  $value
-     * @return mixed
+     * @param  TGetOrPutValue|(\Closure(): TGetOrPutValue)  $value
+     * @return TValue|TGetOrPutValue
      */
     public function getOrPut($key, $value)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -951,6 +951,9 @@ assertType('string|User', $collection->get(0, function () {
     return 'string';
 }));
 
+assertType('string|User', $collection->getOrPut(0, 'string'));
+assertType('string|User', $collection->getOrPut(0, fn () => 'string'));
+
 assertType('Illuminate\Support\Collection<int, User>', $collection->forget(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->forget([1, 2]));
 


### PR DESCRIPTION
This PR improves the return type of `Collection::getOrPut()` for static analysis tools and IDEs