### PR TITLE
[10.x] remove redundant optional argument

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -89,7 +89,7 @@ class Response implements ArrayAccess
      */
     public function object()
     {
-        return json_decode($this->body(), false);
+        return json_decode($this->body());
     }
 
     /**


### PR DESCRIPTION
There was an extra redundant optional argument that matches the parameter's default value 