### PR TITLE
[10.x] Escaping functionality within the Grammar

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1622,4 +1622,77 @@ class Connection implements ConnectionInterface
     {
         return static::$resolvers[$driver] ?? null;
     }
+
+    /**
+     * Escapes a value for safe SQL embedding.
+     *
+     * @param  string|float|int|bool  $value
+     * @param  bool $binary
+     * @return string
+     */
+    public function escape($value, $binary = false)
+    {
+        if ($binary) {
+            return $this->escapeBinary($value);
+        } else if (is_numeric($value)) {
+            return (string) $value;
+        } else if (is_bool($value)) {
+            return $this->escapeBool($value);
+        } else {
+            // As many desktop tools and other programming languages still have problems with null bytes, they are
+            // forbidden for textual strings to align the support of the different databases: MySQL is the only database
+            // supporting null bytes within a SQL string in an escaped human-readable format. While PostgreSQL doesn't
+            // support null bytes, all the other ones use the invisible byte that would be hard to spot when viewing or
+            // copying SQL queries.
+            if (str_contains($value, "\00")) {
+                throw new RuntimeException('Strings with null bytes cannot be escaped. Use the binary escape option.');
+            }
+
+            // The documentation of PDO::quote states that it should be theoretically safe to use a quoted string within
+            // a SQL query. While only being "theoretically" safe this behaviour is used within the PHP MySQL driver all
+            // the time as no real prepared statements are used because it is emulating prepares by default. All
+            // remaining known SQL injections are always some strange charset conversion tricks that start by using
+            // invalid UTF-8 sequences. But those attacks are fixed by setting the proper connection charset which is
+            // done by the standard Laravel configuration. To further secure the implementation we can scrub the value
+            // by checking for invalid UTF-8 sequences.
+            if (false === preg_match('//u', $value)) {
+                throw new RuntimeException('Strings with invalid UTF-8 byte sequences cannot be escaped.');
+            }
+
+            return $this->escapeString($value);
+        }
+    }
+
+    /**
+     * Escapes a string value for safe SQL embedding.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function escapeString($value)
+    {
+        return $this->getPdo()->quote($value);
+    }
+
+    /**
+     * Escapes a bool value for safe SQL embedding.
+     *
+     * @param bool $value
+     * @return string
+     */
+    protected function escapeBool($value)
+    {
+        return $value ? '1' : '0';
+    }
+
+    /**
+     * Escapes a binary value for safe SQL embedding.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        throw new RuntimeException('The database connection has no implementation to escape binary values.');
+    }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -257,7 +257,10 @@ class Connection implements ConnectionInterface
      */
     protected function getDefaultQueryGrammar()
     {
-        return new QueryGrammar;
+        $grammar = new QueryGrammar();
+        $grammar->setConnection($this);
+
+        return $grammar;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1634,7 +1634,7 @@ class Connection implements ConnectionInterface
     {
         if ($binary) {
             return $this->escapeBinary($value);
-        } else if (is_numeric($value)) {
+        } elseif (is_numeric($value)) {
             return (string) $value;
         } elseif (is_bool($value)) {
             return $this->escapeBool($value);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1634,7 +1634,7 @@ class Connection implements ConnectionInterface
     {
         if ($value === null) {
             return 'null';
-        } else if ($binary) {
+        } elseif ($binary) {
             return $this->escapeBinary($value);
         } elseif (is_int($value) || is_float($value)) {
             return (string) $value;

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1627,7 +1627,7 @@ class Connection implements ConnectionInterface
      * Escapes a value for safe SQL embedding.
      *
      * @param  string|float|int|bool  $value
-     * @param  bool $binary
+     * @param  bool  $binary
      * @return string
      */
     public function escape($value, $binary = false)
@@ -1636,7 +1636,7 @@ class Connection implements ConnectionInterface
             return $this->escapeBinary($value);
         } else if (is_numeric($value)) {
             return (string) $value;
-        } else if (is_bool($value)) {
+        } elseif (is_bool($value)) {
             return $this->escapeBool($value);
         } else {
             // As many desktop tools and other programming languages still have problems with null bytes, they are
@@ -1666,7 +1666,7 @@ class Connection implements ConnectionInterface
     /**
      * Escapes a string value for safe SQL embedding.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function escapeString($value)
@@ -1677,7 +1677,7 @@ class Connection implements ConnectionInterface
     /**
      * Escapes a bool value for safe SQL embedding.
      *
-     * @param bool $value
+     * @param  bool  $value
      * @return string
      */
     protected function escapeBool($value)
@@ -1688,7 +1688,7 @@ class Connection implements ConnectionInterface
     /**
      * Escapes a binary value for safe SQL embedding.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function escapeBinary($value)

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -15,7 +15,7 @@ abstract class Grammar
      *
      * @var \Illuminate\Database\Connection
      */
-    protected $connection = null;
+    protected $connection;
 
     /**
      * The grammar table prefix.
@@ -204,6 +204,22 @@ abstract class Grammar
     }
 
     /**
+     * Escapes a value for safe SQL embedding.
+     *
+     * @param  string|float|int|bool|null  $value
+     * @param  bool  $binary
+     * @return string
+     */
+    public function escape($value, $binary = false)
+    {
+        if (is_null($this->connection)) {
+            throw new RuntimeException("The database driver's grammar implementation does not support escaping values.");
+        }
+
+        return $this->connection->escape($value, $binary);
+    }
+
+    /**
      * Determine if the given value is a raw expression.
      *
      * @param  mixed  $value
@@ -273,21 +289,5 @@ abstract class Grammar
         $this->connection = $connection;
 
         return $this;
-    }
-
-    /**
-     * Escapes a value for safe SQL embedding.
-     *
-     * @param  string|float|int|bool|null  $value
-     * @param  bool  $binary
-     * @return string
-     */
-    public function escape($value, $binary = false)
-    {
-        if (null === $this->connection) {
-            throw new RuntimeException("The database driver's grammar implementation does not support escaping values.");
-        }
-
-        return $this->connection->escape($value, $binary);
     }
 }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -204,32 +204,6 @@ abstract class Grammar
     }
 
     /**
-     * Escapes a value to use it for safe SQL embedding.
-     *
-     * @param  string|float|int  $value
-     * @return string
-     */
-    public function escape($value)
-    {
-        if (null === $this->connection) {
-            throw new RuntimeException('The grammar has no connection to escape any value.');
-        }
-
-        // The documentation of PDO::quote states that it should be theoretically safe to use a quoted string within
-        // a SQL query. While only being "theoretically" safe this behaviour is used within the PHP MySQL driver all the
-        // time as no real prepared statements are used because it is emulating prepares by default. All remaining known
-        // SQL injections are always some strange charset conversion tricks that start by using invalid UTF-8 sequences.
-        // But those attacks are fixed by setting the proper connection charset which is done by the standard Laravel
-        // configuration. To further secure the implementation we can scrub the value by checking for invalid UTF-8
-        // sequences.
-        if (false === preg_match('//u', (string) $value)) {
-            throw new RuntimeException('The value contains an invalid UTF-8 byte sequence.');
-        }
-
-        return $this->connection->getReadPdo()->quote($value);
-    }
-
-    /**
      * Determine if the given value is a raw expression.
      *
      * @param  mixed  $value
@@ -299,5 +273,21 @@ abstract class Grammar
         $this->connection = $connection;
 
         return $this;
+    }
+
+    /**
+     * Escapes a value for safe SQL embedding.
+     *
+     * @param  string|float|int|bool  $value
+     * @param  bool $binary
+     * @return string
+     */
+    public function escape($value, $binary = false)
+    {
+        if (null === $this->connection) {
+            throw new RuntimeException('The grammar does not support escaping values.');
+        }
+
+        return $this->connection->escape($value, $binary);
     }
 }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -285,7 +285,7 @@ abstract class Grammar
     public function escape($value, $binary = false)
     {
         if (null === $this->connection) {
-            throw new RuntimeException('The grammar does not support escaping values.');
+            throw new RuntimeException("The database driver's grammar implementation does not support escaping values.");
         }
 
         return $this->connection->escape($value, $binary);

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -11,6 +11,13 @@ abstract class Grammar
     use Macroable;
 
     /**
+     * The connection used for escaping values.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection = null;
+
+    /**
      * The grammar table prefix.
      *
      * @var string
@@ -197,6 +204,32 @@ abstract class Grammar
     }
 
     /**
+     * Escapes a value to use it for safe SQL embedding.
+     *
+     * @param  string|float|int  $value
+     * @return string
+     */
+    public function escape($value)
+    {
+        if (null === $this->connection) {
+            throw new RuntimeException('The grammar has no connection to escape any value.');
+        }
+
+        // The documentation of PDO::quote states that it should be theoretically safe to use a quoted string within
+        // a SQL query. While only being "theoretically" safe this behaviour is used within the PHP MySQL driver all the
+        // time as no real prepared statements are used because it is emulating prepares by default. All remaining known
+        // SQL injections are always some strange charset conversion tricks that start by using invalid UTF-8 sequences.
+        // But those attacks are fixed by setting the proper connection charset which is done by the standard Laravel
+        // configuration. To further secure the implementation we can scrub the value by checking for invalid UTF-8
+        // sequences.
+        if (false === preg_match('//u', (string) $value)) {
+            throw new RuntimeException('The value contains an invalid UTF-8 byte sequence.');
+        }
+
+        return $this->connection->getReadPdo()->quote($value);
+    }
+
+    /**
      * Determine if the given value is a raw expression.
      *
      * @param  mixed  $value
@@ -251,6 +284,19 @@ abstract class Grammar
     public function setTablePrefix($prefix)
     {
         $this->tablePrefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Set the grammar's database connection.
+     *
+     * @param  \Illuminate\Database\Connection  $prefix
+     * @return $this
+     */
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
 
         return $this;
     }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -278,7 +278,7 @@ abstract class Grammar
     /**
      * Escapes a value for safe SQL embedding.
      *
-     * @param  string|float|int|bool  $value
+     * @param  string|float|int|bool|null  $value
      * @param  bool  $binary
      * @return string
      */

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -279,7 +279,7 @@ abstract class Grammar
      * Escapes a value for safe SQL embedding.
      *
      * @param  string|float|int|bool  $value
-     * @param  bool $binary
+     * @param  bool  $binary
      * @return string
      */
     public function escape($value, $binary = false)

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -14,6 +14,19 @@ use PDO;
 class MySqlConnection extends Connection
 {
     /**
+     * Escape a binary value for safe SQL embedding.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "x'{$hex}'";
+    }
+
+    /**
      * Determine if the connected database is a MariaDB database.
      *
      * @return bool
@@ -30,8 +43,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        $grammar = new QueryGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new QueryGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -57,8 +69,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        $grammar = new SchemaGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new SchemaGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -93,18 +104,5 @@ class MySqlConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new MySqlDriver;
-    }
-
-    /**
-     * Escapes a binary value for safe SQL embedding.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function escapeBinary($value)
-    {
-        $hex = bin2hex($value);
-
-        return "x'{$hex}'";
     }
 }

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -30,7 +30,10 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        $grammar = new QueryGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -54,7 +57,10 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        $grammar = new SchemaGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -94,4 +94,16 @@ class MySqlConnection extends Connection
     {
         return new MySqlDriver;
     }
+    /**
+     * Escapes a binary value for safe SQL embedding.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "x'{$hex}'";
+    }
 }

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -94,6 +94,7 @@ class MySqlConnection extends Connection
     {
         return new MySqlDriver;
     }
+
     /**
      * Escapes a binary value for safe SQL embedding.
      *

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -97,7 +97,7 @@ class MySqlConnection extends Connection
     /**
      * Escapes a binary value for safe SQL embedding.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function escapeBinary($value)

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -13,14 +13,37 @@ use Illuminate\Filesystem\Filesystem;
 class PostgresConnection extends Connection
 {
     /**
+     * Escape a binary value for safe SQL embedding.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "'\x{$hex}'::bytea";
+    }
+
+    /**
+     * Escape a bool value for safe SQL embedding.
+     *
+     * @param  bool  $value
+     * @return string
+     */
+    protected function escapeBool($value)
+    {
+        return $value ? 'true' : 'false';
+    }
+
+    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Query\Grammars\PostgresGrammar
      */
     protected function getDefaultQueryGrammar()
     {
-        $grammar = new QueryGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new QueryGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -46,8 +69,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        $grammar = new SchemaGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new SchemaGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -82,29 +104,5 @@ class PostgresConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new PostgresDriver;
-    }
-
-    /**
-     * Escapes a binary value for safe SQL embedding.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function escapeBinary($value)
-    {
-        $hex = bin2hex($value);
-
-        return "'\x{$hex}'::bytea";
-    }
-
-    /**
-     * Escapes a bool value for safe SQL embedding.
-     *
-     * @param  bool  $value
-     * @return string
-     */
-    protected function escapeBool($value)
-    {
-        return $value ? 'true' : 'false';
     }
 }

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -83,4 +83,28 @@ class PostgresConnection extends Connection
     {
         return new PostgresDriver;
     }
+
+    /**
+     * Escapes a binary value for safe SQL embedding.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "'\x{$hex}'::bytea";
+    }
+
+    /**
+     * Escapes a bool value for safe SQL embedding.
+     *
+     * @param bool $value
+     * @return string
+     */
+    protected function escapeBool($value)
+    {
+        return $value ? 'true' : 'false';
+    }
 }

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -19,7 +19,10 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        $grammar = new QueryGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -43,7 +46,10 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        $grammar = new SchemaGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -87,7 +87,7 @@ class PostgresConnection extends Connection
     /**
      * Escapes a binary value for safe SQL embedding.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function escapeBinary($value)
@@ -100,7 +100,7 @@ class PostgresConnection extends Connection
     /**
      * Escapes a bool value for safe SQL embedding.
      *
-     * @param bool $value
+     * @param  bool  $value
      * @return string
      */
     protected function escapeBool($value)

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -37,14 +37,26 @@ class SQLiteConnection extends Connection
     }
 
     /**
+     * Escape a binary value for safe SQL embedding.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "x'{$hex}'";
+    }
+
+    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Query\Grammars\SQLiteGrammar
      */
     protected function getDefaultQueryGrammar()
     {
-        $grammar = new QueryGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new QueryGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -70,8 +82,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        $grammar = new SchemaGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new SchemaGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -117,18 +128,5 @@ class SQLiteConnection extends Connection
     protected function getForeignKeyConstraintsConfigurationValue()
     {
         return $this->getConfig('foreign_key_constraints');
-    }
-
-    /**
-     * Escapes a binary value for safe SQL embedding.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function escapeBinary($value)
-    {
-        $hex = bin2hex($value);
-
-        return "x'{$hex}'";
     }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -118,4 +118,17 @@ class SQLiteConnection extends Connection
     {
         return $this->getConfig('foreign_key_constraints');
     }
+
+    /**
+     * Escapes a binary value for safe SQL embedding.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "x'{$hex}'";
+    }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -43,7 +43,10 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        $grammar = new QueryGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -67,7 +70,10 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        $grammar = new SchemaGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -122,7 +122,7 @@ class SQLiteConnection extends Connection
     /**
      * Escapes a binary value for safe SQL embedding.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function escapeBinary($value)

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -55,14 +55,26 @@ class SqlServerConnection extends Connection
     }
 
     /**
+     * Escape a binary value for safe SQL embedding.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "0x{$hex}";
+    }
+
+    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Query\Grammars\SqlServerGrammar
      */
     protected function getDefaultQueryGrammar()
     {
-        $grammar = new QueryGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new QueryGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -88,8 +100,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        $grammar = new SchemaGrammar();
-        $grammar->setConnection($this);
+        ($grammar = new SchemaGrammar)->setConnection($this);
 
         return $this->withTablePrefix($grammar);
     }
@@ -125,18 +136,5 @@ class SqlServerConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new SqlServerDriver;
-    }
-
-    /**
-     * Escapes a binary value for safe SQL embedding.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function escapeBinary($value)
-    {
-        $hex = bin2hex($value);
-
-        return "0x{$hex}";
     }
 }

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -61,7 +61,10 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        $grammar = new QueryGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -85,7 +88,10 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        $grammar = new SchemaGrammar();
+        $grammar->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -126,4 +126,17 @@ class SqlServerConnection extends Connection
     {
         return new SqlServerDriver;
     }
+
+    /**
+     * Escapes a binary value for safe SQL embedding.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function escapeBinary($value)
+    {
+        $hex = bin2hex($value);
+
+        return "0x{$hex}";
+    }
 }

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -130,7 +130,7 @@ class SqlServerConnection extends Connection
     /**
      * Escapes a binary value for safe SQL embedding.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function escapeBinary($value)

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -98,6 +98,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Grammar withTablePrefix(\Illuminate\Database\Grammar $grammar)
  * @method static void resolverFor(string $driver, \Closure $callback)
  * @method static mixed getResolver(string $driver)
+ * @method static string escape(string|float|int|bool $value, bool $binary = false)
  * @method static mixed transaction(\Closure $callback, int $attempts = 1)
  * @method static void beginTransaction()
  * @method static void commit()

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -98,7 +98,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Grammar withTablePrefix(\Illuminate\Database\Grammar $grammar)
  * @method static void resolverFor(string $driver, \Closure $callback)
  * @method static mixed getResolver(string $driver)
- * @method static string escape(string|float|int|bool $value, bool $binary = false)
+ * @method static string escape(string|float|int|bool|null $value, bool $binary = false)
  * @method static mixed transaction(\Closure $callback, int $attempts = 1)
  * @method static void beginTransaction()
  * @method static void commit()

--- a/tests/Integration/Database/MySql/EscapeTest.php
+++ b/tests/Integration/Database/MySql/EscapeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use RuntimeException;
+
+/**
+ * @requires extension pdo_mysql
+ * @requires OS Linux|Darwin
+ */
+class EscapeTest extends MySqlTestCase
+{
+    public function testEscapeInt()
+    {
+        $this->assertSame('42', $this->app['db']->escape(42));
+        $this->assertSame('-6', $this->app['db']->escape(-6));
+    }
+
+    public function testEscapeFloat()
+    {
+        $this->assertSame('3.14159', $this->app['db']->escape(3.14159));
+        $this->assertSame('-3.14159', $this->app['db']->escape(-3.14159));
+    }
+
+    public function testEscapeBool()
+    {
+        $this->assertSame('1', $this->app['db']->escape(true));
+        $this->assertSame('0', $this->app['db']->escape(false));
+    }
+
+    public function testEscapeBinary()
+    {
+        $this->assertSame("x'dead00beef'", $this->app['db']->escape(hex2bin('dead00beef'), true));
+    }
+
+    public function testEscapeString()
+    {
+        $this->assertSame("'Hello\'World'", $this->app['db']->escape("Hello'World"));
+    }
+
+    public function testEscapeStringInvalidUtf8()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding an invalid \x80 utf-8 continuation byte");
+    }
+
+    public function testEscapeStringNullByte()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding a \00 byte");
+    }
+}

--- a/tests/Integration/Database/MySql/EscapeTest.php
+++ b/tests/Integration/Database/MySql/EscapeTest.php
@@ -28,6 +28,12 @@ class EscapeTest extends MySqlTestCase
         $this->assertSame('0', $this->app['db']->escape(false));
     }
 
+    public function testEscapeNull()
+    {
+        $this->assertSame('null', $this->app['db']->escape(null));
+        $this->assertSame('null', $this->app['db']->escape(null, true));
+    }
+
     public function testEscapeBinary()
     {
         $this->assertSame("x'dead00beef'", $this->app['db']->escape(hex2bin('dead00beef'), true));
@@ -35,6 +41,10 @@ class EscapeTest extends MySqlTestCase
 
     public function testEscapeString()
     {
+        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
+        $this->assertSame("'true'", $this->app['db']->escape("true"));
+        $this->assertSame("'false'", $this->app['db']->escape("false"));
+        $this->assertSame("'null'", $this->app['db']->escape("null"));
         $this->assertSame("'Hello\'World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/MySql/EscapeTest.php
+++ b/tests/Integration/Database/MySql/EscapeTest.php
@@ -41,10 +41,10 @@ class EscapeTest extends MySqlTestCase
 
     public function testEscapeString()
     {
-        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
-        $this->assertSame("'true'", $this->app['db']->escape("true"));
-        $this->assertSame("'false'", $this->app['db']->escape("false"));
-        $this->assertSame("'null'", $this->app['db']->escape("null"));
+        $this->assertSame("'2147483647'", $this->app['db']->escape('2147483647'));
+        $this->assertSame("'true'", $this->app['db']->escape('true'));
+        $this->assertSame("'false'", $this->app['db']->escape('false'));
+        $this->assertSame("'null'", $this->app['db']->escape('null'));
         $this->assertSame("'Hello\'World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/Postgres/EscapeTest.php
+++ b/tests/Integration/Database/Postgres/EscapeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use RuntimeException;
+
+/**
+ * @requires extension pdo_pgsql
+ * @requires OS Linux|Darwin
+ */
+class EscapeTest extends PostgresTestCase
+{
+    public function testEscapeInt()
+    {
+        $this->assertSame('42', $this->app['db']->escape(42));
+        $this->assertSame('-6', $this->app['db']->escape(-6));
+    }
+
+    public function testEscapeFloat()
+    {
+        $this->assertSame('3.14159', $this->app['db']->escape(3.14159));
+        $this->assertSame('-3.14159', $this->app['db']->escape(-3.14159));
+    }
+
+    public function testEscapeBool()
+    {
+        $this->assertSame('true', $this->app['db']->escape(true));
+        $this->assertSame('false', $this->app['db']->escape(false));
+    }
+
+    public function testEscapeBinary()
+    {
+        $this->assertSame("'\\xdead00beef'::bytea", $this->app['db']->escape(hex2bin('dead00beef'), true));
+    }
+
+    public function testEscapeString()
+    {
+        $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
+    }
+
+    public function testEscapeStringInvalidUtf8()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding an invalid \x80 utf-8 continuation byte");
+    }
+
+    public function testEscapeStringNullByte()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding a \00 byte");
+    }
+}

--- a/tests/Integration/Database/Postgres/EscapeTest.php
+++ b/tests/Integration/Database/Postgres/EscapeTest.php
@@ -41,10 +41,10 @@ class EscapeTest extends PostgresTestCase
 
     public function testEscapeString()
     {
-        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
-        $this->assertSame("'true'", $this->app['db']->escape("true"));
-        $this->assertSame("'false'", $this->app['db']->escape("false"));
-        $this->assertSame("'null'", $this->app['db']->escape("null"));
+        $this->assertSame("'2147483647'", $this->app['db']->escape('2147483647'));
+        $this->assertSame("'true'", $this->app['db']->escape('true'));
+        $this->assertSame("'false'", $this->app['db']->escape('false'));
+        $this->assertSame("'null'", $this->app['db']->escape('null'));
         $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/Postgres/EscapeTest.php
+++ b/tests/Integration/Database/Postgres/EscapeTest.php
@@ -28,6 +28,12 @@ class EscapeTest extends PostgresTestCase
         $this->assertSame('false', $this->app['db']->escape(false));
     }
 
+    public function testEscapeNull()
+    {
+        $this->assertSame('null', $this->app['db']->escape(null));
+        $this->assertSame('null', $this->app['db']->escape(null, true));
+    }
+
     public function testEscapeBinary()
     {
         $this->assertSame("'\\xdead00beef'::bytea", $this->app['db']->escape(hex2bin('dead00beef'), true));
@@ -35,6 +41,10 @@ class EscapeTest extends PostgresTestCase
 
     public function testEscapeString()
     {
+        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
+        $this->assertSame("'true'", $this->app['db']->escape("true"));
+        $this->assertSame("'false'", $this->app['db']->escape("false"));
+        $this->assertSame("'null'", $this->app['db']->escape("null"));
         $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/SqlServer/EscapeTest.php
+++ b/tests/Integration/Database/SqlServer/EscapeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SqlServer;
+
+use RuntimeException;
+
+class EscapeTest extends SqlServerTestCase
+{
+    public function testEscapeInt()
+    {
+        $this->assertSame('42', $this->app['db']->escape(42));
+        $this->assertSame('-6', $this->app['db']->escape(-6));
+    }
+
+    public function testEscapeFloat()
+    {
+        $this->assertSame('3.14159', $this->app['db']->escape(3.14159));
+        $this->assertSame('-3.14159', $this->app['db']->escape(-3.14159));
+    }
+
+    public function testEscapeBool()
+    {
+        $this->assertSame('1', $this->app['db']->escape(true));
+        $this->assertSame('0', $this->app['db']->escape(false));
+    }
+
+    public function testEscapeBinary()
+    {
+        $this->assertSame('0xdead00beef', $this->app['db']->escape(hex2bin('dead00beef'), true));
+    }
+
+    public function testEscapeString()
+    {
+        $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
+    }
+
+    public function testEscapeStringInvalidUtf8()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding an invalid \x80 utf-8 continuation byte");
+    }
+
+    public function testEscapeStringNullByte()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding a \00 byte");
+    }
+}

--- a/tests/Integration/Database/SqlServer/EscapeTest.php
+++ b/tests/Integration/Database/SqlServer/EscapeTest.php
@@ -37,10 +37,10 @@ class EscapeTest extends SqlServerTestCase
 
     public function testEscapeString()
     {
-        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
-        $this->assertSame("'true'", $this->app['db']->escape("true"));
-        $this->assertSame("'false'", $this->app['db']->escape("false"));
-        $this->assertSame("'null'", $this->app['db']->escape("null"));
+        $this->assertSame("'2147483647'", $this->app['db']->escape('2147483647'));
+        $this->assertSame("'true'", $this->app['db']->escape('true'));
+        $this->assertSame("'false'", $this->app['db']->escape('false'));
+        $this->assertSame("'null'", $this->app['db']->escape('null'));
         $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/SqlServer/EscapeTest.php
+++ b/tests/Integration/Database/SqlServer/EscapeTest.php
@@ -24,6 +24,12 @@ class EscapeTest extends SqlServerTestCase
         $this->assertSame('0', $this->app['db']->escape(false));
     }
 
+    public function testEscapeNull()
+    {
+        $this->assertSame('null', $this->app['db']->escape(null));
+        $this->assertSame('null', $this->app['db']->escape(null, true));
+    }
+
     public function testEscapeBinary()
     {
         $this->assertSame('0xdead00beef', $this->app['db']->escape(hex2bin('dead00beef'), true));
@@ -31,6 +37,10 @@ class EscapeTest extends SqlServerTestCase
 
     public function testEscapeString()
     {
+        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
+        $this->assertSame("'true'", $this->app['db']->escape("true"));
+        $this->assertSame("'false'", $this->app['db']->escape("false"));
+        $this->assertSame("'null'", $this->app['db']->escape("null"));
         $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/Sqlite/EscapeTest.php
+++ b/tests/Integration/Database/Sqlite/EscapeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Sqlite;
+
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use RuntimeException;
+
+class EscapeTest extends DatabaseTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        if (getenv('DB_CONNECTION') !== 'testing') {
+            $this->markTestSkipped('Test requires a Sqlite connection.');
+        }
+
+        $app['config']->set('database.default', 'conn1');
+
+        $app['config']->set('database.connections.conn1', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function testEscapeInt()
+    {
+        $this->assertSame('42', $this->app['db']->escape(42));
+        $this->assertSame('-6', $this->app['db']->escape(-6));
+    }
+
+    public function testEscapeFloat()
+    {
+        $this->assertSame('3.14159', $this->app['db']->escape(3.14159));
+        $this->assertSame('-3.14159', $this->app['db']->escape(-3.14159));
+    }
+
+    public function testEscapeBool()
+    {
+        $this->assertSame('1', $this->app['db']->escape(true));
+        $this->assertSame('0', $this->app['db']->escape(false));
+    }
+
+    public function testEscapeBinary()
+    {
+        $this->assertSame("x'dead00beef'", $this->app['db']->escape(hex2bin('dead00beef'), true));
+    }
+
+    public function testEscapeString()
+    {
+        $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
+    }
+
+    public function testEscapeStringInvalidUtf8()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding an invalid \x80 utf-8 continuation byte");
+    }
+
+    public function testEscapeStringNullByte()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape("I am hiding a \00 byte");
+    }
+}

--- a/tests/Integration/Database/Sqlite/EscapeTest.php
+++ b/tests/Integration/Database/Sqlite/EscapeTest.php
@@ -53,10 +53,10 @@ class EscapeTest extends DatabaseTestCase
 
     public function testEscapeString()
     {
-        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
-        $this->assertSame("'true'", $this->app['db']->escape("true"));
-        $this->assertSame("'false'", $this->app['db']->escape("false"));
-        $this->assertSame("'null'", $this->app['db']->escape("null"));
+        $this->assertSame("'2147483647'", $this->app['db']->escape('2147483647'));
+        $this->assertSame("'true'", $this->app['db']->escape('true'));
+        $this->assertSame("'false'", $this->app['db']->escape('false'));
+        $this->assertSame("'null'", $this->app['db']->escape('null'));
         $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
     }
 

--- a/tests/Integration/Database/Sqlite/EscapeTest.php
+++ b/tests/Integration/Database/Sqlite/EscapeTest.php
@@ -40,6 +40,12 @@ class EscapeTest extends DatabaseTestCase
         $this->assertSame('0', $this->app['db']->escape(false));
     }
 
+    public function testEscapeNull()
+    {
+        $this->assertSame('null', $this->app['db']->escape(null));
+        $this->assertSame('null', $this->app['db']->escape(null, true));
+    }
+
     public function testEscapeBinary()
     {
         $this->assertSame("x'dead00beef'", $this->app['db']->escape(hex2bin('dead00beef'), true));
@@ -47,6 +53,10 @@ class EscapeTest extends DatabaseTestCase
 
     public function testEscapeString()
     {
+        $this->assertSame("'2147483647'", $this->app['db']->escape("2147483647"));
+        $this->assertSame("'true'", $this->app['db']->escape("true"));
+        $this->assertSame("'false'", $this->app['db']->escape("false"));
+        $this->assertSame("'null'", $this->app['db']->escape("null"));
         $this->assertSame("'Hello''World'", $this->app['db']->escape("Hello'World"));
     }
 


### PR DESCRIPTION
So in Laravel 10, a PR of me (#44784) was merged to support database expressions with grammar-specific formatting. The idea is to bring more capabilities of abstracting the SQL flavors of different databases to Laravel. You shouldn't have to use any vendor-specific `raw()` statements anymore.

The idea is to replace those hardcoded SQL constructs with classes (like [tpetry/laravel-query-expressions](https://github.com/tpetry/laravel-query-expressions)) that automatically change the generated SQL based on the used database:
```php
// Instead of:
User::query()
    ->when(isPostgreSQL(), fn ($query) => $query->selectRaw('coalesce("user", "admin") AS "value"'))
    ->when(isMySQL(), fn ($query) => $query->selectRaw('coalesce(`user`, `admin`) AS `value`'))

// You can use:
User::select(new Alias(new Coalesce(['user', 'admin']), 'count'));
````

But one problem still needs to be solved: For some queries you have to use values with a query:
```php
Movie::select([
    new CountFilter(new Equal('released', new Value(2021))),
    new CountFilter(new Equal('released', new Value(2022))),
    new CountFilter(new Equal('genre', new Value('drama'))),
    new CountFilter(new Equal('genre', new Value('action'))),
])->where('streamingservice', 'netflix');
```

Embedding numeric values is easy as they can not be used for SQL injections. But any user-provided string could be an SQL injection vector. This is solved in Laravel by using bindings (placeholders) in queries. But these can't be used for expressions as many parts of the Query Builder and Eloquent would have to be rewritten - the needed changes are too broad.

To solve the problem, I am proposing a solution to add support for database grammars to escape any value for safe embedding into SQL queries. PHP provides this natively with the `PDO::quote` method. But the documentation of it states that it should be *theoretically* safe to use a quoted string within a SQL query. 

In my opinion (and after extensive research) this implementation is safe because of these reasons:

* The PHP MySQL driver emulates prepares by default and does not use actual prepared statements. So the default behavior is already embedding placeholders/bindings into the SQL query. So this approach must be safe.
* All known SQL injections with `PDO::quote()` are always some strange charset conversion tricks that begin by using invalid UTF-8 sequences. But those attacks are fixed by setting the proper connection charset. And Laravel's configuration has a charset setting that will be used. 
* Any value is additionally checked for invalid UTF-8 sequences to further secure the implementation. This eliminates the complete attack vector of inaccurate charset conversions.

What are your opinions?