### PR TITLE
[10.x] Add `HasOneOrMany::shouldAddForeignKeyCheck()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -44,11 +44,11 @@ abstract class HasOneOrMany extends Relation
      * Prevent foreign key check from being added to relationship.
      *
      * @param  bool  $value
-     * @return  void
+     * @return void
      */
     public static function shouldAddForeignKeyCheck($value)
     {
-        self::$shouldAddForeignKeyCheck = $value;
+        static::$shouldAddForeignKeyCheck = $value;
     }
 
     /**
@@ -86,7 +86,6 @@ abstract class HasOneOrMany extends Relation
     {
         $this->localKey = $localKey;
         $this->foreignKey = $foreignKey;
-
         $this->applyForeignKeyCheck = static::$shouldAddForeignKeyCheck;
 
         parent::__construct($query, $parent);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -2099,6 +2100,15 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertSame($pivot, $pivot->refresh());
         $this->assertSame('primary', $pivot->taxonomy);
+    }
+
+    public function testWithoutForeignKeyCheck()
+    {
+        HasOneOrMany::shouldAddForeignKeyCheck(false);
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $this->assertSame('select * from "posts" where "posts"."user_id" = ?', $user->posts()->toSql());
+        HasOneOrMany::shouldAddForeignKeyCheck(true);
+        $this->assertSame('select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null', $user->posts()->toSql());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2109,6 +2109,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('select * from "posts" where "posts"."user_id" = ?', $user->posts()->toSql());
         HasOneOrMany::shouldAddForeignKeyCheck(true);
         $this->assertSame('select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null', $user->posts()->toSql());
+        $this->assertSame(
+            'select * from "posts" where "posts"."user_id" = ?',
+            HasOneOrMany::withoutForeignKeyCheck(fn() => $user->posts()->toSql())
+        );
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/issues/46909

HasOneOrMany adds a `where foreign_key is not null` to all queries, though in most cases it's not needed.

This issue comes up a lot: it makes it hard to debug queries, it's unnecessary in most (all?) cases, and it leads to confusion from developers trying to figure out WHY it was added (if they did something wrong, where it's being added within the framework, etc).

Here is a solution that allows developers to turn it off entirely, or per relationship

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        HasOneOrMany::shouldAddForeignKeyCheck(false);
    }
}
```

Voila. Now instead of:

`'select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null'` 

you get

`'select * from "posts" where "posts"."user_id" = ?`

Don't want it turned off globally? Cool, nothing is different.

Want it turned on globally but want it turned off for some relationship? Have at it.

```php
$posts = HasOneOrMany::withoutForeignKeyCheck($user->posts()->get());
```

In a future release, this static property could be set to false by default, and then maybe in a subsequent release, removed entirely.

## final thought
I like how the DB migration traits within test uses a state class with static properties. Would be nice to see this bound to the container so it could be easily swapped within tests. But I don't see this pattern used elsewhere within the framework, so I assumed something so far out of the usual stood less of a chance of being accepted (especially for an issue that has been a long-standing).