### PR TITLE
[10.x] Add new HTTP status assertions

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -152,6 +152,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 413 "Request Entity Too Large" status code.
+     *
+     * @return $this
+     */
+    public function assertRequestEntityTooLarge()
+    {
+        return $this->assertStatus(413);
+    }
+
+    /**
      * Assert that the response has a 415 "Unsupported Media Type" status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -172,6 +172,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 417 "Expectation Failed" status code.
+     *
+     * @return $this
+     */
+    public function assertExpectationFailed()
+    {
+        return $this->assertStatus(417);
+    }
+
+    /**
      * Assert that the response has a 422 "Unprocessable Entity" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -743,6 +743,24 @@ class TestResponseTest extends TestCase
         $response->assertRequestEntityTooLarge();
     }
 
+    public function testAssertExpectationFailed()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_EXPECTATION_FAILED)
+        );
+
+        $response->assertExpectationFailed();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [417] but received 200.\nFailed asserting that 417 is identical to 200.");
+
+        $response->assertExpectationFailed();
+    }
+
     public function testAssertTooManyRequests()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -725,6 +725,24 @@ class TestResponseTest extends TestCase
         $response->assertGone();
     }
 
+    public function testAssertRequestEntityTooLarge()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_REQUEST_ENTITY_TOO_LARGE)
+        );
+
+        $response->assertRequestEntityTooLarge();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [413] but received 200.\nFailed asserting that 413 is identical to 200.");
+
+        $response->assertRequestEntityTooLarge();
+    }
+
     public function testAssertTooManyRequests()
     {
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
This pull request adds two new payload-related HTTP status assertions. The first one will be responded with, when the request entity is larger than the limits defined by the server. The second one will be sent back when the server cannot meet the expectation of the client, like - sending a (presumably large) message body in this request.

**Examples**

```php
$response = $this->post('/upload/way/too/large/file');
$response->assertRequestEntityTooLarge();

$response = $this->post('/upload/way/too/large/file');
$response->assertExpectationFailed();
```

Thanks.