### PR TITLE
[10.x] Added default value to Database Eloquent and Query Builder `value` and `valueRaw` methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -643,15 +643,18 @@ class Builder implements BuilderContract
      * Get a single column's value from the first result of a query.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $default
      * @return mixed
      */
-    public function value($column)
+    public function value($column, $default = null)
     {
         if ($result = $this->first([$column])) {
             $column = $column instanceof Expression ? $column->getValue($this->getGrammar()) : $column;
 
             return $result->{Str::afterLast($column, '.')};
         }
+
+        return value($default);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2671,13 +2671,14 @@ class Builder implements BuilderContract
      *
      * @param  string  $expression
      * @param  array  $bindings
+     * @param  mixed  $default
      * @return mixed
      */
-    public function rawValue(string $expression, array $bindings = [])
+    public function rawValue(string $expression, array $bindings = [], $default = null)
     {
         $result = (array) $this->selectRaw($expression, $bindings)->first();
 
-        return count($result) > 0 ? reset($result) : null;
+        return count($result) > 0 ? reset($result) : value($default);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2656,13 +2656,14 @@ class Builder implements BuilderContract
      * Get a single column's value from the first result of a query.
      *
      * @param  string  $column
+     * @param  mixed  $default
      * @return mixed
      */
-    public function value($column)
+    public function value($column, $default = null)
     {
         $result = (array) $this->first([$column]);
 
-        return count($result) > 0 ? reset($result) : null;
+        return count($result) > 0 ? reset($result) : value($default);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -335,12 +335,30 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('foo', $builder->value('name'));
     }
 
+    public function testValueDefaultMethodWithModelFound()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $mockModel = new stdClass;
+        $mockModel->name = 'foo';
+        $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
+
+        $this->assertSame('foo', $builder->value('name', 'var'));
+    }
+
     public function testValueMethodWithModelNotFound()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('first')->with(['name'])->andReturn(null);
 
         $this->assertNull($builder->value('name'));
+    }
+
+    public function testValueDefaultMethodWithModelNotFound()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('first')->with(['name'])->andReturn(null);
+
+        $this->assertSame('var', $builder->value('name', 'var'));
     }
 
     public function testValueOrFailMethodWithModelFound()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2580,6 +2580,42 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('bar', $results);
     }
 
+    public function testValueMethodReturnsNotFound()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [2], true)->andReturn(null);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, null)->andReturn(null);
+        $results = $builder->from('users')->where('id', '=', 2)->value('foo');
+        $this->assertNull($results);
+    }
+
+    public function testValueDefaultMethodReturnsSingleColumn()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [1], true)->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturn([['foo' => 'bar']]);
+        $results = $builder->from('users')->where('id', '=', 1)->value('foo', 'notbar');
+        $this->assertSame('bar', $results);
+    }
+
+    public function testValueDefaultMethodReturnsNotFound()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [2], true)->andReturn(null);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, null)->andReturn(null);
+        $results = $builder->from('users')->where('id', '=', 2)->value('foo', 'notbar');
+        $this->assertSame('notbar', $results);
+    }
+
+    public function testValueDefaultMethodReturnsNotFoundClosure()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [2], true)->andReturn(null);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, null)->andReturn(null);
+        $results = $builder->from('users')->where('id', '=', 2)->value('foo', static fn () => 'notbar');
+        $this->assertSame('notbar', $results);
+    }
+
     public function testRawValueMethodReturnsSingleColumn()
     {
         $builder = $this->getBuilder();
@@ -2587,6 +2623,33 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['UPPER("foo")' => 'BAR']])->andReturn([['UPPER("foo")' => 'BAR']]);
         $results = $builder->from('users')->where('id', '=', 1)->rawValue('UPPER("foo")');
         $this->assertSame('BAR', $results);
+    }
+
+    public function testRawValueMethodReturnsNotFound()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select UPPER("foo") from "users" where "id" = ? limit 1', [2], true)->andReturn(null);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, null)->andReturn(null);
+        $results = $builder->from('users')->where('id', '=', 2)->rawValue('UPPER("foo")');
+        $this->assertNull($results);
+    }
+
+    public function testRawValueDefaultMethodReturnsSingleColumn()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select UPPER("foo") from "users" where "id" = ? limit 1', [1], true)->andReturn([['UPPER("foo")' => 'BAR']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['UPPER("foo")' => 'BAR']])->andReturn([['UPPER("foo")' => 'BAR']]);
+        $results = $builder->from('users')->where('id', '=', 1)->rawValue('UPPER("foo")', default: 'NOTBAR');
+        $this->assertSame('BAR', $results);
+    }
+
+    public function testRawValueDefaultMethodReturnsNotFound()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select UPPER("foo") from "users" where "id" = ? limit 1', [2], true)->andReturn(null);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, null)->andReturn(null);
+        $results = $builder->from('users')->where('id', '=', 2)->rawValue('UPPER("foo")', default: 'NOTBAR');
+        $this->assertSame('NOTBAR', $results);
     }
 
     public function testAggregateFunctions()


### PR DESCRIPTION
This small change allow to add a default value to `value` and `valueRaw` database methods.

This default value will be managed by `value` global helper that allow any value or a callback/Closure.

This change doesn't break backwards compatibility and doesn't include any unwanted side effects.

The result is (for example):

```php
$title = Film::where('id', $id)->value('title', 'No Title Found');
```

```php
$title = Film::where('id', $id)->rawValue('UPPER(title)', 'NO TITLE FOUND');
```

```php
$title = Film::where('id', $id)->rawValue('UPPER(title)', fn () => $this->getDefaultTitle());
```