### PR TITLE
[10.x] Add database expressions with bindings

### DIFF
--- a/src/Illuminate/Contracts/Database/Query/ExpressionWithBindings.php
+++ b/src/Illuminate/Contracts/Database/Query/ExpressionWithBindings.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Query;
+
+use Illuminate\Database\Grammar;
+
+interface ExpressionWithBindings
+{
+    /**
+     * Get the value of the expression.
+     */
+    public function getValue(Grammar $grammar): string;
+
+    /**
+     * Get the bindings of the expression.
+     */
+    public function getBindings(Grammar $grammar): array;
+}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Events\TransactionCommitting;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\ExpressionWithBindings;
 use Illuminate\Database\Query\Grammars\Grammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
@@ -1005,6 +1006,16 @@ class Connection implements ConnectionInterface
     public function raw($value)
     {
         return new Expression($value);
+    }
+
+    /**
+     * Get a new database expression with bindings.
+     *
+     * @param  mixed[]  $bindings
+     */
+    public function expression(string $sql, ...$bindings): ExpressionWithBindings
+    {
+        return new ExpressionWithBindings($sql, Arr::flatten($bindings));
     }
 
     /**

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database;
 
 use Closure;
+use Illuminate\Contracts\Database\Query\ExpressionWithBindings;
 
 interface ConnectionInterface
 {
@@ -22,6 +23,13 @@ interface ConnectionInterface
      * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value);
+
+    /**
+     * Get a new database expression with bindings.
+     *
+     * @param  mixed[]  $bindings
+     */
+    public function expression(string $sql, ...$bindings): ExpressionWithBindings;
 
     /**
      * Run a select statement and return a single result.

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database;
 
 use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\ExpressionWithBindings;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
@@ -204,7 +205,7 @@ abstract class Grammar
      */
     public function isExpression($value)
     {
-        return $value instanceof Expression;
+        return $value instanceof Expression || $value instanceof ExpressionWithBindings;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3630,6 +3630,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Create a new database expression with bindings.
+     *
+     * @param  mixed[]  $bindings
+     */
+    public function expression(string $sql, ...$bindings): ExpressionWithBindings
+    {
+        return $this->connection->expression($sql, $bindings);
+    }
+
+    /**
      * Get the current query value bindings in a flattened array.
      *
      * @return array

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -8,6 +8,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use Illuminate\Contracts\Database\Query\ExpressionWithBindings;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
@@ -3703,6 +3704,9 @@ class Builder implements BuilderContract
      */
     public function castBinding($value)
     {
+        if ($value instanceof ExpressionWithBindings)
+            return $value->getBindings($this->grammar);
+
         return $value instanceof BackedEnum ? $value->value : $value;
     }
 
@@ -3732,6 +3736,7 @@ class Builder implements BuilderContract
                         return $binding instanceof ExpressionContract;
                     })
                     ->map([$this, 'castBinding'])
+                    ->flatten()
                     ->values()
                     ->all();
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3714,8 +3714,9 @@ class Builder implements BuilderContract
      */
     public function castBinding($value)
     {
-        if ($value instanceof ExpressionWithBindings)
+        if ($value instanceof ExpressionWithBindings) {
             return $value->getBindings($this->grammar);
+        }
 
         return $value instanceof BackedEnum ? $value->value : $value;
     }

--- a/src/Illuminate/Database/Query/ExpressionWithBindings.php
+++ b/src/Illuminate/Database/Query/ExpressionWithBindings.php
@@ -13,7 +13,8 @@ class ExpressionWithBindings implements Contract
     public function __construct(
         protected readonly string $sql,
         protected readonly array $bindings = [],
-    ) {}
+    ) {
+    }
 
     /**
      * Get the value of the expression.

--- a/src/Illuminate/Database/Query/ExpressionWithBindings.php
+++ b/src/Illuminate/Database/Query/ExpressionWithBindings.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Contracts\Database\Query\ExpressionWithBindings as Contract;
+use Illuminate\Database\Grammar;
+
+class ExpressionWithBindings implements Contract
+{
+    /**
+     * Create a new database expression.
+     */
+    public function __construct(
+        protected readonly string $sql,
+        protected readonly array $bindings = [],
+    ) {}
+
+    /**
+     * Get the value of the expression.
+     */
+    public function getValue(Grammar $grammar): string
+    {
+        return $this->sql;
+    }
+
+    /**
+     * Get the bindings of the expression.
+     */
+    public function getBindings(Grammar $grammar): array
+    {
+        return $this->bindings;
+    }
+}

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -52,6 +52,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Connection beforeExecuting(\Closure $callback)
  * @method static void listen(\Closure $callback)
  * @method static \Illuminate\Contracts\Database\Query\Expression raw(mixed $value)
+ * @method static \Illuminate\Contracts\Database\Query\ExpressionWithBindings expression(string $sql, ...$bindings)
  * @method static bool hasModifiedRecords()
  * @method static void recordsHaveBeenModified(bool $value = true)
  * @method static \Illuminate\Database\Connection setRecordModificationState(bool $value)

--- a/tests/Database/DatabaseExpressionWithBindingsTest.php
+++ b/tests/Database/DatabaseExpressionWithBindingsTest.php
@@ -2,8 +2,14 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\ExpressionWithBindings;
 use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseExpressionWithBindingsTest extends TestCase
@@ -17,6 +23,13 @@ class DatabaseExpressionWithBindingsTest extends TestCase
         $this->grammar = new Grammar;
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
     public function testPropertyRetrieval(): void
     {
         $sql = 'unaccent(?)';
@@ -27,4 +40,60 @@ class DatabaseExpressionWithBindingsTest extends TestCase
         $this->assertEquals($expression->getValue($this->grammar), $sql);
         $this->assertEquals($expression->getBindings($this->grammar), $bindings);
     }
+
+    public function testModelAttributeManipulation(): void
+    {
+        $geometry = 'some geojson string';
+        $newId = 13;
+        $ftsParams = ['foo', 'bar'];
+
+        $connection = $this->mockModelConnection();
+        $connection->shouldReceive('getPdo->lastInsertId')->andReturn($newId);
+
+        $connection
+            ->shouldReceive('insert')
+            ->with(
+                'insert into "my_models" ("location") values (ST_GeomFromGeoJSON(?))',
+                [$geometry],
+            )
+            ->once();
+
+        $connection
+            ->shouldReceive('update')
+            ->with(
+                'update "my_models" set "fts" = to_tsvector(?, ?) where "id" = ?',
+                [
+                    ...$ftsParams,
+                    $newId,
+                ],
+            )
+            ->once();
+
+        $model = new MyModel;
+        $model->location = new ExpressionWithBindings('ST_GeomFromGeoJSON(?)', [$geometry]);
+        $model->save();
+
+        $model->fts = new ExpressionWithBindings('to_tsvector(?, ?)', $ftsParams);
+        $model->save();
+    }
+
+    protected function mockModelConnection()
+    {
+        $processor =  new Processor;
+
+        $connection = m::mock(Connection::class)->makePartial();
+        $connection->shouldReceive('getQueryGrammar')->andReturn($this->grammar);
+        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
+        $connection->shouldReceive('query')->andReturnUsing(fn () => new Builder($connection, $this->grammar, $processor));
+
+        Model::setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
+        $resolver->shouldReceive('connection')->andReturn($connection);
+
+        return $connection;
+    }
+}
+
+class MyModel extends Model
+{
+    public $timestamps = false;
 }

--- a/tests/Database/DatabaseExpressionWithBindingsTest.php
+++ b/tests/Database/DatabaseExpressionWithBindingsTest.php
@@ -104,7 +104,7 @@ class DatabaseExpressionWithBindingsTest extends TestCase
 
     protected function mockModelConnection()
     {
-        $processor =  new Processor;
+        $processor = new Processor;
 
         $connection = m::mock(Connection::class)->makePartial();
         $connection->shouldReceive('getQueryGrammar')->andReturn($this->grammar);

--- a/tests/Database/DatabaseExpressionWithBindingsTest.php
+++ b/tests/Database/DatabaseExpressionWithBindingsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Query\ExpressionWithBindings;
+use Illuminate\Database\Query\Grammars\Grammar;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseExpressionWithBindingsTest extends TestCase
+{
+    protected Grammar $grammar;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->grammar = new Grammar;
+    }
+
+    public function testPropertyRetrieval(): void
+    {
+        $sql = 'unaccent(?)';
+        $bindings = ['term'];
+
+        $expression = new ExpressionWithBindings($sql, $bindings);
+
+        $this->assertEquals($expression->getValue($this->grammar), $sql);
+        $this->assertEquals($expression->getBindings($this->grammar), $bindings);
+    }
+}


### PR DESCRIPTION
The goal of this PR is to add a safe method to provide non-atomic database expressions as attribute values in Eloquent.

This is the proposed syntax:

```php
$object->location = DB::expression('ST_MakePoint(?, ?)', [56.97, 24.09]);
$object->save();
// executes: update "objects" set "location" = ST_MakePoint(?, ?) where "id" = ?
// with bindings [56.97, 24.09, $object->id]
```

To accomplish it I've added a new kind of expression that I've named `ExpressionWithBindings`. I made the new expression class somewhat compatible with the grammar-dependent ideas of #44784 by @tpetry.

While it would be pleasant to add an optional `$bindings` parameter to `DB::raw` and a `getBindings()` method to the existing interface, it would break compatibility with whoever is extending the class.

Instead I've opted to create a completely new interface, a new expression class and an `DB::expression` helper. In addition to leaving more code unaffected, that should also make people feel less incentivized to try this behaviour in other places (like `where` and `order` clauses) where the new tooling is not supported and other tools (like `orderByRaw($expr, $bindings)`) are already sufficient. Creating a completely new interface and methods also allows to make it all entirely natively typed.