### PR TITLE
[10.x] Uses Eloquent Scopes repository [WIP]

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -23,7 +23,7 @@ class Manager
     protected $manager;
 
     /**
-     * The Eloquent Scopes instance
+     * The Eloquent Scopes instance.
      *
      * @var \Illuminate\Database\Eloquent\Scopes
      */

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -23,6 +23,13 @@ class Manager
     protected $manager;
 
     /**
+     * The Eloquent Scopes instance
+     *
+     * @var \Illuminate\Database\Eloquent\Scopes
+     */
+    protected $scopes;
+
+    /**
      * Create a new database capsule manager.
      *
      * @param  \Illuminate\Container\Container|null  $container
@@ -38,6 +45,8 @@ class Manager
         $this->setupDefaultConfiguration();
 
         $this->setupManager();
+
+        $this->setupScopes();
     }
 
     /**
@@ -62,6 +71,16 @@ class Manager
         $factory = new ConnectionFactory($this->container);
 
         $this->manager = new DatabaseManager($this->container, $factory);
+    }
+
+    /**
+     * Build the Eloquent Scopes instance.
+     *
+     * @return void
+     */
+    protected function setupScopes()
+    {
+        $this->scopes = new Scopes();
     }
 
     /**
@@ -135,7 +154,9 @@ class Manager
     {
         Eloquent::setConnectionResolver($this->manager);
 
-        Eloquent::setEloquentScopes(new Scopes());
+        if (! Eloquent::getEloquentScopes()) {
+            Eloquent::setEloquentScopes($this->scopes);
+        }
 
         // If we have an event dispatcher instance, we will go ahead and register it
         // with the Eloquent ORM, allowing for model callbacks while creating and

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Scopes;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
 use PDO;
 
@@ -133,6 +134,8 @@ class Manager
     public function bootEloquent()
     {
         Eloquent::setConnectionResolver($this->manager);
+
+        Eloquent::setEloquentScopes(new Scopes());
 
         // If we have an event dispatcher instance, we will go ahead and register it
         // with the Eloquent ORM, allowing for model callbacks while creating and

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -29,6 +29,8 @@ class DatabaseServiceProvider extends ServiceProvider
         Model::setConnectionResolver($this->app['db']);
 
         Model::setEventDispatcher($this->app['events']);
+
+        Model::setEloquentScopes($this->app['eloquent.scopes']);
     }
 
     /**
@@ -41,6 +43,7 @@ class DatabaseServiceProvider extends ServiceProvider
         Model::clearBootedModels();
 
         $this->registerConnectionServices();
+        $this->registerEloquentScopes();
         $this->registerEloquentFactory();
         $this->registerQueueableEntityResolver();
     }
@@ -76,6 +79,18 @@ class DatabaseServiceProvider extends ServiceProvider
 
         $this->app->singleton('db.transactions', function ($app) {
             return new DatabaseTransactionsManager;
+        });
+    }
+
+    /**
+     * Register the Eloquent Model Global Scopes hub.
+     *
+     * @return void
+     */
+    protected function registerEloquentScopes()
+    {
+        $this->app->singleton('eloquent.scopes', function () {
+            return new Eloquent\Scopes;
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -5,6 +5,15 @@ namespace Illuminate\Database\Eloquent\Concerns;
 trait HasGlobalScopes
 {
     /**
+     * Returns the Eloquent Scopes hub for models
+     *
+     * @return \Illuminate\Database\Eloquent\Scopes|null
+     */
+    public static function getEloquentScopes()
+    {
+        return static::$globalScopes;
+    }
+    /**
      * Sets the Eloquent Scopes hub for models.
      *
      * @param  \Illuminate\Database\Eloquent\Scopes  $eloquentScopes

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 trait HasGlobalScopes
 {
     /**
-     * Returns the Eloquent Scopes hub for models
+     * Returns the Eloquent Scopes hub for models.
      *
      * @return \Illuminate\Database\Eloquent\Scopes|null
      */
@@ -13,6 +13,7 @@ trait HasGlobalScopes
     {
         return static::$globalScopes;
     }
+
     /**
      * Sets the Eloquent Scopes hub for models.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -148,11 +148,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $traitInitializers = [];
 
     /**
-     * The array of global scopes on the model.
+     * The Global Scopes hub.
      *
-     * @var array
+     * @var \Illuminate\Database\Eloquent\Scopes|null
      */
-    protected static $globalScopes = [];
+    protected static $globalScopes;
 
     /**
      * The list of models classes that should not be affected with touch.
@@ -344,7 +344,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         static::$booted = [];
 
-        static::$globalScopes = [];
+        static::$globalScopes?->flushGlobalScopesForModel(static::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Scopes.php
+++ b/src/Illuminate/Database/Eloquent/Scopes.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Eloquent;
 use Closure;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
-use function is_object;
 
 class Scopes
 {

--- a/src/Illuminate/Database/Eloquent/Scopes.php
+++ b/src/Illuminate/Database/Eloquent/Scopes.php
@@ -24,7 +24,7 @@ class Scopes
      */
     public function hasGlobalScope($model, $scope)
     {
-        return !is_null($this->getGlobalScope($model, $scope));
+        return ! is_null($this->getGlobalScope($model, $scope));
     }
 
     /**
@@ -35,7 +35,7 @@ class Scopes
      */
     public function hasScopes($model)
     {
-        return !empty($this->getGlobalScope($model, '*'));
+        return ! empty($this->getGlobalScope($model, '*'));
     }
 
     /**
@@ -139,7 +139,7 @@ class Scopes
     /**
      * Merges the global scopes on top of the already set global scopes.
      *
-     * @param array $scopes
+     * @param  array  $scopes
      * @return void
      */
     public function mergeGlobalScopes(array $scopes)

--- a/src/Illuminate/Database/Eloquent/Scopes.php
+++ b/src/Illuminate/Database/Eloquent/Scopes.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Closure;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+use function is_object;
+
+class Scopes
+{
+    /**
+     * Scopes registered for each model.
+     *
+     * @var array<string, array<\Illuminate\Database\Eloquent\Scope|string|callable>>
+     */
+    public $scopes = [];
+
+    /**
+     * Determine if a model has a global scope.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @return bool
+     */
+    public function hasGlobalScope($model, $scope)
+    {
+        return !is_null($this->getGlobalScope($model, $scope));
+    }
+
+    /**
+     * Determine if a model has any global scope registered.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @return bool
+     */
+    public function hasScopes($model)
+    {
+        return !empty($this->getGlobalScope($model, '*'));
+    }
+
+    /**
+     * Get a global scope registered with the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @return \Illuminate\Database\Eloquent\Scope|\Closure|null
+     */
+    public function getGlobalScope($model, $scope)
+    {
+        if (is_object($model)) {
+            $model = get_class($model);
+        }
+
+        if (is_object($scope)) {
+            $scope = get_class($scope);
+        }
+
+        return Arr::get($this->scopes, $model.'.'.$scope);
+    }
+
+    /**
+     * Return all the Global Scopes registered for an Eloquent Model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @return array<string, array<\Illuminate\Database\Eloquent\Scope|string|callable>>
+     */
+    public function getGlobalScopesForModel($model)
+    {
+        if (is_object($model)) {
+            $model = get_class($model);
+        }
+
+        return Arr::get($this->scopes, $model, []);
+    }
+
+    /**
+     * Register a new global scope on the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|string  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|null  $implementation
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function addGlobalScope($model, $scope, $implementation = null)
+    {
+        if (is_object($model)) {
+            $model = get_class($model);
+        }
+
+        if (is_string($scope) && ($implementation instanceof Closure || $implementation instanceof Scope)) {
+            return $this->scopes[$model][$scope] = $implementation;
+        } elseif ($scope instanceof Closure) {
+            return $this->scopes[$model][spl_object_hash($scope)] = $scope;
+        } elseif ($scope instanceof Scope) {
+            return $this->scopes[$model][get_class($scope)] = $scope;
+        }
+
+        throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
+    }
+
+    /**
+     * Returns the global scopes.
+     *
+     * @return array<string, array<\Illuminate\Database\Eloquent\Scope|string|callable>>
+     */
+    public function getGlobalScopes()
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * Flushes all the Global Scopes for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @return void
+     */
+    public function flushGlobalScopesForModel($model)
+    {
+        if (is_object($model)) {
+            $model = get_class($model);
+        }
+
+        $this->scopes[$model] = [];
+    }
+
+    /**
+     * Sets all the global scopes.
+     *
+     * @param  array<string, array<\Illuminate\Database\Eloquent\Scope|string|callable>>  $scopes
+     * @return void
+     */
+    public function setGlobalScopes(array $scopes)
+    {
+        $this->scopes = $scopes;
+    }
+
+    /**
+     * Merges the global scopes on top of the already set global scopes.
+     *
+     * @param array $scopes
+     * @return void
+     */
+    public function mergeGlobalScopes(array $scopes)
+    {
+        $this->scopes = array_merge_recursive($this->scopes, $scopes);
+    }
+}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Scopes;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\Eloquent\Scopes;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
## What?

Moves Eloquent Scopes into its own Container Service. Currently, scopes are statically registered inside the `Model` class as a static variable `$globalScopes`.

## Problems

Since is a static property, it poses some problems:

- Packages like Laravel Octane can't/won't reset the Global Scopes state.
- There is a risk of memory leaks.

By moving Global Scopes into its own Container Service, we can

1. Keep one instance available everywhere.
1. Mock it, replace it.
1. Let Laravel Octane and similar to _reset_ the scopes state.
2. Avoid accidental memory leaks by adding scopes with different/dynamic names.

## How it works?

The `$globalScopes` array is now a `Scopes` instance. Calls to manipulate the Global Scopes list are redirected to this instance methods.

This also expands the trait responsible of handling Global Scopes with some new tools.

Since the Database package is also available with a Capsule, booting Eloquent or a Model won't replace the `Scopes` instance if there is already one defined statically.

## BC?

There is no documentation or encouragement to use `Model::$globalScopes` directly, so not in sight. Manipulation of this variable could be considered a _hacky thing_.

---

Update: Since it's a very internal change for how Global Scopes work, I'm going to put the change over the master branch, for 11.x.