### PR TITLE
[9.x] Use relation name when loading MorphTo relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -755,7 +755,8 @@ class Builder implements BuilderContract
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
             $relation->initRelation($models, $name),
-            $relation->getEager(), $name
+            $relation->getEager($name),
+            $name
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -113,12 +113,13 @@ class MorphTo extends BelongsTo
      *
      * Called via eager load method of Eloquent query builder.
      *
+     * @param  string|null  $relationName
      * @return mixed
      */
-    public function getEager()
+    public function getEager(?string $relationName = null)
     {
         foreach (array_keys($this->dictionary) as $type) {
-            $this->matchToMorphParents($type, $this->getResultsByType($type));
+            $this->matchToMorphParents($type, $this->getResultsByType($type), $relationName);
         }
 
         return $this->models;
@@ -208,16 +209,19 @@ class MorphTo extends BelongsTo
      *
      * @param  string  $type
      * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  string|null  $relationName
      * @return void
      */
-    protected function matchToMorphParents($type, Collection $results)
+    protected function matchToMorphParents($type, Collection $results, ?string $relationName = null)
     {
+        $relationName ??= $this->relationName;
+
         foreach ($results as $result) {
             $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
-                    $model->setRelation($this->relationName, $result);
+                    $model->setRelation($relationName, $result);
                 }
             }
         }

--- a/tests/Integration/Database/EloquentMorphConstrainTest.php
+++ b/tests/Integration/Database/EloquentMorphConstrainTest.php
@@ -35,20 +35,18 @@ class EloquentMorphConstrainTest extends DatabaseTestCase
             $table->integer('commentable_id');
         });
 
-        Schema::create('images', function(Blueprint $table) {
+        Schema::create('images', function (Blueprint $table) {
             $table->id();
             $table->string('url');
             $table->nullableMorphs('imageable');
         });
 
-        Schema::create('morphable_posts', function(Blueprint $table) {
+        Schema::create('morphable_posts', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->string('description');
             $table->string('other_field');
         });
-
-
 
         $post1 = Post::create(['post_visible' => true]);
         (new Comment)->commentable()->associate($post1)->save();
@@ -84,7 +82,8 @@ class EloquentMorphConstrainTest extends DatabaseTestCase
         $this->assertNull($comments[3]->commentable);
     }
 
-    public function testLazyLoadingException() {
+    public function testLazyLoadingException()
+    {
         Model::shouldBeStrict();
 
         $post = MorphablePost::create([
@@ -99,7 +98,7 @@ class EloquentMorphConstrainTest extends DatabaseTestCase
         $query->with(['simplified_imageable']);
         $images = $query->get();
         $this->assertCount(2, $images);
-        foreach($images as $image) {
+        foreach ($images as $image) {
             $this->assertSame('Laravel', $image->simplified_imageable->name);
             $this->expectException(LazyLoadingViolationException::class);
             $itemName = $image->imageable->name;
@@ -137,8 +136,9 @@ class Image extends Model
     protected $fillable = [
         'url',
         'imageable_id',
-        'imageable_type'
+        'imageable_type',
     ];
+
     public function imageable()
     {
         return $this->morphTo();
@@ -148,7 +148,9 @@ class Image extends Model
     {
         return $this->morphTo('imageable')
             ->constrain([
-                MorphablePost::class => function ($query) { $query->select(['id', 'name']); },
+                MorphablePost::class => function ($query) {
+                    $query->select(['id', 'name']);
+                },
             ]);
     }
 }
@@ -161,6 +163,7 @@ class MorphablePost extends Model
         'description',
         'other_field',
     ];
+
     public function image()
     {
         return $this->morphOne(Image::class, 'imageable');

--- a/tests/Integration/Database/EloquentMorphConstrainTest.php
+++ b/tests/Integration/Database/EloquentMorphConstrainTest.php
@@ -4,12 +4,19 @@ namespace Illuminate\Tests\Integration\Database\EloquentMorphConstrainTest;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphConstrainTest extends DatabaseTestCase
 {
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Model::shouldBeStrict(false);
+    }
+
     protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
         Schema::create('posts', function (Blueprint $table) {
@@ -27,6 +34,21 @@ class EloquentMorphConstrainTest extends DatabaseTestCase
             $table->string('commentable_type');
             $table->integer('commentable_id');
         });
+
+        Schema::create('images', function(Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->nullableMorphs('imageable');
+        });
+
+        Schema::create('morphable_posts', function(Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description');
+            $table->string('other_field');
+        });
+
+
 
         $post1 = Post::create(['post_visible' => true]);
         (new Comment)->commentable()->associate($post1)->save();
@@ -61,6 +83,28 @@ class EloquentMorphConstrainTest extends DatabaseTestCase
         $this->assertTrue($comments[2]->commentable->video_visible);
         $this->assertNull($comments[3]->commentable);
     }
+
+    public function testLazyLoadingException() {
+        Model::shouldBeStrict();
+
+        $post = MorphablePost::create([
+            'name' => 'Laravel',
+            'description' => 'For artisans',
+            'other_field' => 'n/a',
+        ]);
+        $post->image()->create(['url' => 'https://laravel.com']);
+        $post->image()->create(['url' => 'https://forge.laravel.com']);
+
+        $query = Image::query();
+        $query->with(['simplified_imageable']);
+        $images = $query->get();
+        $this->assertCount(2, $images);
+        foreach($images as $image) {
+            $this->assertSame('Laravel', $image->simplified_imageable->name);
+            $this->expectException(LazyLoadingViolationException::class);
+            $itemName = $image->imageable->name;
+        }
+    }
 }
 
 class Comment extends Model
@@ -85,4 +129,40 @@ class Video extends Model
     public $timestamps = false;
     protected $fillable = ['video_visible'];
     protected $casts = ['video_visible' => 'boolean'];
+}
+
+class Image extends Model
+{
+    public $timestamps = false;
+    protected $fillable = [
+        'url',
+        'imageable_id',
+        'imageable_type'
+    ];
+    public function imageable()
+    {
+        return $this->morphTo();
+    }
+
+    public function simplified_imageable()
+    {
+        return $this->morphTo('imageable')
+            ->constrain([
+                MorphablePost::class => function ($query) { $query->select(['id', 'name']); },
+            ]);
+    }
+}
+
+class MorphablePost extends Model
+{
+    public $timestamps = false;
+    protected $fillable = [
+        'name',
+        'description',
+        'other_field',
+    ];
+    public function image()
+    {
+        return $this->morphOne(Image::class, 'imageable');
+    }
 }


### PR DESCRIPTION
https://github.com/laravel/framework/issues/45800 Should resolve this issue.

If we call:
```php
$images = Image::query()->with(['simplified_imageable'])->get();

$images[0]->relationLoaded('imageable'); // ❌ false
$images[0]->relationLoaded('simplified_imageable'); // ✅ true
```

Not sure if the desired behavior is to set both relationships or not. To me, if the calling code is eager loading a relationship that relies on another, it shouldn't also set the parent relationship.

## Changes to existing test
I moved the creation of models out of the `defineDatabaseMigrationsAfterDatabaseRefreshed` method and put them directly into the test that utilizes them.