### PR TITLE
[9.x] Make rules method in FormRequest optional

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -109,7 +109,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function createDefaultValidator(ValidationFactory $factory)
     {
-        $rules = $this->container->call([$this, 'rules']);
+        $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
 
         $validator = $factory->make(
             $this->validationData(), $rules,

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -149,6 +149,15 @@ class FoundationFormRequestTest extends TestCase
         $this->assertSame('bar', $request->validated('nested.foo'));
     }
 
+    public function testRequestCanPassWithoutRulesMethod()
+    {
+        $request = $this->createRequest([], FoundationTestFormRequestWithoutRulesMethod::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals([], $request->all());
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -375,5 +384,13 @@ class FoundationTestFormRequestPassesWithResponseStub extends FormRequest
     public function authorize()
     {
         return Response::allow('baz');
+    }
+}
+
+class FoundationTestFormRequestWithoutRulesMethod extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
This will make the `rules` method in FormRequest objects optional if only the `authorize` method is used.