### PR TITLE
Adding Conditionable to Logger

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -12,6 +12,8 @@ use RuntimeException;
 
 class Logger implements LoggerInterface
 {
+    use Conditionable;
+    
     /**
      * The underlying logger implementation.
      *

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Traits\Conditionable;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -13,7 +13,7 @@ use RuntimeException;
 class Logger implements LoggerInterface
 {
     use Conditionable;
-    
+
     /**
      * The underlying logger implementation.
      *


### PR DESCRIPTION
This PR will add the Conditionable on the Logger to allow conditional logging. There are situations where a user would want conditional logging, by adding the Conditionable trait we can allow the when/unless syntax to be used easily.

```php
Log::when(true, function($logger) {
  $logger->debug('An informational messsdsage.');
});
```

```php
Log::unless(false, function($logger) {
  $logger->debug('An informational messsdsage.');
});
```

```php
Log::channel('daily')->when(false, function($logger) {
  $logger->debug('This wont be logged.');
});
```


