### PR TITLE
[10.x] Do not mutate underlying values on redirect

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -31,7 +31,7 @@ class RedirectController extends Controller
 
         $parameters = $parameters->only(
             $route->getCompiled()->getPathVariables()
-        )->toArray();
+        )->all();
 
         $url = $url->toRoute($route, $parameters, false);
 

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
@@ -33,6 +35,19 @@ class RouteRedirectTest extends TestCase
             'route redirect with two optional replacements' => ['users/{user?}/{repo?}', 'members/{user?}', '/users/22', '/members/22'],
             'route redirect with two optional replacements that switch position' => ['users/{user?}/{switch?}', 'members/{switch?}/{user?}', '/users/11/22', '/members/22/11'],
         ];
+    }
+
+    public function testRouteRedirectWithExplicitRouteModelBinding()
+    {
+        $this->withoutExceptionHandling();
+        Route::middleware([SubstituteBindings::class])->group(function () {
+            Route::redirect('users/{user}', 'users/{user}/overview');
+        });
+        Route::bind('user', fn ($id) => (new User())->setAttribute('id', '999'));
+
+        $response = $this->get('users/1');
+
+        $response->assertRedirect('users/999/overview');
     }
 
     public function testToRouteHelper()


### PR DESCRIPTION
Fixes #46273

Due of the use of `toArray` the underlying values, e.g. an Eloquent model, are also cast to an array if they implement the Arrayable contract.

This means that the following will fail, as the explicit route model binding will return an eloquent model and the model will then be cast to an array and finally the array will be used as the "user" parameter.

```php
Route::redirect('users/{user}', 'users/{user}/overview');

Route::get('users/{user}/overview', fn () => 'foo');

Route::bind('user', fn ($id) => User::findOrFail($id));
````

This should not be a breaking change, as the router can not handle parameters that are an array. The following will throw an "array to string exception"...

```php
Route::redirect('users/{user}', 'users/{user}/overview');

Route::get('users/{user}/overview', fn () => 'foo');

// bind to an array
Route::bind('user', fn ($id) => [$id]);
````

