### PR TITLE
Add a new helper function called are_null

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -427,3 +427,22 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('are_null')) {
+    /**
+     * Check if the all given variables are null.
+     *
+     * @param  mixed  ...$parameters
+     * @return bool
+     */
+    function are_null(...$parameters)
+    {
+        foreach ($parameters as $parameter) {
+            if (! is_null($parameter)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Hi there,
I just added a new helper function called "are_null" to helpers. It would be more convenient and fluent for users.
Instead of writing:
`is_null($a) && is_null($b) && is_null($c)`

Users can write:
`are_null($a, $b, $c)`
