### PR TITLE
[10.x] Make Route isControllerAction method public

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -216,7 +216,7 @@ class Route
      *
      * @return bool
      */
-    protected function isControllerAction()
+    public function isControllerAction()
     {
         return is_string($this->action['uses']) && ! $this->isSerializedClosure();
     }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -86,10 +86,8 @@ class RouteCollection extends AbstractRouteCollection
         // When the route is routing to a controller we will also store the action that
         // is used by the route. This will let us reverse route to controllers while
         // processing a request and easily generate URLs to the given controllers.
-        $action = $route->getAction();
-
-        if (isset($action['controller'])) {
-            $this->addToActionList($action, $route);
+        if ($route->isControllerAction()) {
+            $this->addToActionList($route->getAction(), $route);
         }
     }
 
@@ -135,7 +133,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->actionList = [];
 
         foreach ($this->allRoutes as $route) {
-            if (isset($route->getAction()['controller'])) {
+            if ($route->isControllerAction()) {
                 $this->addToActionList($route->getAction(), $route);
             }
         }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -391,6 +391,19 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('foo.bar', $router->currentRouteName());
     }
 
+    public function testRouteIsControllerAction()
+    {
+        $router = $this->getRouter();
+
+        $controllerRoute = $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
+        $closureRoute = $router->get('foo', function () {
+            return 'foo';
+        });
+
+        $this->assertTrue($controllerRoute->isControllerAction());
+        $this->assertFalse($closureRoute->isControllerAction());
+    }
+
     public function testRouteGetAction()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/discussions/46332.

Currently `isControllerAction` is a `protected` method on the `\Illuminate\Routing\Route` class. This makes distinguishing between controller- and closure-based routes difficult and slightly cumbersome, as can be seen here:
https://github.com/laravel/framework/blob/38342ab7d7a4e52fe78109d37a145d8309641da1/src/Illuminate/Routing/RouteCollection.php#L86-L93

This PR makes this method public, to allow for more consistent checks on controller- vs. closure-based routes, both within the framework and in all applications using it.