### PR TITLE
[10.x] Add `isLocal` and `isProduction` method to `Application` contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -86,6 +86,20 @@ interface Application extends Container
     public function environment(...$environments);
 
     /**
+     * Determine if the application is in the local environment.
+     *
+     * @return bool
+     */
+    public function isLocal();
+
+    /**
+     * Determine if the application is in the production environment.
+     *
+     * @return bool
+     */
+    public function isProduction();
+
+    /**
      * Determine if the application is running in the console.
      *
      * @return bool


### PR DESCRIPTION
When type `->isLocal()` or `isProduction()` on `app` instance, IDE will automatically suggest completion for developers


![Screenshot 2023-02-25 121726](https://user-images.githubusercontent.com/56961917/221340126-0e477b92-56bc-4f7f-953f-4156f1a493cc.png)
