### PR TITLE
[10.x] Remove unused param from `assertFound` | `assertMovedPermanently`

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -54,7 +54,6 @@ trait AssertsStatusCodes
     /**
      * Assert that the response has a 301 "Moved Permanently" status code.
      *
-     * @param  int  $status
      * @return $this
      */
     public function assertMovedPermanently()
@@ -65,7 +64,6 @@ trait AssertsStatusCodes
     /**
      * Assert that the response has a 302 "Found" status code.
      *
-     * @param  int  $status
      * @return $this
      */
     public function assertFound()


### PR DESCRIPTION
There is no need to `@param` in phpdoc !!