### PR TITLE
[10.x] Add `assertSeeInJson` and `assertDontSeeInJson`

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -299,6 +299,38 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
+     * Assert that the expected value is contained within the given path of the JSON.
+     *
+     * @param  string|null  $path
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertSee($path, string $value)
+    {
+        $json = json_encode($this->json($path), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        PHPUnit::assertStringContainsString($value, $json);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the expected value is not contained within the given path of the JSON.
+     *
+     * @param  string|null  $path
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertDontSee($path, string $value)
+    {
+        $json = json_encode($this->json($path), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        PHPUnit::assertStringNotContainsString($value, $json);
+
+        return $this;
+    }
+
+    /**
      * Reorder associative array keys to make it easy to compare arrays.
      *
      * @param  array  $data

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -746,6 +746,34 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the expected value is contained within the given path in the response.
+     *
+     * @param  string|null  $path
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertSeeInJson($path, string $value)
+    {
+        $this->decodeResponseJson()->assertSee($path, $value);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the expected value is not contained within the given path in the response.
+     *
+     * @param  string|null  $path
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertDontSeeInJson($path, string $value)
+    {
+        $this->decodeResponseJson()->assertDontSee($path, $value);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a given JSON structure.
      *
      * @param  array|null  $structure

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1249,6 +1249,10 @@ class TestResponseTest extends TestCase
             ],
         ]);
 
+        $response->assertSeeInJson(null, '你好');
+        $response->assertSeeInJson(null, 'Hallo');
+        $response->assertSeeInJson('greetings.nl.text', 'Hallo');
+
         $response->assertSeeInJson('greetings', '你好');
         $response->assertSeeInJson('greetings.cn', '你好');
         $response->assertDontSeeInJson('greetings.nl', '你好');

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2217,7 +2217,8 @@ class TestResponseTest extends TestCase
 
     private function makeMockJsonResponse(array $data): TestResponse
     {
-        return TestResponse::fromBaseResponse(new Response(new class ($data) implements JsonSerializable {
+        return TestResponse::fromBaseResponse(new Response(new class($data) implements JsonSerializable
+        {
             public function __construct(public array $data)
             {
                 //


### PR DESCRIPTION
This PR adds two assertions to the TestResponse: `assertSeeInJson` and `assertDontSeeInJson`. These assertions are similar to `assertSee`, but they start looking from a specified path in the json.

Last week I was testing an api endpoint that returned data similar to this:

```json
{
    "members": [
        {
            "name": "Alice",
        },
        {
            "name": "Jimmy",
        }
    ],
    "invites": [
        {
            "name": "Paul"
        }
    ]
}
```

In many cases I don't really care exactly where in the response a value is. It's fine as long as it is or isn't included. So for example, if I wanted to assert that Jimmy is either a member or invited, but Gaby isn't, I'd do this:

```php
$response = $this->getJson('/api/members-and-invites');

$response->assertSee('Jimmy');
$response ->assertDontSee('Gaby');
```

But in this case, I wanted to assert that specific users were either members or invited. For this I currently have two options:
- I could use something like `->assertJsonFragment(['members' => ['name' => 'Jimmy']])`. This isn't convenient, and I'm not even sure if it works.
- Or I could use `->assertJsonPath('members.1.name', 'Jimmy')`. Still not very convenient, but it works. Big downside is that I have to ensure the data is always sorted in the same order, which means I can't use random test data from faker.

With the new `assertSeeInJson` and `assertDontSeeInJson` methods, making the assertions explained above is a lot easier:

```php
$response = $this->getJson('/api/members-and-invites');

$response->assertSeeInJson('members', 'Jimmy');
$response->assertDontSeeInJson('invites', 'Jimmy');

$response ->assertDontSeeInJson('members', 'Paul');
$response ->assertSeeInJson('invites', 'Paul');
```


