### PR TITLE
[10.x] Add a possibility to set a custom on_stats function for the Http Facade

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -960,9 +960,10 @@ class PendingRequest
         $laravelData = $this->parseRequestData($method, $url, $options);
 
         $onStats = function ($transferStats) {
-            if (($callback = $this->options['on_stats'] ?? false) instanceof Closure) {
-                $transferStats = $callback($transferStats) ?? $transferStats;
+            if (($callback = ($this->options['on_stats'] ?? false)) instanceof Closure) {
+                $transferStats = $callback($transferStats) ?: $transferStats;
             }
+
             $this->transferStats = $transferStats;
         };
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -960,15 +960,11 @@ class PendingRequest
         $laravelData = $this->parseRequestData($method, $url, $options);
 
         $onStats = function ($transferStats) {
+            if (($callback = $this->options['on_stats'] ?? false) instanceof Closure) {
+                $transferStats = $callback($transferStats) ?? $transferStats;
+            }
             $this->transferStats = $transferStats;
         };
-
-        if (data_get($this->options, 'on_stats') instanceof Closure) {
-            $onStats = function ($transferStats) use ($onStats) {
-                $onStats($transferStats);
-                call_user_func($this->options['on_stats'], $transferStats);
-            };
-        }
 
         return $this->buildClient()->$clientMethod($method, $url, $this->mergeOptions([
             'laravel_data' => $laravelData,

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -21,7 +21,6 @@ use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use JsonSerializable;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -6,6 +6,7 @@ use Exception;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\RequestSending;
@@ -20,6 +21,7 @@ use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use JsonSerializable;
@@ -2178,5 +2180,24 @@ class HttpClientTest extends TestCase
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'https://laravel.com/docs/9.x/validation';
         });
+    }
+
+    public function testTheTransferStatsAreCustomable()
+    {
+        Log::shouldReceive()
+            ->info('closure_stats')
+            ->once();
+
+        $stats = $this->factory
+            ->withOptions([
+                'on_stats' => function (TransferStats $stats) {
+                    Log::info('closure_stats');
+                },
+            ])
+            ->get('https://example.com')
+            ->handlerStats();
+
+        $this->assertIsArray($stats);
+        $this->assertNotEmpty($stats);
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2182,16 +2182,14 @@ class HttpClientTest extends TestCase
         });
     }
 
-    public function testTheTransferStatsAreCustomable()
+    public function testTheTransferStatsAreCustomizable(): void
     {
-        Log::shouldReceive()
-            ->info('closure_stats')
-            ->once();
+        $onStatsFunctionCalled = false;
 
         $stats = $this->factory
             ->withOptions([
-                'on_stats' => function (TransferStats $stats) {
-                    Log::info('closure_stats');
+                'on_stats' => function (TransferStats $stats) use (&$onStatsFunctionCalled) {
+                    $onStatsFunctionCalled = true;
                 },
             ])
             ->get('https://example.com')
@@ -2199,5 +2197,6 @@ class HttpClientTest extends TestCase
 
         $this->assertIsArray($stats);
         $this->assertNotEmpty($stats);
+        $this->assertTrue($onStatsFunctionCalled);
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2199,4 +2199,21 @@ class HttpClientTest extends TestCase
         $this->assertNotEmpty($stats);
         $this->assertTrue($onStatsFunctionCalled);
     }
+
+    public function testTheTransferStatsAreCustomizableOnFake(): void
+    {
+        $onStatsFunctionCalled = false;
+
+        $this->factory
+            ->fake()
+            ->withOptions([
+                'on_stats' => function (TransferStats $stats) use (&$onStatsFunctionCalled) {
+                    $onStatsFunctionCalled = true;
+                },
+            ])
+            ->get('https://foo.bar')
+            ->handlerStats();
+
+        $this->assertTrue($onStatsFunctionCalled);
+    }
 }


### PR DESCRIPTION
## Idea
I was working on a package that logs the transfer stats of the guzzle requests. To support the Http Facade of the framework I intended to do the same here, but the framework overwrites any custom functions, the idea was to add a possiblity to have both.

## Functionality
In the `sendRequest` Method, we check if we have a user function set and then use a closure to do the default and necessary step to add the stats to the response object and afterward call the user function.

## Disclaimer
It is my first pull request on a big project, so I'm sorry to bother in the first place.

Not sure if it is appropriate to tag driesvints, but he declined the first PR because the test were failing, but requested a resend of it. This should pass (hopefully)