### PR TITLE
[10.x] Allow pruning all cancelled and unfinished queue batches

### DIFF
--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -46,7 +46,7 @@ class PruneBatchesCommand extends Command
 
         $this->components->info("{$count} entries deleted.");
 
-        if ($this->option('unfinished')) {
+        if ($this->option('unfinished') !== null) {
             $count = 0;
 
             if ($repository instanceof DatabaseBatchRepository) {
@@ -56,7 +56,7 @@ class PruneBatchesCommand extends Command
             $this->components->info("{$count} unfinished entries deleted.");
         }
 
-        if ($this->option('cancelled')) {
+        if ($this->option('cancelled') !== null) {
             $count = 0;
 
             if ($repository instanceof DatabaseBatchRepository) {

--- a/tests/Queue/PruneBatchesCommandTest.php
+++ b/tests/Queue/PruneBatchesCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Bus\BatchRepository;
+use Illuminate\Bus\DatabaseBatchRepository;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Console\PruneBatchesCommand;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class PruneBatchesCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testAllowPruningAllUnfinishedBatches()
+    {
+        $container = new Container;
+        $container->instance(BatchRepository::class, $repo = m::spy(DatabaseBatchRepository::class));
+
+        $command = new PruneBatchesCommand;
+        $command->setLaravel($container);
+
+        $command->run(new ArrayInput(['--unfinished' => 0]), new NullOutput());
+
+        $repo->shouldHaveReceived('pruneUnfinished')->once();
+    }
+
+    public function testAllowPruningAllCancelledBatches()
+    {
+        $container = new Container;
+        $container->instance(BatchRepository::class, $repo = m::spy(DatabaseBatchRepository::class));
+
+        $command = new PruneBatchesCommand;
+        $command->setLaravel($container);
+
+        $command->run(new ArrayInput(['--cancelled' => 0]), new NullOutput());
+
+        $repo->shouldHaveReceived('pruneCancelled')->once();
+    }
+}

--- a/tests/Queue/PruneBatchesCommandTest.php
+++ b/tests/Queue/PruneBatchesCommandTest.php
@@ -6,9 +6,8 @@ use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Console\PruneBatchesCommand;
-use Illuminate\Support\Carbon;
-use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 


### PR DESCRIPTION
### Overview

I was previously unable to prune all queue batches on my local system during developemnt. This is due to a bug with how `php artisan queue:prune-batches` handles the flags `--unfinished=0 --cancelled=0`. With this change users will have a slightly nicer experience while developing against the Queue Batches feature.

_Before:_

![image](https://user-images.githubusercontent.com/797280/233203395-85099271-1b99-4063-8f9b-1cff493643ca.png)

_After:_

![image](https://user-images.githubusercontent.com/797280/233203495-d755aa6c-3b21-48ba-9777-e76eb94a3fc9.png)

### Changes in depth

There is a minor bug in the `php artisan queue:prune-batches` command when trying to delete all batches through pruning with the number of hours set to `0`.

The command allows you to prune unfinished and cancelled batches with the `--unfinished` and `--cancelled` flags respectively. These flags take a value of the number of hours to prune from, however, unlike the main `--hours` flag, these flags previously didn't support passing `0` (zero) as a value.

When passing `--unfinished=0` or `--cancelled=0` the command **wouldn't** acknowledge that you had passed the option at all. This was due to the check for these options:

```php
if ($this->option('unfinished')) {
    ...
}
```

When `0` is passed then the above will evaluate to `false`. The fix is to explicitly check whether the option is `null`:

```
if ($this->option('unfinished') !== null) {
    ...
}
```

### Testing

All Laravel tests passed locally after this change. I added a basic test to cover each flag with a value of `0`.

### Future

It could be useful to have a flag like `php artisan queue:prune-batches --all`. Although this flag would be potentially dangerous in production, it would short-hand the command that I have been running during development.