### PR TITLE
add removeSpaces method for strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1006,6 +1006,17 @@ class Str
     }
 
     /**
+     * Remove all occurrence of space characters from the given subject.
+     *
+     * @param  string  $subject
+     * @return string
+     */
+    public static function removeSpaces(string $subject)
+    {
+        return str_ireplace(' ', '', $subject);
+    }
+
+    /**
      * Reverse the given string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -589,6 +589,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Remove all space characters.
+     *
+     * @return static
+     */
+    public function removeSpaces()
+    {
+        return new static(Str::removeSpaces($this->value));
+    }
+
+    /**
      * Reverse the string.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -628,6 +628,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('Foobar', Str::remove(['f', '|'], 'Foo|bar'));
     }
 
+    public function testRemoveSpaces()
+    {
+        $this->assertSame('Foobar', Str::removeSpaces('Foo bar'));
+    }
+
     public function testReverse()
     {
         $this->assertSame('FooBar', Str::reverse('raBooF'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -882,6 +882,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Foobar', (string) $this->stringable('Foo|bar')->remove(['f', '|']));
     }
 
+    public function testRemoveSpaces()
+    {
+        $this->assertSame('Foobar', (string) $this->stringable('Foo bar')->removeSpaces());
+    }
+
     public function testReverse()
     {
         $this->assertSame('FooBar', (string) $this->stringable('raBooF')->reverse());


### PR DESCRIPTION
A slightly quicker / nicer way to remove spaces from strings. 

I find myself quite often using `->remove(' ')` to strip spaces out of strings, so this seemed like a nice addition. 

Happy to contribute to the docs should this be approved. 
