### PR TITLE
[10.x] Collection `except()` method can accept a `string` value

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -356,7 +356,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string  $keys
      * @return static
      */
     public function except($keys)


### PR DESCRIPTION
I am doing something along the lines of this...

```php
collect($this->selected)->except('order')->count();
```

...but Larastan is complaining that a `string` can't be passed to the `except()` method, when in fact, it can.

