### PR TITLE
[10.x] Add `updateMany` method to Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1049,6 +1049,11 @@ class Builder implements BuilderContract
         );
     }
 
+    public function updateMany(array $updateValues, array $values, string $column = 'id')
+    {
+        return $this->whereIn($column, $values)->update($updateValues);
+    }
+
     /**
      * Update the column's update timestamp.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1057,7 +1057,7 @@ class Builder implements BuilderContract
      * @param  string  $column
      * @return int
      */
-    public function updateMany(array $updateValues, array $values, string $column = 'id')
+    public function updateMany(array $values, array $updateValues, string $column = 'id')
     {
         return $this->whereIn($column, $values)->update($updateValues);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1049,6 +1049,14 @@ class Builder implements BuilderContract
         );
     }
 
+    /**
+     * Update many rows.
+     *
+     * @param  array  $updateValues
+     * @param  array  $values
+     * @param  string  $column
+     * @return int
+     */
     public function updateMany(array $updateValues, array $values, string $column = 'id')
     {
         return $this->whereIn($column, $values)->update($updateValues);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -511,6 +511,27 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('Nuno Maduro', $user4->name);
     }
 
+    public function testUpdateMany()
+    {
+        EloquentTestUser::create(['name' => 'taylor', 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['name' => 'milwad', 'email' => 'milwad.dev@gmail.com']);
+        EloquentTestUser::create(['name' => 'lorem', 'email' => 'lorem@gmail.com']);
+        EloquentTestUser::create(['name' => 'test', 'email' => 'test@gmail.com']);
+
+        EloquentTestUser::updateMany([1, 2, 3], ['name' => 'laravel']);
+
+        $this->assertEquals('laravel', EloquentTestUser::where('id', 1)->value('name'));
+        $this->assertEquals('laravel', EloquentTestUser::where('id', 2)->value('name'));
+        $this->assertEquals('laravel', EloquentTestUser::where('id', 3)->value('name'));
+        $this->assertEquals('test', EloquentTestUser::where('id', 4)->value('name'));
+        $this->assertNotEquals('laravel', EloquentTestUser::where('id', 4)->value('name'));
+        $this->assertEquals(4, EloquentTestUser::count());
+
+        EloquentTestUser::updateMany([4], ['email' => 'john@gmail.com']);
+
+        $this->assertEquals('john@gmail.com', EloquentTestUser::where('id', 4)->value('email'));
+    }
+
     public function testUpdateOrCreate()
     {
         $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
Suppose you want to update some records, most of the time you act like this:
```php
$user1 = User::query()->findOrFail(1);
$user2 = User::query()->findOrFail(2);
$user3 = User::query()->findOrFail(3);

$user1->update(['name' => 'milwad']);
$user2->update(['name' => 'milwad']);
$user3->update(['name' => 'milwad']);
```

OR maybe do a little better:
```php
User::query()->whereIn('id', [1, 2, 3])->update(['name' => 'milwad']);
````
But it is a bit boring compared to methods like `insert`.

With `updateMany` method can update multi records in one line:
```php
User::query()->updateMany([1, 2, 3], ['name' => 'milwad']);
```

** Note ** The default column of updateMany is `id`, you can change it if you want!
```php
User::query()->updateMany(['milwad', 'taylor'], ['name' => 'laravel'], 'name');
```