### PR TITLE
[10.x] feat add `whereLike()` and `whereLikeContain()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1252,7 +1252,7 @@ class Builder implements BuilderContract
     {
         $type = 'like';
 
-        $this->wheres[] = compact('type', 'value', 'column', 'boolean','not');
+        $this->wheres[] = compact('type', 'value', 'column', 'boolean', 'not');
 
         $this->addBinding($value, 'where');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1240,6 +1240,92 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where like clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null|int  $value
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereLike($column, $value, $boolean = 'and', $not = false)
+    {
+        $type = 'like';
+
+        $this->wheres[] = compact('type', 'value', 'column', 'boolean','not');
+
+        $this->addBinding($value, 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add a where like any word clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null|int  $value
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereLikeContain($column, $value, $boolean = 'and', $not = false)
+    {
+        return $this->whereLike($column, "%$value%", $boolean, $not);
+    }
+
+    /**
+     * Add an or where not like clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null|int  $value
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereLike($column, $value, $not = false)
+    {
+        return $this->whereLike($column, $value, 'or', $not);
+    }
+
+    /**
+     * Add an or where not like clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null|int  $value
+     * @param  bool  $not
+     * @return $this
+     */
+    public function orWhereLikeContain($column, $value, $not = false)
+    {
+        return $this->whereLikeContain($column, $value, 'or', $not);
+    }
+
+    /**
+     * Add a where not like clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null|int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLike($column, $value, $boolean = 'and')
+    {
+        return $this->whereLike($column, $value, $boolean, true);
+    }
+
+    /**
+     * Add a where like any word clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null|int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLikeContain($column, $value, $boolean = 'and')
+    {
+        return $this->whereLikeContain($column, $value, $boolean, true);
+    }
+
+    /**
      * Add a where between statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -370,6 +370,22 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        $operator = $where['not'] ? ' not like ' : ' like ';
+
+        $value = $this->parameter($where['value']);
+
+        return $this->wrap($where['column']).$operator.$value;
+    }
+
+    /**
      * Compile a "between" where clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -68,6 +68,22 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "where like" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereLike(Builder $query, $where)
+    {
+        $operator = $where['not'] ? ' not like ' : ' like ';
+
+        $value = $this->parameter($where['value']);
+
+        return $this->wrap($where['column']).'::text'.$operator.$value;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -404,6 +404,123 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
+    public function testWhereLikeAndWhereLikeContainMySQL()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from `users` where `id` like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLikeContain('id', '1');
+        $this->assertSame('select * from `users` where `id` like ?', $builder->toSql());
+        $this->assertEquals([0 => '%1%'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLike('id','2');
+        $this->assertSame(
+            'select * from `users` where `id` like ? or `id` like ?',
+            $builder->toSql()
+        );
+        $this->assertEquals([0 => '1', 1 => 2], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLikeContain('id','2');
+        $this->assertSame(
+            'select * from `users` where `id` like ? or `id` like ?',
+            $builder->toSql()
+        );
+        $this->assertEquals([0 => '1', 1 => '%2%'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from `users` where `id` not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotLikeContain('id', '1');
+        $this->assertSame('select * from `users` where `id` not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%1%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAndWhereLikeContainPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from "users" where "id"::text like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLikeContain('id', '1');
+        $this->assertSame('select * from "users" where "id"::text like ?', $builder->toSql());
+        $this->assertEquals([0 => '%1%'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLike('id','2');
+        $this->assertSame(
+            'select * from "users" where "id"::text like ? or "id"::text like ?',
+            $builder->toSql()
+        );
+        $this->assertEquals([0 => '1', 1 => 2], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLikeContain('id','2');
+        $this->assertSame(
+            'select * from "users" where "id"::text like ? or "id"::text like ?',
+            $builder->toSql()
+        );
+        $this->assertEquals([0 => '1', 1 => '%2%'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from "users" where "id"::text not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereNotLikeContain('id', '1');
+        $this->assertSame('select * from "users" where "id"::text not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%1%'], $builder->getBindings());
+    }
+
+    public function testWhereLikeAndWhereLikeContainSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('id', '1');
+        $this->assertSame('select * from [users] where [id] like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLikeContain('id', '1');
+        $this->assertSame('select * from [users] where [id] like ?', $builder->toSql());
+        $this->assertEquals([0 => '%1%'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLike('id','2');
+        $this->assertSame(
+            'select * from [users] where [id] like ? or [id] like ?',
+            $builder->toSql()
+        );
+        $this->assertEquals([0 => '1', 1 => 2], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLikeContain('id','2');
+        $this->assertSame(
+            'select * from [users] where [id] like ? or [id] like ?',
+            $builder->toSql()
+        );
+        $this->assertEquals([0 => '1', 1 => '%2%'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereNotLike('id', '1');
+        $this->assertSame('select * from [users] where [id] not like ?', $builder->toSql());
+        $this->assertEquals([0 => '1'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereNotLikeContain('id', '1');
+        $this->assertSame('select * from [users] where [id] not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%1%'], $builder->getBindings());
+    }
+
     public function testWhereDateMySql()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -417,7 +417,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '%1%'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLike('id','2');
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLike('id', '2');
         $this->assertSame(
             'select * from `users` where `id` like ? or `id` like ?',
             $builder->toSql()
@@ -425,7 +425,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1', 1 => 2], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLikeContain('id','2');
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLikeContain('id', '2');
         $this->assertSame(
             'select * from `users` where `id` like ? or `id` like ?',
             $builder->toSql()
@@ -456,7 +456,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '%1%'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
-        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLike('id','2');
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLike('id', '2');
         $this->assertSame(
             'select * from "users" where "id"::text like ? or "id"::text like ?',
             $builder->toSql()
@@ -464,7 +464,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1', 1 => 2], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
-        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLikeContain('id','2');
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLikeContain('id', '2');
         $this->assertSame(
             'select * from "users" where "id"::text like ? or "id"::text like ?',
             $builder->toSql()
@@ -495,7 +495,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '%1%'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLike('id','2');
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLike('id', '2');
         $this->assertSame(
             'select * from [users] where [id] like ? or [id] like ?',
             $builder->toSql()
@@ -503,7 +503,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '1', 1 => 2], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users')->whereLike('id','1')->orWhereLikeContain('id','2');
+        $builder->select('*')->from('users')->whereLike('id', '1')->orWhereLikeContain('id', '2');
         $this->assertSame(
             'select * from [users] where [id] like ? or [id] like ?',
             $builder->toSql()


### PR DESCRIPTION
add methods that handle queries for performing 'where like' searches in the database.

* `whereLike()`, `whereNotLike()` , `orWhereLike()`
* `whereLikeContain()` , `whereNotLikeContain()` , `orWhereLikeContain()`

```php
 // select * from `users` where `name` like laravel;
  
 User::whereLike('name', 'laravel')->get();
  
// select * from `users` where `name` like "%laravel%";

 User::whereLikeContain('name', 'laravel')->get();
```


```php  

 // select * from `users` where `name` like laravel or `name` like forge;
 User::whereLike('name', 'laravel')->orWhereLike('name','forge')->get();
 
 // select * from `users` where `name` like "%laravel%" or `name` like "%forge%";
 User::whereLikeContain('name', 'laravel')->orWhereLikeContain('name','forge')->get();
 
 // select * from `users` where `name` not like laravel and `name` not like "%forge%";
 User::whereNotLike('name', 'laravel')->whereNotLikeContain('name','forge')->get();
```