### PR TITLE
[10.x] Add when/unless to $fail of (closure/class) validation rule

### DIFF
--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -144,9 +144,10 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
             }
 
             /**
-             * Fail the rule and add message to errors if the given "value" is (or resolves to) truthy.
+             * Raise the error message if the given condition is true.
              *
-             * @var self
+             * @param  mixed  $failed
+             * @return $this
              */
             public function when($failed)
             {
@@ -156,9 +157,10 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
             }
 
             /**
-             * Fail the rule and add message to errors if the given "value" is (or resolves to) false.
+             * Raise the error message unless the given condition is true.
              *
-             * @var self
+             * @param  mixed  $failed
+             * @return $this
              */
             public function unless($failed)
             {

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -204,9 +204,10 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             }
 
             /**
-             * Fail the rule and add message to errors if the given "value" is (or resolves to) truthy.
+             * Raise the error message if the given condition is true.
              *
-             * @var self
+             * @param  mixed  $failed
+             * @return $this
              */
             public function when($failed)
             {
@@ -216,9 +217,10 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             }
 
             /**
-             * Fail the rule and add message to errors if the given "value" is (or resolves to) false.
+             * Raise the error message unless the given condition is true.
              *
-             * @var self
+             * @param  mixed  $failed
+             * @return $this
              */
             public function unless($failed)
             {

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -97,8 +97,6 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
                         : '__invoke';
 
         $this->invokable->{$method}($attribute, $value, function ($attribute, $message = null) {
-            $this->failed = true;
-
             return $this->pendingPotentiallyTranslatedString($attribute, $message);
         });
 
@@ -164,7 +162,9 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             ? fn ($message) => $this->messages[] = $message
             : fn ($message) => $this->messages[$attribute] = $message;
 
-        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor) extends PotentiallyTranslatedString
+        $fail = fn () => $this->failed = true;
+
+        return new class($message ?? $attribute, $this->validator->getTranslator(), $destructor, $fail) extends PotentiallyTranslatedString
         {
             /**
              * The callback to call when the object destructs.
@@ -174,17 +174,56 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
             protected $destructor;
 
             /**
+             * The callback to call when rule should fail.
+             *
+             * @var \Closure
+             */
+            protected $fail;
+
+            /**
+             * Indicates if the validation callback failed.
+             *
+             * @var bool
+             */
+            public $failed = true;
+
+            /**
              * Create a new pending potentially translated string.
              *
              * @param  string  $message
              * @param  \Illuminate\Contracts\Translation\Translator  $translator
              * @param  \Closure  $destructor
              */
-            public function __construct($message, $translator, $destructor)
+            public function __construct($message, $translator, $destructor, $fail)
             {
                 parent::__construct($message, $translator);
 
                 $this->destructor = $destructor;
+                $this->fail = $fail;
+            }
+
+            /**
+             * Fail the rule and add message to errors if the given "value" is (or resolves to) truthy.
+             *
+             * @var self
+             */
+            public function when($failed)
+            {
+                $this->failed = value($failed);
+
+                return $this;
+            }
+
+            /**
+             * Fail the rule and add message to errors if the given "value" is (or resolves to) false.
+             *
+             * @var self
+             */
+            public function unless($failed)
+            {
+                $this->failed = ! value($failed);
+
+                return $this;
             }
 
             /**
@@ -194,6 +233,12 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
              */
             public function __destruct()
             {
+                if (! $this->failed) {
+                    return;
+                }
+
+                ($this->fail)();
+
                 ($this->destructor)($this->toString());
             }
         };

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -413,6 +413,174 @@ class ValidationInvokableRuleTest extends TestCase
         $this->assertSame($rule, $invokableValidationRule->invokable());
     }
 
+    public function testItCanChooseToFailInvokableRule()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1')->when(true);
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1')->when(false);
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1')->when(true);
+                $fail('error 2')->when(false);
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1')->when(false);
+                $fail('error 2')->when(true);
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 2']], $validator->messages()->messages());
+
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1')->unless(true);
+                $fail('error 2')->unless(false);
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 2']], $validator->messages()->messages());
+
+        $rule = new class() implements ValidationRule
+        {
+            public function validate($attribute, $value, $fail): void
+            {
+                $fail('error 1')->unless(false);
+                $fail('error 2')->unless(true);
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+    }
+
+    public function testItCanChooseToFailClosureValidationRule()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(true);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(false);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1');
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(true);
+            $fail('error 2')->when(false);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->when(false);
+            $fail('error 2')->when(true);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 2']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->unless(true);
+            $fail('error 2')->unless(false);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 2']], $validator->messages()->messages());
+
+        $rule = function ($attribute, $value, $fail) {
+            $fail('error 1')->unless(false);
+            $fail('error 2')->unless(true);
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['foo' => ['error 1']], $validator->messages()->messages());
+    }
+
     private function getIlluminateArrayTranslator()
     {
         return new Translator(


### PR DESCRIPTION
Resubmission of #46788. That PR was closed because of a misunderstanding. The `InvokableValidationeRule` class is used for both new validation rule classes (= with a `validate` method) and old validation rule classes (= with an `_invoke` method).
https://github.com/laravel/framework/blob/3e5a6b38f6b180e57b1adb3e89945465892ee216/src/Illuminate/Validation/InvokableValidationRule.php#L95-L103

-----

When using a closure validation rule (or a [custom validation rule class](https://laravel.com/docs/10.x/validation#using-rule-objects)), you always have an if-statement:
```php
function ($attribute, $value, $fail) {
    if ($value !== 'foo') {
        return;
    }

    $fail('value should be foo');
}

// or

function ($attribute, $value, $fail) {
    if ($value === 'foo') {
        $fail('value should be foo');
    }   
}

// or

function ($attribute, $value, $fail) {
    $fails = // ... some very long line of code that checks the value ...

    if ($fails) {
        $fail('value should be foo');
    }   
}
```
That is a lot of lines of code for something that is essentially always a truth check. It is also sometimes annoying when the check in the if-statement is too long and does not fit on one line. You then have to assign the check to a variable outside the if-statement.

So I thought: why not add a when/unless-method to the $fail variable? This makes the code a lot cleaner in my opinion. It also reads natural: "it fails when ..." or "it fails unless ...".
```php
function ($attribute, $value, $fail) {
    $fail('value should be foo')->when($value !== 'foo');
    // or
    $fail('value should be foo')->unless($value === 'foo');
    // or
    $fail('value should be foo')->unless(function () use ($value) {
        // some very long check that now can be more easily
        // split on multiple lines
    });
}
```
It is a pretty small change that makes a big DX difference in my opinion.