### PR TITLE
[10.x] Adds ability to restore/set Global Scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -60,7 +60,7 @@ trait HasGlobalScopes
     }
 
     /**
-     * Get all the global scopes registered.
+     * Get all of the global scopes that are currently registered.
      *
      * @return array
      */
@@ -70,9 +70,9 @@ trait HasGlobalScopes
     }
 
     /**
-     * Set all the global scopes.
+     * Set the current global scopes.
      *
-     * @params  array  $scopes
+     * @params array  $scopes
      * @return void
      */
     public static function setAllGlobalScopes($scopes)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -60,6 +60,27 @@ trait HasGlobalScopes
     }
 
     /**
+     * Get all the global scopes registered.
+     *
+     * @return array
+     */
+    public static function getAllGlobalScopes()
+    {
+        return static::$globalScopes;
+    }
+
+    /**
+     * Set all the global scopes.
+     *
+     * @params  array  $scopes
+     * @return void
+     */
+    public static function setAllGlobalScopes($scopes)
+    {
+        static::$globalScopes = $scopes;
+    }
+
+    /**
      * Get the global scopes for this class instance.
      *
      * @return array


### PR DESCRIPTION
## What?

Allows the static array for Global Scopes to be _restored_ by allowing to retrieve and set them all.

```php
use Illuminate\Database\Eloquent\Model;

$scopes = Model::getAllGlobalScopes();

// Handle request..

Model::setAllGlobalScopes($scopes);
```

## Why?

Because the current implementation of Global Scopes, by being static, has _some_ problems on Laravel Octane:

- Global Scopes list can _bleed_ into other requests in Laravel Octane.
- Global Scopes with dynamic names can cause memory leaks.

This only adds two new methods to retrieve and set ALL of the Global Scopes. This allows Laravel Octane to save the original list, and restore it before handling the next request, avoiding bleeding or memory leaks.

It doesn't fix the problem with modifying a Scope instance state. This should be documented on Laravel Octane by warning the developer that Scope instances are _shared_ across requests and, if needed, these should be manually "reset" before the next:

```php
use App\Models\Album;
use App\Scopes\ShowPrivatePhotos;
use Illuminate\Support\Facades\Event;
use Laravel\Octane\Events\RequestHandled;
 
/**
 * Register any other events for your application.
 */
public function boot(): void
{
    Event::listen(RequestHandled::class, function () {
        $privateScope = Album::getGlobalScope(ShowPrivatePhotos::class);

        $privateScope->removeAuthenticatedUserID();
    });
}
```

## BC?

Nope, only additive.