### PR TITLE
[10.x] Add syntax sugar to the Process::pipe method

### DIFF
--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -274,12 +274,14 @@ class Factory
     /**
      * Start defining a series of piped processes.
      *
-     * @param  callable  $callback
+     * @param  callable|array  $callback
      * @return \Illuminate\Process\Pipe
      */
-    public function pipe(callable $callback, ?callable $output = null)
+    public function pipe(callable|array $callback, ?callable $output = null)
     {
-        return (new Pipe($this, $callback))->run(output: $output);
+        return is_array($callback)
+            ? (new Pipe($this, $callback))->runSimple()
+            : (new Pipe($this, $callback))->run(output: $output);
     }
 
     /**

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -280,7 +280,9 @@ class Factory
     public function pipe(callable|array $callback, ?callable $output = null)
     {
         return is_array($callback)
-            ? (new Pipe($this, $callback))->runSimple()
+            ? (new Pipe($this, fn ($pipe) => collect($callback)->each(
+                fn ($command) => $pipe->command($command)
+            )))->run(output: $output)
             : (new Pipe($this, $callback))->run(output: $output);
     }
 

--- a/src/Illuminate/Process/Pipe.php
+++ b/src/Illuminate/Process/Pipe.php
@@ -88,7 +88,7 @@ class Pipe
     }
 
     /**
-     * Runs the processes in the pipe as simple commands
+     * Runs the processes in the pipe as simple commands.
      *
      * @return \Illuminate\Contracts\Process\ProcessResult
      */

--- a/src/Illuminate/Process/Pipe.php
+++ b/src/Illuminate/Process/Pipe.php
@@ -18,10 +18,9 @@ class Pipe
     protected $factory;
 
     /**
-     * The callback that resolves the pending processes,
-     * or array of string processes to run.
+     * The callback that resolves the pending processes.
      *
-     * @var callable|array
+     * @var callable
      */
     protected $callback;
 
@@ -36,10 +35,10 @@ class Pipe
      * Create a new series of piped processes.
      *
      * @param  \Illuminate\Process\Factory  $factory
-     * @param  callable|array  $callback
+     * @param  callable  $callback
      * @return void
      */
-    public function __construct(Factory $factory, callable|array $callback)
+    public function __construct(Factory $factory, callable $callback)
     {
         $this->factory = $factory;
         $this->callback = $callback;
@@ -85,32 +84,6 @@ class Pipe
                         $output($type, $buffer, $key);
                     } : null);
                 });
-    }
-
-    /**
-     * Runs the processes in the pipe as simple commands.
-     *
-     * @return \Illuminate\Contracts\Process\ProcessResult
-     */
-    public function runSimple()
-    {
-        return collect($this->callback)
-            ->reduce(function ($previousProcessResult, $command) {
-                if (! is_string($command)) {
-                    throw new InvalidArgumentException('Process pipe must only contain strings.');
-                }
-
-                if ($previousProcessResult && $previousProcessResult->failed()) {
-                    return $previousProcessResult;
-                }
-
-                $pendingProcess = $this->command($command);
-
-                return $pendingProcess->when(
-                    $previousProcessResult,
-                    fn () => $pendingProcess->input($previousProcessResult->output())
-                )->run();
-            });
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -35,7 +35,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\Factory assertDidntRun(\Closure|string $callback)
  * @method static \Illuminate\Process\Factory assertNothingRan()
  * @method static \Illuminate\Process\Pool pool(callable $callback)
- * @method static \Illuminate\Process\Pipe pipe(callable $callback, callable|null $output = null)
+ * @method static \Illuminate\Process\Pipe pipe(callable|array $callback, callable|null $output = null)
  * @method static \Illuminate\Process\ProcessPoolResults concurrently(callable $callback, callable|null $output = null)
  * @method static \Illuminate\Process\PendingProcess newPendingProcess()
  * @method static void macro(string $name, object|callable $macro)

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -534,6 +534,44 @@ class ProcessTest extends TestCase
         $this->assertTrue($pipe->failed());
     }
 
+    public function testProcessSimplePipe()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $factory = new Factory;
+        $factory->fake([
+            'cat *' => "Hello, world\nfoo\nbar",
+        ]);
+
+        $pipe = $factory->pipe([
+            'cat test',
+            'grep -i "foo"',
+        ]);
+
+        $this->assertSame("foo\n", $pipe->output());
+    }
+
+    public function testProcessSimplePipeFailed()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $factory = new Factory;
+        $factory->fake([
+            'cat *' => $factory->result(exitCode: 1),
+        ]);
+
+        $pipe = $factory->pipe([
+            'cat test',
+            'grep -i "foo"',
+        ]);
+
+        $this->assertTrue($pipe->failed());
+    }
+
     public function testFakeInvokedProcessOutputWithLatestOutput()
     {
         $factory = new Factory;


### PR DESCRIPTION
## What changes

This adds a syntax sugar for the Process::pipe, allowing it to run simple commands without configuration like this:

```php
$result = Process::pipe([
    'cat test',
    'grep -i "foo"',
]);

$result->output(); // "foo"
```

Taking into consideration that the content of `test.txt` will be:

```
Hello, world
foo
```

## Why

This idea was shared by @nunomaduro on Twitter: https://twitter.com/enunomaduro/status/1645805234151895041 and I think this can be a simple way to run a pipeline of simple commands when we don't need to configure the commands to run.

## Implementation Details

I thought about creating a SimplePipe class to not reuse the Pipe class for this, but IDK if that's a good idea. I'd love to get feedback and update the PR if needed.