### PR TITLE
Class based after validation rules

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -97,7 +97,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
         }
 
         if (method_exists($this, 'after')) {
-            $validator->after($this->container->call($this->after(...)));
+            $validator->after($this->container->call(
+                $this->after(...),
+                ['validator' => $validator]
+            ));
         }
 
         $this->setValidator($validator);

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -96,6 +96,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->withValidator($validator);
         }
 
+        if (method_exists($this, 'after')) {
+            $validator->after($this->container->call($this->after(...)));
+        }
+
         $this->setValidator($validator);
 
         return $this->validator;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -383,7 +383,7 @@ class Validator implements ValidatorContract
     /**
      * Add an after validation callback.
      *
-     * @param  callable|string|array  $callback
+     * @param  callable|array|string  $callback
      * @return $this
      */
     public function after($callback)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -383,11 +383,19 @@ class Validator implements ValidatorContract
     /**
      * Add an after validation callback.
      *
-     * @param  callable|string  $callback
+     * @param  callable|string|array  $callback
      * @return $this
      */
     public function after($callback)
     {
+        if (is_array($callback) && ! is_callable($callback)) {
+            foreach ($callback as $rule) {
+                $this->after(method_exists($rule, 'after') ? $rule->after(...) : $rule);
+            }
+
+            return $this;
+        }
+
         $this->after[] = fn () => $callback($this);
 
         return $this;

--- a/tests/Validation/ValidatorAfterRuleTest.php
+++ b/tests/Validation/ValidatorAfterRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidatorAfterRuleTest extends TestCase
+{
+    public function testAfterAcceptsArrayOfRules()
+    {
+        $validator = new Validator(new Translator(new ArrayLoader, 'en'), [], []);
+
+        $validator->after([
+            fn ($validator) => $validator->errors()->add('closure', 'true'),
+            new InvokableAfterRule,
+            new AfterMethodRule,
+        ])->messages()->messages();
+
+        $this->assertSame($validator->messages()->messages(), [
+            'closure' => ['true'],
+            'invokableAfterRule' => ['true'],
+            'afterMethodRule' => ['true'],
+        ]);
+    }
+}
+
+class InvokableAfterRule
+{
+    public function __invoke($validator)
+    {
+        $validator->errors()->add('invokableAfterRule', 'true');
+    }
+}
+
+class AfterMethodRule
+{
+    public function __invoke()
+    {
+        //
+    }
+
+    public function after($validator)
+    {
+        $validator->errors()->add('afterMethodRule', 'true');
+    }
+}


### PR DESCRIPTION
This PR proposes improvements to "after" validation rules.

Currently, "after" validation rules must be handled with a callable. I find they generally take the following shape.

```php
<?php

Validator::make(/* .. */)->after(function ($validator) use (/* ... */): void {
    if (/* ... */) {
        $validator->errors()->add(/* ... */);
    }

    if (/* ... */) {
        $validator->errors()->add(/* ... */);
    }

    if (/* ... */) {
        $validator->errors()->add(/* ... */);
    }
});
```

It would also be possible to extract this out to a single callable class:

```php
<?php

class AfterRule
{
    public function __construct(/* ... */)
    {
        //
    }

    public function __invoke($validator): void
    {
        if (/* ... */) {
            $validator->errors()->add(/* ... */);
        }

        if (/* ... */) {
            $validator->errors()->add(/* ... */);
        }

        if (/* ... */) {
            $validator->errors()->add(/* ... */);
        }
    }
}

Validator::make(/* .. */)->after(new AfterRule(/* ... */));
```

This is well and good, however it doesn't lend itself to rule composition and rule reuse.

If I want to reuse one of these validation checks I end up with clunky to use abstractions.

```php
<?php

class AfterRuleOne
{
    public function __construct(/* ... */) 
    {
        //
    }

    public function __invoke($validator): void
    {
        if (/* ... */) {
            $validator->errors()->add(/* ... */);
        }
    }
}

class AfterRuleOne
{
    public function __construct(/* ... */) 
    {
        //
    }

    public function __invoke($validator): void
    {
        if (/* ... */) {
            $validator->errors()->add(/* ... */);
        }

        if (/* ... */) {
            $validator->errors()->add(/* ... */);
        }
    }
}

Validator::make(/* .. */)->after(function ($validator) use (/* ... */): void {
    (new AfterRuleOne(/* ... */))($validator);
    (new AfterRuleTwo(/* ... */))($validator);
});
```

Or a little bit better, I could use static methods on the extracted classes:

```php
<?php

Validator::make(/* .. */)->after(function ($validator) use (/* ... */): void {
    AfterRuleOne($validator, /* ... */);
    AfterRuleTwo($validator, /* ... */);
});
```

I'd like to propose that introduce a new after rule concept by allowing an array of rules to be passed to the "after" method.

```php
<?php

Validator::make(/* .. */)->after([
    new AfterRuleOne(/* ... */),
    new AfterRuleTwo(/* ... */),
    function ($validator) use (/* ... */): void => {
        // ...
    },
});
```

This is based on how normal class based validation rules work. The "after rule" just needs to implement an `after($validator)` method. Callables are also accepted, so you may pass a `Closure` or an invokable class.

If the class is invokable _and_ has an `after` method, the after method takes precedence.

Any state, or services, required by the rule should be passed into the constructor, again matching the way normal class based validation rules work.

## Form Requests

As form requests are how a large part of the community handle validation rules, I've made some potential improvements there as well.

In my opinion, adding "after" rules in a form request already feels a little out of place with other Laravel APIs.

```php
<?php

class UserRequest
{
    public function rules(): array
    {
        return [
            //
        ];
    }

    public function withValidator($validator): void
    {
        $service = app(MyService::class);

        $validator->after([
            new AfterRule($this->value, $service),
        ]);
    }
}
```

I understand that `withValidator` gives you total access to the validator, but in my personal experience I only ever use this method for adding "after" rules to the validator. Additionally, the `rules` method is called by the container, but the `withValidator` method does not give the same affordance. Dependencies need to be resolved manually.

This is where the `after` method comes into play.

```php
<?php

class UserRequest
{
    protected function rules(): array
    {
        return [
            //
        ];
    }

    protected function after(MyService $service): array
    {
        return [
            new AfterRule($this->value, $service),
            // ...
        ];
    }
}
```

