### PR TITLE
[9.x] Fix preg_split error when there is a slash in the attribute

### DIFF
--- a/src/Illuminate/Validation/ValidationData.php
+++ b/src/Illuminate/Validation/ValidationData.php
@@ -54,7 +54,7 @@ class ValidationData
     {
         $keys = [];
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute, '/'));
 
         foreach ($data as $key => $value) {
             if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {


### PR DESCRIPTION
I needed to validate data with a slash, but I got an error, which I investigated and determined that the slash itself was the cause.

The reason is that the current code does not escape the normal slash, but only escapes the backslash, which makes the regular expression invalid and throws an error.

Please, merge it also to [10.x] branch.