### PR TITLE
[10.x] Support `insert` method on `HasOneOrMany`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -486,4 +486,34 @@ abstract class HasOneOrMany extends Relation
     {
         return $this->localKey;
     }
+
+    /**
+     * Get the foreign attributes.
+     *
+     * @return array
+     */
+    public function getForeignAttributes()
+    {
+        return [$this->getForeignKeyName() => $this->getParentKey()];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insert(array $values)
+    {
+        if (empty($values)) {
+            return true;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        foreach ($values as $key => $value) {
+            $values[$key] = array_merge($value, $this->getForeignAttributes());
+        }
+
+        return parent::insert($values);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -124,4 +124,17 @@ abstract class MorphOneOrMany extends HasOneOrMany
     {
         return $this->morphClass;
     }
+
+    /**
+     * Get the foreign attributes.
+     *
+     * @return array
+     */
+    public function getForeignAttributes()
+    {
+        return [
+            $this->getForeignKeyName() => $this->getParentKey(),
+            $this->getMorphType() => $this->getMorphClass(),
+        ];
+    }
 }

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -51,6 +51,17 @@ class EloquentHasManyTest extends DatabaseTestCase
         $this->assertEquals($oldestLogin->id, $user->oldestLogin->id);
         $this->assertEquals($latestLogin->id, $user->latestLogin->id);
     }
+
+    public function testInsertWithForeignKeyOnHasMany()
+    {
+        $user = EloquentHasManyTestUser::create();
+
+        $user->logins()->insert(['login_time' => '2010-01-01']);
+
+        $login = $user->logins()->first();
+
+        $this->assertEquals($user->id, $login->eloquent_has_many_test_user_id);
+    }
 }
 
 class EloquentHasManyTestUser extends Model

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -69,6 +69,18 @@ class EloquentMorphManyTest extends DatabaseTestCase
         $this->assertEquals($latestComment->id, $post->latestComment->id);
         $this->assertEquals($oldestComment->id, $post->oldestComment->id);
     }
+
+    public function testInsertWithForeignKeyOnMorphMany()
+    {
+        $post = Post::create(['title' => 'foo']);
+
+        $post->comments()->insert(['name' => 'bar']);
+
+        $comment = $post->comments()->first();
+
+        $this->assertEquals($post->id, $comment->commentable_id);
+        $this->assertEquals(Post::class, $comment->commentable_type);
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
This pull request adds support for inserting related data on `HasOneOrMany` relationships. Before this change, inserting related data using `$parent->children()->insert(...)` would result in the creation of a new child record without the foreign key being set. With this change, inserting related data will automatically set the foreign key to the primary key of the parent record, ensuring that all records are correctly linked together.

Please be aware that using `$parent->children()->create(...)` is not equivalent to using the `insert` method. When dealing with a large number of records (e.g. 1000), the `create` method will create each record one by one, leading to the execution of 1000 individual queries. In contrast, using `insert` will only execute one query.