### PR TITLE
[9.x] Fix Job delay property when dispatched through facade + `data_get()` closure fix

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -76,7 +76,7 @@ if (! function_exists('data_get')) {
 
             if (Arr::accessible($target) && Arr::exists($target, $segment)) {
                 $target = $target[$segment];
-            } elseif (is_object($target) && isset($target->{$segment})) {
+            } elseif (! $target instanceof Closure && is_object($target) && isset($target->{$segment})) {
                 $target = $target->{$segment};
             } else {
                 return value($default);

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -114,7 +114,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a new job onto the queue after (n) seconds.
      *
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -114,11 +114,11 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a new job onto the queue after (n) seconds.
      *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
-     * @return void
+     * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
     {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -301,7 +301,7 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
-        $delay = $delay ?? data_get($job, 'delay');
+        $delay ??= data_get($job, 'delay');
 
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
@@ -327,7 +327,8 @@ abstract class Queue
      */
     protected function shouldDispatchAfterCommit($job)
     {
-        if ($afterCommit = data_get($job, 'afterCommit')) {
+        $afterCommit = data_get($job, 'afterCommit');
+        if (!is_null($afterCommit)) {
             return $afterCommit;
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -328,7 +328,7 @@ abstract class Queue
     protected function shouldDispatchAfterCommit($job)
     {
         $afterCommit = data_get($job, 'afterCommit');
-        if (!is_null($afterCommit)) {
+        if (! is_null($afterCommit)) {
             return $afterCommit;
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -301,6 +301,8 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
+        $delay = $delay ?? $job?->delay;
+
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
             return $this->container->make('db.transactions')->addCallback(

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -301,7 +301,7 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
-        $delay = $delay ?? $job?->delay;
+        $delay = $delay ?? data_get($job, 'delay');
 
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
@@ -327,8 +327,8 @@ abstract class Queue
      */
     protected function shouldDispatchAfterCommit($job)
     {
-        if (! $job instanceof Closure && is_object($job) && isset($job->afterCommit)) {
-            return $job->afterCommit;
+        if ($afterCommit = data_get($job, 'afterCommit')) {
+            return $afterCommit;
         }
 
         if (isset($this->dispatchAfterCommit)) {


### PR DESCRIPTION
Fix for https://github.com/laravel/framework/issues/46568 and an improvement for https://github.com/laravel/framework/pull/46505.

This also includes a helpful improvement for the `data_get()` global helper, since for PHP 8.0, trying to access properties on a closure (closures are still `is_object()`) will cause it to error. This PR makes it so that when you now call `data_get($closure, 'someProperty')`, it will return null (or some other default).

Sadly I couldn't make any tests for the `enqueueUsing` method to test the correct `$delay` property, since the method calls a closure further on within the function which is different for each and every Queue driver.