### PR TITLE
Fake fixes

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -60,11 +60,11 @@ class Bus extends Facade
      */
     public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)
     {
-        $actualBus = static::isFake()
+        $actualDispatcher = static::isFake()
                 ? static::getFacadeRoot()->dispatcher
                 : static::getFacadeRoot();
 
-        return tap(new BusFake($actualBus, $jobsToFake, $batchRepository), function ($fake) {
+        return tap(new BusFake($actualDispatcher, $jobsToFake, $batchRepository), function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -60,10 +60,12 @@ class Bus extends Facade
      */
     public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)
     {
-        return tap(new BusFake(static::getFacadeRoot(), $jobsToFake, $batchRepository), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        $actualBus = static::isFake()
+                ? static::getFacadeRoot()->dispatcher
+                : static::getFacadeRoot();
+
+        return tap(new BusFake($actualBus, $jobsToFake, $batchRepository), function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -47,13 +47,15 @@ class Event extends Facade
      */
     public static function fake($eventsToFake = [])
     {
-        return tap(new EventFake(static::getFacadeRoot(), $eventsToFake), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
+        $actualDispatcher = static::isFake()
+                ? static::getFacadeRoot()->dispatcher
+                : static::getFacadeRoot();
 
-                Model::setEventDispatcher($fake);
-                Cache::refreshEventDispatcher();
-            }
+        return tap(new EventFake($actualDispatcher, $eventsToFake), function ($fake) {
+            static::swap($fake);
+
+            Model::setEventDispatcher($fake);
+            Cache::refreshEventDispatcher();
         });
     }
 

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -65,10 +65,12 @@ class Mail extends Facade
      */
     public static function fake()
     {
-        return tap(new MailFake(static::getFacadeRoot()), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        $actualMailManager = static::isFake()
+                ? static::getFacadeRoot()->manager
+                : static::getFacadeRoot();
+
+        return tap(new MailFake($actualMailManager), function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -49,10 +49,8 @@ class Notification extends Facade
      */
     public static function fake()
     {
-        return tap(new NotificationFake(), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        return tap(new NotificationFake, function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -76,10 +76,12 @@ class Queue extends Facade
      */
     public static function fake($jobsToFake = [])
     {
-        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        $actualQueueManager = static::isFake()
+                ? static::getFacadeRoot()->queue
+                : static::getFacadeRoot();
+
+        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, $actualQueueManager), function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -20,7 +20,7 @@ class BusFake implements Fake, QueueingDispatcher
      *
      * @var \Illuminate\Contracts\Bus\QueueingDispatcher
      */
-    protected $dispatcher;
+    public $dispatcher;
 
     /**
      * The job types that should be intercepted instead of dispatched.

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -20,7 +20,7 @@ class EventFake implements Dispatcher, Fake
      *
      * @var \Illuminate\Contracts\Events\Dispatcher
      */
-    protected $dispatcher;
+    public $dispatcher;
 
     /**
      * The event types that should be intercepted instead of dispatched.

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -22,7 +22,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      *
      * @var MailManager
      */
-    protected $manager;
+    public $manager;
 
     /**
      * The mailer currently being used to send a message.

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -20,7 +20,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      *
      * @var \Illuminate\Contracts\Queue\Queue
      */
-    protected $queue;
+    public $queue;
 
     /**
      * The job types that should be intercepted instead of pushed to the queue.


### PR DESCRIPTION
This fixes double calls to fake by retrieving the actual underlying implementation in question and always swapping. Restores the behavior of "clearing" fakes by calling `fake` twice in a test.