### PR TITLE
fix: Eloquent model toJson fix for existing errors.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1648,10 +1648,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw JsonEncodingException::forModel($this, json_last_error_msg());
+        try {
+            $json = json_encode($this->jsonSerialize(), $options);
+        } catch (\JsonException $e) {
+            throw JsonEncodingException::forModel($this, $e->getMessage());
+        }
+        if (! ($options & JSON_THROW_ON_ERROR)) {
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw JsonEncodingException::forModel($this, json_last_error_msg());
+            }
         }
 
         return $json;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1648,11 +1648,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function toJson($options = 0)
     {
-        try {
-            $json = json_encode($this->jsonSerialize(), $options);
-        } catch (\JsonException $e) {
-            throw JsonEncodingException::forModel($this, $e->getMessage());
-        }
+        $json = json_encode($this->jsonSerialize(), $options);
         if (! ($options & JSON_THROW_ON_ERROR)) {
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw JsonEncodingException::forModel($this, json_last_error_msg());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2678,7 +2678,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testToJsonWithNumeric()
     {
         $model = new EloquentModelStub([
-            'number' => '12345.678'
+            'number' => '12345.678',
         ]);
 
         $json = $model->toJson();
@@ -2695,7 +2695,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->expectException(JsonEncodingException::class);
 
         $model = new EloquentModelStub([
-            'name' => "\xB1\x31" // an invalid UTF-8 sequence
+            'name' => "\xB1\x31", // an invalid UTF-8 sequence
         ]);
 
         $json = $model->toJson();
@@ -2706,7 +2706,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->expectException(\JsonException::class);
 
         $model = new EloquentModelStub([
-            'name' => "\xB1\x31" // an invalid UTF-8 sequence
+            'name' => "\xB1\x31", // an invalid UTF-8 sequence
         ]);
 
         $json = $model->toJson(JSON_THROW_ON_ERROR);
@@ -2718,7 +2718,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->expectException(\JsonException::class);
 
         $model = new EloquentModelStub([
-            'name' => "\xB1\x31" // an invalid UTF-8 sequence
+            'name' => "\xB1\x31", // an invalid UTF-8 sequence
         ]);
 
         $json = $model->toJson(JSON_THROW_ON_ERROR);
@@ -2729,7 +2729,7 @@ class DatabaseEloquentModelTest extends TestCase
         @json_decode('[invalid json]');
 
         $model = new EloquentModelStub([
-            'name' => "Taylor Otwell" // an invalid UTF-8 sequence
+            'name' => 'Taylor Otwell', // an invalid UTF-8 sequence
         ]);
 
         $json = $model->toJson();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2703,7 +2703,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testJsonThrowsOnInvalidWithThrowOnErrorFlag()
     {
-        $this->expectException(JsonEncodingException::class);
+        $this->expectException(\JsonException::class);
 
         $model = new EloquentModelStub([
             'name' => "\xB1\x31" // an invalid UTF-8 sequence
@@ -2712,10 +2712,10 @@ class DatabaseEloquentModelTest extends TestCase
         $json = $model->toJson(JSON_THROW_ON_ERROR);
     }
 
-    public function testJsonThrowsOnInvalidWithThrowOnErrorFlagEvenWithExistingError()
+    public function testJsonThrowsJsonExceptionOnInvalidWithThrowOnErrorFlagEvenWithExistingError()
     {
         @json_decode('[invalid json]');
-        $this->expectException(JsonEncodingException::class);
+        $this->expectException(\JsonException::class);
 
         $model = new EloquentModelStub([
             'name' => "\xB1\x31" // an invalid UTF-8 sequence


### PR DESCRIPTION
# The Problem

Related to this issue:

https://github.com/laravel/framework/issues/46368

When casting an eloquent model to JSON using the ```toJson``` method and passing in the `JSON_THROW_ON_ERROR` option, if there was a previous, unrelated JSON error, an erroneous exception would be thrown.

The problem related to this line here:

```php
public function toJson($options = 0)
{
    $json = json_encode($this->jsonSerialize(), $options);

    // This line will always trigger if JSON_THROW_ON_ERROR is passed
    // as an option, and an existing json_encode or json_decode error exists
    if (json_last_error() !== JSON_ERROR_NONE) { 
        throw JsonEncodingException::forModel($this, json_last_error_msg());
    }

    return $json;
}
```

The situation transpires when someone has a previous JSON error, but passes the JSON_THROW_ON_ERROR flag to the toJson function:

```php
// ... earlier on

$array = @json_decode('{some badly formed, but non essesntial, JSON'});

// now json_last_error() is not JSON_ERROR_NONE
// ... and then later in the code ...

$widget = new Widget(); // An Eloquent Model
$widget->name = 'bob';

try {
    $json = $widget->toJson(JSON_THROW_ON_ERROR);
} catch (JsonEncodingException $e) {
    var_dump($e->getMessage()); // Syntax error
} catch (\JsonException $e) {
}
```

This happened to me in developing using the `@js` directive from Livewire, which uses the ```JSON_THROW_ON_ERROR``` flag as a required option.

I think because PHP supports both ways of handling JSON errors, it should be handled both ways by Laravel as well.

## Why fix this?

A good example is the `@js` directive in Livewire. This will *always* fail if there has been *any* json error without the use of `JSON_THROW_ON_ERROR`.

Considering that handling json errors in both ways is still supported, Laravel should support this as well.

## Proposed solution

The solution is fairly simple - we see if `JSON_THROW_ON_ERROR` was passed as an option, and only throw on error in that case:

```php
public function toJson($options = 0)
{
    $json = json_encode($this->jsonSerialize(), $options);
    if (! ($options & JSON_THROW_ON_ERROR)) {
        if (json_last_error() !== JSON_ERROR_NONE) {
            throw JsonEncodingException::forModel($this, json_last_error_msg());
        }
    }

    return $json;
}
```

## Tests

Included in this PR are 7 tests appended to `DatabaseEloquentModelTest.php` to test various toJson parameters and outputs, including exception cases.

Integration tests are hard to write, because this is such a core feature.

## Related

This contrived example demonstrates the problem well:

```php
$object = @json_decode('[invalid json]');

try {
    $json = json_encode("\xB1\x31", JSON_THROW_ON_ERROR); // an invalid UTF-8 sequence
} catch (JsonException $e) {
    var_dump($e->getCode()); // 5
    var_dump($e->getMessage()); // Malformed UTF-8 characters, possibly incorrectly encoded 
}

var_dump(json_last_error()); // 4
var_dump(json_last_error_msg()); // Syntax error
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
