### PR TITLE
Move methods with 'never' return type to abstract class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Release Notes for 10.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v10.1.2...10.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v10.1.3...10.x)
 
+
+## [v10.1.3 (2023-02-22)](https://github.com/laravel/framework/compare/v10.1.2...v10.1.3)
+
+### Added
+- Added protected method `Illuminate/Http/Resources/Json/JsonResource::newCollection()` for simplifies collection customisation ([#46217](https://github.com/laravel/framework/pull/46217))
 
 ### Fixed
 - Fixes constructable migrations ([#46223](https://github.com/laravel/framework/pull/46223))
+
+### Changes
+- Accept time when generating ULID in `Str::ulid()` ([#46201](https://github.com/laravel/framework/pull/46201))
+
 
 ## [v10.1.2 (2023-02-22)](https://github.com/laravel/framework/compare/v10.1.1...v10.1.2)
 
@@ -20,6 +29,7 @@
 ### Fixed
 - Fixed `Illuminate/Collections/Arr::shuffle()` for empty array ([0c6cae0](https://github.com/laravel/framework/commit/0c6cae0ef647158b9554cad05ff39db7e7ad0d33))
 
+
 ## [v10.1.0 (2023-02-21)](https://github.com/laravel/framework/compare/v10.0.3...v10.1.0)
 
 ### Fixed
@@ -31,15 +41,18 @@
 - Use mixed return type on controller stubs ([#46166](https://github.com/laravel/framework/pull/46166))
 - Use InteractsWithDictionary in Eloquent collection ([#46196](https://github.com/laravel/framework/pull/46196))
 
+
 ## [v10.0.3 (2023-02-17)](https://github.com/laravel/framework/compare/v10.0.2...v10.0.3)
 
 ### Added
 - Added missing expression support for pluck in Builder ([#46146](https://github.com/laravel/framework/pull/46146))
 
+
 ## [v10.0.2 (2023-02-16)](https://github.com/laravel/framework/compare/v10.0.1...v10.0.2)
 
 ### Added
 - Register policies automatically to the gate ([#46132](https://github.com/laravel/framework/pull/46132))
+
 
 ## [v10.0.1 (2023-02-16)](https://github.com/laravel/framework/compare/v10.0.0...v10.0.1)
 
@@ -52,6 +65,7 @@
 ### Changed
 - Add AddQueuedCookiesToResponse to middlewarePriority so it is handled in the right place ([#46130](https://github.com/laravel/framework/pull/46130))
 - Show queue connection in MonitorCommand ([#46122](https://github.com/laravel/framework/pull/46122))
+
 
 ## [v10.0.0 (2023-02-14)](https://github.com/laravel/framework/compare/v10.0.0...10.x)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 10.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.52.3...10.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.52.4...10.x)
+
+## [v9.52.4](https://github.com/laravel/framework/compare/v9.52.3...v9.52.4) - 2023-02-22
+
+### Fixed
+
+- Fixes constructable migrations ([#46223](https://github.com/laravel/framework/pull/46223))
 
 ## [v9.52.3](https://github.com/laravel/framework/compare/v10.1.1...v9.52.3) - 2023-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 10.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v10.1.3...10.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v10.1.4...10.x)
+
+
+## [v10.1.4 (2023-02-23)](https://github.com/laravel/framework/compare/v10.1.3...v10.1.4)
+
+### Changed
+- Improve Facade Fake Awareness ([#46188](https://github.com/laravel/framework/pull/46188), [#46232](https://github.com/laravel/framework/pull/46232))
 
 
 ## [v10.1.3 (2023-02-22)](https://github.com/laravel/framework/compare/v10.1.2...v10.1.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 10.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v10.1.1...10.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v10.1.2...10.x)
+
+
+## [v10.1.2 (2023-02-22)](https://github.com/laravel/framework/compare/v10.1.1...v10.1.2)
+
+### Reverted
+- Reverted changes in `Arr::random()` ([cf3eb90](https://github.com/laravel/framework/commit/cf3eb90a6473444bb7a78d1a3af1e9312a62020d))
 
 
 ## [v10.1.1 (2023-02-21)](https://github.com/laravel/framework/compare/v10.1.0...v10.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,62 @@
 # Release Notes for 10.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v10.1.1...10.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.52.3...10.x)
 
+## [v9.52.3](https://github.com/laravel/framework/compare/v10.1.1...v9.52.3) - 2023-02-22
+
+### Reverted
+
+- Revert changes from `Arr::random()` ([cf3eb90](https://github.com/laravel/framework/commit/cf3eb90a6473444bb7a78d1a3af1e9312a62020d))
 
 ## [v10.1.1 (2023-02-21)](https://github.com/laravel/framework/compare/v10.1.0...v10.1.1)
 
 ### Added
+
 - Add the ability to re-resolve cache drivers ([#46203](https://github.com/laravel/framework/pull/46203))
 
 ### Fixed
-- Fixed `Illuminate/Collections/Arr::shuffle()` for empty array ([0c6cae0](https://github.com/laravel/framework/commit/0c6cae0ef647158b9554cad05ff39db7e7ad0d33))
 
+- Fixed `Illuminate/Collections/Arr::shuffle()` for empty array ([0c6cae0](https://github.com/laravel/framework/commit/0c6cae0ef647158b9554cad05ff39db7e7ad0d33))
 
 ## [v10.1.0 (2023-02-21)](https://github.com/laravel/framework/compare/v10.0.3...v10.1.0)
 
 ### Fixed
+
 - Fixing issue where 0 is discarded as a valid timestamp ([#46158](https://github.com/laravel/framework/pull/46158))
 - Fix custom themes not reseting on Markdown renderer ([#46200](https://github.com/laravel/framework/pull/46200))
 
 ### Changed
+
 - Use secure randomness in Arr:random and Arr:shuffle ([#46105](https://github.com/laravel/framework/pull/46105))
 - Use mixed return type on controller stubs ([#46166](https://github.com/laravel/framework/pull/46166))
 - Use InteractsWithDictionary in Eloquent collection ([#46196](https://github.com/laravel/framework/pull/46196))
 
-
 ## [v10.0.3 (2023-02-17)](https://github.com/laravel/framework/compare/v10.0.2...v10.0.3)
 
 ### Added
-- Added missing expression support for pluck in Builder ([#46146](https://github.com/laravel/framework/pull/46146))
 
+- Added missing expression support for pluck in Builder ([#46146](https://github.com/laravel/framework/pull/46146))
 
 ## [v10.0.2 (2023-02-16)](https://github.com/laravel/framework/compare/v10.0.1...v10.0.2)
 
 ### Added
--  Register policies automatically to the gate ([#46132](https://github.com/laravel/framework/pull/46132))
 
+- Register policies automatically to the gate ([#46132](https://github.com/laravel/framework/pull/46132))
 
 ## [v10.0.1 (2023-02-16)](https://github.com/laravel/framework/compare/v10.0.0...v10.0.1)
 
 ### Added
+
 - Standard Input can be applied to PendingProcess ([#46119](https://github.com/laravel/framework/pull/46119))
 
 ### Fixed
+
 - Fix Expression string casting ([#46137](https://github.com/laravel/framework/pull/46137))
 
 ### Changed
+
 - Add AddQueuedCookiesToResponse to middlewarePriority so it is handled in the right place ([#46130](https://github.com/laravel/framework/pull/46130))
 - Show queue connection in MonitorCommand ([#46122](https://github.com/laravel/framework/pull/46122))
-
 
 ## [v10.0.0 (2023-02-14)](https://github.com/laravel/framework/compare/v10.0.0...10.x)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Release Notes for 10.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v10.1.4...10.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v10.1.5...10.x)
+
+
+## [v10.1.5 (2023-02-24)](https://github.com/laravel/framework/compare/v10.1.4...v10.1.5)
+
+### Fixed
+- Fixed `Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase::expectsDatabaseQueryCount()` $connection parameter ([#46228](https://github.com/laravel/framework/pull/46228))
+- Fixed Facade Fake ([#46257](https://github.com/laravel/framework/pull/46257))
+
+### Changed
+- Remove autoload dumping from make:migration ([#46215](https://github.com/laravel/framework/pull/46215))
 
 
 ## [v10.1.4 (2023-02-23)](https://github.com/laravel/framework/compare/v10.1.3...v10.1.4)

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -373,4 +373,14 @@ abstract class Broadcaster implements BroadcasterContract
     {
         return preg_match('/^'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
     }
+
+    /**
+     * Get all of the registered channels.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getChannels()
+    {
+        return collect($this->channels);
+    }
 }

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -33,6 +33,8 @@ class CacheTableCommand extends Command
 
     /**
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -63,8 +65,6 @@ class CacheTableCommand extends Command
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/cache.stub'));
 
         $this->components->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1568,6 +1568,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @return static
+     */
+    public function dot()
+    {
+        return new static(Arr::dot($this->all()));
+    }
+
+    /**
      * Convert a flatten "dot" notation array into an expanded array.
      *
      * @return static

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1519,6 +1519,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @return static
+     */
+    public function dot()
+    {
+        return $this->passthru('dot', []);
+    }
+
+    /**
      * Convert a flatten "dot" notation array into an expanded array.
      *
      * @return static

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -39,6 +39,8 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      * The Composer instance.
      *
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -93,8 +95,6 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
         $this->writeMigration($name, $table, $create);
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -38,7 +38,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '10.1.4';
+    const VERSION = '10.1.5';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Support\Collection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Terminal;
+
+#[AsCommand(name: 'channel:list')]
+class ChannelListCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'channel:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all registered private broadcast channels';
+
+    /**
+     * The terminal width resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $terminalWidthResolver;
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Contracts\Broadcasting\Broadcaster
+     * @return void
+     */
+    public function handle(Broadcaster $broadcaster)
+    {
+        $channels = $broadcaster->getChannels();
+
+        if (! $this->laravel->providerIsLoaded('App\Providers\BroadcastServiceProvider') &&
+            file_exists($this->laravel->path('Providers/BroadcastServiceProvider.php'))) {
+            $this->components->warn('The [App\Providers\BroadcastServiceProvider] has not been loaded. Your private channels may not be loaded.');
+        }
+
+        if (! $channels->count()) {
+            return $this->components->error("Your application doesn't have any private broadcasting channels.");
+        }
+
+        $this->displayChannels($channels);
+    }
+
+    /**
+     * Display the channel information on the console.
+     *
+     * @param  Collection  $channels
+     * @return void
+     */
+    protected function displayChannels($channels)
+    {
+        $this->output->writeln($this->forCli($channels));
+    }
+
+    /**
+     * Convert the given channels to regular CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $channels
+     * @return array
+     */
+    protected function forCli($channels)
+    {
+        $maxChannelName = $channels->keys()->max(function ($channelName) {
+            return mb_strlen($channelName);
+        });
+
+        $terminalWidth = $this->getTerminalWidth();
+
+        $channelCount = $this->determineChannelCountOutput($channels, $terminalWidth);
+
+        return $channels->map(function ($channel, $channelName) use ($maxChannelName, $terminalWidth) {
+            $resolver = $channel instanceof Closure ? 'Closure' : $channel;
+
+            $spaces = str_repeat(' ', max($maxChannelName + 6 - mb_strlen($channelName), 0));
+
+            $dots = str_repeat('.', max(
+                $terminalWidth - mb_strlen($channelName.$spaces.$resolver) - 6, 0
+            ));
+
+            $dots = empty($dots) ? $dots : " $dots";
+
+            return sprintf(
+                '  <fg=blue;options=bold>%s</> %s<fg=white>%s</><fg=#6C7280>%s</>',
+                $channelName,
+                $spaces,
+                $resolver,
+                $dots,
+            );
+        })
+            ->filter()
+            ->sort()
+            ->prepend('')
+            ->push('')->push($channelCount)->push('')
+            ->toArray();
+    }
+
+    /**
+     * Determine and return the output for displaying the number of registered chanels in the CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $channels
+     * @param  int  $terminalWidth
+     * @return string
+     */
+    protected function determineChannelCountOutput($channels, $terminalWidth)
+    {
+        $channelCountText = 'Showing ['.$channels->count().'] private channels';
+
+        $offset = $terminalWidth - mb_strlen($channelCountText) - 2;
+
+        $spaces = str_repeat(' ', $offset);
+
+        return $spaces.'<fg=blue;options=bold>Showing ['.$channels->count().'] private channels</>';
+    }
+
+    /**
+     * Get the terminal width.
+     *
+     * @return int
+     */
+    public static function getTerminalWidth()
+    {
+        return is_null(static::$terminalWidthResolver)
+            ? (new Terminal)->getWidth()
+            : call_user_func(static::$terminalWidthResolver);
+    }
+
+    /**
+     * Set a callback that should be used when resolving the terminal width.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveTerminalWidthUsing($resolver)
+    {
+        static::$terminalWidthResolver = $resolver;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,7 +46,9 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         $stub = parent::replaceClass($stub, $name);
 
-        return str_replace(['dummy:command', '{{ command }}'], $this->option('command'), $stub);
+        $command = $this->option('command') ?: 'app:'.Str::of($name)->classBasename()->kebab()->value();
+
+        return str_replace(['dummy:command', '{{ command }}'], $command, $stub);
     }
 
     /**
@@ -94,7 +97,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the console command already exists'],
-            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned', 'command:name'],
+            ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that will be used to invoke the class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
+use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ComponentMakeCommand;
@@ -165,6 +166,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected $devCommands = [
         'CacheTable' => CacheTableCommand::class,
         'CastMake' => CastMakeCommand::class,
+        'ChannelList' => ChannelListCommand::class,
         'ChannelMake' => ChannelMakeCommand::class,
         'ComponentMake' => ComponentMakeCommand::class,
         'ConsoleMake' => ConsoleMakeCommand::class,

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -109,7 +109,7 @@ if (! function_exists('app')) {
      *
      * @param  string|null  $abstract
      * @param  array  $parameters
-     * @return mixed|\Illuminate\Contracts\Foundation\Application
+     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Foundation\Application|mixed
      */
     function app($abstract = null, array $parameters = [])
     {

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -7,11 +7,14 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Traits\Conditionable;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class Logger implements LoggerInterface
 {
+    use Conditionable;
+
     /**
      * The underlying logger implementation.
      *

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -33,6 +33,8 @@ class NotificationTableCommand extends Command
 
     /**
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -63,8 +65,6 @@ class NotificationTableCommand extends Command
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/notifications.stub'));
 
         $this->components->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -33,6 +33,8 @@ class BatchesTableCommand extends Command
 
     /**
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -65,8 +67,6 @@ class BatchesTableCommand extends Command
         );
 
         $this->components->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -33,6 +33,8 @@ class FailedTableCommand extends Command
 
     /**
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -65,8 +67,6 @@ class FailedTableCommand extends Command
         );
 
         $this->components->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -33,6 +33,8 @@ class TableCommand extends Command
 
     /**
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -65,8 +67,6 @@ class TableCommand extends Command
         );
 
         $this->components->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Queue/Events/JobPopped.php
+++ b/src/Illuminate/Queue/Events/JobPopped.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobPopped
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job|null
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->connectionName = $connectionName;
+        $this->job = $job;
+    }
+}

--- a/src/Illuminate/Queue/Events/JobPopping.php
+++ b/src/Illuminate/Queue/Events/JobPopping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobPopping
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @return void
+     */
+    public function __construct($connectionName)
+    {
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobPopped;
+use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
@@ -342,13 +344,20 @@ class Worker
             return $connection->pop($queue);
         };
 
+        $this->raiseBeforeJobPopEvent($connection->getConnectionName());
+
         try {
             if (isset(static::$popCallbacks[$this->name])) {
-                return (static::$popCallbacks[$this->name])($popJobCallback, $queue);
+                return tap(
+                    (static::$popCallbacks[$this->name])($popJobCallback, $queue),
+                    fn ($job) => $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job)
+                );
             }
 
             foreach (explode(',', $queue) as $queue) {
                 if (! is_null($job = $popJobCallback($queue))) {
+                    $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
+
                     return $job;
                 }
             }
@@ -599,6 +608,31 @@ class Worker
         );
 
         return (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
+    }
+
+    /**
+     * Raise the before job has been popped.
+     *
+     * @param  string  $connectionName
+     * @return void
+     */
+    protected function raiseBeforeJobPopEvent($connectionName)
+    {
+        $this->events->dispatch(new JobPopping($connectionName));
+    }
+
+    /**
+     * Raise the after job has been popped.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
+     * @return void
+     */
+    protected function raiseAfterJobPopEvent($connectionName, $job)
+    {
+        $this->events->dispatch(new JobPopped(
+            $connectionName, $job
+        ));
     }
 
     /**

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
@@ -2,18 +2,11 @@
 
 namespace {{ namespace }};
 
-use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Routing\SingletonController as Controller;
 use Illuminate\Http\Request;
 
 class {{ class }} extends Controller
 {
-    /**
-     * Store the newly created resource in storage.
-     */
-    public function store(Request $request): never
-    {
-        abort(404);
-    }
 
     /**
      * Display the resource.
@@ -29,13 +22,5 @@ class {{ class }} extends Controller
     public function update(Request $request)
     {
         //
-    }
-
-    /**
-     * Remove the resource from storage.
-     */
-    public function destroy(): never
-    {
-        abort(404);
     }
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
@@ -2,26 +2,11 @@
 
 namespace {{ namespace }};
 
-use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Routing\SingletonController as Controller;
 use Illuminate\Http\Request;
 
 class {{ class }} extends Controller
 {
-    /**
-     * Show the form for creating the resource.
-     */
-    public function create(): never
-    {
-        abort(404);
-    }
-
-    /**
-     * Store the newly created resource in storage.
-     */
-    public function store(Request $request): never
-    {
-        abort(404);
-    }
 
     /**
      * Display the resource.
@@ -45,13 +30,5 @@ class {{ class }} extends Controller
     public function update(Request $request)
     {
         //
-    }
-
-    /**
-     * Remove the resource from storage.
-     */
-    public function destroy(): never
-    {
-        abort(404);
     }
 }

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -31,7 +31,7 @@ class RedirectController extends Controller
 
         $parameters = $parameters->only(
             $route->getCompiled()->getPathVariables()
-        )->toArray();
+        )->all();
 
         $url = $url->toRoute($route, $parameters, false);
 

--- a/src/Illuminate/Routing/SingletonController.php
+++ b/src/Illuminate/Routing/SingletonController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Request;
+
+
+
+class SingletonController extends Controller
+{
+    use AuthorizesRequests, ValidatesRequests;
+  
+    
+    /**
+     * Show the form for creating the resource.
+     */
+    public function create(): never
+    {
+        abort(404);
+    }
+
+    /**
+     * Store the newly created resource in storage.
+     */
+    public function store(Request $request): never
+    {
+        abort(404);
+    }
+
+
+    /**
+     * Remove the resource from storage.
+     */
+    public function destroy(): never
+    {
+        abort(404);
+    }
+}

--- a/src/Illuminate/Routing/SingletonController.php
+++ b/src/Illuminate/Routing/SingletonController.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Request;
 
 
 
-class SingletonController extends Controller
+abstract class SingletonController extends Controller
 {
     use AuthorizesRequests, ValidatesRequests;
   

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -33,6 +33,8 @@ class SessionTableCommand extends Command
 
     /**
      * @var \Illuminate\Support\Composer
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     protected $composer;
 
@@ -63,8 +65,6 @@ class SessionTableCommand extends Command
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/database.stub'));
 
         $this->components->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -28,6 +28,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
  * @method static array|null resolveAuthenticatedUser(\Illuminate\Http\Request $request)
  * @method static void resolveAuthenticatedUserUsing(\Closure $callback)
  * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string $channel, callable|string $callback, array $options = [])
+ * @method static \Illuminate\Support\Collection getChannels()
  *
  * @see \Illuminate\Broadcasting\BroadcastManager
  * @see \Illuminate\Broadcasting\Broadcasters\Broadcaster

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -60,10 +60,12 @@ class Bus extends Facade
      */
     public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)
     {
-        return tap(new BusFake(static::getFacadeRoot(), $jobsToFake, $batchRepository), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        $actualDispatcher = static::isFake()
+                ? static::getFacadeRoot()->dispatcher
+                : static::getFacadeRoot();
+
+        return tap(new BusFake($actualDispatcher, $jobsToFake, $batchRepository), function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -47,13 +47,15 @@ class Event extends Facade
      */
     public static function fake($eventsToFake = [])
     {
-        return tap(new EventFake(static::getFacadeRoot(), $eventsToFake), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
+        $actualDispatcher = static::isFake()
+                ? static::getFacadeRoot()->dispatcher
+                : static::getFacadeRoot();
 
-                Model::setEventDispatcher($fake);
-                Cache::refreshEventDispatcher();
-            }
+        return tap(new EventFake($actualDispatcher, $eventsToFake), function ($fake) {
+            static::swap($fake);
+
+            Model::setEventDispatcher($fake);
+            Cache::refreshEventDispatcher();
         });
     }
 

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -31,6 +31,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Psr\Log\LoggerInterface getLogger()
  * @method static \Illuminate\Contracts\Events\Dispatcher getEventDispatcher()
  * @method static void setEventDispatcher(\Illuminate\Contracts\Events\Dispatcher $dispatcher)
+ * @method static \Illuminate\Log\Logger|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static \Illuminate\Log\Logger|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  *
  * @see \Illuminate\Log\LogManager
  */

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -65,10 +65,12 @@ class Mail extends Facade
      */
     public static function fake()
     {
-        return tap(new MailFake(static::getFacadeRoot()), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        $actualMailManager = static::isFake()
+                ? static::getFacadeRoot()->manager
+                : static::getFacadeRoot();
+
+        return tap(new MailFake($actualMailManager), function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -49,10 +49,8 @@ class Notification extends Facade
      */
     public static function fake()
     {
-        return tap(new NotificationFake(), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        return tap(new NotificationFake, function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -76,10 +76,12 @@ class Queue extends Facade
      */
     public static function fake($jobsToFake = [])
     {
-        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()), function ($fake) {
-            if (! static::isFake()) {
-                static::swap($fake);
-            }
+        $actualQueueManager = static::isFake()
+                ? static::getFacadeRoot()->queue
+                : static::getFacadeRoot();
+
+        return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, $actualQueueManager), function ($fake) {
+            static::swap($fake);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -35,7 +35,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\HttpFoundation\ParameterBag|mixed json(string|null $key = null, mixed $default = null)
  * @method static \Illuminate\Http\Request createFrom(\Illuminate\Http\Request $from, \Illuminate\Http\Request|null $to = null)
  * @method static \Illuminate\Http\Request createFromBase(\Symfony\Component\HttpFoundation\Request $request)
- * @method static \Illuminate\Http\Request duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
+ * @method static \Illuminate\Http\Request duplicate(array|null $query = null, array|null $request = null, array|null $attributes = null, array|null $cookies = null, array|null $files = null, array|null $server = null)
  * @method static bool hasSession(bool $skipIfUninitialized = false)
  * @method static \Symfony\Component\HttpFoundation\Session\SessionInterface getSession()
  * @method static \Illuminate\Contracts\Session\Session session()

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -20,7 +20,7 @@ class BusFake implements Fake, QueueingDispatcher
      *
      * @var \Illuminate\Contracts\Bus\QueueingDispatcher
      */
-    protected $dispatcher;
+    public $dispatcher;
 
     /**
      * The job types that should be intercepted instead of dispatched.

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -20,7 +20,7 @@ class EventFake implements Dispatcher, Fake
      *
      * @var \Illuminate\Contracts\Events\Dispatcher
      */
-    protected $dispatcher;
+    public $dispatcher;
 
     /**
      * The event types that should be intercepted instead of dispatched.

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -22,7 +22,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      *
      * @var MailManager
      */
-    protected $manager;
+    public $manager;
 
     /**
      * The mailer currently being used to send a message.

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -20,7 +20,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      *
      * @var \Illuminate\Contracts\Queue\Queue
      */
-    protected $queue;
+    public $queue;
 
     /**
      * The job types that should be intercepted instead of pushed to the queue.

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -35,7 +35,6 @@ class CacheTableCommandTest extends TestCase
         $creator->shouldReceive('create')->once()->with('create_cache_table', $path)->andReturn($path);
         $files->shouldReceive('get')->once()->andReturn('foo');
         $files->shouldReceive('put')->once()->with($path, 'foo');
-        $composer->shouldReceive('dumpAutoloads')->once();
 
         $this->runCommand($command);
     }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -30,7 +30,6 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $creator->shouldReceive('create')->once()
                 ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
-        $composer->shouldReceive('dumpAutoloads')->once();
 
         $this->runCommand($command, ['name' => 'create_foo']);
     }

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
@@ -33,6 +35,19 @@ class RouteRedirectTest extends TestCase
             'route redirect with two optional replacements' => ['users/{user?}/{repo?}', 'members/{user?}', '/users/22', '/members/22'],
             'route redirect with two optional replacements that switch position' => ['users/{user?}/{switch?}', 'members/{switch?}/{user?}', '/users/11/22', '/members/22/11'],
         ];
+    }
+
+    public function testRouteRedirectWithExplicitRouteModelBinding()
+    {
+        $this->withoutExceptionHandling();
+        Route::middleware([SubstituteBindings::class])->group(function () {
+            Route::redirect('users/{user}', 'users/{user}/overview');
+        });
+        Route::bind('user', fn ($id) => (new User())->setAttribute('id', '999'));
+
+        $response = $this->get('users/1');
+
+        $response->assertRedirect('users/999/overview');
     }
 
     public function testToRouteHelper()

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -35,7 +35,6 @@ class SessionTableCommandTest extends TestCase
         $creator->shouldReceive('create')->once()->with('create_sessions_table', $path)->andReturn($path);
         $files->shouldReceive('get')->once()->andReturn('foo');
         $files->shouldReceive('put')->once()->with($path, 'foo');
-        $composer->shouldReceive('dumpAutoloads')->once();
 
         $this->runCommand($command);
     }


### PR DESCRIPTION
In this PR, the methods with a 'never' return type are moved to a proper Class.

If validated it would be cool if we make sure that ProfileController extends SingletonController : 

Route::singleton('profile', ProfileController::class);

