### PR TITLE
[10.x] Support array syntax for casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -723,6 +723,8 @@ trait HasAttributes
      */
     public function mergeCasts($casts)
     {
+        unset(static::$castsCache[static::class]);
+
         $this->casts = array_merge($this->casts, $casts);
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -723,11 +723,21 @@ trait HasAttributes
      */
     public function mergeCasts($casts)
     {
-        unset(static::$castsCache[static::class]);
+        $this->clearCastsCache();
 
         $this->casts = array_merge($this->casts, $casts);
 
         return $this;
+    }
+
+    /**
+     * Clear the casts cache.
+     *
+     * @return void
+     */
+    protected function clearCastsCache()
+    {
+        unset(static::$castsCache[static::class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -173,13 +173,6 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
-     * The cache of the casts.
-     *
-     * @var null|array
-     */
-    protected static $castsCache = null;
-
-    /**
      * The encrypter instance that is used to encrypt attributes.
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter|null
@@ -723,21 +716,9 @@ trait HasAttributes
      */
     public function mergeCasts($casts)
     {
-        $this->clearCastsCache();
-
         $this->casts = array_merge($this->casts, $casts);
 
         return $this;
-    }
-
-    /**
-     * Clear the casts cache.
-     *
-     * @return void
-     */
-    protected function clearCastsCache()
-    {
-        unset(static::$castsCache[static::class]);
     }
 
     /**
@@ -1514,11 +1495,7 @@ trait HasAttributes
      */
     public function getCasts()
     {
-        if (isset(static::$castsCache[static::class])) {
-            return static::$castsCache[static::class];
-        }
-
-        static::$castsCache[static::class] = [];
+        $casts = [];
 
         foreach ($this->casts as $attribute => $cast) {
             if (is_array($cast)) {
@@ -1527,14 +1504,14 @@ trait HasAttributes
                 $cast = $cast.':'.implode(',', $arguments);
             }
 
-            static::$castsCache[static::class][$attribute] = $cast;
+            $casts[$attribute] = $cast;
         }
 
         if ($this->getIncrementing()) {
-            static::$castsCache[static::class] = array_merge([$this->getKeyName() => $this->getKeyType()], static::$castsCache[static::class]);
+            return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
         }
 
-        return static::$castsCache[static::class];
+        return $casts;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1502,9 +1502,11 @@ trait HasAttributes
      */
     public function getCasts()
     {
-        if (! is_null(static::$castsCache)) {
-            return static::$castsCache;
+        if (isset(static::$castsCache[static::class])) {
+            return static::$castsCache[static::class];
         }
+
+        static::$castsCache[static::class] = [];
 
         foreach ($this->casts as $attribute => $cast) {
             if (is_array($cast)) {
@@ -1513,14 +1515,14 @@ trait HasAttributes
                 $cast = $cast.':'.implode(',', $arguments);
             }
 
-            static::$castsCache[$attribute] = $cast;
+            static::$castsCache[static::class][$attribute] = $cast;
         }
 
         if ($this->getIncrementing()) {
-            static::$castsCache[$this->getKeyName()] = $this->getKeyType();
+            static::$castsCache[static::class][$this->getKeyName()] = $this->getKeyType();
         }
 
-        return static::$castsCache;
+        return static::$castsCache[static::class];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -173,6 +173,13 @@ trait HasAttributes
     protected static $castTypeCache = [];
 
     /**
+     * The cache of the casts.
+     *
+     * @var null|array
+     */
+    protected static $castsCache = null;
+
+    /**
      * The encrypter instance that is used to encrypt attributes.
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter|null
@@ -1495,7 +1502,9 @@ trait HasAttributes
      */
     public function getCasts()
     {
-        $casts = [];
+        if (! is_null(static::$castsCache)) {
+            return static::$castsCache;
+        }
 
         foreach ($this->casts as $attribute => $cast) {
             if (is_array($cast)) {
@@ -1504,14 +1513,14 @@ trait HasAttributes
                 $cast = $cast.':'.implode(',', $arguments);
             }
 
-            $casts[$attribute] = $cast;
+            static::$castsCache[$attribute] = $cast;
         }
 
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
+            static::$castsCache[$this->getKeyName()] = $this->getKeyType();
         }
 
-        return $casts;
+        return static::$castsCache;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -754,7 +754,7 @@ trait HasAttributes
             case 'double':
                 return $this->fromFloat($value);
             case 'decimal':
-                return $this->asDecimal($value, explode(':', $this->resolveCastType($key), 2)[1]);
+                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
             case 'string':
                 return (string) $value;
             case 'bool':
@@ -833,31 +833,13 @@ trait HasAttributes
             return;
         }
 
-        $castType = $this->resolveCastType($key);
+        $castType = $this->getCasts()[$key];
 
         if ($value instanceof $castType) {
             return $value;
         }
 
         return $this->getEnumCaseFromValue($castType, $value);
-    }
-
-    /**
-     * Resolve the cast type of the given model attribute.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    protected function resolveCastType($key)
-    {
-        $castType = $this->getCasts()[$key];
-
-        if (is_array($castType)) {
-            [$castType, $arguments] = [array_shift($castType), $castType];
-            $castType = $castType.':'.implode(',', $arguments);
-        }
-
-        return $castType;
     }
 
     /**
@@ -868,7 +850,7 @@ trait HasAttributes
      */
     protected function getCastType($key)
     {
-        $castType = $this->resolveCastType($key);
+        $castType = $this->getCasts()[$key];
 
         if (isset(static::$castTypeCache[$castType])) {
             return static::$castTypeCache[$castType];
@@ -1160,7 +1142,7 @@ trait HasAttributes
      */
     protected function setEnumCastableAttribute($key, $value)
     {
-        $enumClass = $this->resolveCastType($key);
+        $enumClass = $this->getCasts()[$key];
 
         if (! isset($value)) {
             $this->attributes[$key] = null;
@@ -1580,7 +1562,7 @@ trait HasAttributes
             return false;
         }
 
-        $castType = $this->parseCasterClass($this->resolveCastType($key));
+        $castType = $this->parseCasterClass($casts[$key]);
 
         if (in_array($castType, static::$primitiveCastTypes)) {
             return false;
@@ -1607,7 +1589,7 @@ trait HasAttributes
             return false;
         }
 
-        $castType = $this->getCastType($key);
+        $castType = $casts[$key];
 
         if (in_array($castType, static::$primitiveCastTypes)) {
             return false;
@@ -1658,7 +1640,7 @@ trait HasAttributes
      */
     protected function resolveCasterClass($key)
     {
-        $castType = $this->resolveCastType($key);
+        $castType = $this->getCasts()[$key];
 
         $arguments = [];
 
@@ -2061,11 +2043,11 @@ trait HasAttributes
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
-        } elseif ($this->isClassCastable($key) && in_array($this->resolveCastType($key), [AsArrayObject::class, AsCollection::class])) {
+        } elseif ($this->isClassCastable($key) && in_array($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->resolveCastType($key), [AsEnumArrayObject::class, AsEnumCollection::class])) {
+        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && $original !== null && in_array($this->resolveCastType($key), [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
+        } elseif ($this->isClassCastable($key) && $original !== null && in_array($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
             return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1495,15 +1495,17 @@ trait HasAttributes
      */
     public function getCasts()
     {
-        $casts = array_map(static function (array|string $castType) {
-            if (is_array($castType)) {
-                [$castType, $arguments] = [array_shift($castType), $castType];
+        $casts = [];
 
-                $castType = $castType.':'.implode(',', $arguments);
+        foreach ($this->casts as $attribute => $cast) {
+            if (is_array($cast)) {
+                [$cast, $arguments] = [array_shift($cast), $cast];
+
+                $cast = $cast.':'.implode(',', $arguments);
             }
 
-            return $castType;
-        }, $this->casts);
+            $casts[$attribute] = $cast;
+        }
 
         if ($this->getIncrementing()) {
             return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -179,6 +179,23 @@ trait HasAttributes
      */
     public static $encrypter;
 
+    
+    /**
+     * Initialize the trait.
+     *
+     * @return void
+     */
+    protected function initializeHasAttributes()
+    {
+        foreach ($this->casts as $attribute => $cast) {
+            if (is_array($cast)) {
+                [$cast, $arguments] = [array_shift($cast), $cast];
+
+                $this->casts[$attribute] = $cast.':'.implode(',', $arguments);
+            }
+        }
+    }
+
     /**
      * Convert the model's attributes to an array.
      *
@@ -1495,23 +1512,11 @@ trait HasAttributes
      */
     public function getCasts()
     {
-        $casts = [];
-
-        foreach ($this->casts as $attribute => $cast) {
-            if (is_array($cast)) {
-                [$cast, $arguments] = [array_shift($cast), $cast];
-
-                $cast = $cast.':'.implode(',', $arguments);
-            }
-
-            $casts[$attribute] = $cast;
-        }
-
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
+            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
         }
 
-        return $casts;
+        return $this->casts;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1521,7 +1521,7 @@ trait HasAttributes
         }
 
         if ($this->getIncrementing()) {
-            static::$castsCache[static::class][$this->getKeyName()] = $this->getKeyType();
+            static::$castsCache[static::class] = array_merge([$this->getKeyName() => $this->getKeyType()], static::$castsCache[static::class]);
         }
 
         return static::$castsCache[static::class];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -179,7 +179,6 @@ trait HasAttributes
      */
     public static $encrypter;
 
-    
     /**
      * Initialize the trait.
      *
@@ -193,8 +192,7 @@ trait HasAttributes
     /**
      * Convert array casts to string casts.
      *
-     * @param array<string|array<string,string>>  $casts
-     *
+     * @param  array<string|array<string,string>>  $casts
      * @return void
      */
     protected function convertArrayCasts($casts)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1495,11 +1495,20 @@ trait HasAttributes
      */
     public function getCasts()
     {
+        $casts = array_map(static function (array|string $castType) {
+            if (is_array($castType)) {
+                [$castType, $arguments] = [array_shift($castType), $castType];
+                $castType = $castType . ':' . implode(',', $arguments);
+            }
+    
+            return $castType;
+        }, $this->casts);
+    
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+            return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
         }
-
-        return $this->casts;
+    
+        return $casts;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -187,13 +187,31 @@ trait HasAttributes
      */
     protected function initializeHasAttributes()
     {
-        foreach ($this->casts as $attribute => $cast) {
+        $this->casts = $this->convertArrayCasts($this->casts);
+    }
+
+    /**
+     * Convert array casts to string casts.
+     *
+     * @param array<string|array<string,string>>  $casts
+     *
+     * @return void
+     */
+    protected function convertArrayCasts($casts)
+    {
+        $normalizedCasts = [];
+
+        foreach ($casts as $attribute => $cast) {
             if (is_array($cast)) {
                 [$cast, $arguments] = [array_shift($cast), $cast];
 
-                $this->casts[$attribute] = $cast.':'.implode(',', $arguments);
+                $cast = $cast.':'.implode(',', $arguments);
             }
+
+            $normalizedCasts[$attribute] = $cast;
         }
+
+        return $normalizedCasts;
     }
 
     /**
@@ -733,7 +751,7 @@ trait HasAttributes
      */
     public function mergeCasts($casts)
     {
-        $this->casts = array_merge($this->casts, $casts);
+        $this->casts = array_merge($this->casts, $this->convertArrayCasts($casts));
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1498,16 +1498,16 @@ trait HasAttributes
         $casts = array_map(static function (array|string $castType) {
             if (is_array($castType)) {
                 [$castType, $arguments] = [array_shift($castType), $castType];
-                $castType = $castType . ':' . implode(',', $arguments);
+                $castType = $castType.':'.implode(',', $arguments);
             }
-    
+
             return $castType;
         }, $this->casts);
-    
+
         if ($this->getIncrementing()) {
             return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
         }
-    
+
         return $casts;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1498,6 +1498,7 @@ trait HasAttributes
         $casts = array_map(static function (array|string $castType) {
             if (is_array($castType)) {
                 [$castType, $arguments] = [array_shift($castType), $castType];
+
                 $castType = $castType.':'.implode(',', $arguments);
             }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1721,8 +1721,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function replicate(array $except = null)
     {
-        $this->clearCastsCache();
-
         $defaults = array_values(array_filter([
             $this->getKeyName(),
             $this->getCreatedAtColumn(),

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1721,6 +1721,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function replicate(array $except = null)
     {
+        $this->clearCastsCache();
+
         $defaults = array_values(array_filter([
             $this->getKeyName(),
             $this->getCreatedAtColumn(),

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2261,7 +2261,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($model->getCasts()['foo'], AsEnumArrayObject::class.':'.StringStatus::class);
     }
 
-
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2248,6 +2248,20 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayHasKey('foo', $model->getCasts());
     }
 
+    public function testMergeCastsMergesCastsWithArraySyntax()
+    {
+        $model = new EloquentModelCastingStub;
+
+        $castCount = count($model->getCasts());
+        $this->assertArrayNotHasKey('foo', $model->getCasts());
+
+        $model->mergeCasts(['foo' => [AsEnumArrayObject::class, StringStatus::class]]);
+        $this->assertCount($castCount + 1, $model->getCasts());
+        $this->assertArrayHasKey('foo', $model->getCasts());
+        $this->assertEquals($model->getCasts()['foo'], AsEnumArrayObject::class.':'.StringStatus::class);
+    }
+
+
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3039,7 +3039,7 @@ class EloquentModelCastingStub extends Model
         'asEncryptedCollectionAttribute' => AsEncryptedCollection::class,
         'asEncryptedArrayObjectAttribute' => AsEncryptedArrayObject::class,
         'asEnumCollectionAttribute' => AsEnumCollection::class.':'.StringStatus::class,
-        'asEnumArrayObjectAttribute' => [AsEnumArrayObject::class, StringStatus::class],
+        'asEnumArrayObjectAttribute' => AsEnumArrayObject::class.':'.StringStatus::class,
     ];
 
     public function jsonAttributeValue()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3039,7 +3039,7 @@ class EloquentModelCastingStub extends Model
         'asEncryptedCollectionAttribute' => AsEncryptedCollection::class,
         'asEncryptedArrayObjectAttribute' => AsEncryptedArrayObject::class,
         'asEnumCollectionAttribute' => AsEnumCollection::class.':'.StringStatus::class,
-        'asEnumArrayObjectAttribute' => AsEnumArrayObject::class.':'.StringStatus::class,
+        'asEnumArrayObjectAttribute' => [AsEnumArrayObject::class, StringStatus::class],
     ];
 
     public function jsonAttributeValue()


### PR DESCRIPTION
Currently, to pass arguments to casts, we use string concatenation: 

```php
protected $casts = [
    'secret' => Hash::class.':sha256',
];
```

This pull request implements the array syntax to perform the same thing, but in a more readable way:

```php
protected $casts = [
    'secret' => [Hash::class, 'sha256']
];
```

```php
protected $casts = [
    'songs' => [DataCollection::class, SongData::class],
];
```