### PR TITLE
[10.x] Gracefully handle invalid code points in `e()`

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -120,7 +120,7 @@ if (! function_exists('e')) {
             $value = $value->value;
         }
 
-        return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8', $doubleEncode);
+        return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', $doubleEncode);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -37,6 +37,12 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($str, e($html));
     }
 
+    public function testEWithInvalidCodePoints()
+    {
+        $str = mb_convert_encoding('føø bar', 'ISO-8859-1', 'UTF-8');
+        $this->assertEquals('f�� bar', e($str));
+    }
+
     /**
      * @requires PHP >= 8.1
      */


### PR DESCRIPTION
When provided a string containing invalid code points (e.g. wrong encoding or unaligned truncation), the `e()` helper will silently swallow the whole argument and return an empty string.

I propose adding `ENT_SUBSTITUTE` to the flags for `htmlspecialchars()`, aligning `e()` with the [default behavior](https://www.php.net/manual/en/function.htmlspecialchars.php) of `htmlspecialchars()` since PHP 8.1:

> `ENT_SUBSTITUTE` Replace invalid code unit sequences with a Unicode Replacement Character `U+FFFD` (UTF-8) or `&#xFFFD;` (otherwise) instead of returning an empty string.

Developers and end-users alike will likely be less surprised by the occasional `�`, than the escaped string vanishing entirely.
