### PR TITLE
[10.x] Fix `$timestamps` within test Models

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2345,6 +2345,7 @@ class EloquentTestFriendPivot extends Pivot
 {
     protected $table = 'friends';
     protected $guarded = [];
+    public $timestamps = false;
 
     public function user()
     {

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -14,6 +14,7 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
+            $table->timestamps();
         });
     }
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -171,6 +171,8 @@ class CustomPivotCastTestProject extends Model
 
 class CustomPivotCastTestCollaborator extends Pivot
 {
+    public $timestamps = false;
+
     protected $attributes = [
         'permissions' => '["create", "update"]',
     ];

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -150,6 +150,8 @@ class PivotEventsTestCollaborator extends Pivot
 {
     public $table = 'project_users';
 
+    public $timestamps = false;
+
     protected $casts = [
         'permissions' => 'json',
     ];

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -182,9 +182,13 @@ class PivotSerializationTestTag extends Model
 class PivotSerializationTestCollaborator extends Pivot
 {
     public $table = 'project_users';
+
+    public $timestamps = false;
 }
 
 class PivotSerializationTestTagAttachment extends MorphPivot
 {
     public $table = 'taggables';
+
+    public $timestamps = false;
 }

--- a/tests/Integration/Database/EloquentPivotTest.php
+++ b/tests/Integration/Database/EloquentPivotTest.php
@@ -129,6 +129,8 @@ class PivotTestCollaborator extends Pivot
 {
     public $table = 'collaborators';
 
+    public $timestamps = false;
+
     protected $casts = [
         'permissions' => 'json',
     ];
@@ -137,6 +139,8 @@ class PivotTestCollaborator extends Pivot
 class PivotTestContributor extends Pivot
 {
     public $table = 'contributors';
+
+    public $timestamps = false;
 
     public $incrementing = true;
 
@@ -148,6 +152,8 @@ class PivotTestContributor extends Pivot
 class PivotTestSubscription extends Pivot
 {
     public $table = 'subscriptions';
+
+    public $timestamps = false;
 
     protected $attributes = [
         'status' => 'active',


### PR DESCRIPTION
In work on another PR, I noticed that the `$timestamps` property for a number of models on tests were not set properly.