### PR TITLE
Use pivot model `fromDateTime` instead of assuming Carbon

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -396,7 +396,7 @@ trait InteractsWithPivotTable
         if ($this->using) {
             $pivotModel = new $this->using;
 
-            $fresh = $fresh->format($pivotModel->getDateFormat());
+            $fresh = $pivotModel->fromDateTime($fresh);
         }
 
         if (! $exists && $this->hasPivotColumn($this->createdAt())) {


### PR DESCRIPTION
`InteractsWithPivotTable` assumes `freshTimestamp()` is a Carbon instance, but it doesn't have to be. For normal models, that already works, because you can override `Model`'s `freshTimestamp` and `fromDateTime`, but the pivot model doesn't use `fromDateTime`.

In my app I want Laravel to update timestamps with Laravel logic, but I don't want 1000s of Carbon instances everywhere for easy time comparisons, so I store and use ints for timestamps, and I never automagically use Carbon. These 3 method overrides in my app's Model do all of that very simply:

```php
trait MyCustomTimestamps {
	public function freshTimestamp() {
		return time();
	}

	public function asDateTime($value) {
		return $value;
	}

	public function fromDateTime($value) {
		return $value;
	}
}
```

except for the pivot model's automatic timestamp.

I've been using the same local patch in Laravel 8 - 10, and it still works. This is that PR.