### PR TITLE
Fix Str::isJson('123') issues

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -428,7 +428,7 @@ class Str
      */
     public static function isJson($value)
     {
-        if (! is_string($value)) {
+        if (! is_string($value) || is_numeric($value)) {
             return false;
         }
 


### PR DESCRIPTION
When you call Str::isJson('123') it returns true, but 123 isn't JSON. Fix this issues

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
