### PR TITLE
[10.x] Update test matrix dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/guzzle:^7.5 guzzlehttp/psr7:^2.4 predis/predis:^2.0.2 --no-interaction --no-update
+          command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
         if: matrix.php >= 8.2
 
       - name: Install dependencies
@@ -133,14 +133,14 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require symfony/css-selector:~6.0 ramsey/collection:^1.2 brick/math:^0.9.3 --no-interaction --no-update
+          command: composer require symfony/css-selector:^6.0 --no-interaction --no-update
 
       - name: Set Minimum PHP 8.2 Versions
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzlehttp/guzzle:~7.5 guzzlehttp/psr7:~2.4 predis/predis:~2.0.2 --no-interaction --no-update
+          command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
         if: matrix.php >= 8.2
 
       - name: Install dependencies


### PR DESCRIPTION

Hey,

I was reviewing the test workflows and stumbled upon some small things which probably can be changed or removed.

Here the outputs of `composer depends <package>` which were run after `composer update`

### composer depends guzzlehttp/guzzle

guzzlehttp/guzzle (^7.5) will already be installed because it is a framework dependency.

```
laravel/framework          10.x-dev requires (for development) guzzlehttp/guzzle (^7.5)             
aws/aws-sdk-php            3.261.16 requires                   guzzlehttp/guzzle (^6.5.8 || ^7.4.5) 
league/flysystem           3.12.3   conflicts                  guzzlehttp/guzzle (<7.0)             
league/flysystem-aws-s3-v3 3.12.2   conflicts                  guzzlehttp/guzzle (<7.0)
```

### composer depends guzzlehttp/psr7

guzzlehttp/psr7 (^2.4) still needs to be installed via the matrix.

```
aws/aws-sdk-php   3.261.16 requires guzzlehttp/psr7 (^1.8.5 || ^2.3) 
guzzlehttp/guzzle 7.5.0    requires guzzlehttp/psr7 (^1.9 || ^2.4)
``` 

### composer depends predis/predis

predis/predis (^2.0.2) will already be installed because it is a framework dependency.

```
laravel/framework 10.x-dev requires (for development) predis/predis (^2.0.2)
```

### Windows Matrix Changes

It seems like the installed dependencies for the workflow were out of sync with the requirements of the Linux Test Matrix.

### symfony/css-selector:^6.0

Maybe this should be added as a require in Laravel 11.x? My reason would be that tests are only run against this css-selector but I dont mind either way.
