### PR TITLE
[11.x] Convert route parameters to camelCase

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -611,7 +611,7 @@ class ResourceRegistrar
             $value = Str::singular($value);
         }
 
-        return str_replace('-', '_', $value);
+        return Str::camel($value);
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -767,12 +767,12 @@ class RouteRegistrarTest extends TestCase
     public function testCanOverrideParametersOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
-                     ->parameters(['users' => 'admin_user']);
+                     ->parameters(['users' => 'adminUser']);
 
         $this->router->resource('posts', RouteRegistrarControllerStub::class)
                      ->parameter('posts', 'topic');
 
-        $this->assertStringContainsString('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
+        $this->assertStringContainsString('adminUser', $this->router->getRoutes()->getByName('users.show')->uri);
         $this->assertStringContainsString('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1456,21 +1456,21 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertSame('foo-bars/{foo_bar}', $routes[0]->uri());
+        $this->assertSame('foo-bars/{fooBar}', $routes[0]->uri());
 
         $router = $this->getRouter();
         $router->resource('foo-bar.foo-baz', 'FooController', ['only' => ['show']]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertSame('foo-bar/{foo_bar}/foo-baz/{foo_baz}', $routes[0]->uri());
+        $this->assertSame('foo-bar/{fooBar}/foo-baz/{fooBaz}', $routes[0]->uri());
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show'], 'as' => 'prefix']);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertSame('foo-bars/{foo_bar}', $routes[0]->uri());
+        $this->assertSame('foo-bars/{fooBar}', $routes[0]->uri());
         $this->assertSame('prefix.foo-bars.show', $routes[0]->getName());
 
         ResourceRegistrar::verbs([


### PR DESCRIPTION
This PR is the result of this tweet:
https://twitter.com/pascalbaljet/status/1635970593970331649

Currently, registering routes with dashes results in parameters with an underscore.
```
Route::resource('document-version', DocumentVersionController:: class);
// Route Name: document-version.edit
// URI + Segment name: document-version/{document_version}/edit

Route::singleton('document-version.comments', DocumentVersionCommentsController::class);
// Route Name: document-version.comments.edit
// URI + Segment name: document-version/{document_version}/comments/edit
```

The parameters can be renamed using the `parameter` function, but it would be nice if this was the default behavior.
This PR updates the above examples to the following:

```
Route::resource('document-version', DocumentVersionController:: class);
// Route Name: document-version.edit
// URI + Segment name: document-version/{documentVersion}/edit

Route::singleton('document-version.comments', DocumentVersionCommentsController::class);
// Route Name: document-version.comments.edit
// URI + Segment name: document-version/{documentVersion}/comments/edit
```