### PR TITLE
[10.x] Integrate PHP-FPM in docker-compose for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: ./
       dockerfile: ./docker/DockerFile
-    # awk-landmark (do not remove) #
     restart: unless-stopped
+    container_name: laravel_local
     volumes:
       - ./src/:/var/www/html/src/
       - ./tests/:/var/www/html/tests/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,19 @@ services:
     # awk-landmark (do not remove) #
     restart: unless-stopped
     volumes:
-      - .:/var/www/html
-      - /www/html/vendor/
-      - /www/html/docker-compose.yml
-      - /www/html/DockerFile/
+      - ./src/:/var/www/html/src/
+      - ./tests/:/var/www/html/tests/
+      - ./types/:/var/www/html/types/
+      - ./vendor/:/var/www/html/vendor/
+      - ./CHANGELOG.md:/var/www/html/CHANGELOG.md
+      - ./LICENSE.md:/var/www/html/LICENSE.md
+      - ./README.md:/var/www/html/README.md
+      - ./.styleci.yml:/var/www/html/.styleci.yml
+      - ./composer.json:/var/www/html/composer.json
+      - ./composer.lock:/var/www/html/composer.lock
+      - ./phpunit.xml.dist:/var/www/html/phpunit.xml.dist
+      - ./phpstan.src.neon.dist:/var/www/html/phpstan.src.neon.dist
+      - ./phpstan.types.neon.dist:/var/www/html/phpstan.types.neon.dist
   dynamodb:
     image: amazon/dynamodb-local
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,18 @@
 version: '3'
 services:
+
+
+  laravel:
+    build:
+      context: ./
+      dockerfile: ./docker/DockerFile
+    # awk-landmark (do not remove) #
+    restart: unless-stopped
+    volumes:
+      - .:/var/www/html
+      - /www/html/vendor/
+      - /www/html/docker-compose.yml
+      - /www/html/DockerFile/
   dynamodb:
     image: amazon/dynamodb-local
     ports:

--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -1,0 +1,53 @@
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+
+FROM php:8.1-fpm
+
+# Set Environment Variables
+ENV DEBIAN_FRONTEND noninteractive
+
+#
+#--------------------------------------------------------------------------
+# Software's Installation
+#--------------------------------------------------------------------------
+#
+# Installing tools and PHP extentions using "apt", "docker-php", "pecl",
+#
+
+# Install "curl", "libmemcached-dev", "libpq-dev", "libjpeg-dev",
+#         "libpng-dev", "libfreetype6-dev", "libssl-dev", "libmcrypt-dev",
+RUN set -eux; \
+    apt-get update; \
+    apt-get upgrade -y; \
+    apt-get install -y --no-install-recommends \
+            curl \
+            libmemcached-dev \
+            libz-dev \
+            libpq-dev \
+            libjpeg-dev \
+            libpng-dev \
+            libfreetype6-dev \
+            libssl-dev \
+            libwebp-dev \
+            libxpm-dev \
+            libmcrypt-dev \
+            libonig-dev; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    # Install the PHP pdo_mysql extention
+    docker-php-ext-install pdo_mysql; \
+    # Install the PHP pdo_pgsql extention
+    docker-php-ext-install pdo_pgsql; \
+    # Install the PHP gd library
+    docker-php-ext-configure gd \
+            --prefix=/usr \
+            --with-jpeg \
+            --with-webp \
+            --with-xpm \
+            --with-freetype; \
+    docker-php-ext-install gd; \
+    php -r 'var_dump(gd_info());'

--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -14,14 +14,10 @@ ENV DEBIAN_FRONTEND noninteractive
 # Software's Installation
 #--------------------------------------------------------------------------
 #
-# Installing tools and PHP extentions using "apt", "docker-php", "pecl",
+# Installing tools and PHP extensions using "apt", "docker-php", "pecl",
 #
 
-# Install "curl", "libmemcached-dev", "libpq-dev", "libjpeg-dev",
-#         "libpng-dev", "libfreetype6-dev", "libssl-dev", "libmcrypt-dev",
-RUN set -eux; \
-    apt-get update; \
-    apt-get upgrade -y; \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
             curl \
             git \
@@ -38,11 +34,16 @@ RUN set -eux; \
             libwebp-dev \
             libxpm-dev \
             libmcrypt-dev \
-            libonig-dev; \
+            libonig-dev && \
     rm -rf /var/lib/apt/lists/*
 
-
-USER root
+RUN docker-php-ext-configure gd \
+            --prefix=/usr \
+            --with-jpeg \
+            --with-webp \
+            --with-xpm \
+            --with-freetype && \
+    docker-php-ext-install gd pdo_mysql pdo_pgsql intl gmp zip
 
 # Get latest Composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
@@ -50,25 +51,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-RUN set -eux; \
-    # Install the PHP pdo_mysql extention
-    docker-php-ext-install pdo_mysql; \
-    # Install the PHP pdo_pgsql extention
-    docker-php-ext-install pdo_pgsql; \
-    # Install the PHP gd library
-    docker-php-ext-configure gd \
-            --prefix=/usr \
-            --with-jpeg \
-            --with-webp \
-            --with-xpm \
-            --with-freetype; \
-    docker-php-ext-install gd;
-
-
-RUN docker-php-ext-configure intl
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install gmp
-RUN docker-php-ext-install zip
-
+WORKDIR /var/www/html
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -24,8 +24,12 @@ RUN set -eux; \
     apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
             curl \
+            git \
+            libzip-dev \
             libmemcached-dev \
             libz-dev \
+            libicu-dev \
+            libgmp-dev \
             libpq-dev \
             libjpeg-dev \
             libpng-dev \
@@ -36,6 +40,15 @@ RUN set -eux; \
             libmcrypt-dev \
             libonig-dev; \
     rm -rf /var/lib/apt/lists/*
+
+
+USER root
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 RUN set -eux; \
     # Install the PHP pdo_mysql extention
@@ -49,5 +62,13 @@ RUN set -eux; \
             --with-webp \
             --with-xpm \
             --with-freetype; \
-    docker-php-ext-install gd; \
-    php -r 'var_dump(gd_info());'
+    docker-php-ext-install gd;
+
+
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install gmp
+RUN docker-php-ext-install zip
+
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+[ ! -d "vendor" ] && mkdir vendor
+
+composer install
+
+docker-php-entrypoint "php-fpm"


### PR DESCRIPTION
The motivation of this PR is to integrate the PHP-FPM container to allow more developers to contribute to the framework without being forced to install/switch to the correct PHP version unless I missed something.

