### PR TITLE
[10.x] Add option to create macroable method for paginationInformation.

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -50,7 +50,7 @@ class PaginatedResourceResponse extends ResourceResponse
             'meta' => $this->meta($paginated),
         ];
 
-        if (method_exists($this->resource, 'paginationInformation')) {
+        if (method_exists($this->resource, 'paginationInformation') || $this->resource->hasMacro('paginationInformation')) {
             return $this->resource->paginationInformation($request, $paginated, $default);
         }
 

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -50,7 +50,8 @@ class PaginatedResourceResponse extends ResourceResponse
             'meta' => $this->meta($paginated),
         ];
 
-        if (method_exists($this->resource, 'paginationInformation') || $this->resource->hasMacro('paginationInformation')) {
+        if (method_exists($this->resource, 'paginationInformation') || 
+            $this->resource->hasMacro('paginationInformation')) {
             return $this->resource->paginationInformation($request, $paginated, $default);
         }
 


### PR DESCRIPTION
This pull request allows customizing pagination information without having to extend all resources to a base resource.

This way it is possible to include the paginationInformation into a mixin:
```php 
/** @mixin \Illuminate\Http\Resources\Json\ResourceCollection */
class ResourceCollectionMixin
{
    public function paginationInformation(): Closure
    {
        return fn ($request, $paginated, $default) => collect($default)->mapWithKeysRecursively(fn ($item, $key) => [Str::camel($key) => $item])->toArray();
    }
}
```
