### PR TITLE
[10.x] Added curl_error_code: 77 to DetectsLostConnections

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -61,6 +61,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000] [2002] No such file or directory',
             'SSL: Operation timed out',
             'Reason: Server is in script upgrade mode. Only administrator can connect at this time.',
+            'Unknown $curl_error_code: 77',
         ]);
     }
 }


### PR DESCRIPTION
My team encountered a few times on different servers that after day or tow of successful processing, our queue jobs are getting curl error 77, which is related to SSL errors.

Today I found [this article](https://maxchadwick.xyz/blog/curl-error-77-with-php-fpm-after-yum-update) and indeed there was an upgrade a day before
```
2023-03-08 10:05:49 configure php8.1-curl:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1 <none>
2023-03-08 10:05:49 status unpacked php8.1-curl:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:49 status half-configured php8.1-curl:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:50 status installed php8.1-curl:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:50 configure php8.1-opcache:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1 <none>
2023-03-08 10:05:50 status unpacked php8.1-opcache:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:50 status half-configured php8.1-opcache:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:50 status installed php8.1-opcache:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:50 configure php8.1-cli:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1 <none>
2023-03-08 10:05:50 status unpacked php8.1-cli:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:50 status half-configured php8.1-cli:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status installed php8.1-cli:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status triggers-pending php8.1-cli:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 configure php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1 <none>
2023-03-08 10:05:51 status unpacked php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status unpacked php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status unpacked php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status unpacked php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status unpacked php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status unpacked php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:51 status half-configured php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:53 status installed php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
2023-03-08 10:05:53 status triggers-pending php8.1-fpm:amd64 8.1.16+repack-1+ubuntu18.04.1+deb.sury.org+1
```

At first I thought about fixing it in my project using the `JobFailed` event
```
Queue::failing(function (JobFailed $event) {
    if ($event->exception instanceof \CurlException && $event->exception->getCode() == 77) {
          Artisan::call("queue:restart");
    }
});
```
But I don't want to restart all my queue workers in all servers only because of this error, and I think this problem should be fixed in the framework.