### PR TITLE
JSON encoding / decoding customization for JSON based cass

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -23,14 +23,14 @@ class AsArrayObject implements Castable
                     return;
                 }
 
-                $data = json_decode($attributes[$key], true);
+                $data = Json::decode($attributes[$key]);
 
                 return is_array($data) ? new ArrayObject($data) : null;
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => json_encode($value)];
+                return [$key => Json::encode($value)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -24,14 +24,14 @@ class AsCollection implements Castable
                     return;
                 }
 
-                $data = json_decode($attributes[$key], true);
+                $data = Json::decode($attributes[$key]);
 
                 return is_array($data) ? new Collection($data) : null;
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => json_encode($value)];
+                return [$key => Json::encode($value)];
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -21,7 +21,7 @@ class AsEncryptedArrayObject implements Castable
             public function get($model, $key, $value, $attributes)
             {
                 if (isset($attributes[$key])) {
-                    return new ArrayObject(json_decode(Crypt::decryptString($attributes[$key]), true));
+                    return new ArrayObject(Json::decode(Crypt::decryptString($attributes[$key])));
                 }
 
                 return null;
@@ -30,7 +30,7 @@ class AsEncryptedArrayObject implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    return [$key => Crypt::encryptString(json_encode($value))];
+                    return [$key => Crypt::encryptString(Json::encode($value))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -22,7 +22,7 @@ class AsEncryptedCollection implements Castable
             public function get($model, $key, $value, $attributes)
             {
                 if (isset($attributes[$key])) {
-                    return new Collection(json_decode(Crypt::decryptString($attributes[$key]), true));
+                    return new Collection(Json::decode(Crypt::decryptString($attributes[$key])));
                 }
 
                 return null;
@@ -31,7 +31,7 @@ class AsEncryptedCollection implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    return [$key => Crypt::encryptString(json_encode($value))];
+                    return [$key => Crypt::encryptString(Json::encode($value))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -34,7 +34,7 @@ class AsEnumArrayObject implements Castable
                     return;
                 }
 
-                $data = json_decode($attributes[$key], true);
+                $data = Json::decode($attributes[$key]);
 
                 if (! is_array($data)) {
                     return;
@@ -61,7 +61,7 @@ class AsEnumArrayObject implements Castable
                     $storable[] = $this->getStorableEnumValue($enum);
                 }
 
-                return [$key => json_encode($storable)];
+                return [$key => Json::encode($storable)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -34,7 +34,7 @@ class AsEnumCollection implements Castable
                     return;
                 }
 
-                $data = json_decode($attributes[$key], true);
+                $data = Json::decode($attributes[$key]);
 
                 if (! is_array($data)) {
                     return;
@@ -52,9 +52,9 @@ class AsEnumCollection implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 $value = $value !== null
-                    ? (new Collection($value))->map(function ($enum) {
+                    ? Json::encode((new Collection($value))->map(function ($enum) {
                         return $this->getStorableEnumValue($enum);
-                    })->toJson()
+                    })->jsonSerialize())
                     : null;
 
                 return [$key => $value];

--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+class Json
+{
+    /**
+     * The custom JSON encoder.
+     *
+     * @var callable|null
+     */
+    protected $encoder;
+
+    /**
+     * The custom JSON decode.
+     *
+     * @var callable|null
+     */
+    protected $decoder;
+
+    /**
+     * Encode the given value.
+     */
+    public static function encode(mixed $value): mixed
+    {
+        return isset(static::$encoder) ? (static::$encoder)($value) : json_encode($value);
+    }
+
+    /**
+     * Decode the given value.
+     */
+    public static function decode(mixed $value): mixed
+    {
+        return isset(static::$decoder) ? (static::$decoder)($value) : json_decode($value, true);
+    }
+
+    /**
+     * Encode all values using the given callable.
+     */
+    public static function encodeUsing(?callable $encoder): void
+    {
+        static::$encoder = $encoder;
+    }
+
+    /**
+     * Decode all values using the given callable.
+     */
+    public static function decodeUsing(?callable $decoder): void
+    {
+        static::$decoder = $decoder;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -9,14 +9,14 @@ class Json
      *
      * @var callable|null
      */
-    protected $encoder;
+    protected static $encoder;
 
     /**
      * The custom JSON decode.
      *
      * @var callable|null
      */
-    protected $decoder;
+    protected static $decoder;
 
     /**
      * Encode the given value.

--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -29,9 +29,11 @@ class Json
     /**
      * Decode the given value.
      */
-    public static function decode(mixed $value): mixed
+    public static function decode(mixed $value, ?bool $associative = true): mixed
     {
-        return isset(static::$decoder) ? (static::$decoder)($value) : json_decode($value, true);
+        return isset(static::$decoder)
+                ? (static::$decoder)($value, $associative)
+                : json_decode($value, $associative);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MissingAttributeException;
@@ -1241,7 +1242,7 @@ trait HasAttributes
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return Json::encode($value);
     }
 
     /**
@@ -1253,7 +1254,7 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        return json_decode($value ?? '', ! $asObject);
+        return Json::decode($value ?? '', ! $asObject);
     }
 
     /**


### PR DESCRIPTION
This PR allows the customization of `json_encode` and `json_decode` for the `array` and `collection` casts, as well as `AsArrayObject`, `AsCollection`, `AsEnumArrayObject`, etc.

```php
use Illuminate\Database\Eloquent\Casts\Json;

Json::encodeUsing(fn ($value) => json_encode($value));

Json::decodeUsing(fn ($value, $associative) => json_decode($value, $associative));
```

This customization would typically be done in a service provider.