### PR TITLE
[10.x] console.stub: remove void return type from handle

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -23,7 +23,7 @@ class {{ class }} extends Command
     /**
      * Execute the console command.
      */
-    public function handle(): void
+    public function handle()
     {
         //
     }


### PR DESCRIPTION
Return type of a command can be the status code as int. The void type suggests that there is no return type expected. This made me search through code and documentation to check if there's now a different way of passing the exit code.

Hence to avoid confusion I suggest to remove the void type and let the user decide later, if it should be void or int.
