### PR TITLE
[10.x] Store instantiated middleware within Kernel

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -116,7 +116,7 @@ class Kernel implements KernelContract
     /**
      * Stores instances of middleware to be used when terminating the request.
      *
-     * @var array<int, class-string>
+     * @var array<int, callable>
      */
     protected $terminatingMiddlewareInstances = [];
 
@@ -177,7 +177,7 @@ class Kernel implements KernelContract
         $this->bootstrap();
 
         $middlewareList = [];
-        foreach($this->app->shouldSkipMiddleware() ? [] : $this->middleware as $middlewareInstance) {
+        foreach ($this->app->shouldSkipMiddleware() ? [] : $this->middleware as $middlewareInstance) {
             $middlewareInstance = $this->app->make($middlewareInstance);
             $middlewareList[] = $middlewareInstance;
 
@@ -199,7 +199,7 @@ class Kernel implements KernelContract
      */
     public function bootstrap()
     {
-        $this->terminatingMiddlewareInstances = [];
+        $this->resetTerminatingMiddlewareInstances();
 
         if (! $this->app->hasBeenBootstrapped()) {
             $this->app->bootstrapWith($this->bootstrappers());
@@ -271,7 +271,7 @@ class Kernel implements KernelContract
             }
         }
 
-        $this->terminatingMiddlewareInstances = [];
+        $this->resetTerminatingMiddlewareInstances();
     }
 
     /**
@@ -378,6 +378,16 @@ class Kernel implements KernelContract
         }
 
         return $this;
+    }
+
+    /**
+     * Clear the list of terminating middleware instances.
+     *
+     * @return void
+     */
+    protected function resetTerminatingMiddlewareInstances()
+    {
+        $this->terminatingMiddlewareInstances = [];
     }
 
     /**

--- a/tests/Integration/Http/KernelTest.php
+++ b/tests/Integration/Http/KernelTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use Orchestra\Testbench\Foundation\Http\Kernel as HttpKernel;
+class KernelTest extends TestCase
+{
+    protected function resolveApplicationHttpKernel($app)
+    {
+        $app->singleton('Illuminate\Contracts\Http\Kernel', IntegrationKernelTest::class);
+    }
+
+    public function testMiddlewareIsCalledOnce()
+    {
+        Route::get('/');
+
+        $this->getJson('/');
+
+        $this->assertEquals(1, IntegrationTerminatingMiddleware::$terminateCalled);
+        $this->assertEquals(1, IntegrationTerminatingMiddleware::$timesInstantiated);
+    }
+}
+
+class IntegrationKernelTest extends HttpKernel
+{
+    public function __construct(Application $app, Router $router)
+    {
+        parent::__construct($app, $router);
+        $this->pushMiddleware(IntegrationTerminatingMiddleware::class);
+    }
+}
+
+class IntegrationTerminatingMiddleware {
+    public static $timesInstantiated = 0;
+
+    public static $terminateCalled = 0;
+
+    public function __construct()
+    {
+        self::$timesInstantiated++;
+    }
+
+    public function handle($request, $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate()
+    {
+        self::$terminateCalled++;
+    }
+}

--- a/tests/Integration/Http/KernelTest.php
+++ b/tests/Integration/Http/KernelTest.php
@@ -5,8 +5,9 @@ namespace Illuminate\Tests\Integration\Http;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
-use Orchestra\Testbench\TestCase;
 use Orchestra\Testbench\Foundation\Http\Kernel as HttpKernel;
+use Orchestra\Testbench\TestCase;
+
 class KernelTest extends TestCase
 {
     protected function resolveApplicationHttpKernel($app)
@@ -34,7 +35,8 @@ class IntegrationKernelTest extends HttpKernel
     }
 }
 
-class IntegrationTerminatingMiddleware {
+class IntegrationTerminatingMiddleware
+{
     public static $timesInstantiated = 0;
 
     public static $terminateCalled = 0;


### PR DESCRIPTION
## Problem
Right now, all of the Http\Kernel@sendRequestThroughRouter() instantiates all of the middleware to pipe the request through. Then subsequently, Kernel@terminateMiddleware() instantiates all the middleware again just to check if there's a terminate() method on the middleware.

### But is it really a problem?
For a lot of users, this will probably have a pretty minimal impact.

But if you have numerous middleware that require the container to resolve and inject dependencies, every request is made slower by this duplication of instantiation.

## Solution
Store middleware instances within the Kernel.

## Room for improvement
Router@runRouteWithinStack() could push check for terminating middleware and push that to the Kernel's $terminatingMiddlewareInstances array (though there's a dependency conflict).

It might also be nice to have a TerminatingMiddleware interface or a separate middleware stack that's just for terminating middleware.

To me, the co-mingling of the middlewares is very messy.