### PR TITLE
[10.x] Add processors to logging (placeholders)

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -16,6 +16,8 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Handler\WhatFailureGroupHandler;
 use Monolog\Logger as Monolog;
+use Monolog\Processor\ProcessorInterface;
+use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -293,7 +295,7 @@ class LogManager implements LoggerInterface
                     $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
                 ), $config
             ),
-        ]);
+        ], $config['with_placeholders'] ?? true ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -309,7 +311,7 @@ class LogManager implements LoggerInterface
                 $config['path'], $config['days'] ?? 7, $this->level($config),
                 $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
             ), $config),
-        ]);
+        ], $config['with_placeholders'] ?? true ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -333,7 +335,7 @@ class LogManager implements LoggerInterface
                 $config['bubble'] ?? true,
                 $config['exclude_fields'] ?? []
             ), $config),
-        ]);
+        ], $config['with_placeholders'] ?? true ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -349,7 +351,7 @@ class LogManager implements LoggerInterface
                 Str::snake($this->app['config']['app.name'], '-'),
                 $config['facility'] ?? LOG_USER, $this->level($config)
             ), $config),
-        ]);
+        ], $config['with_placeholders'] ?? true ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -364,7 +366,7 @@ class LogManager implements LoggerInterface
             $this->prepareHandler(new ErrorLogHandler(
                 $config['type'] ?? ErrorLogHandler::OPERATING_SYSTEM, $this->level($config)
             )),
-        ]);
+        ], $config['with_placeholders'] ?? true ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -383,6 +385,14 @@ class LogManager implements LoggerInterface
                 $config['handler'].' must be an instance of '.HandlerInterface::class
             );
         }
+        collect($config['processors'] ?? [])->each(function ($processor) {
+            $processor = $processor['processor'] ?? $processor;
+            if (! is_a($processor, ProcessorInterface::class, true)) {
+                throw new InvalidArgumentException(
+                    $processor.' must be an instance of '.ProcessorInterface::class
+                );
+            }
+        });
 
         $with = array_merge(
             ['level' => $this->level($config)],
@@ -392,7 +402,8 @@ class LogManager implements LoggerInterface
 
         return new Monolog($this->parseChannel($config), [$this->prepareHandler(
             $this->app->make($config['handler'], $with), $config
-        )]);
+        )], collect($config['processors'] ?? [])->map(fn ($processor) => $this->app->make($processor['processor'] ?? $processor, $processor['with'] ?? [])
+        )->toArray());
     }
 
     /**

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -15,6 +15,8 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Level;
 use Monolog\Logger as Monolog;
+use Monolog\Processor\MemoryUsageProcessor;
+use Monolog\Processor\PsrLogMessageProcessor;
 use Monolog\Processor\UidProcessor;
 use Orchestra\Testbench\TestCase;
 use ReflectionProperty;
@@ -63,6 +65,7 @@ class LogManagerTest extends TestCase
                 'stream' => 'php://stderr',
                 'bubble' => false,
             ],
+            'processors' => [PsrLogMessageProcessor::class],
         ]);
 
         $config->set('logging.channels.stdout', [
@@ -84,6 +87,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(Logger::class, $logger);
         $this->assertCount(2, $handlers);
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
+        $this->assertInstanceOf(PsrLogMessageProcessor::class, $logger->getLogger()->getProcessors()[0]);
         $this->assertInstanceOf(StreamHandler::class, $handlers[1]);
         $this->assertEquals(Level::Notice, $handlers[0]->getLevel());
         $this->assertEquals(Level::Info, $handlers[1]->getLevel());
@@ -211,6 +215,39 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(NullHandler::class, $handler);
     }
 
+    public function testLogManagerCreatesMonologHandlerWithProcessors()
+    {
+        $config = $this->app->make('config');
+        $config->set('logging.channels.memory', [
+            'driver' => 'monolog',
+            'name' => 'memory',
+            'handler' => StreamHandler::class,
+            'with' => [
+                'stream' => 'php://stderr',
+            ],
+            'processors' => [
+                MemoryUsageProcessor::class,
+                ['processor' => PsrLogMessageProcessor::class, 'with' => ['removeUsedContextFields' => true]],
+            ],
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('memory');
+        $handler = $logger->getLogger()->getHandlers()[0];
+        $processors = $logger->getLogger()->getProcessors();
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(MemoryUsageProcessor::class, $processors[0]);
+        $this->assertInstanceOf(PsrLogMessageProcessor::class, $processors[1]);
+
+        $removeUsedContextFields = new ReflectionProperty(get_class($processors[1]), 'removeUsedContextFields');
+        $removeUsedContextFields->setAccessible(true);
+
+        $this->assertTrue($removeUsedContextFields->getValue($processors[1]));
+    }
+
     public function testItUtilisesTheNullDriverDuringTestsWhenNullDriverUsed()
     {
         $config = $this->app->make('config');
@@ -264,6 +301,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(StreamHandler::class, $handler);
         $this->assertInstanceOf(LineFormatter::class, $formatter);
+        $this->assertInstanceOf(PsrLogMessageProcessor::class, $logger->getLogger()->getProcessors()[0]);
 
         $config->set('logging.channels.formattedsingle', [
             'driver' => 'single',
@@ -273,6 +311,7 @@ class LogManagerTest extends TestCase
             'formatter_with' => [
                 'dateFormat' => 'Y/m/d--test',
             ],
+            'with_placeholders' => false,
         ]);
 
         $logger = $manager->channel('formattedsingle');
@@ -281,6 +320,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(StreamHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
+        $this->assertEmpty($logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);
@@ -306,6 +346,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(StreamHandler::class, $handler);
         $this->assertInstanceOf(LineFormatter::class, $formatter);
+        $this->assertInstanceOf(PsrLogMessageProcessor::class, $logger->getLogger()->getProcessors()[0]);
 
         $config->set('logging.channels.formatteddaily', [
             'driver' => 'daily',
@@ -315,6 +356,7 @@ class LogManagerTest extends TestCase
             'formatter_with' => [
                 'dateFormat' => 'Y/m/d--test',
             ],
+            'with_placeholders' => false,
         ]);
 
         $logger = $manager->channel('formatteddaily');
@@ -323,6 +365,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(StreamHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
+        $this->assertEmpty($logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);
@@ -347,6 +390,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(SyslogHandler::class, $handler);
         $this->assertInstanceOf(LineFormatter::class, $formatter);
+        $this->assertInstanceOf(PsrLogMessageProcessor::class, $logger->getLogger()->getProcessors()[0]);
 
         $config->set('logging.channels.formattedsyslog', [
             'driver' => 'syslog',
@@ -355,6 +399,7 @@ class LogManagerTest extends TestCase
             'formatter_with' => [
                 'dateFormat' => 'Y/m/d--test',
             ],
+            'with_placeholders' => false,
         ]);
 
         $logger = $manager->channel('formattedsyslog');
@@ -363,6 +408,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(SyslogHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
+        $this->assertEmpty($logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -290,6 +290,7 @@ class LogManagerTest extends TestCase
             'driver' => 'single',
             'name' => 'ds',
             'path' => storage_path('logs/laravel.log'),
+            'replace_placeholders' => true,
         ]);
 
         $manager = new LogManager($this->app);
@@ -311,7 +312,7 @@ class LogManagerTest extends TestCase
             'formatter_with' => [
                 'dateFormat' => 'Y/m/d--test',
             ],
-            'with_placeholders' => false,
+            'replace_placeholders' => false,
         ]);
 
         $logger = $manager->channel('formattedsingle');
@@ -335,6 +336,7 @@ class LogManagerTest extends TestCase
             'driver' => 'daily',
             'name' => 'dd',
             'path' => storage_path('logs/laravel.log'),
+            'replace_placeholders' => true,
         ]);
 
         $manager = new LogManager($this->app);
@@ -356,7 +358,7 @@ class LogManagerTest extends TestCase
             'formatter_with' => [
                 'dateFormat' => 'Y/m/d--test',
             ],
-            'with_placeholders' => false,
+            'replace_placeholders' => false,
         ]);
 
         $logger = $manager->channel('formatteddaily');
@@ -379,6 +381,7 @@ class LogManagerTest extends TestCase
         $config->set('logging.channels.defaultsyslog', [
             'driver' => 'syslog',
             'name' => 'ds',
+            'replace_placeholders' => true,
         ]);
 
         $manager = new LogManager($this->app);
@@ -399,7 +402,7 @@ class LogManagerTest extends TestCase
             'formatter_with' => [
                 'dateFormat' => 'Y/m/d--test',
             ],
-            'with_placeholders' => false,
+            'replace_placeholders' => false,
         ]);
 
         $logger = $manager->channel('formattedsyslog');


### PR DESCRIPTION
Maybe this PR should target `11.x`.

This PR adds the possibility to use Monolog processors and adds a default `PsrLogMessageProcessor` to all drivers.
Following @Crell's [post](https://peakd.com/hive-168588/@crell/using-psr-3-placeholders-properly), the logger should be able to use placeholders by default:
```php
Log::info('Showing the user profile for user: {id}', ['id' => $id]);
```
It's not the case today so I added it in this PR.
It can be disabled with `with_placeholders`:
```php
// logging.php

'channels' => [
    'single' => [
        'driver' => 'single',
        'path' => storage_path('logs/laravel.log'),
        'level' => env('LOG_LEVEL', 'debug'),
        'with_placeholders' => false,
    ],
],
```

This PR also adds the possibility to configure processors for the `monolog` driver:

```php
// logging.php

'channels' => [
    'memory' => [
        'driver' => 'monolog',
        'handler' => Monolog\Handler\StreamHandler::class,
        'level' => 'notice',
        'with' => [
            'stream' => 'php://stderr',
        ],
        'processors' => [
            // simple syntax
            Monolog\Processor\MemoryUsageProcessor::class,
            // complex syntax
            ['processor' => Monolog\Processor\PsrLogMessageProcessor::class, 'with' => ['removeUsedContextFields' => true]],
        ],
    ],
],
```