### PR TITLE
Add moveToTop and moveToBottom methods in collections to move specific element to top or bottom of the array using value or key.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -855,6 +855,8 @@ class Arr
     }
 
     /**
+     * Move a specific element to top of the array using "key" or "value"
+     *
      * @param array $array
      * @param int|string $data
      * @param string $by
@@ -878,6 +880,8 @@ class Arr
     }
 
     /**
+     * Move a specific element to bottom of the array using "key" or "value"
+     *
      * @param array $array
      * @param int|string $data
      * @param string $by

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -855,62 +855,48 @@ class Arr
     }
 
     /**
-     * Move specific element to top of the array using "value".
-     *
      * @param array $array
-     * @param int|string $value
+     * @param int|string $data
+     * @param string $by
      * @return array
      */
-    public static function moveToTopByValue(array $array, int|string $value) : array
+    public static function moveToTop(array $array, int|string $data, string $by = "key") : array
     {
-        $getArr = [(array_keys($array, $value)[0]) => $value];
-        $key = (array_keys($array, $value)[0]);
-        unset($array[$key]);
-        $getArr += $array;
-        return $getArr;
-    }
+        if ($by === "value") {
+            $getArr = [(array_keys($array, $data)[0]) => $data];
+            $key = (array_keys($array, $data)[0]);
+            unset($array[$key]);
+            $getArr += $array;
+            return $getArr;
+        }
 
-    /**
-     * Move specific element to bottom of the array using "value".
-     *
-     * @param array $array
-     * @param int|string $value
-     * @return array
-     */
-    public static function moveToBottomByValue(array $array, int|string $value) : array
-    {
-        $key = (array_keys($array, $value)[0]);
-        unset($array[$key]);
-        $array[$key] = $value;
-        return $array;
-    }
-
-    /**
-     * Move specific element to top of the array using "key".
-     *
-     * @param array $array
-     * @param int|string $key
-     * @return array
-     */
-    public static function moveToTopByKey(array $array, int|string $key) : array
-    {
-        $getArr = array($key => $array[$key]);
-        unset($array[$key]);
+        //by "key"
+        $getArr = array($data => $array[$data]);
+        unset($array[$data]);
         return $getArr + $array;
+
     }
 
     /**
-     * Move specific element to bottom of the array using "key".
-     *
      * @param array $array
-     * @param int|string $key
+     * @param int|string $data
+     * @param string $by
      * @return array
      */
-    public static function moveToBottomByKey(array $array, int|string $key) : array
+    public static function moveToBottom(array $array, int|string $data, string $by = "key") : array
     {
-        $value = $array[$key];
-        unset($array[$key]);
-        $array[$key] = $value;
+        if ($by === "value") {
+            $key = (array_keys($array, $data)[0]);
+            unset($array[$key]);
+            $array[$key] = $data;
+            return $array;
+        }
+
+        //by "key"
+        $value = $array[$data];
+        unset($array[$data]);
+        $array[$data] = $value;
         return $array;
+
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -853,4 +853,64 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Move specific element to top of the array using "value".
+     *
+     * @param array $array
+     * @param int|string $value
+     * @return array
+     */
+    public static function moveToTopByValue(array $array, int|string $value) : array
+    {
+        $getArr = [(array_keys($array, $value)[0]) => $value];
+        $key = (array_keys($array, $value)[0]);
+        unset($array[$key]);
+        $getArr += $array;
+        return $getArr;
+    }
+
+    /**
+     * Move specific element to bottom of the array using "value".
+     *
+     * @param array $array
+     * @param int|string $value
+     * @return array
+     */
+    public static function moveToBottomByValue(array $array, int|string $value) : array
+    {
+        $key = (array_keys($array, $value)[0]);
+        unset($array[$key]);
+        $array[$key] = $value;
+        return $array;
+    }
+
+    /**
+     * Move specific element to top of the array using "key".
+     *
+     * @param array $array
+     * @param int|string $key
+     * @return array
+     */
+    public static function moveToTopByKey(array $array, int|string $key) : array
+    {
+        $getArr = array($key => $array[$key]);
+        unset($array[$key]);
+        return $getArr + $array;
+    }
+
+    /**
+     * Move specific element to bottom of the array using "key".
+     *
+     * @param array $array
+     * @param int|string $key
+     * @return array
+     */
+    public static function moveToBottomByKey(array $array, int|string $key) : array
+    {
+        $value = $array[$key];
+        unset($array[$key]);
+        $array[$key] = $value;
+        return $array;
+    }
 }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1761,4 +1761,29 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+
+    /**
+     * @param $data
+     * @param $by
+     * @return $this
+     */
+    public function moveToTop($data, $by)
+    {
+        $this->items = Arr::moveToTop($this->items, $data, $by);
+        return $this;
+    }
+
+    /**
+     * @param $data
+     * @param $by
+     * @return $this
+     */
+    public function moveToBottom($data, $by)
+    {
+        $this->items = Arr::moveToBottom($this->items, $data, $by);
+        return $this;
+    }
+
+
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1178,4 +1178,176 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testMoveToTopByValue()
+    {
+        $testValue1 = "Zero"; // string
+
+        $testArray1 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            0 => "Zero",
+            4 => "Four"
+        ];
+
+        $testExpect1 = [
+            0 => "Zero",
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            4 => "Four",
+        ];
+
+        $this->assertSame($testExpect1, Arr::moveToTopByValue($testArray1, $testValue1));
+
+        $testValue2 = 0; // int
+
+        $testArray2 = [
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Zero" => 0,
+            "Four" => 4
+        ];
+
+        $testExpect2 = [
+            "Zero" => 0,
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Four" => 4
+        ];
+
+        $this->assertSame($testExpect2, Arr::moveToTopByValue($testArray2, $testValue2));
+    }
+
+    public function testMoveToBottomByValue()
+    {
+        $testValue1 = "Zero"; // string
+
+        $testArray1 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            0 => "Zero",
+            4 => "Four"
+        ];
+
+        $testExpect1 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            4 => "Four",
+            0 => "Zero",
+        ];
+
+        $this->assertSame($testExpect1, Arr::moveToBottomByValue($testArray1, $testValue1));
+
+        $testValue2 = 0; // int
+
+        $testArray2 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            0 => 0,
+            4 => "Four"
+        ];
+
+        $testExpect2 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            4 => "Four",
+            0 => 0,
+        ];
+
+        $this->assertSame($testExpect2, Arr::moveToBottomByValue($testArray2, $testValue2));
+    }
+
+    public function testMoveToTopByKey()
+    {
+        $testValue1 = "Zero"; // string
+
+        $testArray1 = [
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Zero" => 0,
+            "Four" => 4
+        ];
+
+        $testExpect1 = [
+            "Zero" => 0,
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Four" => 4
+        ];
+
+        $this->assertSame($testExpect1, Arr::moveToTopByKey($testArray1, $testValue1));
+
+        $testValue2 = 0; // int
+
+        $testArray2 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            0 => "Zero",
+            4 => "Four"
+        ];
+
+        $testExpect2 = [
+            0 => "Zero",
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            4 => "Four",
+        ];
+
+        $this->assertSame($testExpect2, Arr::moveToTopByKey($testArray2, $testValue2));
+    }
+
+    public function testMoveToBottomByKey()
+    {
+        $testValue1 = "Zero"; // string
+
+        $testArray1 = [
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Zero" => 0,
+            "Four" => 4
+        ];
+
+        $testExpect1 = [
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Four" => 4,
+            "Zero" => 0,
+        ];
+
+        $this->assertSame($testExpect1, Arr::moveToBottomByKey($testArray1, $testValue1));
+
+        $testValue2 = 0; // int
+
+        $testArray2 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            0 => "Zero",
+            4 => "Four"
+        ];
+
+        $testExpect2 = [
+            1 => "One",
+            2 => "Two",
+            3 => "Three",
+            4 => "Four",
+            0 => "Zero",
+        ];
+
+        $this->assertSame($testExpect2, Arr::moveToBottomByKey($testArray2, $testValue2));
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1181,7 +1181,7 @@ class SupportArrTest extends TestCase
 
     public function testMoveToTopByValue()
     {
-        $testValue1 = "Zero"; // string
+        $testData1 = "Zero"; // string
 
         $testArray1 = [
             1 => "One",
@@ -1199,9 +1199,9 @@ class SupportArrTest extends TestCase
             4 => "Four",
         ];
 
-        $this->assertSame($testExpect1, Arr::moveToTopByValue($testArray1, $testValue1));
+        $this->assertSame($testExpect1, Arr::moveToTop($testArray1, $testData1,"value"));
 
-        $testValue2 = 0; // int
+        $testData2 = 0; // int
 
         $testArray2 = [
             "One" => 1,
@@ -1219,12 +1219,12 @@ class SupportArrTest extends TestCase
             "Four" => 4
         ];
 
-        $this->assertSame($testExpect2, Arr::moveToTopByValue($testArray2, $testValue2));
+        $this->assertSame($testExpect2, Arr::moveToTop($testArray2, $testData2,"value"));
     }
 
     public function testMoveToBottomByValue()
     {
-        $testValue1 = "Zero"; // string
+        $testData1 = "Zero"; // string
 
         $testArray1 = [
             1 => "One",
@@ -1242,9 +1242,9 @@ class SupportArrTest extends TestCase
             0 => "Zero",
         ];
 
-        $this->assertSame($testExpect1, Arr::moveToBottomByValue($testArray1, $testValue1));
+        $this->assertSame($testExpect1, Arr::moveToBottom($testArray1, $testData1,"value"));
 
-        $testValue2 = 0; // int
+        $testData2 = 0; // int
 
         $testArray2 = [
             "One" => 1,
@@ -1262,12 +1262,12 @@ class SupportArrTest extends TestCase
             "Zero" => 0,
         ];
 
-        $this->assertSame($testExpect2, Arr::moveToBottomByValue($testArray2, $testValue2));
+        $this->assertSame($testExpect2, Arr::moveToBottom($testArray2, $testData2, "value"));
     }
 
     public function testMoveToTopByKey()
     {
-        $testKey1 = "Zero"; // string
+        $testData1 = "Zero"; // string
 
         $testArray1 = [
             "One" => 1,
@@ -1285,9 +1285,9 @@ class SupportArrTest extends TestCase
             "Four" => 4
         ];
 
-        $this->assertSame($testExpect1, Arr::moveToTopByKey($testArray1, $testKey1));
+        $this->assertSame($testExpect1, Arr::moveToTop($testArray1, $testData1,"key"));
 
-        $testKey2 = 0; // int
+        $testData2 = 0; // int
 
         $testArray2 = [
             1 => "One",
@@ -1305,12 +1305,12 @@ class SupportArrTest extends TestCase
             4 => "Four",
         ];
 
-        $this->assertSame($testExpect2, Arr::moveToTopByKey($testArray2, $testKey2));
+        $this->assertSame($testExpect2, Arr::moveToTop($testArray2, $testData2,"key"));
     }
 
     public function testMoveToBottomByKey()
     {
-        $testKey1 = "Zero"; // string
+        $testData1 = "Zero"; // string
 
         $testArray1 = [
             "One" => 1,
@@ -1328,9 +1328,9 @@ class SupportArrTest extends TestCase
             "Zero" => 0,
         ];
 
-        $this->assertSame($testExpect1, Arr::moveToBottomByKey($testArray1, $testKey1));
+        $this->assertSame($testExpect1, Arr::moveToBottom($testArray1, $testData1,"key"));
 
-        $testKey2 = 0; // int
+        $testData2 = 0; // int
 
         $testArray2 = [
             1 => "One",
@@ -1348,6 +1348,6 @@ class SupportArrTest extends TestCase
             0 => "Zero",
         ];
 
-        $this->assertSame($testExpect2, Arr::moveToBottomByKey($testArray2, $testKey2));
+        $this->assertSame($testExpect2, Arr::moveToBottom($testArray2, $testData2,"key"));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1267,7 +1267,7 @@ class SupportArrTest extends TestCase
 
     public function testMoveToTopByKey()
     {
-        $testValue1 = "Zero"; // string
+        $testKey1 = "Zero"; // string
 
         $testArray1 = [
             "One" => 1,
@@ -1285,9 +1285,9 @@ class SupportArrTest extends TestCase
             "Four" => 4
         ];
 
-        $this->assertSame($testExpect1, Arr::moveToTopByKey($testArray1, $testValue1));
+        $this->assertSame($testExpect1, Arr::moveToTopByKey($testArray1, $testKey1));
 
-        $testValue2 = 0; // int
+        $testKey2 = 0; // int
 
         $testArray2 = [
             1 => "One",
@@ -1305,12 +1305,12 @@ class SupportArrTest extends TestCase
             4 => "Four",
         ];
 
-        $this->assertSame($testExpect2, Arr::moveToTopByKey($testArray2, $testValue2));
+        $this->assertSame($testExpect2, Arr::moveToTopByKey($testArray2, $testKey2));
     }
 
     public function testMoveToBottomByKey()
     {
-        $testValue1 = "Zero"; // string
+        $testKey1 = "Zero"; // string
 
         $testArray1 = [
             "One" => 1,
@@ -1328,9 +1328,9 @@ class SupportArrTest extends TestCase
             "Zero" => 0,
         ];
 
-        $this->assertSame($testExpect1, Arr::moveToBottomByKey($testArray1, $testValue1));
+        $this->assertSame($testExpect1, Arr::moveToBottomByKey($testArray1, $testKey1));
 
-        $testValue2 = 0; // int
+        $testKey2 = 0; // int
 
         $testArray2 = [
             1 => "One",
@@ -1348,6 +1348,6 @@ class SupportArrTest extends TestCase
             0 => "Zero",
         ];
 
-        $this->assertSame($testExpect2, Arr::moveToBottomByKey($testArray2, $testValue2));
+        $this->assertSame($testExpect2, Arr::moveToBottomByKey($testArray2, $testKey2));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1247,19 +1247,19 @@ class SupportArrTest extends TestCase
         $testValue2 = 0; // int
 
         $testArray2 = [
-            1 => "One",
-            2 => "Two",
-            3 => "Three",
-            0 => 0,
-            4 => "Four"
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Zero" => 0,
+            "Four" => 4
         ];
 
         $testExpect2 = [
-            1 => "One",
-            2 => "Two",
-            3 => "Three",
-            4 => "Four",
-            0 => 0,
+            "One" => 1,
+            "Two" => 2,
+            "Three" => 3,
+            "Four" => 4,
+            "Zero" => 0,
         ];
 
         $this->assertSame($testExpect2, Arr::moveToBottomByValue($testArray2, $testValue2));


### PR DESCRIPTION
### Add 2 new methods of collections to move specific element top or bottom of the array using value or key.


- **`moveToTop($array, $data, $by)`** - This method helps to move a specific element to the top of the array using the "value" or "key" of the array data.
       
        Example 1 :
        
        $data = "Zero";    // string | int (You can pass string | int on the basis of array values.)
        $by = "value";     // Move the element to the top using by "value" or "key"

        $array = [
            1 => "One",
            2 => "Two",
            3 => "Three",
            0 => "Zero",
            4 => "Four"
        ];
        
        moveToTop($array, $data, $by);

        //Output
        [
            0 => "Zero",
            1 => "One",
            2 => "Two",
            3 => "Three",
            4 => "Four",
        ]

       In above example, array values are string. so, in that case, $data should contain a string.
       
       ------------------------------------------------------------------------------------------------------------------------

       Example 2:

       $data = 0;             // string | int (You can pass string | int on the basis of array keys.)
       $by = "value";         // Move the element to the top using by "value" or "key"

       $array = [
           "One" => 1,
           "Two" => 2,
           "Three" => 3,
           "Zero" => 0,
           "Four" => 4
      ];
      
      moveToTop($array, $value, $by);
      
      //Output
      [
          "Zero" => 0,
          "One" => 1,
          "Two" => 2,
          "Three" => 3,
          "Four" => 4
      ];
       
      In the above example, array values are integers. so, in that case, $data should contain an integer.
      
      Also, move to the top of the element using by key, in that case, $data should be relevant to the keys of the array.



- **`moveToBottom($array, $data, $by)`** - This method helps to move a specific element to the bottom of the array using the "value" or "key" of the array data.
    
        Example 1 :

        $data = 0;    // string | int (You can pass string | int on the basis of array values.)
        $by = "key";     // Move the element to the top using by "value" or "key"

        $array = [
            1 => "One",
            2 => "Two",
            3 => "Three",
            0 => "Zero",
            4 => "Four"
        ];
        
        moveToBottom($array, $data, $by);

        //Output
        [
            1 => "One",
            2 => "Two",
            3 => "Three",
            4 => "Four",
            0 => "Zero",
        ];


        In the above example, array keys are int. In that case  $data should contain a integer.

       ------------------------------------------------------------------------------------------------------------------------

       Example 2:

       $data = "Zero";     // string | int (You can pass string | int on the basis of array keys.)
       $by = "key";        // Move the element to the top using by "value" or "key"

        $array = [
           "One" => 1,
           "Two" => 2,
           "Three" => 3,
           "Zero" => 0,
           "Four" => 4
      ];
      
      moveToBottom($array, $value, $by);
      
      //Output
      [
          "One" => 1,
          "Two" => 2,
          "Three" => 3,
          "Four" => 4,
          "Zero" => 0,
      ];

      In the above example, array keys are string. In that case  $data should contain a string.

      Also, move to the bottom of the element using by value, in that case, $data should be relevant to the values of the array.