### PR TITLE
[10.x] Added whereTrue() and whereFalse() method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2037,6 +2037,52 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where 'field' = true" clause to the query.
+     *
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereTrue($column, $boolean = 'and')
+    {
+        return $this->where($column, '=', true, $boolean);
+    }
+
+    /**
+     * Add a "or where 'field' is true" clause to the query.
+     *
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return $this
+     */
+    public function orWhereTrue($column)
+    {
+        return $this->whereTrue($column, 'or');
+    }
+
+    /**
+     * Add a "where 'field' is false" clause to the query.
+     *
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereFalse($column, $boolean = 'and')
+    {
+        return $this->where($column, '=', false, $boolean);
+    }
+
+    /**
+     * Add a "or where 'field' is false" clause to the query.
+     *
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return $this
+     */
+    public function orWhereFalse($column)
+    {
+        return $this->whereFalse($column, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|\Illuminate\Contracts\Database\Query\Expression|string  ...$groups

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5538,6 +5538,42 @@ SQL;
         $this->assertEquals([], $clone->getBindings());
     }
 
+    public function testWhereTrue()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTrue('is_admin');
+
+        $this->assertSame('select * from "users" where "is_admin" = ?', $builder->toSql());
+        $this->assertEquals([true], $builder->getBindings());
+    }
+
+    public function testOrWhereTrue()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereTrue('is_admin');
+
+        $this->assertSame('select * from "users" where "id" = ? or "is_admin" = ?', $builder->toSql());
+        $this->assertEquals([1, true], $builder->getBindings());
+    }
+
+    public function testWhereFalse()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereFalse('is_admin');
+
+        $this->assertSame('select * from "users" where "is_admin" = ?', $builder->toSql());
+        $this->assertEquals([false], $builder->getBindings());
+    }
+
+    public function testOrWhereFalse()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereFalse('is_admin');
+
+        $this->assertSame('select * from "users" where "id" = ? or "is_admin" = ?', $builder->toSql());
+        $this->assertEquals([1, false], $builder->getBindings());
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -19,6 +19,7 @@ class EloquentWhereTest extends DatabaseTestCase
             $table->string('name');
             $table->string('email');
             $table->string('address');
+            $table->boolean('is_admin')->default(false);
         });
     }
 
@@ -325,6 +326,98 @@ class EloquentWhereTest extends DatabaseTestCase
         $this->assertSame('first-name', $results[0]);
         $this->assertSame('second-name', $results[1]);
         $this->assertCount(3, DB::getQueryLog());
+    }
+
+    public function testWhereTrue()
+    {
+        $adminUser = UserWhereTest::create([
+            'name' => 'first-name',
+            'email' => 'first-email',
+            'address' => 'first-address',
+            'is_admin' => true,
+        ]);
+
+        $nonAdminUser = UserWhereTest::create([
+            'name' => 'second-name',
+            'email' => 'second-email',
+            'address' => 'second-address',
+            'is_admin' => false,
+        ]);
+
+        $this->assertTrue($adminUser->is(UserWhereTest::whereTrue('is_admin')->first()));
+        $this->assertFalse($nonAdminUser->is(UserWhereTest::whereTrue('is_admin')->first()));
+    }
+
+    public function testWhereFalse()
+    {
+        $adminUser = UserWhereTest::create([
+            'name' => 'first-name',
+            'email' => 'first-email',
+            'address' => 'first-address',
+            'is_admin' => true,
+        ]);
+
+        $nonAdminUser = UserWhereTest::create([
+            'name' => 'second-name',
+            'email' => 'second-email',
+            'address' => 'second-address',
+            'is_admin' => false,
+        ]);
+
+        $this->assertFalse($adminUser->is(UserWhereTest::whereFalse('is_admin')->first()));
+        $this->assertTrue($nonAdminUser->is(UserWhereTest::whereFalse('is_admin')->first()));
+    }
+
+    public function testOrWhereTrue()
+    {
+        UserWhereTest::create([
+            'name' => 'first-name',
+            'email' => 'first-email',
+            'address' => 'first-address',
+            'is_admin' => true,
+        ]);
+
+        UserWhereTest::create([
+            'name' => 'second-name',
+            'email' => 'second-email',
+            'address' => 'second-address',
+            'is_admin' => false,
+        ]);
+
+        UserWhereTest::create([
+            'name' => 'third-name',
+            'email' => 'third-email',
+            'address' => 'third-address',
+            'is_admin' => false,
+        ]);
+
+        $this->assertCount(2, UserWhereTest::where('name', 'second-name')->orWhereTrue('is_admin')->get());
+    }
+
+    public function testOrWhereFalse()
+    {
+        UserWhereTest::create([
+            'name' => 'first-name',
+            'email' => 'first-email',
+            'address' => 'first-address',
+            'is_admin' => true,
+        ]);
+
+        UserWhereTest::create([
+            'name' => 'second-name',
+            'email' => 'second-email',
+            'address' => 'second-address',
+            'is_admin' => false,
+        ]);
+
+        UserWhereTest::create([
+            'name' => 'third-name',
+            'email' => 'third-email',
+            'address' => 'third-address',
+            'is_admin' => true,
+        ]);
+
+        $this->assertCount(2, UserWhereTest::where('name', 'first-name')->orWhereFalse('is_admin')->get());
     }
 }
 


### PR DESCRIPTION
This PR is in response to a pool I took: #46071 .

It's not uncommon to have boolean fields in tables, and querying for them is only possible with something like
```php
$query->where('admin', true);
```

To make the code more readable, this PR adds two methods: `whereTrue()` and `whereFalse()`, plus the "or" versions. So now, the query above can be rewritten as
```php
$query->whereTrue('admin');
```

The SQL created is
```sql
"admin" = true
```

which is valid in MySQL, PostgreSQL, SQLite and SQL Server