### PR TITLE
[10.x] Allow overwrite or extension of options sent to SQS when using pushRaw

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -110,9 +110,10 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->sqs->sendMessage([
-            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload,
-        ])->get('MessageId');
+        return $this->sqs->sendMessage(array_merge([
+            'QueueUrl' => $this->getQueue($queue),
+            'MessageBody' => $payload,
+        ], $options))->get('MessageId');
     }
 
     /**


### PR DESCRIPTION
As a developer it would be beneficial to have the option to overwrite or extend the parameters sent to SQS when using the `pushRaw` method.

This PR aims to add that flexibility to the framework.

It may break SQS calls if a codebase is calling the function using the 3 parameters with wrongful options accepted by AWS SQS.