### PR TITLE
[10.x] Add isMatch method to Str and Stringable helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -424,6 +424,32 @@ class Str
     }
 
     /**
+     * Determine if a given string matches a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isMatch($pattern, $value)
+    {
+        $value = (string) $value;
+
+        if (! is_iterable($pattern)) {
+            $pattern = [$pattern];
+        }
+
+        foreach ($pattern as $pattern) {
+            $pattern = (string) $pattern;
+
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if a given string is a valid UUID.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -424,32 +424,6 @@ class Str
     }
 
     /**
-     * Determine if a given string matches a given pattern.
-     *
-     * @param  string|iterable<string>  $pattern
-     * @param  string  $value
-     * @return bool
-     */
-    public static function isMatch($pattern, $value)
-    {
-        $value = (string) $value;
-
-        if (! is_iterable($pattern)) {
-            $pattern = [$pattern];
-        }
-
-        foreach ($pattern as $pattern) {
-            $pattern = (string) $pattern;
-
-            if (preg_match($pattern, $value) === 1) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Determine if a given string is a valid UUID.
      *
      * @param  string  $value
@@ -634,6 +608,32 @@ class Str
         }
 
         return $matches[1] ?? $matches[0];
+    }
+
+    /**
+     * Determine if a given string matches a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isMatch($pattern, $value)
+    {
+        $value = (string) $value;
+
+        if (! is_iterable($pattern)) {
+            $pattern = [$pattern];
+        }
+
+        foreach ($pattern as $pattern) {
+            $pattern = (string) $pattern;
+
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -311,17 +311,6 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Determine if a given string matches a given pattern.
-     *
-     * @param  string|iterable<string>  $pattern
-     * @return bool
-     */
-    public function isMatch($pattern)
-    {
-        return Str::isMatch($pattern, $this->value);
-    }
-
-    /**
      * Determine if a given string is a valid UUID.
      *
      * @return bool
@@ -449,6 +438,17 @@ class Stringable implements JsonSerializable
     public function match($pattern)
     {
         return new static(Str::match($pattern, $this->value));
+    }
+
+    /**
+     * Determine if a given string matches a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @return bool
+     */
+    public function isMatch($pattern)
+    {
+        return Str::isMatch($pattern, $this->value);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -311,6 +311,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string matches a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @return bool
+     */
+    public function isMatch($pattern)
+    {
+        return Str::isMatch($pattern, $this->value);
+    }
+
+    /**
      * Determine if a given string is a valid UUID.
      *
      * @return bool


### PR DESCRIPTION
This PR adds **isMatch** method for both `Illuminate\Support\Str` and `Illuminate\Support\Stringable`.

Additionally, I recently had a need to perform a regex pattern match: I just needed to check that my variable contains the complex regex pattern. While I was trying to find a solution, I found a problem. `Str` does not contain method that accepts complex regex pattern and returns boolean.

First of all  `Illuminate\Support\Str` and `Illuminate\Support\Stringable` already has methods to perform pattern matching. There are `is` and `match` methods:
- `is()` is good for checking string in more human-readable way, but it not supports complex patterns.

  ```php
  str('foobar')->is('f*o*'); // true
  str('foobar')->is('/f.*o.*/'); // false / Regex patterns not supported
  ```

- `match()` in the other hand supports complex pattern matching but returns **string** that has been matched. It forces us to additionally check that result of the method call is not containing an empty string, **which is not the same thing as check if a string contains pattern**.

  ```php
  // I.e. Does 'foobar' contain pattern /f.*o.*/ ?
  str('foobar')->match('/f.*o.*/')->isNotEmpty(); // true

  // This is why match() followed by isNotEmpty() is not the same thing as checking string for pattern match

  // I.e. Does 'foobar' contain pattern /^f.*r(.*)/ ?
  str('foobar')->match('/^f.*r(.*)/')->isNotEmpty(); // false
  // But preg_match for this pair returns
  preg_match('/^f.*r(.*)/', 'foobar') === 1; // true
  ```

So I suggest adding an isMatch method that will allow you to check the string for the presence of a pattern in it.
Some examples:
```php
str('foobar')->isMatch('/^f.*r(.*)/'); // true
str('foobar')->isMatch('/f.*o.*/'); // true
str('foobar')->isMatch(['/f.*o.*/', '/barfoo/']); // true / I.e. matches at least one pattern (like match()) 

// Same for Str
Str::isMatch('/^f.*r(.*)/', 'foobar'); // true
Str::isMatch('/f.*o.*/', 'foobar'); // true
Str::isMatch(['/f.*o.*/', '/barfoo/'], 'foobar'); // true
```

✔️This PR does not contain breaking changes.
✔️This PR only adds new features.