### PR TITLE
[9.x] Fixes calling index() on ForeignKeyDefinition

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -73,4 +73,16 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->onDelete('no action');
     }
+
+    /**
+     * Set a column index name or otherwise default to the existing index created for the foreign-key.
+     *
+     * @return $this
+     */
+    public function index()
+    {
+        $this->attributes['index'] = count($parameters = func_get_args()) > 0 ? reset($parameters) : ($this->index ?? true);
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -75,13 +75,13 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
-     * Set a column index name or otherwise default to the existing index created for the foreign-key.
+     * Set a column index name or default to the existing index created for the foreign-key.
      *
      * @return $this
      */
     public function index()
     {
-        $this->attributes['index'] = count($parameters = func_get_args()) > 0 ? reset($parameters) : ($this->index ?? true);
+        $this->attributes['index'] = count($parameters = func_get_args()) > 0 ? $parameters : ($this->index ?? true);
 
         return $this;
     }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -75,13 +75,13 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
-     * Set a column index name or default to the existing index created for the foreign-key.
+     * Set a column index name or default to the existing index created for the foreign key.
      *
      * @return $this
      */
     public function index()
     {
-        $this->attributes['index'] = count($parameters = func_get_args()) > 0 ? $parameters : ($this->index ?? true);
+        $this->attributes['index'] = count($parameters = func_get_args()) > 0 ? reset($parameters) : ($this->index ?? true);
 
         return $this;
     }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1399,6 +1399,23 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertTrue($c);
     }
 
+    public function testCanAddIndexToForeignKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->index();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->index('custom_index_name');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `custom_index_name` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
+    }
+
     protected function getConnection()
     {
         return m::mock(Connection::class);

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -993,7 +993,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->index("custom_index_name");
+        $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->index('custom_index_name');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
@@ -1019,7 +1019,6 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
-
     }
 
     public function testAddingGeometry()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -993,6 +993,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable', $statements[0]);
 
         $blueprint = new Blueprint('users');
+        $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->index("custom_index_name");
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "custom_index_name" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable', $statements[0]);
+
+        $blueprint = new Blueprint('users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable(false)->initiallyImmediate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
@@ -1012,6 +1019,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
+
     }
 
     public function testAddingGeometry()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -206,7 +206,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->create();
         $blueprint->string('foo')->primary();
         $blueprint->string('order_id');
-        $blueprint->foreign('order_id')->references('id')->on('orders')->index("custom_name");
+        $blueprint->foreign('order_id')->references('id')->on('orders')->index('custom_name');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -201,6 +201,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('foo')->primary();
+        $blueprint->string('order_id');
+        $blueprint->foreign('order_id')->references('id')->on('orders')->index("custom_name");
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
     }
 
     public function testAddingUniqueKey()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -960,6 +960,23 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         );
     }
 
+    public function testCanAddIndexToForeignKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->index();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "users_foo_id_foreign" foreign key ("foo_id") references "orders" ("id")', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->index('custom_index_name');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "custom_index_name" foreign key ("foo_id") references "orders" ("id")', $statements[0]);
+    }
+
     protected function getConnection()
     {
         return m::mock(Connection::class);


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/46750

The issue that referenced this was using 10.x, but I am assuming this would be considered a bug fix (if accepted) so I targeted 9.x.

Upon a bit more research, it looks like all the databases would already add an index to the FK, so if this PR is not approved, I would suggest adding something in the docs that indicates you should not use `ForeignKeyDefinition@index()` unless providing a different name for the index.