### PR TITLE
[10.x] New Validate Attribute , csv for csv mime type

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -66,6 +66,7 @@ return [
         'string' => 'The :attribute field must be greater than or equal to :value characters.',
     ],
     'image' => 'The :attribute field must be an image.',
+    'csv' => 'The :attribute field must be an CSV.',
     'in' => 'The selected :attribute is invalid.',
     'in_array' => 'The :attribute field must exist in :other.',
     'integer' => 'The :attribute field must be an integer.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1258,7 +1258,6 @@ trait ValidatesAttributes
     {
         return $this->validateMimes($attribute, $value, ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp']);
     }
-    
     /**
      * Validate the MIME type of a file is an csv MIME type.
      *

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1258,6 +1258,18 @@ trait ValidatesAttributes
     {
         return $this->validateMimes($attribute, $value, ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp']);
     }
+    
+    /**
+     * Validate the MIME type of a file is an csv MIME type.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateCsv($attribute, $value)
+    {
+        return $this->validateMimes($attribute, $value, ['text/csv', 'application/csv', 'text/x-comma-separated-values', 'text/x-csv']);
+    }
 
     /**
      * Validate an attribute is contained within a list of values.


### PR DESCRIPTION
for csv mime type validation use `csv` 

```
 $validator = Validator::make($request->all(), [
              'file' => 'required|csv'
          ]);
```