### PR TITLE
[10.x] Fix toJson json_encode error handling

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1653,7 +1653,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         } catch (\JsonException $e) {
             throw JsonEncodingException::forModel($this, $e->getMessage());
         }
-        if (!($options & JSON_THROW_ON_ERROR)) {
+        if (! ($options & JSON_THROW_ON_ERROR)) {
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw JsonEncodingException::forModel($this, json_last_error_msg());
             }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1648,10 +1648,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw JsonEncodingException::forModel($this, json_last_error_msg());
+        try {
+            $json = json_encode($this->jsonSerialize(), $options);
+        } catch (\JsonException $e) {
+            throw JsonEncodingException::forModel($this, $e->getMessage());
+        }
+        if (!($options & JSON_THROW_ON_ERROR)) {
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw JsonEncodingException::forModel($this, json_last_error_msg());
+            }
         }
 
         return $json;


### PR DESCRIPTION
Fixes issue 46368

toJson would previously fail if there was any previous json_encode/decode errors, as the json_last_error would survive even through its own json_encode call, if JSON_THROW_ON_ERROR was passed as a flag.

BREAKING CHANGE: this will break workflows that relied on catching a JsonException rather than a JsonEncodingException

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
