### PR TITLE
[10.x] Check only for first key in JSON response

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -81,7 +81,7 @@ class ResourceResponse implements Responsable
      */
     protected function haveDefaultWrapperAndDataIsUnwrapped($data)
     {
-        return $this->wrapper() && ! array_key_exists($this->wrapper(), $data);
+        return $this->wrapper() && array_key_first($data) != $this->wrapper();
     }
 
     /**
@@ -95,8 +95,7 @@ class ResourceResponse implements Responsable
     protected function haveAdditionalInformationAndDataIsUnwrapped($data, $with, $additional)
     {
         return (! empty($with) || ! empty($additional)) &&
-               (! $this->wrapper() ||
-                ! array_key_exists($this->wrapper(), $data));
+               (! $this->wrapper() || array_key_first($data) != $this->wrapper());
     }
 
     /**


### PR DESCRIPTION
Based on issue https://github.com/laravel/framework/issues/46322
The developer can set a wrapper for response and we don't need to check if that wrapper exists on the responses keys. Only check for first key is enough.
So developer can make something like this simply:
```
{
    "test": {
        "id": "X",
        "test": "test"
    }
}
```
