### PR TITLE
[10.x] Fix issue with @json incorrectly compiling when argument has one or more commas

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -663,6 +663,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Parse the arguments from the given expression.
+     *
+     * @param  string  $expression
+     * @return array
+     */
+    protected function parseArguments($expression)
+    {
+        return preg_split('/,(?=(?:[^"\'\[(]*"[^"\'\])]*")*[^"\'\])]*$)/', $this->stripParentheses($expression));
+    }
+
+    /**
      * Register a custom Blade compiler.
      *
      * @param  callable  $compiler

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -19,7 +19,7 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        $parts = explode(',', $this->stripParentheses($expression));
+        $parts = $this->parseArguments($expression);
 
         $options = isset($parts[1]) ? trim($parts[1]) : $this->encodingOptions;
 

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -25,8 +25,8 @@ class BladeJsonTest extends AbstractBladeTestCase
      */
     public function testStatementIsCompiledCorrectlyWhenArgumentContainsComma($expression)
     {
-        $string = 'var foo = @json(' . $expression . ');';
-        $expected = 'var foo = <?php echo json_encode(' . $expression . ', 15, 512) ?>;';
+        $string = 'var foo = @json('.$expression.');';
+        $expected = 'var foo = <?php echo json_encode('.$expression.', 15, 512) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -34,15 +34,38 @@ class BladeJsonTest extends AbstractBladeTestCase
     public static function jsonArgumentsProvider()
     {
         return [
-            'single quoted string' => ['\'foo, bar, baz\''],
-            'double quoted string' => ['"foo, bar, baz"'],
-            'method call with variable arguments' => ['$var->method($foo, $bar, $baz)'],
-            'method call with array argument' => ['$var->method([$foo, $bar, $baz])'],
-            'array single quote string values' => ['[\'foo\', \'bar\', \'baz\']'],
-            'array double quote string values' => ['["foo", "bar", "baz"]'],
-            'array with method call' => ['[$var->method([$foo, $bar, $baz])]'],
-            'closure' => ['function () { return ["foo", "bar", "baz"]; }'],
-            'closure short' => ['fn () => ["foo", "bar", "baz"]'],
+            ['123'],
+            ['1.23'],
+            ['\'foo\''],
+            ['"foo"'],
+            ['<<<TEXT
+foo, bar, baz
+TEXT'],
+            ['<<<\'TEXT\'
+foo, bar, baz
+TEXT'],
+            ['\'foo, bar, baz\''],
+            ['"foo, bar, baz"'],
+            ['$var->method($foo, $bar, $baz)'],
+            ['$var->method([$foo, $bar, $baz])'],
+            ['[\'foo\', \'bar\', \'baz\']'],
+            ['["foo", "bar", "baz"]'],
+            ['[$var->method([$foo, $bar, $baz])]'],
+            ['function () { return ["foo", "bar", "baz"]; }'],
+            ['fn () => ["foo", "bar", "baz"]'],
+            ['[[\'foo\', \'bar\', \'baz\']]'],
+            ['[["foo", "bar", "baz"]]'],
+            ['$var?->foo?->method($foo, $bar, $baz)'],
+            ['new Dummy($foo, $bar, $baz)'],
+            ['new class($foo, $bar, $baz) {
+    public function __construct(
+        public readonly string $foo,
+        public readonly string $bar,
+        public readonly string $baz,
+    )
+    {
+    }
+}'],
         ];
     }
 }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -19,4 +19,30 @@ class BladeJsonTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    /**
+     * @dataProvider jsonArgumentsProvider
+     */
+    public function testStatementIsCompiledCorrectlyWhenArgumentContainsComma($expression)
+    {
+        $string = 'var foo = @json(' . $expression . ');';
+        $expected = 'var foo = <?php echo json_encode(' . $expression . ', 15, 512) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public static function jsonArgumentsProvider()
+    {
+        return [
+            'single quoted string' => ['\'foo, bar, baz\''],
+            'double quoted string' => ['"foo, bar, baz"'],
+            'method call with variable arguments' => ['$var->method($foo, $bar, $baz)'],
+            'method call with array argument' => ['$var->method([$foo, $bar, $baz])'],
+            'array single quote string values' => ['[\'foo\', \'bar\', \'baz\']'],
+            'array double quote string values' => ['["foo", "bar", "baz"]'],
+            'array with method call' => ['[$var->method([$foo, $bar, $baz])]'],
+            'closure' => ['function () { return ["foo", "bar", "baz"]; }'],
+            'closure short' => ['fn () => ["foo", "bar", "baz"]'],
+        ];
+    }
 }


### PR DESCRIPTION
I ran into the issue as described in #46908 myself recently and fixed it by parsing the arguments using `preg_split` instead of a simple `explode`.

The regex is a slightly modified version of the one from the SO answer below. It now also ensures that commas within parentheses and brackets are ignored.
https://stackoverflow.com/questions/18893390/splitting-on-comma-outside-quotes/18893443#18893443

We should probably add more cases to the `jsonArgumentsProvider` data provider before even considering merging this.