### PR TITLE
[10.x] Add AssertStatusCodes@assertInternalServerError

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -170,4 +170,14 @@ trait AssertsStatusCodes
     {
         return $this->assertStatus(429);
     }
+
+    /**
+     * Assert that the response has a 500 "Internal Server Error" status code.
+     *
+     * @return $this
+     */
+    public function assertInternalServerError()
+    {
+        return $this->assertStatus(500);
+    }
 }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -773,6 +773,18 @@ class TestResponseTest extends TestCase
         $response->assertServerError();
     }
 
+    public function testAssertInternalServerError()
+    {
+        $statusCode = 500;
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertInternalServerError();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
Adds a helper to TestResponse for checking if the response code === 500. There is a `assertServerError` method in TestResponse, but it's checking for a range of status codes instead of precisely 500.