### PR TITLE
[10.x] Use method on UploadedFile to validate image dimensions

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -34,16 +34,6 @@ trait FileHelpers
     }
 
     /**
-     * Get the file's image size details.
-     *
-     * @return array|null
-     */
-    public function imageSize()
-    {
-        return @getimagesize($this->getRealPath());
-    }
-
-    /**
      * Get a filename for the file.
      *
      * @param  string|null  $path
@@ -62,5 +52,15 @@ trait FileHelpers
         }
 
         return $path.$hash.$extension;
+    }
+
+    /**
+     * Get the dimensions of the image (if applicable).
+     *
+     * @return array|null
+     */
+    public function dimensions()
+    {
+        return @getimagesize($this->getRealPath());
     }
 }

--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -34,6 +34,16 @@ trait FileHelpers
     }
 
     /**
+     * Get the file's image size details.
+     *
+     * @return array|null
+     */
+    public function imageSize()
+    {
+        return @getimagesize($this->getRealPath());
+    }
+
+    /**
      * Get a filename for the file.
      *
      * @param  string|null  $path

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -687,17 +687,17 @@ trait ValidatesAttributes
             return false;
         }
 
-        $sizeDetails = method_exists($value, 'dimensions')
+        $dimensions = method_exists($value, 'dimensions')
                 ? $value->dimensions()
                 : @getimagesize($value->getRealPath());
 
-        if (! $sizeDetails) {
+        if (! $dimensions) {
             return false;
         }
 
         $this->requireParameterCount(1, $parameters, 'dimensions');
 
-        [$width, $height] = $sizeDetails;
+        [$width, $height] = $dimensions;
 
         $parameters = $this->parseNamedParameters($parameters);
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -687,7 +687,9 @@ trait ValidatesAttributes
             return false;
         }
 
-        $sizeDetails = method_exists($value, 'imageSize') ? $value->imageSize() : @getimagesize($value->getRealPath());
+        $sizeDetails = method_exists($value, 'dimensions')
+                ? $value->dimensions()
+                : @getimagesize($value->getRealPath());
 
         if (! $sizeDetails) {
             return false;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -683,7 +683,13 @@ trait ValidatesAttributes
             return true;
         }
 
-        if (! $this->isValidFileInstance($value) || ! $sizeDetails = @getimagesize($value->getRealPath())) {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        $sizeDetails = method_exists($value, 'imageSize') ? $value->imageSize() : @getimagesize($value->getRealPath());
+
+        if (! $sizeDetails) {
             return false;
         }
 

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -111,7 +111,7 @@ class UploadedFileWithCustomImageSizeMethod extends UploadedFile
         return 'png';
     }
 
-    public function imageSize()
+    public function dimensions()
     {
         return [200, 200];
     }

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -30,6 +30,20 @@ class ValidationImageFileRuleTest extends TestCase
         );
     }
 
+    public function testDimensionsWithCustomImageSizeMethod()
+    {
+        $this->fails(
+            File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
+            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data($tmpFile = tmpfile())['uri'], 'foo.png'),
+            ['validation.dimensions'],
+        );
+
+        $this->passes(
+            File::image()->dimensions(Rule::dimensions()->width(200)->height(200)),
+            new UploadedFileWithCustomImageSizeMethod(stream_get_meta_data($tmpFile = tmpfile())['uri'], 'foo.png'),
+        );
+    }
+
     protected function fails($rule, $values, $messages)
     {
         $this->assertValidationRules($rule, $values, false, $messages);
@@ -82,5 +96,23 @@ class ValidationImageFileRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
+    }
+}
+
+class UploadedFileWithCustomImageSizeMethod extends UploadedFile
+{
+    public function isValid(): bool
+    {
+        return true;
+    }
+
+    public function guessExtension(): string
+    {
+        return 'png';
+    }
+
+    public function imageSize()
+    {
+        return [200, 200];
     }
 }


### PR DESCRIPTION
Currently it is not possible in Livewire to validate the dimensions of a file. This is because the validation rule uses the php's `getimagesize` method.

To make this is more flexible and to allow Livewire to implement support for the 'dimensions' validation rule, I added an `imageSize` method to the `UploadedFile` class. If that method exists, it uses that method to get the image size details. If the method does not exist, it still uses the raw `getimagesize` method. That way, Livewire (or project-specific classes that extend `UploadedFile` class) can override the `imageSize` method and use another way to get the image size details.