### PR TITLE
Add New Validation Rule AlphaDashChar

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -20,6 +20,7 @@ return [
     'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',
     'alpha' => 'The :attribute field must only contain letters.',
     'alpha_dash' => 'The :attribute field must only contain letters, numbers, dashes, and underscores.',
+    'alpha_dash_char' => 'The :attribute field must only contain letters, dashes, and underscores.',
     'alpha_num' => 'The :attribute field must only contain letters and numbers.',
     'array' => 'The :attribute field must be an array.',
     'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -377,6 +377,28 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute contains only characters, dashes, and underscores.
+     * If the 'ascii' option is passed, validate that an attribute contains only ascii characters,
+     * dashes, and underscores.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAlphaDashChar($attribute, $value, $parameters)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        if (isset($parameters[0]) && $parameters[0] === 'ascii') {
+            return preg_match('/\A[a-zA-Z_-]+\z/u', $value) > 0;
+        }
+
+        return preg_match('/\A[\pL\pM_-]+\z/u', $value) > 0;
+    }
+
+    /**
      * Validate that an attribute contains only alpha-numeric characters.
      * If the 'ascii' option is passed, validate that an attribute contains only ascii alpha-numeric characters.
      *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4601,6 +4601,25 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateAlphaDashChar()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls-_dlks'], ['x' => 'AlphaDashChar']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'AlphaDashChar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'AlphaDashChar']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'من_هنا'], ['x' => 'AlphaDashChar']); // eastern arabic letters
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDashChar']); // ends with newline
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateAlphaWithAsciiOption()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -4696,6 +4715,31 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDash:ascii']); // ends with newline
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAlphaDashCharWithAsciiOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls-_dlks'], ['x' => 'AlphaDashChar:ascii']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'AlphaDashChar:ascii']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'AlphaDashChar:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'ユニコードを基盤技術と-_'], ['x' => 'AlphaDashChar:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'AlphaDashChar:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'من-هنا'], ['x' => 'AlphaDashChar:ascii']); // eastern arabic letters
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDashChar:ascii']); // ends with newline
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
Validate that an attribute contains only characters, dashes, and underscores.

The field under validation must be entirely Unicode  **characters** contained in \p{L}, \p{M}, as well as ASCII dashes (**-**) and ASCII underscores (**_**).

To restrict this validation rule to characters in the ASCII range (a-z and A-Z), you may provide the ascii option to the validation rule:

```php
'username' => 'alpha_dash_char:ascii',
```

Example:

```php
'username' => 'asls-_dlks', // true
'username' => 'aslsdlks', // true
'username' => 'asls dlks', // false
'username' => 'नमस्कार-_, // false
'username' => 'من-هنا', // false
```

