### PR TITLE
[10.x] Using enum case's key for pure Enum validation

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
 use Illuminate\Contracts\Validation\Rule;
 use TypeError;
+use UnitEnum;
 
 class Enum implements Rule
 {
@@ -38,8 +40,12 @@ class Enum implements Rule
             return true;
         }
 
-        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type) || ! method_exists($this->type, 'tryFrom')) {
+        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type)) {
             return false;
+        }
+
+        if (! is_subclass_of($this->type, BackedEnum::class)) {
+            return defined($this->type.'::'.$value) and constant($this->type.'::'.$value) instanceof UnitEnum;
         }
 
         try {

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -140,7 +140,7 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
-    public function testValidationFailsOnPureEnum()
+    public function testValidationPassesOnPureEnum()
     {
         $v = new Validator(
             resolve('translator'),
@@ -152,7 +152,7 @@ class ValidationEnumRuleTest extends TestCase
             ]
         );
 
-        $this->assertTrue($v->fails());
+        $this->assertFalse($v->fails());
     }
 
     public function testValidationFailsWhenProvidingStringToIntegerType()


### PR DESCRIPTION
Related: #40380
This PR handle [pure enum](https://www.php.net/manual/en/language.enumerations.basics.php) validation.
If provided `$type` is a pure enum, the value checks against enum case keys.
There is no breaking change.