### PR TITLE
[9.x] Removes unnecessary creatable API singleton parameter

### DIFF
--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -90,12 +90,11 @@ class PendingSingletonResourceRegistration
     /**
      * Indicate that the resource should have creation and storage routes.
      *
-     * @param  bool  $creatable
      * @return $this
      */
-    public function creatable($creatable = true)
+    public function creatable()
     {
-        $this->options['creatable'] = $creatable;
+        $this->options['creatable'] = true;
 
         return $this;
     }
@@ -103,12 +102,11 @@ class PendingSingletonResourceRegistration
     /**
      * Indicate that the resource should have a deletion route.
      *
-     * @param  bool  $destroyable
      * @return $this
      */
-    public function destroyable($destroyable = true)
+    public function destroyable()
     {
-        $this->options['destroyable'] = $destroyable;
+        $this->options['destroyable'] = true;
 
         return $this;
     }


### PR DESCRIPTION
# Issue

Currently the `creatable()` and `destroyable()` methods in an API singleton resource route registartion accept boolean parameters that aren't taken into consideration later.

```php
Route::apiSingleton('route', Controller::class)
    ->creatable()
    ->destroyable();
```

# Possible solution

Removal of these parameters as suggested [here](https://github.com/laravel/framework/pull/46665#issuecomment-1494838213)
