### PR TITLE
[10.x] Adds optional parameter to afterMaking/afterCreating factory methods to support handling complex state

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -686,7 +686,7 @@ abstract class Factory
     {
         $instances->each(function ($model) {
             $this->afterMaking->each(function ($callback) use ($model) {
-                $callback($model);
+                $callback($model, $this);
             });
         });
     }
@@ -702,7 +702,7 @@ abstract class Factory
     {
         $instances->each(function ($model) use ($parent) {
             $this->afterCreating->each(function ($callback) use ($model, $parent) {
-                $callback($model, $parent);
+                $callback($model, $parent, $this);
             });
         });
     }


### PR DESCRIPTION
When instantiating an Eloquent Factory, the configure() method is called immediately. That causes $this to be bound at the very beginning of the factory's life. 

Factory states are great for tracking data that corresponds neatly to model attributes. But sometimes state is more complex than that, and in those cases, allowing the factory itself to track some additional properties would be very useful. Currently that data is lost, however, due to the early binding of $this. Any properties (other than "state") that are manipulated prior to calling create() or make() are unavailable in the callbacks.

This PR passes the factory object to the "afterMaking" and "afterCreating" callbacks. This allows callbacks to access the factory itself _as it exists when the callbacks are executed_. 

