### PR TITLE
[9.x] Typehint tap to input value

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -293,9 +293,11 @@ if (! function_exists('tap')) {
     /**
      * Call the given Closure with the given value then return the value.
      *
-     * @param  mixed  $value
+     * @template TTapValue
+     *
+     * @param  TTapValue  $value
      * @param  callable|null  $callback
-     * @return mixed
+     * @return TTapValue|\Illuminate\Support\HigherOrderTapProxy
      */
     function tap($value, $callback = null)
     {


### PR DESCRIPTION
This allows `tap($myObject)->someFunctionHere()` to be properly typehinted so that chained functions are inferred as elements from `$myObject`,

I've targeted 9.x because this is code annotation only and useful for everyone.