### PR TITLE
[10.x] Add methods to determine if API resource has pivot loaded

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -329,11 +329,34 @@ trait ConditionallyLoadsAttributes
         }
 
         return $this->when(
-            isset($this->resource->$accessor) &&
-            ($this->resource->$accessor instanceof $table ||
-            $this->resource->$accessor->getTable() === $table),
+            $this->hasPivotLoadedAs($accessor, $table),
             ...[$value, $default]
         );
+    }
+
+    /**
+     * Determine if the resource has the specified pivot table loaded.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    protected function hasPivotLoaded($table)
+    {
+        return $this->hasPivotLoadedAs('pivot', $table);
+    }
+
+    /**
+     * Determine if the resource has the specified pivot table loaded with a custom accessor.
+     *
+     * @param  string  $accessor
+     * @param  string  $table
+     * @return bool
+     */
+    protected function hasPivotLoadedAs($accessor, $table)
+    {
+        return isset($this->resource->$accessor) &&
+            ($this->resource->$accessor instanceof $table ||
+            $this->resource->$accessor->getTable() === $table);
     }
 
     /**


### PR DESCRIPTION
I've refactored the trait code that checks if an API resource has a pivot here into a separate method, because it makes it easier to do complex checks in a `Resource`, which is something I've found myself needing to do:

```
$this->mergeWhen(
    $this->resource->field === 'whatever' && ! $this->resource->hasPivotLoaded('pivot_table'),
    ['foo' => 'bar'],
);
```

The changes here are covered by existing tests that use `PostResourceWithOptionalPivotRelationship`.