### PR TITLE
[10.x] Add string capability to `withTrashed` method

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -230,11 +230,15 @@ class PendingResourceRegistration
     /**
      * Define which routes should allow "trashed" models to be retrieved when resolving implicit model bindings.
      *
-     * @param  array  $methods
+     * @param  array|string  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function withTrashed(array $methods = [])
+    public function withTrashed(array|string $methods = [])
     {
+        if (is_string($methods)) {
+            $methods = (array) $methods;
+        }
+
         $this->options['trashed'] = $methods;
 
         return $this;

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -8,11 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Routing\Controller;
 
 class ImplicitController extends Controller
 {

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -7,10 +7,71 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Routing\Controller;
+
+class ImplicitController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(ImplicitBindingUser $user)
+    {
+        return $user;
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(ImplicitBindingUser $user)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, ImplicitBindingUser $user)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(ImplicitBindingUser $user)
+    {
+        //
+    }
+}
 
 class ImplicitModelRouteBindingTest extends TestCase
 {

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -202,6 +202,26 @@ PHP);
         ]);
     }
 
+    public function testSoftDeletedModelsCanBeRetrievedUsingWithTrashedMethodWithSpecificFunction()
+    {
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+
+        $user->delete();
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::resource('users', ImplicitController::class)
+            ->middleware(['web'])
+            ->withTrashed('show');
+
+        $response = $this->getJson("/users/{$user->id}");
+
+        $response->assertJson([
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
+    }
+
     public function testEnforceScopingImplicitRouteBindings()
     {
         $user = ImplicitBindingUser::create(['name' => 'Dries']);


### PR DESCRIPTION
When we want to pass a function to the `withTrashed` method, it must be inside an array, but maybe just need to passed one function!
But now you can send string.

Compare 🔥:
```php
Route::resource('milwad', null)->withTrashed(['show']);
Route::resource('milwad', null)->withTrashed('show');
```