### PR TITLE
Return `View` when `fragmentIf` condition isn't met

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -114,7 +114,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
             return $this->fragment($fragment);
         }
 
-        return $this->render();
+        return $this;
     }
 
     /**
@@ -130,7 +130,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
             return $this->fragments($fragments);
         }
 
-        return $this->render();
+        return $this;
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -106,7 +106,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      *
      * @param  bool  $boolean
      * @param  string  $fragment
-     * @return string
+     * @return string|\Illuminate\View\View
      */
     public function fragmentIf($boolean, $fragment)
     {
@@ -122,7 +122,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      *
      * @param  bool  $boolean
      * @param  array  $fragments
-     * @return string
+     * @return string|\Illuminate\View\View
      */
     public function fragmentsIf($boolean, array $fragments)
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using `fragmentIf` (or `fragmentsIf`) and ensuring that the condition isn't met, you're unable to use any `Illuminate\Testing\TestView` helpers as a `View` isn't returned.

I believe this is because the `fragmentIf` is currently returning the view content as a string instead of the `View` itself.

**Example of test which breaks:**

```
$this->get(route('example-route'))
    ->assertViewIs('example.index');
```

_Output:_
```
The response is not a view.
```
