### PR TITLE
[10.x] add Storage::json() method to read and decode a json file

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -63,14 +63,15 @@ class Filesystem
      * Get the contents of a file as decoded JSON.
      *
      * @param  string  $path
+     * @param  int  $flags
      * @param  bool  $lock
      * @return array
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function json($path, $lock = false)
+    public function json($path, $flags = 0, $lock = false)
     {
-        return json_decode($this->get($path, $lock), true);
+        return json_decode($this->get($path, $lock), true, 512, $flags);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -266,16 +266,14 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get the contents of a file as decoded JSON.
      *
      * @param  string  $path
+     * @param  int  $flags
      * @return array|null
      */
-    public function json($path)
+    public function json($path, $flags = 0)
     {
         $content = $this->get($path);
-        if ($content === null) {
-            return null;
-        }
 
-        return json_decode($content, true);
+        return is_null($content) ? null : json_decode($content, true, 512, $flags);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -263,6 +263,22 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Get the contents of a file as decoded JSON.
+     *
+     * @param  string  $path
+     * @return array|null
+     */
+    public function json($path)
+    {
+        $content = $this->get($path);
+        if ($content === null) {
+            return null;
+        }
+
+        return json_decode($content, true);
+    }
+
+    /**
      * Create a streamed response for a given file.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -184,6 +184,20 @@ class FilesystemAdapterTest extends TestCase
         $this->assertNull($filesystemAdapter->get('file.txt'));
     }
 
+    public function testJsonReturnsDecodedJsonData()
+    {
+        $this->filesystem->write('file.json', '{"foo": "bar"}');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $this->assertSame(['foo' => 'bar'], $filesystemAdapter->json('file.json'));
+    }
+
+    public function testJsonReturnsNullIfJsonDataIsInvalid()
+    {
+        $this->filesystem->write('file.json', '{"foo":');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $this->assertNull($filesystemAdapter->json('file.json'));
+    }
+
     public function testMimeTypeNotDetected()
     {
         $this->filesystem->write('unknown.mime-type', '');


### PR DESCRIPTION
Laravel v10.4.0 introduced a `File::json()` method to retrieve json encoded data from a file. That's nice, but often files are accessed using `Storage` and not `File`. Here I'm adding a similar `Storage::json()`, i.e.:

```
$data = Storage::json('sample.json');
```

which is equivalent to:

```
$contents = Storage::get('sample.json');
$data = json_decode($contents, true);
```

This is really the same as #46481, but for `Storage` instead of `File`.
