### PR TITLE
[10.x] Add `tags` in flush method in container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1407,6 +1407,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->instances = [];
         $this->abstractAliases = [];
         $this->scopedInstances = [];
+        $this->tags = [];
     }
 
     /**


### PR DESCRIPTION
When flush the binding, the tags are still and not flushed!

Benchmark:
```
0.054ms => Flush without tags

0.041ms => Flush with tags
```