### PR TITLE
Fix typo in function name

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -138,7 +138,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
         return retry(2, fn () => $this->migrator->repositoryExists(), 0, function ($e) {
             try {
                 if ($e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
-                    return $this->createMissingSqliteDatbase($e->getPrevious()->path);
+                    return $this->createMissingSqliteDatabase($e->getPrevious()->path);
                 }
 
                 $connection = $this->migrator->resolveConnection($this->option('database'));
@@ -163,7 +163,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
      * @param  string  $path
      * @return bool
      */
-    protected function createMissingSqliteDatbase($path)
+    protected function createMissingSqliteDatabase($path)
     {
         if ($this->option('force')) {
             return touch($path);


### PR DESCRIPTION
This fixes a typo in a function name. Who had guessed? 😎 

I searched the API and this repository and didn't find any other references to this function, so we should be fine just fixing the name here!

Cheers
