### PR TITLE
File::json() method to get json decoded data from a file.

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -60,6 +60,22 @@ class Filesystem
     }
 
     /**
+     * Get the json decoded contents of a file.
+     *
+     * @param  string  $path
+     * @param  bool  $lock
+     * @return array
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function json($path, $lock = false)
+    {
+        $contents = $this->get($path, $lock);
+
+        return json_decode($contents, true);
+    }
+
+    /**
      * Get contents of a file with shared access.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -60,7 +60,7 @@ class Filesystem
     }
 
     /**
-     * Get the json decoded contents of a file.
+     * Get the contents of a file as decoded JSON.
      *
      * @param  string  $path
      * @param  bool  $lock
@@ -70,9 +70,7 @@ class Filesystem
      */
     public function json($path, $lock = false)
     {
-        $contents = $this->get($path, $lock);
-
-        return json_decode($contents, true);
+        return json_decode($this->get($path, $lock), true);
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -346,6 +346,20 @@ class FilesystemTest extends TestCase
         $files->getRequire(self::$tempDir.'/file.php');
     }
 
+    public function testJsonReturnsDecodedJsonData()
+    {
+        file_put_contents(self::$tempDir.'/file.json', '{"foo": "bar"}');
+        $files = new Filesystem;
+        $this->assertSame(['foo' => 'bar'], $files->json(self::$tempDir.'/file.json'));
+    }
+
+    public function testJsonReturnsNullIfJsonDataIsInvalid()
+    {
+        file_put_contents(self::$tempDir.'/file.json', '{"foo":');
+        $files = new Filesystem;
+        $this->assertNull($files->json(self::$tempDir . '/file.json'));
+    }
+
     public function testAppendAddsDataToFile()
     {
         file_put_contents(self::$tempDir.'/file.txt', 'foo');


### PR DESCRIPTION
This adds a convenient `File::json()` method to retrieve json encoded data from a file.

Example of current flow:
```
$contents = File::get('sample.json');
$data = json_decode($contents, true);
```
New flow using `File::json`:
```
$data = File::json('sample.json');
```

This additional method will not affect current users and eases the development flow when accessing json files. Tests are included.
