### PR TITLE
[10.x] Support check constraints

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -454,7 +454,7 @@ class Blueprint
      */
     public function dropConstraint($name)
     {
-        return $this->addCommand('dropConstraint', ['symbol' => $name]);
+        return $this->addCommand('dropConstraint', ['constraint' => $name]);
     }
 
     /**
@@ -660,7 +660,7 @@ class Blueprint
      */
     public function check($expression, $name = null)
     {
-        return $this->addCommand('check', ['expression' => $expression, 'symbol' => $name]);
+        return $this->addCommand('check', ['expression' => $expression, 'constraint' => $name]);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -158,12 +158,6 @@ class Blueprint
                     "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification."
                 );
             }
-
-            if ($this->commandsNamed(['dropForeign'])->count() > 0) {
-                throw new BadMethodCallException(
-                    "SQLite doesn't support dropping foreign keys (you would need to re-create the table)."
-                );
-            }
         }
     }
 
@@ -453,6 +447,28 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given constraint should be dropped.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropConstraint($name)
+    {
+        return $this->addCommand('dropConstraint', ['symbol' => $name]);
+    }
+
+    /**
+     * Indicate that the given check constraint should be dropped.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropCheck($name)
+    {
+        return $this->dropConstraint($name);
+    }
+
+    /**
      * Indicate that the given indexes should be renamed.
      *
      * @param  string  $from
@@ -633,6 +649,18 @@ class Blueprint
         $this->commands[count($this->commands) - 1] = $command;
 
         return $command;
+    }
+
+    /**
+     * Specify a check constraint for the table.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $expression
+     * @param  string|null  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function check($expression, $name = null)
+    {
+        return $this->addCommand('check', ['expression' => $expression, 'symbol' => $name]);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -10,12 +10,13 @@ use Illuminate\Support\Fluent;
  * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
+ * @method $this check(\Illuminate\Contracts\Database\Query\Expression|string $expression) Specify a check constraint for the column
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
  * @method $this comment(string $comment) Add a comment to the column (MySQL/PostgreSQL)
  * @method $this default(mixed $value) Specify a "default" value for the column
  * @method $this first() Place the column "first" in the table (MySQL)
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
- * @method $this generatedAs(string|Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
+ * @method $this generatedAs(\Illuminate\Contracts\Database\Query\Expression|string $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(string $indexName = null) Add an index
  * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -172,7 +172,7 @@ abstract class Grammar extends BaseGrammar
     {
         return sprintf('alter table %s add%s check (%s)',
             $this->wrapTable($blueprint),
-            $command->symbol ? ' constraint '.$this->wrap($command->symbol) : '',
+            $command->constraint ? ' constraint '.$this->wrap($command->constraint) : '',
             $this->getValue($command->expression)
         );
     }
@@ -188,7 +188,7 @@ abstract class Grammar extends BaseGrammar
     {
         return sprintf('alter table %s drop constraint %s',
             $this->wrapTable($blueprint),
-            $this->wrap($command->symbol)
+            $this->wrap($command->constraint)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -162,6 +162,37 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a check constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCheck(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s add%s check (%s)',
+            $this->wrapTable($blueprint),
+            $command->symbol ? ' constraint '.$this->wrap($command->symbol) : '',
+            $this->getValue($command->expression)
+        );
+    }
+
+    /**
+     * Compile a drop constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropConstraint(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s drop constraint %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->symbol)
+        );
+    }
+
+    /**
      * Compile the blueprint's added column definitions.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -17,7 +17,7 @@ class MySqlGrammar extends Grammar
      */
     protected $modifiers = [
         'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
-        'Srid', 'Default', 'OnUpdate', 'Invisible', 'Increment', 'Comment', 'After', 'First',
+        'Srid', 'Default', 'OnUpdate', 'Invisible', 'Increment', 'Comment', 'Check', 'After', 'First',
     ];
 
     /**
@@ -1245,6 +1245,20 @@ class MySqlGrammar extends Grammar
     {
         if (is_int($column->srid) && $column->srid > 0) {
             return ' srid '.$column->srid;
+        }
+    }
+
+    /**
+     * Get the SQL for a check constraint column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCheck(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->check)) {
+            return ' check ('.$this->getValue($column->check).')';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -401,9 +401,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
-
-        return "alter table {$this->wrapTable($blueprint)} drop index {$index}";
+        return $this->compileDropIndex($blueprint, $command);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -22,7 +22,7 @@ class PostgresGrammar extends Grammar
      *
      * @var string[]
      */
-    protected $modifiers = ['Collate', 'Nullable', 'Default', 'VirtualAs', 'StoredAs', 'GeneratedAs', 'Increment'];
+    protected $modifiers = ['Collate', 'Nullable', 'Check', 'Default', 'VirtualAs', 'StoredAs', 'GeneratedAs', 'Increment'];
 
     /**
      * The columns available as serials.
@@ -789,11 +789,12 @@ class PostgresGrammar extends Grammar
      */
     protected function typeEnum(Fluent $column)
     {
-        return sprintf(
-            'varchar(255) check ("%s" in (%s))',
-            $column->name,
+        $column->check(sprintf('%s in (%s)',
+            $this->wrap($column),
             $this->quoteString($column->allowed)
-        );
+        ));
+
+        return 'varchar(255)';
     }
 
     /**
@@ -1219,5 +1220,19 @@ class PostgresGrammar extends Grammar
         }
 
         return $sql;
+    }
+
+    /**
+     * Get the SQL for a check constraint column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCheck(Blueprint $blueprint, Fluent $column)
+    {
+        if (! $column->change && ! is_null($column->check)) {
+            return ' check ('.$this->getValue($column->check).')';
+        }
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -427,9 +427,9 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap("{$blueprint->getTable()}_pkey");
+        $command->constraint = $this->wrap("{$blueprint->getTable()}_pkey");
 
-        return 'alter table '.$this->wrapTable($blueprint)." drop constraint {$index}";
+        return $this->compileDropConstraint($blueprint, $command);
     }
 
     /**
@@ -441,9 +441,11 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
+        $command->constraint = $command->index;
 
-        return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
+        $command->index = null;
+
+        return $this->compileDropConstraint($blueprint, $command);
     }
 
     /**
@@ -491,9 +493,11 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
+        $command->constraint = $command->index;
 
-        return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
+        $command->index = null;
+
+        return $this->compileDropConstraint($blueprint, $command);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -427,7 +427,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
-        $command->constraint = $this->wrap("{$blueprint->getTable()}_pkey");
+        $command->constraint = "{$blueprint->getTable()}_pkey";
 
         return $this->compileDropConstraint($blueprint, $command);
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -141,7 +141,7 @@ class SQLiteGrammar extends Grammar
 
         return collect($constraints)->reduce(function ($sql, $constraint) {
             return $sql.sprintf(',%s check (%s)',
-                $constraint->symbol ? ' constraint '.$this->wrap($constraint->symbol) : '',
+                $constraint->constraint ? ' constraint '.$this->wrap($constraint->constraint) : '',
                 $this->getValue($constraint->expression)
             );
         }, '');
@@ -369,9 +369,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
-
-        return "drop index {$index}";
+        return $this->compileDropIndex($blueprint, $command);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -18,7 +18,7 @@ class SQLiteGrammar extends Grammar
      *
      * @var string[]
      */
-    protected $modifiers = ['Increment', 'Nullable', 'Default', 'VirtualAs', 'StoredAs'];
+    protected $modifiers = ['Increment', 'Nullable', 'Check', 'Default', 'VirtualAs', 'StoredAs'];
 
     /**
      * The columns available as serials.
@@ -688,11 +688,12 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeEnum(Fluent $column)
     {
-        return sprintf(
-            'varchar check ("%s" in (%s))',
-            $column->name,
+        $column->check(sprintf('%s in (%s)',
+            $this->wrap($column),
             $this->quoteString($column->allowed)
-        );
+        ));
+
+        return 'varchar';
     }
 
     /**
@@ -1048,6 +1049,20 @@ class SQLiteGrammar extends Grammar
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' primary key autoincrement';
+        }
+    }
+
+    /**
+     * Get the SQL for a check constraint column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCheck(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->check)) {
+            return ' check ('.$this->getValue($column->check).')';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -339,9 +339,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
+        $command->constraint = $command->index;
 
-        return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
+        $command->index = null;
+
+        return $this->compileDropConstraint($blueprint, $command);
     }
 
     /**
@@ -353,9 +355,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
-
-        return "drop index {$index} on {$this->wrapTable($blueprint)}";
+        return $this->compileDropIndex($blueprint, $command);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -21,7 +21,7 @@ class SqlServerGrammar extends Grammar
      *
      * @var string[]
      */
-    protected $modifiers = ['Collate', 'Nullable', 'Default', 'Persisted', 'Increment'];
+    protected $modifiers = ['Collate', 'Nullable', 'Default', 'Persisted', 'Increment', 'Check'];
 
     /**
      * The columns available as serials.
@@ -670,11 +670,12 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeEnum(Fluent $column)
     {
-        return sprintf(
-            'nvarchar(255) check ("%s" in (%s))',
-            $column->name,
+        $column->check(sprintf('%s in (%s)',
+            $this->wrap($column),
             $this->quoteString($column->allowed)
-        );
+        ));
+
+        return 'nvarchar(255)';
     }
 
     /**
@@ -1015,6 +1016,20 @@ class SqlServerGrammar extends Grammar
 
         if ($column->persisted) {
             return ' persisted';
+        }
+    }
+
+    /**
+     * Get the SQL for a check constraint column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCheck(Blueprint $blueprint, Fluent $column)
+    {
+        if (! $column->change && ! is_null($column->check)) {
+            return ' check ('.$this->getValue($column->check).')';
         }
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -638,7 +638,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "role" varchar(255) not null check ("role" in (\'member\', \'admin\'))', $statements[0]);
     }
 
     public function testAddingDate()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -497,7 +497,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "role" varchar not null check ("role" in (\'member\', \'admin\'))', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -686,13 +686,13 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->assertEquals([
             'alter table "users" '.
             'add column "c1" integer not null check (c1 > 10), '.
-            'add column "c2" integer not null check (c2 > 10)'
+            'add column "c2" integer not null check (c2 > 10)',
         ], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "users" add column "c1" integer not null check (c1 > 10)',
-            'alter table "users" add column "c2" integer not null check (c2 > 10)'
+            'alter table "users" add column "c2" integer not null check (c2 > 10)',
         ], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -656,14 +656,14 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $blueprint->toSql($connection, new PostgresGrammar)
         );
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('This database driver does not support dropping constraints.');
-        $blueprint->toSql($connection, new SQLiteGrammar);
-
         $this->assertEquals(
             ['alter table "users" drop constraint "foo"'],
             $blueprint->toSql($connection, new SqlServerGrammar)
         );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('This database driver does not support dropping constraints.');
+        $blueprint->toSql($connection, new SQLiteGrammar);
     }
 
     public function testItEnsuresDroppingMultipleColumnsIsAvailable()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -542,7 +542,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "role" nvarchar(255) not null check ("role" in (N\'member\', N\'admin\'))', $statements[0]);
     }
 
     public function testAddingJson()


### PR DESCRIPTION
Laravel DB migrations supports almost all column types, indexes and constraints, except `CHECK` constraint. This PR adds support for check constraint on tables and columns without a breaking change.

| Database | Supported version on Laravel | Check constraint support | Drop constraint support |
| --- | --- | --- | --- |
| MariaDB | 10.3+ | ✓ ([Docs](https://mariadb.com/kb/en/alter-table/#add-constraint)) |  ✓ ([Docs](https://mariadb.com/kb/en/alter-table/#drop-constraint)) |
| MySQL | 5.7+ | 8.0.16+ ([Docs](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html#alter-table-foreign-key)) |  8.0.19+ ([Docs](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html#alter-table-foreign-key)) |
| PostgreSQL | 10.0+ | ✓ ([Docs](https://www.postgresql.org/docs/10/sql-altertable.html)) |  ✓ ([Docs](https://www.postgresql.org/docs/10/sql-altertable.html)) |
| SQLite | 3.8.8+ | ✓ ([Docs](https://www.sqlite.org/lang_createtable.html#ckconst)) | ✗ ([Docs](https://www.sqlite.org/omitted.html)) |
SQL Server | 2017+ | ✓ ([Docs](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-2017#c-adding-an-unverified-check-constraint-to-an-existing-column)) |  ✓ ([Docs](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-2017#b-dropping-constraints-and-columns)) |

Note: MySQL 5.7 premier support has ended on Oct 2020 and its extended supports ends on Oct 2023.

#### Examples:

- Add check constraints when creating table:
   ```php
   Schema::create('users', function (Blueprint $table) {
       $table->integer('c1')->check('c1 > 10'); // `c1` int not null check (c1 > 10)
       $table->integer('c2');                   // `c2` int not null
       $table->check('c1 + c2 < 100');          // check (c1 + c2 < 100)
       $table->check('c2 <> 0', 'c2_nonzero');  // constraint `c2_nonzero` check (c2 <> 0)
   });
   ```

- Add check constraints when updating table (SQLite doesn't support this):
   ```php
   Schema::table('users', function (Blueprint $table) {
       $table->check('c1 + c2 < 100');         // add check (c1 + c2 < 100)
       $table->check('c2 <> 0', 'c2_nonzero'); // add constraint `c2_nonzero` check (c2 <> 0)
   });
   ```

- Add a column with check constraint:
   ```php
   Schema::table('users', function (Blueprint $table) {
       $table->integer('c2')->check('c2 <> 0'); // add `c2` int not null check (c2 <> 0)
   });
   ```

- Modify a column with check constraint (MySQL Only):
   ```php
   Schema::table('users', function (Blueprint $table) {
       $table->integer('c2')->check('c2 <> 0')->change(); // modify `c2` int not null check (c2 <> 0)
   });
   ```

- Drop a constraint (SQLite doesn't support this):
   ```php
   Schema::table('users', function (Blueprint $table) {
       $table->dropCheck('c2_nonzero')      // drop constraint `c2_nonzero`
       // Or alternatively:
       $table->dropConstraint('c2_nonzero') // drop constraint `c2_nonzero`
   });
   ```