### PR TITLE
[10.x] Move SetUniqueIds to run before the creating event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1279,7 +1279,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if ($this->usesUniqueIds()) {
             $this->setUniqueIds();
         }
-        
+
         if ($this->fireModelEvent('creating') === false) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1276,6 +1276,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function performInsert(Builder $query)
     {
+        if ($this->usesUniqueIds()) {
+            $this->setUniqueIds();
+        }
+        
         if ($this->fireModelEvent('creating') === false) {
             return false;
         }
@@ -1285,10 +1289,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // convenience. After, we will just continue saving these model instances.
         if ($this->usesTimestamps()) {
             $this->updateTimestamps();
-        }
-
-        if ($this->usesUniqueIds()) {
-            $this->setUniqueIds();
         }
 
         // If the model has an incrementing key, we can use the "insertGetId" method on


### PR DESCRIPTION
This fixes a BC caused by PR #46161 reported in https://github.com/laravel/framework/pull/46161#issuecomment-1487489163

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
