### PR TITLE
[10.x] `setValue()` in Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1087,6 +1087,17 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * @param string $attribute key to set value for, supports dot notation.
+     * @param mixed $value value to set.
+     * @return void
+     */
+    public function setValue($attribute, $value)
+    {
+        Arr::set($this->data, $attribute, $value);
+    }
+
+
+    /**
      * Get the validation rules.
      *
      * @return array

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1089,8 +1089,8 @@ class Validator implements ValidatorContract
     /**
      * Set the value of a given attribute.
      *
-     * @param  string  $attribute  name of attribute (supports dot notation).
-     * @param  mixed  $value  value to set.
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return void
      */
     public function setValue($attribute, $value)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1087,15 +1087,16 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * @param string $attribute key to set value for, supports dot notation.
-     * @param mixed $value value to set.
+     * Set the value of a given attribute.
+     *
+     * @param  string $attribute name of attribute (supports dot notation)
+     * @param  mixed $value value to set.
      * @return void
      */
     public function setValue($attribute, $value)
     {
         Arr::set($this->data, $attribute, $value);
     }
-
 
     /**
      * Get the validation rules.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1089,8 +1089,8 @@ class Validator implements ValidatorContract
     /**
      * Set the value of a given attribute.
      *
-     * @param  string  $attribute name of attribute (supports dot notation).
-     * @param  mixed  $value value to set.
+     * @param  string  $attribute  name of attribute (supports dot notation).
+     * @param  mixed  $value  value to set.
      * @return void
      */
     public function setValue($attribute, $value)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1089,8 +1089,8 @@ class Validator implements ValidatorContract
     /**
      * Set the value of a given attribute.
      *
-     * @param  string $attribute name of attribute (supports dot notation)
-     * @param  mixed $value value to set.
+     * @param  string  $attribute name of attribute (supports dot notation).
+     * @param  mixed  $value value to set.
      * @return void
      */
     public function setValue($attribute, $value)


### PR DESCRIPTION
Followup of: https://github.com/laravel/framework/pull/46162

### Why

For package development, i would like to make it possible for rules to override data to make the validation 'type-safe'.
There is now no possible way to efficiently update a value inline. i can call `setData()` but it would completly reload the rules itself as well cause in big slowdown.

Alternatively I could sub-class Validator and add it myself, but this would greatly risk my package no longer being compatible with other packages AND people their own code repository.


### Usage:

```php
abstract class BaseTypeSafeRule implements ValidationRule, DataAwareRule, ValidatorAwareRule
{
    private array $data;
    private Validator $validator;

    public function setData(array $data)
    {
        $this->data = $data;
    }

    public function setValidator(Validator $validator)
    {
        $this->validator = $validator;
    }

    protected function modifyValue(string $attribute, mixed $value): void
    {
       // with this PR:
       $this->validator->setValue($attribute, $value);

        // previously: very slow!
        Arr::set($this->data, $attribute, $value);
        $this->validator->setData($this->data);
    }

    protected function translate(string $key, array $replacements = []): string|array
    {
        return $this->validator->getTranslator()->get($key, $replacements);
    }
}
```

