### PR TITLE
[10.x] Fix a missing `provides()` method in ParallelTestingServiceProvider.

### DIFF
--- a/src/Illuminate/Testing/ParallelTestingServiceProvider.php
+++ b/src/Illuminate/Testing/ParallelTestingServiceProvider.php
@@ -44,9 +44,11 @@ class ParallelTestingServiceProvider extends ServiceProvider implements Deferrab
     public function provides()
     {
         $services = [];
+
         if ($this->app->runningInConsole()) {
             $services[] = ParallelTesting::class;
         }
+
         return $services;
     }
 }

--- a/src/Illuminate/Testing/ParallelTestingServiceProvider.php
+++ b/src/Illuminate/Testing/ParallelTestingServiceProvider.php
@@ -35,4 +35,18 @@ class ParallelTestingServiceProvider extends ServiceProvider implements Deferrab
             });
         }
     }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        $services = [];
+        if ($this->app->runningInConsole()) {
+            $services[] = ParallelTesting::class;
+        }
+        return $services;
+    }
 }


### PR DESCRIPTION
`ParallelTestingServiceProvider` implements `DeferrableProvider`.
However, it cannot Deferring correctly because the `provides()` function is not defined.

This PR add the missing `provides()` method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
