### PR TITLE
[10.x] Deprecate Stringable test and whenTest methods

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -468,6 +468,8 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @param  string  $pattern
      * @return bool
+     * 
+     * @deprecated use isMatch instead
      */
     public function test($pattern)
     {
@@ -981,6 +983,19 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Execute the given callback if the string matches the given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenMatch($pattern, $callback, $default = null)
+    {
+        return $this->when($this->isMatch($pattern), $callback, $default);
+    }
+
+    /**
      * Execute the given callback if the string is not an exact match with the given value.
      *
      * @param  string  $value
@@ -1062,6 +1077,8 @@ class Stringable implements JsonSerializable, ArrayAccess
      * @param  callable  $callback
      * @param  callable|null  $default
      * @return static
+     * 
+     * @deprecated use whenMatch instead
      */
     public function whenTest($pattern, $callback, $default = null)
     {


### PR DESCRIPTION
## What does this PR propose
- Add `whenMatch` (or `whenIsMatch`, i don't know what is better 👀) method as alternative for `whenTest`
- Move `Illuminate\Support\Stringable` `test` and `whenTest` methods to **deprecated** status

## Why it do so
### First reason
Recently `isMatch` method was added to `Illuminate\Support\Str` and `Illuminate\Support\Stringable`. It allows to check is string matching given pattern(s). There is also `test` method in `Illuminate\Support\Stringable` which do exactly the following:
```php
str(string)->match(pattern)->isNotEmpty();
```
In prevoius PR, I explained why this is not fully correct way to check if string contains pattern.
> From #46303:
>
> `match()` in the other hand supports complex pattern matching but returns string that has been matched. It forces us to additionally check that result of the method call is not containing an empty string, **which is not the same thing as check if a string contains pattern**.
>
> ```php
> // I.e. Does 'foobar' contain pattern /f.*o.*/ ?
> str('foobar')->match('/f.*o.*/')->isNotEmpty(); // true
> 
> // This is why match() followed by isNotEmpty() is not the same thing as checking string for pattern match
> 
> // I.e. Does 'foobar' contain pattern /^f.*r(.*)/ ?
> str('foobar')->match('/^f.*r(.*)/')->isNotEmpty(); // false
> // But preg_match for this pair returns
> preg_match('/^f.*r(.*)/', 'foobar') === 1; // true
> ```
### Second reason
`Illuminate\Support\Stringable` now has 2 methods for checking pattern matching which is ambigous in **my opinion**.
### Third reason
In **my opinion** `test` is not the best name for function that matches string against pattern.

## P.S.
I will glad to discuss this.