### PR TITLE
[10.x] Set a custom schemaPath for TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Traits;
 
-use Illuminate\Support\Facades\File;
-
 trait CanConfigureMigrationCommands
 {
     /**
@@ -85,12 +83,12 @@ trait CanConfigureMigrationCommands
         }
 
         // check if the path is simply the filename of the schema
-        if (file_exists($schemaPathWithinDatabaseMigrationsPath = database_path('schema/' . $schemaPath))) {
+        if (file_exists($schemaPathWithinDatabaseMigrationsPath = database_path('schema/'.$schemaPath))) {
             return $schemaPathWithinDatabaseMigrationsPath;
         }
 
         // check if the path provided is relative to the root database path
-        if (file_exists(($schemaPathWithinDatabasePath = database_path($schemaPath)))) {
+        if (file_exists($schemaPathWithinDatabasePath = database_path($schemaPath))) {
             return $schemaPathWithinDatabasePath;
         }
 

--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Foundation\Testing\Traits;
 
+use Illuminate\Support\Facades\File;
+
 trait CanConfigureMigrationCommands
 {
     /**
@@ -12,13 +14,15 @@ trait CanConfigureMigrationCommands
     protected function migrateFreshUsing()
     {
         $seeder = $this->seeder();
+        $schemaPath = $this->useSchemaPath();
 
         return array_merge(
             [
                 '--drop-views' => $this->shouldDropViews(),
                 '--drop-types' => $this->shouldDropTypes(),
             ],
-            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()]
+            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()],
+            $schemaPath ? ['--schema-path' => $schemaPath] : [],
         );
     }
 
@@ -60,5 +64,36 @@ trait CanConfigureMigrationCommands
     protected function seeder()
     {
         return property_exists($this, 'seeder') ? $this->seeder : false;
+    }
+
+    /**
+     * Determine the schema path, checking if the path is absolute, relative to
+     * the database directory, or within the database schema/ directory.
+     *
+     * @return bool
+     */
+    protected function useSchemaPath(): bool
+    {
+        $schemaPath = $this->schemaPath ?? false;
+
+        if (! $schemaPath) {
+            return false;
+        }
+
+        if (file_exists($schemaPath)) {
+            return $schemaPath;
+        }
+
+        // check if the path is simply the filename of the schema
+        if (file_exists($schemaPathWithinDatabaseMigrationsPath = database_path('schema/' . $schemaPath))) {
+            return $schemaPathWithinDatabaseMigrationsPath;
+        }
+
+        // check if the path provided is relative to the root database path
+        if (file_exists(($schemaPathWithinDatabasePath = database_path($schemaPath)))) {
+            return $schemaPathWithinDatabasePath;
+        }
+
+        return false;
     }
 }

--- a/tests/Foundation/Testing/DatabaseMigrationsTest.php
+++ b/tests/Foundation/Testing/DatabaseMigrationsTest.php
@@ -94,6 +94,31 @@ class DatabaseMigrationsTest extends TestCase
 
         $refreshTestDatabaseReflection->invoke($this->traitObject);
     }
+
+    public function testRefreshDatabaseWithSchema()
+    {
+        $tempDirectory = sys_get_temp_dir().'/tmp';
+        @mkdir($tempDirectory);
+        touch($file = $tempDirectory.'/schema.sql');
+
+        $this->traitObject->schemaPath = $file;
+
+        $this->traitObject
+            ->expects($this->once())
+            ->method('artisan')
+            ->with('migrate:fresh', [
+                '--drop-views' => false,
+                '--drop-types' => false,
+                '--seed' => false,
+                '--schema-path' => $file,
+            ]);
+        $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('runDatabaseMigrations');
+
+        $refreshTestDatabaseReflection->invoke($this->traitObject);
+
+        unlink($file);
+        rmdir($tempDirectory);
+    }
 }
 
 class DatabaseMigrationsTestMockClass
@@ -105,4 +130,6 @@ class DatabaseMigrationsTestMockClass
     public $dropViews = false;
 
     public $dropTypes = false;
+
+    public $schemaPath = false;
 }


### PR DESCRIPTION
## Problem
We are building a V3 of our application and it doesn't make sense to copy over all of the migrations. We are leveraging the schema dump functionality.

However, by default, migrations attempt to look for a schema that matches the database connection name. This means we would have to maintain two SQL files (one for the `mysql` and one for `mysql_testing`). I originally overrode the `migrateFreshUsing()` method within our application's base TestCase to force it to use the name of our default connection:
```php
    protected function migrateFreshUsing(): array
    {
        $migrateFreshOptions = $this->baseMigrateFreshUsing();

        if ($schemaPath = $this->getSchemaPath()) {
            $migrateFreshOptions['--schema-path'] = $schemaPath;
        }

        return $migrateFreshOptions;
    }

    /**
     * overrides the default schema path checking so that two copies of
     * the schema (with the same data) do not need to be maintained
     *
     * @return string
     */
    protected function getSchemaPath(): string
    {
        return database_path('schema/mysql-schema.dump');
    }
```

I figured if we needed this functionality, maybe others could benefit too?

But I think more useful is the fact that a common test SQL file could be used within tests. Our application has over 1000 test cases, almost all of which touch the database. We could put all of our common seeders into a schema dump which would shorten the dev-test feedback loop.

## Usage
Within a class that extends Tests\TestCase, set a schema path. For example:

```php
use Illuminate\Foundation\Testing\RefreshDatabase;
use Tests\TestCase;

class UserTest extends TestCase
{
    use RefreshDatabase;

    protected $schemaPath = 'lot_of_users_seeded.dump';

    public function testDoesUserExist()
    {
         $this->assertExists(User::first());
    }
}
```

## Questions
I think that there should be a test case that actually confirms the database schema is loaded. **Where should this test case live and what TestCase it should extend from**? I'm not sure what namespace of directories it would belong to (since it looks like the test harness uses that to determine which runners to use). If someone could steer me in the right direction, I would like to add that.