### PR TITLE
[10.x] Add `insertWithCasts()` to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1027,9 +1027,11 @@ class Builder implements BuilderContract
             }
         }
 
-        foreach ($values as $key => $value) {
-            $values[$key] = $this->newModelInstance(array_merge($timestampColumns, $value))->getAttributes();
-        }
+        $this->model->unguarded(function() use (&$values, $timestampColumns) {
+            foreach ($values as $key => $value) {
+                $values[$key] = $this->newModelInstance(array_merge($timestampColumns, $value))->getAttributes();
+            }
+        });
 
         return $this->toBase()->insert($values);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1009,7 +1009,7 @@ class Builder implements BuilderContract
             return true;
         }
 
-        if (!is_array(reset($values))) {
+        if (! is_array(reset($values))) {
             $values = [$values];
         }
 
@@ -1027,7 +1027,7 @@ class Builder implements BuilderContract
             }
         }
 
-        $this->model->unguarded(function() use (&$values, $timestampColumns) {
+        $this->model->unguarded(function () use (&$values, $timestampColumns) {
             foreach ($values as $key => $value) {
                 $values[$key] = $this->newModelInstance(array_merge($timestampColumns, $value))->getAttributes();
             }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2115,7 +2115,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertCount(3, $users = EloquentTestUser::get());
 
-        $users->each(function(EloquentTestUser $user) {
+        $users->each(function (EloquentTestUser $user) {
             $this->assertInstanceOf(\DateTime::class, $user->created_at);
             $this->assertInstanceOf(\DateTime::class, $user->updated_at);
         });
@@ -2136,7 +2136,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertCount(2, $testsWithJson = EloquentTestWithJSON::get());
 
-        $testsWithJson->each(function(EloquentTestWithJSON $testWithJson) {
+        $testsWithJson->each(function (EloquentTestWithJSON $testWithJson) {
             $this->assertIsArray($testWithJson->json);
             $this->assertArrayHasKey('album', $testWithJson->json);
         });

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2106,21 +2106,24 @@ class DatabaseEloquentIntegrationTest extends TestCase
         DB::enableQueryLog();
 
         $this->assertTrue(EloquentTestUser::insertWithCasts([
-            ['email' => 'someperson@fake.com', 'birthday' => '1980-01-01'],
-            ['email' => 'adifferentpersonbutequally@fake.com', 'birthday' => null],
+            ['email' => 'taylorotwell@gmail.com', 'birthday' => null],
+            ['email' => 'someperson@fake.com', 'birthday' => new Carbon('1980-01-01')],
+            ['email' => 'adifferentpersonbutequally@fake.com', 'birthday' => '2001-12-29'],
         ]));
 
         $this->assertCount(1, DB::getQueryLog());
 
-        $this->assertCount(2, $users = EloquentTestUser::get());
+        $this->assertCount(3, $users = EloquentTestUser::get());
 
         $users->each(function(EloquentTestUser $user) {
             $this->assertInstanceOf(\DateTime::class, $user->created_at);
             $this->assertInstanceOf(\DateTime::class, $user->updated_at);
         });
 
-        $this->assertInstanceOf(\DateTime::class, $users->first()->birthday);
-        $this->assertNull($users->firstWhere('id', 2)->birthday);
+        $this->assertNull($users[0]->birthday);
+        $this->assertInstanceOf(\DateTime::class, $users[1]->birthday);
+        $this->assertInstanceOf(\DateTime::class, $users[2]->birthday);
+        $this->assertEquals('2001-12-29', $users[2]->birthday->format('Y-m-d'));
 
         DB::flushQueryLog();
 


### PR DESCRIPTION
## The Problem
The method is designed to cast properties, set default values if not supplied, and set the models timestamps where applicable.

The presenting problem is spelled out more fully here in https://github.com/laravel/framework/pull/46791, though it only mentions the pain point of created_at/updated_at timestamps. I have personally either had to write code like this within multiple projects or suffered the consequences of forgetting that Model@insert() doesn't do any handy casting or setting of defaults.

### How it would be done today
For context let's consider this model (and associated enum).
```php
// App/Enums/Genre
enum Genre: string
{
    case Rock = 'rock';

    case HipHop = 'hip-hop';
}
```
```php
// App/Models/Album
use Illuminate\Database\Eloquent\Model;

class Album extends Model
{
    public $timestamps = true;

    protected $fillable = [
        'artist',
        'title',
        'genre',
        'release_date',
        'stats',
    ];

    protected $casts = [
        'genre' => Genre::class,
        'release_date' => 'datetime',
        'stats' => 'json',
    ];
    
    protected $attributes = [
        'artist' => 'unknown',
    ];
}
```
Say we have an action that can accept data from a form or elsewhere.
```php
use App\Enums\Genre;
use App\Models\Album;
use Carbon\Carbon;

$inputData = [
    ['artist' => 'Built to Spill', 'title' => 'Keep It Like a Secret', 'genre' => Genre::Rock, 'release_date' => '1999-02-02', 'stats' => []],
    ['artist' => 'Tom Petty', 'title' => 'Highway Companion', 'genre' => 'rock', 'release_date' => new Carbon('2006-07-25'), 'stats' => ['producer' => 'Jeff Lynne']],
    ['title' => 'Ill Communication', 'genre' => Genre::HipHop, 'release_date' => null, 'stats' => new stdClass]
];
$values = collect($inputData)->map(function(array $values) {
    // make sure we have a valid enum case
    if (! $values['genre'] instanceof Genre) {
        $values['genre'] = Genre::tryFrom($values['genre']);
    }
    $values['genre'] = $values['genre']?->value;

    // make sure the date is formatted for DB layer
    if ($values['release_date'] instanceof \DateTime) {
        $values['release_date'] = $values['release_date']->format('Y-m-d');
    }
    
    // make sure that the stats column is properly encoded to a string
    if (!is_string($values['stats'])) {
        $values['stats'] = json_encode($values['stats']);
    }
    
    // set the model's default value defined in Artist::$attributes
    if (!isset($values['artist'])) {
        $values['artist'] = \App\Models\Album::newModelInstance()->artist; // get the default value from the model
    }

    return array_merge($values, [
        'created_at' => now(),
        'updated_at' => now()
    ]);
});

\App\Models\Album::insert($values->toArray());
```

Pretty messy for something that feels standard. We can just create them one by one, but then we have repeated writes to the database. For a large database with many connections or if this whole Action is happening within a request lifecycle, that is not an ideal solution.

## Solution
We add an `Eloquent\Builder@insertWithCasts()` method that makes the above much less painful.

### The above example relying on `insertWithCasts()`
```php
use App\Models\Album;
use App\Enums\Genre;

Album::insertWithCasts([
    ['artist' => 'Built to Spill', 'title' => 'Keep It Like a Secret', 'genre' => Genre::Rock, 'release_date' => '1999-02-02', 'stats' => []],
    ['artist' => 'Tom Petty', 'title' => 'Highway Companion', 'genre' => 'rock', 'release_date' => new Carbon('2006-07-25'), 'stats' => ['producer' => 'Jeff Lynne']],
    ['title' => 'Ill Communication', 'genre' => Genre::HipHop, 'release_date' => null, 'stats' => new stdClass]
]);

$albums = Album::get();
$albums[0]->release_date->format('m/d/Y'); // '02/02/1999'
$albums[1]->stats['producer']; // 'Jeff Lynne'
$albums[2]->artist; // 'unknown'
```

## Final Thoughts
I think there's probably a better name for this method. I would prefer to call it `createMany()`, but as @bert-w pointed out, then there's the expectation it will emit model events.