### PR TITLE
[10.x] Add columns params to `firstWhere` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -306,7 +306,7 @@ class Builder implements BuilderContract
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @param array|string  $columns
+     * @param  array|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and', $columns = ['*'])

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -306,11 +306,12 @@ class Builder implements BuilderContract
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
+     * @param array|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|static|null
      */
-    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
+    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and', $columns = ['*'])
     {
-        return $this->where(...func_get_args())->first();
+        return $this->where(...func_get_args())->first($columns);
     }
 
     /**

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -249,6 +249,32 @@ class EloquentWhereTest extends DatabaseTestCase
         );
     }
 
+    public function testFirstWhereWithSelectColumns()
+    {
+        $firstUser = UserWhereTest::create([
+            'name' => 'test-name',
+            'email' => 'test-email',
+            'address' => 'test-address',
+        ]);
+        $secondUser = UserWhereTest::create([
+            'name' => 'test-name1',
+            'email' => 'test-email1',
+            'address' => 'test-address1',
+        ]);
+
+        // firstUser assertions
+        $this->assertTrue($firstUser->is(UserWhereTest::firstWhere('name', $firstUser->name)));
+        $this->assertEquals('test-name', UserWhereTest::firstWhere('name', 'test-name', columns: 'name')->name);
+        $this->assertEquals('test-email', UserWhereTest::firstWhere('email', 'test-email', columns: 'email')->email);
+        $this->assertNull(UserWhereTest::firstWhere('email', 'test-email', columns: 'name')->email);
+
+        // secondUser assertions
+        $this->assertTrue($secondUser->is(UserWhereTest::firstWhere('name', $secondUser->name)));
+        $this->assertEquals('test-name1', UserWhereTest::firstWhere('name', 'test-name1', columns: 'name')->name);
+        $this->assertEquals('test-email1', UserWhereTest::firstWhere('email', 'test-email1', columns: 'email')->email);
+        $this->assertNull(UserWhereTest::firstWhere('email', 'test-email1', columns: 'name')->email);
+    }
+
     public function testSole()
     {
         $expected = UserWhereTest::create([

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -265,13 +265,17 @@ class EloquentWhereTest extends DatabaseTestCase
         // firstUser assertions
         $this->assertTrue($firstUser->is(UserWhereTest::firstWhere('name', $firstUser->name)));
         $this->assertEquals('test-name', UserWhereTest::firstWhere('name', 'test-name', columns: 'name')->name);
+        $this->assertEquals('test-name', UserWhereTest::firstWhere('name', 'test-name', columns: ['name', 'email'])->name);
         $this->assertEquals('test-email', UserWhereTest::firstWhere('email', 'test-email', columns: 'email')->email);
+        $this->assertEquals('test-email', UserWhereTest::firstWhere('email', 'test-email', columns: ['name', 'email'])->email);
         $this->assertNull(UserWhereTest::firstWhere('email', 'test-email', columns: 'name')->email);
 
         // secondUser assertions
         $this->assertTrue($secondUser->is(UserWhereTest::firstWhere('name', $secondUser->name)));
         $this->assertEquals('test-name1', UserWhereTest::firstWhere('name', 'test-name1', columns: 'name')->name);
+        $this->assertEquals('test-name1', UserWhereTest::firstWhere('name', 'test-name1', columns: ['name', 'email'])->name);
         $this->assertEquals('test-email1', UserWhereTest::firstWhere('email', 'test-email1', columns: 'email')->email);
+        $this->assertEquals('test-email1', UserWhereTest::firstWhere('email', 'test-email1', columns: ['name', 'email'])->email);
         $this->assertNull(UserWhereTest::firstWhere('email', 'test-email1', columns: 'name')->email);
     }
 


### PR DESCRIPTION
When use `firstWhere`, you can't to select columns, ex:
```php
User::query()->firstWhere('name', 'Dr');
```

But now if you want to select specific columns you can do like this:
```php
User::query()->firstWhere('name', 'Dr', columns: 'name'); // Just (name)
User::query()->firstWhere('name', 'Dr', columns: ['name', 'email']); // (name, email)
User::query()->firstWhere('name', '!=', 'Dr', columns: ['name', 'email']); // (name, email)
```

> **_NOTE:_**  If column selection is not available in this method, the feature of `first` method in `firstWhere` will be lost ⚠️

<hr>

There is no breaking changes.
Added tests successfully ✅