### PR TITLE
Update Handler.php to logging Auth exception 

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
+use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Application as ConsoleApplication;
@@ -358,6 +359,7 @@ class Handler implements ExceptionHandlerContract
                 'userId' => Auth::id(),
             ]);
         } catch (Throwable $e) {
+            (new Logger('Auth Error'))->error($e->getMessage());
             return [];
         }
     }


### PR DESCRIPTION
If a custom driver with provider used in `auth.config` and it was not implemented in `AuthServiceProvider`, therefore, it was catch in context method and returning empty array. I faced with similar issue which was no log was recorded. For the reason of this issue I added error logger to make it reportable