### PR TITLE
[9.x] Make createIndexName function public

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1645,7 +1645,7 @@ class Blueprint
      * @param  array  $columns
      * @return string
      */
-    protected function createIndexName($type, array $columns)
+    public function createIndexName(string $type, array $columns): string
     {
         $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 


### PR DESCRIPTION
Having this function public is useful to create a default index name according to the standard without creating your own function.  This is useful for checking if an index already exists.

See https://stackoverflow.com/a/45883428/6383358 for an example of a use case.

Also cleaned up function definition for later versions of Php.