### PR TITLE
[10.x] Add support for `Attribute` union return types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2211,8 +2211,9 @@ trait HasAttributes
     }
 
     /**
-     * Determine if a "Attribute" return type exists for an attribute.
+     * Determine if an attribute return type exists for an attribute.
      *
+     * @param  object  $instance
      * @param  string  $method
      * @return bool
      */
@@ -2220,7 +2221,8 @@ trait HasAttributes
     {
         $returnType = (new ReflectionMethod($instance, $method))->getReturnType();
 
-        if ($returnType instanceof ReflectionNamedType && $returnType->getName() === Attribute::class) {
+        if ($returnType instanceof ReflectionNamedType &&
+            $returnType->getName() === Attribute::class) {
             return true;
         }
 

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -13,6 +13,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $instance = new HasAttributesWithoutConstructor();
         $attributes = $instance->getMutatedAttributes();
         $this->assertEquals(['some_attribute'], $attributes);
+        $this->assertEquals('some_value', $instance->getAttribute('some_attribute'));
     }
 
     public function testWithConstructorArguments()
@@ -20,6 +21,16 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $instance = new HasAttributesWithConstructorArguments(null);
         $attributes = $instance->getMutatedAttributes();
         $this->assertEquals(['some_attribute'], $attributes);
+        $this->assertEquals('some_value', $instance->getAttribute('some_attribute'));
+    }
+
+    public function testWithUnionReturnType()
+    {
+        $instance = new HasAttributesWithUnionReturnType();
+        $attributes = $instance->getMutatedAttributes();
+        $this->assertEquals(['some_attribute'], $attributes);
+        $this->assertEquals('some_value', $instance->getAttribute('some_attribute'));
+        $this->assertEquals('other_value', $instance->someAttribute(true));
     }
 }
 
@@ -30,6 +41,7 @@ class HasAttributesWithoutConstructor
     public function someAttribute(): Attribute
     {
         return new Attribute(function () {
+            return 'some_value';
         });
     }
 }
@@ -38,5 +50,21 @@ class HasAttributesWithConstructorArguments extends HasAttributesWithoutConstruc
 {
     public function __construct($someValue)
     {
+    }
+}
+
+class HasAttributesWithUnionReturnType
+{
+    use HasAttributes;
+
+    public function someAttribute(bool $someArgument = false): Attribute|string
+    {
+        if ($someArgument) {
+            return 'other_value';
+        }
+
+        return new Attribute(function () {
+            return 'some_value';
+        });
     }
 }


### PR DESCRIPTION
Attributes currently require `Attribute` be the only return type of the model method, supporting union types allows developers to replicate relationship-ish functionality in models.

Here's my use case, I have a attribute called `scholarships`, and I want to be able to optionally call the method and pass arguments in to get a subset of my dataset, similar to how you might use a `BelongsToMany`:

```php
<?php

namespace App\Concerns;

use App\Support\Dataset;
use Illuminate\Database\Eloquent\Casts\Attribute;
use Illuminate\Support\Collection;

trait HasScholarships
{
    public function scholarships(int $first_year = null, int $last_year = null): Attribute|Collection
    {
        if (func_get_args()) {
            return Dataset::scholarships(...func_get_args(), school: $this);
        }

        return Attribute::make(fn () => Dataset::scholarships(school: $this));
    }
}
```

This allows me to continue using `$school->scholarships` as I already am currently, and adds support for using the method directly to retrieve a subset of the data via `$school->scholarships(2019, 2021)`.

The idea here is it gives me a fluent api similar to how relationships work where the attribute returns the data and calling the method returns the query builder.