### PR TITLE
[9.x] Fix evaluation of factories returned from definition closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -471,7 +471,7 @@ abstract class Factory
         return collect($definition)
             ->map($evaluateRelations = function ($attribute) {
                 if ($attribute instanceof self) {
-                    $attribute = $this->getRandomRecycledModel($attribute->modelName())
+                    $attribute = $this->getRandomRecycledModel($attribute->modelName())?->getKey()
                         ?? $attribute->recycle($this->recycle)->create()->getKey();
                 } elseif ($attribute instanceof Model) {
                     $attribute = $attribute->getKey();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
this was originally fixed in #42344 but in #44107 this was changed to support recycling which removed the `getKey` call so if you had a closure returning a factory in the definition in your factory it would cause an sql error with trying to insert the string representation of the resolved model (in second map of this function) into the database because the factory ends up resolved to model instead of the key. This appears to only happen when using a recycled model via `recycle` in my testing which is when `getRandomRecycledModel` returns model.

note: #44328 changed the method to support multiple models but remained without `getKey` call.

```php
class PostFactory extends Factory
{
    public function definition()
    {
        return [
            'title' => 'post',
            'user_id' => function (array $attributes) {
                return User::factory();
            },
        ];
    }
}
```