### PR TITLE
[10.x] Allow Event::assertListening to check for invokable event listeners

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -95,7 +95,10 @@ class EventFake implements Dispatcher, Fake
                     if (Str::contains($expectedListener, '@')) {
                         $normalizedListener = Str::parseCallback($expectedListener);
                     } else {
-                        $normalizedListener = [$expectedListener, 'handle'];
+                        $normalizedListener = [
+                            $expectedListener,
+                            method_exists($expectedListener, '__invoke') ? '__invoke' : 'handle'
+                        ];
                     }
                 }
             }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -147,6 +147,7 @@ class EventFakeTest extends TestCase
             'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle',
             PostEventSubscriber::class,
             [PostEventSubscriber::class, 'foo'],
+            InvokableEventSubscriber::class
         ]);
 
         foreach ($listenersOfSameEventInRandomOrder as $listener) {
@@ -172,6 +173,7 @@ class EventFakeTest extends TestCase
         Event::assertListening(NonImportantEvent::class, Closure::class);
         Event::assertListening('eloquent.saving: '.Post::class, PostObserver::class.'@saving');
         Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
+        Event::assertListening('event', InvokableEventSubscriber::class);
     }
 
     public function testMissingMethodsAreForwarded()
@@ -226,6 +228,14 @@ class PostEventSubscriber
 class PostAutoEventSubscriber
 {
     public function handle($event)
+    {
+        //
+    }
+}
+
+class InvokableEventSubscriber
+{
+    public function __invoke($event)
     {
         //
     }


### PR DESCRIPTION
Resolves https://github.com/laravel/framework/issues/46652