### PR TITLE
[10.x] Fix deprecations for embedded images in symfony mailer

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\File;
 
 /**
  * @mixin \Symfony\Component\Mime\Email
@@ -344,12 +346,16 @@ class Message
                 function ($path) use ($file) {
                     $cid = $file->as ?? Str::random();
 
-                    $this->message->embedFromPath($path, $cid, $file->mime);
+                    $this->message->addPart(
+                        (new DataPart(new File($path), $cid, $file->mime))->asInline()
+                    );
 
                     return "cid:{$cid}";
                 },
                 function ($data) use ($file) {
-                    $this->message->embed($data(), $file->as, $file->mime);
+                    $this->message->addPart(
+                        (new DataPart($data(), $file->as, $file->mime))->asInline()
+                    );
 
                     return "cid:{$file->as}";
                 }
@@ -358,7 +364,9 @@ class Message
 
         $cid = Str::random(10);
 
-        $this->message->embedFromPath($file, $cid);
+        $this->message->addPart(
+            (new DataPart(new File($file), $cid))->asInline()
+        );
 
         return "cid:$cid";
     }
@@ -373,7 +381,9 @@ class Message
      */
     public function embedData($data, $name, $contentType = null)
     {
-        $this->message->embed($data, $name, $contentType);
+        $this->message->addPart(
+            (new DataPart($data, $name, $contentType))->asInline()
+        );
 
         return "cid:$name";
     }


### PR DESCRIPTION
Fixes #46462 

It seems like Symfony has deprecated the old way of embedding images in Mails since 6.2:
https://symfony.com/doc/current/mailer.html#embedding-images

This PR implements the new way of embedding images.