### PR TITLE
[10.x] Add HasOneOrMany@withoutForeignKeyNullCheck() to specify whether to apply foreign_key is not null constraint

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -26,6 +26,13 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
+     * Whether to check if the foreign key is null.
+     *
+     * @var bool
+     */
+    protected $applyForeignKeyCheck = true;
+
+    /**
      * Create a new has one or many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -84,8 +91,24 @@ abstract class HasOneOrMany extends Relation
 
             $query->where($this->foreignKey, '=', $this->getParentKey());
 
-            $query->whereNotNull($this->foreignKey);
+            $query->beforeQuery(function ($query) {
+                if ($this->applyForeignKeyCheck) {
+                    $query->whereNotNull($this->foreignKey);
+                }
+            });
         }
+    }
+
+    /**
+     * Disable applying the foreign key null check on the relationship.
+     *
+     * @return $this
+     */
+    public function withoutForeignKeyNullCheck()
+    {
+        $this->applyForeignKeyCheck = false;
+
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -287,6 +287,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $builder->shouldReceive('beforeQuery');
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -104,7 +104,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $user = HasOneOfManyTestUser::create();
         $relation = $user->latest_login();
         $relation->addEagerConstraints([$user]);
-        $this->assertSame('select MAX("logins"."id") as "id_aggregate", "logins"."user_id" from "logins" where "logins"."user_id" = ? and "logins"."user_id" is not null and "logins"."user_id" in (1) group by "logins"."user_id"', $relation->getOneOfManySubQuery()->toSql());
+        $this->assertSame('select MAX("logins"."id") as "id_aggregate", "logins"."user_id" from "logins" where "logins"."user_id" = ? and "logins"."user_id" in (1) and "logins"."user_id" is not null group by "logins"."user_id"', $relation->getOneOfManySubQuery()->toSql());
     }
 
     public function testGlobalScopeIsNotAppliedWhenRelationIsDefinedWithoutGlobalScope()
@@ -116,7 +116,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $user = HasOneOfManyTestUser::create();
         $relation = $user->latest_login_without_global_scope();
         $relation->addEagerConstraints([$user]);
-        $this->assertSame('select "logins".* from "logins" inner join (select MAX("logins"."id") as "id_aggregate", "logins"."user_id" from "logins" where "logins"."user_id" = ? and "logins"."user_id" is not null and "logins"."user_id" in (1) group by "logins"."user_id") as "latestOfMany" on "latestOfMany"."id_aggregate" = "logins"."id" and "latestOfMany"."user_id" = "logins"."user_id" where "logins"."user_id" = ? and "logins"."user_id" is not null', $relation->getQuery()->toSql());
+        $this->assertSame('select "logins".* from "logins" inner join (select MAX("logins"."id") as "id_aggregate", "logins"."user_id" from "logins" where "logins"."user_id" = ? and "logins"."user_id" in (1) and "logins"."user_id" is not null group by "logins"."user_id") as "latestOfMany" on "latestOfMany"."id_aggregate" = "logins"."id" and "latestOfMany"."user_id" = "logins"."user_id" where "logins"."user_id" = ? and "logins"."user_id" is not null', $relation->getQuery()->toSql());
 
         HasOneOfManyTestLogin::addGlobalScope('test', function ($query) {
         });

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -326,6 +326,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->builder = m::mock(Builder::class);
         $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $this->builder->shouldReceive('beforeQuery');
         $this->related = m::mock(Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $this->parent = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2113,8 +2113,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertSame('select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null', $user->posts()->toSql());
         $this->assertSame('select * from "posts" where "posts"."user_id" = ?', $user->posts()->withoutForeignKeyNullCheck()->toSql());
-
     }
+
     /**
      * Helpers...
      */

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2101,6 +2101,20 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('primary', $pivot->taxonomy);
     }
 
+    public function testWithoutForeignKeyNullCheckOnHasMany()
+    {
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $user->posts()->createMany([
+            ['name' => 'test 1'],
+            ['name' => 'test 2'],
+        ]);
+
+        $this->assertCount(2, $user->posts);
+
+        $this->assertSame('select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null', $user->posts()->toSql());
+        $this->assertSame('select * from "posts" where "posts"."user_id" = ?', $user->posts()->withoutForeignKeyNullCheck()->toSql());
+
+    }
     /**
      * Helpers...
      */

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -58,7 +58,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $product = MorphOneOfManyTestProduct::create();
         $relation = $product->current_state();
         $relation->addEagerConstraints([$product]);
-        $this->assertSame('select MAX("states"."id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_type" = ? and "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_id" in (1) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
+        $this->assertSame('select MAX("states"."id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_type" = ? and "states"."stateful_id" = ? and "states"."stateful_id" in (1) and "states"."stateful_type" = ? and "states"."stateful_id" is not null group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
     }
 
     public function testReceivingModel()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -356,8 +356,8 @@ class DatabaseEloquentMorphTest extends TestCase
     protected function getOneRelation()
     {
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('beforeQuery')->once();
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
@@ -371,8 +371,8 @@ class DatabaseEloquentMorphTest extends TestCase
     protected function getManyRelation()
     {
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('beforeQuery')->once();
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
@@ -392,8 +392,8 @@ class DatabaseEloquentMorphTest extends TestCase
         ]);
 
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $builder->shouldReceive('beforeQuery')->once();
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(EloquentModelNamespacedStub::class);

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -46,6 +46,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $related = m::mock(EloquentNoTouchingModelStub::class)->makePartial();
         $builder->shouldReceive('getModel')->andReturn($related);
         $builder->shouldReceive('whereNotNull');
+        $builder->shouldReceive('beforeQuery');
         $builder->shouldReceive('where');
         $builder->shouldReceive('withoutGlobalScopes')->andReturn($builder);
         $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
@@ -76,6 +77,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
             $builder->shouldReceive('getModel')->andReturn($related);
             $builder->shouldReceive('whereNotNull');
+            $builder->shouldReceive('beforeQuery');
             $builder->shouldReceive('where');
             $builder->shouldReceive('withoutGlobalScopes')->andReturn($builder);
             $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
@@ -107,7 +109,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
             $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
             $builder->shouldReceive('getModel')->andReturn($related);
-            $builder->shouldReceive('whereNotNull');
+            $builder->shouldReceive('beforeQuery');
             $builder->shouldReceive('where');
             $builder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
             $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
@@ -120,7 +122,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
             $anotherParent->shouldReceive('getAttribute')->with('id')->andReturn(2);
             $anotherBuilder->shouldReceive('getModel')->andReturn($anotherRelated);
-            $anotherBuilder->shouldReceive('whereNotNull');
+            $anotherBuilder->shouldReceive('beforeQuery');
             $anotherBuilder->shouldReceive('where');
             $anotherBuilder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
             $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id');
@@ -157,7 +159,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
             $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
             $builder->shouldReceive('getModel')->andReturn($related);
-            $builder->shouldReceive('whereNotNull');
+            $builder->shouldReceive('beforeQuery')->once();
             $builder->shouldReceive('where');
             $builder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
             $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
@@ -170,7 +172,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
             $anotherParent->shouldReceive('getAttribute')->with('id')->andReturn(2);
             $anotherBuilder->shouldReceive('getModel')->andReturn($relatedChild);
-            $anotherBuilder->shouldReceive('whereNotNull');
+            $anotherBuilder->shouldReceive('beforeQuery')->once();
             $anotherBuilder->shouldReceive('where');
             $anotherBuilder->shouldReceive('withoutGlobalScopes')->andReturnSelf();
             $anotherRelation = new HasOne($anotherBuilder, $anotherParent, 'foreign_key', 'id');

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -515,7 +515,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
 
         $this->assertSame(
-            'select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null and "posts"."deleted_at" is null',
+            'select * from "posts" where "posts"."user_id" = ? and "posts"."deleted_at" is null and "posts"."user_id" is not null',
             $abigail->posts()->toSql()
         );
     }


### PR DESCRIPTION
This issue seems to be kind of recurring. Most recently brought up here: https://github.com/laravel/framework/issues/46909. I think the biggest complaint I have is that it's a bizarre addition to most queries and I imagine countless developers have spent untold numbers of hours trying to figure out why that was added to their query (and if they did something wrong to make it so).

Here's a non-breaking change solution. Let the calling code specify whether or not the FK check needs to be applied.

I think this makes way to a softer landing were the maintainers to ever wish to drop this unneeded constraint. In a future release, HasOneOrMany::$applyForeignKeyCheck could default to false.

```php
class User extends Model
{
    public function posts()
    {
        return $this->hasMany(Post::class)->withoutForeignKeyNullCheck();
    }
}
```

Might be nice if this was somehow set statically so that within AppServiceProvider's `boot()` it could be called like:

```php
HasOneOrMany::withoutForeignKeyNullCheck();
```

but then that would require there to be both a protected static variable and an instance level variable. I'll happily add that if desired.

### Notes on Tests
You'll notice a lot of the tests were changed. They fell into two categories:
1. The query statement is slightly different (the `foreign_key is not null` is applied at the end after other scopes) but the content is the same
2. Tests that mock the Builder instance expected `whereNotNull()` to be called, but instead we will now check for `beforeQuery()`