### PR TITLE
[10.x] fix compiled view file ends with .php

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -118,7 +118,7 @@ trait ResolvesDumpSource
      */
     protected function isCompiledViewFile($file)
     {
-        return str_starts_with($file, $this->compiledViewPath);
+        return str_starts_with($file, $this->compiledViewPath) && str_ends_with($file,'.php');
     }
 
     /**

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -118,7 +118,7 @@ trait ResolvesDumpSource
      */
     protected function isCompiledViewFile($file)
     {
-        return str_starts_with($file, $this->compiledViewPath) && str_ends_with($file,'.php');
+        return str_starts_with($file, $this->compiledViewPath) && str_ends_with($file ,'.php');
     }
 
     /**

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -118,7 +118,7 @@ trait ResolvesDumpSource
      */
     protected function isCompiledViewFile($file)
     {
-        return str_starts_with($file, $this->compiledViewPath) && str_ends_with($file ,'.php');
+        return str_starts_with($file, $this->compiledViewPath) && str_ends_with($file, '.php');
     }
 
     /**


### PR DESCRIPTION
hi, current implementation fails when a view contains following

```
<?php
eval("dump(Auth::user());");
```

with error : failed to open file `.../storage/framework/views/some-file-name.php(3) : eval()'d code`

``` "file_get_contents(...storage/framework/views/some-file-name.php(3) : eval()'d code): Failed to open stream: No such file or directory"```

this is due to the "eval' code" string appended at the end of the file name.

This fix also checks the file name ends with .php to correctly validate before reading the file

Thanks
