### PR TITLE
[10.x] Make sure pivot model has previously defined values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -510,6 +510,8 @@ trait InteractsWithPivotTable
      */
     public function newPivot(array $attributes = [], $exists = false)
     {
+        $attributes = array_merge(array_column($this->pivotValues, 'value', 'column'), $attributes);
+
         $pivot = $this->related->newPivot(
             $this->parent, $attributes, $this->table, $exists, $this->using
         );


### PR DESCRIPTION
This is a retry of #46522, however I try to be more clear about the issue here, also added tests with another approach.

-----

Due to Taylor's [comment](https://github.com/laravel/framework/pull/46522#issuecomment-1478419961), my previous PR was closed, because the `withPivotValue` was mixed up with the `withPivot` method, however they are two diffent methods. (Also, as I see, the `withPivotValue` is not even documented, so if you wish, I gladly open a PR to document it, because I find it super handy.)

The `withPivotValue` defines a `wherePivot` statement and sets a pivot value when saving the relation. So it is used when saving AND retreiving relations.

The `withPivot` method just retrieves a pivot column, it does not even define a where statement.

When using the `withPivotValue`, that value is not being set when making a new pivot model using the relationship itself (`$model->relation()->newPivot()`). 

It means, if a developer is using a custom pivot model, and that model has default attribute values using the `$attributes` array, when saving the relationship, the `withPivotValue` won't work, however it should override the proper attribute in the  `$attributes` array.
