### PR TITLE
[10.x] Add next due to schedule:work output

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -31,13 +31,12 @@ class ScheduleWorkCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @return void
      */
-    public function handle(Schedule $schedule)
+    public function handle()
     {
         $this->components->info(
-            'Running scheduled tasks every minute. '.$this->getNextDueInformation($schedule),
+            'Running scheduled tasks every minute. '.$this->getNextDueInformation(app(Schedule::class)),
             $this->getLaravel()->isLocal() ? OutputInterface::VERBOSITY_NORMAL : OutputInterface::VERBOSITY_VERBOSE
         );
 


### PR DESCRIPTION
Copy some code from `schedule:list` to extract next due information.

![image](https://user-images.githubusercontent.com/379924/224925756-7acb01c9-8da3-4594-9703-4afdc8ac8bf2.png)
![image](https://user-images.githubusercontent.com/379924/224925807-5d03adbe-2e6b-45e3-a15b-f660486c24f2.png)

This PR is based on #46459 with added extra commit to move `handle(Schedule $schedule)` to `app()` call to prevent public signature changes.