### PR TITLE
added the ability to change the database date format

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1468,7 +1468,12 @@ trait HasAttributes
      */
     public function getDateFormat()
     {
-        return $this->dateFormat ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
+        if (empty($dateFormat = $this->dateFormat)) {
+            $connection = $this->getConnection();
+            $dateFormat = $connection->getConfig('date_format') ?: $connection->getQueryGrammar()->getDateFormat();
+        }
+
+        return $dateFormat;
     }
 
     /**


### PR DESCRIPTION
Before: 
```php
date_default_timezone_set('Asia/Tashkent'); // +05
$model = new Order();
$model->date = 'Fri, 24 Feb 2023 00:00:00 GMT'; // or $model->date = '2023-02-24T00:00:00.000000Z';
echo $model->utc(); // 2023-02-23T19:00:00.000000Z
```
this is because the database date format is hardcoded to Illuminate\Database\Grammar. Now we can configure date format in database.php
example: 
```php
  'pgsql' => [
      'driver' => 'pgsql',
      ....,
      'date_format' => 'Y-m-d H:i:sP',
  ],
```