### PR TITLE
[10.x] Fix error message for `missing_unless` rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -105,7 +105,7 @@ return [
     'min_digits' => 'The :attribute field must have at least :min digits.',
     'missing' => 'The :attribute field must be missing.',
     'missing_if' => 'The :attribute field must be missing when :other is :value.',
-    'missing_unless' => 'The :attribute field must be missing unless :other is :value.',
+    'missing_unless' => 'The :attribute field must be missing unless :other is in :values.',
     'missing_with' => 'The :attribute field must be missing when :values is present.',
     'missing_with_all' => 'The :attribute field must be missing when :values are present.',
     'multiple_of' => 'The :attribute field must be a multiple of :value.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -217,7 +217,15 @@ trait ReplacesAttributes
      */
     protected function replaceMissingUnless($message, $attribute, $rule, $parameters)
     {
-        return $this->replaceMissingIf($message, $attribute, $rule, $parameters);
+        $other = $this->getDisplayableAttribute($parameters[0]);
+
+        $values = [];
+
+        foreach (array_slice($parameters, 1) as $value) {
+            $values[] = $this->getDisplayableValue($parameters[0], $value);
+        }
+
+        return str_replace([':other', ':values'], [$other, implode(', ', $values)], $message);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2320,27 +2320,27 @@ class ValidationValidatorTest extends TestCase
     public function testValidateMissingUnless()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.missing_unless' => 'The :attribute field must be missing unless :other is :value.'], 'en');
+        $trans->addLines(['validation.missing_unless' => 'The :attribute field must be missing unless :other is in :values.'], 'en');
 
         $v = new Validator($trans, ['foo' => 'yes', 'bar' => '2'], ['foo' => 'missing_unless:bar,1']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The foo field must be missing unless bar is 2.', $v->errors()->first('foo'));
+        $this->assertSame('The foo field must be missing unless bar is in 1.', $v->errors()->first('foo'));
 
         $v = new Validator($trans, ['foo' => '', 'bar' => '2'], ['foo' => 'missing_unless:bar,1']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The foo field must be missing unless bar is 2.', $v->errors()->first('foo'));
+        $this->assertSame('The foo field must be missing unless bar is in 1.', $v->errors()->first('foo'));
 
         $v = new Validator($trans, ['foo' => ' ', 'bar' => '2'], ['foo' => 'missing_unless:bar,1']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The foo field must be missing unless bar is 2.', $v->errors()->first('foo'));
+        $this->assertSame('The foo field must be missing unless bar is in 1.', $v->errors()->first('foo'));
 
         $v = new Validator($trans, ['foo' => null, 'bar' => '2'], ['foo' => 'missing_unless:bar,1']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The foo field must be missing unless bar is 2.', $v->errors()->first('foo'));
+        $this->assertSame('The foo field must be missing unless bar is in 1.', $v->errors()->first('foo'));
 
         $v = new Validator($trans, ['foo' => [], 'bar' => '2'], ['foo' => 'missing_unless:bar,1']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The foo field must be missing unless bar is 2.', $v->errors()->first('foo'));
+        $this->assertSame('The foo field must be missing unless bar is in 1.', $v->errors()->first('foo'));
 
         $v = new Validator($trans, ['foo' => new class implements Countable
         {
@@ -2350,7 +2350,7 @@ class ValidationValidatorTest extends TestCase
             }
         }, 'bar' => '2', ], ['foo' => 'missing_unless:bar,1']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The foo field must be missing unless bar is 2.', $v->errors()->first('foo'));
+        $this->assertSame('The foo field must be missing unless bar is in 1.', $v->errors()->first('foo'));
 
         $v = new Validator($trans, ['foo' => 'foo', 'bar' => '1'], ['foo' => 'missing_unless:bar,1']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
This PR is intended to fix the error message for `missing_unless` rule. Based on the code snippet below, the error message produced for `missing_rule` was wrong, IMO.

**Code**
```php
$data = [
    'item_1' => '',
    'item_2' => '',
];

$rules = [
    'item_2' => ['missing_unless:item_1,foo,bar'],
];

$v = Validator::make($data, $rules);
$v->passes();

dump($v->errors()->messages());
```

**Output**
```
array:1 [▼ // app/Http/Controllers/TestController.php:27
  "item_2" => array:1 [▼
    0 => "The item 2 field must be missing unless item 1 is ."
  ]
]
```

Based on `required_unless` and `prohibited_unless` rules, the output should be quite similar, which is to list the values needed to satisfy the rule. So the output of error message for `missing_unless` rule should be: `The item 2 field must be missing unless item 1 is in foo, bar.`.