### PR TITLE
Allow use of pivot models on a different connection from the parent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -46,7 +46,7 @@ trait AsPivot
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
-        $instance->setConnection($parent->getConnectionName())
+        $instance->setConnection($instance->getConnectionName() ?: $parent->getConnectionName())
             ->setTable($table)
             ->forceFill($attributes)
             ->syncOriginal();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using many-to-many relationships across databases, the connection for the pivot model is incorrectly set to the parent model's connection, even if a connection is manually specified on the pivot model.

My example:

```
class User extends Model
{
    protected $connection = 'db-a';

    public function songs()
    {
        return $this->belongsToMany(Song::class, 'UserSongs', 'userID', 'songID')
            ->using(UserSong::class);
    }
}

class Song extends Model
{
    protected $connection = 'db-b';
}

class UserSong extends Pivot
{
    protected $connection = 'db-b';
}
```

```
$song = new Song();
...
$user->songs()->attach($newSong, []);
```

The `attach()` method calls `InteractsWithPivotTable::attachUsingCustomClass()`, which calls `InteractsWithPivotTable::newPivot()`, which calls `Model::newPivot()` on the parent model.
`Model::newPivot()` calls `AsPivot::fromRawAttributes()` on the pivot class, which calls `AsPivot::fromAttributes()`, which sets the connection to the parent's connection.

This fails when the pivot table isn't on the same connection as the parent model.