### PR TITLE
[10.x] Add `whereEnum` to the route constraints

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 
 trait CreatesRegularExpressionRouteConstraints
 {
@@ -71,6 +72,22 @@ trait CreatesRegularExpressionRouteConstraints
     public function whereIn($parameters, array $values)
     {
         return $this->assignExpressionToParameters($parameters, implode('|', $values));
+    }
+
+    /**
+     * Specify that the given route parameters must be one of the enum values.
+     *
+     * @param  array|string  $parameters
+     * @param  class-string<\UnitEnum>  $enum
+     * @return $this
+     */
+    public function whereEnum($parameters, string $enum)
+    {
+        if (! enum_exists($enum)) {
+            throw new InvalidArgumentException("The enum [{$enum}] does not exist.");
+        }
+
+        return $this->whereIn($parameters, array_column($enum::cases(), 'value'));
     }
 
     /**


### PR DESCRIPTION
Here is my use-case:

```php
Route::get('/cards/{type?}', [CardController::class, 'index'])
    ->whereEnum('type', CardFilterType::class)
    ->name('dashboard');

Route::get('/cards/{card}', [CardController::class, 'show'])
    ->whereUuid('card')
    ->name('cards.show');

class CardController
{
    public function index(CardFilterType $type = CardFilterType::Live)
```

If I remove `->whereEnum` call from the routes code, it will serve the `cards.show` route instead of a `dashboard`.