### PR TITLE
[10.x] Add generics on app() / resolve() / App::make() / App::makeWith()

### DIFF
--- a/bin/facades.php
+++ b/bin/facades.php
@@ -3,6 +3,8 @@
 require __DIR__.'/../vendor/autoload.php';
 
 use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
@@ -377,6 +379,13 @@ function handleUnknownIdentifierType($method, $typeNode)
         $method->getDeclaringClass()->getName() === Request::class
     ) {
         return 'object';
+    }
+
+    if (
+        $typeNode->name === 'TClassString' &&
+        in_array($method->getDeclaringClass()->getName(), [Application::class, Container::class])
+    ) {
+        return 'mixed';
     }
 
     echo 'Found unknown type: '.$typeNode->name;

--- a/bin/phpstan.sh
+++ b/bin/phpstan.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-config=${1:-"types"}
-
-./vendor/bin/phpstan clear-result-cache
-./vendor/bin/phpstan analyze -c ./phpstan.$config.neon.dist

--- a/bin/phpstan.sh
+++ b/bin/phpstan.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+config=${1:-"types"}
+
+./vendor/bin/phpstan clear-result-cache
+./vendor/bin/phpstan analyze -c ./phpstan.$config.neon.dist

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -706,9 +706,14 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * An alias function name for make().
      *
-     * @param  string|callable  $abstract
+     * @template TClassString
+     *
+     * @phpstan-param class-string<TClassString>  $abstract
+     * @phpstan-return TClassString
+     *
+     * @param  class-string<TClassString>|string|callable  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return TClassString|mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
@@ -720,9 +725,14 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string|callable  $abstract
+     * @template TClassString
+     *
+     * @phpstan-param class-string<TClassString>  $abstract
+     * @phpstan-return TClassString
+     *
+     * @param  class-string<TClassString>|string|callable  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return TClassString|mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -709,6 +709,7 @@ class Container implements ArrayAccess, ContainerContract
      * @template TClassString
      *
      * @phpstan-param class-string<TClassString>  $abstract
+     *
      * @phpstan-return TClassString
      *
      * @param  class-string<TClassString>|string|callable  $abstract
@@ -728,6 +729,7 @@ class Container implements ArrayAccess, ContainerContract
      * @template TClassString
      *
      * @phpstan-param class-string<TClassString>  $abstract
+     *
      * @phpstan-return TClassString
      *
      * @param  class-string<TClassString>|string|callable  $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -164,9 +164,14 @@ interface Container extends ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template TClassString
+     *
+     * @phpstan-param class-string<TClassString>  $abstract
+     * @phpstan-return TClassString
+     *
+     * @param  class-string<TClassString>|string  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return TClassString|mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -167,6 +167,7 @@ interface Container extends ContainerInterface
      * @template TClassString
      *
      * @phpstan-param class-string<TClassString>  $abstract
+     *
      * @phpstan-return TClassString
      *
      * @param  class-string<TClassString>|string  $abstract

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -910,6 +910,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @template TClassString
      *
      * @phpstan-param class-string<TClassString>  $abstract
+     *
      * @phpstan-return TClassString
      *
      * @param  class-string<TClassString>|string  $abstract

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -907,9 +907,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template TClassString
+     *
+     * @phpstan-param class-string<TClassString>  $abstract
+     * @phpstan-return TClassString
+     *
+     * @param  class-string<TClassString>|string  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return TClassString|mixed
      */
     public function make($abstract, array $parameters = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -107,9 +107,14 @@ if (! function_exists('app')) {
     /**
      * Get the available container instance.
      *
-     * @param  string|null  $abstract
+     * @template TClassString
+     *
+     * @phpstan-param class-string<TClassString>  $abstract
+     * @phpstan-return TClassString
+     *
+     * @param  class-string<TClassString>|string|null  $abstract
      * @param  array  $parameters
-     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Foundation\Application|mixed
+     * @return TClassString|\Illuminate\Contracts\Foundation\Application|\Illuminate\Foundation\Application|mixed
      */
     function app($abstract = null, array $parameters = [])
     {
@@ -752,9 +757,14 @@ if (! function_exists('resolve')) {
     /**
      * Resolve a service from the container.
      *
-     * @param  string  $name
+     * @template TClassString
+     *
+     * @phpstan-param class-string<TClassString>  $name
+     * @phpstan-return TClassString
+     *
+     * @param  class-string<TClassString>|string  $name
      * @param  array  $parameters
-     * @return mixed
+     * @return TClassString|mixed
      */
     function resolve($name, array $parameters = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -110,6 +110,7 @@ if (! function_exists('app')) {
      * @template TClassString
      *
      * @phpstan-param class-string<TClassString>  $abstract
+     *
      * @phpstan-return TClassString
      *
      * @param  class-string<TClassString>|string|null  $abstract
@@ -760,6 +761,7 @@ if (! function_exists('resolve')) {
      * @template TClassString
      *
      * @phpstan-param class-string<TClassString>  $name
+     *
      * @phpstan-return TClassString
      *
      * @param  class-string<TClassString>|string  $name

--- a/types/Cache/Repository.php
+++ b/types/Cache/Repository.php
@@ -4,9 +4,9 @@ use Illuminate\Cache\Repository;
 
 use function PHPStan\Testing\assertType;
 
-/** @var Repository $cache */
 $cache = resolve(Repository::class);
 
+assertType(Repository::class, $cache);
 assertType('mixed', $cache->get('key'));
 assertType('int', $cache->get('cache', 27));
 assertType('int', $cache->get('cache', function (): int {

--- a/types/Contracts/Cache/Repository.php
+++ b/types/Contracts/Cache/Repository.php
@@ -4,9 +4,9 @@ use Illuminate\Contracts\Cache\Repository;
 
 use function PHPStan\Testing\assertType;
 
-/** @var Repository $cache */
 $cache = resolve(Repository::class);
 
+assertType(Repository::class, $cache);
 assertType('mixed', $cache->get('key'));
 assertType('mixed', $cache->get('cache', 27));
 assertType('mixed', $cache->get('cache', function (): int {


### PR DESCRIPTION
My changes are only to the docblocks, nothing fancy or any changes in the core logic. This should prevent us from using too many @var docblocks when using resolvers.

Please refer to my open discussion here: https://github.com/laravel/framework/discussions/46907

**Works perfectly using this plugin:** [PHP Intelephense](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client)

* PHPStan shows no issues without forcing the use of `@var` docblock
* Type-hint
<img src="https://user-images.githubusercontent.com/4581415/235323925-36620717-a537-41a1-bcb2-45a360469a7e.png" width="30%" />
* Hovering to the variable
<img src="https://user-images.githubusercontent.com/4581415/235323905-c2c16264-7ca3-4dfe-8511-a3dd1d24f0f6.png" width="30%" />

