### PR TITLE
add acronym string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1293,6 +1293,29 @@ class Str
     }
 
     /**
+     * Generates an acronym from a given text and combines it with an optional delimiter.
+     *
+     * @param  string $string
+     * @param  string $delimiter
+     * @return string
+     */
+    public static function acronym($string, $delimiter = '')
+    {
+        if (empty($string)) {
+            return '';
+        }
+
+        $acronym = '';
+        $words = preg_split('/[^\p{L}]+/u', $string);
+
+        foreach ($words as $word) {
+            $acronym .= mb_substr($word, 0, 1) . $delimiter;
+        }
+
+        return $acronym;
+    }
+
+    /**
      * Get the number of words a string contains.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -917,6 +917,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Generates an acronym and combines it with an optional delimiter.
+     *
+     * @param  string $delimiter
+     * @return static
+     */
+    public function acronym($delimiter = '')
+    {
+        return new static(Str::acronym($this->value, $delimiter));
+    }
+
+    /**
      * Execute the given callback if the string contains a given substring.
      *
      * @param  string|iterable<string>  $needles

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -826,6 +826,14 @@ class SupportStrTest extends TestCase
         $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));
     }
 
+    public function testAcronym()
+    {
+        $this->assertSame('LF', Str::acronym('Laravel Framework'));
+        $this->assertSame('lf', Str::acronym('laravel.framework!'));
+        $this->assertSame('İbPk', Str::acronym('İşte bir PHP kodu'));
+        $this->assertSame('H.W.', Str::acronym('Hello World', '.'));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -217,6 +217,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame(['He_llo_', 'World'], $this->stringable('He_llo_World')->ucsplit()->toArray());
     }
 
+    public function testAcronymOnStringable()
+    {
+        $this->assertSame('LF', (string) $this->stringable('Laravel Framework')->acronym());
+        $this->assertSame('lf', (string) $this->stringable('laravel.framework')->acronym());
+        $this->assertSame('İbPk', (string) $this->stringable('İşte bir PHP kodu')->acronym());
+        $this->assertSame('H.W.', (string) $this->stringable('Hello World')->acronym('.'));
+    }
+
     public function testWhenEndsWith()
     {
         $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenEndsWith('ark', function ($stringable) {


### PR DESCRIPTION
add acronym string helper

usage: ``Str::acronym('Amazon Web Services'); // AWS``