### PR TITLE
[10.x] Fix api singleton route registration

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class ResourceRegistrar

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -427,7 +427,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function apiSingleton($name, $controller, array $options = [])
     {
-        $only = ['show', 'update', 'destroy'];
+        $only = ['store', 'show', 'update', 'destroy'];
 
         if (isset($options['except'])) {
             $only = array_diff($only, (array) $options['except']);

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1088,6 +1088,68 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals([], $this->router->getMiddlewareGroups());
     }
 
+    public function testCanRegisterApiSingleton()
+    {
+        $this->router->apiSingleton('users', RouteRegistrarControllerStub::class);
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
+    }
+
+    public function testCanRegisterCreatableApiSingleton()
+    {
+        $this->router->apiSingleton('users', RouteRegistrarControllerStub::class)->creatable();
+
+        $this->assertCount(4, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.store'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
+    public function testApiSingletonAcceptsCreatableMethodParameter()
+    {
+        $this->router->apiSingleton('users', RouteRegistrarControllerStub::class)->creatable(false);
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
+    }
+
+    public function testApiSingletonCreatableNotDestroyable()
+    {
+        $this->router->apiSingleton('users', RouteRegistrarControllerStub::class)
+            ->creatable(true)
+            ->destroyable(false);
+
+        $this->assertCount(3, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.store'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
+    public function testApiSingletonCanBeJustDestroyable()
+    {
+        $this->router->apiSingleton('users', RouteRegistrarControllerStub::class)
+            ->creatable(false)
+            ->destroyable(true);
+
+        $this->assertCount(3, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.store'));
+    }
+
+    public function testApiSingletonDoesntAllowEdit()
+    {
+        $this->router->apiSingleton('users', RouteRegistrarControllerStub::class)
+            ->only('edit');
+
+        $this->assertCount(0, $this->router->getRoutes());
+    }
+
     /**
      * Get the last route registered with the router.
      *


### PR DESCRIPTION
# Issues

## Creatable API singleton resource

### Context

When creating an API Singleton resource we're given the possibility to use the `creatable` method that accepts a `bool $creatable` parameter.

### Problem

This parameter is currently being ignore. It will register a `store` endpoint event when `false` is passed into the creatable method.

## Cannot use `destroyable(false)` with `creatable()`

### Context

```php
Route::apiSingleton('route', Controller::class)
    ->creatable()
    ->destroyable(false);
```

### Problem

Since the destroyable function's parameter is also ignore we cannot have a resource that is creatable but not destroyable.

## API Singleton with edit endpoint

### Context

```php
Route::apiSingleton('route', Controller::class)
    ->only(['edit']);
```

### Problem

This registers the edit route.

# Notes

I've included some tests of what I believe to be the expected usage, some of this tests do not pass with the current implementation, my implementation addresses all issues listed above.

Also, this is my first laravel/framework PR, if you feel that something can be improved, please comment and I'll improve it.
