### PR TITLE
Pass through IGNITION_LOCAL_SITES_PATH environment variable when serving

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -57,6 +57,7 @@ class ServeCommand extends Command
      */
     public static $passthroughVariables = [
         'APP_ENV',
+        'IGNITION_LOCAL_SITES_PATH',
         'LARAVEL_SAIL',
         'PATH',
         'PHP_CLI_SERVER_WORKERS',


### PR DESCRIPTION
This PR adds `IGNITION_LOCAL_SITES_PATH` to the list of environment variables passed to the PHP server process by `artisan serve`. This enables the fix proposed in https://github.com/laravel/sail/pull/576, which deals with opening files in your IDE by clicking on the filename displayed by the Ignition error page when using Docker. Further details are better described and discussed in https://github.com/laravel/sail/pull/576.