### PR TITLE
[10.x] Named static methods for middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -29,6 +29,18 @@ class Authenticate implements AuthenticatesRequests
     }
 
     /**
+     * Specify the guards for the middleware.
+     *
+     * @param  string  $guard
+     * @param  string  $others
+     * @return string
+     */
+    public static function using($guard, ...$others)
+    {
+        return static::class.':'.implode(',', [$guard, ...$others]);
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
+++ b/src/Illuminate/Auth/Middleware/AuthenticateWithBasicAuth.php
@@ -26,6 +26,20 @@ class AuthenticateWithBasicAuth
     }
 
     /**
+     * Specify the guard and field for the middleware.
+     *
+     * @param  string|null  $guard
+     * @param  string|null  $field
+     * @return string
+     *
+     * @named-arguments-supported
+     */
+    public static function using($guard = null, $field = null)
+    {
+        return static::class.':'.implode(',', func_get_args());
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -33,7 +33,7 @@ class Authorize
      * @param  string  ...$models
      * @return string
      */
-    public static function can($ability, ...$models)
+    public static function using($ability, ...$models)
     {
         return static::class.':'.implode(',', [$ability, ...$models]);
     }

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -27,6 +27,18 @@ class Authorize
     }
 
     /**
+     * Specify the ability and models for the middleware.
+     *
+     * @param  string  $ability
+     * @param  string  ...$models
+     * @return string
+     */
+    public static function can($ability, ...$models)
+    {
+        return static::class.':'.implode(',', [$ability, ...$models]);
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -10,6 +10,17 @@ use Illuminate\Support\Facades\URL;
 class EnsureEmailIsVerified
 {
     /**
+     * Specify the redirect route for the middleware.
+     *
+     * @param  string  $route
+     * @return string
+     */
+    public static function redirectTo($route)
+    {
+        return static::class.':'.$route;
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -64,7 +64,7 @@ class RequirePassword
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  $redirectToRoute
-     * @param  int|string|null  $passwordTimeoutSeconds
+     * @param  string|int|null  $passwordTimeoutSeconds
      * @return mixed
      */
     public function handle($request, Closure $next, $redirectToRoute = null, $passwordTimeoutSeconds = null)

--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -45,12 +45,26 @@ class RequirePassword
     }
 
     /**
+     * Specify the redirect route and timeout for the middleware.
+     *
+     * @param  string|null  $redirectToRoute
+     * @param  string|null  $passwordTimeoutSeconds
+     * @return string
+     *
+     * @named-arguments-supported
+     */
+    public static function using($redirectToRoute = null, $passwordTimeoutSeconds = null)
+    {
+        return static::class.':'.implode(',', func_get_args());
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  $redirectToRoute
-     * @param  int|null  $passwordTimeoutSeconds
+     * @param  int|string|null  $passwordTimeoutSeconds
      * @return mixed
      */
     public function handle($request, Closure $next, $redirectToRoute = null, $passwordTimeoutSeconds = null)
@@ -63,7 +77,7 @@ class RequirePassword
             }
 
             return $this->responseFactory->redirectGuest(
-                $this->urlGenerator->route($redirectToRoute ?? 'password.confirm')
+                $this->urlGenerator->route($redirectToRoute ?: 'password.confirm')
             );
         }
 

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -4,10 +4,29 @@ namespace Illuminate\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class SetCacheHeaders
 {
+    /**
+     * Specify the options for the middleware.
+     *
+     * @param  array|string  $options
+     * @return string
+     */
+    public static function using($options)
+    {
+        if (is_string($options)) {
+            return static::class.':'.$options;
+        }
+
+        return collect($options)
+            ->map(fn ($value, $key) => is_int($key) ? $value : "{$key}={$value}")
+            ->map(fn ($value) => Str::finish($value, ';'))
+            ->pipe(fn ($options) => rtrim(static::class.':'.$options->implode(''), ';'));
+    }
+
     /**
      * Add cache related HTTP headers.
      *

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -24,7 +24,7 @@ class ThrottleRequests
     protected $limiter;
 
     /**
-     * Specify the name rate limitr to use for the middleware.
+     * Specify the named rate limiter to use for the middleware.
      *
      * @param  string  $name
      * @return string
@@ -35,7 +35,7 @@ class ThrottleRequests
     }
 
     /**
-     * Specify the rate limit configuration for the middleware.
+     * Specify the rate limiter configuration for the middleware.
      *
      * @param  int  $maxAttempts
      * @param  int  $decayMinutes

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -24,6 +24,32 @@ class ThrottleRequests
     protected $limiter;
 
     /**
+     * Specify the name rate limitr to use for the middleware.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public static function using($name)
+    {
+        return static::class.':'.$name;
+    }
+
+    /**
+     * Specify the rate limit configuration for the middleware.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @param  string  $prefix
+     * @return string
+     *
+     * @named-arguments-supported
+     */
+    public static function with($maxAttempts = 60, $decayMinutes = 1, $prefix = '')
+    {
+        return static::class.':'.implode(',', func_get_args());
+    }
+
+    /**
      * Create a new request throttler.
      *
      * @param  \Illuminate\Cache\RateLimiter  $limiter

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -24,6 +24,17 @@ class ThrottleRequests
     protected $limiter;
 
     /**
+     * Create a new request throttler.
+     *
+     * @param  \Illuminate\Cache\RateLimiter  $limiter
+     * @return void
+     */
+    public function __construct(RateLimiter $limiter)
+    {
+        $this->limiter = $limiter;
+    }
+
+    /**
      * Specify the named rate limiter to use for the middleware.
      *
      * @param  string  $name
@@ -47,17 +58,6 @@ class ThrottleRequests
     public static function with($maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
         return static::class.':'.implode(',', func_get_args());
-    }
-
-    /**
-     * Create a new request throttler.
-     *
-     * @param  \Illuminate\Cache\RateLimiter  $limiter
-     * @return void
-     */
-    public function __construct(RateLimiter $limiter)
-    {
-        $this->limiter = $limiter;
     }
 
     /**

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -17,6 +17,26 @@ class ValidateSignature
     ];
 
     /**
+     * Specify the url signature is for a relative URL.
+     *
+     * @return string
+     */
+    public static function relative()
+    {
+        return static::class.':relative';
+    }
+
+    /**
+     * Specify the url signature is for a absolute URL.
+     *
+     * @return class-string
+     */
+    public static function absolute()
+    {
+        return static::class;
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -17,7 +17,7 @@ class ValidateSignature
     ];
 
     /**
-     * Specify the url signature is for a relative URL.
+     * Specify that the URL signature is for a relative URL.
      *
      * @return string
      */
@@ -27,7 +27,7 @@ class ValidateSignature
     }
 
     /**
-     * Specify the url signature is for a absolute URL.
+     * Specify that the URL signature is for an absolute URL.
      *
      * @return class-string
      */

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
 use Illuminate\Auth\RequestGuard;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
@@ -34,6 +35,30 @@ class AuthenticateMiddlewareTest extends TestCase
         m::close();
 
         Container::setInstance(null);
+    }
+
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) Authenticate::using('foo');
+        $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo', $signature);
+
+        $signature = (string) Authenticate::using('foo', 'bar');
+        $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar', $signature);
+
+        $signature = (string) Authenticate::using('foo', 'bar', 'baz');
+        $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar,baz', $signature);
+    }
+
+    public function testItCanGenerateDefinitionViaStaticMethodForBasic()
+    {
+        $signature = (string) AuthenticateWithBasicAuth::using('guard');
+        $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard', $signature);
+
+        $signature = (string) AuthenticateWithBasicAuth::using('guard', 'field');
+        $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard,field', $signature);
+
+        $signature = (string) AuthenticateWithBasicAuth::using(field: 'field');
+        $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:,field', $signature);
     }
 
     public function testDefaultUnauthenticatedThrows()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -55,6 +55,18 @@ class AuthorizeMiddlewareTest extends TestCase
         Container::setInstance(null);
     }
 
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) Authorize::can('ability');
+        $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability', $signature);
+
+        $signature = (string) Authorize::can('ability', 'model');
+        $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model', $signature);
+
+        $signature = (string) Authorize::can('ability', 'model', \App\Models\Comment::class);
+        $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model,App\Models\Comment', $signature);
+    }
+
     public function testSimpleAbilityUnauthorized()
     {
         $this->expectException(AuthorizationException::class);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -57,13 +57,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) Authorize::can('ability');
+        $signature = (string) Authorize::using('ability');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability', $signature);
 
-        $signature = (string) Authorize::can('ability', 'model');
+        $signature = (string) Authorize::using('ability', 'model');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model', $signature);
 
-        $signature = (string) Authorize::can('ability', 'model', \App\Models\Comment::class);
+        $signature = (string) Authorize::using('ability', 'model', \App\Models\Comment::class);
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model,App\Models\Comment', $signature);
     }
 

--- a/tests/Auth/EnsureEmailIsVerifiedTest.php
+++ b/tests/Auth/EnsureEmailIsVerifiedTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
+use PHPUnit\Framework\TestCase;
+
+class EnsureEmailIsVerifiedTest extends TestCase
+{
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) EnsureEmailIsVerified::redirectTo('route.name');
+        $this->assertSame('Illuminate\Auth\Middleware\EnsureEmailIsVerified:route.name', $signature);
+    }
+}

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -12,6 +12,29 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class CacheTest extends TestCase
 {
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) Cache::using('max_age=120;no-transform;s_maxage=60;');
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60;', $signature);
+
+        $signature = (string) Cache::using('max_age=120;no-transform;s_maxage=60');
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60', $signature);
+
+        $signature = (string) Cache::using([
+            'max_age=120',
+            'no-transform',
+            's_maxage=60',
+        ]);
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60', $signature);
+
+        $signature = (string) Cache::using([
+            'max_age' => 120,
+            'no-transform',
+            's_maxage' => '60',
+        ]);
+        $this->assertSame('Illuminate\Http\Middleware\SetCacheHeaders:max_age=120;no-transform;s_maxage=60', $signature);
+    }
+
     public function testDoNotSetHeaderWhenMethodNotCacheable()
     {
         $request = new Request;

--- a/tests/Integration/Auth/Middleware/RequirePasswordTest.php
+++ b/tests/Integration/Auth/Middleware/RequirePasswordTest.php
@@ -12,6 +12,18 @@ use Orchestra\Testbench\TestCase;
 
 class RequirePasswordTest extends TestCase
 {
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) RequirePassword::using('route.name');
+        $this->assertSame('Illuminate\Auth\Middleware\RequirePassword:route.name', $signature);
+
+        $signature = (string) RequirePassword::using('route.name', 100);
+        $this->assertSame('Illuminate\Auth\Middleware\RequirePassword:route.name,100', $signature);
+
+        $signature = (string) RequirePassword::using(passwordTimeoutSeconds: 100);
+        $this->assertSame('Illuminate\Auth\Middleware\RequirePassword:,100', $signature);
+    }
+
     public function testUserSeesTheWantedPageIfThePasswordWasRecentlyConfirmed()
     {
         $this->withoutExceptionHandling();

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -95,4 +95,25 @@ class ThrottleRequestsTest extends TestCase
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
     }
+
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) ThrottleRequests::using('gold-tier');
+        $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:gold-tier', $signature);
+
+        $signature = (string) ThrottleRequests::with(25);
+        $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25', $signature);
+
+        $signature = (string) ThrottleRequests::with(25, 2);
+        $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25,2', $signature);
+
+        $signature = (string) ThrottleRequests::with(25, 2, 'foo');
+        $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25,2,foo', $signature);
+
+        $signature = (string) ThrottleRequests::with(maxAttempts: 25, decayMinutes: 2, prefix: 'foo');
+        $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:25,2,foo', $signature);
+
+        $signature = (string) ThrottleRequests::with(prefix: 'foo');
+        $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:60,1,foo', $signature);
+    }
 }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -276,6 +276,15 @@ class UrlSigningTest extends TestCase
         }
     }
 
+    public function testItCanGenerateMiddlewareDefinitionViaStaticMethod()
+    {
+        $signature = (string) ValidateSignature::relative();
+        $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:relative', $signature);
+
+        $signature = (string) ValidateSignature::absolute();
+        $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature', $signature);
+    }
+
     protected function createValidateSignatureMiddleware(array $ignore)
     {
         return new class($ignore) extends ValidateSignature


### PR DESCRIPTION
Continuation of https://github.com/laravel/framework/pull/46219. Framework first version of "[HasParameters](https://github.com/timacdonald/has-parameters/)".

This PR introduces a more "typed" API for all the first party middleware - which gives a nicer DX than the "stringy" API, in my opinion.

```php
Route::get('users', UserController::class)
    ->middleware([

        Authenticate::class, // default.
        Authenticate::using('web'), // specify a guard.
        Authenticate::using('web', 'another'), // specify multiple guards.

        AuthenticateWithBasicAuth::class, // default.
        AuthenticateWithBasicAuth::using('web'), // specify a guard.
        AuthenticateWithBasicAuth::using('web', 'field'), // specify field
        AuthenticateWithBasicAuth::using(field: 'field'), // supports named arguments

        Authorize::using('access-nova'), // specify an ability.
        Authorize::using('store', Post::class), // specify an ability with a model.
        Authorize::using('update', 'post', 'comment'), // specify multiple models.

        EnsureEmailIsVerified::class, // default.
        EnsureEmailIsVerified::redirectTo('route.name'), // specify a redirect.

        RequirePassword::class, // default.
        RequirePassword::using('route.name'), // specify a redirect.
        RequirePassword::using('route.name', 100), // specify both.
        RequirePassword::using(passwordTimeoutSeconds: 100), // supports named arguments

        SetCacheHeaders::using('max_age=120;no-transform;s_maxage=60'), // using a string.
        SetCacheHeaders::using([
            'max_age=120',
            'no-transform',
            's_maxage=60',
        ]), // using a list of values.
        SetCacheHeaders::using([
            'max_age' => 120,
            'no-transform',
            's_maxage' => '60',
        ]), // using a hash/list of values.

        ValidateSignature::class, // default (absolute).
        ValidateSignature::relative(), // relative URL.
        ValidateSignature::absolute(), // absolute URL. This is the default, but provided a named method for completeness.

        ThrottleRequests::using('gold-tier'), // named rate limiter
        ThrottleRequests::with(100, 1, 'foo'), // custom with attempts, decay, and prefix
        ThrottleRequests::with(prefix: 'foo'), // supports named arguments.
    ]);
```

If we made this the documented approach, we could potentially remove the middleware aliases from the kernel.

https://github.com/laravel/laravel/blob/5070934fc5fb8bea7a4c8eca44a6b0bd59571be7/app/Http/Kernel.php#L48-L66