### PR TITLE
[10.x] Add `withConsoleEvents()` testing helper

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -93,4 +93,14 @@ trait InteractsWithConsole
 
         return $this;
     }
+
+    /**
+     * Enable rerouting Symfony command events on tests.
+     *
+     * @return $this
+     */
+    protected function withRerouteSymfonyCommandEvents()
+    {
+        $this->app[Kernel::class]->rerouteSymfonyCommandEvents();
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -99,7 +99,7 @@ trait InteractsWithConsole
      *
      * @return $this
      */
-    protected function withRerouteSymfonyCommandEvents()
+    protected function withCommandEvents()
     {
         $this->app[Kernel::class]->rerouteSymfonyCommandEvents();
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -99,7 +99,7 @@ trait InteractsWithConsole
      *
      * @return $this
      */
-    protected function withCommandEvents()
+    protected function withConsoleEvents()
     {
         $this->app[Kernel::class]->rerouteSymfonyCommandEvents();
     }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -275,5 +275,7 @@ class FoundationHelpersTest extends TestCase
 
         // Should fallback to en_US
         $this->assertSame('Australian Capital Territory', fake()->state());
+
+        app()->flush();
     }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -241,41 +241,4 @@ class FoundationHelpersTest extends TestCase
 
         $this->assertSame('expected', mix('asset.png'));
     }
-
-    public function testFakeReturnsSameInstance()
-    {
-        app()->instance('config', new ConfigRepository([]));
-
-        $this->assertSame(fake(), fake());
-        $this->assertSame(fake(), fake('en_US'));
-        $this->assertSame(fake('en_AU'), fake('en_AU'));
-        $this->assertNotSame(fake('en_US'), fake('en_AU'));
-
-        app()->flush();
-    }
-
-    public function testFakeUsesLocale()
-    {
-        mt_srand(12345, MT_RAND_PHP);
-        app()->instance('config', new ConfigRepository([]));
-
-        // Should fallback to en_US
-        $this->assertSame('Arkansas', fake()->state());
-        $this->assertContains(fake('de_DE')->state(), [
-            'Baden-Württemberg', 'Bayern', 'Berlin', 'Brandenburg', 'Bremen', 'Hamburg', 'Hessen', 'Mecklenburg-Vorpommern', 'Niedersachsen', 'Nordrhein-Westfalen', 'Rheinland-Pfalz', 'Saarland', 'Sachsen', 'Sachsen-Anhalt', 'Schleswig-Holstein', 'Thüringen',
-        ]);
-        $this->assertContains(fake('fr_FR')->region(), [
-            'Auvergne-Rhône-Alpes', 'Bourgogne-Franche-Comté', 'Bretagne', 'Centre-Val de Loire', 'Corse', 'Grand Est', 'Hauts-de-France',
-            'Île-de-France', 'Normandie', 'Nouvelle-Aquitaine', 'Occitanie', 'Pays de la Loire', "Provence-Alpes-Côte d'Azur",
-            'Guadeloupe', 'Martinique', 'Guyane', 'La Réunion', 'Mayotte',
-        ]);
-
-        app()->instance('config', new ConfigRepository(['app' => ['faker_locale' => 'en_AU']]));
-        mt_srand(4, MT_RAND_PHP);
-
-        // Should fallback to en_US
-        $this->assertSame('Australian Capital Territory', fake()->state());
-
-        app()->flush();
-    }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
-use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -118,20 +118,18 @@ class FoundationHelpersTest extends TestCase
 
     public function testFakeReturnsSameInstance()
     {
-        app()->instance('config', new ConfigRepository([]));
+        $this->instance('config', new ConfigRepository([]));
 
         $this->assertSame(fake(), fake());
         $this->assertSame(fake(), fake('en_US'));
         $this->assertSame(fake('en_AU'), fake('en_AU'));
         $this->assertNotSame(fake('en_US'), fake('en_AU'));
-
-        app()->flush();
     }
 
     public function testFakeUsesLocale()
     {
         mt_srand(12345, MT_RAND_PHP);
-        app()->instance('config', new ConfigRepository([]));
+        $this->instance('config', new ConfigRepository([]));
 
         // Should fallback to en_US
         $this->assertSame('Arkansas', fake()->state());
@@ -144,7 +142,7 @@ class FoundationHelpersTest extends TestCase
             'Guadeloupe', 'Martinique', 'Guyane', 'La Réunion', 'Mayotte',
         ]);
 
-        app()->instance('config', new ConfigRepository(['app' => ['faker_locale' => 'en_AU']]));
+        $this->instance('config', new ConfigRepository(['app' => ['faker_locale' => 'en_AU']]));
         mt_srand(4, MT_RAND_PHP);
 
         // Should fallback to en_US

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -116,6 +116,17 @@ class FoundationHelpersTest extends TestCase
         unlink($manifest);
     }
 
+    public function testFakeReturnsSameInstance()
+    {
+        app()->instance('config', new ConfigRepository([]));
+
+        $this->assertSame(fake(), fake());
+        $this->assertSame(fake(), fake('en_US'));
+        $this->assertSame(fake('en_AU'), fake('en_AU'));
+        $this->assertNotSame(fake('en_US'), fake('en_AU'));
+
+        app()->flush();
+    }
 
     public function testFakeUsesLocale()
     {

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Exception;
+use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
@@ -113,6 +114,30 @@ class FoundationHelpersTest extends TestCase
         $this->assertCount(1, $handler->reported);
 
         unlink($manifest);
+    }
+
+
+    public function testFakeUsesLocale()
+    {
+        mt_srand(12345, MT_RAND_PHP);
+        app()->instance('config', new ConfigRepository([]));
+
+        // Should fallback to en_US
+        $this->assertSame('Arkansas', fake()->state());
+        $this->assertContains(fake('de_DE')->state(), [
+            'Baden-Württemberg', 'Bayern', 'Berlin', 'Brandenburg', 'Bremen', 'Hamburg', 'Hessen', 'Mecklenburg-Vorpommern', 'Niedersachsen', 'Nordrhein-Westfalen', 'Rheinland-Pfalz', 'Saarland', 'Sachsen', 'Sachsen-Anhalt', 'Schleswig-Holstein', 'Thüringen',
+        ]);
+        $this->assertContains(fake('fr_FR')->region(), [
+            'Auvergne-Rhône-Alpes', 'Bourgogne-Franche-Comté', 'Bretagne', 'Centre-Val de Loire', 'Corse', 'Grand Est', 'Hauts-de-France',
+            'Île-de-France', 'Normandie', 'Nouvelle-Aquitaine', 'Occitanie', 'Pays de la Loire', "Provence-Alpes-Côte d'Azur",
+            'Guadeloupe', 'Martinique', 'Guyane', 'La Réunion', 'Mayotte',
+        ]);
+
+        app()->instance('config', new ConfigRepository(['app' => ['faker_locale' => 'en_AU']]));
+        mt_srand(4, MT_RAND_PHP);
+
+        // Should fallback to en_US
+        $this->assertSame('Australian Capital Territory', fake()->state());
     }
 
     protected function makeManifest($directory = '')


### PR DESCRIPTION
Make it easier to document testing console events since it is disabled by default when running tests.