### PR TITLE
[10.x] routesAreCached performance

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -188,6 +188,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $absoluteCachePathPrefixes = ['/', '\\'];
 
     /**
+     * Indicates if the application cache was resolved.
+     *
+     * @var bool
+     */
+    protected $routesAreCached = false;
+
+    /**
      * Create a new Illuminate application instance.
      *
      * @param  string|null  $basePath
@@ -1120,7 +1127,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        return $this['files']->exists($this->getCachedRoutesPath());
+        if ($this->routesAreCached) {
+            return true;
+        }
+
+        $this->routesAreCached = $this['files']->exists($this->getCachedRoutesPath());
+
+        return $this->routesAreCached;
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -188,7 +188,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $absoluteCachePathPrefixes = ['/', '\\'];
 
     /**
-     * Indicates if the application cache was resolved.
+     * Indicates if the application routes cache was resolved.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -190,9 +190,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Indicates if the application routes cache was resolved.
      *
-     * @var bool
+     * @var bool|null
      */
-    protected $routesAreCached = false;
+    protected $routesAreCached = null;
 
     /**
      * Create a new Illuminate application instance.
@@ -1127,11 +1127,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        if ($this->routesAreCached) {
-            return true;
+        if (is_null($this->routesAreCached)) {
+            $this->routesAreCached = $this['files']->exists($this->getCachedRoutesPath());
         }
-
-        $this->routesAreCached = $this['files']->exists($this->getCachedRoutesPath());
 
         return $this->routesAreCached;
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1127,11 +1127,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        if (is_null($this->routesAreCached)) {
-            $this->routesAreCached = $this['files']->exists($this->getCachedRoutesPath());
-        }
-
-        return $this->routesAreCached;
+        return $this->routesAreCached ??= $this['files']->exists($this->getCachedRoutesPath());
     }
 
     /**


### PR DESCRIPTION
## Intro

I develop a large-scale application designed as a feature-based (modular) application.
To decouple features, I use dedicated ServiceProvider for each feature.

Most of the time a feature `ServiceProvider` contains the following:

```php
namespace App\Features\ExampleFeature;

use Illuminate\Support\ServiceProvider as BaseServiceProvider;

final class ServiceProvider extends BaseServiceProvider
{
    public function boot(): void
    {
        $this->loadRoutesFrom(__DIR__ . '/example-feature-routes.php');
    }
}

```

Before registering routes `loadRoutesFrom` method checks if routes are cached

```php
protected function loadRoutesFrom($path)
{
    if (! ($this->app instanceof CachesRoutes && $this->app->routesAreCached())) {
        require $path;
    }
}
```

The `routesAreCached` method does a filesystem call to check if the`cache/routes-v7.php` file exists.

```php
public function routesAreCached()
{
    return $this['files']->exists($this->getCachedRoutesPath());
}
```

## The Problem

Currently my application contains more than 300 features with corresponding route files to be registered, this means that the framework has to do more than 300 filesystem calls to check if routes are cached, and they are always cached in case of our production. The amount of features constantly grows, which leads to a performance bottleneck.

Simple benchmarking gave me insights that currently it takes about 1.5ms solely for `loadRoutesFrom` calls.

## The Solution

I simply memoized the `routesAreCached` call within the application since if routes are cached once, they will be cached for the entire application lifecycle.

After this fix, it takes about `0.031ms` for `loadRoutesFrom` calls, also fixing bottleneck for case when route files amount grows even more.