### PR TITLE
[10.x] Add newCollection method to Fluent class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -96,6 +96,17 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Create a new Collection instance.
+     *
+     * @param  array  $instances
+     * @return \Illuminate\Support\Collection<TKey, TValue>
+     */
+    public function newCollection(array $instances = [])
+    {
+        return new Collection($instances);
+    }
+
+    /**
      * Determine if the given offset exists.
      *
      * @param  TKey  $offset

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Fluent;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -128,6 +129,27 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $users = FactoryTestUserFactory::times(10)->create();
         $this->assertCount(10, $users);
+    }
+
+    public function test_basic_fluent_instance_can_be_made()
+    {
+        $fluent = FactoryTestFluentFactory::new()->make();
+        $this->assertInstanceOf(Fluent::class, $fluent);
+
+        $fluent = FactoryTestFluentFactory::new()->makeOne();
+        $this->assertInstanceOf(Fluent::class, $fluent);
+
+        $fluent = FactoryTestFluentFactory::new()->make(['name' => 'Taylor Otwell']);
+        $this->assertInstanceOf(Fluent::class, $fluent);
+        $this->assertSame('Taylor Otwell', $fluent->name);
+
+        $fluent = FactoryTestFluentFactory::new()->set('name', 'Taylor Otwell')->make();
+        $this->assertInstanceOf(Fluent::class, $fluent);
+        $this->assertSame('Taylor Otwell', $fluent->name);
+
+        $fluentCollection = FactoryTestFluentFactory::times(10)->make();
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $fluentCollection);
+        $this->assertCount(10, $fluentCollection);
     }
 
     public function test_expanded_closure_attributes_are_resolved_and_passed_to_closures()
@@ -846,6 +868,19 @@ class FactoryTestUser extends Eloquent
     public function factoryTestRoles()
     {
         return $this->belongsToMany(FactoryTestRole::class, 'role_user', 'user_id', 'role_id')->withPivot('admin');
+    }
+}
+
+class FactoryTestFluentFactory extends Factory
+{
+    protected $model = Fluent::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'options' => null,
+        ];
     }
 }
 

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayIterator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use IteratorAggregate;
 use PHPUnit\Framework\TestCase;
@@ -112,6 +113,16 @@ class SupportFluentTest extends TestCase
         $results = $fluent->toJson();
 
         $this->assertJsonStringEqualsJsonString(json_encode(['foo']), $results);
+    }
+
+    public function testNewCollectionReturnsResultAsCollection()
+    {
+        $array = ['name' => 'Taylor', 'age' => 25];
+        $fluent = new Fluent();
+        $collection = $fluent->newCollection($array);
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals($array, $collection->all());
     }
 }
 


### PR DESCRIPTION
This pull request is inspired by the nice solution @stevebauman wrote in an [article](https://stevebauman.ca/create-api-responses-with-eloquent-factories/) about how to solve a problem using of the `Factory::times(2)` method on a Fluent-based Model factory.

This PR resolves an issue where an error will be thrown when using the `MyFactory::times(2)` method with Model Factories using the `Fluent::class` instead of an Eloquent model.

```
TypeError : Illuminate\Database\Eloquent\Factories\Factory::callAfterMaking(): Argument #1 ($instances) must be of type Illuminate\Support\Collection, Illuminate\Support\Fluent given
```

This error occurs because the `Fluent::class` does not have a `newCollection()` method, so passes a single instance of the `Fluent::class` instead of a `Collection` to the `Factory::callAfterMaking()`.

While the Model Factories isn't intended to be used by non-eloquent instances, it really works great for generating objects which doesn't need to be persisted to the database.

Please let me know you what you think.