### PR TITLE
[10.x] Throw LogicException when calling `FileFactory@image()` if mimetype is not supported

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -49,6 +49,8 @@ class FileFactory
      * @param  int  $width
      * @param  int  $height
      * @return \Illuminate\Http\Testing\File
+     *
+     * @throws \LogicException
      */
     public function image($name, $width = 10, $height = 10)
     {
@@ -64,9 +66,15 @@ class FileFactory
      * @param  int  $height
      * @param  string  $extension
      * @return resource
+     *
+     * @throws \LogicException
      */
     protected function generateImage($width, $height, $extension)
     {
+        if (! function_exists('imagecreatetruecolor')) {
+            throw new \LogicException("GD extension is not installed");
+        }
+
         return tap(tmpfile(), function ($temp) use ($width, $height, $extension) {
             ob_start();
 
@@ -75,6 +83,11 @@ class FileFactory
                 : 'jpeg';
 
             $image = imagecreatetruecolor($width, $height);
+
+            if (! function_exists($functionName = "image{$extension}")) {
+                ob_get_clean();
+                throw new \LogicException("{$functionName} does not exist and image cannot be generated");
+            }
 
             call_user_func("image{$extension}", $image);
 

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Testing;
 
+use LogicException;
+
 class FileFactory
 {
     /**
@@ -72,7 +74,7 @@ class FileFactory
     protected function generateImage($width, $height, $extension)
     {
         if (! function_exists('imagecreatetruecolor')) {
-            throw new \LogicException('GD extension is not installed');
+            throw new LogicException('GD extension is not installed.');
         }
 
         return tap(tmpfile(), function ($temp) use ($width, $height, $extension) {
@@ -86,7 +88,8 @@ class FileFactory
 
             if (! function_exists($functionName = "image{$extension}")) {
                 ob_get_clean();
-                throw new \LogicException("{$functionName} does not exist and image cannot be generated");
+
+                throw new LogicException("{$functionName} function is not defined and image cannot be generated.");
             }
 
             call_user_func("image{$extension}", $image);

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -92,7 +92,7 @@ class FileFactory
                 throw new LogicException("{$functionName} function is not defined and image cannot be generated.");
             }
 
-            call_user_func("image{$extension}", $image);
+            call_user_func($functionName, $image);
 
             fwrite($temp, ob_get_clean());
         });

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -72,7 +72,7 @@ class FileFactory
     protected function generateImage($width, $height, $extension)
     {
         if (! function_exists('imagecreatetruecolor')) {
-            throw new \LogicException("GD extension is not installed");
+            throw new \LogicException('GD extension is not installed');
         }
 
         return tap(tmpfile(), function ($temp) use ($width, $height, $extension) {

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -116,6 +116,29 @@ class HttpTestingFileFactoryTest extends TestCase
         );
     }
 
+    /** @dataProvider generateImageDataProvider */
+    public function testCallingCreateWithoutGDLoadedThrowsAnException(string $fileExtension, string $driver)
+    {
+        if ($this->isGDSupported($driver)) {
+            $this->markTestSkipped("Requires no {$driver}");
+        }
+
+        $this->expectException(\LogicException::class);
+        (new FileFactory)->image("test.{$fileExtension}");
+    }
+
+    public static function generateImageDataProvider(): array
+    {
+        return [
+            'jpeg' => ['jpeg', 'JPEG Support'],
+            'png' => ['png', 'PNG Support'],
+            'gif' => ['gif', 'GIF Create Support'],
+            'webp' => ['webp', 'WebP Support'],
+            'wbmp' => ['wbmp', 'WBMP Support'],
+            'bmp' => ['bmp', 'BMP Support'],
+        ];
+    }
+
     /**
      * @param  string  $driver
      * @return bool


### PR DESCRIPTION
The issue here was illuminated by https://github.com/laravel/framework/issues/46852. 

I opted for checking if `function_exists` rather than `extension_loaded` since this would allow for a developer to write their own `imagecreatetruecolor()` and `imagejpeg()` (or whatever extension) to output the contents.