### PR TITLE
adds type-hint to Arr::isList

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -408,7 +408,7 @@ class Arr
      * @param  array  $array
      * @return bool
      */
-    public static function isAssoc(array $array)
+    public static function isAssoc(array $array): bool
     {
         return ! array_is_list($array);
     }
@@ -421,7 +421,7 @@ class Arr
      * @param  array  $array
      * @return bool
      */
-    public static function isList($array)
+    public static function isList(array $array): bool
     {
         return array_is_list($array);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Throwable;
+use TypeError;
 
 class SupportArrTest extends TestCase
 {
@@ -497,6 +499,13 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isList([0 => 'foo', 'bar' => 'baz']));
         $this->assertFalse(Arr::isList([0 => 'foo', 2 => 'bar']));
         $this->assertFalse(Arr::isList(['foo' => 'bar', 'baz' => 'qux']));
+
+        try {
+            Arr::isList(null);
+            $this->fail("No TypeError thrown");
+        } catch (Throwable $throwable) {
+            $this->assertInstanceOf(TypeError::class, $throwable);
+        }
     }
 
     public function testOnly()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -502,7 +502,7 @@ class SupportArrTest extends TestCase
 
         try {
             Arr::isList(null);
-            $this->fail("No TypeError thrown");
+            $this->fail('No TypeError thrown');
         } catch (Throwable $throwable) {
             $this->assertInstanceOf(TypeError::class, $throwable);
         }


### PR DESCRIPTION
#### Problem
I was working with `Arr::isList()` in a project when I noticed a test regression. I was not aware that Arr::isList() requires an array to be passed (and I was working with something that returned `?array`). I figured this would help the next dev who might come up against this.

I figured it was an easy enough fix to just add the type-hints. Arr::isAssoc() already had the type-hint added.

##### Note
I was working on 9.x. Not that it makes much of a difference, but just noting.

#### Other Possible Solutions
Remove the typehints and change to `return is_array($array) && array_is_list($array);`