### PR TITLE
[10.x] Add a possibility to set a custom on_stats function for the Http Facade

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -6,6 +6,7 @@ use Exception;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\RequestSending;
@@ -20,6 +21,7 @@ use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use JsonSerializable;
@@ -2178,5 +2180,24 @@ class HttpClientTest extends TestCase
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'https://laravel.com/docs/9.x/validation';
         });
+    }
+
+    public function testTheTransferStatsAreCustomable()
+    {
+        Log::shouldReceive()
+            ->info('closure_stats')
+            ->once();
+
+        $stats = $this->factory
+            ->withOptions([
+                'on_stats' => function (TransferStats $stats) {
+                    Log::info('closure_stats');
+                },
+            ])
+            ->get('https://example.com')
+            ->handlerStats();
+
+        $this->assertIsArray($stats);
+        $this->assertNotEmpty($stats);
     }
 }


### PR DESCRIPTION
## Idea
I was working on a package that logs the transfer stats of the guzzle requests. To support the Http Facade of the framework I intended to do the same here, but the framework overwrites any custom functions, the idea was to add a possiblity to have both.

## Functionality
In the `sendRequest` Method, we check if we have a user function set and then use a closure to do the default and necessary step to add the stats to the response object and afterward call the user function.

## Disclaimer
The test is not good, but I wasn't able to fake a transferStats Object, and it is my first pull request on a big project so I'm sorry to bother in the first place