### PR TITLE
[10.x] remove unused local variable

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -38,6 +38,6 @@ class RequestException extends HttpClientException
             ? \GuzzleHttp\Psr7\Message::bodySummary($response->toPsrResponse())
             : \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
 
-        return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
+        return is_null($summary) ? $message : $message.":\n{$summary}\n";
     }
 }


### PR DESCRIPTION
there was an extra local variable in the return statement.