### PR TITLE
[10.x] Add getContainer method to router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1450,6 +1450,16 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Set the container instance used by the router.
+     *
+     * @return \Illuminate\Container\Container
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
      * Dynamically handle calls into the router instance.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1450,7 +1450,7 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * Set the container instance used by the router.
+     * Get the container instance used by the router.
      *
      * @return \Illuminate\Container\Container
      */


### PR DESCRIPTION
The Router instance's container can be set at any point using the `setContainer` method. It would be nice to have access to the container instance that is set to the router.

```php
Route::group(function (Router $router) {
    // Do something using the container
    $router->getContainer()->...; // it might be more convinient than using the App facade

    $router->get(...);
});
```