### PR TITLE
[10.x] Reoganizing TrimStrings and ConvertEmptyStringsToNull skip functionality to a common trait

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/HasSkipCallbacks.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/HasSkipCallbacks.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware\Concerns;
+
+use Closure;
+
+trait HasSkipCallbacks
+{
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function shouldSkipDueToCallback($request)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
+    }
+
+    /**
+     * Clears all currently registered callbacks
+     *
+     * @return void
+     */
+    public static function clearSkips()
+    {
+        static::$skipCallbacks = [];
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -3,15 +3,11 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Foundation\Http\Middleware\Concerns\HasSkipCallbacks;
 
 class ConvertEmptyStringsToNull extends TransformsRequest
 {
-    /**
-     * All of the registered skip callbacks.
-     *
-     * @var array
-     */
-    protected static $skipCallbacks = [];
+    use HasSkipCallbacks;
 
     /**
      * Handle an incoming request.
@@ -22,10 +18,8 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      */
     public function handle($request, Closure $next)
     {
-        foreach (static::$skipCallbacks as $callback) {
-            if ($callback($request)) {
-                return $next($request);
-            }
+        if ($this->shouldSkipDueToCallback($request)) {
+            return $next($request);
         }
 
         return parent::handle($request, $next);
@@ -41,16 +35,5 @@ class ConvertEmptyStringsToNull extends TransformsRequest
     protected function transform($key, $value)
     {
         return $value === '' ? null : $value;
-    }
-
-    /**
-     * Register a callback that instructs the middleware to be skipped.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public static function skipWhen(Closure $callback)
-    {
-        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -3,15 +3,11 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Foundation\Http\Middleware\Concerns\HasSkipCallbacks;
 
 class TrimStrings extends TransformsRequest
 {
-    /**
-     * All of the registered skip callbacks.
-     *
-     * @var array
-     */
-    protected static $skipCallbacks = [];
+    use HasSkipCallbacks;
 
     /**
      * The attributes that should not be trimmed.
@@ -31,10 +27,8 @@ class TrimStrings extends TransformsRequest
      */
     public function handle($request, Closure $next)
     {
-        foreach (static::$skipCallbacks as $callback) {
-            if ($callback($request)) {
-                return $next($request);
-            }
+        if ($this->shouldSkipDueToCallback($request)) {
+            return $next($request);
         }
 
         return parent::handle($request, $next);
@@ -54,16 +48,5 @@ class TrimStrings extends TransformsRequest
         }
 
         return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
-    }
-
-    /**
-     * Register a callback that instructs the middleware to be skipped.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public static function skipWhen(Closure $callback)
-    {
-        static::$skipCallbacks[] = $callback;
     }
 }

--- a/tests/Foundation/Http/Middleware/Concerns/HasSkipCallbacksTest.php
+++ b/tests/Foundation/Http/Middleware/Concerns/HasSkipCallbacksTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware\Concerns;
+
+use Illuminate\Foundation\Http\Middleware\Concerns\HasSkipCallbacks;
+use PHPUnit\Framework\TestCase;
+
+class HasSkipCallbacksTest extends TestCase
+{
+    public function testHasSkipCallbacks()
+    {
+        HasSkipCallbacksA::skipWhen(fn($param) => $param === 'test');
+        HasSkipCallbacksA::skipWhen(fn($param) => $param === 'other');
+        $hasSkipCallbacksA = new HasSkipCallbacksA();
+
+        self::assertFalse($hasSkipCallbacksA->shouldSkipDueToCallback('callback'));
+        self::assertTrue($hasSkipCallbacksA->shouldSkipDueToCallback('test'));
+        self::assertTrue($hasSkipCallbacksA->shouldSkipDueToCallback('other'));
+        HasSkipCallbacksA::clearSkips();
+        self::assertFalse($hasSkipCallbacksA->shouldSkipDueToCallback('test'));
+        self::assertFalse($hasSkipCallbacksA->shouldSkipDueToCallback('other'));
+    }
+
+    public function testClassesDontShareCallbacks()
+    {
+        HasSkipCallbacksA::skipWhen(fn($param) => $param === 'test');
+        HasSkipCallbacksB::skipWhen(fn($param) => $param === 'callback');
+        $hasSkipCallbacksA = new HasSkipCallbacksA();
+        $hasSkipCallbacksB = new HasSkipCallbacksB();
+
+        self::assertFalse($hasSkipCallbacksA->shouldSkipDueToCallback('callback'));
+        self::assertTrue($hasSkipCallbacksA->shouldSkipDueToCallback('test'));
+        self::assertFalse($hasSkipCallbacksB->shouldSkipDueToCallback('test'));
+        self::assertTrue($hasSkipCallbacksB->shouldSkipDueToCallback('callback'));
+        HasSkipCallbacksA::clearSkips();
+        HasSkipCallbacksB::clearSkips();
+    }
+}
+
+class HasSkipCallbacksA
+{
+    use HasSkipCallbacks;
+}
+
+class HasSkipCallbacksB
+{
+    use HasSkipCallbacks;
+}


### PR DESCRIPTION
[TrimStrings](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php) and [ConvertEmptyStringsToNull](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php) received additional functionality to allow skipping them entirely based on a static `skipWhen` function in #36856.

This PR consolidates that functionality into a reusable trait to reduce duplication and also potentially allow it to be used with other middleware. Additionally I added automated tests for the original two use cases as well as the trait.