### PR TITLE
[10.x] Allow to customise redirect URL in AuthenticateSession Middleware

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -111,7 +111,7 @@ class AuthenticateSession implements AuthenticatesSessions
     }
 
     /**
-     * Get the path the user should be redirected to when they are not authenticated.
+     * Get the path the user should be redirected to when their session is not autheneticated.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return string|null

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Session\Middleware\AuthenticatesSessions;
+use Illuminate\Http\Request;
 
 class AuthenticateSession implements AuthenticatesSessions
 {
@@ -94,7 +95,9 @@ class AuthenticateSession implements AuthenticatesSessions
 
         $request->session()->flush();
 
-        throw new AuthenticationException('Unauthenticated.', [$this->auth->getDefaultDriver()]);
+        throw new AuthenticationException(
+            'Unauthenticated.', [$this->auth->getDefaultDriver()], $this->redirectTo($request)
+        );
     }
 
     /**
@@ -105,5 +108,16 @@ class AuthenticateSession implements AuthenticatesSessions
     protected function guard()
     {
         return $this->auth;
+    }
+
+    /**
+     * Get the path the user should be redirected to when they are not authenticated.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    protected function redirectTo(Request $request)
+    {
+        //
     }
 }


### PR DESCRIPTION
Hi,

It would be helpful to allow developers to specify the redirect URL when the want to override this middleware in skeleton.

The `AuthenticationException` expects project to have a route name `login` when redirect URL is not supplied.

Notice: `Illuminate\Auth\Middleware\Authenticate` already allows developers to customise it.
