### PR TITLE
[10.x] update return type in docblock for Process pipe method

### DIFF
--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -275,7 +275,7 @@ class Factory
      * Start defining a series of piped processes.
      *
      * @param  callable|array  $callback
-     * @return \Illuminate\Process\Pipe
+     * @return ProcessResultContract
      */
     public function pipe(callable|array $callback, ?callable $output = null)
     {

--- a/src/Illuminate/Process/Factory.php
+++ b/src/Illuminate/Process/Factory.php
@@ -275,7 +275,7 @@ class Factory
      * Start defining a series of piped processes.
      *
      * @param  callable|array  $callback
-     * @return ProcessResultContract
+     * @return \Illuminate\Contracts\Process\ProcessResult
      */
     public function pipe(callable|array $callback, ?callable $output = null)
     {

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -35,7 +35,7 @@ use Illuminate\Process\Factory;
  * @method static \Illuminate\Process\Factory assertDidntRun(\Closure|string $callback)
  * @method static \Illuminate\Process\Factory assertNothingRan()
  * @method static \Illuminate\Process\Pool pool(callable $callback)
- * @method static \Illuminate\Process\Pipe pipe(callable|array $callback, callable|null $output = null)
+ * @method static \Illuminate\Contracts\Process\ProcessResult pipe(callable|array $callback, callable|null $output = null)
  * @method static \Illuminate\Process\ProcessPoolResults concurrently(callable $callback, callable|null $output = null)
  * @method static \Illuminate\Process\PendingProcess newPendingProcess()
  * @method static void macro(string $name, object|callable $macro)


### PR DESCRIPTION
since the pipe is run immediately https://github.com/laravel/framework/commit/e34ab392800bfc175334c90e9321caa7261c2d65 the pipe method doesn't return the `Pipe` anymore, it returns the `ProcessResult`