### PR TITLE
[10.x] Uses `@template-covariant` in collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -12,7 +12,8 @@ use Traversable;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -12,7 +12,8 @@ use Traversable;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -16,7 +16,8 @@ use Traversable;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
  */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -19,7 +19,8 @@ use UnitEnum;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  *
  * @property-read HigherOrderCollectionProxy $average
  * @property-read HigherOrderCollectionProxy $avg

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -4,7 +4,6 @@ namespace Illuminate\Contracts\Support;
 
 /**
  * @template TKey of array-key
- *
  * @template TValue
  */
 interface Arrayable

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -5,7 +5,7 @@ namespace Illuminate\Contracts\Support;
 /**
  * @template TKey of array-key
  *
- * @template-covariant TValue
+ * @template TValue
  */
 interface Arrayable
 {

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -4,7 +4,8 @@ namespace Illuminate\Contracts\Support;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ *
+ * @template-covariant TValue
  */
 interface Arrayable
 {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1055,3 +1055,45 @@ foreach ($collection as $int => $user) {
     assertType('int', $int);
     assertType('User', $user);
 }
+
+class Animal
+{
+}
+class Tiger extends Animal
+{
+}
+class Lion extends Animal
+{
+}
+class Zebra extends Animal
+{
+}
+
+class Zoo
+{
+    /**
+     * @var \Illuminate\Support\Collection<int, Animal>
+     */
+    private Collection $animals;
+
+    public function __construct()
+    {
+        $this->animals = collect([
+            new Tiger,
+            new Lion,
+            new Zebra,
+        ]);
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, Animal>
+     */
+    public function getWithoutZebras(): Collection
+    {
+        return $this->animals->filter(fn (Animal $animal) => ! $animal instanceof Zebra);
+    }
+}
+
+$zoo = new Zoo();
+
+assertType('Illuminate\Support\Collection<int, Animal>', $zoo->getWithoutZebras());


### PR DESCRIPTION
Explanation: here: https://github.com/laravel/framework/pull/46866.