### PR TITLE
[9.x] Fix job delay override + `data_get()` improvement to deal with closures

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -76,7 +76,7 @@ if (! function_exists('data_get')) {
 
             if (Arr::accessible($target) && Arr::exists($target, $segment)) {
                 $target = $target[$segment];
-            } elseif (is_object($target) && isset($target->{$segment})) {
+            } elseif (! $target instanceof Closure && is_object($target) && isset($target->{$segment})) {
                 $target = $target->{$segment};
             } else {
                 return value($default);

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -92,9 +92,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             $this->createPayload($job, $this->getQueue($queue), $data),
             $queue,
             null,
-            function ($payload, $queue) {
-                return $this->pushToDatabase($queue, $payload);
-            }
+            fn ($payload, $queue, $delay) => $this->pushToDatabase($queue, $payload, $delay)
         );
     }
 
@@ -127,9 +125,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
             $this->createPayload($job, $this->getQueue($queue), $data),
             $queue,
             $delay,
-            function ($payload, $queue, $delay) {
-                return $this->pushToDatabase($queue, $payload, $delay);
-            }
+            fn ($payload, $queue, $delayArg) => $this->pushToDatabase($queue, $payload, $delayArg)
         );
     }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -114,7 +114,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a new job onto the queue after (n) seconds.
      *
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -114,11 +114,11 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     /**
      * Push a new job onto the queue after (n) seconds.
      *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
-     * @return void
+     * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
     {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -301,7 +301,7 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
-        $delay = $delay ?? data_get($job, 'delay');
+        $delay ??= data_get($job, 'delay');
 
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
@@ -327,7 +327,8 @@ abstract class Queue
      */
     protected function shouldDispatchAfterCommit($job)
     {
-        if ($afterCommit = data_get($job, 'afterCommit')) {
+        $afterCommit = data_get($job, 'afterCommit');
+        if (!is_null($afterCommit)) {
             return $afterCommit;
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -328,7 +328,7 @@ abstract class Queue
     protected function shouldDispatchAfterCommit($job)
     {
         $afterCommit = data_get($job, 'afterCommit');
-        if (!is_null($afterCommit)) {
+        if (! is_null($afterCommit)) {
             return $afterCommit;
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -301,6 +301,8 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
+        $delay = $delay ?? $job?->delay;
+
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
             return $this->container->make('db.transactions')->addCallback(

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -301,7 +301,7 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
-        $delay = $delay ?? $job?->delay;
+        $delay = $delay ?? data_get($job, 'delay');
 
         if ($this->shouldDispatchAfterCommit($job) &&
             $this->container->bound('db.transactions')) {
@@ -327,8 +327,8 @@ abstract class Queue
      */
     protected function shouldDispatchAfterCommit($job)
     {
-        if (! $job instanceof Closure && is_object($job) && isset($job->afterCommit)) {
-            return $job->afterCommit;
+        if ($afterCommit = data_get($job, 'afterCommit')) {
+            return $afterCommit;
         }
 
         if (isset($this->dispatchAfterCommit)) {

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -136,7 +136,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
             $this->createPayload($job, $this->getQueue($queue), $data),
             $queue,
             null,
-            function ($payload, $queue) {
+            function ($payload, $queue, $delay) {
+                if (! is_null($delay)) {
+                    return $this->laterRaw($delay, $payload, $queue);
+                }
                 return $this->pushRaw($payload, $queue);
             }
         );

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -140,6 +140,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
                 if (! is_null($delay)) {
                     return $this->laterRaw($delay, $payload, $queue);
                 }
+
                 return $this->pushRaw($payload, $queue);
             }
         );

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -113,7 +113,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         return $this->sqs->sendMessage([
             'QueueUrl' => $this->getQueue($queue),
             'MessageBody' => $payload,
-        ] + $delay ? ['DelaySeconds' => $this->secondsUntil($delay)] : [])->get('MessageId');
+        ] + ($delay ? ['DelaySeconds' => $this->secondsUntil($delay)] : []))->get('MessageId');
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/laravel/framework/issues/46568 and an improvement for https://github.com/laravel/framework/pull/46505. Minor changes have been added for all queue drivers (Database, SQS, Redis, Beanstalkd) so a `$delay` property can be passed.

I would say this still is an issue on the basis of:
```php
$job = new MyTestJob;
$job->delay(now()->addMinute());
Queue::push($job);
```

The code sample above should delay the job obviously (which before it didnt). Setting `public $delay = 60;` in some job class should now always make sure the job is delayed 60 seconds (unless you override it using `Queue::later(30, new MyTestJob)`) which imho is also expected behaviour.

Trace/Explanation: Everything goes through the `Illuminate\Queue::enqueueUsing(...)` which in turn calls the `$callback` which is its fifth argument. This callback differs per queue driver and has a `$queue` param.