### PR TITLE
[10.x] Prevent modify lastId by object reference inside chunkById

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -134,6 +134,8 @@ trait BuildsQueries
             if ($countResults == 0) {
                 break;
             }
+            
+            $lastId = data_get($results->last(), $alias);
 
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
@@ -141,8 +143,6 @@ trait BuildsQueries
             if ($callback($results, $page) === false) {
                 return false;
             }
-
-            $lastId = data_get($results->last(), $alias);
 
             if ($lastId === null) {
                 throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");


### PR DESCRIPTION
Hello! I'm using `chunkById` to retrieve and then **modify** data. So, i iterate over retrieved collection and change `id` + some other columns.

If i change id of last element, then by **object reference** `$lastId` inside `chunkById` function also **will be modifie**d which is incorrect behavior and this bug was hard to debug.

Imagine, i have 1000 articles and chunk with step = 500
```
Article::query()
    ->oldest('id')
    ->toBase()
    ->chunkById(500, function (Collection $articles) {
        foreach ($articles as $index => $article) {
            $article->id = 1000; //in production i generate uuid here
            //smth logic
        }
    });
```

This code will have only 1 query for articles with ids from 1 to 500, because `$lastId` then become 1000 and query will not retrive articles with ids 501-1000