### PR TITLE
Force cast json decoded failed_job_ids to array in DatabaseBatchRepository

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -141,7 +141,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             return [
                 'pending_jobs' => $batch->pending_jobs - 1,
                 'failed_jobs' => $batch->failed_jobs,
-                'failed_job_ids' => json_encode(array_values(array_diff(json_decode($batch->failed_job_ids, true), [$jobId]))),
+                'failed_job_ids' => json_encode(array_values(array_diff((array) json_decode($batch->failed_job_ids, true), [$jobId]))),
             ];
         });
 
@@ -164,7 +164,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             return [
                 'pending_jobs' => $batch->pending_jobs,
                 'failed_jobs' => $batch->failed_jobs + 1,
-                'failed_job_ids' => json_encode(array_values(array_unique(array_merge(json_decode($batch->failed_job_ids, true), [$jobId])))),
+                'failed_job_ids' => json_encode(array_values(array_unique(array_merge((array) json_decode($batch->failed_job_ids, true), [$jobId])))),
             ];
         });
 


### PR DESCRIPTION
closes #46580 

This PR fixes the referenced issue forcing an array cast of the json decoded from failed_job_ids column in job_batches table.
Mainly here: 
-  **DatabaseBatchRepository::decrementPendingJobs()** 
- **DatabaseBatchRepository::incrementFailedJobs()**

Thie lines below will be failing if failed_job_ids is null : 
```php
// decrementPendingJobs L: 144
json_encode(array_values(array_diff(json_decode($batch->failed_job_ids, true), [$jobId])))
// incrementFailedJobs L:167
json_encode(array_values(array_unique(array_merge(json_decode($batch->failed_job_ids, true), [$jobId])))),
```
In case if failed_job_ids column has empty or null value for whatever reason (interruption in the issue case, explicit update etc...) it should return an empty array instead of null so the batch won't fail with the exception thrown in the referenced issue.

Thanks.