### PR TITLE
explicit route model binding with multiple fields

### DIFF
--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -50,7 +50,7 @@ class RouteUri
 
             $segments = explode(':', trim($match, '{}?'));
 
-            $bindingFields[$segments[0]] = $segments[1];
+            $bindingFields[$segments[0]] = count($segments) > 2 ? array_slice($segments, 1) : $segments[1];
 
             $uri = str_contains($match, '?')
                 ? str_replace($match, '{'.$segments[0].'?}', $uri)

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -48,6 +48,11 @@ class RouteUriTest extends TestCase
                 '/foo/{bar}',
                 ['bar' => 'slug'],
             ],
+		    [
+                '/foo/{bar:slug:foo}',
+                '/foo/{bar}',
+                ['bar' => ['slug', 'foo']],
+            ],
             [
                 '/foo/{bar}/baz/{qux:slug}',
                 '/foo/{bar}/baz/{qux}',
@@ -57,11 +62,21 @@ class RouteUriTest extends TestCase
                 '/foo/{bar}/baz/{qux:slug}',
                 '/foo/{bar}/baz/{qux}',
                 ['qux' => 'slug'],
+            ],
+		    [
+                '/foo/{bar}/baz/{qux:slug:foo}',
+                '/foo/{bar}/baz/{qux}',
+                ['qux' => ['slug', 'foo']],
             ],
             [
                 '/foo/{bar}/baz/{qux:slug?}',
                 '/foo/{bar}/baz/{qux?}',
                 ['qux' => 'slug'],
+            ],
+		    [
+                '/foo/{bar}/baz/{qux:slug:foo?}',
+                '/foo/{bar}/baz/{qux?}',
+                ['qux' => ['slug', 'foo']],
             ],
             [
                 '/foo/{bar}/baz/{qux:slug?}/{test:id?}',


### PR DESCRIPTION
Hi there. 

currently when defining an explicit route binding it will only check the value for the specified field in the database, like:


    Route::get('/users/{user:username}', fn (User $user) => $user);


that's mean just checking the entered value to the username column in users' table.

now with this PR we will allow multiple checks for the entered value. so, we can do:

    Route::get('/users/{user:username:email}', fn (User $user) => $user);

- First check if there is a record with a username equals to the value in the URL; then return the model.
- if not then will check the email column. if also not found will throw `ModelNotFoundException`.

> **Warning** 
> recommend using this way only in columns that have unique data.


thanks in Advance (the whole Laravel Team). 