### PR TITLE
[10.x] Query builder `keyBy` functionality

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -120,6 +120,13 @@ class Connection implements ConnectionInterface
     protected $fetchMode = PDO::FETCH_OBJ;
 
     /**
+     * The fetch mode override for $statement->fetchAll() calls.
+     *
+     * @var int|null
+     */
+    protected $fetchAllMode;
+
+    /**
      * The number of active transactions.
      *
      * @var int
@@ -418,7 +425,7 @@ class Connection implements ConnectionInterface
 
             $statement->execute();
 
-            return $statement->fetchAll();
+            return $statement->fetchAll($this->fetchAllMode);
         });
     }
 
@@ -491,6 +498,20 @@ class Connection implements ConnectionInterface
         while ($record = $statement->fetch()) {
             yield $record;
         }
+    }
+
+    /**
+     * Set the fetch mode override for calling $statement->fetchAll().
+     *
+     * @param  int|null  $fetchAllMode
+     * @param  bool  $prepend
+     * @return $this
+     */
+    public function setFetchAllMode($fetchAllMode, $prepend = true)
+    {
+        $this->fetchAllMode = $fetchAllMode | ($prepend ? $this->fetchMode : 0);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -425,7 +425,11 @@ class Connection implements ConnectionInterface
 
             $statement->execute();
 
-            return $statement->fetchAll($this->fetchAllMode);
+            if (! is_null($this->fetchAllMode)) {
+                return $statement->fetchAll($this->fetchAllMode);
+            }
+
+            return $statement->fetchAll();
         });
     }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -507,13 +507,25 @@ class Connection implements ConnectionInterface
     /**
      * Set the fetch mode override for calling $statement->fetchAll().
      *
-     * @param  int|null  $fetchAllMode
+     * @param  int  $fetchAllMode
      * @param  bool  $prepend
      * @return $this
      */
     public function setFetchAllMode($fetchAllMode, $prepend = true)
     {
         $this->fetchAllMode = $fetchAllMode | ($prepend ? $this->fetchMode : 0);
+
+        return $this;
+    }
+
+    /**
+     * Reset the fetch mode override for calling $statement->fetchAll().
+     *
+     * @return $this
+     */
+    public function resetFetchAllMode()
+    {
+        $this->fetchAllMode = null;
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2741,8 +2741,8 @@ class Builder implements BuilderContract
      */
     protected function getKeyed($key, $columns = ['*'])
     {
-        return collect($this->onceWithColumns($this->qualifyStarColumns($columns), function () use ($key) {
-            $this->columns = Arr::prepend($this->columns, $key);
+        return collect($this->onceWithColumns(Arr::wrap($columns), function () use ($key) {
+            $this->columns = Arr::prepend($this->qualifyStarColumns($this->columns), $key);
 
             return $this->processor->processSelect($this, $this->runSelect(\PDO::FETCH_UNIQUE));
         }));

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2741,9 +2741,23 @@ class Builder implements BuilderContract
      */
     protected function getKeyed($key, $columns = ['*'])
     {
-        return collect($this->onceWithColumns(Arr::prepend(Arr::wrap($columns), $key), function () {
+        return collect($this->onceWithColumns(Arr::prepend($this->qualifyStarColumns($columns), $key), function () {
             return $this->processor->processSelect($this, $this->runSelect(\PDO::FETCH_UNIQUE));
         }));
+    }
+
+    /**
+     * Qualify columns with their table name if they have not been assigned.
+     * 
+     * @param  array|string  $columns
+     * @return array
+     */
+    protected function qualifyStarColumns($columns)
+    {
+        return array_map(
+            fn ($column) => $column === '*' ? $this->from.'.'.$column : $column,
+            Arr::wrap($columns)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2773,7 +2773,7 @@ class Builder implements BuilderContract
 
         return tap($this->connection->select(
             $this->toSql(), $this->getBindings(), ! $this->useWritePdo
-        ), fn () => $this->connection->setFetchAllMode(null, false)
+        ), fn () => ! is_null($fetchAllMode) ? $this->connection->setFetchAllMode(null, false) : null
         );
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2755,8 +2755,8 @@ class Builder implements BuilderContract
      *
      * After running the callback, the fetch mode is reverted.
      *
-     * @param $mode
-     * @param Closure $callback
+     * @param  int  $mode
+     * @param  Closure  $callback
      * @return \Illuminate\Support\HigherOrderTapProxy|mixed
      */
     protected function onceWithFetchAllMode($mode, Closure $callback)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2741,7 +2741,9 @@ class Builder implements BuilderContract
      */
     protected function getKeyed($key, $columns = ['*'])
     {
-        return collect($this->onceWithColumns(Arr::prepend($this->qualifyStarColumns($columns), $key), function () {
+        return collect($this->onceWithColumns($this->qualifyStarColumns($columns), function () use ($key) {
+            $this->columns = Arr::prepend($this->columns, $key);
+
             return $this->processor->processSelect($this, $this->runSelect(\PDO::FETCH_UNIQUE));
         }));
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2747,7 +2747,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Qualify columns with their table name if they have not been assigned.
+     * Qualify star columns with their table name if they have not been prefixed.
      *
      * @param  array|string  $columns
      * @return array
@@ -2763,6 +2763,7 @@ class Builder implements BuilderContract
     /**
      * Run the query as a "select" statement against the connection.
      *
+     * @param  int|null  $fetchAllMode
      * @return array
      */
     protected function runSelect($fetchAllMode = null)
@@ -2773,7 +2774,7 @@ class Builder implements BuilderContract
 
         return tap($this->connection->select(
             $this->toSql(), $this->getBindings(), ! $this->useWritePdo
-        ), fn () => ! is_null($fetchAllMode) ? $this->connection->setFetchAllMode(null, false) : null
+        ), fn () => ! is_null($fetchAllMode) ? $this->connection->resetFetchAllMode() : null
         );
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2748,7 +2748,7 @@ class Builder implements BuilderContract
 
     /**
      * Qualify columns with their table name if they have not been assigned.
-     * 
+     *
      * @param  array|string  $columns
      * @return array
      */

--- a/tests/Integration/Database/EloquentKeyByTest.php
+++ b/tests/Integration/Database/EloquentKeyByTest.php
@@ -3,9 +3,6 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Database\MultipleRecordsFoundException;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;

--- a/tests/Integration/Database/EloquentKeyByTest.php
+++ b/tests/Integration/Database/EloquentKeyByTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\MultipleRecordsFoundException;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentKeyByTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->string('address');
+        });
+
+        DB::table('users')->insert([
+            ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com', 'address' => '5th Avenue'],
+            ['name' => 'Lortay Wellot', 'email' => 'lortay@laravel.com', 'address' => '4th Street'],
+        ]);
+    }
+
+    /**
+     * @dataProvider keyByDataProvider
+     */
+    public function testKeyBy($keyBy, $columns, $key, $expected)
+    {
+        $this->assertEquals($expected, json_encode(UserKeyByTest::query()->keyBy($keyBy)->get($columns)[$key]));
+    }
+
+    public static function keyByDataProvider()
+    {
+        return [
+            'Key by name with all columns' => ['name', ['*'], 'Lortay Wellot', '{"id":2,"name":"Lortay Wellot","email":"lortay@laravel.com","address":"4th Street"}'],
+            'Key by name with selected columns not including key' => ['name', ['email', 'address'], 'Taylor Otwell', '{"email":"taylor@laravel.com","address":"5th Avenue"}'],
+            'Key by name with selected columns including key' => ['name', ['name', 'email', 'address'], 'Taylor Otwell', '{"name":"Taylor Otwell","email":"taylor@laravel.com","address":"5th Avenue"}'],
+            'Key by street with selected dot-columns not including key' => ['address', ['users.email'], '5th Avenue', '{"email":"taylor@laravel.com"}'],
+            'Key by street with selected dot-columns including key' => ['address', ['users.address', 'email'], '5th Avenue', '{"address":"5th Avenue","email":"taylor@laravel.com"}'],
+        ];
+    }
+
+    /**
+     * @dataProvider keyByWithSelectDataProvider
+     */
+    public function testKeyByWithSelect($keyBy, $columns, $key, $expected)
+    {
+        $results = UserKeyByTest::query()->keyBy($keyBy)->select($columns)->get();
+
+        $this->assertSame($expected, $results[$key]->getAttributes());
+    }
+
+    public static function keyByWithSelectDataProvider()
+    {
+        return [
+            // The "name" column is supposed to remain empty here since SELECT does not include an extra prepended keyBy column:
+            'SELECT without including extra keyBy column' => ['name', ['name', 'address'], 'Taylor Otwell', ['address' => '5th Avenue']],
+            // Since we prepend an extra "name" column here, we account for PDO to shift the first column as the array key:
+            'SELECT with including extra keyBy column' => ['name', ['name', 'name', 'address'], 'Taylor Otwell', ['name' => 'Taylor Otwell', 'address' => '5th Avenue']],
+        ];
+    }
+}
+
+class UserKeyByTest extends Model
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/EloquentKeyByTest.php
+++ b/tests/Integration/Database/EloquentKeyByTest.php
@@ -56,10 +56,8 @@ class EloquentKeyByTest extends DatabaseTestCase
     public static function keyByWithSelectDataProvider()
     {
         return [
-            // The "name" column is supposed to remain empty here since SELECT does not include an extra prepended keyBy column:
-            'SELECT without including extra keyBy column' => ['name', ['name', 'address'], 'Taylor Otwell', ['address' => '5th Avenue']],
-            // Since we prepend an extra "name" column here, we account for PDO to shift the first column as the array key:
-            'SELECT with including extra keyBy column' => ['name', ['name', 'name', 'address'], 'Taylor Otwell', ['name' => 'Taylor Otwell', 'address' => '5th Avenue']],
+            'keyBy column does not become part of the result if not SELECTed' => ['name', ['address'], 'Taylor Otwell', ['address' => '5th Avenue']],
+            'keyBy column becomes part of the result if SELECTed' => ['name', ['name', 'address'], 'Taylor Otwell', ['name' => 'Taylor Otwell', 'address' => '5th Avenue']],
         ];
     }
 }

--- a/tests/Integration/Database/QueryBuilderKeyByBench.php
+++ b/tests/Integration/Database/QueryBuilderKeyByBench.php
@@ -32,7 +32,7 @@ class QueryBuilderKeyByBench extends DatabaseTestCase
             $data[] = [
                 'title' => $i === $loc ? 'Foo Post' : $fake->title,
                 'content' => $fake->text(100),
-                'created_at' => new Carbon($fake->date('Y-m-d H:i:s'))
+                'created_at' => new Carbon($fake->date('Y-m-d H:i:s')),
             ];
         }
 

--- a/tests/Integration/Database/QueryBuilderKeyByBench.php
+++ b/tests/Integration/Database/QueryBuilderKeyByBench.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Benchmark;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ONLY FOR SHOWCASE PURPOSES. TO BE REMOVED.
+ */
+class QueryBuilderKeyByBench extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->text('content');
+            $table->timestamp('created_at');
+        });
+
+        $data = [];
+        $fake = fake();
+
+        // Define a random spot to have a fixed title so we can search for it.
+        $loc = random_int(0, 999);
+
+        for ($i = 0; $i < 1000; $i++) {
+            $data[] = [
+                'title' => $i === $loc ? 'Foo Post' : $fake->title,
+                'content' => $fake->text(100),
+                'created_at' => new Carbon($fake->date('Y-m-d H:i:s'))
+            ];
+        }
+
+        DB::table('posts')->insert($data);
+    }
+
+    public function testBenchWithKey()
+    {
+        dump(Benchmark::measure(function () {
+            $results = DB::table('posts')->keyBy('title')->get();
+
+            $found = $results['Foo Post'];
+        }, 100));
+    }
+
+    public function testBenchWithoutKey()
+    {
+        dump(Benchmark::measure(function () {
+            $results = DB::table('posts')->get()->keyBy('title');
+
+            $found = $results['Foo Post'];
+        }, 100));
+    }
+}

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -140,6 +140,25 @@ class QueryBuilderTest extends DatabaseTestCase
         Schema::drop('accounting');
     }
 
+    /**
+     * @dataProvider keyByDataProvider
+     */
+    public function testKeyBy($keyBy, $columns, $key, $expected)
+    {
+        $this->assertEquals($expected, json_encode(DB::table('posts')->keyBy($keyBy)->get($columns)[$key]));
+    }
+
+    public static function keyByDataProvider()
+    {
+        return [
+            'Key by title with all columns' => ['title', ['*'], 'Foo Post', '{"id":1,"title":"Foo Post","content":"Lorem Ipsum.","created_at":"2017-11-12 13:14:15"}'],
+            'Key by title with selected columns not including key' => ['title', ['id', 'content'], 'Bar Post', '{"id":2,"content":"Lorem Ipsum."}'],
+            'Key by id with selected columns including key' => ['id', ['id', 'content'], 2, '{"id":2,"content":"Lorem Ipsum."}'],
+            'Key by id with selected dot-columns including key' => ['id', ['posts.id', 'posts.content'], 2, '{"id":2,"content":"Lorem Ipsum."}'],
+            'Key by dot-title with selected dot-columns including key' => ['posts.title', ['posts.title', 'posts.content'], 'Foo Post', '{"title":"Foo Post","content":"Lorem Ipsum."}'],
+        ];
+    }
+
     public function testSole()
     {
         $expected = ['id' => '1', 'title' => 'Foo Post'];

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -145,17 +146,18 @@ class QueryBuilderTest extends DatabaseTestCase
      */
     public function testKeyBy($keyBy, $columns, $key, $expected)
     {
-        $this->assertEquals($expected, json_encode(DB::table('posts')->keyBy($keyBy)->get($columns)[$key]));
+        $record = DB::table('posts')->keyBy($keyBy)->get($columns)[$key];
+        $this->assertEquals($expected, Arr::except((array) $record, 'created_at'));
     }
 
     public static function keyByDataProvider()
     {
         return [
-            'Key by title with all columns' => ['title', ['*'], 'Foo Post', '{"id":1,"title":"Foo Post","content":"Lorem Ipsum.","created_at":"2017-11-12 13:14:15"}'],
-            'Key by title with selected columns not including key' => ['title', ['id', 'content'], 'Bar Post', '{"id":2,"content":"Lorem Ipsum."}'],
-            'Key by id with selected columns including key' => ['id', ['id', 'content'], 2, '{"id":2,"content":"Lorem Ipsum."}'],
-            'Key by id with selected dot-columns including key' => ['id', ['posts.id', 'posts.content'], 2, '{"id":2,"content":"Lorem Ipsum."}'],
-            'Key by dot-title with selected dot-columns including key' => ['posts.title', ['posts.title', 'posts.content'], 'Foo Post', '{"title":"Foo Post","content":"Lorem Ipsum."}'],
+            'Key by title with all columns' => ['title', ['*'], 'Foo Post', ['id' => '1', 'title' => 'Foo Post', 'content' => 'Lorem Ipsum.']],
+            'Key by title with selected columns not including key' => ['title', ['id', 'content'], 'Bar Post', ['id' => '2', 'content' => 'Lorem Ipsum.']],
+            'Key by id with selected columns including key' => ['id', ['id', 'content'], 2, ['id' => '2', 'content' => 'Lorem Ipsum.']],
+            'Key by id with selected dot-columns including key' => ['id', ['posts.id', 'posts.content'], 2, ['id' => '2', 'content' => 'Lorem Ipsum.']],
+            'Key by dot-title with selected dot-columns including key' => ['posts.title', ['posts.title', 'posts.content'], 'Foo Post', ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.']],
         ];
     }
 


### PR DESCRIPTION
This PR adds functionality for query builder results to be keyed by a given column, instantly using PDO. This effectively speeds up computation about 3 times when comparing the following code samples (see benchmark `Illuminate\Tests\Integration\Database\QueryBuilderKeyByBench`):
```php
// Fast:
$builder->keyBy('title')->get();
// Slow:
$builder->get()->keyBy('title');
```

The top syntax makes use of setting a custom PDO fetch mode namely `PDO::FETCH_UNIQUE|PDO::FETCH_OBJ`. This fetch mode is applied directly onto the PDO statement using `$statement->fetchAll($this->fetchAllMode);`.

Noteworthy is that `FETCH_UNIQUE` strips the first column of the result set and sets it as the array key, thus a column `['a', 'b', 'c']` would effectively appear in the result array as `['a' => ['b', 'c']]`. To counteract this behaviour, the column that you pass to `$builder->keyBy($column)` will be prepended to the requested columns such that it actually selects `['a', 'a', 'b', 'c']`. Now the first column can be freely shifted by PDO and the resulting object will be as expected.



There currently seems to be a bug though where leveraging `$statement->setFetchMode(PDO::FETCH_UNIQUE|PDO::FETCH_OBJ)` ([php.net link](https://www.php.net/manual/en/pdostatement.setfetchmode)) does not work for this specific combination (I could not find any bug report), so the code resorts to manually overriding this by calling to `$statement->fetchAll($this->fetchAllMode)` which does the trick.

Use case: any sort of query where you _instantly_ want to retrieve a model from the array without searching through it. For instance, keeping a local cache of all countries (200+) using `$_cache = Country::keyBy('country_code')->get()` which you can then quickly access countries using `$_cache['us']`. This saves quite some time when you don't need to re-key the collection in PHP.