### PR TITLE
[10.x] Add custom name for foreign key in foreignId

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -942,7 +942,7 @@ class Blueprint
 
         return $model->getKeyType() === 'int' && $model->getIncrementing()
                     ? $this->foreignId($column ?: $model->getForeignKey(), $name)
-                    : $this->foreignUuid($column ?: $model->getForeignKey());
+                    : $this->foreignUuid($column ?: $model->getForeignKey(), $name);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1320,7 +1320,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int|null  $length
-     * @param  string|null $name
+     * @param  string|null  $name
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignUlid($column, $length = 26, $name = null)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -913,13 +913,15 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
+     * @param  string|null $name
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function foreignId($column, $name = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'bigInteger',
             'name' => $column,
+            'index' => $name,
             'autoIncrement' => false,
             'unsigned' => true,
         ]));
@@ -932,14 +934,14 @@ class Blueprint
      * @param  string|null  $column
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignIdFor($model, $column = null)
+    public function foreignIdFor($model, $column = null, $name = null)
     {
         if (is_string($model)) {
             $model = new $model;
         }
 
         return $model->getKeyType() === 'int' && $model->getIncrementing()
-                    ? $this->foreignId($column ?: $model->getForeignKey())
+                    ? $this->foreignId($column ?: $model->getForeignKey(), $name)
                     : $this->foreignUuid($column ?: $model->getForeignKey());
     }
 
@@ -1289,13 +1291,15 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
+     * @param  string|null $name
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUuid($column)
+    public function foreignUuid($column, $name = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
+            'index' => $name
         ]));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -913,7 +913,7 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
-     * @param  string|null $name
+     * @param  string|null  $name
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignId($column, $name = null)
@@ -1291,7 +1291,7 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
-     * @param  string|null $name
+     * @param  string|null  $name
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignUuid($column, $name = null)
@@ -1299,7 +1299,7 @@ class Blueprint
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
-            'index' => $name
+            'index' => $name,
         ]));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1320,6 +1320,7 @@ class Blueprint
      *
      * @param  string  $column
      * @param  int|null  $length
+     * @param  string|null $name
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignUlid($column, $length = 26, $name = null)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1322,11 +1322,12 @@ class Blueprint
      * @param  int|null  $length
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUlid($column, $length = 26)
+    public function foreignUlid($column, $length = 26, $name = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'char',
             'name' => $column,
+            'index' => $name,
             'length' => $length,
         ]));
     }

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -47,6 +47,6 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function references($column)
     {
-        return $this->blueprint->foreign($this->name)->references($column);
+        return $this->blueprint->foreign($this->name, $this->index)->references($column);
     }
 }


### PR DESCRIPTION
I stumbled upon an error where I had two very long table names and wanted one to have a foreign key to the other. I used the foreignId Method for that and got an error that the foreign key identifier name was too long. When using the foreign Method you can name your keys if you want so to prevent the error I got, I added the same functionality to foreignId and foreignUuid. 

I tested this in a small test environment with creating and dropping these foreign ids
