### PR TITLE
[9.x] Fix route resource in groups

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -83,6 +83,10 @@ class ResourceRegistrar
         if (isset($options['parameters']) && ! isset($this->parameters)) {
             $this->parameters = $options['parameters'];
         }
+        
+        if ($name === '/') {
+            $name = '';
+        }
 
         // If the resource name contains a slash, we will assume the developer wishes to
         // register these resource routes with a prefix so we will set that up out of
@@ -603,6 +607,12 @@ class ResourceRegistrar
      */
     public function getResourceWildcard($value)
     {
+		// If the name is empty and route in a group stack, then we will take name from the last group
+        if (empty($value) && $this->hasGroupStack()) {
+			$prefix = $this->getLastGroupPrefix();
+			[$value] = $this->getResourcePrefix($prefix);
+		}
+
         if (isset($this->parameters[$value])) {
             $value = $this->parameters[$value];
         } elseif (isset(static::$parameterMap[$value])) {
@@ -678,6 +688,26 @@ class ResourceRegistrar
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');
     }
+	
+	/**
+     * Determine if the router currently has a group stack.
+     *
+     * @return bool
+     */
+	protected function hasGroupStack()
+	{
+		return $this->router->hasGroupStack();
+	}
+	
+	/**
+     * Get the prefix from the last group on the stack of router.
+     *
+     * @return string
+     */
+	protected function getLastGroupPrefix()
+	{
+		return $this->router->getLastGroupPrefix();
+	}
 
     /**
      * Set or unset the unmapped global parameters to singular.


### PR DESCRIPTION
Hi all!

I wanted to use a route resource inside an existing group without an additional name, however this was not possible, so I added the appropriate code.

The reason for this problem was that the ResourceRegistrar relied in creating the route name and the name of the substitution parameters on the received empty name and did not take it from the name of the last group stack, if one exists.

Please, merge it also to [10.x] branch.