### PR TITLE
Add missing DocBlock param \Illuminate\Mail\Mailables\Content::with

### DIFF
--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -140,7 +140,7 @@ class Content
     /**
      * Add a piece of view data to the message.
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed|null  $value
      * @return $this
      */


### PR DESCRIPTION
Provides a missing DocBlock param within `\Illuminate\Mail\Mailables\Content::with` that fixes an error when running Larastan.

<img width="848" alt="Larastan-error" src="https://user-images.githubusercontent.com/33870545/226142834-2a35c6e7-c975-4fb5-b455-ae245c297e57.png">
