### PR TITLE
[9.x] Handle custom formatted `date` and `datetime` attributes casts distinctly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1085,7 +1085,8 @@ trait HasAttributes
     protected function isDateAttribute($key)
     {
         return in_array($key, $this->getDates(), true) ||
-            $this->isDateCastable($key);
+            $this->isDateCastable($key) ||
+            $this->isDateCastableWithCustomFormat($key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -299,7 +299,7 @@ trait HasAttributes
             }
 
             if (isset($attributes[$key]) && ($this->isCustomDateTimeCast($value) ||
-                $this->isImmutableCustomDateTimeCast($value))) {
+                $this->isImmutableCustomDateTimeCast($value) || $this->isCustomDateCast($value))) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
 
@@ -774,6 +774,7 @@ trait HasAttributes
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
             case 'date':
+            case 'custom_date':
                 return $this->asDate($value);
             case 'datetime':
             case 'custom_datetime':
@@ -866,6 +867,8 @@ trait HasAttributes
             $convertedCastType = 'custom_datetime';
         } elseif ($this->isImmutableCustomDateTimeCast($castType)) {
             $convertedCastType = 'immutable_custom_datetime';
+        } elseif ($this->isCustomDateCast($castType)) {
+            $convertedCastType = 'custom_date';
         } elseif ($this->isDecimalCast($castType)) {
             $convertedCastType = 'decimal';
         } else {
@@ -912,8 +915,13 @@ trait HasAttributes
      */
     protected function isCustomDateTimeCast($cast)
     {
-        return str_starts_with($cast, 'date:') ||
+        return //str_starts_with($cast, 'date:') ||
                 str_starts_with($cast, 'datetime:');
+    }
+
+    protected function isCustomDateCast($cast)
+    {
+        return str_starts_with($cast, 'date:');
     }
 
     /**
@@ -1085,8 +1093,7 @@ trait HasAttributes
     protected function isDateAttribute($key)
     {
         return in_array($key, $this->getDates(), true) ||
-            $this->isDateCastable($key) ||
-            $this->isDateCastableWithCustomFormat($key);
+            $this->isDateCastable($key);
     }
 
     /**
@@ -1534,7 +1541,7 @@ trait HasAttributes
      */
     protected function isDateCastableWithCustomFormat($key)
     {
-        return $this->hasCast($key, ['custom_datetime', 'immutable_custom_datetime']);
+        return $this->hasCast($key, ['custom_datetime', 'immutable_custom_datetime', 'custom_date']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -915,10 +915,15 @@ trait HasAttributes
      */
     protected function isCustomDateTimeCast($cast)
     {
-        return //str_starts_with($cast, 'date:') ||
-                str_starts_with($cast, 'datetime:');
+        return str_starts_with($cast, 'datetime:');
     }
 
+    /**
+     * Determine if the cast type is a custom date cast.
+     *
+     * @param  string  $cast
+     * @return bool
+     */
     protected function isCustomDateCast($cast)
     {
         return str_starts_with($cast, 'date:');

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -44,13 +44,16 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         });
 
         TestModel1::create([
-            'date_field' => '2019-10-01',
-            'datetime_field' => '2019-10-01 10:15:20',
-            'immutable_date_field' => '2019-10-01',
-            'immutable_datetime_field' => '2019-10-01 10:15',
+            'date_field' => '2019-10-31',
+            'datetime_field' => '2019-10-31 10:15:20',
+            'immutable_date_field' => '2019-10-31',
+            'immutable_datetime_field' => '2019-10-31 10:15',
         ]);
 
-        $this->assertSame(['2019-10-01', '2019-10-01 10:15:20', '2019-10-01', '2019-10-01 10:15'], $bindings);
+        $this->assertSame([
+            '2019-10-31 00:00:00',
+            '2019-10-31 10:15:20',
+            '2019-10-31 00:00:00', '2019-10-31 10:15:00'], $bindings);
     }
 
     public function testDatesFormattedArrayAndJson()

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -44,16 +44,13 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         });
 
         TestModel1::create([
-            'date_field' => '2019-10-31',
-            'datetime_field' => '2019-10-31 10:15:20',
-            'immutable_date_field' => '2019-10-31',
-            'immutable_datetime_field' => '2019-10-31 10:15',
+            'date_field' => '2019-10-01',
+            'datetime_field' => '2019-10-01 10:15:20',
+            'immutable_date_field' => '2019-10-01',
+            'immutable_datetime_field' => '2019-10-01 10:15',
         ]);
 
-        $this->assertSame([
-            '2019-10-31 00:00:00',
-            '2019-10-31 10:15:20',
-            '2019-10-31 00:00:00', '2019-10-31 10:15:00'], $bindings);
+        $this->assertSame(['2019-10-01', '2019-10-01 10:15:20', '2019-10-01', '2019-10-01 10:15'], $bindings);
     }
 
     public function testDatesFormattedArrayAndJson()


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/46737