### PR TITLE
[10.x] Add `foreignIdCascadeDelete` to Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -943,6 +943,11 @@ class Blueprint
                     : $this->foreignUuid($column ?: $model->getForeignKey());
     }
 
+    public function foreignIdCascadeDelete($column, $table = null, $on = 'id')
+    {
+        return $this->foreignId($column)->constrained($table, $on)->cascadeOnDelete();
+    }
+
     /**
      * Create a new float column on the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -943,6 +943,12 @@ class Blueprint
                     : $this->foreignUuid($column ?: $model->getForeignKey());
     }
 
+    /**
+     * @param  string  $column
+     * @param  string|null  $table
+     * @param  string  $on
+     * @return \Illuminate\Database\Schema\ForeignKeyDefinition
+     */
     public function foreignIdCascadeDelete($column, $table = null, $on = 'id')
     {
         return $this->foreignId($column)->constrained($table, $on)->cascadeOnDelete();


### PR DESCRIPTION
Suppose you want to define a foreign key. 
Well, a series of methods such as cascadeOnDelete are fixed and are always written.
Because of this `foreignIdCascadeDelete` method, it is very easy and fast to define a foreign key with one method and we don't have to add additional code.

```php
 $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
```

```php
$table->foreignIdCascadeDelete('user_id', 'users'); // OR
$table->foreignIdCascadeDelete('user_id'); 
```

If accepted I added tests and foreignIdNullDelete method.