### PR TITLE
[10.x] Fix enums uses with optional implicit parameters

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -84,7 +84,7 @@ class ImplicitRouteBinding
 
             $parameterValue = $parameters[$parameterName];
 
-            $backedEnumClass = (string) $parameter->getType();
+            $backedEnumClass = $parameter->getType()?->getName();
 
             $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);
 

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -150,7 +150,7 @@ class Reflector
     {
         $backedEnumClass = $parameter->getType()?->getName();
 
-        if (null === $backedEnumClass) {
+        if (is_null($backedEnumClass)) {
             return false;
         }
 

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -148,7 +148,11 @@ class Reflector
      */
     public static function isParameterBackedEnumWithStringBackingType($parameter)
     {
-        $backedEnumClass = (string) $parameter->getType();
+        $backedEnumClass = $parameter->getType()?->getName();
+
+        if (null === $backedEnumClass) {
+            return false;
+        }
 
         if (enum_exists($backedEnumClass)) {
             $reflectionBackedEnum = new ReflectionEnum($backedEnumClass);

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -31,6 +31,24 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category')->value);
     }
 
+    public function test_it_can_resolve_the_implicit_backed_enum_route_bindings_for_the_given_route_with_optional_parameter()
+    {
+        $action = ['uses' => function (?CategoryBackedEnum $category = null) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => 'fruits'];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertSame('fruits', $route->parameter('category')->value);
+    }
+
     public function test_it_does_not_resolve_implicit_non_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryEnum $category) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1893,6 +1893,20 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('foo', 'GET'))->getContent();
     }
 
+    public function testImplicitBindingsWithOptionalParameterUsingEnumIsAlwaysCastedToEnum()
+    {
+        include_once 'enums.php';
+
+        $router = $this->getRouter();
+        $router->get('foo/{bar?}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (?\Illuminate\Tests\Routing\CategoryBackedEnum $bar = null) {
+                $this->assertInstanceOf(CategoryBackedEnum::class, $bar);
+            },
+        ]);
+        $router->dispatch(Request::create('foo/people', 'GET'))->getContent();
+    }
+
     public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
     {
         $this->expectException(ModelNotFoundException::class);


### PR DESCRIPTION
Fixes the bug outlined in #46471.

Essentially this boils down to the use string typecasting when checking if you had type-hinted your controller method to expect an optional enum parameter which defaulted to null in the controller class. 

The issue is only relevant for the cases where the parameter is defined as an optional parameter in the controller and uses implicit routing.