### PR TITLE
[10.x] Handle empty arrays for DynamoDbStore multi-key operations

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -129,6 +129,10 @@ class DynamoDbStore implements LockProvider, Store
      */
     public function many(array $keys)
     {
+        if (count($keys) === 0) {
+            return [];
+        }
+
         $prefixedKeys = array_map(function ($key) {
             return $this->prefix.$key;
         }, $keys);
@@ -219,6 +223,10 @@ class DynamoDbStore implements LockProvider, Store
      */
     public function putMany(array $values, $seconds)
     {
+        if (count($values) === 0) {
+            return true;
+        }
+
         $expiration = $this->toTimestamp($seconds);
 
         $this->dynamo->batchWriteItem([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When using the DynamoDB cache driver, if someone passes an empty list of keys to `Cache::many([])` or an empty key/value array to `Cache::putMany([])`, DynamoDB will give an error response and the call will throw an exception. For example:

> InvalidArgumentException: Found 1 error while validating the input provided for the BatchGetItem operation:
[RequestItems][vapor_cache][Keys] expected list element count to be >= 1, but found list element count of 0

This behaviour is unlike other cache drivers, which do not throw exceptions. For example:

```php
>>> Cache::store('database')->many([])
=> []

>>> Cache::store('database')->putMany([])
=> true
```

That resulted in a papercut since I'm using the db driver for development and dynamo when deploying to vapor. 

This PR adds a check for the array size and returns early if there's no Dynamo call to make.