### PR TITLE
[10.x] Add `assertPathIs` to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -980,7 +980,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * 
+     * Assert that the response url equals the given url.
      *
      * @param  string  $url
      * @return $this

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -980,6 +980,19 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * 
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function assertUrlIs($url)
+    {
+        PHPUnit::assertEquals($url, request()->path());
+
+        return $this;
+    }
+
+    /**
      * Assert that the response view equals the given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -980,12 +980,12 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the response url equals the given url.
+     * Assert that the response url path equals the given url (path).
      *
      * @param  string  $url
      * @return $this
      */
-    public function assertUrlIs($url)
+    public function assertUrlPathIs($url)
     {
         PHPUnit::assertEquals($url, request()->path());
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -987,7 +987,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertUrlPathIs($url)
     {
-        PHPUnit::assertEquals($url, request()->path());
+        PHPUnit::assertEquals($url, app('request')->path());
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -985,7 +985,7 @@ class TestResponse implements ArrayAccess
      * @param  string  $url
      * @return $this
      */
-    public function assertUrlPathIs($url)
+    public function assertPathIs($url)
     {
         PHPUnit::assertEquals($url, app('request')->path());
 


### PR DESCRIPTION
Adds `assertPathIs()` to allow for something like:

```php
// Route
Route::get('milwad', function () {
    return 'milwad-dev';
})->name('milwad.index');

Route::get('laravel/framework', function () {
    return 'laravel';
})->name('laravel.index');

// Test
$response1 = $this->get(route('milwad.index')); 
$response1->assertPathIs('milwad'); ✅ Pass

$response2 = $this->get(route('laravel.index'));
$response2->assertPathIs('laravel/framework'); ✅ Pass

$response1->assertPathIs('dev'); ❌ Fail
$response2->assertPathIs('laravel'); ❌ Fail
```

If accepted, I will add related tests!

