### PR TITLE
[10.x] Added assertDatabaseHasCount

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
+use Illuminate\Testing\Constraints\HasCountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\NotSoftDeletedInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
@@ -64,6 +65,24 @@ trait InteractsWithDatabase
     {
         $this->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), $count)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the count of table entries for a given where condition in the database.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  int  $count
+     * @param  array  $data
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseHasCount($table, int $count, array $data, $connection = null)
+    {
+        $this->assertThat(
+            $this->getTable($table), new HasCountInDatabase($this->getConnection($connection, $table), $data, $count)
         );
 
         return $this;

--- a/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Illuminate\Testing\Constraints;
 
 use Illuminate\Database\Connection;

--- a/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
@@ -1,0 +1,139 @@
+<?php
+namespace Illuminate\Testing\Constraints;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class HasCountInDatabase extends Constraint
+{
+    /**
+     * Number of records that will be shown in the console in case of failure.
+     *
+     * @var int
+     */
+    protected $show = 3;
+
+    /**
+     * The database connection.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The expected table entries count that will be checked against the actual count.
+     *
+     * @var int
+     */
+    protected $expectedCount;
+
+    /**
+     * The actual table entries count that will be checked against the expected count.
+     *
+     * @var int
+     */
+    protected $actualCount;
+
+    /**
+     * The data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  array  $data
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function __construct(Connection $database, array $data, int $expectedCount)
+    {
+        $this->data = $data;
+
+        $this->database = $database;
+
+        $this->expectedCount = $expectedCount;
+    }
+
+    /**
+     * Check if the data is found in the given table.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table): bool
+    {
+        $this->actualCount = $this->database->table($table)->where($this->data)->count();
+
+        return $this->actualCount === $this->expectedCount;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table): string
+    {
+        return sprintf(
+            "table [%s] matches expected entries count of %s. Entries found: %s.\n\n%s",
+            $table, $this->expectedCount, $this->actualCount, $this->getAdditionalInfo($table)
+        );
+    }
+
+    /**
+     * Get additional info about the records found in the database table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    protected function getAdditionalInfo($table)
+    {
+        $query = $this->database->table($table);
+
+        $similarResults = $query->where(
+            array_key_first($this->data),
+            $this->data[array_key_first($this->data)]
+        )->select(array_keys($this->data))->limit($this->show)->get();
+
+        if ($similarResults->isNotEmpty()) {
+            $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        } else {
+            $query = $this->database->table($table);
+
+            $results = $query->select(array_keys($this->data))->limit($this->show)->get();
+
+            if ($results->isEmpty()) {
+                return 'The table is empty';
+            }
+
+            $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        }
+
+        if ($query->count() > $this->show) {
+            $description .= sprintf(' and %s others', $query->count() - $this->show);
+        }
+
+        return $description;
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toString($options = 0): string
+    {
+        foreach ($this->data as $key => $data) {
+            $output[$key] = $data instanceof Expression ? (string) $data : $data;
+        }
+
+        return json_encode($output ?? [], $options);
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -153,15 +153,6 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHasCount($this->table, 1, $this->data);
     }
 
-    public function testAssertTableEntriesCountWrongForCondition()
-    {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
-        $this->mockCountBuilder(1);
-
-        $this->assertDatabaseHasCount($this->table, 3, $this->data);
-    }
-
     public function testDontSeeInDatabaseDoesNotFindResults()
     {
         $this->mockCountBuilder(0);

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -95,20 +95,23 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
-    public function testSeeAmountInDatabaseFindsResults(){
+    public function testSeeAmountInDatabaseFindsResults()
+    {
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseHasCount($this->table, 1, $this->data);
     }
 
-    public function testAssertDatabaseHasCountSupportModels(){
+    public function testAssertDatabaseHasCountSupportModels()
+    {
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseHasCount(ProductStub::class, 1, $this->data);
         $this->assertDatabaseHasCount(new ProductStub, 1, $this->data);
     }
 
-    public function testSeeAmountInDatabaseDoesNotFindResults(){
+    public function testSeeAmountInDatabaseDoesNotFindResults()
+    {
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The table is empty.');
 


### PR DESCRIPTION
# Problem
There is currently no method to assert in a database test how many entries are for a specific set of key/values condition. 

# Use Case
We seed a table with `x` amount of entries. The method we test should set a flag from `false` to `true` for `y` amount of entries.

Currently, we cannot check how many entries had the flag set to `true`.

`assertDatabaseHas` will check only if some entries have the flag set as `true`, while `assertDatabaseCount` will check that there are a total of `x` entries in the table.

`assertDatabaseHasCount('table', $y, ['flag' => true])` will assert that exacly `y` entries have the flag set to `true`

# Solution
`assertDatabaseHasCount` is a combination of `assertDatabaseHas` and `assertDatabaseCount`. 

A new constraint `HasCountInDatabase` was created that checks for both amount and data.
This constrained is then asserted in `InteractsWithDatabase` and wrapped as `assertDatabaseHasCount`

Since the logic follows `assertDatabaseHas` and `assertDatabaseCount` it shouldn't break any existing features. 
