### PR TITLE
[10.x] Extract common code to `getResourceRegistrar()` method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -322,11 +322,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function resource($name, $controller, array $options = [])
     {
-        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
-            $registrar = $this->container->make(ResourceRegistrar::class);
-        } else {
-            $registrar = new ResourceRegistrar($this);
-        }
+        $registrar = $this->getResourceRegistrar();
 
         return new PendingResourceRegistration(
             $registrar, $name, $controller, $options
@@ -392,11 +388,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function singleton($name, $controller, array $options = [])
     {
-        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
-            $registrar = $this->container->make(ResourceRegistrar::class);
-        } else {
-            $registrar = new ResourceRegistrar($this);
-        }
+        $registrar = $this->getResourceRegistrar();
 
         return new PendingSingletonResourceRegistration(
             $registrar, $name, $controller, $options
@@ -437,6 +429,22 @@ class Router implements BindingRegistrar, RegistrarContract
             'only' => $only,
             'apiSingleton' => true,
         ], $options));
+    }
+
+    /**
+     * Get the ResourceRegistrar instance.
+     *
+     * @return \Illuminate\Routing\ResourceRegistrar
+     */
+    protected function getResourceRegistrar()
+    {
+        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
+            $registrar = $this->container->make(ResourceRegistrar::class);
+        } else {
+            $registrar = new ResourceRegistrar($this);
+        }
+
+        return $registrar;
     }
 
     /**


### PR DESCRIPTION
This PR extracts the common code between the singleton() and resource() methods to a new method called getResourceRegistrar(). This avoids code duplication. Both singleton() and resource() now call the getResourceRegistrar() method to retrieve an instance of the ResourceRegistrar class for the current container.