### PR TITLE
[10.x] Use foreignUlid if model uses HasUlids trait when call foreignIdFor 

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -938,9 +938,19 @@ class Blueprint
             $model = new $model;
         }
 
-        return $model->getKeyType() === 'int' && $model->getIncrementing()
-                    ? $this->foreignId($column ?: $model->getForeignKey())
-                    : $this->foreignUuid($column ?: $model->getForeignKey());
+        $column = $column ?: $model->getForeignKey();
+
+        if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
+            return $this->foreignId($column);
+        }
+
+        $modelTraits = class_uses_recursive($model);
+
+        if (in_array('Illuminate\Database\Eloquent\Concerns\HasUlids', $modelTraits, true)) {
+            return $this->foreignUlid($column);
+        }
+
+        return  $this->foreignUuid($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
@@ -946,11 +947,11 @@ class Blueprint
 
         $modelTraits = class_uses_recursive($model);
 
-        if (in_array('Illuminate\Database\Eloquent\Concerns\HasUlids', $modelTraits, true)) {
+        if (in_array(HasUlids::class, $modelTraits, true)) {
             return $this->foreignUlid($column);
         }
 
-        return  $this->foreignUuid($column);
+        return $this->foreignUuid($column);
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -372,6 +372,22 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
+    public function testGenerateRelationshipColumnWithUlidModel()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUlidStub.php';
+
+        $base = new Blueprint('posts', function (Blueprint $table) {
+            $table->foreignIdFor('EloquentModelUlidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "eloquent_model_ulid_stub_id" char(26) not null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+    }
+
     public function testDropRelationshipColumnWithIncrementalModel()
     {
         $base = new Blueprint('posts', function ($table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -383,9 +383,16 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock(Connection::class);
 
         $blueprint = clone $base;
+
         $this->assertEquals([
             'alter table "posts" add column "eloquent_model_ulid_stub_id" char(26) not null',
         ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `eloquent_model_ulid_stub_id` char(26) not null',
+        ], $blueprint->toSql($connection, new MySqlGrammar()));
     }
 
     public function testDropRelationshipColumnWithIncrementalModel()

--- a/tests/Database/stubs/EloquentModelUlidStub.php
+++ b/tests/Database/stubs/EloquentModelUlidStub.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelUlidStub extends Model
+{
+    use HasUlids;
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'model';
+}


### PR DESCRIPTION
`foreignIdFor` creates column uses UUID type in Postgres, but related model uses ULID. So we have an error with that like this
` invalid input syntax for type uuid: "01gytdbw84sf4d0d2tsserk73t"`

I think it should check what trait mode uses and pick the correct method for it
