### PR TITLE
Update ConsoleApplicationTest.php

### DIFF
--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -22,11 +22,12 @@ class ConsoleApplicationTest extends TestCase
     {
         $app = $this->getMockConsole(['addToParent']);
         $command = m::mock(Command::class);
-        $command->shouldReceive('setLaravel')->once()->with(m::type(ApplicationContract::class));
-        $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->willReturn($command);
+        $application = m::type(ApplicationContract::class);
+        $command->shouldReceive('setLaravel')->once()->with($application);
+        $app->expects($this->once())->method('addToParent')->with($command)->willReturn($command);
         $result = $app->add($command);
-
-        $this->assertEquals($command, $result);
+        
+        $this->assertSame($command, $result);
     }
 
     public function testLaravelNotSetOnSymfonyCommands()


### PR DESCRIPTION
i removed the $this->equalTo() check in the addToParent expectation,
as it is not necessary since we are already passing the exact same object instance to the method
and added a separate variable $application to store the expected argument for the setLaravel method
this makes the code more readable and easier to change if necessary.
also changed the assertion method from assertEquals to assertSame
as we want to ensure that the same object instance is returned from the add method