### PR TITLE
[10.x] Allow specifying index name when calling `ForeignIdColumnDefinition@constrained()`

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -35,10 +35,8 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      * @param  string|null  $indexName
      * @return \Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function constrained($table = null, $column = null, $indexName = null)
+    public function constrained($table = null, $column = 'id', $indexName = null)
     {
-        $column ??= 'id';
-
         return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -38,6 +38,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     public function constrained($table = null, $column = null, $indexName = null)
     {
         $column ??= 'id';
+
         return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -31,22 +31,25 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      * Create a foreign key constraint on this column referencing the "id" column of the conventionally related table.
      *
      * @param  string|null  $table
-     * @param  string  $column
+     * @param  string|null  $column
+     * @param  string|null  $indexName
      * @return \Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function constrained($table = null, $column = 'id')
+    public function constrained($table = null, $column = null, $indexName = null)
     {
-        return $this->references($column)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
+        $column ??= 'id';
+        return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
     }
 
     /**
      * Specify which column this foreign ID references on another table.
      *
      * @param  string  $column
+     * @param  string  $indexName
      * @return \Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function references($column)
+    public function references($column, $indexName = null)
     {
-        return $this->blueprint->foreign($this->name)->references($column);
+        return $this->blueprint->foreign($this->name, $indexName)->references($column);
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -497,6 +497,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingForeignIdSpecifyingIndexNameInConstraint()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table `users` add `company_id` bigint unsigned not null',
+            'alter table `users` add constraint `my_index` foreign key (`company_id`) references `companies` (`id`)',
+        ], $statements);
+    }
+
     public function testAddingBigIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -500,7 +500,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertSame([
             'alter table `users` add `company_id` bigint unsigned not null',

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -416,6 +416,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingForeignIdSpecifyingIndexNameInConstraint()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" bigint not null',
+            'alter table "users" add constraint "my_index" foreign key ("company_id") references "companies" ("id")',
+        ], $statements);
+    }
+
     public function testAddingBigIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -419,7 +419,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertSame([
             'alter table "users" add column "company_id" bigint not null',

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -324,7 +324,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertSame([
             'alter table "users" add column "company_id" integer not null',

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -321,6 +321,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingForeignIdSpecifyingIndexNameInConstraint()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add column "company_id" integer not null'
+        ], $statements);
+    }
     public function testAddingBigIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -327,9 +327,10 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertSame([
-            'alter table "users" add column "company_id" integer not null'
+            'alter table "users" add column "company_id" integer not null',
         ], $statements);
     }
+
     public function testAddingBigIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -366,6 +366,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingForeignIdSpecifyingIndexNameInConstraint()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertSame([
+            'alter table "users" add "company_id" bigint not null',
+            'alter table "users" add constraint "my_index" foreign key ("company_id") references "companies" ("id")',
+        ], $statements);
+    }
+
     public function testAddingBigIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -369,7 +369,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testAddingForeignIdSpecifyingIndexNameInConstraint()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->foreignId('company_id')->constrained(null, null, 'my_index');
+        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertSame([
             'alter table "users" add "company_id" bigint not null',


### PR DESCRIPTION
## Problem
I prefer verbose naming. I have a migration that looks like this:

```php
use App\Models\KnowledgeBaseResource;
use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;


return new class extends Migration
{
    public function up(): void
    {
        Schema::create('company_knowledge_base_resource_matches', function (Blueprint $table) {
            $table->id();
            $table->foreignIdFor(KnowledgeBaseResource::class)->nullable()->constrained()->nullOnDelete();
            $table->timestamps();
        });
    }
}
```

Which blows up:
```zsh
SQLSTATE[42000]: Syntax error or access violation: 1059 Identifier name 'company_knowledge_base_resource_matches_knowledge_resource_id_foreign' is too long (Connection: mysql, SQL: alter table `company_knowledge_base_resource_matches` add constraint `company_knowledge_base_resource_matches_knowledge_resource_id_foreign` foreign key (`knowledge_base_resource_id`) references `knowledge_base_resources` (`id`) on delete set null)
```

This can be worked around, but doesn't allow the developer to use the nice features of the schema builder, puts a lot more of a lift on developers, and leaves more room for error.

```php
Schema::create('company_knowledge_base_resource_matches', function (Blueprint $table) {
    $table->id();
    $table->foreignIdFor(KnowledgeBaseResource::class)->nullable();
    $table->timestamps();
    
    $table->foreign('knowledge_base_resource_id', 'my_foreign_index')->references('id')->on('knowledge_base_resources')->constrained()->nullOnDelete();
});
```

### Solution
Allow calling code to specify the index name within the call to `ForeignIdColumnDefinition@constrained()`.

This should not break backwards compatibility.

I also changed the second parameter of `constrained()` so that it allows null to be passed, which will coalesce to 'id'.  I think this improves developer experience, so, a developer might write this instead:
```php
Schema::create('company_knowledge_base_resource_matches', function (Blueprint $table) {
    $table->id();
    $table->foreignIdFor(KnowledgeBaseResource::class)
        ->nullable()
        ->constrained(null, null, 'my_foreign_index')
        ->nullOnDelete();
    $table->timestamps();
});
```

instead of: `$table->foreignIdFor(SomeModel::class)->constrained(null, 'id', 'my_foreign_index')`