### PR TITLE
[10.x] Replace deprecated `Rule` class with `ValidationRule` in Enum validation

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -2,10 +2,11 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use TypeError;
+use Closure;
 
-class Enum implements Rule
+class Enum implements ValidationRule
 {
     /**
      * The type of the enum.
@@ -26,40 +27,30 @@ class Enum implements Rule
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if ($value instanceof $this->type) {
-            return true;
+            return;
         }
 
-        if (is_null($value) || ! enum_exists($this->type) || ! method_exists($this->type, 'tryFrom')) {
-            return false;
+        if (! is_null($value) && enum_exists($this->type) && method_exists($this->type, 'tryFrom')) {
+            try {
+                if (! is_null($this->type::tryFrom($value))) {
+                    return;
+                }
+            } catch (TypeError) {
+            }
         }
 
-        try {
-            return ! is_null($this->type::tryFrom($value));
-        } catch (TypeError) {
-            return false;
-        }
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return array
-     */
-    public function message()
-    {
-        $message = trans('validation.enum');
-
-        return $message === 'validation.enum'
-            ? ['The selected :attribute is invalid.']
-            : $message;
+        $fail('validation.enum')->translate([
+            'attribute' => $attribute,
+        ]);
     }
 }

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use TypeError;
-use Closure;
 
 class Enum implements ValidationRule
 {

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -15,7 +15,7 @@ include 'Enums.php';
 
 class ValidationEnumRuleTest extends TestCase
 {
-    public function testvalidationPassesWhenPassingCorrectEnum()
+    public function testValidationPassesWhenPassingCorrectEnum()
     {
         $v = new Validator(
             resolve('translator'),
@@ -32,7 +32,7 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
-    public function testvalidationPassesWhenPassingInstanceOfEnum()
+    public function testValidationPassesWhenPassingInstanceOfEnum()
     {
         $v = new Validator(
             resolve('translator'),
@@ -47,7 +47,7 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
-    public function testvalidationPassesWhenPassingInstanceOfPureEnum()
+    public function testValidationPassesWhenPassingInstanceOfPureEnum()
     {
         $v = new Validator(
             resolve('translator'),
@@ -75,7 +75,7 @@ class ValidationEnumRuleTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+        $this->assertEquals(['validation.enum'], $v->messages()->get('status'));
     }
 
     public function testValidationFailsWhenProvidingDifferentType()
@@ -91,7 +91,7 @@ class ValidationEnumRuleTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+        $this->assertEquals(['validation.enum'], $v->messages()->get('status'));
     }
 
     public function testValidationPassesWhenProvidingDifferentTypeThatIsCastableToTheEnumType()
@@ -122,7 +122,7 @@ class ValidationEnumRuleTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+        $this->assertEquals(['validation.enum'], $v->messages()->get('status'));
     }
 
     public function testValidationPassesWhenProvidingNullButTheFieldIsNullable()
@@ -168,7 +168,7 @@ class ValidationEnumRuleTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+        $this->assertEquals(['validation.enum'], $v->messages()->get('status'));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This PR updates the Enum validation rules in Laravel to use the new `ValidationRule` class instead of the deprecation `Rule` class. This is important because the Rule class has been removed in the new version of Laravel.