### PR TITLE
[11.x] Catch pipeline exception

### DIFF
--- a/src/Illuminate/Contracts/Pipeline/Pipeline.php
+++ b/src/Illuminate/Contracts/Pipeline/Pipeline.php
@@ -37,4 +37,12 @@ interface Pipeline
      * @return mixed
      */
     public function then(Closure $destination);
+
+    /**
+     * Set the catch callback for the pipeline.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function catch(Closure $callback);
 }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -39,6 +39,13 @@ class Pipeline implements PipelineContract
     protected $method = 'handle';
 
     /**
+     * The closures to be called on exceptions.
+     *
+     * @var Closure
+     */
+    protected $catchCallback;
+
+    /**
      * Create a new class instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
@@ -113,7 +120,28 @@ class Pipeline implements PipelineContract
             array_reverse($this->pipes()), $this->carry(), $this->prepareDestination($destination)
         );
 
+        if ($this->catchCallback) {
+            try {
+                return $pipeline($this->passable);
+            } catch (\Throwable $th) {
+                return call_user_func($this->catchCallback, $th, $this->passable);
+            }
+        }
+
         return $pipeline($this->passable);
+    }
+
+    /**
+     * Set the catch callback for the pipeline.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function catch(Closure $callback)
+    {
+        $this->catchCallback = $callback;
+
+        return $this;
     }
 
     /**

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -97,6 +97,23 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
+    public function testPipeAndCatchException()
+    {
+        $function = function ($piped, $next) {
+            throw new RuntimeException('foo');
+        };
+
+        (new Pipeline(new Container))
+            ->send('bar')
+            ->through([$function])
+            ->catch(function ($e, $passable) {
+                $this->assertInstanceOf(RuntimeException::class, $e);
+                $this->assertSame('bar', $passable);
+                $this->assertSame('foo', $e->getMessage());
+            })
+            ->thenReturn();
+    }
+
     public function testPipelineUsageWithPipe()
     {
         $object = new stdClass();


### PR DESCRIPTION
This PR adds a new `catch` method when using a Pipeline object. Following the addition of Pipeline Facade #46271, I think it would be helpful to chain a catch callback directly on the pipeline object.

With this PR, the following would be possible:

```php
            Pipeline::send($this->organization)
                ->via('handle')
                ->through([
                    VerifyOnboardingIsComplete::class,
                    VerifyOrganizationHasValidPaymentMethod::class,
                    ...
                ])
                ->catch(function (VerificationFailed $th) {
                    NewOrganizationHasNotBeenAuthorized::dispatch($this->organization, $th);
                })
                ->then(function (Organization $organization) {
                    NewOrganizationHasBeenAuthorized::dispatch($organization);
                });
```