### PR TITLE
[10.x] Set timestamps on Model::insert()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -106,7 +106,6 @@ class Builder implements BuilderContract
         'getConnection',
         'getGrammar',
         'implode',
-        'insert',
         'insertGetId',
         'insertOrIgnore',
         'insertUsing',
@@ -493,6 +492,40 @@ class Builder implements BuilderContract
         }
 
         return $result;
+    }
+
+    /**
+     * Insert new records into the database.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function insert(array $values) {
+        if (empty($values)) {
+            return true;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+
+        if (($modelInstance = $this->newModelInstance())->usesTimestamps()) {
+            $now = $modelInstance->freshTimestamp();
+            $timestampColumns = [];
+            if ($createdAtColumn = $modelInstance->getCreatedAtColumn()) {
+                $timestampColumns[$createdAtColumn] = $now;
+            }
+            if ($updatedAtColumn = $modelInstance->getUpdatedAtColumn()) {
+                $timestampColumns[$updatedAtColumn] = $now;
+            }
+
+            foreach($values as $key => $value) {
+                $values[$key] = array_merge($timestampColumns, $value);
+            }
+        }
+
+        return $this->toBase()->insert($values);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -495,12 +495,13 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Insert new records into the database.
+     * Insert new records into the database, setting the appropriate timestamps if necessary.
      *
      * @param  array  $values
      * @return bool
      */
-    public function insert(array $values) {
+    public function insert(array $values)
+    {
         if (empty($values)) {
             return true;
         }
@@ -508,7 +509,6 @@ class Builder implements BuilderContract
         if (! is_array(reset($values))) {
             $values = [$values];
         }
-
 
         if (($modelInstance = $this->newModelInstance())->usesTimestamps()) {
             $now = $modelInstance->freshTimestamp();
@@ -520,7 +520,7 @@ class Builder implements BuilderContract
                 $timestampColumns[$updatedAtColumn] = $now;
             }
 
-            foreach($values as $key => $value) {
+            foreach ($values as $key => $value) {
                 $values[$key] = array_merge($timestampColumns, $value);
             }
         }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -909,11 +909,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertInstanceOf(Builder::class, $builder->foobar());
 
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('insert')->once()->with(['bar'])->andReturn('foo');
-
-        $this->assertSame('foo', $builder->insert(['bar']));
-
-        $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insertOrIgnore')->once()->with(['bar'])->andReturn('foo');
 
         $this->assertSame('foo', $builder->insertOrIgnore(['bar']));

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2121,7 +2121,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertCount(2, $testItems);
 
-        foreach($testItems as $testItem) {
+        foreach ($testItems as $testItem) {
             $this->assertInstanceOf(\DateTime::class, $testItem->created_at);
             $this->assertInstanceOf(\DateTime::class, $testItem->updated_at);
         }
@@ -2134,7 +2134,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testInsertSetsOnlyCreatedAtColumn()
     {
         $this->assertTrue(EloquentUserWithoutUpdatedAt::insert([
-            ['id' => 19]
+            ['id' => 19],
         ]));
 
         $this->assertCount(1, $users = EloquentUserWithoutUpdatedAt::get());
@@ -2144,15 +2144,12 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testInsertSetsOnlyUpdatedAtColumn()
     {
         $this->assertTrue(EloquentUserWithoutCreatedAt::insert([
-            ['id' => 19]
+            ['id' => 19],
         ]));
 
         $this->assertCount(1, $users = EloquentUserWithoutCreatedAt::get());
         $this->assertInstanceOf(\DateTime::class, $users[0]->updated_at);
     }
-
-
-
 
     /**
      * Helpers...
@@ -2463,5 +2460,5 @@ class EloquentUserWithoutCreatedAt extends Eloquent
 {
     protected $table = 'users_without_created_at';
     protected $guarded = [];
-    public const CREATED_AT =  null;
+    public const CREATED_AT = null;
 }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2107,7 +2107,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             ['id' => 199], ['id' => 2007],
         ]));
 
-        $testItems = EloquentTestItem::query()->get();
+        $testItems = EloquentTestItem::get();
 
         $this->assertCount(2, $testItems);
 
@@ -2361,6 +2361,7 @@ class EloquentTestFriendPivot extends Pivot
 {
     protected $table = 'friends';
     protected $guarded = [];
+    public $timestamps = false;
 
     public function user()
     {

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2101,6 +2101,22 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('primary', $pivot->taxonomy);
     }
 
+    public function testInsertSetsTimestampColumns()
+    {
+        $this->assertTrue(EloquentTestItem::insert([
+            ['id' => 199], ['id' => 2007],
+        ]));
+
+        $testItems = EloquentTestItem::query()->get();
+
+        $this->assertCount(2, $testItems);
+
+        $this->assertNotNull($testItems[0]->created_at);
+        $this->assertNotNull($testItems[1]->created_at);
+        $this->assertNotNull($testItems[0]->updated_at);
+        $this->assertNotNull($testItems[1]->updated_at);
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -49,7 +49,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = 0;
-        $connection->whenQueryingForLongerThan(now()->addMilliseconds(1), function () use (&$called) {
+        $connection->whenQueryingForLongerThan(now()->addMilliseconds(2), function () use (&$called) {
             $called++;
         });
 

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -49,7 +49,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = 0;
-        $connection->whenQueryingForLongerThan(now()->addMilliseconds(2), function () use (&$called) {
+        $connection->whenQueryingForLongerThan(now()->addMilliseconds(1), function () use (&$called) {
             $called++;
         });
 

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -14,6 +14,7 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
+            $table->timestamps();
         });
     }
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -171,6 +171,7 @@ class CustomPivotCastTestProject extends Model
 
 class CustomPivotCastTestCollaborator extends Pivot
 {
+    public $timestamps = false;
     protected $attributes = [
         'permissions' => '["create", "update"]',
     ];

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -149,6 +149,7 @@ class PivotEventsTestProject extends Model
 class PivotEventsTestCollaborator extends Pivot
 {
     public $table = 'project_users';
+    public $timestamps = false;
 
     protected $casts = [
         'permissions' => 'json',

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -182,9 +182,11 @@ class PivotSerializationTestTag extends Model
 class PivotSerializationTestCollaborator extends Pivot
 {
     public $table = 'project_users';
+    public $timestamps = false;
 }
 
 class PivotSerializationTestTagAttachment extends MorphPivot
 {
     public $table = 'taggables';
+    public $timestamps = false;
 }

--- a/tests/Integration/Database/EloquentPivotTest.php
+++ b/tests/Integration/Database/EloquentPivotTest.php
@@ -128,6 +128,7 @@ class PivotTestProject extends Model
 class PivotTestCollaborator extends Pivot
 {
     public $table = 'collaborators';
+    public $timestamps = false;
 
     protected $casts = [
         'permissions' => 'json',
@@ -137,6 +138,7 @@ class PivotTestCollaborator extends Pivot
 class PivotTestContributor extends Pivot
 {
     public $table = 'contributors';
+    public $timestamps = false;
 
     public $incrementing = true;
 
@@ -148,6 +150,7 @@ class PivotTestContributor extends Pivot
 class PivotTestSubscription extends Pivot
 {
     public $table = 'subscriptions';
+    public $timestamps = false;
 
     protected $attributes = [
         'status' => 'active',


### PR DESCRIPTION
## Problem
Assume we have a model (`MyModel`) with timestamps. The following code inserts the data to the DB, but never sets the timestamps.

```php
for($i = 0; $i < 100; $i++) {
    $toInsert[] = ['name' => faker()->name()];
}

MyModel::insert($toInsert);

assert(MyModel::query()->latest()->first()->created_at instanceof \DateTime); // ❌  AssertionError
```

The way around this is to explicitly set the `created_at` and `updated_at` columns.

```php
for($i = 0; $i < 100; $i++) {
    $toInsert[] = [
        'name' => faker()->name(),
        'created_at' => now(),
        'updated_at' => now(),
    ];
}

MyModel::insert($toInsert);

assert(MyModel::query()->latest()->first()->created_at instanceof \DateTime); // 👍 
```

## Solution
With this PR, if the Model uses timestamps, we'll set the created_at and/or updated_at columns to the current time upon calling Eloquent\Builder@insert()

### Changes made to tests
For a number of Eloquent tests (especially those relying on Pivot models), no $timestamps property was ever set. I have updated those. I fear that this very necessity could be seen as the functionality being a breaking change. I personally don't think that it is, and was more or less oversight within the tests.

### Final thoughts
It would be really nice to have a distinct method that casts all properties when doing an insert, rather than just the timestamps. Builder::insertWithCasts() could handle type juggling as well as timestamps. That way if client code needs to use an insert where the table has a json column, they don't have to remember to json_encode() the data. I would not tie it into the insert() method as it's computational waste to retrieve a model and cast properties.