### PR TITLE
[10.x] Add isMatchAll method for both Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -637,6 +637,32 @@ class Str
     }
 
     /**
+     * Determine if a given string matches all given patterns.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isMatchAll($pattern, $value)
+    {
+        $value = (string) $value;
+
+        if (! is_iterable($pattern)) {
+            return preg_match((string) $pattern, $value) === 1;
+        }
+
+        foreach ($pattern as $pattern) {
+            $pattern = (string) $pattern;
+
+            if (preg_match($pattern, $value) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -453,6 +453,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Determine if a given string matches all given patterns.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @return bool
+     */
+    public function isMatchAll($pattern)
+    {
+        return Str::isMatchAll($pattern, $this->value);
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -458,6 +458,33 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isMatch(['/^[a-zA-Z,!]+$/', '/^(.*(.*(.*)))/'], 'Hello, Laravel!'));
     }
 
+    public function testIsMatchAll()
+    {
+        $string = 'Laravel is best PHP framework!';
+
+        $truePatterns = [
+            '/laravel/i',
+            '/^(.*)is(.*)[.!?]$/',
+        ];
+
+        $falsePatterns = [
+            '/php/',
+            '/^(.*)is the(.*)[.!?]$/',
+        ];
+
+        $this->assertTrue(Str::isMatchAll($truePatterns, $string));
+        $this->assertTrue(Str::isMatchAll($truePatterns[0], $string));
+        $this->assertTrue(Str::isMatchAll($truePatterns[1], $string));
+
+        $this->assertFalse(Str::isMatchAll($falsePatterns, $string));
+        $this->assertFalse(Str::isMatchAll($falsePatterns[0], $string));
+        $this->assertFalse(Str::isMatchAll($falsePatterns[1], $string));
+
+        $this->assertFalse(Str::isMatchAll([...$truePatterns, ...$falsePatterns], $string));
+        $this->assertFalse(Str::isMatchAll([$truePatterns[1], $falsePatterns[0]], $string));
+        $this->assertFalse(Str::isMatchAll([$falsePatterns[1], $truePatterns[0]], $string));
+    }
+
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -80,6 +80,33 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('Hello, Laravel!')->isMatch(['/^[a-zA-Z,!]+$/', '/^(.*(.*(.*)))/']));
     }
 
+    public function testIsMatchAll()
+    {
+        $stringable = $this->stringable('Laravel is best PHP framework!');
+
+        $truePatterns = [
+            '/laravel/i',
+            '/^(.*)is(.*)[.!?]$/',
+        ];
+
+        $falsePatterns = [
+            '/php/',
+            '/^(.*)is the(.*)[.!?]$/',
+        ];
+
+        $this->assertTrue($stringable->isMatchAll($truePatterns));
+        $this->assertTrue($stringable->isMatchAll($truePatterns[0]));
+        $this->assertTrue($stringable->isMatchAll($truePatterns[1]));
+
+        $this->assertFalse($stringable->isMatchAll($falsePatterns));
+        $this->assertFalse($stringable->isMatchAll($falsePatterns[0]));
+        $this->assertFalse($stringable->isMatchAll($falsePatterns[1]));
+
+        $this->assertFalse($stringable->isMatchAll([...$truePatterns, ...$falsePatterns]));
+        $this->assertFalse($stringable->isMatchAll([$truePatterns[1], $falsePatterns[0]]));
+        $this->assertFalse($stringable->isMatchAll([$falsePatterns[1], $truePatterns[0]]));
+    }
+
     public function testIsEmpty()
     {
         $this->assertTrue($this->stringable('')->isEmpty());


### PR DESCRIPTION
This PR adds `isMatchAll` method for both `Illuminate\Support\Str` and `Illuminate\Support\Stringable`. 
It is an addition for https://github.com/laravel/framework/pull/46303 that allows to determine is string matches all provided regex patterns as something between `is` and `matchAll` methods.

PR does not contain breaking changes.