### PR TITLE
[10.x] Fix docblock type for dispatchAfterCommit queue property.

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -33,7 +33,7 @@ abstract class Queue
     /**
      * Indicates that jobs should be dispatched after all database transactions have committed.
      *
-     * @return $this
+     * @var bool
      */
     protected $dispatchAfterCommit;
 


### PR DESCRIPTION
This PR fixes the docblock for the `$dispatchAfterCommit` propery on the `Queue` class.

No executable code modified, just an updated docblock. No tests needed.