### PR TITLE
[10.x] Skip isParameterBackedEnumWithStringBackingType for non ReflectionNamedType

### DIFF
--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -148,7 +148,7 @@ class Reflector
      */
     public static function isParameterBackedEnumWithStringBackingType($parameter)
     {
-        if(! $parameter->getType() instanceof ReflectionNamedType) {
+        if (! $parameter->getType() instanceof ReflectionNamedType) {
             return false;
         }
 

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -148,6 +148,10 @@ class Reflector
      */
     public static function isParameterBackedEnumWithStringBackingType($parameter)
     {
+        if(! $parameter->getType() instanceof ReflectionNamedType) {
+            return false;
+        }
+
         $backedEnumClass = $parameter->getType()?->getName();
 
         if (is_null($backedEnumClass)) {


### PR DESCRIPTION
#46483 May cause error `Call to undefined method ReflectionUnionType::getName()` at https://github.com/laravel/framework/blob/10.x/src/Illuminate/Support/Reflector.php#L151 if route action and parameter are defined as a union like this
```
public function edit(TwillModelContract|int $id): mixed {...}
```
(actual code from Twill CMS https://github.com/area17/twill/blob/3.x/src/Http/Controllers/Admin/ModuleController.php#L1131 )

This is because `ReflectionUnionType` and `ReflectionIntersectionType` don't have a `getName()` method, unlike `ReflectionNamedType`. So we need to skip checking if *$parameter* is not an instance of `ReflectionNamedType`.

