### PR TITLE
Fix for the "put" method in the Cache/Repository

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -201,7 +201,7 @@ class Repository implements ArrayAccess, CacheContract
     public function put($key, $value, $ttl = null)
     {
         if (is_array($key)) {
-            return $this->putMany($key, $value);
+            return $this->putMany($key, $ttl);
         }
 
         if ($ttl === null) {


### PR DESCRIPTION
The `put` method call has been updated to pass `ttl` as the second argument instead of `value` when invoking the `putMany` method. The reason for this modification is that the `putMany` method expects the `ttl` as the second argument.
