### PR TITLE
[10.x] Fix default pivot model values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -510,6 +510,8 @@ trait InteractsWithPivotTable
      */
     public function newPivot(array $attributes = [], $exists = false)
     {
+        $attributes = array_merge(array_column($this->pivotValues, 'value', 'column'), $attributes);
+
         $pivot = $this->related->newPivot(
             $this->parent, $attributes, $this->table, $exists, $this->using
         );


### PR DESCRIPTION
Recently I faced with a situation, when using the `withPivotValue` method on a  `BelongsToMany` relationship definition does not take effect when saving the pivot record.

-----------

I have the following setup:

```php
class User extends Model
{
    public function categories(): BelongsToMany
    {
        return $this->belongsToMany(Category::class, 'subscriptions')
                    ->withPivotValue('type', 'manager')
                    ->using(Subscription::class);
    }

    public function subscriptions(): BelongsToMany
    {
        return $this->belongsToMany(Category::class, 'subscriptions')
                    ->withPivotValue('type', 'player')
                    ->using(Subscription::class);
    }
}
```

```php
class Subscription extends Pivot
{
    public $table = 'subscriptions';

    protected $attributes = [
        'type' => 'player',
    ];
}
```

Before the fix, when attaching a category to a user, the pivot attributes that are defined in the `withPivotValue` method are overridden by the pivot model's `$attributes` property.

```php
$category = Category::first();
$user = User::first();

$user->categories()->attach($category); // try to attach as a category NOT as a subscription

$user->categories->isEmpty() // true

$user->subscriptions->isEmpty() // false

$user->subscriptions->first()->pivot->role // palyer
```

So, when I try to attach a category to a user using the `categories` relation, since it cannot override the default value using the `withPivotValue`, the attached category model takes place in the wrong relationship. Also, I think this is a bug.

--------

The same Pivot Model can be used in different relationships, so overriding its default attributes from a relationship definition would be great.