### PR TITLE
[10.x] Add ability to set a custom class for the `AsCollection` and `AsEncryptedCollection` casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class AsCollection implements Castable
 {
@@ -31,6 +32,10 @@ class AsCollection implements Castable
                 $data = Json::decode($attributes[$key]);
 
                 $collectionClass = $this->arguments[0] ?? Collection::class;
+
+                if (! is_a($collectionClass, Collection::class, true)) {
+                    throw new InvalidArgumentException('The provided class must be a Collection');
+                }
 
                 return is_array($data) ? new $collectionClass($data) : null;
             }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class AsCollection implements Castable
 {
@@ -34,6 +35,10 @@ class AsCollection implements Castable
                 $data = Json::decode($attributes[$key]);
 
                 $collectionClass = $this->arguments[0] ?? Collection::class;
+
+                if (! is_subclass_of($collectionClass, Collection::class)) {
+                    throw new InvalidArgumentException('The provided class must be a Collection');
+                }
 
                 return is_array($data) ? new $collectionClass($data) : null;
             }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -18,11 +18,8 @@ class AsCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -34,7 +34,7 @@ class AsCollection implements Castable
                 $collectionClass = $this->arguments[0] ?? Collection::class;
 
                 if (! is_a($collectionClass, Collection::class, true)) {
-                    throw new InvalidArgumentException('The provided class must be a Collection');
+                    throw new InvalidArgumentException('The provided class must extend ['.Collection::class.']');
                 }
 
                 return is_array($data) ? new $collectionClass($data) : null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -16,8 +16,11 @@ class AsCollection implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
-        {
+        return new class($arguments[0] ?? Collection::class) implements CastsAttributes {
+            public function __construct(
+                protected string $collectionClass,
+            ) {}
+
             public function get($model, $key, $value, $attributes)
             {
                 if (! isset($attributes[$key])) {
@@ -26,7 +29,7 @@ class AsCollection implements Castable
 
                 $data = Json::decode($attributes[$key]);
 
-                return is_array($data) ? new Collection($data) : null;
+                return is_array($data) ? new $this->collectionClass($data) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -16,11 +16,13 @@ class AsCollection implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class($arguments[0] ?? Collection::class) implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
-            public function __construct(
-                protected string $collectionClass,
-            ) {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)
@@ -31,7 +33,9 @@ class AsCollection implements Castable
 
                 $data = Json::decode($attributes[$key]);
 
-                return is_array($data) ? new $this->collectionClass($data) : null;
+                $collectionClass = $this->arguments[0] ?? Collection::class;
+
+                return is_array($data) ? new $collectionClass($data) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
-use InvalidArgumentException;
 
 class AsCollection implements Castable
 {
@@ -35,10 +34,6 @@ class AsCollection implements Castable
                 $data = Json::decode($attributes[$key]);
 
                 $collectionClass = $this->arguments[0] ?? Collection::class;
-
-                if (! is_subclass_of($collectionClass, Collection::class)) {
-                    throw new InvalidArgumentException('The provided class must be a Collection');
-                }
 
                 return is_array($data) ? new $collectionClass($data) : null;
             }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -16,10 +16,12 @@ class AsCollection implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class($arguments[0] ?? Collection::class) implements CastsAttributes {
+        return new class($arguments[0] ?? Collection::class) implements CastsAttributes
+        {
             public function __construct(
                 protected string $collectionClass,
-            ) {}
+            ) {
+            }
 
             public function get($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -34,7 +34,7 @@ class AsCollection implements Castable
                 $collectionClass = $this->arguments[0] ?? Collection::class;
 
                 if (! is_a($collectionClass, Collection::class, true)) {
-                    throw new InvalidArgumentException('The provided class must extend ['.Collection::class.']');
+                    throw new InvalidArgumentException('The provided class must extend ['.Collection::class.'].');
                 }
 
                 return is_array($data) ? new $collectionClass($data) : null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
+use InvalidArgumentException;
 
 class AsEncryptedCollection implements Castable
 {
@@ -26,6 +27,10 @@ class AsEncryptedCollection implements Castable
             public function get($model, $key, $value, $attributes)
             {
                 $collectionClass = $this->arguments[0] ?? Collection::class;
+
+                if (! is_a($collectionClass, Collection::class, true)) {
+                    throw new InvalidArgumentException('The provided class must be a Collection');
+                }
 
                 if (isset($attributes[$key])) {
                     return new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -17,12 +17,21 @@ class AsEncryptedCollection implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class implements CastsAttributes
+        return new class($arguments) implements CastsAttributes
         {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
             public function get($model, $key, $value, $attributes)
             {
+                $collectionClass = $this->arguments[0] ?? Collection::class;
+
                 if (isset($attributes[$key])) {
-                    return new Collection(Json::decode(Crypt::decryptString($attributes[$key])));
+                    return new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -29,7 +29,7 @@ class AsEncryptedCollection implements Castable
                 $collectionClass = $this->arguments[0] ?? Collection::class;
 
                 if (! is_a($collectionClass, Collection::class, true)) {
-                    throw new InvalidArgumentException('The provided class must extend ['.Collection::class.']');
+                    throw new InvalidArgumentException('The provided class must extend ['.Collection::class.'].');
                 }
 
                 if (isset($attributes[$key])) {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
+use InvalidArgumentException;
 
 class AsEncryptedCollection implements Castable
 {
@@ -29,6 +30,10 @@ class AsEncryptedCollection implements Castable
             public function get($model, $key, $value, $attributes)
             {
                 $collectionClass = $this->arguments[0] ?? Collection::class;
+
+                if (! is_subclass_of($collectionClass, Collection::class)) {
+                    throw new InvalidArgumentException('The provided class must be a Collection');
+                }
 
                 if (isset($attributes[$key])) {
                     return new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -29,7 +29,7 @@ class AsEncryptedCollection implements Castable
                 $collectionClass = $this->arguments[0] ?? Collection::class;
 
                 if (! is_a($collectionClass, Collection::class, true)) {
-                    throw new InvalidArgumentException('The provided class must be a Collection');
+                    throw new InvalidArgumentException('The provided class must extend ['.Collection::class.']');
                 }
 
                 if (isset($attributes[$key])) {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -19,11 +19,8 @@ class AsEncryptedCollection implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected $arguments;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->arguments = $arguments;
             }
 
             public function get($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
-use InvalidArgumentException;
 
 class AsEncryptedCollection implements Castable
 {
@@ -30,10 +29,6 @@ class AsEncryptedCollection implements Castable
             public function get($model, $key, $value, $attributes)
             {
                 $collectionClass = $this->arguments[0] ?? Collection::class;
-
-                if (! is_subclass_of($collectionClass, Collection::class)) {
-                    throw new InvalidArgumentException('The provided class must be a Collection');
-                }
 
                 if (isset($attributes[$key])) {
                     return new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));


### PR DESCRIPTION
Example:
```php
protected $casts = [
    'elements' => AsCollection::class.':'.ElementCollection::class,
    // or
    'elements' => AsEncryptedCollection::class.':'.ElementCollection::class,
];
```


(In a similar way to `AsEnumCollection`)

```php
protected $casts = [
    'statuses' => AsEnumCollection::class.':'.ServerStatus::class,
];
```