### PR TITLE
[10.x] Allow Blueprint to use an Enum case for column default

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -37,7 +37,7 @@ trait InteractsWithDictionary
      * Get a value from an enum case if it is backed, otherwise use the case name.
      *
      * @param  UnitEnum  $attribute
-     * @return mixed
+     * @return string | int
      */
     protected function getEnumValue(UnitEnum $attribute)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -24,12 +24,23 @@ trait InteractsWithDictionary
             }
 
             if ($attribute instanceof UnitEnum) {
-                return $attribute instanceof BackedEnum ? $attribute->value : $attribute->name;
+                return $this->getEnumValue($attribute);
             }
 
             throw new InvalidArgumentException('Model attribute value is an object but does not have a __toString method.');
         }
 
         return $attribute;
+    }
+
+    /**
+     * Get a value from an enum case if it is backed, otherwise use the case name.
+     *
+     * @param  UnitEnum  $attribute
+     * @return mixed
+     */
+    protected function getEnumValue(UnitEnum $attribute)
+    {
+        return $attribute instanceof BackedEnum ? $attribute->value : $attribute->name;
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\TableDiff;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
@@ -16,6 +17,7 @@ use RuntimeException;
 abstract class Grammar extends BaseGrammar
 {
     use CompilesJsonPaths;
+    use InteractsWithDictionary;
 
     /**
      * The possible column modifiers.
@@ -308,6 +310,8 @@ abstract class Grammar extends BaseGrammar
         if ($value instanceof Expression) {
             return $this->getValue($value);
         }
+
+        $value = $this->getDictionaryKey($value);
 
         return is_bool($value)
                     ? "'".(int) $value."'"

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -311,7 +311,9 @@ abstract class Grammar extends BaseGrammar
             return $this->getValue($value);
         }
 
-        $value = $this->getDictionaryKey($value);
+        if ($value instanceof \UnitEnum) {
+            $value = $this->getEnumValue($value);
+        }
 
         return is_bool($value)
                     ? "'".(int) $value."'"

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class DatabaseSchemaBuilderIntegrationTest extends TestCase
 {

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -6,7 +6,6 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
 include 'Enums.php';
@@ -135,7 +134,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testCanUseIntegerBackedEnumAsDefault()
     {
-        $this->schemaBuilder()->create('articles', function(Blueprint $table) {
+        $this->schemaBuilder()->create('articles', function (Blueprint $table) {
             $table->string('name');
             $table->integer('status')->default(IntegerStatus::pending);
         });
@@ -152,7 +151,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testCanUseStringBackedEnumAsDefault()
     {
-        $this->schemaBuilder()->create('articles', function(Blueprint $table) {
+        $this->schemaBuilder()->create('articles', function (Blueprint $table) {
             $table->string('name');
             $table->string('status')->default(StringStatus::unknown);
         });
@@ -168,7 +167,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testCanUseUnitEnumAsDefault()
     {
-        $this->schemaBuilder()->create('articles', function(Blueprint $table) {
+        $this->schemaBuilder()->create('articles', function (Blueprint $table) {
             $table->string('name');
             $table->string('status')->default(UnitEnumStatus::Draft);
         });

--- a/tests/Database/Enums.php
+++ b/tests/Database/Enums.php
@@ -9,6 +9,7 @@ enum StringStatus: string
     case draft = 'draft';
     case pending = 'pending';
     case done = 'done';
+    case unknown = 'we do not know';
 }
 
 enum IntegerStatus: int
@@ -39,4 +40,9 @@ enum ArrayableStatus: string implements Arrayable
             'description' => $this->description(),
         ];
     }
+}
+
+enum UnitEnumStatus
+{
+    case Draft;
 }


### PR DESCRIPTION
## Problem

I need to create a column with a default value that is sourced from an enum.

```php
use App\Enums\Access\UserRegistrationRequestDispositionEnum;
use App\Models\User;
use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

return new class extends Migration
{
    public function up(): void
    {
        Schema::create('user_registration_requests', function (Blueprint $table) {
            $table->id();
            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
            $table->tinyInteger('disposition')->default(UserRegistrationRequestDispositionEnum::PENDING);
            $table->timestamps();
        });
    }

    public function down(): void
    {
        Schema::dropIfExists('user_registration_requests');
    }
};
```

This throws an exception.

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/42181698/227724914-0165172a-8cd1-4854-b72f-fa379e25945e.png">

Enums do not have a `__toString()` method, so the attempt to cast fails.

The current workaround is use the enum's value:
```php
$table->tinyInteger('disposition')->default(UserRegistrationRequestDispositionEnum::PENDING->value);
```

## Solution
Initially I thought to rely on the `InteractsWithDictionary@getDictionaryKey()` because it already handles this UnitEnum/BackedEnum juggling, however, I ended up splitting the enum juggling to a separate function.

## Other Thoughts
Maybe this should be a global helper function (`getEnumValue()`) instead of embedded within a trait?