### PR TITLE
Cast json decoded failed_job_ids to array in DatabaseBatchRepository::toBatch

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -357,7 +357,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             (int) $batch->total_jobs,
             (int) $batch->pending_jobs,
             (int) $batch->failed_jobs,
-            json_decode($batch->failed_job_ids, true),
+            (array) json_decode($batch->failed_job_ids, true),
             $this->unserialize($batch->options),
             CarbonImmutable::createFromTimestamp($batch->created_at),
             $batch->cancelled_at ? CarbonImmutable::createFromTimestamp($batch->cancelled_at) : $batch->cancelled_at,


### PR DESCRIPTION

closes #46327 

This PR fixes the referenced issue with array casting the json decoded array from failed_job_ids column in job_batches table.
In case if failed_job_ids column has empty or null value for whatever reason (interruption in the issue case, explicit update etc...) it should return an empty array instead of null so the batch won't fail with the exception thrown in the referenced issue.

Kindly

