### PR TITLE
[10.x] Fixed calculation of middleware priority

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -74,10 +74,10 @@ class SortedMiddleware extends Collection
     protected function priorityMapIndex($priorityMap, $middleware)
     {
         foreach ($this->middlewareNames($middleware) as $name) {
-            foreach ($priorityMap as $index => $className) {
-                if ($name === $className || is_a($name, $className, true)) {
-                    return $index;
-                }
+            $priorityIndex = array_search($name, $priorityMap);
+            
+            if ($priorityIndex !== false) {
+                return $priorityIndex;
             }
         }
     }
@@ -99,6 +99,14 @@ class SortedMiddleware extends Collection
         if ($interfaces !== false) {
             foreach ($interfaces as $interface) {
                 yield $interface;
+            }
+        }
+        
+        $parents = @class_parents($stripped);
+
+        if ($parents !== false) {
+            foreach ($parents as $parent) {
+                yield $parent;
             }
         }
     }

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -75,7 +75,7 @@ class SortedMiddleware extends Collection
     {
         foreach ($this->middlewareNames($middleware) as $name) {
             foreach ($priorityMap as $index => $className) {
-                if ($middlewareName === $className || is_a($name, $className, true)) {
+                if ($name === $className || is_a($name, $className, true)) {
                     return $index;
                 }
             }

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -74,10 +74,10 @@ class SortedMiddleware extends Collection
     protected function priorityMapIndex($priorityMap, $middleware)
     {
         foreach ($this->middlewareNames($middleware) as $name) {
-            $priorityIndex = array_search($name, $priorityMap);
-
-            if ($priorityIndex !== false) {
-                return $priorityIndex;
+            foreach ($priorityMap as $index => $className) {
+                if (is_a($name, $className, true)) {
+                    return $index;
+                }
             }
         }
     }

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -75,7 +75,7 @@ class SortedMiddleware extends Collection
     {
         foreach ($this->middlewareNames($middleware) as $name) {
             foreach ($priorityMap as $index => $className) {
-                if (is_a($name, $className, true)) {
+                if ($middlewareName === $className || is_a($name, $className, true)) {
                     return $index;
                 }
             }

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -77,7 +77,6 @@ class RoutingSortedMiddlewareTest extends TestCase
             'Something',
             'Something',
             'Something',
-            'Something',
             SecondChildStub::class,
             'Otherthing',
             FirstStub::class.':api',

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -64,4 +64,117 @@ class RoutingSortedMiddlewareTest extends TestCase
         $this->assertEquals(['a', $closure, 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], ['a', $closure, 'b', $closure2, 'foo']))->all());
         $this->assertEquals([$closure, $closure2, 'foo', 'a'], (new SortedMiddleware(['a', 'b'], [$closure, $closure2, 'foo', 'a']))->all());
     }
+    
+    
+<?php
+namespace Illuminate\Tests\Routing;
+use Illuminate\Routing\SortedMiddleware;
+use PHPUnit\Framework\TestCase;
+class RoutingSortedMiddlewareTest extends TestCase
+{
+    public function testMiddlewareCanBeSortedByPriority()
+    {
+        $priority = [
+            'First',
+            'Second',
+            'Third',
+        ];
+        $middleware = [
+            'Something',
+            'Something',
+            'Something',
+            'Something',
+            'Second',
+            'Otherthing',
+            'First:api',
+            'Third:foo',
+            'First:foo,bar',
+            'Third',
+            'Second',
+        ];
+        $expected = [
+            'Something',
+            'First:api',
+            'First:foo,bar',
+            'Second',
+            'Otherthing',
+            'Third:foo',
+            'Third',
+        ];
+        $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
+        $this->assertEquals([], (new SortedMiddleware(['First'], []))->all());
+        $this->assertEquals(['First'], (new SortedMiddleware(['First'], ['First']))->all());
+        $this->assertEquals(['First', 'Second'], (new SortedMiddleware(['First', 'Second'], ['Second', 'First']))->all());
+    }
+    public function testItDoesNotMoveNonStringValues()
+    {
+        $closure = function () {
+            return 'foo';
+        };
+        $closure2 = function () {
+            return 'bar';
+        };
+        $this->assertEquals([2, 1], (new SortedMiddleware([1, 2], [2, 1]))->all());
+        $this->assertEquals(['Second', $closure], (new SortedMiddleware(['First', 'Second'], ['Second', $closure]))->all());
+        $this->assertEquals(['a', 'b', $closure], (new SortedMiddleware(['a', 'b'], ['b', $closure, 'a']))->all());
+        $this->assertEquals([$closure2, 'a', 'b', $closure, 'foo'], (new SortedMiddleware(['a', 'b'], [$closure2, 'b', $closure, 'a', 'foo']))->all());
+        $this->assertEquals([$closure, 'a', 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], [$closure, 'b', $closure2, 'foo', 'a']))->all());
+        $this->assertEquals(['a', $closure, 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], ['a', $closure, 'b', $closure2, 'foo']))->all());
+        $this->assertEquals([$closure, $closure2, 'foo', 'a'], (new SortedMiddleware(['a', 'b'], [$closure, $closure2, 'foo', 'a']))->all());
+    }
+
+    public function testItSortsUsingParentsAndContracts()
+    {
+        $priority = [
+            FirstContractStub::class,
+            SecondStub::class,
+            'Third',
+        ];
+
+        $middleware = [
+            'Something',
+            'Something',
+            'Something',
+            'Something',
+            SecondChildStub::class,
+            'Otherthing',
+            FirstStub::class.':api',
+            'Third:foo',
+            FirstStub::class.':foo,bar',
+            'Third',
+            SecondChildStub::class,
+        ];
+
+        $expected = [
+            'Something',
+            FirstStub::class.':api',
+            FirstStub::class.':foo,bar',
+            SecondChildStub::class,
+            'Otherthing',
+            'Third:foo',
+            'Third',
+        ];
+
+        $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
+    }
+}
+
+interface FirstContractStub
+{
+    //
+}
+
+class FirstStub implements FirstContractStub
+{
+    //
+}
+
+class SecondStub
+{
+    //
+}
+
+class SecondChildStub extends SecondStub
+{
+    //
 }


### PR DESCRIPTION
This PR fixes how middleware priority is calculated. Now it works with subclasses.

Let's say we use this middleware group:
```
// app/Http/Kernel.php
protected $middlewareGroups = [
        'web' => [
            \Illuminate\Routing\Middleware\ThrottleRequests::class,
            \App\Http\Middleware\EncryptCookies::class,
            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
        ],
];
```
The default middleware priorities are these:
```
// vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php
protected $middlewarePriority = [
        \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
        \Illuminate\Cookie\Middleware\EncryptCookies::class,                // <-- NOTE THIS
        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,    // <-- THIS
        \Illuminate\Session\Middleware\StartSession::class,
        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
        \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
        \Illuminate\Routing\Middleware\ThrottleRequests::class,             // <-- AND THIS
        \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
        \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions::class,
        \Illuminate\Routing\Middleware\SubstituteBindings::class,
        \Illuminate\Auth\Middleware\Authorize::class,
    ];
```
The middleware in `\App\Http\Middleware\EncryptCookies` is a subclass of `\Illuminate\Cookie\Middleware\EncryptCookies` but with the existing code the final middleware stack is calculated as:
```
array:3 [▼ // vendor/laravel/framework/src/Illuminate/Routing/SortedMiddleware.php:23
  0 => "Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse"
  1 => "Illuminate\Routing\Middleware\ThrottleRequests"
  2 => "App\Http\Middleware\EncryptCookies"
]
```
(This results in queued cookies not being encoded and hence lost)

With the suggested fix the middleware stack is calculated correctly:
```
array:3 [▼ // vendor/laravel/framework/src/Illuminate/Routing/SortedMiddleware.php:23
  0 => "App\Http\Middleware\EncryptCookies"
  1 => "Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse"
  2 => "Illuminate\Routing\Middleware\ThrottleRequests"
]
```