### PR TITLE
[10.x] Add default method for `withValidator`

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -7,7 +7,7 @@ use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
-use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
@@ -148,7 +148,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    protected function failedValidation(Validator $validator)
+    protected function failedValidation(ValidatorContract $validator)
     {
         throw (new ValidationException($validator))
                     ->errorBag($this->errorBag)
@@ -256,7 +256,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return $this
      */
-    public function setValidator(Validator $validator)
+    public function setValidator(ValidatorContract $validator)
     {
         $this->validator = $validator;
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -92,9 +92,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $validator = $this->createDefaultValidator($factory);
         }
 
-        if (method_exists($this, 'withValidator')) {
-            $this->withValidator($validator);
-        }
+        $this->withValidator($validator);
 
         if (method_exists($this, 'after')) {
             $validator->after($this->container->call(
@@ -289,5 +287,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $this->container = $container;
 
         return $this;
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     */
+    public function withValidator(Validator $validator)
+    {
+        //
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
 
 class FormRequest extends Request implements ValidatesWhenResolved
 {
@@ -295,7 +296,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  \Illuminate\Validation\Validator  $validator
      * @return void
      */
-    public function withValidator(\Illuminate\Validation\Validator $validator)
+    public function withValidator(Validator $validator)
     {
         //
     }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -292,7 +292,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Configure the validator instance.
      *
-     * @param  \Illuminate\Validation\Validator  $validator
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
      */
     public function withValidator(Validator $validator)

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -292,10 +292,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Configure the validator instance.
      *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  \Illuminate\Validation\Validator  $validator
      * @return void
      */
-    public function withValidator(Validator $validator)
+    public function withValidator(\Illuminate\Validation\Validator $validator)
     {
         //
     }


### PR DESCRIPTION
This pull request adds the `withValidator` default method to `FormRequest`. This is mainly for IDE completion and static analysis.

Currently, `withValidator` does not exist by default in `FormRequest`, and developers must refer to the documentation carefully to ensure that it is implemented correctly in their `FormRequest`. This can be a cause of mistakes and also the development experience is not good because completion does not work. In addition, since static analysis does not work well, it is difficult to notice mistakes until it actually runs. This is concerning from a safety viewpoint.

Therefore, this pull request expects to improve the development experience and safety by implementing the default method for `withValidator` in `FormRequest`.