### PR TITLE
[10.x] Add `selectResultsets` to database Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -423,6 +423,39 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Run a select statement against the database and returns all the result sets.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @return array
+     */
+    public function selectResultsets($query, $bindings = [], $useReadPdo = true)
+    {
+        return $this->run($query, $bindings, function ($query, $bindings) use ($useReadPdo) {
+            if ($this->pretending()) {
+                return [];
+            }
+
+            $statement = $this->prepared(
+                $this->getPdoForSelect($useReadPdo)->prepare($query)
+            );
+
+            $this->bindValues($statement, $this->prepareBindings($bindings));
+
+            $statement->execute();
+
+            $sets = [];
+
+            do {
+                $sets[] = $statement->fetchAll();
+            } while ($statement->nextRowset());
+
+            return $sets;
+        });
+    }
+
+    /**
      * Run a select statement against the database and returns a generator.
      *
      * @param  string  $query

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -423,14 +423,14 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Run a select statement against the database and returns all the result sets.
+     * Run a select statement against the database and returns all of the result sets.
      *
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @return array
      */
-    public function selectResultsets($query, $bindings = [], $useReadPdo = true)
+    public function selectResultSets($query, $bindings = [], $useReadPdo = true)
     {
         return $this->run($query, $bindings, function ($query, $bindings) use ($useReadPdo) {
             if ($this->pretending()) {


### PR DESCRIPTION
At our company many of our logic is written in SQL stored procedures, and many of them returns with multiple result sets. This PR adds a `selectResultsets` method to the DB facade so that the multiple result sets of these SPs can be get via a single framework call.
(Using the underlying PDO layer might be a solution but those calls does not logged by the framework.)

An example:
```php
list($user_params, $user_notifications) = DB::selectResultsets("CALL get_user_params_and_notifications(?)", Auth::id());
```