### PR TITLE
[10x] Allow calling getControllerClass on closure-based routes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -280,11 +280,11 @@ class Route
     /**
      * Get the controller class used for the route.
      *
-     * @return string
+     * @return string|null
      */
     public function getControllerClass()
     {
-        return $this->parseControllerCallback()[0];
+        return $this->isControllerAction() ? $this->parseControllerCallback()[0] : null;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -405,6 +405,19 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($route->getAction('unknown_property'));
     }
 
+    public function testRouteGetControllerClass()
+    {
+        $router = $this->getRouter();
+
+        $controllerRoute = $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
+        $closureRoute = $router->get('foo', function () {
+            return 'foo';
+        });
+
+        $this->assertSame(RouteTestControllerStub::class, $controllerRoute->getControllerClass());
+        $this->assertNull($closureRoute->getControllerClass());
+    }
+
     public function testResolvingBindingParameters()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/discussions/46332.

Currently calling `getControllerClass` on any `Route` is allowed, but throws an exception `TypeError: str_contains(): Argument #1 ($haystack) must be of type string, Closure given` whenever the route is closure based. This makes checking a route collection for routes using a specific controller quite hard.

This PR adds a fallback value of `null` for these cases, which is much easier to handle than the exception.