### PR TITLE
[10.x] Add `Str::flat` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -364,7 +364,7 @@ class Str
      */
     public static function flat($value)
     {
-        return Str::slug($value, '');
+        return static::slug($value, '');
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -364,9 +364,7 @@ class Str
      */
     public static function flat($value)
     {
-        $string = static::replace(['-', '_', ' '], '', $value);
-
-        return static::lower($string);
+        return Str::slug($value, '');
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -357,6 +357,19 @@ class Str
     }
 
     /**
+     * Convert a value to flat case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function flat($value)
+    {
+        $string = static::replace(['-', '_', ' '], '', $value);
+
+        return static::lower($string);
+    }
+
+    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -292,6 +292,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Convert a value to flat case.
+     *
+     * @return static
+     */
+    public function flat()
+    {
+        return new static(Str::flat($this->value));
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -359,6 +359,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('abcbbc', Str::finish('abcbbcbc', 'bc'));
     }
 
+    public function testFlat()
+    {
+        $this->assertSame('foobar', Str::flat('Foo BAR'));
+        $this->assertSame('foobar', Str::flat('foo_bar'));
+        $this->assertSame('foobar', Str::flat('foobar'));
+    }
+
     public function testWrap()
     {
         $this->assertEquals('"value"', Str::wrap('value', '"'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -361,7 +361,7 @@ class SupportStrTest extends TestCase
 
     public function testFlat()
     {
-        $this->assertSame('foobar', Str::flat('Foo BAR'));
+        $this->assertSame('foobar', Str::flat('Foo,BAR!'));
         $this->assertSame('foobar', Str::flat('foo_bar'));
         $this->assertSame('foobar', Str::flat('foobar'));
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -743,6 +744,13 @@ class SupportStringableTest extends TestCase
         $this->assertSame('abbc', (string) $this->stringable('ab')->finish('bc'));
         $this->assertSame('abbc', (string) $this->stringable('abbcbc')->finish('bc'));
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
+    }
+
+    public function testFlat()
+    {
+        $this->assertSame('foobar', (string) $this->stringable('Foo BAR')->flat());
+        $this->assertSame('foobar', (string) $this->stringable('foo_bar')->flat());
+        $this->assertSame('foobar', (string) $this->stringable('foobar')->flat());
     }
 
     public function testIs()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -747,7 +747,7 @@ class SupportStringableTest extends TestCase
 
     public function testFlat()
     {
-        $this->assertSame('foobar', (string) $this->stringable('Foo BAR')->flat());
+        $this->assertSame('foobar', (string) $this->stringable('Foo,BAR!')->flat());
         $this->assertSame('foobar', (string) $this->stringable('foo_bar')->flat());
         $this->assertSame('foobar', (string) $this->stringable('foobar')->flat());
     }


### PR DESCRIPTION
# Description

This PR adds a `Str::flat()` helper method used to convert values to "flatcase" naming convention. 

```php
// laravelframework
Str::flat('Laravel Framework');

// laravelframework
Str::flat('LARAVEL-FRAMEWORK');
```

# Purpose

Though flatcase naming conventions are more used in other programming languages such as Java, it can be useful for e.g. making hashtags or creating old-style URLs without hyphens.