### PR TITLE
[10.x] Do not use null to initialise $lastExecutionStartedAt

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -38,7 +38,7 @@ class ScheduleWorkCommand extends Command
             $this->getLaravel()->isLocal() ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 
-        [$lastExecutionStartedAt, $executions] = [null, []];
+        [$lastExecutionStartedAt, $executions] = [Carbon::now(), []];
 
         $command = implode(' ', array_map(fn ($arg) => ProcessUtils::escapeArgument($arg), [
             PHP_BINARY,

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -38,7 +38,7 @@ class ScheduleWorkCommand extends Command
             $this->getLaravel()->isLocal() ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 
-        [$lastExecutionStartedAt, $executions] = [Carbon::now(), []];
+        [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];
 
         $command = implode(' ', array_map(fn ($arg) => ProcessUtils::escapeArgument($arg), [
             PHP_BINARY,


### PR DESCRIPTION
`$lastExecutionStartedAt` is passed to Carbon::equalTo(), but passing a null value to this method will result in deprecation warning (E_USER_DEPRECATED):
```
Since 2.61.0, it's deprecated to compare a date to null, meaning of such comparison is ambiguous and will no longer be possible in 3.0.0, you should explicitly pass 'now' or make an other check to eliminate null values. in /data/www/vendor/nesbot/carbon/src/Carbon/Traits/Comparison.php on line 1115
```

Passing a null value will result in a `Carbon::now()` object being build and used for comparison, so it should be safe to initialize `$lastExecutionStartedAt` with it.