### PR TITLE
[9.x] Allow WithFaker to be used when app is not bound

### DIFF
--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -43,12 +43,14 @@ trait WithFaker
      */
     protected function makeFaker($locale = null)
     {
-        $locale ??= config('app.faker_locale', Factory::DEFAULT_LOCALE);
+        if (isset($this->app)) {
+            $locale ??= $this->app->make('config')->get('app.faker_locale', Factory::DEFAULT_LOCALE);
 
-        if (isset($this->app) && $this->app->bound(Generator::class)) {
-            return $this->app->make(Generator::class, ['locale' => $locale]);
+            if ($this->app->bound(Generator::class)) {
+                return $this->app->make(Generator::class, ['locale' => $locale]);
+            }
         }
 
-        return Factory::create($locale);
+        return Factory::create($locale ?? Factory::DEFAULT_LOCALE);
     }
 }


### PR DESCRIPTION
## Problem
I wanted to use the WithFaker trait outside of the base TestCase. `makeFaker()` will throw an exception because `config()` is not available until `Illuminate\Foundation\helpers.php` has been required

## Solution
Rely on `\Faker\Factory::DEFAULT_LOCALE` and if the app is bound, then use the app's config.

## Other Thoughts
Unit tests, by nature, shouldn't require setting up the entire application. The Laravel application pushes us towards using PHPUnit's TestCase class, which doesn't set up anything. Makes sense... except... For our application, we are running into the problem where we want a few broader categories for tests.

Ideally, we would like to have Unit tests (for testing that doesn't rely on Laravel at all), Feature tests (which are still testing small pieces of the application, but would require Events, Notifications, database seeding, etc), and then finally Integration tests (which test multiple features spanning many units of work). Trying to make a test case that doesn't extend from the Foundation TestCase is difficult.

It might be nice to move `Illuminate\Foundation\Testing\TestCase@setUpTraits()` to a Trait so that it's easier to compose a base `*TestCase` class. Otherwise, we have to copy-paste code from the Foundation TestCase which is better to avoid.

I think this level of granularity could be helpful. Happy to implement this if it's desirable.