### PR TITLE
[10.x] Fix `Queue::push()` ignoring job delays

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -76,13 +76,17 @@ class BeanstalkdQueue extends Queue implements QueueContract
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  object|string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
     {
+        if ($job->delay ?? null) {
+            return $this->later($job->delay, $job, $data, $queue);
+        }
+
         return $this->enqueueUsing(
             $job,
             $this->createPayload($job, $this->getQueue($queue), $data),

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -80,13 +80,17 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  object|string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
     {
+        if ($job->delay ?? null) {
+            return $this->later($job->delay, $job, $data, $queue);
+        }
+
         return $this->enqueueUsing(
             $job,
             $this->createPayload($job, $this->getQueue($queue), $data),
@@ -118,7 +122,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
-     * @return void
+     * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
     {

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -131,6 +131,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function push($job, $data = '', $queue = null)
     {
+        if ($job->delay ?? null) {
+            return $this->later($job->delay, $job, $data, $queue);
+        }
+
         return $this->enqueueUsing(
             $job,
             $this->createPayload($job, $this->getQueue($queue), $data),

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -82,13 +82,17 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  object|string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
     {
+        if ($job->delay ?? null) {
+            return $this->later($job->delay, $job, $data, $queue);
+        }
+
         return $this->enqueueUsing(
             $job,
             $this->createPayload($job, $queue ?: $this->default, $data),


### PR DESCRIPTION
This PR fixes job delay not working when dispatched like this:

```php
$job = new SomeJob();

$job->delay(now()->addMinute());

Queue::push($job);
```

The `delay()` method comes from the `Queuable` trait, which is on jobs by default. The code above looks like it should work, but it doesn't. This is a pretty annoying problem to deal with, because during development you're likely to use the `sync` queue connection that doesn't support delays. This means you won't notice that the delay doesn't work until you push your code to production. 

In my case I wrote a job that pinged a server, and on failure re-dispatched itself with a 30 second delay. Because the delay didn't work it executed all attempts in a row instantly without any delay. Luckily I made my code stop after 3 attempts, if I didn't have that limit it would have have been stuck in an infinite loop.

Fixes https://github.com/laravel/framework/issues/46568