### PR TITLE
[10.x] Refactor `parseCasterClass()` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1670,9 +1670,7 @@ trait HasAttributes
      */
     protected function parseCasterClass($class)
     {
-        return ! str_contains($class, ':')
-            ? $class
-            : explode(':', $class, 2)[0];
+        return explode(':', $class)[0];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1670,7 +1670,7 @@ trait HasAttributes
      */
     protected function parseCasterClass($class)
     {
-        return explode(':', $class)[0];
+        return explode(':', $class, 2)[0];
     }
 
     /**


### PR DESCRIPTION
The updated version of the `parseCasterClas()` method avoids using `str_contains()` and instead uses `explode()` to split the string at the first occurrence of ':'. If ':' is not present, it returns the whole string, otherwise, it returns only the part before ':'.