### PR TITLE
[10.x] Add `WithConsoleEvents` helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench-core": "^8.3",
+        "orchestra/testbench-core": "^8.4",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpdoc-parser": "^1.15",
         "phpstan/phpstan": "^1.4.7",

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -118,11 +118,11 @@ class Kernel implements KernelContract
         $this->app = $app;
         $this->events = $events;
 
-        if (! $this->app->runningUnitTests()) {
-            $this->rerouteSymfonyCommandEvents();
-        }
-
         $this->app->booted(function () {
+            if (! $app->runningUnitTests()) {
+                $this->rerouteSymfonyCommandEvents();
+            }
+
             $this->defineConsoleSchedule();
         });
     }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -119,7 +119,7 @@ class Kernel implements KernelContract
         $this->events = $events;
 
         $this->app->booted(function () {
-            if (! $app->runningUnitTests()) {
+            if (! $this->app->runningUnitTests()) {
                 $this->rerouteSymfonyCommandEvents();
             }
 

--- a/src/Illuminate/Foundation/Testing/WithConsoleEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithConsoleEvents.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+
+trait WithConsoleEvents
+{
+    /**
+     * Register console events.
+     *
+     * @return void
+     */
+    protected function setUpWithConsoleEvents()
+    {
+        $this->app[ConsoleKernel::class]->rerouteSymfonyCommandEvents();
+    }
+}

--- a/tests/Integration/Console/CommandEventsTest.php
+++ b/tests/Integration/Console/CommandEventsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Testing\WithConsoleEvents;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\Foundation\Application as Testbench;
@@ -14,6 +15,8 @@ use Orchestra\Testbench\TestCase;
 
 class CommandEventsTest extends TestCase
 {
+    use WithConsoleEvents;
+
     /**
      * The path to the file that execution logs will be written to.
      *
@@ -43,17 +46,6 @@ class CommandEventsTest extends TestCase
         });
 
         parent::setUp();
-    }
-
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    protected function defineEnvironment($app)
-    {
-        $app->make(ConsoleKernel::class)->rerouteSymfonyCommandEvents();
     }
 
     /**


### PR DESCRIPTION
Make it easier to register console events on specific test without adding a massive memory leak and make it easier to be documented.

Also, move `rerouteSymfonyCommandEvents` to only initiate after the application has been booted. Fixes laravel/framework#46693

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
