### PR TITLE
[10.x] Add ArrayAccess to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -397,6 +397,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Convert GitHub flavored Markdown into HTML.
      *
+     * @param  array  $options
      * @return static
      */
     public function markdown(array $options = [])
@@ -407,6 +408,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Convert inline Markdown into HTML.
      *
+     * @param  array  $options
      * @return static
      */
     public function inlineMarkdown(array $options = [])
@@ -511,6 +513,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Call the given callback and return a new string.
      *
+     * @param  callable  $callback
      * @return static
      */
     public function pipe(callable $callback)
@@ -576,6 +579,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Repeat the string.
      *
+     * @param  int  $times
      * @return static
      */
     public function repeat(int $times)
@@ -818,6 +822,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Swap multiple keywords in a string with other keywords.
      *
+     * @param  array  $map
      * @return static
      */
     public function swap(array $map)
@@ -1193,6 +1198,8 @@ class Stringable implements JsonSerializable, ArrayAccess
 
     /**
      * Convert the object to a string when JSON encoded.
+     *
+     * @return string
      */
     public function jsonSerialize(): string
     {

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1207,6 +1207,50 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Determine if the given offset exists.
+     *
+     * @param  mixed  $offset
+     * @return bool
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->value[$offset]);
+    }
+
+    /**
+     * Get the value at the given offset.
+     *
+     * @param  mixed  $offset
+     * @return string
+     */
+    public function offsetGet(mixed $offset): string
+    {
+        return $this->value[$offset];
+    }
+
+    /**
+     * Set the value at the given offset.
+     *
+     * @param  mixed  $offset
+     * @return void
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->value[$offset] = $value;
+    }
+
+    /**
+     * Unset the value at the given offset.
+     *
+     * @param  mixed  $offset
+     * @return void
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->value[$offset]);
+    }
+
+    /**
      * Proxy dynamic properties onto methods.
      *
      * @param  string  $key
@@ -1225,25 +1269,5 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function __toString()
     {
         return (string) $this->value;
-    }
-
-    public function offsetExists(mixed $offset): bool
-    {
-        return isset($this->value[$offset]);
-    }
-
-    public function offsetGet(mixed $offset): string
-    {
-        return $this->value[$offset];
-    }
-
-    public function offsetSet(mixed $offset, mixed $value): void
-    {
-        $this->value[$offset] = $value;
-    }
-
-    public function offsetUnset(mixed $offset): void
-    {
-        unset($this->value[$offset]);
     }
 }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use ArrayAccess;
 use Closure;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Traits\Conditionable;
@@ -10,7 +11,7 @@ use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 
-class Stringable implements JsonSerializable
+class Stringable implements JsonSerializable, ArrayAccess
 {
     use Conditionable, Macroable, Tappable;
 
@@ -396,7 +397,6 @@ class Stringable implements JsonSerializable
     /**
      * Convert GitHub flavored Markdown into HTML.
      *
-     * @param  array  $options
      * @return static
      */
     public function markdown(array $options = [])
@@ -407,7 +407,6 @@ class Stringable implements JsonSerializable
     /**
      * Convert inline Markdown into HTML.
      *
-     * @param  array  $options
      * @return static
      */
     public function inlineMarkdown(array $options = [])
@@ -512,7 +511,6 @@ class Stringable implements JsonSerializable
     /**
      * Call the given callback and return a new string.
      *
-     * @param  callable  $callback
      * @return static
      */
     public function pipe(callable $callback)
@@ -578,7 +576,6 @@ class Stringable implements JsonSerializable
     /**
      * Repeat the string.
      *
-     * @param  int  $times
      * @return static
      */
     public function repeat(int $times)
@@ -821,7 +818,6 @@ class Stringable implements JsonSerializable
     /**
      * Swap multiple keywords in a string with other keywords.
      *
-     * @param  array  $map
      * @return static
      */
     public function swap(array $map)
@@ -1197,8 +1193,6 @@ class Stringable implements JsonSerializable
 
     /**
      * Convert the object to a string when JSON encoded.
-     *
-     * @return string
      */
     public function jsonSerialize(): string
     {
@@ -1224,5 +1218,25 @@ class Stringable implements JsonSerializable
     public function __toString()
     {
         return (string) $this->value;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->value[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): string
+    {
+        return $this->value[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->value[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->value[$offset]);
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1184,7 +1184,7 @@ class SupportStringableTest extends TestCase
     {
         $str = $this->stringable('my string');
         $this->assertSame('m', $str[0]);
-        $this->assertSame('s', $str[4]);
+        $this->assertSame('t', $str[4]);
         $this->assertTrue(isset($str[2]));
         $this->assertFalse(isset($str[10]));
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1179,4 +1179,13 @@ class SupportStringableTest extends TestCase
 
         $this->stringable('not a date')->toDate();
     }
+
+    public function testArrayAccess()
+    {
+        $str = $this->stringable('my string');
+        $this->assertSame('m', $str[0]);
+        $this->assertSame('s', $str[4]);
+        $this->assertTrue(isset($str[2]));
+        $this->assertFalse(isset($str[10]));
+    }
 }


### PR DESCRIPTION
Hi,

This little PR adds `ArrayAccess` to `Stringable`.

It allows to make its behavior more like a real string, by proxifying the calls.

```diff
- str('My StRinG')->lower()->value()[0]
+ str('My StRinG')->lower()[0]
```

Thanks,
Matt'