### PR TITLE
Make error pages more flexible and informative (#46865)

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/401.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/401.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Unauthorized'))
-@section('code', '401')
-@section('message', __('Unauthorized'))

--- a/src/Illuminate/Foundation/Exceptions/views/402.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/402.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Payment Required'))
-@section('code', '402')
-@section('message', __('Payment Required'))

--- a/src/Illuminate/Foundation/Exceptions/views/403.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/403.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Forbidden'))
-@section('code', '403')
-@section('message', __($exception->getMessage() ?: 'Forbidden'))

--- a/src/Illuminate/Foundation/Exceptions/views/404.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/404.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Not Found'))
-@section('code', '404')
-@section('message', __('Not Found'))

--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Page Expired'))
-@section('code', '419')
-@section('message', __('Page Expired'))

--- a/src/Illuminate/Foundation/Exceptions/views/429.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/429.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Too Many Requests'))
-@section('code', '429')
-@section('message', __('Too Many Requests'))

--- a/src/Illuminate/Foundation/Exceptions/views/4xx.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/4xx.blade.php
@@ -1,0 +1,11 @@
+@extends('errors::minimal')
+
+@php
+    $statusCode = $exception->getStatusCode();
+    $statusText = __(\Symfony\Component\HttpFoundation\Response::$statusTexts[$statusCode]);
+    $statusMessage = !empty($exception->getMessage()) ? ': ' . __($exception->getMessage()) : '';
+@endphp
+
+@section('title', "$statusCode: $statusText")
+@section('code', $statusCode)
+@section('message', $statusText . $statusMessage )

--- a/src/Illuminate/Foundation/Exceptions/views/500.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/500.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Server Error'))
-@section('code', '500')
-@section('message', __('Server Error'))

--- a/src/Illuminate/Foundation/Exceptions/views/503.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/503.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::minimal')
-
-@section('title', __('Service Unavailable'))
-@section('code', '503')
-@section('message', __('Service Unavailable'))

--- a/src/Illuminate/Foundation/Exceptions/views/5xx.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/5xx.blade.php
@@ -1,0 +1,11 @@
+@extends('errors::minimal')
+
+@php
+    $statusCode = $exception->getStatusCode();
+    $statusText = __(\Symfony\Component\HttpFoundation\Response::$statusTexts[$statusCode]);
+    $statusMessage = !empty($exception->getMessage()) ? ': ' . __($exception->getMessage()) : '';
+@endphp
+
+@section('title', "$statusCode: $statusText")
+@section('code', $statusCode)
+@section('message', $statusText . $statusMessage )


### PR DESCRIPTION
This change continues the effort to make working with error pages more flexible and easy.

Some time ago, Laravel began supporting "fallback error pages," which was a great improvement. However, the built-in error pages were still provided in an old-fashioned manner, limiting some possibilities and forcing users to create more custom error pages to replace the built-in ones.

This pull request addresses that issue. Now, users can simply place their `4xx.blade.php` and `5xx.blade.php` files in their error template folders, and they're good to go! There is no longer a need to create multiple files for each individual error code to override the built-in pages.

Additionally, this PR adds the error code to the `<title>` tag and the error message to the "message" section if provided.