### PR TITLE
[10.x] Add `bindWhen` to Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -378,6 +378,22 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Register a binding when condition is true.
+     *
+     * @param  bool  $condition
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @param  bool  $shared
+     * @return void
+     */
+    public function bindWhen($condition, $abstract, $concrete = null, $shared = false)
+    {
+        if ($condition) {
+            $this->bind($abstract, $concrete, $shared);
+        }
+    }
+
+    /**
      * Register a shared binding in the container.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -73,17 +73,6 @@ interface Container extends ContainerInterface
     public function bindIf($abstract, $concrete = null, $shared = false);
 
     /**
-     * Register a binding when condition is true.
-     *
-     * @param  bool  $condition
-     * @param  string  $abstract
-     * @param  \Closure|string|null  $concrete
-     * @param  bool  $shared
-     * @return void
-     */
-    public function bindWhen($condition, $abstract, $concrete = null, $shared = false);
-
-    /**
      * Register a shared binding in the container.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -82,7 +82,7 @@ interface Container extends ContainerInterface
      * @return void
      */
     public function bindWhen($condition, $abstract, $concrete = null, $shared = false);
-    
+
     /**
      * Register a shared binding in the container.
      *

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -73,6 +73,17 @@ interface Container extends ContainerInterface
     public function bindIf($abstract, $concrete = null, $shared = false);
 
     /**
+     * Register a binding when condition is true.
+     *
+     * @param  bool  $condition
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @param  bool  $shared
+     * @return void
+     */
+    public function bindWhen($condition, $abstract, $concrete = null, $shared = false);
+    
+    /**
      * Register a shared binding in the container.
      *
      * @param  string  $abstract

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -69,9 +69,6 @@ class ContainerTest extends TestCase
     public function testBindWhenIfConditionIsTrue()
     {
         $container = new Container;
-        $container->bind('surname', function () {
-            return 'Taylor';
-        });
         $container->bindWhen(true, 'name', function () {
             return 'Dayle';
         });

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -66,6 +66,19 @@ class ContainerTest extends TestCase
         $this->assertSame('Dayle', $container->make('name'));
     }
 
+    public function testBindWhenIfConditionIsTrue()
+    {
+        $container = new Container;
+        $container->bind('surname', function () {
+            return 'Taylor';
+        });
+        $container->bindWhen(true, 'name', function () {
+            return 'Dayle';
+        });
+
+        $this->assertSame('Dayle', $container->make('name'));
+    }
+
     public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
     {
         $container = new Container;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -79,6 +79,16 @@ class ContainerTest extends TestCase
         $this->assertSame('Dayle', $container->make('name'));
     }
 
+    public function testBindWhenIfConditionIsFalse()
+    {
+        $container = new Container;
+        $container->bindWhen(false, 'name', function () {
+            return 'Dayle';
+        });
+
+        $this->assertFalse($container->bound('name'));
+    }
+
     public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
     {
         $container = new Container;


### PR DESCRIPTION
When you want to add condition for binding you must follow like this:
```php
if (! $this->app->isProduction()) {
    $this->app->bind(Implicit::class, function (Application $app) {
       return new ImplicitMain;
    });
}
```

But is not beautiful for Laravel framework!

We can use `bindWhen`:
```php
$this->app->bindWhen(! $this->app->isProduction(), Implicit::class, function (Application $app) {
   return new ImplicitMain;
});
```