### PR TITLE
[10.x] Fetch Pivot fully before detaching

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -474,25 +474,26 @@ trait InteractsWithPivotTable
     protected function detachUsingCustomClass($ids)
     {
         return $this->getCurrentlyAttachedPivots($ids)->reduce(
-            fn($value, $pivot) => $value + $pivot->delete(),
+            fn ($value, $pivot) => $value + $pivot->delete(),
             0
         );
     }
 
     /**
      * Get the pivot models that are currently attached.
+     *
      * @param  mixed|null  $ids
      * @return \Illuminate\Support\Collection
      */
     protected function getCurrentlyAttachedPivots($ids = null)
     {
-        $methodName = is_null($ids) ? 'newPivotQuery' :  'newPivotStatementForId';
+        $methodName = is_null($ids) ? 'newPivotQuery' : 'newPivotStatementForId';
 
         return $this->{$methodName}($ids)->get()->map($this->mapIntoPivot(...));
     }
 
     /**
-     * @param \stdClass $record
+     * @param  \stdClass  $record
      * @return Pivot
      */
     protected function mapIntoPivot($record)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -493,6 +493,8 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Convert a raw database record into a Pivot object.
+     *
      * @param  \stdClass  $record
      * @return Pivot
      */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -118,11 +118,12 @@ class MorphToMany extends BelongsToMany
     /**
      * Get the pivot models that are currently attached.
      *
+     * @param  mixed|null  $ids
      * @return \Illuminate\Support\Collection
      */
-    protected function getCurrentlyAttachedPivots()
+    protected function getCurrentlyAttachedPivots($ids = null)
     {
-        return parent::getCurrentlyAttachedPivots()->map(function ($record) {
+        return parent::getCurrentlyAttachedPivots($ids)->map(function ($record) {
             return $record instanceof MorphPivot
                             ? $record->setMorphType($this->morphType)
                                      ->setMorphClass($this->morphClass)

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -59,6 +59,8 @@ class EloquentPivotEventsTest extends DatabaseTestCase
         PivotEventsTestCollaborator::$eventsCalled = [];
         $project->collaborators()->detach($user);
         $this->assertEquals(['deleting', 'deleted'], PivotEventsTestCollaborator::$eventsCalled);
+        $this->assertEquals('owner', PivotEventsTestCollaborator::$lastModelDeleting->role);
+        $this->assertEquals('owner', PivotEventsTestCollaborator::$lastModelDeleted->role);
     }
 
     public function testPivotWithPivotCriteriaTriggerEventsToBeFiredOnCreateUpdateNoneOnDetach()
@@ -158,6 +160,9 @@ class PivotEventsTestCollaborator extends Pivot
 
     public static $eventsCalled = [];
 
+    public static $lastModelDeleting = null;
+    public static $lastModelDeleted = null;
+
     public static function boot()
     {
         parent::boot();
@@ -190,10 +195,12 @@ class PivotEventsTestCollaborator extends Pivot
 
         static::deleting(function ($model) {
             static::$eventsCalled[] = 'deleting';
+            static::$lastModelDeleting = $model;
         });
 
         static::deleted(function ($model) {
             static::$eventsCalled[] = 'deleted';
+            static::$lastModelDeleted = $model;
         });
     }
 }


### PR DESCRIPTION
https://github.com/laravel/framework/issues/46851

This allows for dispatching model events on a Pivot when detaching that includes *all* attributes of the Pivot model. Previously models only contained their foreign and related keys populated.

This was in particular a problem for model event listeners/observers: additional pivot columns would not be available to those functions if they needed to act based on pivot columns within the `deleted` or `deleting` events.

### Additional thoughts
It might be nice to have a distinct set of events for detaching/detached. I think this might be an idea for 11.x. My thinking is that it might provide better granularity to the client code, but I can't think of specific a use case at this time.