### PR TITLE
[10.x] Add createOrFail() to HasOneOrMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -329,6 +329,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
+     *
      * @throws \Throwable
      */
     public function createOrFail(array $attributes = [])

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -327,6 +327,16 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     * @throws \Throwable
+     */
+    public function createOrFail(array $attributes = [])
+    {
+        return $this->getConnection()->transaction(fn () => $this->create($attributes));
+    }
+
+    /**
      * Create a new instance of the related model without raising any events to the parent model.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1354,6 +1354,25 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->saveOrFail();
     }
 
+    public function testCreateOrFailHasMany()
+    {
+        $user = EloquentTestUser::firstOrCreate(['id' => 1, 'email' => 'john@mulaney.net']);
+        $this->assertInstanceOf(
+            EloquentTestPost::class,
+            $user->posts()->createOrFail(['name' => 'New In Town', 'created_at' => now()])
+        );
+    }
+
+    public function testHasManyCreateOrFailOnDuplicateEntry()
+    {
+        $user = EloquentTestUser::firstOrCreate(['id' => 1, 'email' => 'mitch@hedberg.com']);
+        $user->posts()->create(['id' => 1, 'name' => 'Fork lift', 'created_at' => now()]);
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('SQLSTATE[23000]:');
+        $user->posts()->createOrFail(['id' => 1, 'name' => 'Lift a crate of forks', 'created_at' => now()]);
+    }
+
     public function testMultiInsertsWithDifferentValues()
     {
         $date = '1970-01-01';


### PR DESCRIPTION
This allows a user to do something like this:
```php
$user = User::create();
$user->posts()->createOrFail(['name' => 'Hello World']);
```

If this PR is received favorably, will add this to other Relations