### PR TITLE
[10.x] Stop adding constraints twice on *Many to *One relationships via one()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,13 @@ class HasMany extends HasOneOrMany
      */
     public function one()
     {
-        return new HasOne($this->getQuery(), $this->parent, $this->foreignKey, $this->localKey);
+        return HasOne::noConstraints(fn() => new HasOne(
+            $this->getQuery(),
+            $this->parent,
+            $this->foreignKey,
+            $this->localKey
+        ));
+
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,13 +13,12 @@ class HasMany extends HasOneOrMany
      */
     public function one()
     {
-        return HasOne::noConstraints(fn() => new HasOne(
+        return HasOne::noConstraints(fn () => new HasOne(
             $this->getQuery(),
             $this->parent,
             $this->foreignKey,
             $this->localKey
         ));
-
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -88,7 +88,7 @@ class HasManyThrough extends Relation
      */
     public function one()
     {
-        return new HasOneThrough(
+        return HasOneThrough::noConstraints(fn () => new HasOneThrough(
             $this->getQuery(),
             $this->farParent,
             $this->throughParent,
@@ -96,7 +96,7 @@ class HasManyThrough extends Relation
             $this->secondKey,
             $this->getLocalKeyName(),
             $this->getSecondLocalKeyName(),
-        );
+        ));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,13 @@ class MorphMany extends MorphOneOrMany
      */
     public function one()
     {
-        return new MorphOne($this->getQuery(), $this->getParent(), $this->morphType, $this->foreignKey, $this->localKey);
+        return MorphMany::noConstraints(fn () => new MorphOne(
+            $this->getQuery(),
+            $this->getParent(),
+            $this->morphType,
+            $this->foreignKey,
+            $this->localKey
+        ));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,7 @@ class MorphMany extends MorphOneOrMany
      */
     public function one()
     {
-        return MorphMany::noConstraints(fn () => new MorphOne(
+        return MorphOne::noConstraints(fn () => new MorphOne(
             $this->getQuery(),
             $this->getParent(),
             $this->morphType,


### PR DESCRIPTION
@siarheipashkevich reported that constraints are duplicated when being converted from HasMany/HasManyThrough/MorphMany to HasOne/HasOneThrough/MorphOne

This PR will stop adding those constraints twice by employing the `Relation::noConstraint()` method (which was a TIL moment and I must say, is 🔥)