### PR TITLE
[10.x] Fix implode docblock to accept callable as parameter in collection

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -549,7 +549,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
+     * @param  callable|string  $value
      * @param  string|null  $glue
      * @return string
      */


### PR DESCRIPTION
The Laravel documentation describes it is possible to pass a closure into the implode function on a collection. [Collections Implode documentation](https://laravel.com/docs/10.x/collections#method-implode)
But in the Enumerable interface of collections, it does not accept a callable.

In this pull request, I added the callable to the Enumerable interface as an accepted parameter, the same as in the Collection class.