### PR TITLE
[10.x] Fix infinite loading on batches list on Horizon

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
@@ -338,8 +339,12 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             ! Str::contains($serialized, [':', ';'])) {
             $serialized = base64_decode($serialized);
         }
-
-        return unserialize($serialized);
+        
+        try {
+            return unserialize($serialized);
+        } catch (ModelNotFoundException $e) {
+            return [];
+        }
     }
 
     /**


### PR DESCRIPTION
As described on this issue: https://github.com/laravel/horizon/issues/1259

If a model is deleted while it still exists on the batches list (serialized), it will cause the batches list to be broken.

The reason for this is that when the unserialize function is called, it tries to invoke the __unserialize() or __wakeup() methods automatically, and if the model does not exist, an exception is thrown.