### PR TITLE
After

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -97,7 +97,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         }
 
         if (method_exists($this, 'after')) {
-            $validator->after($this->after());
+            $validator->after($this->container->call([$this, 'after']));
         }
 
         $this->setValidator($validator);

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -96,6 +96,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->withValidator($validator);
         }
 
+        if (method_exists($this, 'after')) {
+            $validator->after($this->after());
+        }
+
         $this->setValidator($validator);
 
         return $this->validator;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -124,7 +124,7 @@ class Validator implements ValidatorContract
     protected $after = [];
 
     /**
-     * The sentinal value to stop executing after rules.
+     * Indicates that the validator should skip subsequent after validation rules.
      *
      * @var bool
      */

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -124,13 +124,6 @@ class Validator implements ValidatorContract
     protected $after = [];
 
     /**
-     * Indicates that the validator should skip subsequent after validation rules.
-     *
-     * @var bool
-     */
-    protected $skipSubsequentAfterRules = false;
-
-    /**
      * The array of custom error messages.
      *
      * @var array
@@ -454,17 +447,11 @@ class Validator implements ValidatorContract
             }
         }
 
-        $this->skipSubsequentAfterRules = false;
-
         // Here we will spin through all of the "after" hooks on this validator and
         // fire them off. This gives the callbacks a chance to perform all kinds
         // of other validation that needs to get wrapped up in this operation.
         foreach ($this->after as $after) {
             $after();
-
-            if ($this->skipSubsequentAfterRules) {
-                break;
-            }
         }
 
         return $this->messages->isEmpty();
@@ -496,18 +483,6 @@ class Validator implements ValidatorContract
         }
 
         return false;
-    }
-
-    /**
-     * Indicate that the validator should skip subsequent after rules.
-     *
-     * @return $this
-     */
-    public function skipSubsequentAfterRules()
-    {
-        $this->skipSubsequentAfterRules = true;
-
-        return $this;
     }
 
     /**

--- a/tests/Validation/ValidatorAfterRuleTest.php
+++ b/tests/Validation/ValidatorAfterRuleTest.php
@@ -72,30 +72,6 @@ class ValidatorAfterRuleTest extends TestCase
         ]);
     }
 
-    public function testItCanStopSubsequentValidationRules()
-    {
-        $validator = $this->validator();
-        $container = new Container;
-        $container->bind(InjectedDependency::class, fn () => new InjectedDependency('expected-value'));
-        $validator->setContainer($container);
-
-        $messages = $validator->after([
-            fn ($validator) => $validator->errors()->add('callable', 'true'),
-            'Illuminate\Tests\Validation\localFunction',
-            InvokableClass::class,
-            function ($validator) {
-                $validator->skipSubsequentAfterRules();
-            },
-            InvokableClassWithDependency::class,
-        ])->messages()->messages();
-
-        $this->assertSame($messages, [
-            'callable' => ['true'],
-            'localFunction' => ['true'],
-            'invokable' => ['true'],
-        ]);
-    }
-
     private function validator(): Validator
     {
         $validator = new Validator(new Translator(new ArrayLoader, 'en'), [], []);

--- a/tests/Validation/ValidatorAfterRuleTest.php
+++ b/tests/Validation/ValidatorAfterRuleTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+function localFunction(Validator $validator) {
+    $validator->errors()->add('localFunction', 'true');
+}
+
+class ValidatorAfterRuleTest extends TestCase
+{
+    public function testItAcceptsFunctionString()
+    {
+        $validator = $this->validator();
+
+        $messages = $validator->after('Illuminate\Tests\Validation\localFunction')->messages()->messages();
+
+        $this->assertSame($validator->messages()->messages(), [
+            'localFunction' => ['true'],
+        ]);
+    }
+
+    public function testItAcceptsInvokableClass()
+    {
+        $validator = $this->validator();
+
+        $messages = $validator->after(InvokableClass::class)->messages()->messages();
+
+        $this->assertSame($messages, [
+            'invokable' => ['true'],
+        ]);
+    }
+
+    public function testItResolvesDependencies()
+    {
+        $validator = $this->validator();
+        $container = new Container;
+        $container->bind(InjectedDependency::class, fn () => new InjectedDependency('expected-value'));
+        $validator->setContainer($container);
+
+        $messages = $validator->after(InvokableClassWithDependency::class)->messages()->messages();
+
+        $this->assertSame($messages, [
+            'invokableWithDependency' => ['expected-value'],
+        ]);
+    }
+
+    public function testItSupportsAnArray()
+    {
+        $validator = $this->validator();
+        $container = new Container;
+        $container->bind(InjectedDependency::class, fn () => new InjectedDependency('expected-value'));
+        $validator->setContainer($container);
+
+        $validator->after([
+            fn ($validator) => $validator->errors()->add('callable', 'true'),
+            'Illuminate\Tests\Validation\localFunction',
+            InvokableClass::class,
+            InvokableClassWithDependency::class,
+        ])->messages()->messages();
+
+        $this->assertSame($validator->messages()->messages(), [
+            'callable' => ['true'],
+            'localFunction' => ['true'],
+            'invokable' => ['true'],
+            'invokableWithDependency' => ['expected-value'],
+        ]);
+    }
+
+    public function testItCanStopSubsequentValidationRules()
+    {
+        $validator = $this->validator();
+        $container = new Container;
+        $container->bind(InjectedDependency::class, fn () => new InjectedDependency('expected-value'));
+        $validator->setContainer($container);
+
+        $messages = $validator->after([
+            fn ($validator) => $validator->errors()->add('callable', 'true'),
+            'Illuminate\Tests\Validation\localFunction',
+            InvokableClass::class,
+            function ($validator) {
+                $validator->skipSubsequentAfterRules();
+            },
+            InvokableClassWithDependency::class,
+        ])->messages()->messages();
+
+        $this->assertSame($messages, [
+            'callable' => ['true'],
+            'localFunction' => ['true'],
+            'invokable' => ['true'],
+        ]);
+    }
+
+    private function validator(): Validator
+    {
+        $validator = new Validator(new Translator(new ArrayLoader, 'en'), [], []);
+
+        $validator->setContainer(new Container);
+
+        return $validator;
+    }
+}
+
+class InvokableClass
+{
+    public function __invoke(Validator $validator)
+    {
+        $validator->errors()->add('invokable', 'true');
+    }
+}
+
+class InvokableClassWithDependency
+{
+    public function __construct(private InjectedDependency $dependency)
+    {
+        //
+    }
+
+    public function __invoke(Validator $validator)
+    {
+        $validator->errors()->add('invokableWithDependency', $this->dependency->value);
+    }
+}
+
+class InjectedDependency
+{
+    public function __construct(public $value)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR introduces developer experience improvements to the existing "after" validation rule feature.

Currently, after validation rules must be callables.

```php
Validator::make(/* .. */)->after(function ($validator) {
    // ...
});
```

or in a form request...

```php
class PostRequest extends FormRequest
{
    // ...

    public function withValidator($validator)
    {
        $validator->after(function ($validator) {
            // ...
        });
    }
}
```

If the callable is a class, it must be "new"d up, potentially from the container if it has dependencies.

```php
$after = App::make(AfterRule::class);

Validator::make(/* .. */)->after($after);
```

or in a form request...

```php
class PostRequest extends FormRequest
{
    // ...

    public function withValidator($validator)
    {
        $after = App::make(AfterRule::class);

        $validator->after($after);
    }
}
```

Lastly, when extracting after rules out to discrete classes, combining them is kinda cumbersome.


```php
Validator::make(/* .. */)->after(function ($validator) {
    App::make(FooAfterRule::class)($validator);
    App::make(BarAfterRule::class)($validator);
});
```

or

```php
Validator::make(/* .. */)
    ->after(App::make(FooAfterRule::class))
    ->after(App::make(BarAfterRule::class));
```

or in a form request...

```php
class PostRequest extends FormRequest
{
    // ...

    public function withValidator($validator)
    {
        $validator->after(App::make(FooAfterRule::class))
                  ->after(App::make(BarAfterRule::class));
    }
}
```

Extracting smaller classes is useful for adhering to "create more small things", for testibility, and for sharing rules across logic paths.

To improve the DX of the after rule, I'd like to propose that we allow:

- Passing a class-string.
- Passing an array.

Passing a class string will resolve the class from the container.

```diff
- $after = App::make(AfterRule::class);
-
- Validator::make(/* .. */)->after($after);
+ Validator::make(/* .. */)->after(AfterRule::class);
```

```diff
class PostRequest extends FormRequest
{
    // ...

    public function withValidator($validator)
    {
-        $after = App::make(AfterRule::class);
-
-        $validator->after($after);
+        $validator->after(AfterRule::class);
    }
}
```

Passing an array will chain multiple "after" calls.

```diff
- Validator::make(/* .. */)->after(function ($validator) {
-     App::make(FooAfterRule::class)($validator);
-     App::make(BarAfterRule::class)($validator);
- });
+ Validator::make(/* .. */)->after([
+     FooAfterRule::class,
+     BarAfterRule::class,
+ });
```
```diff
- Validator::make(/* .. */)
-     ->after(App::make(FooAfterRule::class))
-     ->after(App::make(BarAfterRule::class));
+ Validator::make(/* .. */)->after([
+     FooAfterRule::class,
+     BarAfterRule::class,
+ });
```

```diff
class PostRequest extends FormRequest
{
    // ...

    public function withValidator($validator)
    {
-         $validator->after(App::make(FooAfterRule::class))
-                   ->after(App::make(BarAfterRule::class));
+         $validator->after([
+             FooAfterRule::class,
+             BarAfterRule::class,
+         ]);
    }
}
```

The array may contain a combination of callables and class-strings.

```php
Validator::make(/* ... */)->after([
    FooAfterRule::class,
    function ($validator) {
        // ...
    },
]);
```


Bonus round: Dependencies for closures and more terse request after validation.

When in a form request, we lose the ability for dependency injection for closure based after validation rules. I'd like to also propose that we introduce an optional `after` method on the request that is invoked by the container, like the `rules` method.

This improves two things:

1. Provides dependencies to closure based after rules
2. Creates a more terse after validation rule method.

```diff
class PostRequest extends FormRequest
{
    // ...

-     public function withValidator($validator)
-     {
-         $validator->after([
-             FooAfterRule::class,
-             BarAfterRule::class,
-         ]);
+     public function after()
+     {
+         return [
+             FooAfterRule::class,
+             BarAfterRule::class,
+         ];
      }
}
```

Literally 100% of the time I've ever written a "withValidator" method, it is the same thing over and over. Get the validator and call "after" on it.

We also get dependency injection:


```php
class PostRequest extends FormRequest
{
    // ...

    public function after(MyService $service)
    {
        return [
            FooAfterRule::class,
            BarAfterRule::class,
            function ($validator) use ($service) {
                if ($service->check(/* ... */)) {
                    $validator->errors()->add(/* ... */);
                }
            },
        ];
     }
}
```