### PR TITLE
Don't add bug label to every new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: "Report something that's broken."
-labels: ["bug"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
I personally liked it more that the bug label was only assigned to confirmed bugs and not to every issue.

Maybe there could be a `needs-triage` label instead.

(Close the PR if you think the current behaviour is wanted)