### PR TITLE
[10.x] Generate default command name based on class name

### DIFF
--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,7 +46,13 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         $stub = parent::replaceClass($stub, $name);
 
-        return str_replace(['dummy:command', '{{ command }}'], $this->option('command'), $stub);
+        $command = $this->option('command') ?: sprintf(
+            '%s:%s',
+            Str::of($this->laravel->getNamespace())->trim('\\')->lower()->replace('\\', '-')->toString(),
+            Str::of($name)->classBasename()->kebab()->toString()
+        );
+
+        return str_replace(['dummy:command', '{{ command }}'], $command, $stub);
     }
 
     /**
@@ -94,7 +101,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the console command already exists'],
-            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned', 'command:name'],
+            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -46,11 +46,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         $stub = parent::replaceClass($stub, $name);
 
-        $command = $this->option('command') ?: sprintf(
-            '%s:%s',
-            Str::of($this->laravel->getNamespace())->trim('\\')->lower()->replace('\\', '-')->toString(),
-            Str::of($name)->classBasename()->kebab()->toString()
-        );
+        $command = $this->option('command') ?: 'app:'.Str::of($name)->classBasename()->kebab()->value();
 
         return str_replace(['dummy:command', '{{ command }}'], $command, $stub);
     }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -97,7 +97,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the console command already exists'],
-            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned'],
+            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that will be used to invoke the class'],
         ];
     }
 }


### PR DESCRIPTION
This PR changes the default `command:name` based on the current app namespace and the command class name.

------

I know there is a `--command` option, but – at least for me – it feels a bit more streamlined generating a default command name based on the given class.

For example the `php artisan make:command MigrateOldDb` will generate `$signature = 'app:migrate-old-db'`.

-------

Right now, it uses the application namespace. So, when changing from the default `App` namespace, the generated command signature will change as well. For example if the base namespace is `Laravel\Forge`, the generated command signature will be `laravel-forge:migrate-old-db`.

To simplify this, we might just use the `app:` prefix, since by using the `--command` option, the command name can be changed easily.

------

I didn't find tests related to the `make:*` commands. Am I missing something? If you're willing to merge, I would gladly add some tests as well.

Thanks.