### PR TITLE
[10.x] Set CallQueuedHandler queue-related properties from queued EventListener

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -131,24 +131,10 @@ class CallQueuedListener implements ShouldQueue
      */
     protected function setQueueVariables($handler)
     {
-        if (isset($handler->tries)) {
-            $this->tries = $handler->tries;
-        }
-
-        if (isset($handler->maxExceptions)) {
-            $this->maxExceptions = $handler->maxExceptions;
-        }
-
-        if (isset($handler->backoff)) {
-            $this->backoff = $handler->backoff;
-        }
-
-        if (isset($handler->retryUntil)) {
-            $this->retryUntil = $handler->retryUntil;
-        }
-
-        if (isset($handler->timeout)) {
-            $this->timeout = $handler->timeout;
+        foreach(['tries', 'maxExceptions', 'backoff', 'retryUntil', 'timeout'] as $key) {
+            if (isset($handler->{$key})) {
+                $this->{$key} = $handler->{$key};
+            }
         }
 
         return $handler;

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -131,7 +131,7 @@ class CallQueuedListener implements ShouldQueue
      */
     protected function setQueueVariables($handler)
     {
-        foreach(['tries', 'maxExceptions', 'backoff', 'retryUntil', 'timeout'] as $key) {
+        foreach (['tries', 'maxExceptions', 'backoff', 'retryUntil', 'timeout'] as $key) {
             if (isset($handler->{$key})) {
                 $this->{$key} = $handler->{$key};
             }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -125,6 +125,8 @@ class CallQueuedListener implements ShouldQueue
     }
 
     /**
+     * If set, copy queue related variables from the listener class.
+     *
      * @param  object $handler
      * @return  object
      */

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -127,8 +127,8 @@ class CallQueuedListener implements ShouldQueue
     /**
      * If set, copy queue related variables from the listener class.
      *
-     * @param  object $handler
-     * @return  object
+     * @param  object  $handler
+     * @return object
      */
     protected function setQueueVariables($handler)
     {

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -160,7 +160,7 @@ class CallQueuedListener implements ShouldQueue
      *
      * The event instance and the exception will be passed.
      *
-     * @param  Throwable  $e
+     * @param  \Throwable  $e
      * @return void
      */
     public function failed($e)

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -7,7 +7,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
-use Throwable;
 
 class CallQueuedListener implements ShouldQueue
 {

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Throwable;
 
 class CallQueuedListener implements ShouldQueue
 {
@@ -104,7 +105,11 @@ class CallQueuedListener implements ShouldQueue
             $this->job, $container->make($this->class)
         );
 
-        $handler->{$this->method}(...array_values($this->data));
+        try {
+            $handler->{$this->method}(...array_values($this->data));
+        } catch (Throwable $exception) {
+            $this->fail($exception);
+        }
     }
 
     /**
@@ -128,7 +133,7 @@ class CallQueuedListener implements ShouldQueue
      *
      * The event instance and the exception will be passed.
      *
-     * @param  \Throwable  $e
+     * @param  Throwable  $e
      * @return void
      */
     public function failed($e)

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -101,15 +101,11 @@ class CallQueuedListener implements ShouldQueue
     {
         $this->prepareData();
 
-        $handler = $this->setJobInstanceIfNecessary(
+        $handler = $this->setQueueVariables($this->setJobInstanceIfNecessary(
             $this->job, $container->make($this->class)
-        );
+        ));
 
-        try {
-            $handler->{$this->method}(...array_values($this->data));
-        } catch (Throwable $exception) {
-            $this->fail($exception);
-        }
+        $handler->{$this->method}(...array_values($this->data));
     }
 
     /**
@@ -126,6 +122,35 @@ class CallQueuedListener implements ShouldQueue
         }
 
         return $instance;
+    }
+
+    /**
+     * @param  object $handler
+     * @return  object
+     */
+    protected function setQueueVariables($handler)
+    {
+        if (isset($handler->tries)) {
+            $this->tries = $handler->tries;
+        }
+
+        if (isset($handler->maxExceptions)) {
+            $this->maxExceptions = $handler->maxExceptions;
+        }
+
+        if (isset($handler->backoff)) {
+            $this->backoff = $handler->backoff;
+        }
+
+        if (isset($handler->retryUntil)) {
+            $this->retryUntil = $handler->retryUntil;
+        }
+
+        if (isset($handler->timeout)) {
+            $this->timeout = $handler->timeout;
+        }
+
+        return $handler;
     }
 
     /**


### PR DESCRIPTION
CallQueuedHandler does not respect a queued Event Listener's properties, they just default to whatever is set on CallQueuedHandler.

This PR will carry over those properties.

This resolves at least one of the issues identified in https://github.com/laravel/framework/issues/46756

I'll add test cases if there is any reason to.