### PR TITLE
Encode array values to JSON for `DB::insert()` and `Model::create()`

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -716,11 +716,12 @@ class Connection implements ConnectionInterface
             // We need to transform all instances of DateTimeInterface into the actual
             // date string. Each query grammar maintains its own date string format
             // so we'll just ask the grammar for the format to get from the date.
-            if ($value instanceof DateTimeInterface) {
-                $bindings[$key] = $value->format($grammar->getDateFormat());
-            } elseif (is_bool($value)) {
-                $bindings[$key] = (int) $value;
-            }
+            $bindings[$key] = match (true) {
+                $value instanceof DateTimeInterface => $value->format($grammar->getDateFormat()),
+                is_bool($value) => (int) $value,
+                is_array($value) => json_encode($value),
+                default => $value
+            };
         }
 
         return $bindings;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -463,6 +463,10 @@ class DatabaseConnectionTest extends TestCase
         $conn->setQueryGrammar($grammar);
         $result = $conn->prepareBindings($bindings);
         $this->assertEquals(['test' => 'bar'], $result);
+
+        $jsonBindings = ['test' => ['key' => 'value']];
+        $result = $conn->prepareBindings($jsonBindings);
+        $this->assertEquals(['test' => json_encode(['key' => 'value'])], $result);
     }
 
     public function testLogQueryFiresEventsIfSet()


### PR DESCRIPTION
When dealing with Eloquent and the Base Query Builder, it is currently possible to update JSON columns by passing an array as the column value, like this;

```php
DB::table('users')->update([
    'meta' => [
        'key' => 'value'
    ]
]);

User::first()->update([
    'meta' => [
        'key' => 'value'
    ]
]);
```

This correctly encodes the `meta` column value as JSON before executing the query.

However, for inserts, this is not the case.

```php
DB::table('users')->insert([
    'name' => 'Newton Job'
    'meta'  => [
        'key' => 'value'
    ]
]); // Exception: Array to string conversion

User::create([
    'name' => 'Newton Job'
    'meta'  => [
        'key' => 'value'
    ]
]); // Exception: Array to string conversion

DB::insert("insert into users (name, meta) values (?, ?)", [
    'Newton Job'
    ['key' => 'value']
]); // Exception: Array to string conversion
```

This PR fixes that problem by updating the `Illuminate\Database\Connection::prepareBindings` method to also prepare array bindings for execution (similar to booleans and DateTime).