### PR TITLE
[10.x] Fixes RateLimiter@limiter docblock

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -53,7 +53,7 @@ class RateLimiter
      * Get the given named rate limiter.
      *
      * @param  string  $name
-     * @return \Closure
+     * @return \Closure|null
      */
     public function limiter(string $name)
     {


### PR DESCRIPTION
`RateLimiter::limiter()` can return either a closure OR null (if key does not exist in array)