### PR TITLE
[10.x] Remove MySQL warning 1681 on boolean field migration.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -731,7 +731,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeBoolean(Fluent $column)
     {
-        return 'tinyint(1)';
+        return 'boolean';
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -778,7 +778,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` boolean not null', $statements[0]);
     }
 
     public function testAddingEnum()


### PR DESCRIPTION
This pull request replaces column definition for a boolean type from `tinyint(1)` to `boolean`.

As documentation on [Numeric Type Attributes](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html) states:

> As of MySQL 8.0.17, the ZEROFILL attribute is deprecated for numeric data types, **as is the display width attribute for integer data types**. You should expect support for ZEROFILL and display widths for integer data types to be removed in a future version of MySQL.

It was long way planned (see, [2015 WL#13127](https://dev.mysql.com/worklog/task/?id=13127)) and finally it's here.

There are several ways to fix it:
* Just to remove size and use `tinyint`. But it can be considered as breaking BC (same "smart" editors can consider `tinyint(1)` as a boolean - I saw this ugly stuff). Also long time ago someone complained [about it's size](https://github.com/laravel/framework/issues/1202).
* Use `boolean`, which is an alias for `tinyint(1)` which doesn't produce a warning (this PR).
* Use `bit(1)`, which is [by recommended percona](https://www.percona.com/blog/efficient-boolean-value-storage-for-innodb-tables/) but it would be a breaking BC.
* Use other type, also a breaking BC.

**Way to reproduce the warning.**

Currently it's almost impossible to get this warning in the Laravel application. It's hidden down inside. [Proposal](https://wiki.php.net/rfc/pdo-mysql-get-warning-count) to get warnings count thru PDO has been rejected 2 years ago. Call to `SHOW WARNINGS` via PRO produces error 1295 'This command is not supported in the prepared statement protocol yet', and call to 'SELECT @@warning_count' always returns 1, no matter of what.

But we can use mysqli in php or mysql client to see that stuff:
```
mysql> create table `with_boolean` (`boolean_field` tinyint(1) not null);
Query OK, 0 rows affected, 1 warning (0.03 sec)

mysql> show warnings;
+---------+------+------------------------------------------------------------------------------+
| Level   | Code | Message                                                                      |
+---------+------+------------------------------------------------------------------------------+
| Warning | 1681 | Integer display width is deprecated and will be removed in a future release. |
+---------+------+------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```
Compare to:
```
mysql> create table `with_boolean` (`boolean_field` BOOLEAN not null);
Query OK, 0 rows affected (0.03 sec)

mysql> show warnings;
Empty set (0.00 sec)

mysql> show columns from `with_boolean`;
+---------------+------------+------+-----+---------+-------+
| Field         | Type       | Null | Key | Default | Extra |
+---------------+------------+------+-----+---------+-------+
| boolean_field | tinyint(1) | NO   |     | NULL    |       |
+---------------+------------+------+-----+---------+-------+
1 row in set (0.01 sec)
```
As you can see, it still reads as `tinyint(1)`, but doesn't produce a warning.

**Backward compatibility**

* MySQL 5.7 [has boolean alias](https://dev.mysql.com/doc/refman/5.7/en/numeric-type-syntax.html).
* MariaDB 10.3 [has boolean alias](https://mariadb.com/kb/en/boolean/).
* On readout field is described as `tinyint(1)`, so any user code, which relays on that behavior still works.
* I do not expect it to break `change()` migration functionality. At least different test runs went well.
* Only _can break_, if some library will parse compiled line. But I don't know if any exists.
* In case MySQL or MariaDB will introduce real boolean type in any release (which should be counted as major), it _can lead_ to problems in some third party libraries, that relay on `tinyint(1)`.
