### PR TITLE
[10.x] Trying to get XSRF from cookie if not found anywhere else

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -160,6 +160,10 @@ class VerifyCsrfToken
             }
         }
 
+        if (! $token && $this->shouldAddXsrfTokenCookie()) {
+            $token = $request->cookie('XSRF-TOKEN');
+        }
+
         return $token;
     }
 


### PR DESCRIPTION
If the XSRF token is passed to the client in the cookie response, why not read it from the request cookie if it hasn't been passed anywhere else?

This will allow you not to send extra headers every time and not to show the decrypted CSRF token in the meta tag.

Reading a token from a cookie supports encryption if the middleware (`\Illuminate\Cookie\Middleware\EncryptCookies::class`) is enabled and will work correctly if disabled.