### PR TITLE
[10.x] Add new HTTP status assertions

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -180,4 +180,14 @@ trait AssertsStatusCodes
     {
         return $this->assertStatus(429);
     }
+
+    /**
+     * Assert that the response has a 503 "Service Unavailable" status code.
+     *
+     * @return $this
+     */
+    public function assertServiceUnavailable()
+    {
+        return $this->assertStatus(503);
+    }
 }

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -142,6 +142,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 410 "Gone" status code.
+     *
+     * @return $this
+     */
+    public function assertGone()
+    {
+        return $this->assertStatus(410);
+    }
+
+    /**
      * Assert that the response has a 415 "Unsupported Media Type" status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -182,6 +182,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 500 "Internal Server Error" status code.
+     *
+     * @return $this
+     */
+    public function assertInternalServerError()
+    {
+        return $this->assertStatus(500);
+    }
+
+    /**
      * Assert that the response has a 503 "Service Unavailable" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -707,6 +707,24 @@ class TestResponseTest extends TestCase
         $this->fail();
     }
 
+    public function testAssertGone()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_GONE)
+        );
+
+        $response->assertGone();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [410] but received 200.\nFailed asserting that 410 is identical to 200.");
+
+        $response->assertGone();
+    }
+
     public function testAssertTooManyRequests()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -791,6 +791,24 @@ class TestResponseTest extends TestCase
         $response->assertServerError();
     }
 
+    public function testAssertServiceUnavailable()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE)
+        );
+
+        $response->assertServiceUnavailable();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [503] but received 200.\nFailed asserting that 503 is identical to 200.");
+
+        $response->assertServiceUnavailable();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -791,6 +791,24 @@ class TestResponseTest extends TestCase
         $response->assertServerError();
     }
 
+    public function testAssertInternalServerError()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR)
+        );
+
+        $response->assertInternalServerError();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [500] but received 200.\nFailed asserting that 500 is identical to 200.");
+
+        $response->assertInternalServerError();
+    }
+
     public function testAssertServiceUnavailable()
     {
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
This pull request adds a couple of new HTTP status assertions that I find useful when writing test cases myself. Although ``$response->assertServerError()`` - assertion can be used to determine server-related errors, they do not allow us to thoroughly check the exact status the server responds with. I hope other developers will find them equally useful.

**Examples**
```
$response = $this->get('/');
$response->assertGone();

$response = $this->get('/');
$response->assertInternalServerError();

$response = $this->get('/');
$response->assertServiceUnavailable();
```

Thank you.

