### PR TITLE
[10.x] Add a method called assertUriTooLong in AssertsStatusCodes

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -152,6 +152,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 414 "URI Too Long" status code.
+     *
+     * @return $this
+     */
+    public function assertUriTooLong()
+    {
+        return $this->assertStatus(414);
+    }
+
+    /**
      * Assert that the response has a 415 "Unsupported Media Type" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -725,6 +725,25 @@ class TestResponseTest extends TestCase
         $response->assertGone();
     }
 
+    public function testAssertUriTooLong()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_REQUEST_URI_TOO_LONG)
+        );
+
+        $response->assertUriTooLong();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [414] but received 200.\nFailed asserting that 414 is identical to 200.");
+
+        $response->assertUriTooLong();
+        $this->fail();
+    }
+
     public function testAssertTooManyRequests()
     {
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
This pull request provides a method in the testing environment to assert the uri is too long.
```php
$this->get('when the uri is too long')
     ->assertUriTooLong();

```