### PR TITLE
[10.x] Cross-database support for all relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -757,6 +757,8 @@ class Builder implements BuilderContract
 
         $constraints($relation);
 
+        $this->query->prependDatabaseNameIfCrossDatabaseQuery($relation->getBaseQuery());
+
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -54,6 +54,8 @@ trait QueriesRelationships
             $relation->getRelated()->newQueryWithoutRelationships(), $this
         );
 
+        $this->query->prependDatabaseNameIfCrossDatabaseQuery($hasQuery->getQuery());
+
         // Next we will call any given callback as an "anonymous" scope so they can get the
         // proper logical grouping of the where clauses if needed by this Eloquent query
         // builder. Then, we will be ready to finalize and return this query instance.

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -210,9 +210,12 @@ class BelongsToMany extends Relation
         // model instance. Then we can set the "where" for the parent models.
         $query->join(
             $this->table,
-            $this->getQualifiedRelatedKeyName(),
-            '=',
-            $this->getQualifiedRelatedPivotKeyName()
+            function ($join) {
+                $join->on($this->getQualifiedRelatedKeyName(), '=', $this->getQualifiedRelatedPivotKeyName());
+                if (is_null($this->using)) {
+                    $join->setConnection($this->parent->getConnection());
+                }
+            }
         );
 
         return $this;
@@ -334,6 +337,10 @@ class BelongsToMany extends Relation
     public function using($class)
     {
         $this->using = $class;
+
+        foreach ($this->query?->getQuery()->joins ?? [] as $join) {
+            $join->setConnection((new $class)->getConnection());
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -127,7 +127,13 @@ class HasManyThrough extends Relation
 
         $farKey = $this->getQualifiedFarKeyName();
 
-        $query->join($this->throughParent->getTable(), $this->getQualifiedParentKeyName(), '=', $farKey);
+        $query->join(
+            $this->throughParent->getTable(),
+            function ($join) use ($farKey) {
+                $join->on($this->getQualifiedParentKeyName(), '=', $farKey);
+                $join->setConnection($this->parent->getConnection());
+            }
+        );
 
         if ($this->throughParentSoftDeletes()) {
             $query->withGlobalScope('SoftDeletableHasManyThrough', function ($query) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -369,7 +369,7 @@ class Builder implements BuilderContract
     protected function parseSub($query)
     {
         if ($query instanceof self || $query instanceof EloquentBuilder || $query instanceof Relation) {
-            $baseQuery = match(get_class($query)) {
+            $baseQuery = match (get_class($query)) {
                 EloquentBuilder::class => $query->getQuery(),
                 Relation::class => $query->getQuery()->getQuery(),
                 default => $query

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
+use Illuminate\Database\ConnectionInterface;
 
 class JoinClause extends Builder
 {
@@ -120,6 +121,19 @@ class JoinClause extends Builder
     public function newQuery()
     {
         return new static($this->newParentQuery(), $this->type, $this->table);
+    }
+
+    /**
+     * Set the connection for this join clause.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return $this
+     */
+    public function setConnection(ConnectionInterface $connection)
+    {
+        $this->connection = $connection;
+
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -52,7 +52,9 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
 
-        $builder->shouldReceive('join')->once()->with('club_user', 'users.id', '=', 'club_user.user_id');
+        $builder->shouldReceive('join')->once()->with(
+            m::on(fn ($arg) => is_string($arg)), m::on(fn ($arg) => is_callable($arg))
+        );
         $builder->shouldReceive('where')->once()->with('club_user.club_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('club_user.is_admin', '=', 1, 'and');
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -763,7 +763,9 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testRelationshipEagerLoadProcess()
     {
-        $builder = m::mock(Builder::class.'[getRelation]', [$this->getMockQueryBuilder()]);
+        $baseBuilder = $this->getMockQueryBuilder();
+        $baseBuilder->shouldReceive('prependDatabaseNameIfCrossDatabaseQuery')->once();
+        $builder = m::mock(Builder::class.'[getRelation]', [$baseBuilder]);
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
@@ -772,6 +774,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
+        $relation->shouldReceive('getBaseQuery')->once()->andReturn(new \stdClass);
         $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
         $results = $builder->eagerLoadRelations(['models']);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -786,6 +786,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testRelationshipEagerLoadProcessForImplicitlyEmpty()
     {
         $queryBuilder = $this->getMockQueryBuilder();
+        $queryBuilder->shouldReceive('prependDatabaseNameIfCrossDatabaseQuery')->once();
         $builder = m::mock(Builder::class.'[getRelation]', [$queryBuilder]);
         $builder->setEagerLoads(['parentFoo' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -545,6 +545,8 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithWhereHasWithSpecificColumns()
     {
         $model = new EloquentModelWithWhereHasStub;
+        $connection = $this->addMockConnection($model);
+        $connection->shouldReceive('getDatabaseName')->andReturn('forge');
         $instance = $model->newInstance()->newQuery()->withWhereHas('foo:diaa,fares');
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('select')->once()->with(['diaa', 'fares']);
@@ -2524,6 +2526,8 @@ class DatabaseEloquentModelTest extends TestCase
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });
+
+        return $connection;
     }
 
     public function testTouchingModelWithTimestamps()

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -101,7 +101,9 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('tags.id');
         $related->shouldReceive('getMorphClass')->andReturn(get_class($related));
 
-        $builder->shouldReceive('join')->once()->with('taggables', 'tags.id', '=', 'taggables.tag_id');
+        $builder->shouldReceive('join')->once()->with(
+            m::on(fn ($arg) => is_string($arg)), m::on(fn ($arg) => is_callable($arg))
+        );
         $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));
 

--- a/tests/Integration/Database/EloquentCrossDatabaseTest.php
+++ b/tests/Integration/Database/EloquentCrossDatabaseTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentCrossDatabaseTest;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentCrossDatabaseTest extends DatabaseTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        if (! in_array($default = $app['config']->get('database.default'), ['mysql', 'sqlsrv'])) {
+            $this->markTestSkipped("Cross database queries not supported for $default.");
+        }
+
+        define('__TEST_DEFAULT_CONNECTION', $default);
+        define('__TEST_SECONDARY_CONNECTION', $default.'_two');
+
+        // Create a second connection based on the first connection, but with a different database.
+        $app['config']->set('database.connections.'.__TEST_SECONDARY_CONNECTION, array_merge(
+            $app['config']->get('database.connections.'.__TEST_DEFAULT_CONNECTION),
+            ['database' => 'forge_two']
+        ));
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    protected function setUpDatabaseRequirements(Closure $callback): void
+    {
+        $db = $this->app['config']->get('database.connections.'.__TEST_SECONDARY_CONNECTION.'.database');
+        try {
+            $this->app['db']->connection()->statement('CREATE DATABASE '.$db);
+        } catch(QueryException $e) {
+            // ...
+        }
+
+        parent::setUpDatabaseRequirements($callback);
+    }
+
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        tap(Schema::connection(__TEST_DEFAULT_CONNECTION), function ($schema) {
+            try {
+                $schema->create('posts', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('title');
+                    $table->foreignId('user_id')->nullable();
+                    $table->foreignId('root_tag_id')->nullable();
+                });
+            } catch (QueryException $e) {
+                //
+            }
+        });
+
+        tap(Schema::connection(__TEST_SECONDARY_CONNECTION), function ($schema) {
+            try {
+                $schema->create('users', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('username');
+                });
+
+                $schema->create('sub_posts', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('title');
+                    $table->foreignId('post_id');
+                });
+
+                $schema->create('views', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->integer('hits')->default(1);
+                    $table->morphs('viewable');
+                });
+
+                $schema->create('viewables', function (Blueprint $table) {
+                    $table->foreignId('view_id');
+                    $table->morphs('viewable');
+                });
+
+                $schema->create('comments', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('content');
+                    $table->foreignId('sub_post_id');
+                });
+
+                $schema->create('tags', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('tag');
+                });
+
+                $schema->create('post_tag', function (Blueprint $table) {
+                    $table->foreignId('post_id');
+                    $table->foreignId('tag_id');
+                });
+            } catch (QueryException $e) {
+                //
+            }
+        });
+
+        tap(DB::connection(__TEST_DEFAULT_CONNECTION), function ($db) {
+            $db->table('posts')->insert([
+                ['title' => 'Foobar', 'user_id' => 1],
+                ['title' => 'The title', 'user_id' => 1],
+            ]);
+        });
+
+        tap(DB::connection(__TEST_SECONDARY_CONNECTION), function ($db) {
+            $db->table('users')->insert([
+                ['username' => 'Lortay Wellot'],
+            ]);
+
+            $db->table('sub_posts')->insert([
+                ['title' => 'The subpost title', 'post_id' => 1],
+            ]);
+
+            $db->table('comments')->insert([
+                ['content' => 'The comment content', 'sub_post_id' => 1],
+            ]);
+
+            $db->table('views')->insert([
+                ['hits' => 123, 'viewable_id' => 1, 'viewable_type' => Post::class],
+            ]);
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('posts');
+
+        foreach (['users', 'sub_posts', 'comments', 'views', 'viewables', 'tags', 'post_tag'] as $table) {
+            Schema::connection(__TEST_SECONDARY_CONNECTION)->dropIfExists($table);
+        }
+    }
+
+    public function testRelationships()
+    {
+        // We only test general compilation without errors here, indicating that cross-database queries have been
+        // executed correctly.
+
+        foreach (['comments', 'rootTag', 'subPosts', 'tags', 'user', 'view', 'viewables'] as $relation) {
+            $this->assertInstanceOf(Collection::class, Post::query()->with($relation)->get());
+            $this->assertInstanceOf(Collection::class, Post::query()->withCount($relation)->get());
+            $this->assertInstanceOf(Collection::class, Post::query()->whereHas($relation)->get());
+        }
+
+        $this->assertInstanceOf(Collection::class, View::query()->with('posts')->get());
+        $this->assertInstanceOf(Collection::class, View::query()->withCount('posts')->get());
+        $this->assertInstanceOf(Collection::class, View::query()->whereHas('posts')->get());
+        $this->assertInstanceOf(Collection::class, View::query()->with('viewable')->get());
+        $this->assertInstanceOf(Collection::class, View::query()->whereHas('viewable')->get());
+    }
+}
+
+abstract class BaseModel extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+}
+
+abstract class SecondaryBaseModel extends BaseModel
+{
+    protected $connection = __TEST_SECONDARY_CONNECTION;
+}
+
+class Post extends BaseModel
+{
+    protected $connection = __TEST_DEFAULT_CONNECTION;
+
+    public function comments()
+    {
+        return $this->hasManyThrough(Comment::class, SubPost::class, 'post_id', 'id');
+    }
+
+    public function rootTag()
+    {
+        return $this->hasOne(Tag::class, 'id', 'root_tag_id');
+    }
+
+    public function subPosts()
+    {
+        return $this->hasMany(SubPost::class);
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class)->using(PostTag::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function view()
+    {
+        return $this->morphOne(View::class, 'viewable');
+    }
+
+    public function viewables()
+    {
+        return $this->morphToMany(View::class, 'viewable', 'viewables')->using(Viewable::class);
+    }
+}
+
+class User extends SecondaryBaseModel
+{
+    //
+}
+
+class SubPost extends SecondaryBaseModel
+{
+    //
+}
+
+class Comment extends SecondaryBaseModel
+{
+    //
+}
+
+class Tag extends SecondaryBaseModel
+{
+    //
+}
+
+class View extends SecondaryBaseModel
+{
+    public function posts()
+    {
+        return $this->morphedByMany(Post::class, 'viewable');
+    }
+
+    public function viewable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class PostTag extends Pivot
+{
+    protected $connection = __TEST_SECONDARY_CONNECTION;
+}
+
+class Viewable extends Pivot
+{
+    protected $connection = __TEST_SECONDARY_CONNECTION;
+}


### PR DESCRIPTION
Related to https://github.com/laravel/framework/issues/23042

### Issue
Various relationship methods do not work with cross database relations including `withCount` and `whereHas`. SQL errors were thrown because the database name was not prefixed in all cases. Some work has been done previously to accomplish this, however it wasn't tested thoroughly and several cases were left unconsidered (like joins and specific relation types).

### Requirements
- Any `MorphToMany`/`BelongsToMany` relations are required to have an intermediary Eloquent model defined like so, because the connection from the intermediary table cant be resolved otherwise:
```php
public function taggables()
{
    return $this->morphToMany(...)->using(Taggable::class);
}
```
- The rest of the relations work out of the box and any joins/froms that happen on a different connection automatically have their database name prefixed.

### Task status
- [x] Test all relationship methods (only correct SQL execution is tested)

### Support status
- [x] MySQL 5.7
- [x] MySQL 8.0
- [x] MariaDB 10.0
- [x] SQL Server 2019 (FIXED prefixing `dbo` was required. A custom config override `'schema'` has been added in the database configuration, similar to Postgres)
- [x] NOT SUPPORTED: PostgreSQL 14 (it requires additional pgsql extensions `dblink` and/or `postgres_fdw`)
- [x] NOT SUPPORTED: SQLite
