### PR TITLE
[10.x] Remove obsolete method_exists(ReflectionClass::class, 'isEnum') call

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -78,7 +78,7 @@ trait RouteDependencyResolverTrait
         // the list of parameters. If it is we will just skip it as it is probably a model
         // binding and we do not want to mess with those; otherwise, we resolve it here.
         if ($className && ! $this->alreadyInParameters($className, $parameters)) {
-            $isEnum = method_exists(ReflectionClass::class, 'isEnum') && (new ReflectionClass($className))->isEnum();
+            $isEnum = (new ReflectionClass($className))->isEnum();
 
             return $parameter->isDefaultValueAvailable()
                 ? ($isEnum ? $parameter->getDefaultValue() : null)


### PR DESCRIPTION
As the minimum PHP version for Laravel 10 is 8.1, this should now always return true, and therefore can be safely removed.