### PR TITLE
Update type hinting for Kernel::setArtisan()

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -474,7 +474,7 @@ class Kernel implements KernelContract
     /**
      * Set the Artisan application instance.
      *
-     * @param  \Illuminate\Console\Application  $artisan
+     * @param  \Illuminate\Console\Application|null  $artisan
      * @return void
      */
     public function setArtisan($artisan)


### PR DESCRIPTION
I am overwriting the `refreshTestDatabase()` method in my application. And my static analyser is giving an error that setArtisan() cannot accept `null` as a value.

The property itself is nullable. So this change will reflect that option in the phpdoc of the method as well.