### PR TITLE
[10.x] Add missing ignored methods to Component

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -329,6 +329,10 @@ abstract class Component
             'view',
             'withName',
             'withAttributes',
+            'flushCache',
+            'forgetFactory',
+            'forgetComponentsResolver',
+            'resolveComponentsUsing',
         ], $this->except);
     }
 


### PR DESCRIPTION
The `flushCache`, `forgetFactory`, `forgetComponentsResolver`, and `resolveComponentsUsing` methods were added to `Illuminate\View\Component` in #44487. They are public static methods, which means they are being collected in `extractPublicMethods` and an invokable variable is being created for each of them for every component instance. This is incurring a small but noticeable performance penalty when rendering large numbers of components.

This PR simply adds these methods to the array of ignored methods so they don't get extracted.