### PR TITLE
[10.x] Fix whereNull queries with raw expressions for the MySql grammar

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -23,8 +23,10 @@ class MySqlGrammar extends Grammar
      */
     protected function whereNull(Builder $query, $where)
     {
-        if ($this->isJsonSelector($where['column'])) {
-            [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
+        $columnValue = (string) $this->getValue($where['column']);
+
+        if ($this->isJsonSelector($columnValue)) {
+            [$field, $path] = $this->wrapJsonFieldAndPath($columnValue);
 
             return '(json_extract('.$field.$path.') is null OR json_type(json_extract('.$field.$path.')) = \'NULL\')';
         }
@@ -41,8 +43,10 @@ class MySqlGrammar extends Grammar
      */
     protected function whereNotNull(Builder $query, $where)
     {
-        if ($this->isJsonSelector($where['column'])) {
-            [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
+        $columnValue = (string) $this->getValue($where['column']);
+
+        if ($this->isJsonSelector($columnValue)) {
+            [$field, $path] = $this->wrapJsonFieldAndPath($columnValue);
 
             return '(json_extract('.$field.$path.') is not null AND json_type(json_extract('.$field.$path.')) != \'NULL\')';
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1411,6 +1411,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testBasicWhereNullExpressionsMysql()
+    {
+        $builder = $this->getMysqlBuilder();
+        $builder->select('*')->from('users')->whereNull(new Raw('id'));
+        $this->assertSame('select * from `users` where id is null', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getMysqlBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull(new Raw('id'));
+        $this->assertSame('select * from `users` where `id` = ? or id is null', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function testJsonWhereNullMysql()
     {
         $builder = $this->getMySqlBuilder();
@@ -1422,6 +1435,20 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereNotNull('items->id');
+        $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is not null AND json_type(json_extract(`items`, \'$."id"\')) != \'NULL\')', $builder->toSql());
+    }
+
+    public function testJsonWhereNullExpressionMysql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNull(new Raw('items->id'));
+        $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is null OR json_type(json_extract(`items`, \'$."id"\')) = \'NULL\')', $builder->toSql());
+    }
+
+    public function testJsonWhereNotNullExpressionMysql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotNull(new Raw('items->id'));
         $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is not null AND json_type(json_extract(`items`, \'$."id"\')) != \'NULL\')', $builder->toSql());
     }
 


### PR DESCRIPTION
Hello team :wave:

I was migrating from Laravel 9 to 10 and got this error on some instances of using DB::raw():
`TypeError: str_contains(): Argument #1 ($haystack) must be of type string, Illuminate\Database\Query\Expression given`.

This error was not present in Laravel 9, and code like this `->select('*')->from('users')->whereNull(new Raw('id'))` worked fine.

The issue was in `whereNull()` and `whereNotNull()` methods for the MySQL grammar. It has a different implementation from the other grammars for these two methods. I think we're only missing a check for raw DB expressions.

I hope these changes are correct or at least in the right direction.