### PR TITLE
[10.x] Replace Deprecated DBAL Comparator creation with schema aware Comparator

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -60,7 +60,7 @@ class ChangeColumn
     {
         $current = $schema->introspectTable($grammar->getTablePrefix().$blueprint->getTable());
 
-        return (new Comparator)->compareTables(
+        return $schema->createComparator()->compareTables(
             $current, static::getTableWithColumnChanges($blueprint, $current)
         );
     }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
-use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connection;

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -323,11 +323,10 @@ abstract class Grammar extends BaseGrammar
      */
     public function getDoctrineTableDiff(Blueprint $blueprint, SchemaManager $schema)
     {
-        $table = $this->getTablePrefix().$blueprint->getTable();
+        $tableName = $this->getTablePrefix().$blueprint->getTable();
+        $table = $schema->introspectTable($tableName);
 
-        return tap(new TableDiff($table), function ($tableDiff) use ($schema, $table) {
-            $tableDiff->fromTable = $schema->introspectTable($table);
-        });
+        return new TableDiff(tableName: $tableName, fromTable: $table);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -324,6 +324,7 @@ abstract class Grammar extends BaseGrammar
     public function getDoctrineTableDiff(Blueprint $blueprint, SchemaManager $schema)
     {
         $tableName = $this->getTablePrefix().$blueprint->getTable();
+
         $table = $schema->introspectTable($tableName);
 
         return new TableDiff(tableName: $tableName, fromTable: $table);

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -64,7 +64,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE "BINARY", age INTEGER NOT NULL)',
+                'CREATE TABLE users (name VARCHAR(255) NOT NULL, age INTEGER NOT NULL)',
                 'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
                 'DROP TABLE __temp__users',
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
@@ -330,7 +330,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (name CHAR(50) NOT NULL COLLATE "BINARY")',
+                'CREATE TABLE users (name CHAR(50) NOT NULL)',
                 'INSERT INTO users (name) SELECT name FROM __temp__users',
                 'DROP TABLE __temp__users',
             ],

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -352,7 +352,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
                 'CREATE TABLE users (name CHAR(50) NOT NULL COLLATE "BINARY")',
                 'INSERT INTO users (name) SELECT name FROM __temp__users',
                 'DROP TABLE __temp__users',
-            ]
+            ],
         ];
 
         $this->assertContains($queries, $expected);

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -73,6 +73,18 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
                 'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
                 'DROP TABLE __temp__users',
             ],
+            [
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE "BINARY", age INTEGER NOT NULL)',
+                'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
+                'DROP TABLE __temp__users',
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (first_name VARCHAR(255) NOT NULL, age VARCHAR(255) NOT NULL)',
+                'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
+                'DROP TABLE __temp__users',
+            ],
         ];
 
         $this->assertContains($queries, $expected);
@@ -334,6 +346,13 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
                 'INSERT INTO users (name) SELECT name FROM __temp__users',
                 'DROP TABLE __temp__users',
             ],
+            [
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (name CHAR(50) NOT NULL COLLATE "BINARY")',
+                'INSERT INTO users (name) SELECT name FROM __temp__users',
+                'DROP TABLE __temp__users',
+            ]
         ];
 
         $this->assertContains($queries, $expected);

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -81,7 +81,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
                 'DROP TABLE __temp__users',
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (first_name VARCHAR(255) NOT NULL, age VARCHAR(255) NOT NULL)',
+                'CREATE TABLE users (first_name VARCHAR(255) NOT NULL, age VARCHAR(255) NOT NULL COLLATE "BINARY")',
                 'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
                 'DROP TABLE __temp__users',
             ],

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -95,10 +95,35 @@ class SchemaBuilderTest extends DatabaseTestCase
         }
 
         Schema::create('test', function (Blueprint $table) {
-            $table->integer('test_column');
+            $table->text('test_column');
         });
 
         foreach (['tinyText', 'text', 'mediumText', 'longText'] as $type) {
+            $blueprint = new Blueprint('test', function ($table) use ($type) {
+                $table->$type('test_column')->change();
+            });
+
+            $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
+
+            $uppercase = strtoupper($type);
+
+            $expected = ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL"];
+
+            $this->assertEquals($expected, $queries);
+        }
+    }
+
+    public function testChangeTextColumnToTextColumn()
+    {
+        if ($this->driver !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+
+        Schema::create('test', static function (Blueprint $table) {
+            $table->text('test_column');
+        });
+
+        foreach (['tinyText', 'mediumText', 'longText'] as $type) {
             $blueprint = new Blueprint('test', function ($table) use ($type) {
                 $table->$type('test_column')->change();
             });

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -95,7 +95,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         }
 
         Schema::create('test', function (Blueprint $table) {
-            $table->text('test_column');
+            $table->integer('test_column');
         });
 
         foreach (['tinyText', 'text', 'mediumText', 'longText'] as $type) {


### PR DESCRIPTION
Reference to change in DBAL and why this needs to be done: https://github.com/doctrine/dbal/pull/4746

This is currently causing this bug in Laravel where certain migration changes are ignored: https://github.com/laravel/framework/issues/46492

Not sure if this is affecting other database types.

An example project of the existing bug can be found here: https://github.com/liamh101/laravel-column-bug