### PR TITLE
Move methods with 'never' return type to abstract class

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.api.stub
@@ -2,18 +2,11 @@
 
 namespace {{ namespace }};
 
-use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Routing\SingletonController as Controller;
 use Illuminate\Http\Request;
 
 class {{ class }} extends Controller
 {
-    /**
-     * Store the newly created resource in storage.
-     */
-    public function store(Request $request): never
-    {
-        abort(404);
-    }
 
     /**
      * Display the resource.
@@ -29,13 +22,5 @@ class {{ class }} extends Controller
     public function update(Request $request)
     {
         //
-    }
-
-    /**
-     * Remove the resource from storage.
-     */
-    public function destroy(): never
-    {
-        abort(404);
     }
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.singleton.stub
@@ -2,26 +2,11 @@
 
 namespace {{ namespace }};
 
-use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Routing\SingletonController as Controller;
 use Illuminate\Http\Request;
 
 class {{ class }} extends Controller
 {
-    /**
-     * Show the form for creating the resource.
-     */
-    public function create(): never
-    {
-        abort(404);
-    }
-
-    /**
-     * Store the newly created resource in storage.
-     */
-    public function store(Request $request): never
-    {
-        abort(404);
-    }
 
     /**
      * Display the resource.
@@ -45,13 +30,5 @@ class {{ class }} extends Controller
     public function update(Request $request)
     {
         //
-    }
-
-    /**
-     * Remove the resource from storage.
-     */
-    public function destroy(): never
-    {
-        abort(404);
     }
 }

--- a/src/Illuminate/Routing/SingletonController.php
+++ b/src/Illuminate/Routing/SingletonController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Request;
+
+
+
+abstract class SingletonController extends Controller
+{
+    use AuthorizesRequests, ValidatesRequests;
+
+
+    /**
+     * Show the form for creating the resource.
+     */
+    public function create(): never
+    {
+        abort(404);
+    }
+
+    /**
+     * Store the newly created resource in storage.
+     */
+    public function store(Request $request): never
+    {
+        abort(404);
+    }
+
+
+    /**
+     * Remove the resource from storage.
+     */
+    public function destroy(): never
+    {
+        abort(404);
+    }
+}

--- a/src/Illuminate/Routing/SingletonController.php
+++ b/src/Illuminate/Routing/SingletonController.php
@@ -6,12 +6,9 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 
-
-
 abstract class SingletonController extends Controller
 {
     use AuthorizesRequests, ValidatesRequests;
-
 
     /**
      * Show the form for creating the resource.
@@ -28,7 +25,6 @@ abstract class SingletonController extends Controller
     {
         abort(404);
     }
-
 
     /**
      * Remove the resource from storage.


### PR DESCRIPTION
In this PR, the methods with a 'never' return type is moved to a proper Class.

If validated it would be cool if we make sure that ProfileController extends SingletonController :

Route::singleton('profile', ProfileController::class);