### PR TITLE
[10.x] Add support for perHours and perDays function in rate limit

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -83,6 +83,18 @@ class Limit
     }
 
     /**
+     * Create a new rate limit using hours as decay time.
+     *
+     * @param  int  $decayHours
+     * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perHours($decayHours, $maxAttempts)
+    {
+        return new static('', $maxAttempts, 60 * $decayHours);
+    }
+
+    /**
      * Create a new rate limit using days as decay time.
      *
      * @param  int  $maxAttempts
@@ -90,6 +102,18 @@ class Limit
      * @return static
      */
     public static function perDay($maxAttempts, $decayDays = 1)
+    {
+        return new static('', $maxAttempts, 60 * 24 * $decayDays);
+    }
+
+    /**
+     * Create a new rate limit using days as decay time.
+     *
+     * @param  int  $decayDays
+     * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perDays($decayDays, $maxAttempts)
     {
         return new static('', $maxAttempts, 60 * 24 * $decayDays);
     }


### PR DESCRIPTION
This pull request aims to add support for perHours and perDays functions in the rate limit feature of Laravel. Currently, Laravel only provides the ability to set rate limits per minutes using the throttle middleware. perDay and perHour functions prototype should be changed in next version of framework.