### PR TITLE
Fixes the logical issue of `isDirty` && `isClean` methods 🐛

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -177,6 +177,13 @@ trait HasAttributes
     public static $encrypter;
 
     /**
+     * Indicates whether all attributes are dirty.
+     *
+     * @var bool
+     */
+    protected $isAllAttributesAreDirty = false;
+
+    /**
      * Convert the model's attributes to an array.
      *
      * @return array
@@ -1971,11 +1978,13 @@ trait HasAttributes
         // all of the attributes for the entire array we will return false at end.
         foreach (Arr::wrap($attributes) as $attribute) {
             if (array_key_exists($attribute, $changes)) {
-                return true;
+                $this->isAllAttributesAreDirty = $this->isAllAttributesAreDirty || true;
+            } elseif (!array_key_exists($attribute, $changes)) {
+                $this->isAllAttributesAreDirty = $this->isAllAttributesAreDirty || false;
             }
         }
 
-        return false;
+        return $this->isAllAttributesAreDirty;
     }
 
     /**


### PR DESCRIPTION
Hey Folks! 👋

When I was using `isDirty` and `isClean` methods I discovered a logical issue when passing multiple attributes, let's take a look over the next code for more illustration

```PHP
$user = User::first();
$user->name = "The name has changed";

return $user->isDirty(['name']);
```

The result of the previous code will be `true` because the **name** is actually changed, also let's pass the not changed attribute to the `isDirty` method.

```PHP
$user = User::first();
$user->name = "The name has changed";

return $user->isDirty(['email']);
```

The result of the previous code will be `false` because the **false** is not actually changed, but what if we pass a mix of changed and not changed attributes, what would be the result?

```PHP
$user = User::first();
$user->name = "The name has changed";

return $user->isDirty(['name', 'email']);
```

The result of the previous code will be `true` despite the `email` attribute not being changed and it does not make sense, and when I opened the source code I found that Laravel return `true` if the first attribute **only** has changed without checking the rest attributes. So, this PR solves that issue by using the logical operation between all attributes, also I've thought to print an array with boolean values for all attributes and indicate if each attribute has changed.

```PHP
$user = User::first();
$user->name = "The name has changed";

return $user->isDirty(['name', 'email']);
```

I suggest printing the result as shown in the next form instead of printing one boolean value.

```
[true, false]
```
