### PR TITLE
Fix issue with `e()` function not accepting arrays as arguments

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -102,7 +102,7 @@ if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.
      *
-     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|\BackedEnum|string|null  $value
+     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|\BackedEnum|array|string|null  $value
      * @param  bool  $doubleEncode
      * @return string
      */
@@ -118,6 +118,10 @@ if (! function_exists('e')) {
 
         if ($value instanceof BackedEnum) {
             $value = $value->value;
+        }
+
+        if (is_array($value)) {
+            return json_encode($value);
         }
 
         return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8', $doubleEncode);

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -63,4 +63,23 @@ class BladeEchoTest extends AbstractBladeTestCase
             $this->compiler->compileString('@{{ $name }}
             '));
     }
+
+    public function testEWithArray()
+    {
+        $array = ['a', 'b', 'c'];
+        $result = e($array);
+        $this->assertEquals(json_encode($array), $result);
+
+        $emptyArray = [];
+        $emptyResult = e($emptyArray);
+        $this->assertEquals(json_encode($emptyArray), $emptyResult);
+
+        $associativeArray = ['name' => 'John', 'age' => 30];
+        $associativeResult = e($associativeArray);
+        $this->assertEquals(json_encode($associativeArray), $associativeResult);
+
+        $nestedArray = [['a', 'b'], ['c', 'd']];
+        $nestedResult = e($nestedArray);
+        $this->assertEquals(json_encode($nestedArray), $nestedResult);
+    }
 }


### PR DESCRIPTION
Previously, the `e()` function in Laravel was throwing an error when an array was passed as its first argument. This was due to the fact that the function only accepts strings as its input. To fix this issue, the code was modified to check if the input is an array, and if so, it was encoded as a JSON string using `json_encode()`.

Almost all sites built with Laravel get this error. For example laracasts.com, forge.laravel.com, filamentphp.com

There are the error screenshots when trying to pass array to parameters:

![image](https://user-images.githubusercontent.com/56961917/234663961-ddf3d8bd-559e-4e0c-bc74-ee9b47361bed.png)
![image](https://user-images.githubusercontent.com/56961917/234664041-6e1b635f-fe07-424d-8346-4bac70ca95d0.png)
![image](https://user-images.githubusercontent.com/56961917/234664117-b5464033-2656-47d9-a3ff-6a700409dbd1.png)

Trying to pass an array to email input
![Screenshot from 2023-04-27 01-11-47](https://user-images.githubusercontent.com/56961917/234665876-41888e33-be4b-41e2-a40b-f7610012baec.png)

oops
![Screenshot from 2023-04-27 01-11-56](https://user-images.githubusercontent.com/56961917/234665882-b95f8882-ee97-413f-9d8f-c05f8e01b24a.png)


This ensured that the `e()` function could safely handle arrays and strings.

before implement:
![Screenshot from 2023-04-27 00-48-23](https://user-images.githubusercontent.com/56961917/234662970-891c890c-47c6-49d0-b60f-fded493fabb0.png)

after:
![Screenshot from 2023-04-27 00-48-33](https://user-images.githubusercontent.com/56961917/234662814-b30b94e3-8df2-49e6-ad11-6d90655ea705.png)

p/s: if the code of PR is not satisfactory, you (the core team) can fix this error yourself.