### PR TITLE
[10.x] Better speed of `pop` method in Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -942,7 +942,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $collectionCount = $this->count();
 
         foreach (range(1, min($count, $collectionCount)) as $item) {
-            array_push($results, array_pop($this->items));
+            $results[] = array_pop($this->items);
         }
 
         return new static($results);


### PR DESCRIPTION
A little faster than previous way (I'm using Benchmark).
```php
// First way
array_push($results, array_pop($this->items));
collect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])->pop(); // 0.009ms OR 0.013ms

// Second way 
$results[] = array_pop($this->items); 
collect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])->pop(); // 0.006ms
```

Also, the second way has a better style code than the first way. 