### PR TITLE
[10.x] Fixes `Expression` no longer implements `Stringable`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,7 +648,7 @@ class Builder implements BuilderContract
     public function value($column)
     {
         if ($result = $this->first([$column])) {
-            $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+            $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
 
             return $result->{Str::afterLast($column, '.')};
         }
@@ -665,7 +665,7 @@ class Builder implements BuilderContract
      */
     public function soleValue($column)
     {
-        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
 
         return $this->sole([$column])->{Str::afterLast($column, '.')};
     }
@@ -680,7 +680,7 @@ class Builder implements BuilderContract
      */
     public function valueOrFail($column)
     {
-        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
 
         return $this->firstOrFail([$column])->{Str::afterLast($column, '.')};
     }
@@ -866,7 +866,7 @@ class Builder implements BuilderContract
     {
         $results = $this->toBase()->pluck($column, $key);
 
-        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
 
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
@@ -1784,7 +1784,7 @@ class Builder implements BuilderContract
      */
     public function qualifyColumn($column)
     {
-        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
 
         return $this->model->qualifyColumn($column);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Concerns\QueriesRelationships;
@@ -647,6 +648,8 @@ class Builder implements BuilderContract
     public function value($column)
     {
         if ($result = $this->first([$column])) {
+            $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+
             return $result->{Str::afterLast($column, '.')};
         }
     }
@@ -662,6 +665,8 @@ class Builder implements BuilderContract
      */
     public function soleValue($column)
     {
+        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+
         return $this->sole([$column])->{Str::afterLast($column, '.')};
     }
 
@@ -675,6 +680,8 @@ class Builder implements BuilderContract
      */
     public function valueOrFail($column)
     {
+        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+
         return $this->firstOrFail([$column])->{Str::afterLast($column, '.')};
     }
 
@@ -858,6 +865,8 @@ class Builder implements BuilderContract
     public function pluck($column, $key = null)
     {
         $results = $this->toBase()->pluck($column, $key);
+
+        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
 
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
@@ -1775,6 +1784,8 @@ class Builder implements BuilderContract
      */
     public function qualifyColumn($column)
     {
+        $column = $column instanceof Expression ? $query->getGrammar->wrap($column) : $column;
+
         return $this->model->qualifyColumn($column);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,7 +648,7 @@ class Builder implements BuilderContract
     public function value($column)
     {
         if ($result = $this->first([$column])) {
-            $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
+            $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
 
             return $result->{Str::afterLast($column, '.')};
         }
@@ -665,7 +665,7 @@ class Builder implements BuilderContract
      */
     public function soleValue($column)
     {
-        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
 
         return $this->sole([$column])->{Str::afterLast($column, '.')};
     }
@@ -680,7 +680,7 @@ class Builder implements BuilderContract
      */
     public function valueOrFail($column)
     {
-        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
 
         return $this->firstOrFail([$column])->{Str::afterLast($column, '.')};
     }
@@ -866,7 +866,7 @@ class Builder implements BuilderContract
     {
         $results = $this->toBase()->pluck($column, $key);
 
-        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
 
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
@@ -1784,7 +1784,7 @@ class Builder implements BuilderContract
      */
     public function qualifyColumn($column)
     {
-        $column = $column instanceof Expression ? $query->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
 
         return $this->model->qualifyColumn($column);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,7 +648,7 @@ class Builder implements BuilderContract
     public function value($column)
     {
         if ($result = $this->first([$column])) {
-            $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
+            $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
             return $result->{Str::afterLast($column, '.')};
         }
@@ -665,7 +665,7 @@ class Builder implements BuilderContract
      */
     public function soleValue($column)
     {
-        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
         return $this->sole([$column])->{Str::afterLast($column, '.')};
     }
@@ -680,7 +680,7 @@ class Builder implements BuilderContract
      */
     public function valueOrFail($column)
     {
-        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
         return $this->firstOrFail([$column])->{Str::afterLast($column, '.')};
     }
@@ -866,7 +866,7 @@ class Builder implements BuilderContract
     {
         $results = $this->toBase()->pluck($column, $key);
 
-        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
@@ -1784,7 +1784,7 @@ class Builder implements BuilderContract
      */
     public function qualifyColumn($column)
     {
-        $column = $column instanceof Expression ? $this->getGrammar()->wrap($column) : $column;
+        $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
         return $this->model->qualifyColumn($column);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
