### PR TITLE
allow serialization customization of relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -353,9 +353,7 @@ trait HasAttributes
         $attributes = [];
 
         foreach ($this->getArrayableRelations() as $key => $value) {
-
             if ($value instanceof Collection || $value instanceof Model) {
-
                 if (count($this->getVisibleForRelation($key))) {
                     $value->setVisible($this->getVisibleForRelation($key));
                 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -18,9 +18,11 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MissingAttributeException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Support\Arr;
@@ -351,6 +353,18 @@ trait HasAttributes
         $attributes = [];
 
         foreach ($this->getArrayableRelations() as $key => $value) {
+
+            if ($value instanceof Collection || $value instanceof Model) {
+
+                if (count($this->getVisibleForRelation($key))) {
+                    $value->setVisible($this->getVisibleForRelation($key));
+                }
+
+                if (count($this->getHiddenForRelation($key))) {
+                    $value->setHidden($this->getHiddenForRelation($key));
+                }
+            }
+
             // If the values implement the Arrayable interface we can just call this
             // toArray method on the instances which will convert both models and
             // collections to their proper array form and we'll set the values.

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -121,4 +121,38 @@ trait HidesAttributes
     {
         return value($condition, $this) ? $this->makeHidden($attributes) : $this;
     }
+
+    /**
+     * @param  string  $relation
+     * @return array
+     */
+    public function getVisibleForRelation(string $relation): array
+    {
+        $visibleRelations = [];
+
+        foreach ($this->getVisible() as $visible) {
+            if (str_starts_with($visible, $relation . '.')) {
+                $visibleRelations[] = explode($relation.'.', $visible)[1];
+            }
+        }
+
+        return $visibleRelations;
+    }
+
+    /**
+     * @param  string  $relation
+     * @return array
+     */
+    public function getHiddenForRelation(string $relation): array
+    {
+        $hiddenRelations = [];
+
+        foreach ($this->getHidden() as $hidden) {
+            if (str_starts_with($hidden, $relation . '.')) {
+                $hiddenRelations[] = explode($relation.'.', $hidden)[1];
+            }
+        }
+
+        return $hiddenRelations;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -131,7 +131,7 @@ trait HidesAttributes
         $visibleRelations = [];
 
         foreach ($this->getVisible() as $visible) {
-            if (str_starts_with($visible, $relation . '.')) {
+            if (str_starts_with($visible, $relation.'.')) {
                 $visibleRelations[] = explode($relation.'.', $visible)[1];
             }
         }
@@ -148,7 +148,7 @@ trait HidesAttributes
         $hiddenRelations = [];
 
         foreach ($this->getHidden() as $hidden) {
-            if (str_starts_with($hidden, $relation . '.')) {
+            if (str_starts_with($hidden, $relation.'.')) {
                 $hiddenRelations[] = explode($relation.'.', $hidden)[1];
             }
         }


### PR DESCRIPTION
currently you can set which attributes are "visible" or "hidden" when an Eloquent Model is serialized, and you can also set whether a relationship is visible or hidden.  but you cannot set the visibility of the individual attributes of your relationships at call time.  this change allows users to do that.

this can be activated by using dot notation

```php
$product->setVisible(['id', 'name', 'price', 'manufacturer', 'manufacturer.id', 'manufacturer.name']);
```

Couple questions:

1.  Are relationships guaranteed to be Eloquent Models or Eloquent Collections? If so, I can probably remove the conditional check for that.
2. It would be nice to make this recursive so it could support any depth of relationships. Wanted to gauge interest first, though.
3. Not sure what the current policy is on typing in the framework, so I might have to make some adjustments with that.
