### PR TITLE
[10.x] Add whereEnum route constraints

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Routing;
 
+use BackedEnum;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 
 trait CreatesRegularExpressionRouteConstraints
 {
@@ -71,6 +73,28 @@ trait CreatesRegularExpressionRouteConstraints
     public function whereIn($parameters, array $values)
     {
         return $this->assignExpressionToParameters($parameters, implode('|', $values));
+    }
+
+    /**
+     * Specify that the given route parameters must be valid case of provided enum.
+     *
+     * @param array|string $parameters
+     * @param class-string $enum
+     * @return $this
+     */
+    public function whereEnum($parameters, $enum)
+    {
+        if (! enum_exists($enum)) {
+            throw new InvalidArgumentException(
+                "Enum [{$enum}] not found"
+            );
+        }
+
+        $cases = collect($enum::cases())
+            ->map(fn ($case) => $case instanceof BackedEnum ? $case->value : $case->name)
+            ->implode('|');
+
+        return $this->assignExpressionToParameters($parameters, $cases);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -86,6 +86,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar whereUlid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUuid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereIn(array|string $parameters, array $values)
+ * @method static \Illuminate\Routing\RouteRegistrar whereEnum(array|string $parameters, string $enum)
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -884,6 +884,33 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereEnumRegistration()
+    {
+        $wheres = ['foo' => 'People|Fruits', 'bar' => 'People|Fruits'];
+
+        $this->router->get('/{foo}/{bar}')->whereEnum(['foo', 'bar'], CategoryEnum::class);
+        $this->router->get('/api/{bar}/{foo}')->whereEnum(['bar', 'foo'], '\Illuminate\Tests\Routing\CategoryEnum');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereEnumRegistrationForBackedEnum()
+    {
+        $wheres = ['foo' => 'people|fruits', 'bar' => 'people|fruits'];
+
+        $this->router->get('/{foo}/{bar}')->whereEnum(['foo', 'bar'], CategoryBackedEnum::class);
+        $this->router->get('/api/{bar}/{foo}')->whereEnum(['bar', 'foo'],
+            '\Illuminate\Tests\Routing\CategoryBackedEnum');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testGroupWhereNumberRegistrationOnRouteRegistrar()
     {
         $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
@@ -1011,6 +1038,42 @@ class RouteRegistrarTest extends TestCase
         });
 
         $this->router->whereIn(['bar', 'foo'], ['one', 'two'])->prefix('/api/{bar}/{foo}')->group(function ($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereEnumRegistrationOnRouter()
+    {
+        $wheres = ['foo' => 'People|Fruits', 'bar' => 'People|Fruits'];
+
+        $this->router->whereEnum(['foo', 'bar'], CategoryEnum::class)->prefix('/{foo}/{bar}')->group(function ($router) {
+            $router->get('/');
+        });
+
+        $this->router->whereEnum(['bar', 'foo'], '\Illuminate\Tests\Routing\CategoryEnum')->prefix('/api/{bar}/{foo}')->group(function ($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereEnumRegistrationOnRouterForBackedEnum()
+    {
+        $wheres = ['foo' => 'people|fruits', 'bar' => 'people|fruits'];
+
+        $this->router->whereEnum(['foo', 'bar'], CategoryBackedEnum::class)->prefix('/{foo}/{bar}')->group(function ($router) {
+            $router->get('/');
+        });
+
+        $this->router->whereEnum(['bar', 'foo'], '\Illuminate\Tests\Routing\CategoryBackedEnum')->prefix('/api/{bar}/{foo}')->group(function ($router) {
             $router->get('/');
         });
 


### PR DESCRIPTION
Allow an option to create route constraints based on enum/backed-enum cases, which specifies that the given route parameters must be valid case of provided enum class.

**For basic enum**: route parameter must match enum case name
**For backed enum**: route parameter must match enum case value

_**Note**: parameter value is case sensitive_

#### Usage

```
Route::get('{foo}', [MyController::class, 'index'])->whereEnum('foo', MyEnum::class);

Route::prefix('{foo}')->whereEnum('foo', MyEnum::class)->group(function () {
    Route::get('', [MyController::class, 'index']);
});
```