### PR TITLE
[10.x] fix namespace

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -19,7 +19,7 @@ trait Batchable
     /**
      * The fake batch, if applicable.
      *
-     * @var \Illuminate\Support\Testing\BatchFake
+     * @var \Illuminate\Support\Testing\Fakes\BatchFake
      */
     private $fakeBatch;
 
@@ -77,7 +77,7 @@ trait Batchable
      * @param  \Carbon\CarbonImmutable  $createdAt
      * @param  \Carbon\CarbonImmutable|null  $cancelledAt
      * @param  \Carbon\CarbonImmutable|null  $finishedAt
-     * @return array{0: $this, 1: \Illuminate\Support\Testing\BatchFake}
+     * @return array{0: $this, 1: \Illuminate\Support\Testing\Fakes\BatchFake}
      */
     public function withFakeBatch(string $id = '',
                                   string $name = '',


### PR DESCRIPTION
Fixes the namespace for fake batches; see [the `use` statement](https://github.com/laravel/framework/blob/8c3a23d466debf20ff601eb373f9e60a9ed1fe86/src/Illuminate/Bus/Batchable.php#L8) for reference