### PR TITLE
[10.x] Add some methods in Str.php to extract numbers from string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1445,4 +1445,89 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Extract the integer numbers from the given string.
+     *
+     * @param  string  $string
+     * @return array
+     */
+    public static function getIntegerNumbers($string)
+    {
+        preg_match_all('/(?<!\.)\b\d+\b(?!\.)/', $string, $matches);
+
+        return array_map('intval', $matches[0]);
+    }
+
+    /**
+     * Extract the float numbers from the given string.
+     *
+     * @param  string  $string
+     * @return array
+     */
+    public static function getFloatNumbers($string)
+    {
+        preg_match_all('/\b\d+\.\d+\b/', $string, $matches);
+
+        return array_map('floatval', $matches[0]);
+    }
+
+    /**
+     * Extract numbers from the given string.
+     *
+     * @param  string  $string
+     * @param  bool  $justInteger
+     * @param  bool  $justFloat
+     * @return array
+     */
+    public static function getNumbers($string, $justInteger = false, $justFloat = false)
+    {
+        if ($justFloat === $justInteger) {
+            preg_match_all('!\d+(?:\.\d+)?!', $string, $matches);
+
+            foreach ($matches[0] as $number) {
+                $numbers[] = str_contains($number, '.') ? floatval($number) : intval($number);
+            }
+
+            return $numbers ?? [];
+        }
+
+        if ($justInteger) {
+            return static::getIntegerNumbers($string);
+        }
+
+        if ($justFloat) {
+            return static::getFloatNumbers($string);
+        }
+    }
+
+    /**
+     * Extract the first number from the given string.
+     *
+     * @param  string  $string
+     * @param  bool  $integer
+     * @param  bool  $float
+     * @return int|float|null
+     */
+    public static function getFirstNumber($string, $integer = false, $float = false)
+    {
+        $numbers = static::getNumbers($string, $integer, $float);
+
+        return $numbers[0] ?? null;
+    }
+
+    /**
+     * Extract the last number from the given string.
+     *
+     * @param  string  $string
+     * @param  bool  $integer
+     * @param  bool  $float
+     * @return int|float|null
+     */
+    public static function getLastNumber($string, $integer = false, $float = false)
+    {
+        $numbers = static::getNumbers($string, $integer, $float);
+
+        return $numbers[count($numbers) - 1] ?? null;
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1119,6 +1119,55 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(strlen(Str::password()) === 32);
     }
+
+    public function testGetIntegerNumbers()
+    {
+        $string = 'I had 7$ and bought 3 books for 4.5$ and 1 pen for 0.5$. I have 2$ now.';
+
+        $this->assertSame([7, 3, 1, 2], Str::getIntegerNumbers($string));
+        $this->assertSame([], Str::getIntegerNumbers('There is one float number 1.5 and no integer number.'));
+        $this->assertSame([], Str::getIntegerNumbers('There is no number.'));
+    }
+
+    public function testGetFloatNumbers()
+    {
+        $string = 'I had 7$ and bought 3 books for 4.5$ and 1 pen for 0.5$. I have 2$ now.';
+
+        $this->assertSame([4.5, 0.5], Str::getFloatNumbers($string));
+        $this->assertSame([], Str::getFloatNumbers('There is 1 integer and no float number.'));
+        $this->assertSame([], Str::getFloatNumbers('There is no number.'));
+    }
+
+    public function testGetNumbers()
+    {
+        $string = 'I had 7$ and bought 3 books for 4.5$ and 1 pen for 0.5$. I have 2$ now.';
+
+        $this->assertSame([7, 3, 4.5, 1, 0.5, 2], Str::getNumbers($string));
+        $this->assertSame([7, 3, 1, 2], Str::getNumbers($string, justInteger: true));
+        $this->assertSame([4.5, 0.5], Str::getNumbers($string, justFloat: true));
+        $this->assertSame([7, 3, 4.5, 1, 0.5, 2], Str::getNumbers($string, justInteger: true, justFloat: true));
+        $this->assertSame([], Str::getNumbers('There is no number.'));
+    }
+
+    public function testGetFirstNumber()
+    {
+        $string = 'I had 7$ and bought 3 books for 4.5$ and 1 pen for 0.5$. I have 2$ now.';
+
+        $this->assertSame(7, Str::getFirstNumber($string));
+        $this->assertSame(7, Str::getFirstNumber($string, integer: true));
+        $this->assertSame(4.5, Str::getFirstNumber($string, float: true));
+        $this->assertNull(Str::getFirstNumber('There is no number.'));
+    }
+
+    public function testGetLastNumber()
+    {
+        $string = 'I had 7$ and bought 3 books for 4.5$ and 1 pen for 0.5$. I have 2$ now.';
+
+        $this->assertSame(2, Str::getLastNumber($string));
+        $this->assertSame(2, Str::getLastNumber($string, integer: true));
+        $this->assertSame(0.5, Str::getLastNumber($string, float: true));
+        $this->assertNull(Str::getLastNumber('There is no number.'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
My idea is that the framework needs some methods to extract numbers from strings. So I came to the conclusion to add these methods and made this PR.
Here are the examples:

```php
$string = 'I had 7$ and bought 3 books for 4.5$ and 1 pen for 0.5$. I have 2$ now.';

Str::getNumbers($string); // [7, 3, 4.5, 1, 0.5, 2]

Str::getIntegerNumbers($string); // [7, 3, 1, 2]

Str::getFloatNumbers($string); // [4.5, 0.5]

Str::getFirstNumber($string); // 7

Str::getFirstNumber($string, integer: true); // 7

Str::getFirstNumber($string, float: true); // 4.5

Str::getLastNumber($string); // 2

Str::getLastNumber($string, integer: true); // 2

Str::getLastNumber($string, float: true); // 4.5
```
