### PR TITLE
[9.x] Cross-database support for all relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -750,6 +750,8 @@ class Builder implements BuilderContract
 
         $constraints($relation);
 
+        $this->query->prependDatabaseNameIfCrossDatabaseQuery($relation->getBaseQuery());
+
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -54,6 +54,8 @@ trait QueriesRelationships
             $relation->getRelated()->newQueryWithoutRelationships(), $this
         );
 
+        $this->query->prependDatabaseNameIfCrossDatabaseQuery($hasQuery);
+
         // Next we will call any given callback as an "anonymous" scope so they can get the
         // proper logical grouping of the where clauses if needed by this Eloquent query
         // builder. Then, we will be ready to finalize and return this query instance.

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -54,7 +54,7 @@ trait QueriesRelationships
             $relation->getRelated()->newQueryWithoutRelationships(), $this
         );
 
-        $this->query->prependDatabaseNameIfCrossDatabaseQuery($hasQuery);
+        $this->query->prependDatabaseNameIfCrossDatabaseQuery($hasQuery->getQuery());
 
         // Next we will call any given callback as an "anonymous" scope so they can get the
         // proper logical grouping of the where clauses if needed by this Eloquent query

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -208,22 +208,15 @@ class BelongsToMany extends Relation
         // We need to join to the intermediate table on the related model's primary
         // key column with the intermediate table's foreign key for the related
         // model instance. Then we can set the "where" for the parent models.
-//        $query->join(
-//            $this->table,
-//            $this->getQualifiedRelatedKeyName(),
-//            '=',
-//            $this->getQualifiedRelatedPivotKeyName()
-//        );
-
         $query->join(
             $this->table,
             function ($join) {
                 $join->on($this->getQualifiedRelatedKeyName(), '=', $this->getQualifiedRelatedPivotKeyName());
-                $join->setConnection($this->parent->getConnection());
+                if (is_null($this->using)) {
+                    $join->setConnection($this->parent->getConnection());
+                }
             }
         );
-
-//        $this->parent->newQuery()->toBase()->prependDatabaseNameIfCrossDatabaseQuery($query);
 
         return $this;
     }
@@ -343,6 +336,10 @@ class BelongsToMany extends Relation
     public function using($class)
     {
         $this->using = $class;
+
+        foreach ($this->getBaseQuery()->joins as $join) {
+            $join->setConnection((new $class)->getConnection());
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -337,7 +337,7 @@ class BelongsToMany extends Relation
     {
         $this->using = $class;
 
-        foreach ($this->getBaseQuery()->joins as $join) {
+        foreach ($this->query?->getQuery()->joins ?? [] as $join) {
             $join->setConnection((new $class)->getConnection());
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -208,12 +208,22 @@ class BelongsToMany extends Relation
         // We need to join to the intermediate table on the related model's primary
         // key column with the intermediate table's foreign key for the related
         // model instance. Then we can set the "where" for the parent models.
+//        $query->join(
+//            $this->table,
+//            $this->getQualifiedRelatedKeyName(),
+//            '=',
+//            $this->getQualifiedRelatedPivotKeyName()
+//        );
+
         $query->join(
             $this->table,
-            $this->getQualifiedRelatedKeyName(),
-            '=',
-            $this->getQualifiedRelatedPivotKeyName()
+            function ($join) {
+                $join->on($this->getQualifiedRelatedKeyName(), '=', $this->getQualifiedRelatedPivotKeyName());
+                $join->setConnection($this->parent->getConnection());
+            }
         );
+
+//        $this->parent->newQuery()->toBase()->prependDatabaseNameIfCrossDatabaseQuery($query);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -109,7 +109,13 @@ class HasManyThrough extends Relation
 
         $farKey = $this->getQualifiedFarKeyName();
 
-        $query->join($this->throughParent->getTable(), $this->getQualifiedParentKeyName(), '=', $farKey);
+        $query->join(
+            $this->throughParent->getTable(),
+            function ($join) use ($farKey) {
+                $join->on($this->getQualifiedParentKeyName(), '=', $farKey);
+                $join->setConnection($this->parent->getConnection());
+            }
+        );
 
         if ($this->throughParentSoftDeletes()) {
             $query->withGlobalScope('SoftDeletableHasManyThrough', function ($query) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -395,6 +395,13 @@ class Builder implements BuilderContract
             if (! str_starts_with($query->from, $databaseName) && ! str_contains($query->from, '.')) {
                 $query->from($databaseName.'.'.$query->from);
             }
+
+            foreach ($query->joins as $join) {
+                /** @var JoinClause $join */
+                if (! str_starts_with($join->table, $databaseName) && ! str_contains($join->table, '.')) {
+                    $join->table = $databaseName . '.' . $join->table;
+                }
+            }
         }
 
         return $query;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -397,7 +397,6 @@ class Builder implements BuilderContract
             }
 
             foreach ($query->joins as $join) {
-                /** @var JoinClause $join */
                 if (! str_starts_with($join->table, $databaseName) && ! str_contains($join->table, '.')) {
                     $join->table = $databaseName . '.' . $join->table;
                 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -384,7 +384,7 @@ class Builder implements BuilderContract
      * Prepend the database name if the given query is on another database.
      *
      * @param  self  $query
-     * @return mixed
+     * @return void
      */
     public function prependDatabaseNameIfCrossDatabaseQuery($query)
     {
@@ -396,26 +396,25 @@ class Builder implements BuilderContract
 
             if ($this->shouldPrefixDatabaseName($query->from, $database)) {
                 $query->from($database.'.'.$schema.$query->from);
+                $query->prependDatabaseNameForJoins();
             }
-
-            $query->qualifyJoinsIfCrossDatabaseQuery($this);
         }
     }
 
-    public function qualifyJoinsIfCrossDatabaseQuery(self $query)
+    /**
+     * Prepend the database name to each join table.
+     *
+     * @return void
+     */
+    public function prependDatabaseNameForJoins()
     {
-        $database = $query->getConnection()->getDatabaseName();
-
         foreach ($this->joins as $join) {
             $schema = '';
             if ($join->getConnection()->getDriverName() === 'sqlsrv') {
                 $schema = ($join->getConnection()->getConfig('schema') ?? 'dbo').'.';
             }
 
-            if (
-                ($joinDatabase = $join->getConnection()->getDatabaseName()) !== $database &&
-                $this->shouldPrefixDatabaseName($join->table, $joinDatabase)
-            ) {
+            if ($this->shouldPrefixDatabaseName($join->table, $joinDatabase = $join->getConnection()->getDatabaseName())) {
                 $join->table = $joinDatabase.'.'.$schema.$join->table;
             }
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -383,11 +383,13 @@ class Builder implements BuilderContract
     /**
      * Prepend the database name if the given query is on another database.
      *
-     * @param  mixed  $query
+     * @param  self|EloquentBuilder|Relation  $query
      * @return mixed
      */
-    protected function prependDatabaseNameIfCrossDatabaseQuery($query)
+    public function prependDatabaseNameIfCrossDatabaseQuery($query)
     {
+        $query = $query instanceof EloquentBuilder ? $query->getQuery() : $query;
+
         if ($query->getConnection()->getDatabaseName() !==
             $this->getConnection()->getDatabaseName()) {
             $databaseName = $query->getConnection()->getDatabaseName();
@@ -396,7 +398,7 @@ class Builder implements BuilderContract
                 $query->from($databaseName.'.'.$query->from);
             }
 
-            foreach ($query->joins as $join) {
+            foreach ($query->joins ?? [] as $join) {
                 if (! str_starts_with($join->table, $databaseName) && ! str_contains($join->table, '.')) {
                     $join->table = $databaseName . '.' . $join->table;
                 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -388,8 +388,6 @@ class Builder implements BuilderContract
      */
     public function prependDatabaseNameIfCrossDatabaseQuery($query)
     {
-        $query = $query instanceof EloquentBuilder ? $query->getQuery() : $query;
-
         if ($query->getConnection()->getDatabaseName() !==
             $this->getConnection()->getDatabaseName()) {
             $databaseName = $query->getConnection()->getDatabaseName();
@@ -398,7 +396,8 @@ class Builder implements BuilderContract
                 $query->from($databaseName.'.'.$query->from);
             }
 
-            foreach ($query->joins ?? [] as $join) {
+            $baseQuery = ($query instanceof EloquentBuilder || $query instanceof Relation) ? $query->getQuery() : $query;
+            foreach ($baseQuery->joins ?? [] as $join) {
                 if (! str_starts_with($join->table, $databaseName) && ! str_contains($join->table, '.')) {
                     $join->table = $databaseName.'.'.$join->table;
                 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -112,7 +112,7 @@ class Builder implements BuilderContract
      *
      * @var \Illuminate\Database\Query\JoinClause[]
      */
-    public $joins = [];
+    public $joins;
 
     /**
      * The where constraints for the query.
@@ -408,7 +408,7 @@ class Builder implements BuilderContract
      */
     public function prependDatabaseNameForJoins()
     {
-        foreach ($this->joins as $join) {
+        foreach ($this->joins ?? [] as $join) {
             $schema = '';
             if ($join->getConnection()->getDriverName() === 'sqlsrv') {
                 $schema = ($join->getConnection()->getConfig('schema') ?? 'dbo').'.';

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -400,7 +400,7 @@ class Builder implements BuilderContract
 
             foreach ($query->joins ?? [] as $join) {
                 if (! str_starts_with($join->table, $databaseName) && ! str_contains($join->table, '.')) {
-                    $join->table = $databaseName . '.' . $join->table;
+                    $join->table = $databaseName.'.'.$join->table;
                 }
             }
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -110,7 +110,7 @@ class Builder implements BuilderContract
     /**
      * The table joins for the query.
      *
-     * @var \Illuminate\Database\Query\JoinClause[]
+     * @var \Illuminate\Database\Query\JoinClause[]|null
      */
     public $joins;
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -390,8 +390,11 @@ class Builder implements BuilderContract
     {
         if (($databaseName = $query->getConnection()->getDatabaseName()) !==
             $this->getConnection()->getDatabaseName()) {
-            $schema = $query->getConnection()->getDriverName() === 'sqlsrv' ?
-                ($query->getConnection()->getConfig('options.schema_name') ?? 'dbo').'.' : '';
+
+            $schema = '';
+            if ($query->getConnection()->getDriverName() === 'sqlsrv') {
+                $schema = ($query->getConnection()->getConfig('schema') ?? 'dbo').'.';
+            }
 
             $shouldPrefix = fn ($table) => ! str_starts_with($table, $databaseName) && ! str_contains($table, '.');
 

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -122,6 +122,12 @@ class JoinClause extends Builder
         return new static($this->newParentQuery(), $this->type, $this->table);
     }
 
+    public function setConnection($c)
+    {
+        $this->connection = $c;
+        return $this;
+    }
+
     /**
      * Create a new query instance for sub-query.
      *

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
+use Illuminate\Database\ConnectionInterface;
 
 class JoinClause extends Builder
 {
@@ -122,9 +123,16 @@ class JoinClause extends Builder
         return new static($this->newParentQuery(), $this->type, $this->table);
     }
 
-    public function setConnection($c)
+    /**
+     * Set the connection for this join clause.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return $this
+     */
+    public function setConnection(ConnectionInterface $connection)
     {
-        $this->connection = $c;
+        $this->connection = $connection;
+
         return $this;
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -53,7 +53,7 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
 
         $builder->shouldReceive('join')->once()->with(
-            m::on( fn ($arg) => is_string($arg)), m::on( fn($arg) => is_callable($arg))
+            m::on(fn ($arg) => is_string($arg)), m::on(fn ($arg) => is_callable($arg))
         );
         $builder->shouldReceive('where')->once()->with('club_user.club_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('club_user.is_admin', '=', 1, 'and');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -52,7 +52,9 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
 
-        $builder->shouldReceive('join')->once()->with('club_user', 'users.id', '=', 'club_user.user_id');
+        $builder->shouldReceive('join')->once()->with(
+            m::on( fn ($arg) => is_string($arg)), m::on( fn($arg) => is_callable($arg))
+        );
         $builder->shouldReceive('where')->once()->with('club_user.club_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('club_user.is_admin', '=', 1, 'and');
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -763,7 +763,9 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testRelationshipEagerLoadProcess()
     {
-        $builder = m::mock(Builder::class.'[getRelation]', [$this->getMockQueryBuilder()]);
+        $baseBuilder = $this->getMockQueryBuilder();
+        $baseBuilder->shouldReceive('prependDatabaseNameIfCrossDatabaseQuery')->once();
+        $builder = m::mock(Builder::class.'[getRelation]', [$baseBuilder]);
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
@@ -772,6 +774,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
+        $relation->shouldReceive('getBaseQuery')->once()->andReturn(new \stdClass);
         $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
         $results = $builder->eagerLoadRelations(['models']);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -545,6 +545,8 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithWhereHasWithSpecificColumns()
     {
         $model = new EloquentModelWithWhereHasStub;
+        $connection = $this->addMockConnection($model);
+        $connection->shouldReceive('getDatabaseName')->andReturn('forge');
         $instance = $model->newInstance()->newQuery()->withWhereHas('foo:diaa,fares');
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('select')->once()->with(['diaa', 'fares']);
@@ -2524,6 +2526,8 @@ class DatabaseEloquentModelTest extends TestCase
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });
+
+        return $connection;
     }
 
     public function testTouchingModelWithTimestamps()

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -102,7 +102,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $related->shouldReceive('getMorphClass')->andReturn(get_class($related));
 
         $builder->shouldReceive('join')->once()->with(
-            m::on( fn ($arg) => is_string($arg)), m::on( fn($arg) => is_callable($arg))
+            m::on(fn ($arg) => is_string($arg)), m::on(fn ($arg) => is_callable($arg))
         );
         $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -101,7 +101,9 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('tags.id');
         $related->shouldReceive('getMorphClass')->andReturn(get_class($related));
 
-        $builder->shouldReceive('join')->once()->with('taggables', 'tags.id', '=', 'taggables.tag_id');
+        $builder->shouldReceive('join')->once()->with(
+            m::on( fn ($arg) => is_string($arg)), m::on( fn($arg) => is_callable($arg))
+        );
         $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));
 

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\EloquentCrossDatabaseTest;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
@@ -114,7 +114,6 @@ class EloquentCrossDatabaseTest extends MySqlTestCase
                 ['hits' => 123, 'viewable_id' => 1, 'viewable_type' => Post::class],
             ]);
         });
-
     }
 
     protected function destroyDatabaseMigrations()
@@ -137,7 +136,8 @@ class EloquentCrossDatabaseTest extends MySqlTestCase
             $this->assertInstanceOf(Collection::class, Post::query()->whereHas($relation)->get());
         }
 
-        collect(array_merge($db1->getQueryLog(), $db2->getQueryLog()))->each(fn($i) => dump($i['query']));
+        // @TODO debug code
+        collect(array_merge($db1->getQueryLog(), $db2->getQueryLog()))->each(fn ($i) => dump($i['query']));
     }
 }
 

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -15,7 +15,7 @@ class EloquentCrossDatabaseTest extends DatabaseTestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        if (! in_array($default = $app['config']->get('database.default'), ['mysql', 'pgsql', 'sqlsrv'])) {
+        if (! in_array($default = $app['config']->get('database.default'), ['mysql', 'sqlsrv'])) {
             $this->markTestSkipped("Cross database queries not supported for $default.");
         }
 

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -138,17 +138,13 @@ class EloquentCrossDatabaseTest extends MySqlTestCase
 
     public function testRelationships()
     {
-        ($db1 = DB::connection(self::DEFAULT_CONNECTION))->enableQueryLog();
-        ($db2 = DB::connection(self::SECONDARY_CONNECTION))->enableQueryLog();
-
+        // We only test general compilation without errors here, indicating that cross-database queries have been
+        // executed correctly.
         foreach (['user', 'comments', 'tags', 'view'] as $relation) {
             $this->assertInstanceOf(Collection::class, Post::query()->with($relation)->get());
             $this->assertInstanceOf(Collection::class, Post::query()->withCount($relation)->get());
             $this->assertInstanceOf(Collection::class, Post::query()->whereHas($relation)->get());
         }
-
-        // @TODO debug code
-        collect(array_merge($db1->getQueryLog(), $db2->getQueryLog()))->each(fn ($i) => dump($i['query']));
     }
 }
 

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -23,13 +23,15 @@ class EloquentCrossDatabaseTest extends MySqlTestCase
 
     protected function getEnvironmentSetUp($app)
     {
+        if ($app['config']->get('database.default') !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+
         // Create a second connection based on the first connection, but with a different database.
         $app['config']->set('database.connections.'.self::SECONDARY_CONNECTION, array_merge(
             $app['config']->get('database.connections.'.self::DEFAULT_CONNECTION),
             ['database' => 'forge_two']
         ));
-
-        $app['config']->set('database.default', self::DEFAULT_CONNECTION);
 
         parent::getEnvironmentSetUp($app);
     }

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -15,8 +15,8 @@ class EloquentCrossDatabaseTest extends DatabaseTestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        if (($default = $app['config']->get('database.default')) === 'sqlite') {
-            $this->markTestSkipped('Cross database queries not supported for SQLite.');
+        if (! in_array($default = $app['config']->get('database.default'), ['mysql', 'pgsql', 'sqlsrv'])) {
+            $this->markTestSkipped("Cross database queries not supported for $default.");
         }
 
         define('__TEST_DEFAULT_CONNECTION', $default);

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\MySql\MySqlTestCase;
+
+class EloquentCrossDatabaseTest extends MySqlTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'conn1');
+
+        $app['config']->set('database.connections.conn1', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge_one',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('database.connections.conn2', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge_two',
+            'prefix' => '',
+        ]);
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        tap(Schema::connection('conn1'), function ($schema) {
+            try {
+                $schema->create('posts', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('title');
+                    $table->foreignId('user_id')->nullable();
+                });
+            } catch (QueryException $e) {
+                //
+            }
+        });
+
+        tap(Schema::connection('conn2'), function ($schema) {
+            try {
+                $schema->create('users', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('username');
+                });
+
+                $schema->create('sub_posts', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('title');
+                    $table->foreignId('post_id');
+                });
+
+                $schema->create('views', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->integer('hits')->default(1);
+                    $table->morphs('viewable');
+                });
+
+                $schema->create('comments', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('content');
+                    $table->foreignId('sub_post_id');
+                });
+
+                $schema->create('tags', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('tag');
+                });
+
+                $schema->create('post_tag', function (Blueprint $table) {
+                    $table->foreignId('post_id');
+                    $table->foreignId('tag_id');
+                });
+            } catch (QueryException $e) {
+                //
+            }
+        });
+
+        tap(DB::connection('conn1'), function ($db) {
+            $db->table('posts')->insert([
+                ['title' => 'Foobar', 'user_id' => 1],
+                ['title' => 'The title', 'user_id' => 1],
+            ]);
+        });
+
+        tap(DB::connection('conn2'), function ($db) {
+            $db->table('users')->insert([
+                ['username' => 'Lortay Wellot'],
+            ]);
+
+            $db->table('sub_posts')->insert([
+                ['title' => 'The subpost title', 'post_id' => 1],
+            ]);
+
+            $db->table('comments')->insert([
+                ['content' => 'The comment content', 'sub_post_id' => 1],
+            ]);
+
+            $db->table('views')->insert([
+                ['hits' => 123, 'viewable_id' => 1, 'viewable_type' => Post::class],
+            ]);
+        });
+
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('posts');
+
+        foreach (['users', 'sub_posts', 'comments', 'views', 'tags', 'post_tag'] as $table) {
+            Schema::connection('conn2')->dropIfExists($table);
+        }
+    }
+
+    public function testRelationships()
+    {
+        ($db1 = DB::connection('conn1'))->enableQueryLog();
+        ($db2 = DB::connection('conn2'))->enableQueryLog();
+
+        foreach (['user', 'comments', 'tags', 'view'] as $relation) {
+            $this->assertInstanceOf(Collection::class, Post::query()->with($relation)->get());
+            $this->assertInstanceOf(Collection::class, Post::query()->withCount($relation)->get());
+            $this->assertInstanceOf(Collection::class, Post::query()->whereHas($relation)->get());
+        }
+
+        collect(array_merge($db1->getQueryLog(), $db2->getQueryLog()))->each(fn($i) => dump($i['query']));
+    }
+}
+
+abstract class BaseModel extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+}
+
+abstract class Conn2BaseModel extends BaseModel
+{
+    protected $connection = 'conn2';
+}
+
+class Post extends BaseModel
+{
+    protected $connection = 'conn1';
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function comments()
+    {
+        return $this->hasManyThrough(Comment::class, SubPost::class, 'post_id', 'id');
+    }
+
+    public function view()
+    {
+        return $this->morphOne(View::class, 'viewable');
+    }
+}
+
+class User extends Conn2BaseModel
+{
+    //
+}
+
+class SubPost extends Conn2BaseModel
+{
+    //
+}
+
+class Comment extends Conn2BaseModel
+{
+    //
+}
+
+class Tag extends Conn2BaseModel
+{
+    //
+}
+
+class View extends Conn2BaseModel
+{
+    //
+}

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -23,7 +23,7 @@ class EloquentCrossDatabaseTest extends DatabaseTestCase
         define('__TEST_SECONDARY_CONNECTION', $default.'_two');
 
         // Create a second connection based on the first connection, but with a different database.
-        $app['config']->set('database.connections'.__TEST_SECONDARY_CONNECTION, array_merge(
+        $app['config']->set('database.connections.'.__TEST_SECONDARY_CONNECTION, array_merge(
             $app['config']->get('database.connections.'.__TEST_DEFAULT_CONNECTION),
             ['database' => 'forge_two']
         ));


### PR DESCRIPTION
Related to https://github.com/laravel/framework/issues/23042

### Issue
Various relationship methods do not work with cross database relations including `withCount` and `whereHas`. SQL errors were thrown because the database name was not prefixed in all cases. Some work has been done previously to accomplish this, however it wasn't tested thoroughly and several cases were left unconsidered (like joins and specific relation types).

### Requirements
- Any `MorphToMany`/`BelongsToMany` relations are required to have an intermediary Eloquent model defined like so, because the connection from the intermediary table cant be resolved otherwise:
```php
public function taggables()
{
    return $this->morphToMany(...)->using(Taggable::class);
}
```
- The rest of the relations work out of the box and any joins/froms that happen on a different connection automatically have their database name prefixed.

### Task status
- [x] Test all relationship methods (only correct SQL execution is tested)
- [x] There is still one issue with withCount on a `morphTo()` relation, where `$users->query()->withCount('morphable')->get()` results in a syntax error when no additional arguments are given to the relation (the SQL contains `'laravel_reserved_0'.''` because it is missing a key). The issue is solved though once you hardcode the relation as `return $this->morphTo(null, null, null, 'id')`. I excluded the test case from my tests it is an existing issue.

### Support status
- [x] MySQL 5.7
- [x] MySQL 8.0
- [x] MariaDB 10.0
- [x] SQL Server 2019 (FIXED prefixing `dbo` was required. A custom config override `'schema'` has been added in the database configuration, similar to Postgres)
- [x] NOT SUPPORTED: PostgreSQL 14 (it requires additional pgsql extensions `dblink` and/or `postgres_fdw`)
- [x] NOT SUPPORTED: SQLite
