### PR TITLE
[10.x] Alternative database port in Postgres DSN

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -167,13 +167,14 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // name than the database used for "information_schema" queries. This is
         // typically the case if using "pgbouncer" type software when pooling.
         $database = $connect_via_database ?? $database;
+        $port = $connect_via_port ?? $port ?? null;
 
         $dsn = "pgsql:{$host}dbname='{$database}'";
 
         // If a port was specified, we will add it to this Postgres DSN connections
         // format. Once we have done that we are ready to return this connection
         // string back out for usage, as this has been fully constructed here.
-        if (isset($config['port'])) {
+        if ($port !== null) {
             $dsn .= ";port={$port}";
         }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -232,6 +232,22 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresApplicationUseAlternativeDatabaseNameAndPort()
+    {
+        $dsn = 'pgsql:dbname=\'baz\';port=2345';
+        $config = ['database' => 'bar', 'connect_via_database' => 'baz', 'port' => 5432, 'connect_via_port' => 2345];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(stdClass::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresConnectorReadsIsolationLevelFromConfig()
     {
         $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';


### PR DESCRIPTION
PR #43542 has added support for alternative database names in the DSN for PostgreSQL.
This PR did not add support for an alternative port in the DSN, making it incompatible with the PgBouncer implementation of DigitalOcean (and most probably others).

This PR allows setting a different port that is used only for generating the PostgresConnector DSN, with the connect_via_port option. The port that should be used for the connect_via_database option should be specified here.