### PR TITLE
[10.x] Correct password generation

### DIFF
--- a/src/Illuminate/Support/Exceptions/PasswordInvalidArgumentsException.php
+++ b/src/Illuminate/Support/Exceptions/PasswordInvalidArgumentsException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Support\Exceptions;
+
+use RuntimeException;
+
+class PasswordInvalidArgumentsException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Support/Exceptions/PasswordInvalidLengthArgument.php
+++ b/src/Illuminate/Support/Exceptions/PasswordInvalidLengthArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Support\Exceptions;
+
+use RuntimeException;
+
+class PasswordInvalidLengthArgument extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Support/Password.php
+++ b/src/Illuminate/Support/Password.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Exception;
+use Illuminate\Support\Exceptions\PasswordInvalidArgumentsException;
+use Illuminate\Support\Exceptions\PasswordInvalidLengthArgument;
+
+class Password
+{
+    /**
+     * Password length.
+     *
+     * @var int
+     */
+    protected int $length = 32;
+
+    /**
+     * Using letters.
+     *
+     * @var bool
+     */
+    protected bool $withLetters = true;
+
+    /**
+     * Using numbers.
+     *
+     * @var bool
+     */
+    protected bool $withNumbers = true;
+
+    /**
+     * Using special symbols.
+     *
+     * @var bool
+     */
+    protected bool $withSymbols = true;
+
+    /**
+     * Using spaces.
+     *
+     * @var bool
+     */
+    protected bool $withSpaces = false;
+
+    /**
+     * Valid letters.
+     *
+     * @var string[]
+     */
+    protected array $allowedLetters = [
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+        'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+        'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
+        'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+        'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    ];
+
+    /**
+     * Valid numbers.
+     *
+     * @var string[]
+     */
+    protected array $allowedNumbers = [
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    ];
+
+    /**
+     * Valid special symbols.
+     *
+     * @var string[]
+     */
+    protected array $allowedSymbols = [
+        '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
+        '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
+        ']', '|', ':', ';',
+    ];
+
+    /**
+     * Setting the length.
+     *
+     * @param  int  $length
+     * @return $this
+     */
+    public function setLength(int $length): self
+    {
+        $this->length = $length;
+
+        return $this;
+    }
+
+    /**
+     * Setting the flag for using letters.
+     *
+     * @param  bool  $withLetters
+     * @return $this
+     */
+    public function withLetters(bool $withLetters): self
+    {
+        $this->withLetters = $withLetters;
+
+        return $this;
+    }
+
+    /**
+     * Setting the flag for using numbers.
+     *
+     * @param  bool  $withNumbers
+     * @return $this
+     */
+    public function withNumbers(bool $withNumbers): self
+    {
+        $this->withNumbers = $withNumbers;
+
+        return $this;
+    }
+
+    /**
+     * Setting the flag for using special symbols.
+     *
+     * @param  bool  $withSymbols
+     * @return $this
+     */
+    public function withSymbols(bool $withSymbols): self
+    {
+        $this->withSymbols = $withSymbols;
+
+        return $this;
+    }
+
+    /**
+     * @param  bool  $withSpaces
+     * @return $this
+     */
+    public function withSpaces(bool $withSpaces): self
+    {
+        $this->withSpaces = $withSpaces;
+
+        return $this;
+    }
+
+    /**
+     * Setting valid letters.
+     *
+     * @param  string[]  $letters
+     * @return $this
+     */
+    public function allowedLetters(array $letters): self
+    {
+        $this->allowedLetters = $letters;
+
+        return $this;
+    }
+
+    /**
+     * Setting valid numbers.
+     *
+     * @param  string[]  $numbers
+     * @return $this
+     */
+    public function allowedNumbers(array $numbers): self
+    {
+        $this->allowedNumbers = $numbers;
+
+        return $this;
+    }
+
+    /**
+     * Setting valid special symbols.
+     *
+     * @param  string[]  $symbols
+     * @return $this
+     */
+    public function allowedSymbols(array $symbols): self
+    {
+        $this->allowedSymbols = $symbols;
+
+        return $this;
+    }
+
+    /**
+     * Generate password.
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function build(): string
+    {
+        $minLength = (int) $this->withLetters +
+            (int) $this->withNumbers +
+            (int) $this->withSymbols +
+            (int) $this->withSpaces;
+
+        if ($this->length < $minLength) {
+            throw new PasswordInvalidLengthArgument(
+                sprintf('Minimum password length must be %d characters', $minLength)
+            );
+        }
+
+        $letters = $this->allowedLetters;
+        $numbers = $this->allowedNumbers;
+        $symbols = $this->allowedSymbols;
+
+        $combination = (new Collection)
+            ->when($this->withLetters, fn ($c) => $c->merge($letters))
+            ->when($this->withNumbers, fn ($c) => $c->merge($numbers))
+            ->when($this->withSymbols, fn ($c) => $c->merge($symbols));
+
+        if ($combination->count() === 0) {
+            throw new PasswordInvalidArgumentsException('Not a valid set of parameters for generating a password');
+        }
+
+        $chars = new Collection();
+        while ($chars->count() < $this->length) {
+            $chars = $chars->merge($combination);
+        }
+
+        return $chars
+            ->shuffle()
+            ->take($this->length)
+            ->when($this->withLetters, fn ($c) => $c->splice(1)->merge($letters[array_rand($letters)]))
+            ->when($this->withNumbers, fn ($c) => $c->splice(1)->merge($numbers[array_rand($numbers)]))
+            ->when($this->withSymbols, fn ($c) => $c->splice(1)->merge($symbols[array_rand($symbols)]))
+            ->when($this->withSpaces, function ($c) use ($minLength) {
+                $count = random_int(1, max(1, intval(($this->length - 2) / $minLength)));
+                $result = $c->slice($count);
+
+                for ($i = 0; $i < $count; $i++) {
+                    $pos = random_int(1, max(1, $result->count() - 2));
+                    $result = $result
+                        ->slice(0, $pos)
+                        ->add(' ')
+                        ->merge($result->slice($pos));
+                }
+
+                return $result;
+            })
+            ->implode('');
+    }
+}

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -773,25 +773,13 @@ class Str
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {
-        return (new Collection)
-                ->when($letters, fn ($c) => $c->merge([
-                    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-                    'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                    'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-                    'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
-                    'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-                ]))
-                ->when($numbers, fn ($c) => $c->merge([
-                    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-                ]))
-                ->when($symbols, fn ($c) => $c->merge([
-                    '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
-                    '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
-                    ']', '|', ':', ';',
-                ]))
-                ->when($spaces, fn ($c) => $c->merge([' ']))
-                ->pipe(fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)]))
-                ->implode('');
+        return (new Password())
+            ->setLength($length)
+            ->withLetters($letters)
+            ->withNumbers($numbers)
+            ->withSymbols($symbols)
+            ->withSpaces($spaces)
+            ->build();
     }
 
     /**

--- a/tests/Support/SupportPasswordTest.php
+++ b/tests/Support/SupportPasswordTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Exceptions\PasswordInvalidArgumentsException;
+use Illuminate\Support\Exceptions\PasswordInvalidLengthArgument;
+use Illuminate\Support\Password;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+
+class SupportPasswordTest extends TestCase
+{
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function dataProviderPasswordCreation(): array
+    {
+        return [
+            'invalid arguments' => [
+                'length' => 16,
+                'withLetters' => false,
+                'withNumbers' => false,
+                'withSymbols' => false,
+                'withSpaces' => false,
+                'exception' => PasswordInvalidArgumentsException::class,
+            ],
+            'invalid length argument 1' => [
+                'length' => 1,
+                'withLetters' => true,
+                'withNumbers' => true,
+                'withSymbols' => false,
+                'withSpaces' => false,
+                'exception' => PasswordInvalidLengthArgument::class,
+            ],
+            'invalid length argument 2' => [
+                'length' => 2,
+                'withLetters' => true,
+                'withNumbers' => true,
+                'withSymbols' => true,
+                'withSpaces' => false,
+                'exception' => PasswordInvalidLengthArgument::class,
+            ],
+            'invalid length argument 3' => [
+                'length' => 3,
+                'withLetters' => true,
+                'withNumbers' => true,
+                'withSymbols' => true,
+                'withSpaces' => true,
+                'exception' => PasswordInvalidLengthArgument::class,
+            ],
+            'only letters' => [
+                'length' => 16,
+                'withLetters' => true,
+                'withNumbers' => false,
+                'withSymbols' => false,
+                'withSpaces' => false,
+                'exception' => null,
+            ],
+            'only numbers' => [
+                'length' => 16,
+                'withLetters' => false,
+                'withNumbers' => true,
+                'withSymbols' => false,
+                'withSpaces' => false,
+                'exception' => null,
+            ],
+            'only symbols' => [
+                'length' => 16,
+                'withLetters' => false,
+                'withNumbers' => false,
+                'withSymbols' => true,
+                'withSpaces' => false,
+                'exception' => null,
+            ],
+            'only letters with spaces' => [
+                'length' => 16,
+                'withLetters' => true,
+                'withNumbers' => false,
+                'withSymbols' => false,
+                'withSpaces' => true,
+                'exception' => null,
+            ],
+            'only numbers with spaces' => [
+                'length' => 16,
+                'withLetters' => false,
+                'withNumbers' => true,
+                'withSymbols' => false,
+                'withSpaces' => true,
+                'exception' => null,
+            ],
+            'only symbols with spaces' => [
+                'length' => 16,
+                'withLetters' => false,
+                'withNumbers' => false,
+                'withSymbols' => true,
+                'withSpaces' => true,
+                'exception' => null,
+            ],
+            'letters and numbers and symbols' => [
+                'length' => 16,
+                'withLetters' => true,
+                'withNumbers' => true,
+                'withSymbols' => true,
+                'withSpaces' => false,
+                'exception' => null,
+            ],
+            'letters and numbers and symbols with spaces' => [
+                'length' => 16,
+                'withLetters' => true,
+                'withNumbers' => true,
+                'withSymbols' => true,
+                'withSpaces' => true,
+                'exception' => null,
+            ],
+            'short password' => [
+                'length' => 1,
+                'withLetters' => true,
+                'withNumbers' => false,
+                'withSymbols' => false,
+                'withSpaces' => false,
+                'exception' => null,
+            ],
+            'long password' => [
+                'length' => 2048,
+                'withLetters' => true,
+                'withNumbers' => true,
+                'withSymbols' => true,
+                'withSpaces' => true,
+                'exception' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderPasswordCreation
+     *
+     * @return void
+     */
+    public function testPasswordCreation(
+        int $length,
+        bool $withLetters,
+        bool $withNumbers,
+        bool $withSymbols,
+        bool $withSpaces,
+        ?string $exception
+    ): void {
+        if ($exception !== null) {
+            $this->expectException($exception);
+        }
+
+        $generator = (new Password())
+            ->setLength($length)
+            ->withLetters($withLetters)
+            ->withNumbers($withNumbers)
+            ->withSymbols($withSymbols)
+            ->withSpaces($withSpaces);
+
+        $password = $generator->build();
+
+        $this->assertTrue(strlen($password) === $length);
+        $this->assertChars($generator, 'allowedLetters', $password, $withLetters);
+        $this->assertChars($generator, 'allowedNumbers', $password, $withNumbers);
+        $this->assertChars($generator, 'allowedSymbols', $password, $withSymbols);
+
+        $hasSpaces = Str::contains($password, ' ');
+        $this->assertThat($hasSpaces, $withSpaces ? $this->isTrue() : $this->isFalse());
+
+        $this->assertFalse(Str::substr($password, 0, 1) === ' ');
+        $this->assertFalse(Str::substr($password, Str::length($password) - 1, 1) === ' ');
+    }
+
+    /**
+     * @param  Password  $generator
+     * @param  string  $property
+     * @param  string  $password
+     * @param  bool  $with
+     * @return void
+     *
+     * @throws ReflectionException
+     */
+    private function assertChars(Password $generator, string $property, string $password, bool $with): void
+    {
+        $letters = $this->readProperty($generator, $property);
+        $hasLetters = preg_match('~['.preg_quote(implode('', $letters), '~').']~iu', $password) === 1;
+        $this->assertThat($hasLetters, $with ? $this->isTrue() : $this->isFalse());
+    }
+
+    /**
+     * @param  Password  $generator
+     * @param  string  $property
+     * @return string[]
+     *
+     * @throws ReflectionException
+     */
+    private function readProperty(Password $generator, string $property): array
+    {
+        $reflectedClass = new ReflectionClass($generator);
+        $reflection = $reflectedClass->getProperty($property);
+
+        return $reflection->getValue($generator);
+    }
+}


### PR DESCRIPTION
The current implementation of password generation does not work correctly:

- allows spaces around the edges and a password consisting entirely of spaces;
- when specifying several parameters (letters, numbers, special characters), most people (according to my survey) expect that they will be present in the password, but this is not so;
- there is no way to expand / compress the allowed sets of letters, numbers or special characters.

I propose an implementation that does not break the current interface, but solves the problems described above.
