### PR TITLE
[10.x] Add when/unless to $fail of closure validation rule

### DIFF
--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -413,6 +413,76 @@ class ValidationInvokableRuleTest extends TestCase
         $this->assertSame($rule, $invokableValidationRule->invokable());
     }
 
+    public function testItCanChooseToFailClosureValidationRule()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(true);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(false);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1');
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(true);
+            $fail('error 2')->when(false);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(false);
+            $fail('error 2')->when(true);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 2']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->unless(true);
+            $fail('error 2')->unless(false);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 2']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->unless(false);
+            $fail('error 2')->unless(true);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+    }
+
     private function getIlluminateArrayTranslator()
     {
         return new Translator(


### PR DESCRIPTION
When using a closure validation rule, you always have an if-statement:
```php
function ($attribute, $value, $fail) {
    if ($value !== 'foo') {
        return;
    }

    $fail('value should be foo');
}

// or

function ($attribute, $value, $fail) {
    if ($value === 'foo') {
        $fail('value should be foo');
    }   
}

// or

function ($attribute, $value, $fail) {
    $fails = // ... some very long line of code that checks the value ...

    if ($fails) {
        $fail('value should be foo');
    }   
}
```
That is a lot of lines of code for something that is essentially always a truth check. It is also sometimes annoying when the check in the if-statement is too long and does not fit on one line. You then have to assign the check to a variable outside the if-statement.

So I thought: why not add a when/unless-method to the $fail variable? This makes the code a lot cleaner in my opinion.
```php
function ($attribute, $value, $fail) {
    $fail('value should be foo')->when($value !== 'foo');
    // or
    $fail('value should be foo')->unless($value === 'foo');
    // or
    $fail('value should be foo')->unless(function () use ($value) {
        // some very long check that now can be more easily
        // split on multiple lines
    });
}
```
It is a pretty small change in the ClosureValidationRule that makes a big DX difference in my opinion.