### PR TITLE
[10.x] Added "isValidSignedUrl" method

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -451,9 +451,9 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Determine whether the given URL is a valid, signed URL.
      *
-     * @param string $url
-     * @param bool $absolute
-     * @param array $ignoreQuery
+     * @param  string  $url
+     * @param  bool  $absolute
+     * @param  array  $ignoreQuery
      * @return bool
      */
     public function isValidSignedUrl(string $url, bool $absolute = true, array $ignoreQuery = [])

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -449,6 +449,19 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Determine whether the given URL is a valid, signed URL.
+     *
+     * @param string $url
+     * @param bool $absolute
+     * @param array $ignoreQuery
+     * @return bool
+     */
+    public function isValidSignedUrl(string $url, bool $absolute = true, array $ignoreQuery = [])
+    {
+        return $this->hasValidSignature(Request::create($url), $absolute, $ignoreQuery);
+    }
+
+    /**
      * Get the URL to a named route.
      *
      * @param  string  $name


### PR DESCRIPTION
Hey!

This PR is only a small one and proposes a new `URL::isValidSignedUrl` method for syntactic sugar.

I've been working with some code where we're storing signed URLs in the database. In my tests, I'm currently asserting that we're storing these signed URLs by using something along these lines:

```php
$this->assertTrue(
    URL::hasValidSignature(Request::create($model->signed_url))
);
```

With the new proposed method, this could be changed to something like so:

```php
$this->assertTrue(
    URL::isValidSignedUrl($model->signed_url)
);
```

I feel like the new method might be a bit easier to understand because you can pass a raw string to the method rather than needing to use `Request::create($url)`.

I know this is only a small change, but if it's something you think might be worthwhile, please let me know if you'd like anything changing 😄