### PR TITLE
[10.x] Add generic typehints to collections returned from `Stringable` methods

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -254,7 +254,7 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @param  string  $delimiter
      * @param  int  $limit
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, string>
      */
     public function explode($delimiter, $limit = PHP_INT_MAX)
     {
@@ -267,7 +267,7 @@ class Stringable implements JsonSerializable, ArrayAccess
      * @param  string|int  $pattern
      * @param  int  $limit
      * @param  int  $flags
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, string>
      */
     public function split($pattern, $limit = -1, $flags = 0)
     {
@@ -909,7 +909,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Split a string by uppercase characters.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, string>
      */
     public function ucsplit()
     {

--- a/types/Support/Stringable.php
+++ b/types/Support/Stringable.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Stringable;
+
+use function PHPStan\Testing\assertType;
+
+$stringable = new Stringable();
+
+assertType('Illuminate\Support\Collection<int, string>', $stringable->explode(''));
+
+assertType('Illuminate\Support\Collection<int, string>', $stringable->split(1));
+
+assertType('Illuminate\Support\Collection<int, string>', $stringable->ucsplit());


### PR DESCRIPTION
The `Stringable` class implements a few methods that return collections, like `explode`, `split`, and `ucsplit`. We can specify the `TKey` and `TValue` templates for these collections, since these methods obviously transform a `string` to a `string[]`.