### PR TITLE
[10.x] Allow separate directory for locks on filestore

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -144,7 +144,9 @@ class CacheManager implements FactoryContract
      */
     protected function createFileDriver(array $config)
     {
-        return $this->repository(new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null));
+        return $this->repository(
+            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null))->setLockPath($config['lock_path'] ?? null)
+        );
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -145,7 +145,8 @@ class CacheManager implements FactoryContract
     protected function createFileDriver(array $config)
     {
         return $this->repository(
-            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null))->setLockPath($config['lock_path'] ?? null)
+            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null))
+                ->setLockDirectory($config['lock_path'] ?? null)
         );
     }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -36,6 +36,11 @@ class FileStore implements Store, LockProvider
     protected $filePermission;
 
     /**
+     * The path to the lock directory
+     */
+    protected ?string $lockPath = null;
+
+    /**
      * Create a new file cache store instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -210,7 +215,14 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        return new FileLock($this, $name, $seconds, $owner);
+        $this->ensureCacheDirectoryExists($this->lockPath ?? $this->directory);
+
+        return new FileLock(
+            new self($this->files, $this->lockPath ?? $this->directory, $this->filePermission),
+            $name,
+            $seconds,
+            $owner
+        );
     }
 
     /**
@@ -372,5 +384,12 @@ class FileStore implements Store, LockProvider
     public function getPrefix()
     {
         return '';
+    }
+
+    public function setLockPath(string $lockPath): self
+    {
+        $this->lockPath = $lockPath;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -29,18 +29,18 @@ class FileStore implements Store, LockProvider
     protected $directory;
 
     /**
+     * The file cache lock directory.
+     *
+     * @var string|null
+     */
+    protected $lockDirectory;
+
+    /**
      * Octal representation of the cache file permissions.
      *
      * @var int|null
      */
     protected $filePermission;
-
-    /**
-     * The path to the lock directory.
-     *
-     * @var string|null
-     */
-    protected $lockPath;
 
     /**
      * Create a new file cache store instance.
@@ -217,10 +217,10 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        $this->ensureCacheDirectoryExists($this->lockPath ?? $this->directory);
+        $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
 
         return new FileLock(
-            new self($this->files, $this->lockPath ?? $this->directory, $this->filePermission),
+            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
             $name,
             $seconds,
             $owner
@@ -379,6 +379,19 @@ class FileStore implements Store, LockProvider
     }
 
     /**
+     * Set the cache directory where locks should be stored.
+     *
+     * @param  string|null  $lockDirectory
+     * @return $this
+     */
+    public function setLockDirectory($lockDirectory)
+    {
+        $this->lockDirectory = $lockDirectory;
+
+        return $this;
+    }
+
+    /**
      * Get the cache key prefix.
      *
      * @return string
@@ -386,12 +399,5 @@ class FileStore implements Store, LockProvider
     public function getPrefix()
     {
         return '';
-    }
-
-    public function setLockPath(?string $lockPath): self
-    {
-        $this->lockPath = $lockPath;
-
-        return $this;
     }
 }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -36,7 +36,7 @@ class FileStore implements Store, LockProvider
     protected $filePermission;
 
     /**
-     * The path to the lock directory
+     * The path to the lock directory.
      */
     protected ?string $lockPath = null;
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -37,8 +37,10 @@ class FileStore implements Store, LockProvider
 
     /**
      * The path to the lock directory.
+     *
+     * @var string|null $lockPath
      */
-    protected ?string $lockPath = null;
+    protected $lockPath;
 
     /**
      * Create a new file cache store instance.

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -386,7 +386,7 @@ class FileStore implements Store, LockProvider
         return '';
     }
 
-    public function setLockPath(string $lockPath): self
+    public function setLockPath(?string $lockPath): self
     {
         $this->lockPath = $lockPath;
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -38,7 +38,7 @@ class FileStore implements Store, LockProvider
     /**
      * The path to the lock directory.
      *
-     * @var string|null $lockPath
+     * @var string|null
      */
     protected $lockPath;
 


### PR DESCRIPTION
Issue: 

When using the `file` driver, upon executing `php artisan cache:clear` or calling `\Cache::flush();`, all locks are cleared.

Similar to what other drivers offer, this PR adds the ability to define a separate directory for Locks when using the `file` driver.

Example:
```
        'file' => [
            'driver' => 'file',
            'path'   => storage_path().'/framework/cache',
            'lock_path' => storage_path().'/framework/lock',
        ],
 ```

- [X]  Backward compatible, not adding the `lock_path` config would yield the same result as before
- [X]  Makes the FileStore driver more consistent with other drivers namely RedisStore and Database store