### PR TITLE
add explainAnalyze

### DIFF
--- a/src/Illuminate/Database/Concerns/ExplainsQueries.php
+++ b/src/Illuminate/Database/Concerns/ExplainsQueries.php
@@ -21,4 +21,20 @@ trait ExplainsQueries
 
         return new Collection($explanation);
     }
+
+    /**
+     * Explain Analyze the query.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function explainAnalyze()
+    {
+        $sql = $this->toSql();
+
+        $bindings = $this->getBindings();
+
+        $explanation = $this->getConnection()->select('EXPLAIN ANALYZE '.$sql, $bindings);
+
+        return new Collection($explanation);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -102,6 +102,7 @@ class Builder implements BuilderContract
         'exists',
         'existsOr',
         'explain',
+        'explainAnalyze',
         'getBindings',
         'getConnection',
         'getGrammar',

--- a/tests/Integration/Database/EloquentExplainAnalyzeTest.php
+++ b/tests/Integration/Database/EloquentExplainAnalyzeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentExplainAnalyzeTest extends DatabaseTestCase
+{
+    public function testExplainAnalyzeMySql()
+    {
+        if ($this->driver !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->assertObjectHasProperty('EXPLAIN', UserExplainAnalyzeTest::query()->explainAnalyze()?->first());
+
+        Schema::drop('users');
+    }
+
+    public function testExplainAnalyzePostgres()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a PgSQL connection.');
+        }
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->assertObjectHasProperty('QUERY PLAN', UserExplainAnalyzeTest::query()->explainAnalyze()?->first());
+
+        Schema::drop('users');
+    }
+}
+
+class UserExplainAnalyzeTest extends Model
+{
+    protected $table = 'users';
+    protected $fillable = ['name'];
+}

--- a/tests/Integration/Database/QueryExplainAnalyzeTest.php
+++ b/tests/Integration/Database/QueryExplainAnalyzeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class QueryExplainAnalyzeTest extends DatabaseTestCase
+{
+    public function testExplainAnalyzeMySql()
+    {
+        if ($this->driver !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->assertObjectHasProperty('EXPLAIN', DB::table('users')->explainAnalyze()?->first());
+
+        Schema::drop('users');
+    }
+
+    public function testExplainAnalyzePostgres()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a PgSQl connection.');
+        }
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->assertObjectHasProperty('QUERY PLAN', DB::table('users')->explainAnalyze()?->first());
+
+        Schema::drop('users');
+    }
+}


### PR DESCRIPTION
Add `EXPLAIN ANALYZE`

```php
User::where('votes', 100)->explainAnalyze();
```

```php
DB::table('users')->where('votes', 100)->explainAnalyze();
```

Only support `mysql` and `pgsql` connections.