### PR TITLE
Check and define the place the columns should be by defining one inse…

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -258,6 +258,17 @@ class Blueprint
                 continue;
             }
 
+            //if the public after varible is set and the column has no after tag add the after tag
+            if($this->after && !$column['after']){
+                $column['after'] = $this->after;
+            }
+
+            //set value for the public after varible to be set in the up comming column in current migration file
+            if($column['after']){
+                $this->after = $column['name'];
+            }
+
+
             foreach ($grammar->getFluentCommands() as $commandName) {
                 $this->addCommand($commandName, compact('column'));
             }


### PR DESCRIPTION
user has to define the after tag onec and the upcoming columns (after tag ) will be automatic set to the column above it  
example:
 Schema::table('islands', function (Blueprint $table) {
            $table->integer('example')->after('name');
            $table->integer('example2');
            $table->integer('example3');
            $table->integer('example4');
            $table->integer('example5')->after('example3');
            $table->integer('example6');
        });
