### PR TITLE
[10.x] Store terminating Middleware class-strings to avoid unnecessary middleware instantiation in `Kernel@terminate()`

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -116,7 +116,7 @@ class Kernel implements KernelContract
     /**
      * Stores instances of middleware to be used when terminating the request.
      *
-     * @var array<int, class-string>
+     * @var array<int, callable>
      */
     protected $terminatingMiddlewareInstances = [];
 
@@ -177,7 +177,7 @@ class Kernel implements KernelContract
         $this->bootstrap();
 
         $middlewareList = [];
-        foreach($this->app->shouldSkipMiddleware() ? [] : $this->middleware as $middlewareInstance) {
+        foreach ($this->app->shouldSkipMiddleware() ? [] : $this->middleware as $middlewareInstance) {
             $middlewareInstance = $this->app->make($middlewareInstance);
             $middlewareList[] = $middlewareInstance;
 
@@ -199,7 +199,7 @@ class Kernel implements KernelContract
      */
     public function bootstrap()
     {
-        $this->terminatingMiddlewareInstances = [];
+        $this->resetTerminatingMiddlewareInstances();
 
         if (! $this->app->hasBeenBootstrapped()) {
             $this->app->bootstrapWith($this->bootstrappers());
@@ -271,7 +271,7 @@ class Kernel implements KernelContract
             }
         }
 
-        $this->terminatingMiddlewareInstances = [];
+        $this->resetTerminatingMiddlewareInstances();
     }
 
     /**
@@ -378,6 +378,16 @@ class Kernel implements KernelContract
         }
 
         return $this;
+    }
+
+    /**
+     * Clear the list of terminating middleware instances.
+     *
+     * @return void
+     */
+    protected function resetTerminatingMiddlewareInstances()
+    {
+        $this->terminatingMiddlewareInstances = [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -199,7 +199,7 @@ class Kernel implements KernelContract
      */
     public function bootstrap()
     {
-        $this->resetTerminatingMiddlewareInstances();
+        $this->resetTerminatingMiddleware();
 
         if (! $this->app->hasBeenBootstrapped()) {
             $this->app->bootstrapWith($this->bootstrappers());
@@ -272,7 +272,7 @@ class Kernel implements KernelContract
             }
         }
 
-        $this->resetTerminatingMiddlewareInstances();
+        $this->resetTerminatingMiddleware();
     }
 
     /**
@@ -382,17 +382,17 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Clear the list of terminating middleware instances.
+     * Clear the list of terminating middleware classes.
      *
      * @return void
      */
-    protected function resetTerminatingMiddlewareInstances()
+    protected function resetTerminatingMiddleware()
     {
         $this->terminatingMiddleware = [];
     }
 
     /**
-     * Add a new middleware class to the end of the
+     * Add a new middleware class to the end of the terminating middleware stack.
      *
      * @param  callable  $middleware
      * @return void

--- a/tests/Integration/Http/KernelTest.php
+++ b/tests/Integration/Http/KernelTest.php
@@ -21,8 +21,9 @@ class KernelTest extends TestCase
 
         $this->getJson('/');
 
-        $this->assertEquals(1, IntegrationTerminatingMiddleware::$terminateCalled);
-        $this->assertEquals(1, IntegrationTerminatingMiddleware::$timesInstantiated);
+        $this->assertEquals(1, IntegrationTerminatingMiddleware::$timesTerminateCalled);
+        $this->assertEquals(2, IntegrationTerminatingMiddleware::$timesInstantiated);
+        $this->assertEquals(1, IntegrationMiddleware::$timesInstantiated);
     }
 }
 
@@ -32,27 +33,42 @@ class IntegrationKernelTest extends HttpKernel
     {
         parent::__construct($app, $router);
         $this->pushMiddleware(IntegrationTerminatingMiddleware::class);
+        $this->pushMiddleware(IntegrationMiddleware::class);
     }
 }
 
-class IntegrationTerminatingMiddleware
+class IntegrationMiddleware
 {
     public static $timesInstantiated = 0;
 
-    public static $terminateCalled = 0;
-
     public function __construct()
     {
-        self::$timesInstantiated++;
+        static::$timesInstantiated++;
     }
 
     public function handle($request, $next)
     {
         return $next($request);
     }
+}
+class IntegrationTerminatingMiddleware
+{
+    public static $timesInstantiated = 0;
 
+    public static $timesTerminateCalled = 0;
+
+    public function __construct()
+    {
+        static::$timesInstantiated++;
+    }
+
+    public function handle($request, $next)
+    {
+        return $next($request);
+    }
     public function terminate()
     {
-        self::$terminateCalled++;
+        static::$timesTerminateCalled++;
     }
 }
+

--- a/tests/Integration/Http/KernelTest.php
+++ b/tests/Integration/Http/KernelTest.php
@@ -71,4 +71,3 @@ class IntegrationTerminatingMiddleware
         static::$timesTerminateCalled++;
     }
 }
-

--- a/tests/Integration/Http/KernelTest.php
+++ b/tests/Integration/Http/KernelTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use Orchestra\Testbench\Foundation\Http\Kernel as HttpKernel;
+class KernelTest extends TestCase
+{
+    protected function resolveApplicationHttpKernel($app)
+    {
+        $app->singleton('Illuminate\Contracts\Http\Kernel', IntegrationKernelTest::class);
+    }
+
+    public function testMiddlewareIsCalledOnce()
+    {
+        Route::get('/');
+
+        $this->getJson('/');
+
+        $this->assertEquals(1, IntegrationTerminatingMiddleware::$terminateCalled);
+        $this->assertEquals(1, IntegrationTerminatingMiddleware::$timesInstantiated);
+    }
+}
+
+class IntegrationKernelTest extends HttpKernel
+{
+    public function __construct(Application $app, Router $router)
+    {
+        parent::__construct($app, $router);
+        $this->pushMiddleware(IntegrationTerminatingMiddleware::class);
+    }
+}
+
+class IntegrationTerminatingMiddleware {
+    public static $timesInstantiated = 0;
+
+    public static $terminateCalled = 0;
+
+    public function __construct()
+    {
+        self::$timesInstantiated++;
+    }
+
+    public function handle($request, $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate()
+    {
+        self::$terminateCalled++;
+    }
+}

--- a/tests/Integration/Http/KernelTest.php
+++ b/tests/Integration/Http/KernelTest.php
@@ -5,8 +5,9 @@ namespace Illuminate\Tests\Integration\Http;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
-use Orchestra\Testbench\TestCase;
 use Orchestra\Testbench\Foundation\Http\Kernel as HttpKernel;
+use Orchestra\Testbench\TestCase;
+
 class KernelTest extends TestCase
 {
     protected function resolveApplicationHttpKernel($app)
@@ -34,7 +35,8 @@ class IntegrationKernelTest extends HttpKernel
     }
 }
 
-class IntegrationTerminatingMiddleware {
+class IntegrationTerminatingMiddleware
+{
     public static $timesInstantiated = 0;
 
     public static $terminateCalled = 0;


### PR DESCRIPTION
https://github.com/laravel/framework/pull/46888 tweaked this slightly to allow the container to make the middleware again where needed in case bindings have changed during the request lifecycle.