### PR TITLE
Accept json encoding flag as an argument for casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -15,8 +15,15 @@ class AsArrayObject implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
@@ -30,7 +37,9 @@ class AsArrayObject implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => json_encode($value)];
+                $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+                
+                return [$key => json_encode($value, $encodingFlag)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -17,11 +17,8 @@ class AsArrayObject implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -37,9 +34,9 @@ class AsArrayObject implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+                $flags = isset($this->arguments[0]) ? $this->arguments[0] : 0;
 
-                return [$key => json_encode($value, $encodingFlag)];
+                return [$key => json_encode($value, $flags)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -38,7 +38,7 @@ class AsArrayObject implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
-                
+
                 return [$key => json_encode($value, $encodingFlag)];
             }
 

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -18,11 +18,8 @@ class AsCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -38,9 +35,9 @@ class AsCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+                $flags = isset($this->arguments[0]) ? $this->arguments[0] : 0;
 
-                return [$key => json_encode($value, $encodingFlag)];
+                return [$key => json_encode($value, $flags)];
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -16,8 +16,15 @@ class AsCollection implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
@@ -31,7 +38,9 @@ class AsCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => json_encode($value)];
+                $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+
+                return [$key => json_encode($value, $encodingFlag)];
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -16,8 +16,15 @@ class AsEncryptedArrayObject implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (isset($attributes[$key])) {
@@ -30,7 +37,9 @@ class AsEncryptedArrayObject implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    return [$key => Crypt::encryptString(json_encode($value))];
+                    $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+
+                    return [$key => Crypt::encryptString(json_encode($value, $encodingFlag))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -18,11 +18,8 @@ class AsEncryptedArrayObject implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -37,9 +34,9 @@ class AsEncryptedArrayObject implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+                    $flags = isset($this->arguments[0]) ? $this->arguments[0] : 0;
 
-                    return [$key => Crypt::encryptString(json_encode($value, $encodingFlag))];
+                    return [$key => Crypt::encryptString(json_encode($value, $flags))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -17,8 +17,15 @@ class AsEncryptedCollection implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
             public function get($model, $key, $value, $attributes)
             {
                 if (isset($attributes[$key])) {
@@ -31,7 +38,9 @@ class AsEncryptedCollection implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    return [$key => Crypt::encryptString(json_encode($value))];
+                    $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+                    
+                    return [$key => Crypt::encryptString(json_encode($value, $encodingFlag))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -19,11 +19,8 @@ class AsEncryptedCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -38,9 +35,9 @@ class AsEncryptedCollection implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
+                    $flags = isset($this->arguments[0]) ? $this->arguments[0] : 0;
 
-                    return [$key => Crypt::encryptString(json_encode($value, $encodingFlag))];
+                    return [$key => Crypt::encryptString(json_encode($value, $flags))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -39,7 +39,7 @@ class AsEncryptedCollection implements Castable
             {
                 if (! is_null($value)) {
                     $encodingFlag = isset($this->arguments[0]) ? $this->arguments[0] : 0;
-                    
+
                     return [$key => Crypt::encryptString(json_encode($value, $encodingFlag))];
                 }
 

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -21,11 +21,8 @@ class AsEnumArrayObject implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -61,9 +58,9 @@ class AsEnumArrayObject implements Castable
                     $storable[] = $this->getStorableEnumValue($enum);
                 }
 
-                $encodingFlag = isset($this->arguments[1]) ? $this->arguments[1] : 0;
+                $flags = isset($this->arguments[1]) ? $this->arguments[1] : 0;
 
-                return [$key => json_encode($storable, $encodingFlag)];
+                return [$key => json_encode($storable, $flags)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -61,7 +61,9 @@ class AsEnumArrayObject implements Castable
                     $storable[] = $this->getStorableEnumValue($enum);
                 }
 
-                return [$key => json_encode($storable)];
+                $encodingFlag = isset($this->arguments[1]) ? $this->arguments[1] : 0;
+
+                return [$key => json_encode($storable, $encodingFlag)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -51,10 +51,12 @@ class AsEnumCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
+                $encodingFlag = isset($this->arguments[1]) ? $this->arguments[1] : 0;
+
                 $value = $value !== null
                     ? (new Collection($value))->map(function ($enum) {
                         return $this->getStorableEnumValue($enum);
-                    })->toJson()
+                    })->toJson($encodingFlag)
                     : null;
 
                 return [$key => $value];
@@ -62,9 +64,11 @@ class AsEnumCollection implements Castable
 
             public function serialize($model, string $key, $value, array $attributes)
             {
+                $encodingFlag = isset($this->arguments[1]) ? $this->arguments[1] : 0;
+
                 return (new Collection($value))->map(function ($enum) {
                     return $this->getStorableEnumValue($enum);
-                })->toArray();
+                })->toArray($encodingFlag);
             }
 
             protected function getStorableEnumValue($enum)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -21,11 +21,8 @@ class AsEnumCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -51,12 +48,12 @@ class AsEnumCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                $encodingFlag = isset($this->arguments[1]) ? $this->arguments[1] : 0;
+                $flags = isset($this->arguments[1]) ? $this->arguments[1] : 0;
 
                 $value = $value !== null
                     ? (new Collection($value))->map(function ($enum) {
                         return $this->getStorableEnumValue($enum);
-                    })->toJson($encodingFlag)
+                    })->toJson($flags)
                     : null;
 
                 return [$key => $value];
@@ -64,11 +61,11 @@ class AsEnumCollection implements Castable
 
             public function serialize($model, string $key, $value, array $attributes)
             {
-                $encodingFlag = isset($this->arguments[1]) ? $this->arguments[1] : 0;
+                $flags = isset($this->arguments[1]) ? $this->arguments[1] : 0;
 
                 return (new Collection($value))->map(function ($enum) {
                     return $this->getStorableEnumValue($enum);
-                })->toArray($encodingFlag);
+                })->toArray($flags);
             }
 
             protected function getStorableEnumValue($enum)


### PR DESCRIPTION
This PR adds support to pass [json encoding flags](https://www.php.net/manual/en/function.json-encode.php#:~:text=original%0A%20%20%20%C2%BB%C2%A0RFC%207159.-,[flags](https://www.php.net/manual/en/function.json-encode.php#:~:text=original%0A%20%20%20%C2%BB%C2%A0RFC%207159.-,flags,-Bitmask%20consisting%20of),-Bitmask%20consisting%20of) to casts performing json encoding.

It's not a breaking change. If no flag provided then it behaves the same as before this PR.

### Why is this needed? (Usecases)

Because by default native php `json_encode` function escapes multibyte Unicode characters. 
Some languages uses multibyte characters and current casts implementation escapes them before they're stored to database. This made them hard to query later on.

For example let's assume we have an options property on Delivery model and cast it like this:
```php
// Models/Delivery.php
protected $casts = [
    'options' => AsCollection::class,
];

...

$delivery->options = [
    'deliveryAddress' => 'Čerešňová 32, Banská Štiavnica'
];

$delivery->save();
```
when I check the database it is stored like this
```
{"deliveryAddress":"\u010cere\u0161\u0148ov\u00e1 32, Bansk\u00e1 \u0160tiavnica"}
```
when I try to query the database I can't find my record
```sql
select * from deliveries where options like '%Čerešňová%';
>>> 0 results
```

After this PR we can supply 2nd argument to `json_encode` function and we can do following:
```php
// Models/Delivery.php
protected $casts = [
    'options' => AsCollection::class . ":" .  JSON_UNESCAPED_UNICODE, // <--- utilizing arguments passing as documented here: https://laravel.com/docs/10.x/eloquent-mutators#cast-parameters
];

// NOTE: JSON_UNESCAPED_UNICODE is native predefined PHP constant and can be found here: https://www.php.net/manual/en/json.constants.php

...

$delivery->options = [
    'deliveryAddress' => 'Čerešňová 32, Banská Štiavnica'
];

$delivery->save();
```
when I check the database it is stored like this
```
{"deliveryAddress":"Čerešňová 32, Banská Štiavnica"}
```
when I try to query the database I can find my record
```sql
select * from deliveries where options like '%Čerešňová%';
>>> 1 result
```

Of course there is more usecases.
Main point is to be able to pass 2nd argument to `json_encode` function to customize how we want to encode it.

Other people with same problem:
https://laracasts.com/discuss/channels/laravel/model-cats-to-array-utf-8-json-unescaped-unicode