### PR TITLE
[10.x] Pass column to newUniqueId method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1148,7 +1148,7 @@ class Builder implements BuilderContract
         foreach ($this->model->uniqueIds() as $uniqueIdAttribute) {
             foreach ($values as &$row) {
                 if (! array_key_exists($uniqueIdAttribute, $row)) {
-                    $row = array_merge([$uniqueIdAttribute => $this->model->newUniqueId()], $row);
+                    $row = array_merge([$uniqueIdAttribute => $this->model->newUniqueId($uniqueIdAttribute)], $row);
                 }
             }
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -32,7 +32,7 @@ trait HasUlids
      *
      * @return string
      */
-    public function newUniqueId()
+    public function newUniqueId(string $column)
     {
         return strtolower((string) Str::ulid());
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueIds.php
@@ -30,7 +30,7 @@ trait HasUniqueIds
     {
         foreach ($this->uniqueIds() as $column) {
             if (empty($this->{$column})) {
-                $this->{$column} = $this->newUniqueId();
+                $this->{$column} = $this->newUniqueId($column);
             }
         }
     }
@@ -40,7 +40,7 @@ trait HasUniqueIds
      *
      * @return string
      */
-    public function newUniqueId()
+    public function newUniqueId(string $column)
     {
         return null;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -32,7 +32,7 @@ trait HasUuids
      *
      * @return string
      */
-    public function newUniqueId()
+    public function newUniqueId(string $column)
     {
         return (string) Str::orderedUuid();
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I am creating a trait similar to `HasUlids` that needs to check the uniqueness in the database before creating the record. Therefore, I need to access the `$column` variable, this PR passes the column variable to the `newUniqueId` method. Otherwise, I will need to replicate almost the same code in order to achieve this.