### PR TITLE
[10.x] Move Symfony events dispatcher registration to `Console\Kernel`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench-core": "^8.0",
+        "orchestra/testbench-core": "^8.1.1",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpdoc-parser": "^1.15",
         "phpstan/phpstan": "^1.4.7",

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench-core": "^8.1.1",
+        "orchestra/testbench-core": "8.x-dev",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpdoc-parser": "^1.15",
         "phpstan/phpstan": "^1.4.7",

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench-core": "8.x-dev",
+        "orchestra/testbench-core": "^8.1",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpdoc-parser": "^1.15",
         "phpstan/phpstan": "^1.4.7",

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class Application extends SymfonyApplication implements ApplicationContract

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -4,17 +4,12 @@ namespace Illuminate\Console;
 
 use Closure;
 use Illuminate\Console\Events\ArtisanStarting;
-use Illuminate\Console\Events\CommandFinished;
-use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Console\Application as ApplicationContract;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -80,40 +75,7 @@ class Application extends SymfonyApplication implements ApplicationContract
 
         $this->events->dispatch(new ArtisanStarting($this));
 
-        $this->rerouteSymfonyCommandEvents();
-
         $this->bootstrap();
-    }
-
-    /**
-     * Re-route the Symfony command events to their Laravel counterparts.
-     *
-     * @return void
-     */
-    protected function rerouteSymfonyCommandEvents()
-    {
-        $this->setDispatcher($dispatcher = new EventDispatcher);
-
-        $dispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
-            $this->events->dispatch(
-                new CommandStarting(
-                    $event->getCommand()->getName(),
-                    $event->getInput(),
-                    $event->getOutput(),
-                )
-            );
-        });
-
-        $dispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) {
-            $this->events->dispatch(
-                new CommandFinished(
-                    $event->getCommand()->getName(),
-                    $event->getInput(),
-                    $event->getOutput(),
-                    $event->getExitCode(),
-                )
-            );
-        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -433,7 +433,7 @@ class Kernel implements KernelContract
                                     ->resolveCommands($this->commands)
                                     ->setContainerCommandLoader();
 
-            if (! $this->app->runningUnitTests()) {
+            if ($this->symfonyDispatcher instanceof EventDispatcher) {
                 $this->artisan->setDispatcher($this->symfonyDispatcher);
             }
         }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -7,6 +7,8 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Command;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -18,6 +20,10 @@ use Illuminate\Support\Env;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 use Throwable;
 
@@ -38,6 +44,13 @@ class Kernel implements KernelContract
      * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $events;
+
+    /**
+     * The symfony event dispatcher instance.
+     *
+     * @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface|null
+     */
+    protected $symfonyDispatcher = null;
 
     /**
      * The Artisan application instance.
@@ -104,6 +117,8 @@ class Kernel implements KernelContract
 
         $this->app = $app;
         $this->events = $events;
+
+        $this->rerouteSymfonyCommandEvents();
 
         $this->app->booted(function () {
             $this->defineConsoleSchedule();
@@ -417,6 +432,10 @@ class Kernel implements KernelContract
             $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
                                     ->resolveCommands($this->commands)
                                     ->setContainerCommandLoader();
+
+            if (! $this->app->runningUnitTests()) {
+                $this->artisan->setDispatcher($this->symfonyDispatcher);
+            }
         }
 
         return $this->artisan;
@@ -464,5 +483,38 @@ class Kernel implements KernelContract
     protected function renderException($output, Throwable $e)
     {
         $this->app[ExceptionHandler::class]->renderForConsole($output, $e);
+    }
+
+    /**
+     * Re-route the Symfony command events to their Laravel counterparts.
+     *
+     * @internal
+     *
+     * @return void
+     */
+    protected function rerouteSymfonyCommandEvents()
+    {
+        $this->symfonyDispatcher = new EventDispatcher;
+
+        $this->symfonyDispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
+            $this->events->dispatch(
+                new CommandStarting(
+                    $event->getCommand()->getName(),
+                    $event->getInput(),
+                    $event->getOutput(),
+                )
+            );
+        });
+
+        $this->symfonyDispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) {
+            $this->events->dispatch(
+                new CommandFinished(
+                    $event->getCommand()->getName(),
+                    $event->getInput(),
+                    $event->getOutput(),
+                    $event->getExitCode(),
+                )
+            );
+        });
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -118,7 +118,9 @@ class Kernel implements KernelContract
         $this->app = $app;
         $this->events = $events;
 
-        $this->rerouteSymfonyCommandEvents();
+        if (! $this->app->runningUnitTests()) {
+            $this->rerouteSymfonyCommandEvents();
+        }
 
         $this->app->booted(function () {
             $this->defineConsoleSchedule();

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -492,11 +492,11 @@ class Kernel implements KernelContract
      *
      * @internal
      *
-     * @return void
+     * @return $this
      */
     public function rerouteSymfonyCommandEvents()
     {
-        if (! isset($this->symfonyDispatcher)) {
+        if (is_null($this->symfonyDispatcher)) {
             $this->symfonyDispatcher = new EventDispatcher;
 
             $this->symfonyDispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
@@ -520,5 +520,7 @@ class Kernel implements KernelContract
                 );
             });
         }
+
+        return $this;
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -199,8 +199,6 @@ class Kernel implements KernelContract
         }
 
         $this->commandStartedAt = null;
-
-        unset($this->symfonyDispatcher);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -521,8 +521,6 @@ class Kernel implements KernelContract
                     )
                 );
             });
-
-            $this->symfonyDispatcher;
         }
     }
 }

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -66,6 +66,17 @@ class CommandEventsTest extends TestCase
     }
 
     /**
+     * Resolve application Console Kernel implementation.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function resolveApplicationConsoleKernel($app)
+    {
+        $app->singleton('Illuminate\Contracts\Console\Kernel', 'Illuminate\Foundation\Console\Kernel');
+    }
+
+    /**
      * @dataProvider commandEventsProvider
      */
     public function testCommandEventsReceiveParsedInput($processType, $argumentType)

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Event;
@@ -66,14 +67,14 @@ class CommandEventsTest extends TestCase
     }
 
     /**
-     * Resolve application Console Kernel implementation.
+     * Define environment setup.
      *
      * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
-    protected function resolveApplicationConsoleKernel($app)
+    protected function defineEnvironment($app)
     {
-        $app->singleton('Illuminate\Contracts\Console\Kernel', 'Illuminate\Foundation\Console\Kernel');
+        $app->make(ConsoleKernel::class)->rerouteSymfonyCommandEvents();
     }
 
     /**

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -124,14 +124,6 @@ class CommandEventsTest extends TestCase
                 $this->fs->append($this->logfile, '');
 
                 Process::run($phpBinary.' '.base_path('artisan').' command-events-test-command-'.$this->id.' taylor otwell --occupation=coding');
-
-                //exec('APP_ENV=local php '.base_path('artisan').' command-events-test-command-'.$this->id.' taylor otwell --occupation=coding');
-                // Since our command is running in a separate process, we need to wait
-                // until it has finished executing before running our assertions.
-                // $this->waitForLogMessages(
-                //     'CommandStarting', 'taylor', 'otwell', 'coding',
-                //     'CommandFinished', 'taylor', 'otwell', 'coding',
-                // );
                 break;
         }
 

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 class CommandEventsTest extends TestCase
 {
@@ -83,6 +84,8 @@ class CommandEventsTest extends TestCase
      */
     public function testCommandEventsReceiveParsedInput($processType, $argumentType)
     {
+        $phpBinary = (new PhpExecutableFinder)->find();
+
         switch ($processType) {
             case 'foreground':
                 $this->app[ConsoleKernel::class]->registerCommand(new CommandEventsTestCommand);
@@ -120,16 +123,15 @@ class CommandEventsTest extends TestCase
                 // Initialize empty logfile.
                 $this->fs->append($this->logfile, '');
 
-                Process::env(['APP_ENV' => 'local'])
-                    ->run('php '.base_path('artisan').' command-events-test-command-'.$this->id.' taylor otwell --occupation=coding');
+                Process::run($phpBinary.' '.base_path('artisan').' command-events-test-command-'.$this->id.' taylor otwell --occupation=coding');
 
                 //exec('APP_ENV=local php '.base_path('artisan').' command-events-test-command-'.$this->id.' taylor otwell --occupation=coding');
                 // Since our command is running in a separate process, we need to wait
                 // until it has finished executing before running our assertions.
-                $this->waitForLogMessages(
-                    'CommandStarting', 'taylor', 'otwell', 'coding',
-                    'CommandFinished', 'taylor', 'otwell', 'coding',
-                );
+                // $this->waitForLogMessages(
+                //     'CommandStarting', 'taylor', 'otwell', 'coding',
+                //     'CommandFinished', 'taylor', 'otwell', 'coding',
+                // );
                 break;
         }
 


### PR DESCRIPTION
Registering the events under `Illuminate\Console\Application` construct can cause memory leaks especially when running tests caused by #46442.

![image](https://user-images.githubusercontent.com/172966/226089961-1e395cfc-078e-4d7c-a4fc-84f682e48710.png)

### Test running on `10.3.3`

![image](https://user-images.githubusercontent.com/172966/226101136-6834cb0b-1ddd-4f25-aebe-eb11cafe4e4b.png)

### Test running on `10.4.0`

![image](https://user-images.githubusercontent.com/172966/226101257-9b5c5a4b-0d5a-4364-8c79-6c74915de71f.png)
