### PR TITLE
update: add string cast

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -519,7 +519,7 @@ class Str
      */
     public static function lower($value)
     {
-        return mb_strtolower($value, 'UTF-8');
+        return mb_strtolower((string) $value, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
This PR adds `(string)` cast to the value of `mb_strtolower` to fix the following deprecation error from PHP when null is passed:

```
mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/laravel/framework/src/Illuminate/Support/Str.php on line 508
```

So existing logic that use `Str::lower(config('example.can_be_null')) === 'not_null'` still works and don't throw deprecated error.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
