### PR TITLE
[10.x] Add missing `provider` property in SessionGuard

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -95,7 +95,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @var \Illuminate\Contracts\Auth\UserProvider
      */
     protected $provider;
-    
+
     /**
      * The timebox instance.
      *

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -90,6 +90,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $events;
 
     /**
+     * The provider instance.
+     *
+     * @var \Illuminate\Contracts\Auth\UserProvider
+     */
+    protected $provider;
+    
+    /**
      * The timebox instance.
      *
      * @var \Illuminate\Support\Timebox


### PR DESCRIPTION
In `__construct` of SessionGuard class, there is no property for set `provider`

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Auth/SessionGuard.php#L132