### PR TITLE
Revert "[10.x] add Storage::json() method to read and decode a json file"

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -63,15 +63,14 @@ class Filesystem
      * Get the contents of a file as decoded JSON.
      *
      * @param  string  $path
-     * @param  int  $flags
      * @param  bool  $lock
      * @return array
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function json($path, $flags = 0, $lock = false)
+    public function json($path, $lock = false)
     {
-        return json_decode($this->get($path, $lock), true, 512, $flags);
+        return json_decode($this->get($path, $lock), true);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -263,20 +263,6 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
-     * Get the contents of a file as decoded JSON.
-     *
-     * @param  string  $path
-     * @param  int  $flags
-     * @return array|null
-     */
-    public function json($path, $flags = 0)
-    {
-        $content = $this->get($path);
-
-        return is_null($content) ? null : json_decode($content, true, 512, $flags);
-    }
-
-    /**
      * Create a streamed response for a given file.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -184,20 +184,6 @@ class FilesystemAdapterTest extends TestCase
         $this->assertNull($filesystemAdapter->get('file.txt'));
     }
 
-    public function testJsonReturnsDecodedJsonData()
-    {
-        $this->filesystem->write('file.json', '{"foo": "bar"}');
-        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
-        $this->assertSame(['foo' => 'bar'], $filesystemAdapter->json('file.json'));
-    }
-
-    public function testJsonReturnsNullIfJsonDataIsInvalid()
-    {
-        $this->filesystem->write('file.json', '{"foo":');
-        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
-        $this->assertNull($filesystemAdapter->json('file.json'));
-    }
-
     public function testMimeTypeNotDetected()
     {
         $this->filesystem->write('unknown.mime-type', '');


### PR DESCRIPTION
Reverts laravel/framework#46548

This PR changes the sequence of parameters of the `json` method and thus causing a breaking change for anyone using the `lock` param.