### PR TITLE
[10.x] Add additional type to $app property to match app() helper.

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -15,7 +15,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application|\Illuminate\Foundation\Application
      */
     protected $app;
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I am proposing this change after I added `preventLazyLoading` to my `AppServiceProvider` and realised that the code snippet suggested in the docs (shown below) shows an undefined method error in VSCode. This was mostly inspired by the addition of the same type in the `app()` helper, the commit for that can be found here: https://github.com/laravel/framework/commit/2c4a4e7338227bf6ba549402790ef5ba820873ce

Code snippet from docs:

```php
use Illuminate\Database\Eloquent\Model;
 
/**
 * Bootstrap any application services.
 */
public function boot(): void
{
    Model::preventLazyLoading(! $this->app->isProduction());
}
```