### PR TITLE
[10.x] Add missing dependency to `composer.json` in illuminate/support

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -21,6 +21,7 @@
         "doctrine/inflector": "^2.0",
         "illuminate/collections": "^10.0",
         "illuminate/conditionable": "^10.0",
+        "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
         "nesbot/carbon": "^2.62.1",


### PR DESCRIPTION
`Traits/Localizable` trait in illuminate/support references `Illuminate\Container\Container`, but the dependency on illuminate/container is not listed in `composer.json`. This pull request adds it.