### PR TITLE
[10.x] Fix route resource in groups

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -84,6 +84,10 @@ class ResourceRegistrar
             $this->parameters = $options['parameters'];
         }
 
+        if ($name === '/') {
+            $name = '';
+        }
+
         // If the resource name contains a slash, we will assume the developer wishes to
         // register these resource routes with a prefix so we will set that up out of
         // the box so they don't have to mess with it. Otherwise, we will continue.
@@ -603,6 +607,12 @@ class ResourceRegistrar
      */
     public function getResourceWildcard($value)
     {
+        // If the name is empty and route in a group stack, then we will take name from the last group
+        if (empty($value) && $this->hasGroupStack()) {
+            $prefix = $this->getLastGroupPrefix();
+            [$value] = $this->getResourcePrefix($prefix);
+        }
+
         if (isset($this->parameters[$value])) {
             $value = $this->parameters[$value];
         } elseif (isset(static::$parameterMap[$value])) {
@@ -677,6 +687,26 @@ class ResourceRegistrar
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');
+    }
+
+    /**
+     * Determine if the router currently has a group stack.
+     *
+     * @return bool
+     */
+    protected function hasGroupStack()
+    {
+        return $this->router->hasGroupStack();
+    }
+
+    /**
+     * Get the prefix from the last group on the stack of router.
+     *
+     * @return string
+     */
+    protected function getLastGroupPrefix()
+    {
+        return $this->router->getLastGroupPrefix();
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -639,6 +639,22 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
+    public function testCanRegisterApiResourceWithoutSpecificPrefixInGroup()
+    {
+        $this->router->prefix('users')->name('users.')->group(function ($router) {
+            $router->apiResource('/', RouteRegistrarControllerStub::class);
+        });
+
+        $this->assertCount(5, $this->router->getRoutes());
+
+        $this->assertStringContainsString('{user}', $this->router->getRoutes()->getByName('users.update')->uri);
+        $this->assertStringContainsString('{user}', $this->router->getRoutes()->getByName('users.show')->uri);
+        $this->assertStringContainsString('{user}', $this->router->getRoutes()->getByName('users.destroy')->uri);
+
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.create'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.edit'));
+    }
+
     public function testCanRegisterApiResourcesWithExceptOption()
     {
         $this->router->apiResources([


### PR DESCRIPTION
@taylorotwell, added tests (#46547)

---

Hi all!

I wanted to use a route resource inside an existing group without an additional name, however this was not possible, so I added the appropriate code.

The reason for this problem was that the ResourceRegistrar relied in creating the route name and the name of the substitution parameters on the received empty name and did not take it from the name of the last group stack, if one exists.

Please, merge it also to [10.x] branch.