### PR TITLE
[10.x] Add charAt method to both Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -217,7 +217,7 @@ class Str
     }
 
     /**
-     * Get character at the specified index.
+     * Get the character at the specified index.
      *
      * @param  string  $subject
      * @param  int  $index

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -217,6 +217,24 @@ class Str
     }
 
     /**
+     * Get character at the specified index.
+     *
+     * @param  string  $subject
+     * @param  int  $index
+     * @return string|null
+     */
+    public static function charAt($subject, $index)
+    {
+        $length = mb_strlen($subject);
+
+        if ($index < 0 ? $index < -$length : $index > $length - 1) {
+            return null;
+        }
+
+        return mb_substr($subject, $index, 1);
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -100,17 +100,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Get the basename of the class path.
-     *
-     * @return static
-     */
-    public function classBasename()
-    {
-        return new static(class_basename($this->value));
-    }
-
-    /**
-     * Get character at the specified index.
+     * Get the character at the specified index.
      *
      * @param  int  $index
      * @return string|null
@@ -118,6 +108,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function charAt($index)
     {
         return Str::charAt($this->value, $index); 
+    }
+
+    /**
+     * Get the basename of the class path.
+     *
+     * @return static
+     */
+    public function classBasename()
+    {
+        return new static(class_basename($this->value));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -110,6 +110,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Get character at the specified index.
+     *
+     * @param  int  $index
+     * @return string|null
+     */
+    public function charAt($index)
+    {
+        return Str::charAt($this->value, $index); 
+    }
+
+    /**
      * Get the portion of a string before the first occurrence of a given value.
      *
      * @param  string  $search

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -749,6 +749,16 @@ class SupportStrTest extends TestCase
         $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
+    public function testCharAt()
+    {
+        $this->assertEquals('р', Str::charAt('Привет, мир!', 1));
+        $this->assertEquals('ち', Str::charAt('「こんにちは世界」', 4));
+        $this->assertEquals('w', Str::charAt('Привет, world!', 8));
+        $this->assertEquals('界', Str::charAt('「こんにちは世界」', -2));
+        $this->assertEquals(null, Str::charAt('「こんにちは世界」', -200));
+        $this->assertEquals(null, Str::charAt('Привет, мир!', 100));
+    }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', Str::substr('БГДЖИЛЁ', -1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -936,6 +936,16 @@ class SupportStringableTest extends TestCase
         $this->assertSame('fooBarBaz', (string) $this->stringable('foo-bar_baz')->camel());
     }
 
+    public function testCharAt()
+    {
+        $this->assertEquals('р', $this->stringable('Привет, мир!')->charAt(1));
+        $this->assertEquals('ち', $this->stringable('「こんにちは世界」')->charAt(4));
+        $this->assertEquals('w', $this->stringable('Привет, world!')->charAt(8));
+        $this->assertEquals('界', $this->stringable('「こんにちは世界」')->charAt(-2));
+        $this->assertEquals(null, $this->stringable('「こんにちは世界」')->charAt(-200));
+        $this->assertEquals(null, $this->stringable('Привет, мир!')->charAt('Привет, мир!', 100));
+    }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', (string) $this->stringable('БГДЖИЛЁ')->substr(-1));


### PR DESCRIPTION
## What does this PR propose

This PR adds new `charAt` method to both `Illuminate\Support\Str` and `Illuminate\Support\Stringable`.
`charAt` method allows to get a character by index from a **multibyte** string.

If this PR is accepted, you can do the following:
```php
str('Hello, world!')->charAt(1); // (string) 'e'
str('Привет, мир!')->charAt(0); // (string) 'П'
str('「こんにちは世界」')->charAt(4); // (string) 'ち'
```
It also supports negative indexes:
```php
str('Hello, world!')->charAt(-1); // (string) '!'
str('Привет, мир!')->charAt(-12); // (string) 'П'
str('「こんにちは世界」')->charAt(-2); // (string) '界'
```
If index is greater then string length, or if negative index less then negative length, then `null` will be returned:
```php
str('Hello, world!')->charAt(100); // null
str('Привет, мир!')->charAt(-13); // null
str('「こんにちは世界」')->charAt(-2000); // null
```

## Why it do so

Str provides a better way to work with strings in Laravel, because it always work with multibyte strings.
For now there is no way to **simply** get character by index if you work not only with latin characters.

```php
$string = 'Привет';
$string[0]; // not a 'П'

// ArrayAccess was recently added for Stringable
str($string)[0] // not a 'П'

// To actually get a 'П' we need to do the following
$cyrillic_p = mb_substr($string, 0, 1); // 'П'

// I think the following is much better
Str::charAt($string, 0); // 'П'
// or
str($string)->charAt(0); // 'П'
```

## Behavior I would like to discuss
Current implementation will return `null` if index is greater then string length (or if negative index less then negative string length). `null` indicates that string does not contain character at that index. For me this behaviour seems to be more strict then returning empty string (`''`). If you see more meaning in returning empty strings, please describe why.
