### PR TITLE
[10.x] Fix route:cache from excluding octane routes

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -86,12 +86,12 @@ class RouteCacheCommand extends Command
             $routes->refreshActionLookups();
         });
 
-        if($application->has('octane')) {
+        if( $application->has('octane')) {
             $warning = 'Running route:cache while running swoole decreases memory performance';
             $this->components->warn($warning);
             collect($application->octane->getRoutes())
-                ->each( function ($callback, $signature) use ($application) {
-                    list($method, $uri) = explode('/',$signature, 2);
+                ->each(function ($callback, $signature) use ($application) {
+                    [$method, $uri] = explode('/', $signature, 2);
                     $application['router']->addRoute($method, $uri, $callback);
                 });
         }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -86,7 +86,7 @@ class RouteCacheCommand extends Command
             $routes->refreshActionLookups();
         });
 
-        if($this->hasOctane($application)) {
+        if($application->has('octane')) {
             $warning = 'Running route:cache while running swoole decreases memory performance';
             $this->components->warn($warning);
             collect($application->octane->getRoutes())
@@ -97,15 +97,6 @@ class RouteCacheCommand extends Command
         }
 
         return $routes;
-    }
-
-    /**
-     * @param Application $application
-     * @return bool
-     */
-    protected function hasOctane(Application $application): bool
-    {
-        return $application?->octane !== null;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
-use Laravel\Octane\Octane;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'route:cache')]

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -86,7 +86,7 @@ class RouteCacheCommand extends Command
             $routes->refreshActionLookups();
         });
 
-        if( $application->has('octane')) {
+        if ($application->has('octane')) {
             $warning = 'Running route:cache while running swoole decreases memory performance';
             $this->components->warn($warning);
             collect($application->octane->getRoutes())


### PR DESCRIPTION
When running route:cache command with octane routes they are being excluded from the cached routes file. This causes octane routes to 404 when cached.

While caching the routes gives a negative performance to swoole (not sure about road runner) by increasing the amount of memory needed for each request this will at least prevent them prevent them from 404ing.

This will also prevent questions like this

https://github.com/laravel/octane/issues/596
https://github.com/laravel/octane/issues/658

**This PR is a required dependency for this PR.** 

https://github.com/laravel/octane/pull/659

Additonally it doesnt seem like Octane::route method doesn't work with road runner. 



