### PR TITLE
[10.x] Add model:list command

### DIFF
--- a/src/Illuminate/Database/Console/ListModelsCommand.php
+++ b/src/Illuminate/Database/Console/ListModelsCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\ComposerJson;
+use ReflectionClass;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Terminal;
+
+#[AsCommand(name: 'model:list')]
+class ListModelsCommand extends Command
+{
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Lists Eloquent Models';
+
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'model:list {--folder=}';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $models = $this->getModelsLists();
+
+        $data = $this->inspectModels($models);
+
+        $this->printList($data);
+    }
+
+    protected function getModelsLists()
+    {
+        $filterModels = function ($classFilePath, $namespacedClassName) {
+            $reflection = new ReflectionClass($namespacedClassName);
+
+            return $reflection->isSubclassOf(Model::class);
+        };
+
+        $folder = ltrim($this->option('folder'), '=');
+        $folder = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $folder);
+        $pathFilter = $folder ? fn ($path, $relativePath) => str_contains($relativePath, $folder) : null;
+
+        return ComposerJson::make(base_path())->getClasslists($filterModels, $pathFilter);
+    }
+
+    protected function inspectModels($classLists)
+    {
+        $models = [];
+        foreach ($classLists as $path => $classList) {
+            $models[$path] = [];
+            foreach ($classList as $list) {
+                foreach ($list as $class) {
+                    $classPath = $class['currentNamespace'];
+                    $table = (new ReflectionClass($classPath))->newInstanceWithoutConstructor()->getTable();
+                    $models[$path][] = [
+                        'table' => $table,
+                        'class' => $classPath,
+                        'relativePath' => $class['relativePath'],
+                    ];
+                }
+            }
+        }
+
+        return $models;
+    }
+
+    protected function printList($modelsLists)
+    {
+        $output = $this->getOutput();
+        foreach ($modelsLists as $path => $modelsList) {
+            $output->writeln(' - '.$path.'composer.json');
+            foreach ($modelsList as $model) {
+                $output->writeln('    <fg=yellow>'.$model['class'].'</>   (<fg=blue>\''.$model['table'].'\'</>)');
+                $output->writeln('<fg=gray>'.str_repeat('_', (new Terminal())->getWidth()).'</>');
+            }
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+use Illuminate\Database\Console\ListModelsCommand;
 use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
@@ -152,6 +153,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'ShowModel' => ShowModelCommand::class,
+        'ListModel' => ListModelsCommand::class,
         'StorageLink' => StorageLinkCommand::class,
         'Up' => UpCommand::class,
         'ViewCache' => ViewCacheCommand::class,

--- a/src/Illuminate/Support/ComposerJson.php
+++ b/src/Illuminate/Support/ComposerJson.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Exception;
+use InvalidArgumentException;
+use Symfony\Component\Finder\Finder;
+
+class ComposerJson
+{
+    private $result = [];
+
+    public $basePath = null;
+
+    public $ignoredNamespaces = [];
+
+    public static function make($folderPath, $ignoredNamespaces = [])
+    {
+        $folderPath = rtrim($folderPath, '/\\ ');
+        $folderPath = str_replace('/\\', DIRECTORY_SEPARATOR, $folderPath);
+        if (file_exists($folderPath.DIRECTORY_SEPARATOR.'composer.json')) {
+            return new static($folderPath, $ignoredNamespaces);
+        } else {
+            throw new InvalidArgumentException('The path ('.$folderPath.') does not contain a composer.json file.');
+        }
+    }
+
+    private function __construct($basePath, $ignoredNamespaces)
+    {
+        $this->basePath = $basePath;
+        $this->ignoredNamespaces = $ignoredNamespaces;
+    }
+
+    public function readAutoload($purgeShortcuts = false)
+    {
+        $result = [];
+
+        foreach ($this->collectLocalRepos() as $relativePath) {
+            // We avoid autoload-dev for repositories.
+            $result[$relativePath] = $this->readKey('autoload.psr-4', $relativePath);
+        }
+
+        // add the root composer.json
+        $result['/'] = $this->readKey('autoload.psr-4');
+
+        $results = $purgeShortcuts ? $this->purgeAutoloadShortcuts($result) : $result;
+
+        return $this->removedIgnored($results, $this->ignoredNamespaces);
+    }
+
+    public function collectLocalRepos()
+    {
+        $composers = [];
+
+        foreach ($this->readKey('repositories') as $repo) {
+            if (($repo['type'] ?? '') !== 'path') {
+                continue;
+            }
+
+            $dirPath = ltrim($repo['url'], '.\\/');
+
+            $path = $this->basePath.DIRECTORY_SEPARATOR.$dirPath.DIRECTORY_SEPARATOR.'composer.json';
+
+            // Sometimes php can not detect relative paths, so we use the absolute path here.
+            if (file_exists($path)) {
+                $composers[$dirPath] = $dirPath;
+            }
+        }
+
+        return $composers;
+    }
+
+    public function readKey($key, $composerPath = '')
+    {
+        $composer = $this->readComposerFileData($composerPath);
+
+        $value = Arr::get($composer, $key, []);
+
+        if (\in_array($key, ['autoload.psr-4', 'autoload-dev.psr-4'])) {
+            $value = $this->normalizePaths($value, $composerPath);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  string  $path
+     * @return array
+     */
+    public function readComposerFileData($path = '')
+    {
+        $absPath = $this->basePath.DIRECTORY_SEPARATOR.$path;
+
+        $absPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $absPath);
+
+        // ensure it does not end with slash
+        $absPath = rtrim($absPath, DIRECTORY_SEPARATOR);
+
+        if (! isset($this->result[$absPath])) {
+            $this->result[$absPath] = json_decode(file_get_contents($absPath.DIRECTORY_SEPARATOR.'composer.json'), true);
+        }
+
+        return $this->result[$absPath];
+    }
+
+    public function getClasslists(?\Closure $filter, ?\Closure $pathFilter)
+    {
+        $classLists = [];
+
+        foreach ($this->readAutoload(true) as $composerFilePath => $autoload) {
+            foreach ($autoload as $namespace => $psr4Path) {
+                $classLists[$composerFilePath][$namespace] = $this->getClassesWithin($psr4Path, $filter, $pathFilter);
+            }
+        }
+
+        return $classLists;
+    }
+
+    public function getClassesWithin($composerPath, \Closure $filterClass, ?\Closure $pathFilter = null)
+    {
+        $results = [];
+        foreach ($this->getAllPhpFiles($composerPath) as $classFilePath) {
+            $absFilePath = $classFilePath->getRealPath();
+            $relativePath = str_replace(base_path(), '', $absFilePath);
+
+            if ($pathFilter && ! $pathFilter($absFilePath, $relativePath, $classFilePath->getFilename())) {
+                continue;
+            }
+
+            $class = str_replace('.php', '', $classFilePath->getFilename());
+
+            // Exclude blade files
+            if (substr_count($class, '.') !== 0) {
+                continue;
+            }
+
+            $namespacedClass = $this->getNamespacedClassFromPath($absFilePath);
+
+            if (! class_exists($namespacedClass)) {
+                continue;
+            }
+
+            if ($filterClass($classFilePath, $namespacedClass, $class) === false) {
+                continue;
+            }
+
+            $results[] = [
+                'relativePath' => str_replace(base_path(), '', $absFilePath),
+                'fileName' => $classFilePath->getFilename(),
+                'currentNamespace' => $namespacedClass,
+                'absFilePath' => $absFilePath,
+                'class' => $class,
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Checks all the psr-4 loaded classes to have correct namespace.
+     *
+     * @param  array  $autoloads
+     * @return array
+     */
+    public function purgeAutoloadShortcuts($autoloads)
+    {
+        foreach ($autoloads as $composerPath => $psr4Mappings) {
+            foreach ($psr4Mappings as $namespace1 => $psr4Path1) {
+                foreach ($psr4Mappings as $psr4Path2) {
+                    if (strlen($psr4Path1) > strlen($psr4Path2) && Str::startsWith($psr4Path1, $psr4Path2)) {
+                        unset($autoloads[$composerPath][$namespace1]);
+                    }
+                }
+            }
+        }
+
+        return $autoloads;
+    }
+
+    public function getNamespacedClassFromPath($absPath)
+    {
+        $psr4Mappings = $this->readAutoload();
+        // Converts "absolute path" to "relative path":
+        $relativePath = trim(str_replace($this->basePath, '', $absPath), '/\\');
+        $className = str_replace('.php', '', basename($absPath));
+
+        foreach ($psr4Mappings as $composerPath => $psr4Mapping) {
+            if (str_starts_with($relativePath, $composerPath)) {
+                $correctNamespaces = $this->getCorrectNamespaces($psr4Mapping, $relativePath);
+
+                return $this->findShortest($correctNamespaces).'\\'.$className;
+            }
+        }
+
+        $correctNamespaces = $this->getCorrectNamespaces($psr4Mappings['/'], $relativePath);
+
+        return $this->findShortest($correctNamespaces).'\\'.$className;
+    }
+
+    /**
+     * get all ".php" files in directory by giving a path.
+     *
+     * @param  string  $path  Directory path
+     * @return \Symfony\Component\Finder\Finder
+     */
+    public function getAllPhpFiles($path, $basePath = '')
+    {
+        if ($basePath === '') {
+            $basePath = $this->basePath;
+        }
+
+        $basePath = rtrim($basePath, '/\\');
+        $path = ltrim($path, '/\\');
+        $path = $basePath.DIRECTORY_SEPARATOR.$path;
+
+        try {
+            return Finder::create()->files()->name('*.php')->in($path);
+        } catch (Exception) {
+            return [];
+        }
+    }
+
+    private function normalizePaths($value, $path)
+    {
+        $path && $path = Str::finish($path, '/');
+        foreach ($value as $namespace => $_path) {
+            if (is_array($_path)) {
+                foreach ($_path as $i => $p) {
+                    $value[$namespace][$i] = str_replace('//', '/', $path.Str::finish($p, '/'));
+                }
+            } else {
+                $value[$namespace] = str_replace('//', '/', $path.Str::finish($_path, '/'));
+            }
+        }
+
+        return $value;
+    }
+
+    private function removedIgnored($mapping, $ignored = [])
+    {
+        $result = [];
+
+        foreach ($mapping as $i => $map) {
+            foreach ($map as $namespace => $path) {
+                if (! in_array($namespace, $ignored)) {
+                    $result[$i][$namespace] = $path;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    private function findShortest($correctNamespaces)
+    {
+        return array_reduce($correctNamespaces, function ($a, $b) {
+            return ($a === null || strlen($a) >= strlen($b)) ? $b : $a;
+        });
+    }
+
+    private function getCorrectNamespaces($psr4Mapping, $relativePath)
+    {
+        $correctNamespaces = [];
+        $relativePath = str_replace(['\\', '.php'], ['/', ''], $relativePath);
+        foreach ($psr4Mapping as $namespacePrefix => $paths) {
+            foreach ((array) $paths as $path) {
+                if (str_starts_with($relativePath, $path)) {
+                    $correctNamespace = substr_replace($relativePath, $namespacePrefix, 0, strlen($path));
+                    $correctNamespace = str_replace('/', '\\', $correctNamespace);
+                    $correctNamespaces[] = $this->getNamespaceFromFullClass($correctNamespace);
+                }
+            }
+        }
+
+        return $correctNamespaces;
+    }
+
+    private function getNamespaceFromFullClass($class)
+    {
+        $segments = explode('\\', $class);
+        array_pop($segments); // removes the last part
+
+        return trim(implode('\\', $segments), '\\');
+    }
+}

--- a/tests/Support/Fixtures/composer_json/a2/composer.json
+++ b/tests/Support/Fixtures/composer_json/a2/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "iman/ghafoori2",
+    "description": "Some description is here.",
+    "keywords": ["keyword 1", "keyword 2"],
+    "license": "MIT",
+    "type": "project",
+    "require": {
+        "some/framework": "~5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
+    "autoload": {
+        "classmap": [
+            "database",
+            "tests/TestCase.php"
+        ],
+        "files": ["src/MyLibrary/functions.php"],
+        "psr-4": {
+            "G2\\": "ref",
+            "App2\\": "app2"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Imanghafoori\\LaravelMicroscope\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": [
+                "*"
+            ]
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/tests/Support/Fixtures/composer_json/a3/composer.json
+++ b/tests/Support/Fixtures/composer_json/a3/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "iman/ghafoori",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/",
+            "Models\\": "app/Models/",
+            "Test\\": "app/d/",
+            "Database\\Seeders\\": "database/seeders/"
+        }
+    }
+}

--- a/tests/Support/Fixtures/composer_json/composer.json
+++ b/tests/Support/Fixtures/composer_json/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "iman/ghafoori",
+    "description": "Some description.",
+    "keywords": ["framework", "package"],
+    "license": "MIT",
+    "type": "project",
+    "require": {
+        "hello/how": "~5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
+    "autoload": {
+        "files": ["src/MyLib/functions.php", "src/MyLib/functions2.php"],
+        "classmap": [
+            "database",
+            "tests/TestCase.php"
+        ],
+        "psr-4": {
+            "App\\": "app/",
+            "Dapp\\": "dapp",
+            "Map\\": ["m1/", "m2/"]
+        }
+    },
+    "autoload-dev": {
+        "files": ["src/MyLib/functions.php", "src/MyLib/functions2.php"],
+        "psr-4": {
+            "Imanghafoori\\LaravelMicroscope\\Tests\\": "tests"
+        }
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url" : "./a2"
+        }
+    ],
+    "extra": {
+        "some_key": {
+            "dont-discover": [
+                "*"
+            ]
+        }
+    },
+    "minimum-stability": "dev"
+}

--- a/tests/Support/Fixtures/composer_json/shortcut_namespace/composer.json
+++ b/tests/Support/Fixtures/composer_json/shortcut_namespace/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "iman/ghafoori",
+    "autoload": {
+        "psr-4": {
+            "Models\\": "app/Models",
+            "App\\": "app/",
+            "Tests\\": "tests/"
+        }
+    }
+}

--- a/tests/Support/SupportComposerJsonTest.php
+++ b/tests/Support/SupportComposerJsonTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\ComposerJson;
+use PHPUnit\Framework\TestCase;
+
+class SupportComposerJsonTest extends TestCase
+{
+    /** @test */
+    public function getNamespacedClassFromPath()
+    {
+        $reader = ComposerJson::make($p = __DIR__.'/Fixtures/composer_json/shortcut_namespace');
+        $namespace = $reader->getNamespacedClassFromPath($p.'/app/G1/G2.php');
+        $this->assertEquals('App\G1\G2', $namespace);
+
+        $namespace = $reader->getNamespacedClassFromPath($p.'/app/Models/G1/G2.php');
+        $this->assertEquals('Models\G1\G2', $namespace);
+
+        $reader = ComposerJson::make($p = __DIR__.'/Fixtures/composer_json');
+        $namespace = $reader->getNamespacedClassFromPath($p.'/m1/G1/G2.php');
+        $this->assertEquals('Map\G1\G2', $namespace);
+
+        $namespace = $reader->getNamespacedClassFromPath($p.'/m2/G1/G2.php');
+        $this->assertEquals('Map\G1\G2', $namespace);
+
+        $namespace = $reader->getNamespacedClassFromPath($p.'/dapp/dapp/G1/G2.php');
+        $this->assertEquals('Dapp\dapp\G1\G2', $namespace);
+
+        $namespace = $reader->getNamespacedClassFromPath($p.'/a2/ref/ref/G2.php');
+        $this->assertEquals('G2\ref\G2', $namespace);
+    }
+
+    /** @test */
+    public function read_autoload_psr4_purged()
+    {
+        $reader = ComposerJson::make(__DIR__.'/Fixtures/composer_json/shortcut_namespace');
+        $this->assertEquals([
+            '/' => [
+                'App\\' => 'app/',
+                'Tests\\' => 'tests/',
+            ],
+        ], $reader->readAutoload(true));
+    }
+
+    /** @test */
+    public function read_autoload_psr4()
+    {
+        $reader = ComposerJson::make(__DIR__.'/Fixtures/composer_json');
+
+        $expected = [
+            'a2' => [
+                'G2\\' => 'a2/ref/',
+                'App2\\' => 'a2/app2/',
+            ],
+            '/' => [
+                'App\\' => 'app/',
+                'Dapp\\' => 'dapp/', // <==== is normalized
+                'Map\\' => ['m1/', 'm2/'],
+            ],
+        ];
+
+        $this->assertEquals($expected, $reader->readAutoload());
+    }
+
+    /** @test */
+    public function get_namespace_from_relative_path()
+    {
+        $reader = ComposerJson::make($p = __DIR__.'/Fixtures/composer_json/a3');
+        $result = $reader->getNamespacedClassFromPath('app/Hello.php');
+        $this->assertEquals('App\\Hello', $result);
+
+        $result = $reader->getNamespacedClassFromPath('app/appollo.php');
+        $this->assertEquals('App\\appollo', $result);
+
+        $result = $reader->getNamespacedClassFromPath('app/Models/Hello.php');
+        $this->assertEquals('Models\\Hello', $result);
+
+        $result = $reader->getNamespacedClassFromPath('app/appollo.php');
+        $this->assertEquals('App\\appollo', $result);
+
+        $result = $reader->getNamespacedClassFromPath('app/d/appollo.php');
+        $this->assertEquals('Test\\appollo', $result);
+    }
+
+    /** @test */
+    public function readKey()
+    {
+        $reader = ComposerJson::make(__DIR__.'/Fixtures/composer_json');
+        $this->assertEquals('iman/ghafoori', $reader->readKey('name'));
+        $this->assertEquals(['hello/how' => '~5.0'], $reader->readKey('require'));
+        $this->assertEquals('~5.0', $reader->readKey('require.hello/how'));
+        $this->assertEquals(['framework', 'package'], $reader->readKey('keywords'));
+    }
+
+    /** @test */
+    public function expects_real_paths()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ComposerJson::make(__DIR__.'/Stubs/absent');
+    }
+
+    /** @test */
+    public function expects_composer_json_file_to_exist()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ComposerJson::make(__DIR__.'/Stubs/empty');
+    }
+
+    /** @test */
+    public function readComposerFileData()
+    {
+        $reader = ComposerJson::make(__DIR__.'/Fixtures/composer_json');
+        $actual = $reader->readComposerFileData();
+        $expected = [
+            'name' => 'iman/ghafoori',
+            'description' => 'Some description.',
+            'keywords' => ['framework', 'package'],
+            'license' => 'MIT',
+            'type' => 'project',
+            'require' => [
+                'hello/how' => '~5.0',
+            ],
+            'require-dev' => [
+                'phpunit/phpunit' => '~4.0',
+            ],
+            'autoload' => [
+                'classmap' => [
+                    'database',
+                    'tests/TestCase.php',
+                ],
+                'psr-4' => [
+                    'App\\' => 'app/',
+                    'Dapp\\' => 'dapp',
+                    'Map\\' => ['m1/', 'm2/'],
+                ],
+                'files' => [
+                    'src/MyLib/functions.php',
+                    'src/MyLib/functions2.php',
+                ],
+            ],
+            'autoload-dev' => [
+                'psr-4' => [
+                    'Imanghafoori\\LaravelMicroscope\\Tests\\' => 'tests',
+                ],
+                'files' => [
+                    'src/MyLib/functions.php',
+                    'src/MyLib/functions2.php',
+                ],
+            ],
+            'repositories' => [
+                [
+                    'type' => 'path',
+                    'url' => './a2',
+                ],
+            ],
+            'extra' => [
+                'some_key' => [
+                    'dont-discover' => ['*'],
+                ],
+            ],
+            'minimum-stability' => 'dev',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This adds a basic implementation of the `model:list` command, which searches through all the PSR-4 loaded paths in the "composer.json" file.

- It also inspects the local repositories of type "path", so that if a project is modularized into local composer packages there would be no problem.
-  The `--folder=` can be used to filter down to specific folders.

![image](https://user-images.githubusercontent.com/6961695/221428887-9cbc940c-1b30-4f8d-adce-d205efe2e503.png)

It can be improved but I wanted to see if you are ok with the main idea or not.