### PR TITLE
[9.x] Don't use array_values when returning from hmget

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -114,7 +114,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             $dictionary = $dictionary[0];
         }
 
-        return array_values($this->command('hmget', [$key, $dictionary]));
+        return $this->command('hmget', [$key, $dictionary]);
     }
 
     /**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -443,6 +443,10 @@ class RedisConnectionTest extends TestCase
                 $redis->hmget('hash', 'name', 'hobby')
             );
 
+            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'],
+                $redis->hmget('hash', 'name', 'hobby')
+            );
+
             $redis->flushall();
         }
     }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -439,12 +439,8 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
 
-            $this->assertEquals(['mohamed', 'diving'],
+            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'],
                 $redis->hmget('hash', 'name', 'hobby')
-            );
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', ['name', 'hobby'])
             );
 
             $redis->flushall();

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -444,7 +444,7 @@ class RedisConnectionTest extends TestCase
             );
 
             $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'],
-                $redis->hmget('hash', 'name', 'hobby')
+                $redis->hmget('hash', ['name', 'hobby'])
             );
 
             $redis->flushall();


### PR DESCRIPTION
As describe by issue #46534, there is no benefit of parsing the
returned redis key/values with `array_values`. In fact, we are
loosing an information (the keys) which could be handy to keep when
it is read from another code/service/framework, as well as, to
confirm that the values correspond to the requested keys.
A last point, is that performance wise not using `array_values`
could be beneficial as well.

ref #46534