### PR TITLE
[10.x] Add `JoinMany` and `JoinOne` methods for joining Models to Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Eloquent\Concerns\JoinsModels;
 use Illuminate\Database\Eloquent\Concerns\QueriesRelationships;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -29,7 +30,7 @@ use ReflectionMethod;
  */
 class Builder implements BuilderContract
 {
-    use BuildsQueries, ForwardsCalls, QueriesRelationships {
+    use BuildsQueries, ForwardsCalls, QueriesRelationships, JoinsModels {
         BuildsQueries::sole as baseSole;
     }
 
@@ -1288,6 +1289,13 @@ class Builder implements BuilderContract
         }
 
         return $builder;
+    }
+
+    /**
+     * @return array<Scope>
+     */
+    public function getScopes(): array {
+        return $this->scopes;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -62,7 +62,7 @@ trait HasGlobalScopes
     /**
      * Get the global scopes for this class instance.
      *
-     * @return array
+     * @return array<Scope>
      */
     public function getGlobalScopes()
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/JoinsModels.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/JoinsModels.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Str;
+
+trait JoinsModels
+{
+    /**
+     * @param class-string<Model>|Model|Builder<Model> $model
+     * @param string $joinType
+     * @param string|null $overrideJoinColumnName
+     * @return static
+     */
+    public function joinMany($model, string $joinType = 'inner', ?string $overrideJoinColumnName = null): static  {
+        $modelToJoin = is_string($model) ? new $model() : $model;
+        if($model instanceof Builder){
+            $scopes = $model->getScopes();
+            $modelToJoin = $model->getModel();
+        } else {
+            $scopes = $modelToJoin->getGlobalScopes();
+        }
+
+        $this->joinManyOn($this->getModel(), $modelToJoin, $joinType,null, $overrideJoinColumnName);
+        $this->applyScopesWith($scopes, $modelToJoin);
+
+        return $this;
+    }
+
+    /**
+     * @param class-string|Model $model
+     * @param string $joinType
+     * @param string|null $overrideBaseColumn
+     * @return static
+     */
+    public function joinOne($model, string $joinType = 'inner', ?string $overrideBaseColumn = null): static {
+        $modelToJoin = is_string($model) ? new $model() : $model;
+        if($model instanceof Builder){
+            $scopes = $model->getScopes();
+            $modelToJoin = $model->getModel();
+        } else {
+            $scopes = $modelToJoin->getGlobalScopes();
+        }
+        $this->joinOneOn($this->getModel(), $modelToJoin, $joinType, $overrideBaseColumn);
+        $this->applyScopesWith($scopes, $modelToJoin);
+
+        return $this;
+    }
+
+
+    private function joinManyOn(Model $baseModel, Model $modelToJoin, ?string $joinType = 'inner', ?string $overrideBaseColumnName = null, ?string $overrideJoinColumnName = null): static
+    {
+        $manyJoinColumnName = $overrideJoinColumnName ?? (Str::singular($baseModel->getTable()). '_' . $baseModel->getKeyName());
+        return $this->join(
+            $modelToJoin->getTable(),
+            $modelToJoin->qualifyColumn($manyJoinColumnName),
+            '=',
+            $baseModel->qualifyColumn($overrideBaseColumnName ?? $baseModel->getKeyName()),
+            $joinType
+        );
+    }
+
+    private function joinOneOn(Model $baseModel, Model $modelToJoin, string $joinType = 'inner', string $overrideBaseColumnName = null, string $overrideJoinColumnName = null): static
+    {
+        $manyJoinColumnName = $overrideBaseColumnName ?? (Str::singular($modelToJoin->getTable()). '_' . $modelToJoin->getKeyName());
+        return $this->join(
+            $modelToJoin->getTable(),
+            $modelToJoin->qualifyColumn($overrideJoinColumnName ?? $modelToJoin->getKeyName()),
+            '=',
+            $baseModel->qualifyColumn($manyJoinColumnName),
+            $joinType
+        );
+    }
+
+    /**
+     * @param Scope $scopes
+     * @param Model $model
+     * @return static
+     */
+    private function applyScopesWith(array $scopes, Model $model): static
+    {
+        foreach($scopes as $scope){
+            $scope->apply($this, $model);
+        }
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/JoinsModels.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/JoinsModels.php
@@ -32,7 +32,7 @@ trait JoinsModels
     }
 
     /**
-     * @param class-string|Model $model
+     * @param class-string|Model|Builder<Model> $model
      * @param string $joinType
      * @param string|null $overrideBaseColumn
      * @return static

--- a/src/Illuminate/Database/Eloquent/Concerns/JoinsModels.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/JoinsModels.php
@@ -73,7 +73,7 @@ trait JoinsModels
     {
         $modelToJoin = $builderToJoin->getModel();
         $joinColumnName = $overrideBaseColumnName ?? $modelToJoin->getKeyName();
-        $baseColumnName = $overrideJoinColumnName ?? (Str::singular($baseModel->getTable()). '_' . $baseModel->getKeyName());
+        $baseColumnName = $overrideJoinColumnName ?? (Str::singular($modelToJoin->getTable()). '_' . $modelToJoin->getKeyName());
         $this->join(
             $modelToJoin->getTable(), fn(JoinClause $join) =>
                 $join->on(

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -149,7 +149,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The array of global scopes on the model.
      *
-     * @var array
+     * @var array<Scope>
      */
     protected static $globalScopes = [];
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -504,9 +504,10 @@ class Grammar extends BaseGrammar
         // Here we will calculate what portion of the string we need to remove. If this
         // is a join clause query, we need to remove the "on" portion of the SQL and
         // if it is a normal query we need to take the leading "where" of queries.
-        $offset = $query instanceof JoinClause ? 3 : 6;
+        $whereSql = $this->compileWheres($where['query']);
+        $offset = $query instanceof JoinClause  && str_starts_with($whereSql, 'on ') ? 3 : 6;
 
-        return '('.substr($this->compileWheres($where['query']), $offset).')';
+        return '('.substr($whereSql, $offset).')';
     }
 
     /**

--- a/tests/Database/DatabaseEloquentJoinsModelsTest.php
+++ b/tests/Database/DatabaseEloquentJoinsModelsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentJoinsModelsTest extends TestCase
+{
+    private DB $db;
+
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        $this->db = $db;
+    }
+    protected function tearDown(): void
+    {
+        \Mockery::close();
+    }
+    public function testJoinMany(){
+        $mock = \Mockery::mock(Builder::class, [$this->db->getDatabaseManager()->query()])->makePartial();
+        $mock->shouldReceive('join')->withArgs(['comments', 'comments.blog_id', '=', 'blogs.id', 'inner'])->andReturn($mock)->once();
+        $query =$mock->setModel(new Blog());
+        $query->joinMany(Comment::class);
+        \Mockery::close();
+    }
+
+    public function testJoinOne(){
+        $mock = \Mockery::mock(Builder::class, [$this->db->getDatabaseManager()->query()])->makePartial();
+        $mock->shouldReceive('join')->withArgs(['blogs', 'blogs.id', '=', 'comments.blog_id', 'inner'])->andReturn($mock)->once();
+        $query = $mock->setModel(new Comment());
+        $query->joinOne(Blog::class);
+        \Mockery::close();
+    }
+
+    public function testRunsScopes(){
+        $blog = new Blog();
+        $query = $blog->newQuery()->joinMany(DeletableComment::class)->toSql();
+        $this->assertSame('select * from "blogs" inner join "deletable_comments" on "deletable_comments"."blog_id" = "blogs"."id" where "deletable_comments"."deleted_at" is null', $query);
+    }
+
+    public function testCanJoinBuilder(){
+        $blog = new Blog();
+        $query = $blog->newQuery()->joinMany(DeletableComment::withTrashed())->toSql();
+        $this->assertSame('select * from "blogs" inner join "deletable_comments" on "deletable_comments"."blog_id" = "blogs"."id"', $query);
+    }
+
+    public function testAddWhereStatements(){
+        $blog = new Blog();
+        $query = $blog->newQuery()->joinMany(Comment::query()->whereNull('deleted_at'))->toSql();
+        $this->assertSame('select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id" where "comments"."deleted_at" is null', $query);
+    }
+}
+
+
+class Blog extends Model {}
+class Comment extends Model {}
+
+
+class DeletableComment extends Model {
+    use SoftDeletes;
+}

--- a/tests/Database/DatabaseEloquentJoinsModelsTest.php
+++ b/tests/Database/DatabaseEloquentJoinsModelsTest.php
@@ -31,35 +31,60 @@ class DatabaseEloquentJoinsModelsTest extends TestCase
     {
         \Mockery::close();
     }
-    public function testJoinMany(){
+    public function testJoinMany()
+    {
         $mock = \Mockery::mock(Builder::class, [$this->db->getDatabaseManager()->query()])->makePartial();
-        $mock->shouldReceive('join')->withArgs(['comments', 'comments.blog_id', '=', 'blogs.id', 'inner'])->andReturn($mock)->once();
+        $mock->shouldReceive('join')->withSomeOfArgs('comments')->andReturn($mock)->once();
         $query =$mock->setModel(new Blog());
         $query->joinMany(Comment::class);
         \Mockery::close();
     }
 
-    public function testJoinOne(){
+    public function testJoinOne()
+    {
         $mock = \Mockery::mock(Builder::class, [$this->db->getDatabaseManager()->query()])->makePartial();
-        $mock->shouldReceive('join')->withArgs(['blogs', 'blogs.id', '=', 'comments.blog_id', 'inner'])->andReturn($mock)->once();
+        $mock->shouldReceive('join')->withSomeOfArgs('blogs')->andReturn($mock)->once();
         $query = $mock->setModel(new Comment());
         $query->joinOne(Blog::class);
         \Mockery::close();
     }
 
-    public function testRunsScopes(){
+    public function testSimpleHasMany()
+    {
+        $blog = new Blog();
+        $query = $blog->newQuery()->joinMany(Comment::class)->toSql();
+        $this->assertSame('select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id"', $query);
+    }
+
+    public function testSimpleHasOne()
+    {
+        $query = (new Comment())->newQuery()->joinOne(Blog::class)->toSql();
+        $this->assertSame('select * from "comments" inner join "blogs" on "blogs"."id" = "comments"."blog_id"', $query);
+    }
+
+    public function testSimpleHasManyAlternativePrimaryKeyName()
+    {
+        $blog = new Alternative();
+        $query = $blog->newQuery()->joinMany(Blog::class)->toSql();
+        $this->assertSame('select * from "alternatives" inner join "blogs" on "blogs"."alternative_key" = "alternatives"."key"', $query);
+    }
+
+    public function testIncludeScopesInJoin()
+    {
         $blog = new Blog();
         $query = $blog->newQuery()->joinMany(DeletableComment::class)->toSql();
         $this->assertSame('select * from "blogs" inner join "deletable_comments" on "deletable_comments"."blog_id" = "blogs"."id" and ("deletable_comments"."deleted_at" is null)', $query);
     }
 
-    public function testCanJoinBuilder(){
+    public function testCanJoinBuilder()
+    {
         $blog = new Blog();
         $query = $blog->newQuery()->joinMany(DeletableComment::withTrashed())->toSql();
         $this->assertSame('select * from "blogs" inner join "deletable_comments" on "deletable_comments"."blog_id" = "blogs"."id"', $query);
     }
 
-    public function testAddWhereStatements(){
+    public function testAddWhereStatements()
+    {
         $blog = new Blog();
         $query = $blog->newQuery()->joinMany(Comment::query()->whereNull('comments.deleted_at'))->toSql();
         $this->assertSame('select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id" and ("comments"."deleted_at" is null)', $query);
@@ -73,4 +98,9 @@ class Comment extends Model {}
 
 class DeletableComment extends Model {
     use SoftDeletes;
+}
+
+class Alternative extends Model
+{
+    protected $primaryKey = 'key';
 }

--- a/tests/Database/DatabaseEloquentJoinsModelsTest.php
+++ b/tests/Database/DatabaseEloquentJoinsModelsTest.php
@@ -89,12 +89,23 @@ class DatabaseEloquentJoinsModelsTest extends TestCase
         $query = $blog->newQuery()->joinMany(Comment::query()->whereNull('comments.deleted_at'))->toSql();
         $this->assertSame('select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id" and ("comments"."deleted_at" is null)', $query);
     }
+
+    public function testAddingOnRelation()
+    {
+        $blog = new Blog();
+        $query = $blog->comments()->joinOne(User::class)->toSql();
+        $this->assertSame('select * from "comments" inner join "users" on "users"."id" = "comments"."user_id" where "comments"."blog_id" is null and "comments"."blog_id" is not null', $query);
+    }
 }
 
 
-class Blog extends Model {}
+class Blog extends Model {
+    public function comments(){
+        return $this->hasMany(Comment::class);
+    }
+}
 class Comment extends Model {}
-
+class User extends Model {}
 
 class DeletableComment extends Model {
     use SoftDeletes;

--- a/tests/Database/DatabaseEloquentJoinsModelsTest.php
+++ b/tests/Database/DatabaseEloquentJoinsModelsTest.php
@@ -50,7 +50,7 @@ class DatabaseEloquentJoinsModelsTest extends TestCase
     public function testRunsScopes(){
         $blog = new Blog();
         $query = $blog->newQuery()->joinMany(DeletableComment::class)->toSql();
-        $this->assertSame('select * from "blogs" inner join "deletable_comments" on "deletable_comments"."blog_id" = "blogs"."id" where "deletable_comments"."deleted_at" is null', $query);
+        $this->assertSame('select * from "blogs" inner join "deletable_comments" on "deletable_comments"."blog_id" = "blogs"."id" and ("deletable_comments"."deleted_at" is null)', $query);
     }
 
     public function testCanJoinBuilder(){
@@ -61,8 +61,8 @@ class DatabaseEloquentJoinsModelsTest extends TestCase
 
     public function testAddWhereStatements(){
         $blog = new Blog();
-        $query = $blog->newQuery()->joinMany(Comment::query()->whereNull('deleted_at'))->toSql();
-        $this->assertSame('select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id" where "comments"."deleted_at" is null', $query);
+        $query = $blog->newQuery()->joinMany(Comment::query()->whereNull('comments.deleted_at'))->toSql();
+        $this->assertSame('select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id" and ("comments"."deleted_at" is null)', $query);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## How it works

With this Merge a Laravel developer can easily join models without needing to think every time how to join the columns names, as long as you use default laravel naming conventions. You can easily Join models on each other.

```php
class Blog extends Model {
    public function comments(){
        return $this->hasMany(Comment::class);
    }
}

class Comment extends Model {
}

Blog::query()->joinMany(Comment::class)->toSql();
// select * from "blogs"
// inner join "comments" on "comments"."blog_id" = "blogs"."id"
```

It also works with any scopes or where statements.
These will be added to the "on" part of the join to avoid having weird left or right joins. (otherwise if you left joins softdeletable models it would also remove also results that have a related soft deleted model and no other models connected. (in this case a blog with 1 deleted comment would not show up in the results). But that is not the case in this solution :) 

```php
class Blog extends Model {
    public function comments(){
        return $this->hasMany(Comment::class);
    }
}

class Comment extends Model {
    use SoftDeletes
}

Blog::query()->joinMany(Comment::class)->toSql();
// select * from "blogs"
// inner join "comments" on "comments"."blog_id" = "blogs"."id" and "comments"."deleted_at" is null
```

Example with where statement

```php

Blog::query()->joinMany(Comment::query()->where('comments.created_at', '>', '2022-01-01')->toSql();
// select * from "blogs"
// inner join "comments" on "comments"."blog_id" = "blogs"."id" and "comments"."deleted_at" is null and "comments"."created_at" > ?
```

It also works when a relation is the base query:

```php
(new Blog)->comments()->joinOne(User::query()->toSql();
// select * from "comments" inner join "users" on "users"."id" = "comments"."user_id" where "comments"."blog_id" = ? and "comments"."blog_id" is not null
```

### Edge cases

* It currently doesn't work ideally with relations query builder (see below). Although you can join on one you cannot use one in the join as it would add additional constraints.
* Not supported are database/Builder of this moment, i could support it using the "from" table name and singularize it. It's something i would like to add in a followup PR.

## Considerations & future work

### Manually joining Relations

Joining relationships is much harder as it add would add the constraints automatically:

```php
(new Blog())->newQuery()->joinMany($blog->comments())->toSql();
/// select * from "blogs" inner join "comments" on "comments"."blog_id" = "blogs"."id" and ("comments"."blog_id" = ? and "comments"."blog_id" is not null)
```

You might expect to just join all comments instead of only joining the comments for the Blog model that you just created. 
But the problem is the "constraints" are added when making the Relationship, and this class has no control at this point.

To make this work Each relationship should either:
* Not add constraints directly but somehow afterwards, but i expect this would break to many other things
* Keep track of a second query builder that does not have the added contraints
* Or add an extra method "withoutConstraints()" that would remove the "wheres" added on the builder for this relationship. I didn't do enough research to see if this would work.
* Or not add the constraints if the "key" is `null` which happens when you instantiate the model yourself as i did in the example above. But i wonder if this might break anything.

**I would love to solve this with some help**

### Join relationships (future work)

In future work i would like to add a `joinRelation("name")`  

```php
class Blog extends Model {
    public function comments(){
        return $this->hasMany(Comment::class);
    }
}

class Comment extends Model {
    public function user(){
        return $this->belongsToOne(User::class);
    }
}

Blog::query()->joinRelations('comments.user')->toSql();
// select * from "blogs"
// inner join "comments" on "comments"."blog_id" = "blogs"."id"
// inner join "users" on "users"."id" = "comments"."user_id"
```

But there are many considerations here, perhaps ideally we would like to use a table aliases. to be able to join models of the same class. for example:

```php
class User extends Model {
    public function manager(){
        return $this->belongsToOne(User::class);
    }
}
User::query()->joinRelations('manager')->toSql();
// select * from "users"
// inner join "users" as "manager" on "manager"."user_id" = "users"."id"
```

This would need some extra work and some more research on my side.


### Database Builder (future work)

Technically joining a database

### Qualify all column names when joining:

When joining a query Builder it could be the query builder has where statements without qualified table names. This could lead to ambiguous column names.

Consider example below:

```php
Blog::query()->joinMany(Comment::query()->where('created_at', '>', '2022-01-01')->toSql();
// select * from "blogs"
// inner join "comments" on "comments"."blog_id" = "blogs"."id" and "comments"."deleted_at" is null and "created_at" > ?
```

it's unclear if "created_at" is from comments or Blog Table.

This problem also exists when you manually build your join query so i think this can be merged/used with keeping this limitation in mind.  Ideas:

* Ideally the query builder qualifies the name always but this would be a backwards in-compatible change.
* Alternatively all where statements could by qualified by the Model the moment it is joined into the base query.