### PR TITLE
[10.x] Convert eloquent builder to base builder in whereExists

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1689,7 +1689,7 @@ class Builder implements BuilderContract
             // compile the whole thing in the grammar and insert it into the SQL.
             $callback($query);
         } else {
-            $query = $callback;
+            $query = $callback instanceof EloquentBuilder ? $callback->toBase() : $callback;
         }
 
         return $this->addWhereExistsQuery($query, $boolean, $not);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2115,6 +2115,12 @@ class DatabaseQueryBuilderTest extends TestCase
             $this->getBuilder()->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'))
         );
         $this->assertSame('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->whereExists(
+            (new EloquentBuilder($this->getBuilder()))->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'))
+        );
+        $this->assertSame('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
     }
 
     public function testBasicJoins()


### PR DESCRIPTION
The `whereExists` method accepts an Eloquent builder (see docblock on whereExists-methods) but the `addWhereExistsQuery` method used by `whereExists` only accepts a base builder. To fix that I added code that converts Eloquent builder to base builder before calling the `addWhereExistsQuery` method.

(The other solution would be changing the parameter type on the `addWhereExistsQuery` method, but I thought converting the type in the `whereExists` method would probably be the preferred way of handling this)