### PR TITLE
adding not_current_password validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -109,6 +109,7 @@ return [
     'missing_with' => 'The :attribute field must be missing when :values is present.',
     'missing_with_all' => 'The :attribute field must be missing when :values are present.',
     'multiple_of' => 'The :attribute field must be a multiple of :value.',
+    'not_current_password' => 'cannot use the current password.',
     'not_in' => 'The selected :attribute is invalid.',
     'not_regex' => 'The :attribute field format is invalid.',
     'numeric' => 'The :attribute field must be a number.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -508,6 +508,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that the password of the currently authenticated user doesn't matches the given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    protected function validateNotCurrentPassword($attribute, $value, $parameters)
+    {
+        return ! $this->validateCurrentPassword($attribute, $value, $parameters);
+    }
+
+    /**
      * Validate that an attribute is a valid date.
      *
      * @param  string  $attribute


### PR DESCRIPTION
adding not current password will simplify the process of one of the most repeated tasks which is updating password.

for example:
 
    public function store(Request $request): Response
    {
        $validated = $request->validate([
            'old_password' => ['required', 'current_password'],
            'new_password' => ['required', 'not_current_password']
        ]);
 
        // rest of the logic
    }

of course, someone can say we can do the same thing with:

     'old_password' => ['required', 'current_password'],
     'new_password' => ['required', 'different:old_password']

that's true, but some applications demands' that the password should be changed after some period, and does not require the user to enter the current password, just the new password and its confirmation.
    