### PR TITLE
Add Artisan Command to flush sessions

### DIFF
--- a/src/Illuminate/Foundation/Console/SessionFlushCommand.php
+++ b/src/Illuminate/Foundation/Console/SessionFlushCommand.php
@@ -4,12 +4,13 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'session:flush')]
 class SessionFlushCommand extends Command
 {
+    use ConfirmableTrait;
     /**
      * The console command name.
      *
@@ -31,12 +32,10 @@ class SessionFlushCommand extends Command
      */
     public function handle()
     {
-        $isConfirmed =  $this->confirm('Do you really wish to run this command?',false);
-
-        if($isConfirmed){
+        if ($this->confirmToProceed('Do you really wish to run this command?')) {
             $driver = config('session.driver');
-            $method_name = 'clean'.ucfirst($driver);
-            if ( method_exists($this, $method_name) ) {
+            $method_name = 'clean' . ucfirst($driver);
+            if (method_exists($this, $method_name)) {
                 try {
                     $this->$method_name();
                     $this->components->info('Session Data Flushed Successfully.');
@@ -47,27 +46,23 @@ class SessionFlushCommand extends Command
                 $this->components->error("Unable to clean the sessions of the driver '{$driver}'.");
             }
         }
-        else{
-            $this->components->warn('Command Canceled');
-        }
-
     }
     //file
-    protected function cleanFile ()
+    protected function cleanFile()
     {
         $directory = config('session.files');
         $ignoreFiles = ['.gitignore', '.', '..'];
 
         $files = scandir($directory);
 
-        foreach ( $files as $file ) {
-            if( !in_array($file,$ignoreFiles) ) {
+        foreach ($files as $file) {
+            if (!in_array($file, $ignoreFiles)) {
                 unlink($directory . '/' . $file);
             }
         }
     }
     //database
-    protected function cleanDatabase ()
+    protected function cleanDatabase()
     {
         $table = config('session.table');
         DB::table($table)->truncate();
@@ -80,11 +75,9 @@ class SessionFlushCommand extends Command
     //Redis
     protected function cleanRedis()
     {
-        Cache::store("redis")->flush();
     }
     //Memcached
     protected function cleanMemcached()
     {
-        Cache::store("memcached")->flush();
     }
 }

--- a/src/Illuminate/Foundation/Console/SessionFlushCommand.php
+++ b/src/Illuminate/Foundation/Console/SessionFlushCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'session:flush')]
+class SessionFlushCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'session:flush';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flush all user sessions';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $driver = config('session.driver');
+        $method_name = 'clean' . ucfirst($driver);
+        if ( method_exists($this, $method_name) ) {
+            try {
+                $this->$method_name();
+                $this->components->info('Session data cleaned.');
+            } catch (\Exception $e) {
+                $this->components->error($e->getMessage());
+            }
+        } else {
+            $this->components->error("Unable to clean the sessions of the driver '{$driver}'.");
+        }
+    }
+    //file
+    protected function cleanFile () {
+        $directory = config('session.files');
+        $ignoreFiles = ['.gitignore', '.', '..'];
+
+        $files = scandir($directory);
+
+        foreach ( $files as $file ) {
+            if( !in_array($file,$ignoreFiles) ) {
+                unlink($directory . '/' . $file);
+            }
+        }
+    }
+    //database
+    protected function cleanDatabase () {
+        $table = config('session.table');
+        DB::table($table)->truncate();
+    }
+    //cookie
+    protected function cleanCookie(){
+        throw new \Exception("Session driver 'cookie' cant be flushed");
+    }
+    //Redis
+    protected function cleanRedis(){
+        \Cache::store("redis")->flush();
+    }
+    //Memcached
+    protected function cleanMemcached(){
+        \Cache::store("memcached")->flush();
+    }
+}

--- a/src/Illuminate/Foundation/Console/SessionFlushCommand.php
+++ b/src/Illuminate/Foundation/Console/SessionFlushCommand.php
@@ -4,6 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 #[AsCommand(name: 'session:flush')]
 class SessionFlushCommand extends Command
@@ -66,10 +68,10 @@ class SessionFlushCommand extends Command
     }
     //Redis
     protected function cleanRedis(){
-        \Cache::store("redis")->flush();
+        Cache::store("redis")->flush();
     }
     //Memcached
     protected function cleanMemcached(){
-        \Cache::store("memcached")->flush();
+        Cache::store("memcached")->flush();
     }
 }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -197,7 +197,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScopeMake' => ScopeMakeCommand::class,
         'SeederMake' => SeederMakeCommand::class,
         'SessionTable' => SessionTableCommand::class,
-        'SessionFlush' =>SessionFlushCommand::class,
+        'SessionFlush' => SessionFlushCommand::class,
         'Serve' => ServeCommand::class,
         'StubPublish' => StubPublishCommand::class,
         'TestMake' => TestMakeCommand::class,

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -67,6 +67,7 @@ use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ScopeMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Foundation\Console\SessionFlushCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
@@ -196,6 +197,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScopeMake' => ScopeMakeCommand::class,
         'SeederMake' => SeederMakeCommand::class,
         'SessionTable' => SessionTableCommand::class,
+        'SessionFlush' =>SessionFlushCommand::class,
         'Serve' => ServeCommand::class,
         'StubPublish' => StubPublishCommand::class,
         'TestMake' => TestMakeCommand::class,


### PR DESCRIPTION
This pull request adds a new artisan command, session:flush, that allows the user to clear all active sessions in Laravel. The command can be run from the terminal using php artisan session:flush.

This feature can be useful in situations where there are a large number of active sessions, such as when doing maintenance or debugging. Previously, the only way to clear all sessions was to manually delete session files from the storage directory or from the database manually.

To implement this feature, I added a new command file to the Foundation/Console directory. If this PR got accepted I will also update the documentation

I have tested this feature locally and it works as expected. The code follows the Laravel coding standards and conventions.

I appreciate your consideration of this pull request.
