### PR TITLE
Add perSeconds methods to RateLimiting

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
+++ b/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
@@ -8,10 +8,10 @@ class GlobalLimit extends Limit
      * Create a new limit instance.
      *
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int|float  $decayMinutes
      * @return void
      */
-    public function __construct(int $maxAttempts, int $decayMinutes = 1)
+    public function __construct(int $maxAttempts, int|float $decayMinutes = 1)
     {
         parent::__construct('', $maxAttempts, $decayMinutes);
     }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -21,7 +21,7 @@ class Limit
     /**
      * The number of minutes until the rate limit is reset.
      *
-     * @var int
+     * @var int|float
      */
     public $decayMinutes;
 
@@ -37,10 +37,10 @@ class Limit
      *
      * @param  mixed  $key
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int|float  $decayMinutes
      * @return void
      */
-    public function __construct($key = '', int $maxAttempts = 60, int $decayMinutes = 1)
+    public function __construct($key = '', int $maxAttempts = 60, int|float $decayMinutes = 1)
     {
         $this->key = $key;
         $this->maxAttempts = $maxAttempts;
@@ -92,6 +92,18 @@ class Limit
     public static function perDay($maxAttempts, $decayDays = 1)
     {
         return new static('', $maxAttempts, 60 * 24 * $decayDays);
+    }
+
+    /**
+     * Create a new rate limit using seconds as decay time.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decaySeconds
+     * @return static
+     */
+    public static function perSeconds($maxAttempts, $decaySeconds)
+    {
+        return new static('', $maxAttempts, $decaySeconds / 60);
     }
 
     /**


### PR DESCRIPTION
This PR will add `perSeconds()` method to Laravel RateLimiting. Sometimes it needs to set a rate limit within a seconds. I have found myself using rate-limiting with seconds quite often, in API subscriptions to be precise.