### PR TITLE
[10.x] Adding return types flag to MakeController command

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -363,7 +363,7 @@ class ControllerMakeCommand extends GeneratorCommand
                 'Response',
                 'JsonResponse',
                 'View',
-                'Inertia/Response'
+                'Inertia/Response',
             ], default: 0);
 
             if ($returnType !== 'none') {

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -281,8 +281,8 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $returnTypes = match ($returnType) {
             'response' => ['use Illuminate\Http\Response;', ': Response'],
-            'json' => ['use Illuminate\\Http\\JsonResponse;', ': JsonResponse'],
-            'view' => ['use Illuminate\Contracts\View;', ': View\\View|View\\Factory'],
+            'json' => ['use Illuminate\Http\JsonResponse;', ': JsonResponse'],
+            'view' => ['use Illuminate\Contracts\View;', ': View\View|View\Factory'],
             'inertia' => ['use Inertia\Response;', ': Response'],
             default => ['', ''],
         };

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -291,13 +291,14 @@ class ControllerMakeCommand extends GeneratorCommand
             '{{ returnTypeUse }}' => $returnTypes[0],
             '{{returnTypeUse}}' => $returnTypes[0],
             '{{ returnTypeClass }}' => $returnTypes[1],
-            '{{returnTypeUse}}' => $returnTypes[1],
+            '{{returnTypeClass}}' => $returnTypes[1],
         ]);
 
         $replace["\n\n\n"] = "\n\n";
 
         return $replace;
     }
+
     /**
      * Get the console command options.
      *

--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -4,13 +4,14 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(){{ returnTypeClass }}
     {
         //
     }
@@ -26,7 +27,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(string $id){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -4,13 +4,14 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Handle the incoming request.
      */
-    public function __invoke(Request $request)
+    public function __invoke(Request $request){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -5,13 +5,14 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedRequests }}
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(){{ returnTypeClass }}
     {
         //
     }
@@ -27,7 +28,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ model }} ${{ modelVariable }})
+    public function show({{ model }} ${{ modelVariable }}){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -5,13 +5,14 @@ namespace {{ namespace }};
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedRequests }}
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(){{ returnTypeClass }}
     {
         //
     }
@@ -19,7 +20,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(){{ returnTypeClass }}
     {
         //
     }
@@ -35,7 +36,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ model }} ${{ modelVariable }})
+    public function show({{ model }} ${{ modelVariable }}){{ returnTypeClass }}
     {
         //
     }
@@ -43,7 +44,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit({{ model }} ${{ modelVariable }})
+    public function edit({{ model }} ${{ modelVariable }}){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -6,13 +6,14 @@ use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedParentModel }};
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index({{ parentModel }} ${{ parentModelVariable }})
+    public function index({{ parentModel }} ${{ parentModelVariable }}){{ returnTypeClass }}
     {
         //
     }
@@ -28,7 +29,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.api.stub
@@ -6,6 +6,7 @@ use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use {{ namespacedParentModel }};
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
@@ -20,7 +21,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }})
+    public function show({{ parentModel }} ${{ parentModelVariable }}){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.singleton.stub
@@ -6,6 +6,7 @@ use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use {{ namespacedParentModel }};
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
@@ -28,7 +29,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }})
+    public function show({{ parentModel }} ${{ parentModelVariable }}){{ returnTypeClass }}
     {
         //
     }
@@ -36,7 +37,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the resource.
      */
-    public function edit({{ parentModel }} ${{ parentModelVariable }})
+    public function edit({{ parentModel }} ${{ parentModelVariable }}){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -6,13 +6,14 @@ use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
 use {{ namespacedParentModel }};
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index({{ parentModel }} ${{ parentModelVariable }})
+    public function index({{ parentModel }} ${{ parentModelVariable }}){{ returnTypeClass }}
     {
         //
     }
@@ -20,7 +21,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create({{ parentModel }} ${{ parentModelVariable }})
+    public function create({{ parentModel }} ${{ parentModelVariable }}){{ returnTypeClass }}
     {
         //
     }
@@ -36,7 +37,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}){{ returnTypeClass }}
     {
         //
     }
@@ -44,7 +45,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }}){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
@@ -18,7 +19,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show()
+    public function show(){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
@@ -26,7 +27,7 @@ class {{ class }} extends Controller
     /**
      * Display the resource.
      */
-    public function show()
+    public function show(){{ returnTypeClass }}
     {
         //
     }
@@ -34,7 +35,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the resource.
      */
-    public function edit()
+    public function edit(){{ returnTypeClass }}
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -4,13 +4,14 @@ namespace {{ namespace }};
 
 use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
+{{ returnTypeUse }}
 
 class {{ class }} extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(){{ returnTypeClass }}
     {
         //
     }
@@ -18,7 +19,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(){{ returnTypeClass }}
     {
         //
     }
@@ -34,7 +35,7 @@ class {{ class }} extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(string $id){{ returnTypeClass }}
     {
         //
     }
@@ -42,7 +43,7 @@ class {{ class }} extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id)
+    public function edit(string $id){{ returnTypeClass }}
     {
         //
     }


### PR DESCRIPTION
This is a followup on https://github.com/laravel/framework/pull/46166

This PR adds a flag and a prompt to `make:controller` command to specify what types to return.

```
php artisan make:controller UserController --resource --return=XXXXX
```

That XXXXX has 4 different values that I suggest, happy to discuss:

- `response` - will return `Illuminate\Http\Response` in methods
- `json` - will return `Illuminate\Http\JsonResponse`
- `view` - will return `Illuminate\Contracts\View\View|Illuminate\Contracts\View\Factory`
- `inertia` - will return `Inertia\Response`


__Reason for this__: The discussion on the PR above, on Twitter, and my YouTube channel showed that many people *do* want to return something, and quite a few people suggested it to be managed as a flag in Artisan command. So this is my attempt to implement that. Still a bit opinionated, happy to discuss, or even if this PR is rejected, I felt a weird obligation to at least *try* :)

A few notices:

- I added the types only on typical GET methods: `index/create/edit/show`. I suggest to not add types to `store/update/destroy`, because their return types are probably different and individual.
- I didn't cover the case of JSON returns when using Eloquent API Resources, because they return different types than JsonResponse, and also different types if used like `ApiResource::collection()` and `new ApiResource()`.
- This PR adds a new case for Laravel stubs where there may or may not be a new line in "use" section. I haven't seen that happening in other stubs in Make command, so I added a workaround for removing a potential empty line: `$replace["\n\n\n"] = "\n\n";`. Code is not that elegant, any suggestions welcome.