### PR TITLE
[10.x] Fix `validateDecimal()`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -585,11 +585,11 @@ trait ValidatesAttributes
      */
     public function validateDecimal($attribute, $value, $parameters)
     {
+        $this->requireParameterCount(1, $parameters, 'decimal');
+
         if (! $this->validateNumeric($attribute, $value)) {
             return false;
         }
-
-        $this->requireParameterCount(1, $parameters, 'decimal');
 
         $matches = [];
 


### PR DESCRIPTION
An exception occurred when I forgot to set the parameter for `decimal` rule, but the message confused me a bit, since the message is "_Undefined array key 0_", instead of "_Validation rule decimal requires at least 1 parameters._". The error occurred in [`replaceDecimal()`](https://github.com/laravel/framework/blob/88c28e2787aca4055e4ab9a57054be943b65394c/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L82), where it expects `$parameters[0]` exists.