### PR TITLE
[10.x] Add `assertActingIs` in TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -80,6 +80,12 @@ class TestResponse implements ArrayAccess
         return new static($response);
     }
 
+    /**
+     * Assert that response has a correct acting user.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @return $this
+     */
     public function assertActingIs($user)
     {
         PHPUnit::assertEquals($user, app('auth')->user());

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -83,7 +83,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that response has a correct acting user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
     public function assertActingIs($user)

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -80,6 +80,13 @@ class TestResponse implements ArrayAccess
         return new static($response);
     }
 
+    public function assertActingIs($user)
+    {
+        PHPUnit::assertEquals($user, app('auth')->user());
+
+        return $this;
+    }
+
     /**
      * Assert that the response has a successful status code.
      *


### PR DESCRIPTION
Assert acting user.

```php
$user  = User::factory()->create(['name' => 'milwad']);
$user2 = User::factory()->create(['name' => 'taylor']);

$response = $this->actingAs($user)->get('/');

$response->assertActingAs($user); // pass ✅
$response->assertActingAs($user2); // fail ❌
```

If merged, I will add related tests.