### PR TITLE
[10.x] Edit about console output of synchronous running jobs

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -168,20 +168,27 @@ class WorkCommand extends Command
     protected function listenForEvents()
     {
         $this->laravel['events']->listen(JobProcessing::class, function ($event) {
-            $this->writeOutput($event->job, 'starting');
+            if ($event->connectionName != 'sync') {
+                $this->writeOutput($event->job, 'starting');
+            }
         });
 
         $this->laravel['events']->listen(JobProcessed::class, function ($event) {
-            $this->writeOutput($event->job, 'success');
+            if ($event->connectionName != 'sync') {
+                $this->writeOutput($event->job, 'success');
+            }
         });
 
         $this->laravel['events']->listen(JobReleasedAfterException::class, function ($event) {
-            $this->writeOutput($event->job, 'released_after_exception');
+            if ($event->connectionName != 'sync') {
+                $this->writeOutput($event->job, 'released_after_exception');
+            }
         });
 
         $this->laravel['events']->listen(JobFailed::class, function ($event) {
-            $this->writeOutput($event->job, 'failed');
-
+            if ($event->connectionName != 'sync') {
+                $this->writeOutput($event->job, 'failed');
+            }
             $this->logFailedJob($event);
         });
     }


### PR DESCRIPTION
In some cases, synchronous jobs can produce confusing console output. 
In the example below, I realized that a second job running synchronously within a job is actually producing output that shouldn't be there. These two jobs need to run in two different queues if they are not to run synchronously.

![examplejob](https://user-images.githubusercontent.com/3818747/228754512-9868901a-c0fc-4b73-bc40-6a48c469fa86.JPG)
![examplejob2](https://user-images.githubusercontent.com/3818747/228754556-d455daeb-9183-4909-a284-459ab09e615a.JPG)

The output I expect when only the "queue1" queue is listened is as follows.
![beklenen](https://user-images.githubusercontent.com/3818747/228754743-c036c441-57ed-4a20-afd3-44ee5f93cbb1.JPG)

But it continues to produce output in synchronous jobs.

![jobs_outputs](https://user-images.githubusercontent.com/3818747/228754939-d1d69489-52da-4582-a776-0a3cd37666df.JPG)
