### PR TITLE
Fix deprecated class in request.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -17,7 +17,7 @@ class {{ class }} extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
      */
     public function rules(): array
     {


### PR DESCRIPTION
When calling the `make:request` command, I see a deprecation warning for `Illuminate\Contracts\Validation\Rule`. 

This PR just updates the stub to refer to `Illuminate\Contracts\Validation\ValidationRule` as suggested by the deprecation warning.