### PR TITLE
[10.x] db:seed with rollback on failure (rof) option 

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -94,6 +94,7 @@ class FreshCommand extends Command
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
             '--force' => true,
+            '--rof' => true,
         ]));
     }
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -97,6 +97,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 $this->call('db:seed', [
                     '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
                     '--force' => true,
+                    '--rof' => true,
                 ]);
             }
         });


### PR DESCRIPTION
Many of our clients now want a working test suite, which is great!
So I lately quite often find me refactoring their **migrations**, **factories** and **seeders**.

So after tweaking around, you test if the migration and seeders work by hitting:
`migrate:fresh --seed`

Fine, migrations are finished, but ohh no the seeder throws an error.

Now your database has a total unknown state and you also don't exactly know which entries were seeded correctly.

If you have a lot of migrations you don't want to run `migrate:fresh --seed` again and again for each test, cause only the seeder don't worked and that would increase the execution of each "migration test" a lot...

Now a `db:truncate` command, which truncates all your tables, would be cool, so that you can just run `db:seed` afterwards.
But that would mean each time the migration fails you have to do `db:truncate && db:seed`

I therefor added the `db:seed --rof` option, which would **R**ollback **O**n **F**ailure.

In the second commit I made this also the default option for `migrate --seed` and `migrate:fresh --seed`, which would make a lot of sense in this context, but you can decide to maybe take only the first commit for some reason, this would also help a bit here.

Thanks a lot!