### PR TITLE
[10.x] Add `getWhere` To Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -324,7 +324,7 @@ class Builder implements BuilderContract
      */
     public function getWhere($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->where($column, $operator, $value, $boolean)->get();
+        return $this->where(...func_get_args())->get();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -314,6 +314,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a basic where clause to the query, and return the results.
+     *
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return Builder[]|Collection|null
+     */
+    public function getWhere($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->where($column, $operator, $value, $boolean)->get();
+    }
+
+    /**
      * Add an "or where" clause to the query.
      *
      * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -249,6 +249,33 @@ class EloquentWhereTest extends DatabaseTestCase
         );
     }
 
+    public function testGetWhere()
+    {
+        $user1 = UserWhereTest::create([
+            'name' => 'test-name-1',
+            'email' => 'test-email-1',
+            'address' => 'test-address-1',
+        ]);
+        $user2 = UserWhereTest::create([
+            'name' => 'test-name-2',
+            'email' => 'test-email-2',
+            'address' => 'test-address-2',
+        ]);
+        $user3 = UserWhereTest::create([
+            'name' => 'test-name-3',
+            'email' => 'test-email-3',
+            'address' => 'test-address-3',
+        ]);
+
+        $this->assertEquals($user1->name, UserWhereTest::getWhere('name', 'test-name-1')[0]->name);
+        $this->assertEquals($user2->name, UserWhereTest::getWhere('name', 'test-name-2')[0]->name);
+        $this->assertEquals($user3->name, UserWhereTest::getWhere('name', 'test-name-3')[0]->name);
+        $this->assertTrue($user1->is(UserWhereTest::getWhere('name', 'test-name-1')[0]));
+        $this->assertTrue($user2->is(UserWhereTest::getWhere('name', 'test-name-2')[0]));
+        $this->assertTrue($user3->is(UserWhereTest::getWhere('name', 'test-name-3')[0]));
+        $this->assertIsArray(UserWhereTest::getWhere('name', 'test-name-1')->toArray());
+    }
+
     public function testSole()
     {
         $expected = UserWhereTest::create([


### PR DESCRIPTION
A shortcut for ```->where(...)->get()```.

Example:
```php
// Before
User::where('status', 'active')->get(); // Collection

// After
User::getWhere('status', 'active'); // Collection
```

If something was missing, please tell me so that it can be improved.

