### PR TITLE
Add noRetriesLeft method in Cache RateLimiter

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -185,6 +185,18 @@ class RateLimiter
     }
 
     /**
+     * Check if no retries are left for the given key.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @return bool
+     */
+    public function noRetriesLeft($key, $maxAttempts)
+    {
+        return $this->remaining($key, $maxAttempts) === 0;
+    }
+
+    /**
      * Clear the hits and lockout timer for the given key.
      *
      * @param  string  $key

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -57,6 +57,18 @@ class CacheRateLimiterTest extends TestCase
         $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
     }
 
+    public function testNoRetriesLeftReturnsCorrectStatus()
+    {
+        $cache = m::mock(Cache::class);
+
+        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(3);
+        $rateLimiter = new RateLimiter($cache);
+        $this->assertFalse($rateLimiter->NoRetriesLeft('key', 5));
+
+        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(5);
+        $this->assertTrue($rateLimiter->NoRetriesLeft('key', 5));
+    }
+
     public function testClearClearsTheCacheKeys()
     {
         $cache = m::mock(Cache::class);


### PR DESCRIPTION
This method can be used in place of the condition `Ratelimiter::retriesLeft($key, $maxAttempts) === 0`, making the following snippet easier to read:
```php
if (RateLimiter::noRetriesLeft($key, $maxAttempts)) {
    // Do something
}
```