### PR TITLE
[9.x] fix Cache::spy incompatibility with Cache::get

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -58,7 +58,7 @@ class CacheManager implements FactoryContract
     {
         $name = $name ?: $this->getDefaultDriver();
 
-        return $this->stores[$name] = $this->get($name);
+        return $this->stores[$name] ??= $this->resolve($name);
     }
 
     /**
@@ -70,17 +70,6 @@ class CacheManager implements FactoryContract
     public function driver($driver = null)
     {
         return $this->store($driver);
-    }
-
-    /**
-     * Attempt to get the store from the local cache.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Cache\Repository
-     */
-    protected function get($name)
-    {
-        return $this->stores[$name] ?? $this->resolve($name);
     }
 
     /**


### PR DESCRIPTION
See: https://github.com/laravel/framework/issues/41721

The protected `get()` function is unnecessary since the null coalescing assignment operator exists. Since it is a protected function on the `CacheManager` class there should be no breaking changes. 

Removing it also allows `Cache::spy()` to now be called as described in the original issue.