### PR TITLE
[10.x] Fix nested join when not JoinClause instance

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -504,7 +504,7 @@ class Grammar extends BaseGrammar
         // Here we will calculate what portion of the string we need to remove. If this
         // is a join clause query, we need to remove the "on" portion of the SQL and
         // if it is a normal query we need to take the leading "where" of queries.
-        $offset = $query['query'] instanceof JoinClause ? 3 : 6;
+        $offset = $where['query'] instanceof JoinClause ? 3 : 6;
 
         return '('.substr($this->compileWheres($where['query']), $offset).')';
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -504,9 +504,10 @@ class Grammar extends BaseGrammar
         // Here we will calculate what portion of the string we need to remove. If this
         // is a join clause query, we need to remove the "on" portion of the SQL and
         // if it is a normal query we need to take the leading "where" of queries.
-        $offset = $query instanceof JoinClause ? 3 : 6;
+        $sql = $this->compileWheres($where['query']);
+        $offset = $query instanceof JoinClause && !str_starts_with($sql, 'where ') ? 3 : 6;
 
-        return '('.substr($this->compileWheres($where['query']), $offset).')';
+        return '('.substr($sql, $offset).')';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -504,10 +504,9 @@ class Grammar extends BaseGrammar
         // Here we will calculate what portion of the string we need to remove. If this
         // is a join clause query, we need to remove the "on" portion of the SQL and
         // if it is a normal query we need to take the leading "where" of queries.
-        $sql = $this->compileWheres($where['query']);
-        $offset = $query instanceof JoinClause && !str_starts_with($sql, 'where ') ? 3 : 6;
+        $offset = $query['query'] instanceof JoinClause ? 3 : 6;
 
-        return '('.substr($sql, $offset).')';
+        return '('.substr($this->compileWheres($where['query']), $offset).')';
     }
 
     /**


### PR DESCRIPTION
Fixes issue where Nested join would build wrong sql, when joining another Query builder on it.
it would mistakenly cut 'where ' of to 're ' expecting it to say 'on ' (which it doesn't because its not a joinClause but just a regular query builder class inside).

before: 
```
select "users"."id" from "users" inner join "contacts" on "users"."id" = "contacts"."id" and (re "contacts"."id" = ?)
```

now:
```
select "users"."id" from "users" inner join "contacts" on "users"."id" = "contacts"."id" and ("contacts"."id" = ?)
```

