### PR TITLE
[10.x] use the same criteria StartSession uses on previous URL

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -158,7 +158,15 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
 
-        if ($url && rtrim($url, '/') !== $this->request->fullUrl()) {
+        $isSame = $url &&
+            rtrim($url, '/') === $this->request->fullUrl() &&
+            $this->request->isMethod('GET') &&
+            $this->request->route() instanceof Route &&
+            ! $this->request->ajax() &&
+            ! $this->request->prefetch() &&
+            ! $this->request->isPrecognitive();
+
+        if ($url && !$isSame) {
             return $url;
         } elseif ($fallback) {
             return $this->to($fallback);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes https://github.com/laravel/framework/issues/46388

PR https://github.com/laravel/framework/pull/46234 introduced a change on how the previous URL is calculated when the previous URL matches the current URL.

Unfortunately, it breaks redirecting back to the same URL, which is a common pattern on PATCH/PUT, as the previous implementation didn't consider which request method is being used.

This PR

- Changes the previous URL calculation to use the same criteria `StartSession` middleware uses to check if it should update the previous URL in session
