### PR TITLE
[9.x] Allow Eloquent `Builder@withCount` to apply constraints on Relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -633,7 +633,8 @@ trait QueriesRelationships
                 $expression = $column;
             }
 
-            // Apply constraints to the relation.
+            // Apply constraints to the relation so the user can rely on the
+            // scopes/helpers of the relation rather than the Builder.
             $constraints($relation);
 
             // Here, we will grab the relationship sub-query and prepare to add it to the main query

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -633,14 +633,16 @@ trait QueriesRelationships
                 $expression = $column;
             }
 
+            // Apply constraints to the relation.
+            $constraints($relation);
+
             // Here, we will grab the relationship sub-query and prepare to add it to the main query
             // as a sub-select. First, we'll get the "has" query and use that to get the relation
             // sub-query. We'll format this relationship name and append this column if needed.
+
             $query = $relation->getRelationExistenceQuery(
                 $relation->getRelated()->newQuery(), $this, new Expression($expression)
             )->setBindings([], 'select');
-
-            $query->callScope($constraints);
 
             $query = $query->mergeConstraintsFrom($relation->getQuery())->toBase();
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1220,8 +1220,8 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->where('bam', '>', 'qux');
         }]);
 
-        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
-        $this->assertEquals(['qux', true], $builder->getBindings());
+        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "active" = ? and "bam" > ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertEquals([true, 'qux'], $builder->getBindings());
     }
 
     public function testWithCountAndGlobalScope()
@@ -1346,8 +1346,8 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->where('bam', '>', 'qux');
         }]);
 
-        $this->assertSame('select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
-        $this->assertEquals(['qux', true], $builder->getBindings());
+        $this->assertSame('select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "active" = ? and "bam" > ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertEquals([true, 'qux'], $builder->getBindings());
     }
 
     public function testWithExistsAndGlobalScope()

--- a/tests/Integration/Database/EloquentPivotTest.php
+++ b/tests/Integration/Database/EloquentPivotTest.php
@@ -71,7 +71,7 @@ class EloquentPivotTest extends DatabaseTestCase
         $project->collaborators()->attach($user2, ['permissions' => ['hello']]);
 
         $query = PivotTestProject::query()->withCount([
-            'collaborators' => fn($query) => $query->wherePivotNotNull('permissions')
+            'collaborators' => fn ($query) => $query->wherePivotNotNull('permissions'),
         ]);
 
         $this->assertCount(1, $results = $query->get());


### PR DESCRIPTION
https://github.com/laravel/framework/issues/46633

Not sure if this is a breaking change, but targeting 9.x as I believe it's a bug.

Say that SomeModel has a BelongsToMany relationship. Previously, if you passed a constrained relationship to withCount(), it would always pass an Eloquent\Builder instance as the first parameter to the closure. With this change, it should pass the Relation (HasMany, HasOne, MorphTo) instead.

```php
SomeModel::query()->withCount([
    'related_model' => fn (BelongsToMany $query) => $query->wherePivotNull('some_pivot_column'),
])->get();
```

Previously, this would've thrown an exception for the closure expecting `BelongsToMany`. Assuming you did not add a type hint, the Builder instance would've handled the constraint like `$query->where('pivot_null', 'some_pivot_column')`.