### PR TITLE
[10.x] Add toSentence method to Str helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1437,9 +1437,8 @@ class Str
     /**
      * Convert a list of strings into a sentence, with commas and a conjunction.
      *
-     * @param iterable<string> $items
-     * @param string           $conjunction
-     *
+     * @param  iterable<string>  $items
+     * @param  string  $conjunction
      * @return string The generated sentence.
      */
     public static function toSentence($items, $conjunction = 'and')
@@ -1451,7 +1450,7 @@ class Str
         $last = array_pop($items);
 
         if ($items) {
-            return implode(', ', $items) . " {$conjunction} " . $last;
+            return implode(', ', $items)." {$conjunction} ".$last;
         }
 
         return $last;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1435,6 +1435,29 @@ class Str
     }
 
     /**
+     * Convert an array or a Collection of strings into a sentence, with commas and a conjunction.
+     *
+     * @param array<int,string>|Collection<int,string> $items      The input array or Collection of strings.
+     * @param string|null      $conjunction The conjunction to use (default: translated 'and').
+     *
+     * @return string The generated sentence.
+     */
+    public static function toSentence($items, $conjunction = 'and')
+    {
+        if ($items instanceof Collection) {
+            $items = $items->toArray();
+        }
+
+        $last = array_pop($items);
+
+        if ($items) {
+            return implode(', ', $items) . " {$conjunction} " . $last;
+        }
+
+        return $last;
+    }
+
+    /**
      * Remove all strings from the casing caches.
      *
      * @return void

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1435,17 +1435,17 @@ class Str
     }
 
     /**
-     * Convert an array or a Collection of strings into a sentence, with commas and a conjunction.
+     * Convert a list of strings into a sentence, with commas and a conjunction.
      *
-     * @param array<int,string>|Collection<int,string> $items      The input array or Collection of strings.
-     * @param string|null      $conjunction The conjunction to use (default: translated 'and').
+     * @param iterable<string> $items
+     * @param string           $conjunction
      *
      * @return string The generated sentence.
      */
     public static function toSentence($items, $conjunction = 'and')
     {
-        if ($items instanceof Collection) {
-            $items = $items->toArray();
+        if ($items instanceof Traversable) {
+            $items = collect($items)->all();
         }
 
         $last = array_pop($items);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1119,6 +1119,13 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(strlen(Str::password()) === 32);
     }
+
+    public function testToSentence()
+    {
+        $this->assertSame('taylor, caleb and adam', Str::toSentence(['taylor','caleb','adam']));
+        $this->assertSame('taylor and caleb', Str::toSentence(['taylor', 'caleb']));
+        $this->assertSame('taylor', Str::toSentence(['taylor']));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1122,8 +1122,8 @@ class SupportStrTest extends TestCase
 
     public function testToSentence()
     {
-        $this->assertSame('taylor, caleb and adam', Str::toSentence(['taylor','caleb','adam']));
-        $this->assertSame('taylor, caleb and adam', Str::toSentence(collect(['taylor','caleb','adam'])));
+        $this->assertSame('taylor, caleb and adam', Str::toSentence(['taylor', 'caleb', 'adam']));
+        $this->assertSame('taylor, caleb and adam', Str::toSentence(collect(['taylor', 'caleb', 'adam'])));
         $this->assertSame('taylor and caleb', Str::toSentence(['taylor', 'caleb']));
         $this->assertSame('taylor', Str::toSentence(['taylor']));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1123,6 +1123,7 @@ class SupportStrTest extends TestCase
     public function testToSentence()
     {
         $this->assertSame('taylor, caleb and adam', Str::toSentence(['taylor','caleb','adam']));
+        $this->assertSame('taylor, caleb and adam', Str::toSentence(collect(['taylor','caleb','adam'])));
         $this->assertSame('taylor and caleb', Str::toSentence(['taylor', 'caleb']));
         $this->assertSame('taylor', Str::toSentence(['taylor']));
     }


### PR DESCRIPTION
This pull request introduces a new `toSentence` method to the Str helper class, providing a convenient way to convert an array or a Collection of strings into a human-readable `sentence` with commas and a customizable conjunction.

The toSentence method is heavily inspired by the Ruby on Rails [to_sentence helper](https://apidock.com/rails/Array/to_sentence).

I have added the method to the Str Helper, but it would also be convenient to move the method to the Array helper.

### Examples

```PHP
// Using an array of strings
$itemsArray = ['apple', 'banana', 'cherry'];
$sentenceFromArray = Str::toSentence($itemsArray);
// Output: "apple, banana, and cherry"
```
```PHP
// Using a Laravel Collection
$itemsCollection = collect(['apple', 'banana', 'cherry']);
$sentenceFromCollection = Str::toSentence($itemsCollection);
// Output: "apple, banana, and cherry"
```
```PHP
// Using a custom conjunction
$sentenceWithCustomConjunction = Str::toSentence($itemsArray, 'or');
// Output: "apple, banana, or cherry"
```

Thank you very much!