### PR TITLE
[10.x] Add `prefixAll` in Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -557,9 +557,7 @@ class Router implements BindingRegistrar, RegistrarContract
             $action = $this->convertToControllerAction($action);
         }
 
-        $prefix = $this->prefixAll === ''
-            ? $this->prefix($uri)
-            : $this->prefixAll.'/'.$this->prefix($uri);
+        $prefix = $this->getCorrectPrefix($uri);
 
         $route = $this->newRoute(
             $methods, $prefix, $action
@@ -712,6 +710,19 @@ class Router implements BindingRegistrar, RegistrarContract
             $route->getAction(),
             $prependExistingPrefix = false
         ));
+    }
+
+    /**
+     * Get correct prefix.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    protected function getCorrectPrefix(string $uri): string
+    {
+        return $this->prefixAll === ''
+            ? $this->prefix($uri)
+            : $this->prefixAll . '/' . $this->prefix($uri);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -557,7 +557,9 @@ class Router implements BindingRegistrar, RegistrarContract
             $action = $this->convertToControllerAction($action);
         }
 
-        $prefix = $this->prefixAll.'/'.$this->prefix($uri);
+        $prefix = is_null($this->prefixAll)
+            ? $this->prefix($uri)
+            : $this->prefixAll.'/'.$this->prefix($uri);
 
         $route = $this->newRoute(
             $methods, $prefix, $action

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -722,7 +722,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         return $this->prefixAll === ''
             ? $this->prefix($uri)
-            : $this->prefixAll . '/' . $this->prefix($uri);
+            : $this->prefixAll.'/'.$this->prefix($uri);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -557,7 +557,7 @@ class Router implements BindingRegistrar, RegistrarContract
             $action = $this->convertToControllerAction($action);
         }
 
-        $prefix = is_null($this->prefixAll)
+        $prefix = $this->prefixAll === ''
             ? $this->prefix($uri)
             : $this->prefixAll.'/'.$this->prefix($uri);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -557,8 +557,10 @@ class Router implements BindingRegistrar, RegistrarContract
             $action = $this->convertToControllerAction($action);
         }
 
+        $prefix = $this->prefixAll . '/' . $this->prefix($uri);
+
         $route = $this->newRoute(
-            $methods, $this->prefix($uri), $action
+            $methods, $prefix, $action
         );
 
         // If we have groups that need to be merged, we will merge them now after this

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -78,7 +78,7 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @var string
      */
-    protected $prefixAll;
+    protected $prefixAll = '';
 
     /**
      * All of the short-hand keys for middlewares.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -74,6 +74,13 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $currentRequest;
 
     /**
+     * The prefix for all routes.
+     *
+     * @var string
+     */
+    protected $prefixAll;
+
+    /**
      * All of the short-hand keys for middlewares.
      *
      * @var array
@@ -1183,6 +1190,17 @@ class Router implements BindingRegistrar, RegistrarContract
         foreach ($patterns as $key => $pattern) {
             $this->pattern($key, $pattern);
         }
+    }
+
+    /**
+     * Set a global prefix on all routes.
+     *
+     * @param  string $uri
+     * @return void
+     */
+    public function prefixAll($uri)
+    {
+        $this->prefixAll = $uri;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -557,7 +557,7 @@ class Router implements BindingRegistrar, RegistrarContract
             $action = $this->convertToControllerAction($action);
         }
 
-        $prefix = $this->prefixAll . '/' . $this->prefix($uri);
+        $prefix = $this->prefixAll.'/'.$this->prefix($uri);
 
         $route = $this->newRoute(
             $methods, $prefix, $action
@@ -1197,7 +1197,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Set a global prefix on all routes.
      *
-     * @param  string $uri
+     * @param  string  $uri
      * @return void
      */
     public function prefixAll($uri)

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -53,6 +53,7 @@ namespace Illuminate\Support\Facades;
  * @method static array getPatterns()
  * @method static void pattern(string $key, string $pattern)
  * @method static void patterns(array $patterns)
+ * @method static void prefixAll(string $uri)
  * @method static bool hasGroupStack()
  * @method static array getGroupStack()
  * @method static mixed input(string $key, string|null $default = null)


### PR DESCRIPTION
I am working on a modular project in the form of API. Now we have to get the program version on all the routes in the project through the config version and put it on the prefix of all the routes.
https://github.com/milwad-dev/towork-backend/blob/main/Modules/Auth/Providers/AuthServiceProvider.php#LL30
For all modules, we write the module itself in the service provider as follows:

```php
 Route::middleware('api')
            ->prefix('api/'.config('app.version'))
            ->group(__DIR__.'/../Routes/api.php');
```
Now the problem is that if we want to write the prefix like this every time, it will be boring and also it will be very difficult to change it. Suppose we change the method of getting the version of the application!
At that time, to change all the prefixes, we have to come and change them, and this is not interesting.
But with the prefixAll method, we can do this in a very simple way.
Just need write in one Service Provider `App/Providers/RouteServiceProvider` :

```php
public function boot(): void
{
    Route::prefixAll('api/' . config('app.version'));
}
```

Now all routes start with `api/v1/....` .

If approved, I write tests.
