### PR TITLE
[10.x] Fix parsed input arguments for command events

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -13,6 +13,7 @@ use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -93,13 +94,14 @@ class Application extends SymfonyApplication implements ApplicationContract
             $input = $input ?: new ArgvInput
         );
 
-        $command->mergeApplicationDefinition();
+        try {
+            $input->bind(tap($command)->mergeApplicationDefinition()->getDefinition());
+        } catch (ExceptionInterface) {
+            // ...
+        }
 
         $this->events->dispatch(
-            new CommandStarting(
-                $commandName,
-                tap($input)->bind($command->getDefinition()), $output = $output ?: new BufferedConsoleOutput
-            )
+            new CommandStarting($commandName, $input, $output = $output ?: new BufferedConsoleOutput)
         );
 
         $exitCode = parent::doRunCommand($command, $input, $output);

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -87,19 +87,22 @@ class Application extends SymfonyApplication implements ApplicationContract
      *
      * @return int
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    protected function doRunCommand(SymfonyCommand $command, InputInterface $input, OutputInterface $output)
     {
         $commandName = $this->getCommandName(
             $input = $input ?: new ArgvInput
         );
 
+        $command->mergeApplicationDefinition();
+
         $this->events->dispatch(
             new CommandStarting(
-                $commandName, $input, $output = $output ?: new BufferedConsoleOutput
+                $commandName,
+                tap($input)->bind($command->getDefinition()), $output = $output ?: new BufferedConsoleOutput
             )
         );
 
-        $exitCode = parent::run($input, $output);
+        $exitCode = parent::doRunCommand($command, $input, $output);
 
         $this->events->dispatch(
             new CommandFinished($commandName, $input, $output, $exitCode)

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
+
+class CommandEventsTest extends TestCase
+{
+    /**
+     * Each run of this test is assigned a random ID to ensure that separate runs
+     * do not interfere with each other.
+     *
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * The path to the file that execution logs will be written to.
+     *
+     * @var string
+     */
+    protected $logfile;
+
+    /**
+     * Just in case Testbench starts to ship an `artisan` script, we'll check and save a backup.
+     *
+     * @var string|null
+     */
+    protected $originalArtisan;
+
+    /**
+     * The Filesystem instance for writing stubs and logs.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $fs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fs = new Filesystem;
+
+        $this->id = Str::random();
+        $this->logfile = storage_path("logs/command_events_test_{$this->id}.log");
+
+        $this->writeArtisanScript();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->delete($this->logfile);
+        $this->fs->delete(base_path('artisan'));
+
+        if (!is_null($this->originalArtisan)) {
+            $this->fs->put(base_path('artisan'), $this->originalArtisan);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider commandEventsProvider
+     */
+    public function testCommandEventsReceiveParsedInput($processType, $argumentType)
+    {
+        switch ($processType) {
+            case 'foreground':
+                $this->app[\Illuminate\Contracts\Console\Kernel::class]->registerCommand(new CommandEventsTestCommand);
+                $this->app[Dispatcher::class]->listen(function (CommandStarting $event) {
+                    array_map(fn ($e) => $this->fs->append($this->logfile, $e."\n"), [
+                        'CommandStarting',
+                        $event->input->getArgument('firstname'),
+                        $event->input->getArgument('lastname'),
+                        $event->input->getOption('occupation'),
+                    ]);
+                });
+
+                Event::listen(function (CommandFinished $event) {
+                    array_map(fn ($e) => $this->fs->append($this->logfile, $e."\n"), [
+                        'CommandFinished',
+                        $event->input->getArgument('firstname'),
+                        $event->input->getArgument('lastname'),
+                        $event->input->getOption('occupation'),
+                    ]);
+                });
+                switch($argumentType) {
+                    case 'array':
+                        $this->artisan(CommandEventsTestCommand::class, [
+                            'firstname' => 'taylor',
+                            'lastname' => 'otwell',
+                            '--occupation' => 'coding',
+                        ]);
+                        break;
+                    case 'string':
+                        $this->artisan('command-events-test-command taylor otwell --occupation=coding');
+                        break;
+                }
+                break;
+            case 'background':
+                // Initialize empty logfile.
+                $this->fs->append($this->logfile, '');
+                exec('php '.base_path('artisan').' command-events-test-command-'.$this->id.' taylor otwell --occupation=coding');
+                // Since our command is running in a separate process, we need to wait
+                // until it has finished executing before running our assertions.
+                $this->waitForLogMessages(
+                    'CommandStarting', 'taylor', 'otwell', 'coding',
+                    'CommandFinished', 'taylor', 'otwell', 'coding',
+                );
+                break;
+        }
+
+        $this->assertLogged(
+            'CommandStarting', 'taylor', 'otwell', 'coding',
+            'CommandFinished', 'taylor', 'otwell', 'coding',
+        );
+    }
+
+    public static function commandEventsProvider()
+    {
+        return [
+            'Foreground with array' => ['foreground', 'array'],
+            'Foreground with string' => ['foreground', 'string'],
+            'Background' => ['background', 'string'],
+        ];
+    }
+
+    protected function waitForLogMessages(...$messages)
+    {
+        $tries = 0;
+        $sleep = 100000; // 100K microseconds = 0.1 second
+        $limit = 50; // 0.1s * 50 = 5 second wait limit
+
+        do {
+            $log = $this->fs->get($this->logfile);
+
+            if (Str::containsAll($log, $messages)) {
+                return;
+            }
+
+            $tries++;
+            usleep($sleep);
+        } while ($tries < $limit);
+    }
+
+    protected function assertLogged(...$messages)
+    {
+        $log = trim($this->fs->get($this->logfile));
+
+        $this->assertEquals(implode("\n", $messages), $log);
+    }
+
+    protected function writeArtisanScript()
+    {
+        $path = base_path('artisan');
+
+        // Save existing artisan script if there is one
+        if ($this->fs->exists($path)) {
+            $this->originalArtisan = $this->fs->get($path);
+        }
+
+        $thisFile = __FILE__;
+        $logfile = var_export($this->logfile, true);
+
+        $script = <<<PHP
+#!/usr/bin/env php
+<?php
+
+// This is a custom artisan script made specifically for:
+//
+// {$thisFile}
+//
+// It should be automatically cleaned up when the tests have finished executing.
+// If you are seeing this file, an unexpected error must have occurred. Please
+// manually remove it.
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../../../autoload.php';
+
+\$app = require_once __DIR__.'/bootstrap/app.php';
+\$kernel = \$app->make(Illuminate\Contracts\Console\Kernel::class);
+
+class CommandEventsTestCommand extends Illuminate\Console\Command
+{
+    protected \$signature = 'command-events-test-command-{$this->id} {firstname} {lastname} {--occupation=cook}';
+
+    public function handle()
+    {
+        // ...
+    }
+}
+
+// Register command with Kernel
+Illuminate\Console\Application::starting(function (\$artisan) {
+    \$artisan->add(new CommandEventsTestCommand);
+});
+
+// Add command to scheduler so that the after() callback is trigger in our spawned process
+Illuminate\Foundation\Application::getInstance()
+    ->booted(function (\$app) {
+        \$fs = new Illuminate\Filesystem\Filesystem;
+        \$log = fn (\$msg) => \$fs->append({$logfile}, \$msg."\\n");
+
+        \$app[\Illuminate\Events\Dispatcher::class]->listen(function (\Illuminate\Console\Events\CommandStarting \$event) use (\$log) {
+            array_map(fn (\$msg) => \$log(\$msg), [
+                'CommandStarting',
+                \$event->input->getArgument('firstname'),
+                \$event->input->getArgument('lastname'),
+                \$event->input->getOption('occupation'),
+            ]);
+        });
+
+        \$app[\Illuminate\Events\Dispatcher::class]->listen(function (\Illuminate\Console\Events\CommandFinished \$event) use (\$log) {
+            array_map(fn (\$msg) => \$log(\$msg), [
+                'CommandFinished',
+                \$event->input->getArgument('firstname'),
+                \$event->input->getArgument('lastname'),
+                \$event->input->getOption('occupation'),
+            ]);
+        });
+    });
+
+\$status = \$kernel->handle(
+    \$input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+\$kernel->terminate(\$input, \$status);
+
+exit(\$status);
+
+PHP;
+
+        $this->fs->put($path, $script);
+    }
+}
+
+class CommandEventsTestCommand extends \Illuminate\Console\Command
+{
+    protected $signature = 'command-events-test-command {firstname} {lastname} {--occupation=cook}';
+
+    public function handle()
+    {
+        // ...
+    }
+}

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -58,7 +58,7 @@ class CommandEventsTest extends TestCase
         $this->fs->delete($this->logfile);
         $this->fs->delete(base_path('artisan'));
 
-        if (!is_null($this->originalArtisan)) {
+        if (! is_null($this->originalArtisan)) {
             $this->fs->put(base_path('artisan'), $this->originalArtisan);
         }
 
@@ -90,7 +90,7 @@ class CommandEventsTest extends TestCase
                         $event->input->getOption('occupation'),
                     ]);
                 });
-                switch($argumentType) {
+                switch ($argumentType) {
                     case 'array':
                         $this->artisan(CommandEventsTestCommand::class, [
                             'firstname' => 'taylor',


### PR DESCRIPTION
This PR fixes the input arguments for `CommandStarting` and `CommandFinished` events, which were previously empty because the `InputDefinition` (Symfony) was bound later than the events.

The following will now work:
```php
Event::listen(function (CommandStarting $event) {
    Log::info('starting ' . $event->command);
    Log::info($event->input->getOptions()); // Previously `[]`, now filled.
    Log::info($event->input->getArguments()); // Previously `[]`, now filled.
});
```

This is an improvement for https://github.com/laravel/framework/pull/44662 which was later reverted (https://github.com/laravel/framework/pull/44888) because it did not function well when an Artisan command was run through the command line.

This case has now been covered (based on `\tests\Integration\Console\CommandSchedulingTest.php` which uses an actual `artisan` file to simulate such call) and also the in-process artisan calls using array  (`Artisan::call('cmd', ['arg'=> 'abc', '--def' => 123])`) and string (`Artisan::call('cmd abc --def=123')`) syntax have been covered.