### PR TITLE
[11.x] Add support for first-class callable syntax in `App::call(...)`

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -648,8 +648,8 @@ class Container implements ArrayAccess, ContainerContract
     {
         $pushedToBuildStack = false;
 
-        if (is_array($callback) && ! in_array(
-            $className = (is_string($callback[0]) ? $callback[0] : get_class($callback[0])),
+        if (($className = $this->getClassForCallable($callback)) && ! in_array(
+            $className,
             $this->buildStack,
             true
         )) {
@@ -665,6 +665,24 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         return $result;
+    }
+
+    /**
+     * Get the class name for the given callback, if one can be determined.
+     * 
+     * @param  callable|string  $callback
+     * @return string|false
+     */
+    protected function getClassForCallable($callback)
+    {
+        if (
+            is_callable($callback) &&
+            ! ($reflector = new \ReflectionFunction($callback(...)))->isAnonymous()
+        ) {
+            return $reflector->getClosureScopeClass()->name;
+        }
+        
+        return false;
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Container\Container as ContainerContract;
 use LogicException;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionFunction;
 use ReflectionParameter;
 use TypeError;
 
@@ -675,10 +676,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClassForCallable($callback)
     {
-        if (
-            is_callable($callback) &&
-            ! ($reflector = new \ReflectionFunction($callback(...)))->isAnonymous()
-        ) {
+        if (is_callable($callback) &&
+            ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
             return $reflector->getClosureScopeClass()->name ?? false;
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -679,7 +679,7 @@ class Container implements ArrayAccess, ContainerContract
             is_callable($callback) &&
             ! ($reflector = new \ReflectionFunction($callback(...)))->isAnonymous()
         ) {
-            return $reflector->getClosureScopeClass()->name;
+            return $reflector->getClosureScopeClass()->name ?? false;
         }
 
         return false;

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -669,7 +669,7 @@ class Container implements ArrayAccess, ContainerContract
 
     /**
      * Get the class name for the given callback, if one can be determined.
-     * 
+     *
      * @param  callable|string  $callback
      * @return string|false
      */
@@ -681,7 +681,7 @@ class Container implements ArrayAccess, ContainerContract
         ) {
             return $reflector->getClosureScopeClass()->name;
         }
-        
+
         return false;
     }
 

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -496,6 +496,10 @@ class ContextualBindingTest extends TestCase
         // array callable syntax...
         $valueResolvedUsingArraySyntax = $container->call([$object, 'method']);
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingArraySyntax);
+
+        // first class callable syntax...
+        $valueResolvedUsingFirstClassSyntax = $container->call($object->method(...));
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingFirstClassSyntax);
     }
 }
 

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -481,6 +481,22 @@ class ContextualBindingTest extends TestCase
         $this->assertSame('hunter42', $resolvedInstance->settings['password']);
         $this->assertSame('lumen', $resolvedInstance->settings['alias']);
     }
+
+    public function testContextualBindingWorksForMethodInvocation()
+    {
+        $container = new Container;
+
+        $container
+            ->when(ContainerTestContextInjectMethodArgument::class)
+            ->needs(IContainerContextContractStub::class)
+            ->give(ContainerContextImplementationStub::class);
+
+        $object = new ContainerTestContextInjectMethodArgument;
+
+        // array callable syntax...
+        $valueResolvedUsingArraySyntax = $container->call([$object, 'method']);
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingArraySyntax);
+    }
 }
 
 interface IContainerContextContractStub
@@ -618,5 +634,13 @@ class ContainerTestContextInjectFromConfigArray
     public function __construct($settings)
     {
         $this->settings = $settings;
+    }
+}
+
+class ContainerTestContextInjectMethodArgument
+{
+    public function method(IContainerContextContractStub $dependency)
+    {
+        return $dependency;
     }
 }


### PR DESCRIPTION
This PR addresses https://github.com/laravel/framework/issues/46587: contextual binding isn't resolved via `App::call(...)` when called using [first class callable syntax](https://www.php.net/manual/en/functions.first_class_callable_syntax.php) (`$object->methodName(...)`).

Aside from style fixes, the main commits are:

1. Addition of passing tests demonstrating that contextual binding _does_ work when using array syntax: `App::call([$object, 'methodName'])`
2. Addition of failing tests demonstrating that contextual binding is broken when using first class syntax: `App::call($object->methodName(...))`
3. Proposed fix to make the tests pass.

This would be my first contribution to this part of the framework. I have done my best to make the style conform with the surrounding code, but it may not be perfect.

I welcome any suggestions or instructions from the maintainers.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
