### PR TITLE
[10.x] Adds `Countable` to the `InvokedProcessPool` class.

### DIFF
--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -34,6 +34,16 @@ class InvokedProcessPool
     }
 
     /**
+     * Get the total number of processes.
+     *
+     * @return int
+     */
+    public function total()
+    {
+        return count($this->invokedProcesses);
+    }
+
+    /**
      * Get the processes in the pool that are still currently running.
      *
      * @return \Illuminate\Support\Collection

--- a/src/Illuminate/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Process/InvokedProcessPool.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Process;
 
-class InvokedProcessPool
+use Countable;
+
+class InvokedProcessPool implements Countable
 {
     /**
      * The array of invoked processes.
@@ -34,16 +36,6 @@ class InvokedProcessPool
     }
 
     /**
-     * Get the total number of processes.
-     *
-     * @return int
-     */
-    public function total()
-    {
-        return count($this->invokedProcesses);
-    }
-
-    /**
      * Get the processes in the pool that are still currently running.
      *
      * @return \Illuminate\Support\Collection
@@ -61,5 +53,15 @@ class InvokedProcessPool
     public function wait()
     {
         return new ProcessPoolResults(collect($this->invokedProcesses)->map->wait()->all());
+    }
+
+    /**
+     * Get the total number of processes.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->invokedProcesses);
     }
 }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -54,6 +54,20 @@ class ProcessTest extends TestCase
         $this->assertTrue(str_contains($results[1]->output(), 'ProcessTest.php'));
     }
 
+    public function testInvokedProcessPoolTotal()
+    {
+        $factory = new Factory;
+
+        $pool = $factory->pool(function ($pool) {
+            return [
+                $pool->path(__DIR__)->command($this->ls()),
+                $pool->path(__DIR__)->command($this->ls()),
+            ];
+        })->start();
+
+        $this->assertSame($pool->total(), 2);
+    }
+
     public function testProcessPoolCanReceiveOutputForEachProcessViaStartMethod()
     {
         $factory = new Factory;

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -54,7 +54,7 @@ class ProcessTest extends TestCase
         $this->assertTrue(str_contains($results[1]->output(), 'ProcessTest.php'));
     }
 
-    public function testInvokedProcessPoolTotal()
+    public function testInvokedProcessPoolCount()
     {
         $factory = new Factory;
 
@@ -65,7 +65,7 @@ class ProcessTest extends TestCase
             ];
         })->start();
 
-        $this->assertSame($pool->total(), 2);
+        $this->assertCount(2, $pool);
     }
 
     public function testProcessPoolCanReceiveOutputForEachProcessViaStartMethod()


### PR DESCRIPTION
This PR adds a capability to retrieve the total of invokable processes on a pool.

## Usage

```php
$pool = Process::pool(function (Pool $pool) {
    $pool->command('sleep 2; echo 1');
    $pool->command('sleep 3; echo 2');
    $pool->command('sleep 1; echo 3');
})->start();

while ($pool->running()->isNotEmpty()) {
    $completed = count($pool) - count($pool->running());
    $this->components->info(sprintf('%d of %d processes completed!', 
        $completed, 
        count($pool)
    ));
}
```

Cheers.