### PR TITLE
[10.x] Fix phpdoc of `intersectUsing` method in LazyCollection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -633,8 +633,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Intersect the collection with the given items, using the callback.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @param  callable(TValue, TValue): int  $callback
      * @return static
      */
     public function intersectUsing()


### PR DESCRIPTION
There no need to `@param` in `intersectUsing` method!