### PR TITLE
[9.x] Allow Event::assertListening to check for invokable event listeners

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -94,7 +94,10 @@ class EventFake implements Dispatcher
                     if (Str::contains($expectedListener, '@')) {
                         $normalizedListener = Str::parseCallback($expectedListener);
                     } else {
-                        $normalizedListener = [$expectedListener, 'handle'];
+                        $normalizedListener = [
+                            $expectedListener,
+                            method_exists($expectedListener, 'handle') ? 'handle' : '__invoke',
+                        ];
                     }
                 }
             }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -147,6 +147,7 @@ class EventFakeTest extends TestCase
             'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle',
             PostEventSubscriber::class,
             [PostEventSubscriber::class, 'foo'],
+            InvokableEventSubscriber::class,
         ]);
 
         foreach ($listenersOfSameEventInRandomOrder as $listener) {
@@ -172,6 +173,7 @@ class EventFakeTest extends TestCase
         Event::assertListening(NonImportantEvent::class, Closure::class);
         Event::assertListening('eloquent.saving: '.Post::class, PostObserver::class.'@saving');
         Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
+        Event::assertListening('event', InvokableEventSubscriber::class);
     }
 }
 
@@ -229,5 +231,13 @@ class PostObserver
     public function saving(Post $post)
     {
         $post->slug = sprintf('%s-Test', $post->title);
+    }
+}
+
+class InvokableEventSubscriber
+{
+    public function __invoke($event)
+    {
+        //
     }
 }


### PR DESCRIPTION
Resolves https://github.com/laravel/framework/issues/46652

Converted to 9.x bugfix per @driesvints' request [here](https://github.com/laravel/framework/pull/46682).