### PR TITLE
[10.x] Improve DX for defining custom Eloquent builders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
+use ReflectionMethod;
 
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -1565,7 +1566,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        $returnType = (new \ReflectionMethod(static::class, 'query'))->getReturnType()?->getName();
+        $returnType = (new ReflectionMethod(static::class, 'query'))->getReturnType()?->getName();
 
         if (! $returnType) {
             return new Builder($query);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1565,7 +1565,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        return new Builder($query);
+        $returnType = (new \ReflectionMethod(static::class, 'query'))->getReturnType()?->getName();
+
+        if (! $returnType) {
+            return new Builder($query);
+        }
+
+        return new $returnType($query);
     }
 
     /**


### PR DESCRIPTION
### Improvement in this PR

This pull request is an attempt at slightly improving the DX of using custom Eloquent builders in models.

Currently, to get proper IDE support using a custom builder, a model should have the following two methods overridden:

```php
public static function query(): ChirpBuilder
{
    return parent::query();
}

public function newEloquentBuilder($query)
{
    return new ChirpBuilder($query);
}
```

The first one is to get IDE autocompletion using `Model::query`, and the second one is to actually create the correct builder in all queries.

With this PR, the second method no longer needs to be overridden because the builder is guessed thanks to `query`'s return type:

```php
public static function query(): ChirpBuilder
{
    return parent::query();
}
```

### Performance

Since `newEloquentBuilder` now uses `Reflection` under the hood, naturally we could ask whether this implies performance penalties. I ran this benchmark with and without the changes, and the result is `0.009ms` in both situations on my Macbook M1.

```php
Benchmark::dd(static function () {
    Chirp::query();
}, 20_000);
```

---

This could technically be a breaking change, not sure if this should target `master` then?
