### PR TITLE
[10.x] Update RedisTagSet now() to Carbon::now()

### DIFF
--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\LazyCollection;
 
 class RedisTagSet extends TagSet
@@ -16,7 +17,7 @@ class RedisTagSet extends TagSet
      */
     public function addEntry(string $key, int $ttl = 0, $updateWhen = null)
     {
-        $ttl = $ttl > 0 ? now()->addSeconds($ttl)->getTimestamp() : -1;
+        $ttl = $ttl > 0 ? Carbon::now()->addSeconds($ttl)->getTimestamp() : -1;
 
         foreach ($this->tagIds() as $tagKey) {
             if ($updateWhen) {
@@ -72,7 +73,7 @@ class RedisTagSet extends TagSet
     {
         $this->store->connection()->pipeline(function ($pipe) {
             foreach ($this->tagIds() as $tagKey) {
-                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, now()->getTimestamp());
+                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, Carbon::now()->getTimestamp());
             }
         });
     }


### PR DESCRIPTION
When I update my project to Laravel/Lumen-framework 10.X, I got this exception.  It seems there's not a function named now() registered in helpers.php.  I searched for this function declaration and found nothing.  I'd like to know if I could avoid using `now()` here (this patch worked for my project)

Key Stack Trace:
```
  #message: "Call to undefined function Illuminate\Cache\now()"
  #code: 0
  #file: "/data/source/path-to-my-project/vendor/illuminate/cache/RedisTagSet.php"
  #line: 20
  trace: {
    /data/source/path-to-my-project/vendor/illuminate/cache/RedisTagSet.php:20 {
      Illuminate\Cache\RedisTagSet->addEntry(string $key, int $ttl = 0, $updateWhen = null) …
      › {
      ›     $ttl = $ttl > 0 ? now()->addSeconds($ttl)->getTimestamp() : -1;
      › 
    }
    /data/source/path-to-my-project/vendor/illuminate/cache/RedisTaggedCache.php:39 {
      Illuminate\Cache\RedisTaggedCache->put($key, $value, $ttl = null) …
      › 
      › $this->tags->addEntry(
      ›     $this->itemKey($key),
      arguments: {
        $key: "a cache key here"
        $ttl: 1440
      }
    }
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
