### PR TITLE
[10.x] Set custom message option for ModelNotFoundException, when model has been set.

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -36,7 +36,7 @@ class ModelNotFoundException extends RecordsNotFoundException
         $this->model = $model;
         $this->ids = Arr::wrap($ids);
 
-        $this->message = "No query results for model [{$model}]";
+        $this->message = $this->message ?: "No query results for model [{$model}]";
 
         if (count($this->ids) > 0) {
             $this->message .= ' '.implode(', ', $this->ids);


### PR DESCRIPTION
## Description
- Set custom message option for `ModelNotFoundException`, when model has been set.

### Benefit
- User can now set custom message to the `ModelNotFoundException`.

### Before
- When user uses the `ModelNotFoundException`, with `setModel` method, the custom message gets overwritten in `setModel` method. 
Suppose, for below input, 
``` 
   if ($coupon === null) {
      throw (new ModelNotFoundException('Coupon Expired'))->setModel(Coupon::class);
  }
```
- The output was,
` "message": "No query results for model [App\\Models\\Coupon]." `.

Finally, the custom message did not work.

### After

Suppose, for below input, 
``` 
   if ($coupon === null) {
      throw (new ModelNotFoundException('Coupon Expired'))->setModel(Coupon::class);
  }
```
The output now,
` "message": "Coupon Expired." `.

Setting custom message worked now.
