### PR TITLE
[10.x] Collection::mapInstance() to convert class names into concretes

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -829,14 +829,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Resolves class names contained in collection to an instance using service container
+     * Resolves class names contained in collection to an instance using service container.
      *
      * @return $this|Collection
-     *
      */
     public function mapInstance(?array $parameters = [])
     {
-        return $this->map(fn($class) => app($class, $parameters));
+        return $this->map(fn ($class) => app($class, $parameters));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -829,6 +829,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Resolves class names contained in collection to an instance using service container
+     *
+     * @return $this|Collection
+     *
+     */
+    public function mapInstance(?array $parameters = [])
+    {
+        return $this->map(fn($class) => app($class, $parameters));
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -828,10 +828,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Resolves class names contained in collection to an instance using service container
+     * Resolves class names contained in collection to an instance using service container.
      *
      * @return $this|Collection
-     *
      */
     public function mapInstance(?array $parameters = [])
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -828,6 +828,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Resolves class names contained in collection to an instance using service container
+     *
+     * @return $this|Collection
+     *
+     */
+    public function mapInstance(?array $parameters = [])
+    {
+        return $this->passthru('mapInstance', func_get_args());
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use ArrayObject;
 use CachingIterator;
 use Exception;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
@@ -3129,6 +3130,20 @@ class SupportCollectionTest extends TestCase
             ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
             $data->all()
         );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapInstance($collection)
+    {
+        $data = new $collection([
+            Container::class
+        ]);
+
+        $data = $data->mapInstance();
+
+        $this->assertInstanceOf(Container::class, $data->first());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3138,7 +3138,7 @@ class SupportCollectionTest extends TestCase
     public function testMapInstance($collection)
     {
         $data = new $collection([
-            Container::class
+            Container::class,
         ]);
 
         $data = $data->mapInstance();


### PR DESCRIPTION
A new Collection class `mapInstance()` helps you to deal with class strings within a collection. It maps them into concrete classes using the service container.

```php
$exampleComplexInput = [
    'elements' => [
        Elements\User::class => Fields\Users\Id::class,
        Elements\Task::class => Fields\Tasks\Id::class,
        Elements\MediaIndex::class => Fields\MediaIndex\Id::class,
    ],
];

// As easy as this to get instances of all classes provided as keys
$elementInstances = collect($exampleComplexInput['elements'])->keys()->mapInstance(/* $parameters */);

$elementInstances->first(); // Instance of `Elements\User::class`
```