### PR TITLE
[10.x] add user() helper function to reduce the need to write guard()->user()

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -169,10 +169,12 @@ if (! function_exists('auth')) {
 if (! function_exists('user')) {
     /**
      * Get the currently authenticated user.
+     *
+     * @param  string|null  $guard
      */
-    function user(): ?Authenticatable
+    function user($guard = null): ?Authenticatable
     {
-        return auth()->user();
+        return auth($guard)->user();
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
@@ -21,7 +22,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Contracts\Auth\Authenticatable;
 
 if (! function_exists('abort')) {
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -21,6 +21,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 if (! function_exists('abort')) {
     /**
@@ -162,6 +163,16 @@ if (! function_exists('auth')) {
         }
 
         return app(AuthFactory::class)->guard($guard);
+    }
+}
+
+if (! function_exists('user')) {
+    /**
+     * Get the currently authenticated user.
+     */
+    function user(): ?Authenticatable
+    {
+        return auth()->user();
     }
 }
 


### PR DESCRIPTION
During development, I find my self and my team writing every time auth()->user() to access the currently authenticated user, we use this so much that for almost all projects we add this function as a helper function, so I suggest to add it to the framework, in the hope that it will be very helpful for other people as well.