### PR TITLE
[11.x] Add missing method to filesystem contract

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -27,6 +27,14 @@ interface Filesystem
     public function exists($path);
 
     /**
+     * Determine if a file is missing.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    public function missing($path);
+
+    /**
      * Get the contents of a file.
      *
      * @param  string  $path


### PR DESCRIPTION
Adds missing `missing` method to `Illuminate/Contracts/Filesystem/Filesystem`.
