### PR TITLE
[9.x] PHP 8.0 fix for Closure jobs

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -325,7 +325,7 @@ abstract class Queue
      */
     protected function shouldDispatchAfterCommit($job)
     {
-        if (is_object($job) && isset($job->afterCommit)) {
+        if (! $job instanceof Closure && is_object($job) && isset($job->afterCommit)) {
             return $job->afterCommit;
         }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -56,9 +56,9 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $uuid = Str::uuid()->toString();
 
         return [
-            [ $uuid, new MyTestJob, 'MyTestJob', 'CallQueuedHandler' ],
-            [ $uuid, fn () => 0, 'Closure', 'CallQueuedHandler' ],
-            [ $uuid, 'foo', 'foo', 'foo' ],
+            [$uuid, new MyTestJob, 'MyTestJob', 'CallQueuedHandler'],
+            [$uuid, fn () => 0, 'Closure', 'CallQueuedHandler'],
+            [$uuid, 'foo', 'foo', 'foo'],
         ];
     }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -19,10 +19,11 @@ class QueueDatabaseQueueUnitTest extends TestCase
         m::close();
     }
 
-    public function testPushProperlyPushesJobOntoDatabase()
+    /**
+     * @dataProvider pushJobsDataProvider
+     */
+    public function testPushProperlyPushesJobOntoDatabase($uuid, $job, $displayNameStartsWith, $jobStartsWith)
     {
-        $uuid = Str::uuid();
-
         Str::createUuidsUsing(function () use ($uuid) {
             return $uuid;
         });
@@ -31,19 +32,34 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->expects($this->any())->method('currentTime')->willReturn('time');
         $queue->setContainer($container = m::spy(Container::class));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
-        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid) {
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid, $displayNameStartsWith, $jobStartsWith) {
+            $payload = json_decode($array['payload'], true);
+            $this->assertSame($uuid, $payload['uuid']);
+            $this->assertStringContainsString($displayNameStartsWith, $payload['displayName']);
+            $this->assertStringContainsString($jobStartsWith, $payload['job']);
+
             $this->assertSame('default', $array['queue']);
-            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'failOnTimeout' => false, 'backoff' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);
         });
 
-        $queue->push('foo', ['data']);
+        $queue->push($job, ['data']);
 
         $container->shouldHaveReceived('bound')->with('events')->once();
 
         Str::createUuidsNormally();
+    }
+
+    public static function pushJobsDataProvider()
+    {
+        $uuid = Str::uuid()->toString();
+
+        return [
+            [ $uuid, new MyTestJob, 'MyTestJob', 'CallQueuedHandler' ],
+            [ $uuid, fn () => 0, 'Closure', 'CallQueuedHandler' ],
+            [ $uuid, 'foo', 'foo', 'foo' ],
+        ];
     }
 
     public function testDelayedPushProperlyPushesJobOntoDatabase()
@@ -151,5 +167,13 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $record = $queue->buildDatabaseRecord('queue', 'any_payload', 0);
         $this->assertArrayHasKey('payload', $record);
         $this->assertArrayHasKey('payload', array_slice($record, -1, 1, true));
+    }
+}
+
+class MyTestJob
+{
+    public function handle()
+    {
+        // ...
     }
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/46355 (passing a Closure would fail because `isset($closure->someProperty)` throws an error on PHP 8.0).