### PR TITLE
[10.x] Add `clear()` method to facade fakes

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static void dispatchAfterResponse(mixed $command, mixed $handler = null)
  * @method static \Illuminate\Bus\Dispatcher pipeThrough(array $pipes)
  * @method static \Illuminate\Bus\Dispatcher map(array $map)
+ * @method static void clear()
  * @method static void except(array|string $jobsToDispatch)
  * @method static void assertDispatched(string|\Closure $command, callable|int|null $callback = null)
  * @method static void assertDispatchedTimes(string|\Closure $command, int $times = 1)

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void flush(string $event)
  * @method static void subscribe(object|string $subscriber)
  * @method static array|null until(string|object $event, mixed $payload = [])
+ * @method static void clear()
  * @method static array|null dispatch(string|object $event, mixed $payload = [], bool $halt = false)
  * @method static array getListeners(string $eventName)
  * @method static \Closure makeListener(\Closure|string|array $listener, bool $wildcard = false)

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static \Illuminate\Contracts\Foundation\Application getApplication()
  * @method static \Illuminate\Mail\MailManager setApplication(\Illuminate\Contracts\Foundation\Application $app)
  * @method static \Illuminate\Mail\MailManager forgetMailers()
+ * @method static void clear()
  * @method static void alwaysFrom(string $address, string|null $name = null)
  * @method static void alwaysReplyTo(string $address, string|null $name = null)
  * @method static void alwaysReturnPath(string $address)

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
  * @method static \Illuminate\Support\Collection sent(mixed $notifiable, string $notification, callable|null $callback = null)
  * @method static bool hasSent(mixed $notifiable, string $notification)
  * @method static array sentNotifications()
+ * @method static void clear()
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static \Illuminate\Contracts\Queue\Job|null pop(string|null $queue = null)
  * @method static string getConnectionName()
  * @method static \Illuminate\Contracts\Queue\Queue setConnectionName(string $name)
+ * @method static void clear()
  * @method static mixed getJobBackoff(mixed $job)
  * @method static mixed getJobExpiration(mixed $job)
  * @method static void createPayloadUsing(callable|null $callback)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -806,4 +806,15 @@ class BusFake implements Fake, QueueingDispatcher
 
         return $this;
     }
+
+    /**
+     * Remove any commands and batches that have been dispatched
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->commands = [];
+        $this->batches = [];
+    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -808,7 +808,7 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
-     * Remove any commands and batches that have been dispatched
+     * Remove any commands and batches that have been dispatched.
      *
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -382,7 +382,7 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
-     * Remove any events that have been triggered
+     * Remove any events that have been triggered.
      *
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -382,7 +382,7 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
-     * Remove any events that have been dispatched
+     * Remove any events that have been triggered
      *
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -382,6 +382,16 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
+     * Remove any events that have been dispatched
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->events = [];
+    }
+
+    /**
      * Handle dynamic method calls to the dispatcher.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -453,6 +453,17 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
+     * Remove any mailables that have been sent
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->mailables = [];
+        $this->queuedMailables = [];
+    }
+
+    /**
      * Handle dynamic method calls to the mailer.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -453,7 +453,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
-     * Remove any mailables that have been sent
+     * Remove any mailables that have been sent.
      *
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -358,4 +358,14 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     {
         return $this->notifications;
     }
+
+    /**
+     * Remove any notifications that have been sent
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->notifications = [];
+    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -360,7 +360,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
     }
 
     /**
-     * Remove any notifications that have been sent
+     * Remove any notifications that have been sent.
      *
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -513,6 +513,16 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
+     * Remove any jobs that have been dispatched
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->jobs = [];
+    }
+
+    /**
      * Override the QueueManager to prevent circular dependency.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -513,7 +513,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
-     * Remove any jobs that have been dispatched
+     * Remove any jobs that have been dispatched.
      *
      * @return void
      */

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -658,6 +658,24 @@ class SupportTestingBusFakeTest extends TestCase
         $this->assertSame(0, $batch->failedJobs);
         $this->assertSame(0, $batch->pendingJobs);
     }
+
+    public function testClearCommands()
+    {
+        $this->fake->dispatch(new ThirdJob);
+        $this->fake->assertDispatched(ThirdJob::class);
+
+        $this->fake->clear();
+        $this->fake->assertNothingDispatched();
+    }
+
+    public function testClearBatches()
+    {
+        $this->fake->dispatchFakeBatch('batch');
+        $this->fake->assertBatchCount(1);
+
+        $this->fake->clear();
+        $this->fake->assertNothingBatched();
+    }
 }
 
 class BusJobStub

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -154,6 +154,15 @@ class SupportTestingEventFakeTest extends TestCase
             $this->assertStringContainsString('2 unexpected events were dispatched.', $e->getMessage());
         }
     }
+
+    public function testClearEvents()
+    {
+        $this->fake->dispatch(EventStub::class);
+        $this->fake->assertDispatched(EventStub::class);
+
+        $this->fake->clear();
+        $this->fake->assertNothingDispatched();
+    }
 }
 
 class EventStub

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -228,6 +228,15 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->assertEquals('bar', $this->fake->foo());
     }
+
+    public function testClearMailables()
+    {
+        $this->fake->send($this->mailable);
+        $this->fake->assertSent($this->mailable::class);
+
+        $this->fake->clear();
+        $this->fake->assertNothingSent();
+    }
 }
 
 class MailableStub extends Mailable

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -221,6 +221,15 @@ class SupportTestingNotificationFakeTest extends TestCase
 
         $this->fake->assertNotSentTo($user, NotificationWithFalsyShouldSendStub::class);
     }
+
+    public function testClearNotifications()
+    {
+        $this->fake->send(new LocalizedUserStub, new NotificationStub);
+        $this->fake->assertSentTimes(NotificationStub::class, 1);
+
+        $this->fake->clear();
+        $this->fake->assertNothingSent();
+    }
 }
 
 class NotificationStub extends Notification

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -374,6 +374,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $fake->assertNotPushed(JobStub::class);
         $fake->assertPushed(JobToFakeStub::class);
     }
+
+    public function testClearJobs()
+    {
+        $this->fake->push(JobStub::class);
+        $this->fake->assertPushed(JobStub::class);
+
+        $this->fake->clear();
+        $this->fake->assertNothingPushed();
+    }
 }
 
 class JobStub


### PR DESCRIPTION
When testing using facade fakes, it used to be possible to override the facade by faking again to reset the state. Since #46188, this is no longer possible.

This PR includes a `clear()` function on these facades that allows clearing the internal _queue_/_event_/_..._ history.

---

For example, I used to do the following to test notifications over a span of time:
```php
$this->sendReminders();
Notification::assertSentTo($user, ReminderMail::class);

Notification::fake();
$this->travel(3)->days();
$this->sendReminders();
Notification::assertNothingSent();

Notification::fake();
$this->travel(6)->days();
$this->sendReminders();
Notification::assertSentTo($user, ReminderMail::class);
```

This new clear method can now be used instead to clear the internal `$notifications` array.