### PR TITLE
[10.x] allow `$sleepMilliseconds` parameter receive a Closure in `retry` method from PendingRequest

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -131,7 +131,7 @@ class PendingRequest
     /**
      * The number of milliseconds to wait between retries.
      *
-     * @var int
+     * @var Closure|int
      */
     protected $retryDelay = 100;
 
@@ -557,12 +557,12 @@ class PendingRequest
      * Specify the number of times the request should be attempted.
      *
      * @param  int  $times
-     * @param  int  $sleepMilliseconds
+     * @param  Closure|int  $sleepMilliseconds
      * @param  callable|null  $when
      * @param  bool  $throw
      * @return $this
      */
-    public function retry(int $times, int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
+    public function retry(int $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
     {
         $this->tries = $times;
         $this->retryDelay = $sleepMilliseconds;


### PR DESCRIPTION
The `retry` helper accepts either an `int` or a `Closure`. When passing a `Closure` object, the `$attempts` and the `$exception` would be passed, allowed users to implement their own backoff algorithm. The `retry` helper is used in the Pending Request class to perform request retries as well, but in this specific local, the parameters are sent after being informed by `retry` method that belongs to the same class mentioned, and in this method, is not accepted to inform `$sleepMilliseconds` as a `Closure`.

This pull request will allows you to inform `$sleepMilliseconds` parameter as a `Closure` or `int`, opening the possibility to create your own backoff algorithm for retry requests. 

## Example use case

Imagine a scenario where it is necessary to perform a backoff when the exception returned is of type `Request Timeout (408)`, with this modification it would be possible to implement a dynamic strategy as follows:
```PHP
Http::retry(
  times: 2,
  sleepMilliseconds: function (int $attempt, \Throwable $exception): int {
    if ($exception->getCode() === \Illuminate\Http\Response::HTTP_REQUEST_TIMEOUT) {
      return $attempt * 300000; // five minutes in milliseconds
    }
                
    return 0;
  }
);
```