### PR TITLE
[10.x] Improves `trait_uses_recursive` docblock

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -357,7 +357,7 @@ if (! function_exists('trait_uses_recursive')) {
     /**
      * Returns all traits used by a trait and its traits.
      *
-     * @param  string  $trait
+     * @param  object|string  $trait
      * @return array
      */
     function trait_uses_recursive($trait)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/172966/228508745-c41d91d7-1efe-4cbd-a847-e4722cce88a0.png)

It should be possible since the following line would use [`class_uses`](https://www.php.net/manual/en/function.class-uses.php)