### PR TITLE
[10.x] Abstract Model factories into a reusable base factory class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/CrossJoinSequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/CrossJoinSequence.php
@@ -2,25 +2,8 @@
 
 namespace Illuminate\Database\Eloquent\Factories;
 
-use Illuminate\Support\Arr;
+use Illuminate\Support\CrossJoinSequence as BaseCrossJoinSequence;
 
-class CrossJoinSequence extends Sequence
+class CrossJoinSequence extends BaseCrossJoinSequence
 {
-    /**
-     * Create a new cross join sequence instance.
-     *
-     * @param  array  ...$sequences
-     * @return void
-     */
-    public function __construct(...$sequences)
-    {
-        $crossJoined = array_map(
-            function ($a) {
-                return array_merge(...$a);
-            },
-            Arr::crossJoin(...$sequences),
-        );
-
-        parent::__construct(...$crossJoined);
-    }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -2,62 +2,8 @@
 
 namespace Illuminate\Database\Eloquent\Factories;
 
-use Countable;
+use Illuminate\Support\Sequence as BaseSequence;
 
-class Sequence implements Countable
+class Sequence extends BaseSequence
 {
-    /**
-     * The sequence of return values.
-     *
-     * @var array
-     */
-    protected $sequence;
-
-    /**
-     * The count of the sequence items.
-     *
-     * @var int
-     */
-    public $count;
-
-    /**
-     * The current index of the sequence iteration.
-     *
-     * @var int
-     */
-    public $index = 0;
-
-    /**
-     * Create a new sequence instance.
-     *
-     * @param  mixed  ...$sequence
-     * @return void
-     */
-    public function __construct(...$sequence)
-    {
-        $this->sequence = $sequence;
-        $this->count = count($sequence);
-    }
-
-    /**
-     * Get the current count of the sequence items.
-     *
-     * @return int
-     */
-    public function count(): int
-    {
-        return $this->count;
-    }
-
-    /**
-     * Get the next value in the sequence.
-     *
-     * @return mixed
-     */
-    public function __invoke()
-    {
-        return tap(value($this->sequence[$this->index % $this->count], $this), function () {
-            $this->index = $this->index + 1;
-        });
-    }
 }

--- a/src/Illuminate/Support/CrossJoinSequence.php
+++ b/src/Illuminate/Support/CrossJoinSequence.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Support;
+
+class CrossJoinSequence extends Sequence
+{
+    /**
+     * Create a new cross join sequence instance.
+     *
+     * @param  array  ...$sequences
+     * @return void
+     */
+    public function __construct(...$sequences)
+    {
+        $crossJoined = array_map(
+            function ($a) {
+                return array_merge(...$a);
+            },
+            Arr::crossJoin(...$sequences),
+        );
+
+        parent::__construct(...$crossJoined);
+    }
+}

--- a/src/Illuminate/Support/Factory.php
+++ b/src/Illuminate/Support/Factory.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Closure;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\Macroable;
+
+/**
+ * @template TValue
+ */
+abstract class Factory
+{
+    use Conditionable, ForwardsCalls, Macroable {
+        __call as macroCall;
+    }
+
+    /**
+     * The number of items that should be generated.
+     *
+     * @var int|null
+     */
+    protected $count;
+
+    /**
+     * The state transformations that will be applied to the item.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $states;
+
+    /**
+     * The "after making" callbacks that will be applied to the item.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $afterMaking;
+
+    /**
+     * Create a new factory instance.
+     *
+     * @param  int|null  $count
+     * @param  \Illuminate\Support\Collection|null  $states
+     * @param  \Illuminate\Support\Collection|null  $afterMaking
+     * @return void
+     */
+    public function __construct(
+        $count = null,
+        ?Collection $states = null,
+        ?Collection $afterMaking = null,
+    ) {
+        $this->count = $count;
+        $this->states = $states ?? new Collection;
+        $this->afterMaking = $afterMaking ?? new Collection;
+    }
+
+    /**
+     * Define the item's default state.
+     *
+     * @return array<mixed>
+     */
+    abstract public function definition();
+
+    /**
+     * Make an instance of the item with the given attributes.
+     *
+     * @param  array  $expandedAttributes
+     * @param  TValue|null  $parent
+     * @return TValue
+     */
+    abstract protected function makeInstance($expandedAttributes, $parent);
+
+    /**
+     * Build the appropriate collection for the given items.
+     *
+     * @param  array<int, TValue>  $items
+     * @return \Illuminate\Support\Collection<int, TValue>
+     */
+    protected function newCollection(array $items)
+    {
+        return new Collection($items);
+    }
+
+    /**
+     * Get a new factory instance for the given attributes.
+     *
+     * @param (callable(array<mixed>): array<mixed>)|array<mixed> $attributes
+     * @return static
+     */
+    public static function new($attributes = [])
+    {
+        return (new static)->state($attributes)->configure();
+    }
+
+    /**
+     * Get a new factory instance for the given number of items.
+     *
+     * @param  int  $count
+     * @return static
+     */
+    public static function times(int $count)
+    {
+        return static::new()->count($count);
+    }
+
+    /**
+     * Configure the factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this;
+    }
+
+    /**
+     * Build a single instance of the item.
+     *
+     * @param (callable(array<mixed>): array<mixed>)|array<mixed> $attributes
+     * @return TValue
+     */
+    public function makeOne($attributes = [])
+    {
+        return $this->count(null)->make($attributes);
+    }
+
+    /**
+     * Build a collection of items.
+     *
+     * @param (callable(array<mixed>): array<mixed>)|array<mixed> $attributes
+     * @param  TValue|null  $parent
+     * @return \Illuminate\Support\Collection<int, TValue>|TValue
+     */
+    public function make($attributes = [], $parent = null)
+    {
+        if (! empty($attributes)) {
+            return $this->state($attributes)->make([], $parent);
+        }
+
+        if ($this->count === null) {
+            $instance = $this->makeInstance($this->buildExpandedAttributes($parent), $parent);
+
+            $this->callAfterMaking(collect([$instance]));
+
+            return $instance;
+        }
+
+        if ($this->count < 1) {
+            return $this->newCollection([]);
+        }
+
+        $instances = $this->newCollection(array_map(function () use ($parent) {
+            return $this->makeInstance($this->buildExpandedAttributes($parent), $parent);
+        }, range(1, $this->count)));
+
+        $this->callAfterMaking($instances);
+
+        return $instances;
+    }
+
+    /**
+     * Get the states defined on the factory.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getStates()
+    {
+        return $this->states;
+    }
+
+    /**
+     * Build a raw attributes array for the item.
+     *
+     * @param  TValue|null  $parent
+     * @return mixed
+     */
+    protected function buildExpandedAttributes($parent)
+    {
+        return $this->expandAttributes($this->buildRawAttributes($parent));
+    }
+
+    /**
+     * Expand the given attribute into its final form.
+     *
+     * @param  mixed  $attribute
+     * @param  string|int  $key
+     * @return mixed
+     */
+    protected function expandAttribute($attribute, $key)
+    {
+        if ($attribute instanceof self) {
+            $attribute = $attribute->make();
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Expand all attributes to their underlying values.
+     *
+     * @param  array  $definition
+     * @return array
+     */
+    protected function expandAttributes(array $definition)
+    {
+        return collect($definition)
+            ->map(fn ($attribute, $key) => $this->expandAttribute($attribute, $key))
+            ->map(function ($attribute, $key) use (&$definition) {
+                if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
+                    $attribute = $attribute($definition);
+                }
+
+                $attribute = $this->expandAttribute($attribute, $key);
+
+                $definition[$key] = $attribute;
+
+                return $attribute;
+            })
+            ->all();
+    }
+
+    /**
+     * Build the raw attributes for the item as an array.
+     *
+     * @param  TValue|null  $parent
+     * @return array
+     */
+    protected function buildRawAttributes($parent)
+    {
+        return $this->getStates()->reduce(function ($carry, $state) use ($parent) {
+            if ($state instanceof Closure) {
+                $state = $state->bindTo($this);
+            }
+
+            return array_merge($carry, $state($carry, $parent));
+        }, $this->definition());
+    }
+
+    /**
+     * Add a new state transformation to the item definition.
+     *
+     * @param  (callable(array<mixed>, TValue|null): array<mixed>)|array<mixed>  $state
+     * @return static
+     */
+    public function state($state)
+    {
+        return $this->newInstance([
+            'states' => $this->states->concat([
+                is_callable($state) ? $state : function () use ($state) {
+                    return $state;
+                },
+            ]),
+        ]);
+    }
+
+    /**
+     * Set a single item attribute.
+     *
+     * @param  string|int  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function set($key, $value)
+    {
+        return $this->state([$key => $value]);
+    }
+
+    /**
+     * Push a new index-based state transformation to the item definition.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public function push($value)
+    {
+        return $this->state([$value]);
+    }
+
+    /**
+     * Add a new sequenced state transformation to the item definition.
+     *
+     * @param  mixed  ...$sequence
+     * @return static
+     */
+    public function sequence(...$sequence)
+    {
+        return $this->state(new Sequence(...$sequence));
+    }
+
+    /**
+     * Add a new sequenced state transformation to the item definition and update the pending creation count to the size of the sequence.
+     *
+     * @param  array  ...$sequence
+     * @return static
+     */
+    public function forEachSequence(...$sequence)
+    {
+        return $this->state(new Sequence(...$sequence))->count(count($sequence));
+    }
+
+    /**
+     * Add a new cross joined sequenced state transformation to the item definition.
+     *
+     * @param  array  ...$sequence
+     * @return static
+     */
+    public function crossJoinSequence(...$sequence)
+    {
+        return $this->state(new CrossJoinSequence(...$sequence));
+    }
+
+    /**
+     * Add a new "after making" callback to the item definition.
+     *
+     * @param  \Closure(TValue): mixed  $callback
+     * @return static
+     */
+    public function afterMaking(Closure $callback)
+    {
+        return $this->newInstance(['afterMaking' => $this->afterMaking->concat([$callback])]);
+    }
+
+    /**
+     * Call the "after making" callbacks for the given item instances.
+     *
+     * @param  \Illuminate\Support\Collection  $instances
+     * @return void
+     */
+    protected function callAfterMaking(Collection $instances)
+    {
+        $instances->each(function ($model) {
+            $this->afterMaking->each(function ($callback) use ($model) {
+                $callback($model);
+            });
+        });
+    }
+
+    /**
+     * Specify how many items should be generated.
+     *
+     * @param  int|null  $count
+     * @return static
+     */
+    public function count(?int $count)
+    {
+        return $this->newInstance(['count' => $count]);
+    }
+
+    /**
+     * Create a new instance of the factory builder with the given mutated properties.
+     *
+     * @param  array  $arguments
+     * @return static
+     */
+    protected function newInstance(array $arguments = [])
+    {
+        return new static(...[
+            'count' => $this->count,
+            'states' => $this->states,
+            'afterMaking' => $this->afterMaking,
+            ...$arguments,
+        ]);
+    }
+
+    /**
+     * Proxy dynamic factory methods onto their proper methods.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+    }
+}

--- a/src/Illuminate/Support/Sequence.php
+++ b/src/Illuminate/Support/Sequence.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Countable;
+
+class Sequence implements Countable
+{
+    /**
+     * The sequence of return values.
+     *
+     * @var array
+     */
+    protected $sequence;
+
+    /**
+     * The count of the sequence items.
+     *
+     * @var int
+     */
+    public $count;
+
+    /**
+     * The current index of the sequence iteration.
+     *
+     * @var int
+     */
+    public $index = 0;
+
+    /**
+     * Create a new sequence instance.
+     *
+     * @param  mixed  ...$sequence
+     * @return void
+     */
+    public function __construct(...$sequence)
+    {
+        $this->sequence = $sequence;
+        $this->count = count($sequence);
+    }
+
+    /**
+     * Get the current count of the sequence items.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * Get the next value in the sequence.
+     *
+     * @return mixed
+     */
+    public function __invoke()
+    {
+        return tap(value($this->sequence[$this->index % $this->count], $this), function () {
+            $this->index = $this->index + 1;
+        });
+    }
+}

--- a/tests/Support/FactoryTest.php
+++ b/tests/Support/FactoryTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\CrossJoinSequence;
+use Illuminate\Support\Factory;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+use PHPUnit\Framework\TestCase;
+
+class FactoryTest extends TestCase
+{
+    public function test_basic_item_can_be_made()
+    {
+        $requestDetails = SignupRequestFactory::new()->make();
+        $this->assertSame(
+            ['name' => 'Luke Downing', 'age' => 26, 'country' => 'UK'],
+            $requestDetails
+        );
+
+        $requestDetails = SignupRequestFactory::new()->makeOne();
+        $this->assertSame(
+            ['name' => 'Luke Downing', 'age' => 26, 'country' => 'UK'],
+            $requestDetails
+        );
+
+        $requestDetails = SignupRequestFactory::new()->make(['name' => 'Taylor Otwell']);
+        $this->assertSame(
+            ['name' => 'Taylor Otwell', 'age' => 26, 'country' => 'UK'],
+            $requestDetails
+        );
+
+        $requestDetails = SignupRequestFactory::new()->set('name', 'Taylor Otwell')->make();
+        $this->assertSame(
+            ['name' => 'Taylor Otwell', 'age' => 26, 'country' => 'UK'],
+            $requestDetails
+        );
+
+        $requestDetails = SignupRequestFactory::times(3)->make();
+        $this->assertCount(3, $requestDetails);
+    }
+
+    public function test_expanded_closure_attributes_are_resolved_and_passed_to_closures()
+    {
+        $requestDetails = SignupRequestFactory::new()->make([
+            'name' => function () {
+                return 'taylor';
+            },
+            'email' => function ($attributes) {
+                return $attributes['name'].'@laravel.com';
+            },
+        ]);
+
+        $this->assertSame('taylor@laravel.com', $requestDetails['email']);
+    }
+
+    public function test_expanded_closure_attribute_returning_a_factory_is_resolved()
+    {
+        $post = SignupRequestFactory::new()->make([
+            'name' => 'Taylor',
+            'nested-signup' => fn ($attributes) => SignupRequestFactory::new([
+                'name' => 'Freek',
+            ]),
+        ]);
+
+        $this->assertEquals('Freek', $post['nested-signup']['name']);
+    }
+
+    public function test_after_making_callbacks_are_called()
+    {
+        $requestDetails = SignupRequestFactory::new()
+            ->afterMaking(function ($requestDetails) {
+                $_SERVER['__test.request_details.making'] = $requestDetails;
+            })
+            ->make();
+
+        $this->assertSame($requestDetails, $_SERVER['__test.request_details.making']);
+
+        unset($_SERVER['__test.request_details.making']);
+    }
+
+    public function test_sequences()
+    {
+        $requestDetails = SignupRequestFactory::times(2)->sequence(
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Nuno Maduro'],
+        )->make();
+
+        $this->assertSame('Taylor Otwell', $requestDetails[0]['name']);
+        $this->assertSame('Nuno Maduro', $requestDetails[1]['name']);
+    }
+
+    public function test_counted_sequence()
+    {
+        $requestDetails = SignupRequestFactory::new()->forEachSequence(
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Nuno Maduro'],
+        )->make();
+
+        $this->assertCount(2, $requestDetails);
+    }
+
+    public function test_cross_join_sequences()
+    {
+        $assert = function ($signupDetails) {
+            $assertions = [
+                ['first_name' => 'Thomas', 'last_name' => 'Anderson'],
+                ['first_name' => 'Thomas', 'last_name' => 'Smith'],
+                ['first_name' => 'Agent', 'last_name' => 'Anderson'],
+                ['first_name' => 'Agent', 'last_name' => 'Smith'],
+            ];
+
+            foreach ($assertions as $key => $assertion) {
+                $this->assertSame(
+                    $assertion,
+                    Arr::only($signupDetails[$key], ['first_name', 'last_name']),
+                );
+            }
+        };
+
+        $usersByClass = SignupRequestFactory::times(4)
+            ->state(
+                new CrossJoinSequence(
+                    [['first_name' => 'Thomas'], ['first_name' => 'Agent']],
+                    [['last_name' => 'Anderson'], ['last_name' => 'Smith']],
+                ),
+            )
+            ->make();
+
+        $assert($usersByClass);
+
+        $usersByMethod = SignupRequestFactory::times(4)
+            ->crossJoinSequence(
+                [['first_name' => 'Thomas'], ['first_name' => 'Agent']],
+                [['last_name' => 'Anderson'], ['last_name' => 'Smith']],
+            )
+            ->make();
+
+        $assert($usersByMethod);
+    }
+
+    public function test_can_be_macroable()
+    {
+        $factory = SignupRequestFactory::new();
+        $factory->macro('getFoo', function () {
+            return 'Hello World';
+        });
+
+        $this->assertSame('Hello World', $factory->getFoo());
+    }
+
+    public function test_factory_can_conditionally_execute_code()
+    {
+        SignupRequestFactory::new()
+            ->when(true, function () {
+                $this->assertTrue(true);
+            })
+            ->when(false, function () {
+                $this->fail('Unreachable code that has somehow been reached.');
+            })
+            ->unless(false, function () {
+                $this->assertTrue(true);
+            })
+            ->unless(true, function () {
+                $this->fail('Unreachable code that has somehow been reached.');
+            });
+    }
+
+    public function test_attribute_transformers()
+    {
+        $result = FactoryWithCustomTransformers::new()->make();
+
+        $this->assertSame('BAR', $result['foo']);
+    }
+
+    public function test_specialised_build_types()
+    {
+        [$luke, $owen] = SampleDataTransferObjectFactory::new()
+            ->forEachSequence(
+                ['name' => 'Luke Downing'],
+                ['name' => 'Owen Voke'],
+            )
+            ->make();
+
+        $this->assertInstanceOf(SampleDataTransferObject::class, $luke);
+        $this->assertInstanceOf(SampleDataTransferObject::class, $owen);
+
+        $this->assertSame('Luke Downing', $luke->name->toString());
+        $this->assertSame('Owen Voke', $owen->name->toString());
+    }
+
+    public function test_index_based_factories()
+    {
+        $result = IndexBasedFactory::new(['foo'])
+            ->state(['bar'])
+            ->push('baz')
+            ->make(['boom']);
+
+        $this->assertSame(['foo', 'bar', 'baz', 'boom'], $result);
+    }
+}
+
+/**
+ * @extends Factory<array>
+ */
+class SignupRequestFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'name' => 'Luke Downing',
+            'age' => 26,
+            'country' => 'UK',
+        ];
+    }
+
+    protected function makeInstance($expandedAttributes, $parent)
+    {
+        return $expandedAttributes;
+    }
+}
+
+class FactoryWithCustomTransformers extends Factory
+{
+    public function definition()
+    {
+        return [
+            'foo' => Str::of('bar'),
+        ];
+    }
+
+    protected function expandAttribute($attribute, $key)
+    {
+        if ($attribute instanceof Stringable) {
+            return $attribute->upper()->__toString();
+        }
+
+        return parent::expandAttribute($attribute, $key);
+    }
+
+    protected function makeInstance($expandedAttributes, $parent)
+    {
+        return $expandedAttributes;
+    }
+}
+
+class SampleDataTransferObject
+{
+    public function __construct(
+        public Stringable $name,
+        public int $age,
+        public string $country,
+    ) {
+    }
+}
+
+class SampleDataTransferObjectFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'name' => 'Luke Downing',
+            'age' => 26,
+            'country' => 'UK',
+        ];
+    }
+
+    protected function makeInstance($expandedAttributes, $parent)
+    {
+        return new SampleDataTransferObject(
+            Str::of($expandedAttributes['name']),
+            $expandedAttributes['age'],
+            $expandedAttributes['country'],
+        );
+    }
+}
+
+class IndexBasedFactory extends Factory
+{
+    public function definition()
+    {
+        return [];
+    }
+
+    protected function makeInstance($expandedAttributes, $parent)
+    {
+        return $expandedAttributes;
+    }
+}


### PR DESCRIPTION
Hey there!

This PR abstracts the functionality of Model factories into a reusable and type-agnostic factory that can be used to create any desired outcome.

> Note: This PR is intended to have a follow up PR for Laravel 11.x which will make `\Illuminate\Database\Eloquent\Factories\Factory` extend this new class, simplifying and unifying the two. Please see the "So what's happened to Model factories?" section for more details on why we haven't done that in this PR.

> Another Note: This is a big PR, but the only "new" class is the `Factory`, and that class is basically the database factory without the Eloquent stuff. There are no new code concepts. The 11.x follow-up PR will actually remove lines of code rather than add any.

## Motivation

So, for some time now I've been wanting to move [Request Factories](https://github.com/worksome/request-factories) into Laravel. The idea of a common "Factory" is one that crops up often. All of these factories follow the same basic principle:

- Take a simple array based definition
- Specify the number of items
- Alter state as required

Turns out, Model factories support this functionality already! So rather than reinvent the wheel, we could move that common functionality into a lower level class, and leave the abstract Model factory to handle just the eloquent related parts. Suddenly, we'd have something that could not only be used to provide Request Factories in a future PR, but really form the basis of *any* factory desired.

## Examples

### Example 1: The DTO

Let's imagine we have a custom class that is passed around our codebase any time a user updates their account details. That class contains:

- The relevant `User` model
- A `ContactOptions` DTO with preferences for the user
- The preferred language option for the user

We use this class in various places across our application: when we first create a user, when the user updates their preferences, when we want to send the user marketing emails and sundry other circumstances.

As such, our tests will have to create the correct and relevant instances of this class many times over. Building it up manually every time is a real pain. Previously, we'd either have to suck it up and do the manual work or create some crude form of custom factory, either via a function or basic builder class.

With this PR in place, creating our very own custom factory becomes a breeze:

```php
<?php

namespace Tests\Factories;

use App\Models\User;
use Illuminate\Testing\Factory;

class AccountDetailFactory extends Factory
{
    public function definition()
    {
        return [
            'user' => User::factory(),
            'wantsNewsletter' => false,
            'wantsEmails' => false,
            'wantsSms' => false,
            'preferredLanguage' => fn ($attributes) => $attributes['user']->locale,
        ];
    }

    protected function makeInstance($expandedAttributes, $parent)
    {
        return new AccountDetail(
            user: $expandedAttributes['user'],
            contactOptions: new ContactOptions(
                wantsNewsletter: $expandedAttributes['wantsNewsletter'],
                wantsEmails: $expandedAttributes['wantsEmails'],
                wantsSms: $expandedAttributes['wantsSms'],
            ),
            language: $expandedAttributes['preferredLanguage'],
        );
    }
}
```

The abstract `makeInstance` method allows us to take a constructed array of attributes and return any type, which means
we can apply the factory pattern to any class, or type, or... anything.

Of course, the example above is more of a "one-time-use" factory. However, with something like a Request Factory, which returns a plain array of data, you could have an abstract class which extends the base `Factory` and handles the `makeInstance` method for any and all Request Factory classes that extend it.

Of course, all of the useful common functionality is available when using factories:

```php
// We can alter state
AccountDetailFactory::new()->state(['preferredLanguage' => 'en_GB'])->set('wantsSms', true)->make();

// We can create multiples
AccountDetailFactory::times(3)->make();

// We can use sequences to easily create variants
[$withEmail, $withoutEmail] = AccountDetailFactory::new()->forEachSequence(['wantsEmail' => true], ['wantsEmail' => false])->make();
```

And of course, we have a class, so we can add helper methods to our factories as we're used to with Model factories:

```php
// In the factory
public function withName(string $name)
{
  return $this->state(['user' => User::factory(['name' => $name])]);
}

// In our test
AccountDetailFactory::new()->withName('Taylor Otwell')->make();
```

You'll know that Model factories have a few hidden superpowers, such as being able to change a given `Model` into its key "automagically". Well, it's super simple to add that same logic to any factory by overriding the `expandAttribute` method. Let's imagine that `Stringable`s should be automatically converted to strings:

```php
// In our factory
protected function expandAttribute($attribute, $key)
{
    if ($attribute instanceof Stringable) {
        return $atrribute->__toString();
    }

    return $attribute;
}

// In our test
AccountDetailFactory::new()->state(['preferredLanguage' => Str::of('en_GB')])->make();
```

In the example above, the `preferreredLanguage` would automatically be converted to a native string when the factory is built.

### Example 2: Outside of the test suite

**Now here's where things get really cool.** Why should we limit these factories to tests? You'll note that the base factory has nothing tying it down to tests. Let's imagine we're JMac writing regex all day for Laravel Shift. Rather than writing that regex out manually every time, he'd love to implement the builder pattern and dynamically create regex strings using a fluent interface. 

No sweat; the new support `Factory` provides a perfect toolset for this.

```php
class RegexFactory extends Factory
{
    public function definition()
    {
        return [];
    }

    protected function makeInstance($expandedAttributes, $parent)
    {
        $regex = implode('', $expandedAttributes);

        return "/{$regex}/";
    }

    public function any()
    {
        return $this->push('.*');
    }

    public function word()
    {
        return $this->push('\w+');
    }

    public function whitespace()
    {
        return $this->push('\s+');
    }

    public function group(Closure $callable, string $name = null)
    {
        $callable = Closure::bind($callable, $this);

        $value = $callable();

        $formattedValue = $value instanceof self
            ? str($value->make())->after('/')->beforeLast('/')
            : $value;

        return $name
            ? $this->push("(?<{$name}>{$formattedValue})")
            : $this->push("({$formattedValue})");
    }
}
```

You'll note here that we switch from a string based definition to "pushing" items into the definition. Then, in `makeInstance`, we simply implode the expanded attributes down into a regex string. Hey presto, we have ourselves a regex generator.

```php
// Results in /.*(?<example>.*\w+\s+).*/
$regex = RegexFactory::new()
    ->any()
    ->group(fn () => $this->word()->whitespace(), 'example')
    ->any()
    ->make();
```

How cool is that! This expands the use case of factories significantly, and provides an awesome API for practically anything you'd want to fluently construct. It's the reason we opted to put the factory in `Support` rather than `Testing`.

You'll also note that because immutability is built into how the factory works, we can do the cool stuff with grouping and closures without having to "new up" instances of the factory. This is a side benefit of how Laravel has handled model factories but something which is often overlooked when implementing a crude version of factories manually in a project.

## So what's happened to Model factories?

In this PR, absolutely nothing. We played about with altering the Model factory class, but it was a bit of a mess to
do so without introducing breaking changes.

This is because the `$parent` parameter which appears in `make`, `makeInstance` and `getExpandedAttributes`
are all type hinted as `Model`. Removing the typehint would cause a breaking change for anybody who has
overridden these methods in their own model factories.

It is unlikely that many have done this (it isn't recommended anywhere in the docs), and fixing it would be as simple as removing the `Model` typehint, but it's still a breaking change.

We played around with using a `build` method instead of `make`. We also played around with doing some
hacky magic in `__call()`. Neither of those options felt "right".

Instead, we felt it best to have a small level of duplication in Laravel 10. If this PR is accepted, I will
quickly follow up with a PR to Laravel 11 which makes the previously mentioned breaking changes, and unifies
the two factories.

The end result is that the Model Factory will be a subtype of the new base `Factory`, and only add the
necessary functionality to work with Eloquent models, such as `create`, `lazy`, `recycle` etc.

This is the magic, see: Model factories are nothing special, they'll just be a subtype of the base `Factory`.

## Wrapup

I think this could be a really nice way to provide a solid factory structure for quickly building objects not only whilst writing tests, but throughout the codebase.

Laravel already has a solid base, and there's no reason we should reinvent the wheel every time just because we want to build something other than Models. I think this PR provides exactly that, and some really nice integrations could be built on top of it down the line.

Thanks as always for the hard work and dedication to making the greatest framework available ❤️

Kind Regards,
Luke