### PR TITLE
[10.x] Cursor pagination model casting bugfix

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -214,6 +214,10 @@ abstract class AbstractCursorPaginator implements Htmlable
                 if ($item instanceof Model &&
                     ! is_null($parameter = $this->getPivotParameterForItem($item, $parameterName))) {
                     return $parameter;
+                } elseif ($item instanceof Model) {
+                    return $this->ensureParameterIsPrimitive(
+                        $item->getAttributes()[$parameterName] ?? $item->getAttributes()[Str::afterLast($parameterName, '.')]
+                    );
                 } elseif ($item instanceof ArrayAccess || is_array($item)) {
                     return $this->ensureParameterIsPrimitive(
                         $item[$parameterName] ?? $item[Str::afterLast($parameterName, '.')]

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2244,7 +2244,7 @@ class EloquentTestUserWithOmittingGlobalScope extends EloquentTestUser
 
 class EloquentTestUserWithCastOnCursorParameter extends EloquentTestUser
 {
-    public function email() : CastAttribute
+    public function email(): CastAttribute
     {
         return CastAttribute::make(
             get: fn () => 'foobar',


### PR DESCRIPTION
In a project, I have a model that uses a custom cast on a datetime column. It converts the UTC datetime from the database to a carbon instance in a timezone defined in another column.

```php
class Booking extends Model
{
	protected $fillable = [
		'starts_at', // In UTC
		'timezone', // e.g. Europe/Brussels
	];

	protected $casts = [
		'starts' => AsDatetimeWithTimezone::class,
	];
}

// A simplified, compact version of the cast
class AsDatetimeWithTimezone implements CastsAttributes, SerializesCastableAttributes
{
    public function get($model, string $key, $value, array $attributes) : ?Carbon
    {
        return Carbon::parse($value)->setTimezone($model->timezone);
    }

    public function set($model, string $key, $value, array $attributes) : array
    {
        return [
            $key => $value->copy()->setTimezone('UTC')->format($model->getDateFormat()),
            'timezone' => $value->getTimezone()->getName(),
        ];
    }
}
```

In a part of the project, I use cursor pagination to get the bookings and sort them by the `starts_at` column. But I now discovered an issue in the cursor pagination because of the cast on the starts-at column.

To create the next/previous cursor, the cursor pagination gets the starts-at from the model, which is a carbon instance in another timezone than the database timezone (UTC), and converts that carbon instance to a string. But now the base64-encoded next/previous cursor contains a non-UTC datetime string. This causes database records to be skipped when using that cursor to get the next page.

```php
// assume a project with these database values is used to create the next cursor
Project::create([
	'starts_at' => '2023-04-01 10:00', // in UTC
	'timezone' => 'Europe/Brussels',
]);

// Then the next cursor will contain the datetime in Europe/Brussels timezone ... 
dump(base64_decode(Project::orderBy('starts_at')->cursorPaginate()->nextCursor()));
// 'starts_at' => '2023-04-01 12:00

// ... Instead of UTC timezone, which it should be because that is the value in the database
// 'starts_at' => '2023-04-01 10:00
```

To fix that, I updated the `getParametersForItem` method in the `AbstractCursorPaginator` to get the raw attribute value from the Eloquent model, so it does not use a casted value.

