### PR TITLE
[10.x] Fixed server Closing output on invalid `$requestPort`

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -251,9 +251,12 @@ class ServeCommand extends Command
                 $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
             } elseif (str($line)->contains(' Closing')) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                $request = $this->requestsPool[$requestPort];
 
-                [$startDate, $file] = $request;
+                if (empty($this->requestsPool[$requestPort])) {
+                    return;
+                }
+
+                [$startDate, $file] = $this->requestsPool[$requestPort];
 
                 $formattedStartedAt = $startDate->format('Y-m-d H:i:s');
 


### PR DESCRIPTION
Laravel: 10.6.2
PHP: 8.1.17

On a docker deploy I get a random `Undefined array key` error when the server try to manage the `Closing` response on a undefined `$requestPort`.

The server command is:

```
php artisan serve --host=0.0.0.0 --port=80 >> storage/logs/artisan-serve.log 2>&1
```

Maybe the problem is `getRequestPortFromLine` parse, but for now maybe the best option is check the `$this->requestsPool[$requestPort]` value before continue with the output.

![Screenshot from 2023-04-10 11-33-08](https://user-images.githubusercontent.com/644551/230876229-768d005a-17bc-4d46-858f-f111179494c2.png)
