### PR TITLE
[10.x] Allow for converting a HasMany to HasOne && MorphMany to MorphOne

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -7,6 +7,16 @@ use Illuminate\Database\Eloquent\Collection;
 class HasMany extends HasOneOrMany
 {
     /**
+     * Convert the relationship to a "has one" relationship.
+     *
+     * @return Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function hasOne()
+    {
+        return new HasOne($this->getQuery(), $this->parent, $this->foreignKey, $this->localKey);
+    }
+
+    /**
      * Get the results of the relationship.
      *
      * @return mixed
@@ -45,15 +55,5 @@ class HasMany extends HasOneOrMany
     public function match(array $models, Collection $results, $relation)
     {
         return $this->matchMany($models, $results, $relation);
-    }
-
-    /**
-     * Convert the relationship to HasOne.
-     *
-     * @return HasOne
-     */
-    public function hasOne(): HasOne
-    {
-        return new HasOne($this->getQuery(), $this->parent, $this->foreignKey, $this->localKey);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -46,4 +46,14 @@ class HasMany extends HasOneOrMany
     {
         return $this->matchMany($models, $results, $relation);
     }
+
+    /**
+     * Convert the relationship to HasOne.
+     *
+     * @return HasOne
+     */
+    public function hasOne(): HasOne
+    {
+        return new HasOne($this->getQuery(), $this->parent, $this->foreignKey, $this->localKey);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -11,7 +11,7 @@ class HasMany extends HasOneOrMany
      *
      * @return Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function hasOne()
+    public function one()
     {
         return new HasOne($this->getQuery(), $this->parent, $this->foreignKey, $this->localKey);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -82,6 +82,24 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Convert the relationship to a "has one through" relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function hasOneThrough()
+    {
+        return new HasOneThrough(
+            $this->getQuery(),
+            $this->farParent,
+            $this->throughParent,
+            $this->getFirstKeyName(),
+            $this->secondKey,
+            $this->getLocalKeyName(),
+            $this->getSecondLocalKeyName(),
+        );
+    }
+
+    /**
      * Set the base constraints on the relation query.
      *
      * @return void
@@ -770,21 +788,5 @@ class HasManyThrough extends Relation
     public function getSecondLocalKeyName()
     {
         return $this->secondLocalKey;
-    }
-
-    /**
-     * @return HasOneThrough
-     */
-    public function hasOneThrough(): HasOneThrough {
-        return new HasOneThrough(
-            $this->getQuery(),
-            $this->farParent,
-            $this->throughParent,
-            $this->getFirstKeyName(),
-            $this->secondKey,
-            $this->getLocalKeyName(),
-            $this->getSecondLocalKeyName(),
-        );
-
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -86,7 +86,7 @@ class HasManyThrough extends Relation
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function hasOneThrough()
+    public function one()
     {
         return new HasOneThrough(
             $this->getQuery(),

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -771,4 +771,20 @@ class HasManyThrough extends Relation
     {
         return $this->secondLocalKey;
     }
+
+    /**
+     * @return HasOneThrough
+     */
+    public function hasOneThrough(): HasOneThrough {
+        return new HasOneThrough(
+            $this->getQuery(),
+            $this->farParent,
+            $this->throughParent,
+            $this->getFirstKeyName(),
+            $this->secondKey,
+            $this->getLocalKeyName(),
+            $this->getSecondLocalKeyName(),
+        );
+
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -11,7 +11,7 @@ class MorphMany extends MorphOneOrMany
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function morphOne()
+    public function one()
     {
         return new MorphOne($this->getQuery(), $this->getParent(), $this->morphType, $this->foreignKey, $this->localKey);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -59,4 +59,14 @@ class MorphMany extends MorphOneOrMany
 
         return parent::forceCreate($attributes);
     }
+
+    /**
+     * Create a new MorphOne relationship from MorphMany relationship.
+     *
+     * @return MorphOne
+     */
+    public function morphOne(): MorphOne
+    {
+        return new MorphOne($this->getQuery(), $this->getParent(), $this->morphType, $this->foreignKey, $this->localKey);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -7,6 +7,16 @@ use Illuminate\Database\Eloquent\Collection;
 class MorphMany extends MorphOneOrMany
 {
     /**
+     * Convert the relationship to a "morph one" relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
+     */
+    public function morphOne()
+    {
+        return new MorphOne($this->getQuery(), $this->getParent(), $this->morphType, $this->foreignKey, $this->localKey);
+    }
+
+    /**
      * Get the results of the relationship.
      *
      * @return mixed
@@ -58,15 +68,5 @@ class MorphMany extends MorphOneOrMany
         $attributes[$this->getMorphType()] = $this->morphClass;
 
         return parent::forceCreate($attributes);
-    }
-
-    /**
-     * Create a new MorphOne relationship from MorphMany relationship.
-     *
-     * @return MorphOne
-     */
-    public function morphOne(): MorphOne
-    {
-        return new MorphOne($this->getQuery(), $this->getParent(), $this->morphType, $this->foreignKey, $this->localKey);
     }
 }

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentHasManyTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function ($table) {
+            $table->id();
+        });
+
+        Schema::create('logins', function ($table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->timestamp('login_time');
+        });
+    }
+
+    public function testCanGetHasOneFromHasManyRelationship() {
+        $user = User::create();
+
+        $user->logins()->create(['login_time' => now()]);
+
+        $this->assertInstanceOf(HasOne::class, $user->logins()->hasOne());
+    }
+
+    public function testHasOneRelationshipFromHasMany() {
+        $user = User::create();
+
+        Login::create(['user_id' => '99999'.$user->id, 'login_time' => '2020-09-29']);
+        $latestLogin = Login::create(['user_id' => $user->id, 'login_time' => '2023-03-14']);
+        $oldestLogin = Login::create(['user_id' => $user->id, 'login_time' => '2010-01-01']);
+
+
+        $this->assertEquals($oldestLogin->id, $user->oldestLogin->id);
+        $this->assertEquals($latestLogin->id, $user->latestLogin->id);
+    }
+
+}
+
+
+class User extends Model
+{
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function logins(): HasMany {
+        return $this->hasMany(Login::class);
+    }
+
+    public function latestLogin(): HasOne
+    {
+        return $this->logins()->hasOne()->latestOfMany('login_time');
+    }
+
+    public function oldestLogin(): HasOne {
+        return $this->logins()->hasOne()->oldestOfMany('login_time');
+    }
+}
+
+class Login extends Model
+{
+    protected $guarded = [];
+    public $timestamps = false;
+}
+

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -11,19 +11,19 @@ class EloquentHasManyTest extends DatabaseTestCase
 {
     protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
-        Schema::create('users', function ($table) {
+        Schema::create('eloquent_has_many_test_users', function ($table) {
             $table->id();
         });
 
-        Schema::create('logins', function ($table) {
+        Schema::create('eloquent_has_many_test_logins', function ($table) {
             $table->id();
-            $table->foreignId('user_id');
+            $table->foreignId('eloquent_has_many_test_user_id');
             $table->timestamp('login_time');
         });
     }
 
     public function testCanGetHasOneFromHasManyRelationship() {
-        $user = User::create();
+        $user = EloquentHasManyTestUser::create();
 
         $user->logins()->create(['login_time' => now()]);
 
@@ -31,12 +31,20 @@ class EloquentHasManyTest extends DatabaseTestCase
     }
 
     public function testHasOneRelationshipFromHasMany() {
-        $user = User::create();
+        $user = EloquentHasManyTestUser::create();
 
-        Login::create(['user_id' => '99999'.$user->id, 'login_time' => '2020-09-29']);
-        $latestLogin = Login::create(['user_id' => $user->id, 'login_time' => '2023-03-14']);
-        $oldestLogin = Login::create(['user_id' => $user->id, 'login_time' => '2010-01-01']);
-
+        EloquentHasManyTestLogin::create([
+            'eloquent_has_many_test_user_id' => $user->id,
+            'login_time' => '2020-09-29',
+        ]);
+        $latestLogin = EloquentHasManyTestLogin::create([
+            'eloquent_has_many_test_user_id' => $user->id,
+            'login_time' => '2023-03-14',
+        ]);
+        $oldestLogin = EloquentHasManyTestLogin::create([
+            'eloquent_has_many_test_user_id' => $user->id,
+            'login_time' => '2010-01-01'
+        ]);
 
         $this->assertEquals($oldestLogin->id, $user->oldestLogin->id);
         $this->assertEquals($latestLogin->id, $user->latestLogin->id);
@@ -45,13 +53,13 @@ class EloquentHasManyTest extends DatabaseTestCase
 }
 
 
-class User extends Model
+class EloquentHasManyTestUser extends Model
 {
     protected $guarded = [];
     public $timestamps = false;
 
     public function logins(): HasMany {
-        return $this->hasMany(Login::class);
+        return $this->hasMany(EloquentHasManyTestLogin::class);
     }
 
     public function latestLogin(): HasOne
@@ -64,7 +72,7 @@ class User extends Model
     }
 }
 
-class Login extends Model
+class EloquentHasManyTestLogin extends Model
 {
     protected $guarded = [];
     public $timestamps = false;

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -28,7 +28,7 @@ class EloquentHasManyTest extends DatabaseTestCase
 
         $user->logins()->create(['login_time' => now()]);
 
-        $this->assertInstanceOf(HasOne::class, $user->logins()->hasOne());
+        $this->assertInstanceOf(HasOne::class, $user->logins()->one());
     }
 
     public function testHasOneRelationshipFromHasMany()
@@ -65,12 +65,12 @@ class EloquentHasManyTestUser extends Model
 
     public function latestLogin(): HasOne
     {
-        return $this->logins()->hasOne()->latestOfMany('login_time');
+        return $this->logins()->one()->latestOfMany('login_time');
     }
 
     public function oldestLogin(): HasOne
     {
-        return $this->logins()->hasOne()->oldestOfMany('login_time');
+        return $this->logins()->one()->oldestOfMany('login_time');
     }
 }
 

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -22,7 +22,8 @@ class EloquentHasManyTest extends DatabaseTestCase
         });
     }
 
-    public function testCanGetHasOneFromHasManyRelationship() {
+    public function testCanGetHasOneFromHasManyRelationship()
+    {
         $user = EloquentHasManyTestUser::create();
 
         $user->logins()->create(['login_time' => now()]);
@@ -30,7 +31,8 @@ class EloquentHasManyTest extends DatabaseTestCase
         $this->assertInstanceOf(HasOne::class, $user->logins()->hasOne());
     }
 
-    public function testHasOneRelationshipFromHasMany() {
+    public function testHasOneRelationshipFromHasMany()
+    {
         $user = EloquentHasManyTestUser::create();
 
         EloquentHasManyTestLogin::create([
@@ -43,22 +45,21 @@ class EloquentHasManyTest extends DatabaseTestCase
         ]);
         $oldestLogin = EloquentHasManyTestLogin::create([
             'eloquent_has_many_test_user_id' => $user->id,
-            'login_time' => '2010-01-01'
+            'login_time' => '2010-01-01',
         ]);
 
         $this->assertEquals($oldestLogin->id, $user->oldestLogin->id);
         $this->assertEquals($latestLogin->id, $user->latestLogin->id);
     }
-
 }
-
 
 class EloquentHasManyTestUser extends Model
 {
     protected $guarded = [];
     public $timestamps = false;
 
-    public function logins(): HasMany {
+    public function logins(): HasMany
+    {
         return $this->hasMany(EloquentHasManyTestLogin::class);
     }
 
@@ -67,7 +68,8 @@ class EloquentHasManyTestUser extends Model
         return $this->logins()->hasOne()->latestOfMany('login_time');
     }
 
-    public function oldestLogin(): HasOne {
+    public function oldestLogin(): HasOne
+    {
         return $this->logins()->hasOne()->oldestOfMany('login_time');
     }
 }
@@ -77,4 +79,3 @@ class EloquentHasManyTestLogin extends Model
     protected $guarded = [];
     public $timestamps = false;
 }
-

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -83,11 +83,13 @@ class Post extends Model
         return $this->morphMany(Comment::class, 'commentable');
     }
 
-    public function latestComment(): MorphOne {
+    public function latestComment(): MorphOne
+    {
         return $this->comments()->morphOne()->latestOfMany();
     }
 
-    public function oldestComment(): MorphOne {
+    public function oldestComment(): MorphOne
+    {
         return $this->comments()->morphOne()->oldestOfMany();
     }
 }

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -64,7 +64,7 @@ class EloquentMorphManyTest extends DatabaseTestCase
         Carbon::setTestNow('2022-01-01 00:00:00');
         $latestComment = tap((new Comment(['name' => 'The Silver Chair']))->commentable()->associate($post))->save();
 
-        $this->assertInstanceOf(MorphOne::class, $post->comments()->morphOne());
+        $this->assertInstanceOf(MorphOne::class, $post->comments()->one());
 
         $this->assertEquals($latestComment->id, $post->latestComment->id);
         $this->assertEquals($oldestComment->id, $post->oldestComment->id);
@@ -85,12 +85,12 @@ class Post extends Model
 
     public function latestComment(): MorphOne
     {
-        return $this->comments()->morphOne()->latestOfMany();
+        return $this->comments()->one()->latestOfMany();
     }
 
     public function oldestComment(): MorphOne
     {
-        return $this->comments()->morphOne()->oldestOfMany();
+        return $this->comments()->one()->oldestOfMany();
     }
 }
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -48,6 +50,25 @@ class EloquentMorphManyTest extends DatabaseTestCase
 
         $this->assertEquals([1], $comments->pluck('id')->all());
     }
+
+    public function testCanMorphOne()
+    {
+        $post = Post::create(['title' => 'Your favorite book by C.S. Lewis']);
+
+        Carbon::setTestNow('1990-02-02 12:00:00');
+        $oldestComment = tap((new Comment(['name' => 'The Allegory Of Love']))->commentable()->associate($post))->save();
+
+        Carbon::setTestNow('2000-07-02 09:00:00');
+        tap((new Comment(['name' => 'The Screwtape Letters']))->commentable()->associate($post))->save();
+
+        Carbon::setTestNow('2022-01-01 00:00:00');
+        $latestComment = tap((new Comment(['name' => 'The Silver Chair']))->commentable()->associate($post))->save();
+
+        $this->assertInstanceOf(MorphOne::class, $post->comments()->morphOne());
+
+        $this->assertEquals($latestComment->id, $post->latestComment->id);
+        $this->assertEquals($oldestComment->id, $post->oldestComment->id);
+    }
 }
 
 class Post extends Model
@@ -60,6 +81,14 @@ class Post extends Model
     public function comments()
     {
         return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    public function latestComment(): MorphOne {
+        return $this->comments()->morphOne()->latestOfMany();
+    }
+
+    public function oldestComment(): MorphOne {
+        return $this->comments()->morphOne()->oldestOfMany();
     }
 }
 


### PR DESCRIPTION
### Problem
There are often times where I am building a HasMany relationship and I need to get just one item from the collection. This means I have to either define the relationship two times (one for HasMany and then one for HasOne->ofMany()).

```php
class User extends Model
{
    public function logins(): HasMany {
        return $this->hasMany(Login::class, 'some_id', 'the_other_id');
    }
    public function latestLogin(): HasOne {
        return $this->hasOne(Login::class, 'some_id', 'the_other_id')->latestOfMany();
    }
}
```

As you can imagine, if the design of the DB changes (like during early development of a project) or if the relationship isn't simple, this can be cumbersome or lead to duplication of work.
### Proposed Solution
What is added in this PR is the ability to convert a HasMany relationship to HasOne (and MorphMany to MorphOne). So the above code can become

```php
class User extends Model
{
    public function logins(): HasMany {
        return $this->hasMany(Login::class, 'some_id', 'the_other_id');
    }
    public function latestLogin(): HasOne {
        return $this->logins()->hasOne()->latestOfMany();
    }
}
```