### PR TITLE
[11.x] Revert "[9.x] Translation of the default message of the validator"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.52.3...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.52.4...9.x)
+
+
+## [v9.52.4](https://github.com/laravel/framework/compare/v9.52.3...v9.52.4) - 2023-02-22
+
+### Fixed
+- Fixes constructable migrations ([#46223](https://github.com/laravel/framework/pull/46223))
 
 
 ## [v9.52.3](https://github.com/laravel/framework/compare/v9.52.2...v9.52.3) - 2023-02-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.52.2...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.52.3...9.x)
+
+
+## [v9.52.3](https://github.com/laravel/framework/compare/v9.52.2...v9.52.3) - 2023-02-22
+
+### Reverted
+- Revert changes from `Arr::random()` ([cf3eb90](https://github.com/laravel/framework/commit/cf3eb90a6473444bb7a78d1a3af1e9312a62020d))
 
 
 ## [v9.52.2](https://github.com/laravel/framework/compare/v9.52.1...v9.52.2) - 2023-02-21

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -35,7 +35,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\HttpFoundation\ParameterBag|mixed json(string|null $key = null, mixed $default = null)
  * @method static \Illuminate\Http\Request createFrom(\Illuminate\Http\Request $from, \Illuminate\Http\Request|null $to = null)
  * @method static \Illuminate\Http\Request createFromBase(\Symfony\Component\HttpFoundation\Request $request)
- * @method static \Illuminate\Http\Request duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
+ * @method static \Illuminate\Http\Request duplicate(array|null $query = null, array|null $request = null, array|null $attributes = null, array|null $cookies = null, array|null $files = null, array|null $server = null)
  * @method static bool hasSession(bool $skipIfUninitialized = false)
  * @method static \Symfony\Component\HttpFoundation\Session\SessionInterface getSession()
  * @method static \Illuminate\Contracts\Session\Session session()

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -88,15 +88,15 @@ class ValidationException extends Exception
         $messages = $validator->errors()->all();
 
         if (! count($messages) || ! is_string($messages[0])) {
-            return $validator->getTranslator()->get('The given data was invalid.');
+            return 'The given data was invalid.';
         }
 
         $message = array_shift($messages);
 
-        if ($count = count($messages)) {
-            $pluralized = $count === 1 ? 'error' : 'errors';
+        if ($additional = count($messages)) {
+            $pluralized = $additional === 1 ? 'error' : 'errors';
 
-            $message .= ' '.$validator->getTranslator()->get("(and :count more $pluralized)", compact('count'));
+            $message .= " (and {$additional} more {$pluralized})";
         }
 
         return $message;


### PR DESCRIPTION
Reverts laravel/framework#43837. This was a major mistake. Exceptions should not know about translation - it should be handled by the exception rendering layer. Moreover, the validator contract doesn't have a getTranslator method, so this will result in a crash, in general.