### PR TITLE
[10.x] Add "dot" method to Illuminate\Support\Collection class

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1578,6 +1578,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @return static
+     */
+    public function dot()
+    {
+        return new static(Arr::dot($this->all()));
+    }
+
+    /**
      * Return only unique items from the collection array.
      *
      * @param  (callable(TValue, TKey): mixed)|string|null  $key

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1568,16 +1568,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Convert a flatten "dot" notation array into an expanded array.
-     *
-     * @return static
-     */
-    public function undot()
-    {
-        return new static(Arr::undot($this->all()));
-    }
-
-    /**
      * Flatten a multi-dimensional associative array with dots.
      *
      * @return static
@@ -1585,6 +1575,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function dot()
     {
         return new static(Arr::dot($this->all()));
+    }
+
+    /**
+     * Convert a flatten "dot" notation array into an expanded array.
+     *
+     * @return static
+     */
+    public function undot()
+    {
+        return new static(Arr::undot($this->all()));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1519,6 +1519,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @return static
+     */
+    public function dot()
+    {
+        return $this->passthru('dot', []);
+    }
+
+    /**
      * Convert a flatten "dot" notation array into an expanded array.
      *
      * @return static


### PR DESCRIPTION
This PR adds the dot method to the Illuminate\Support\Collection class in Laravel.

Additionally, I recently had a need to perform the dot operation on an array, extract 5 items from the flattened result, and then convert it back to a multi-dimensional array using the undot method. Unfortunately, achieving this with the current implementation required me to write the following code:

```php
Arr::undot(array_slice(Arr::dot($keys), 0, 5))
```
With this PR, users can now easily achieve the same result using the following code:

```php
collect($keys)->dot()->take(5)->undot()
```
This simplifies the code and makes it more readable, providing a better developer experience for users of Laravel's Illuminate\Support\Collection class.