### PR TITLE
[10.x] Mark commands as isolatable

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -73,7 +73,7 @@ class Command extends SymfonyCommand
      *
      * @var int
      */
-    protected $isolatedCommandExitCode = self::SUCCESS;
+    protected $isolatedExitCode = self::SUCCESS;
 
     /**
      * The console command name aliases.
@@ -199,7 +199,7 @@ class Command extends SymfonyCommand
 
             return (int) (is_numeric($this->option('isolated'))
                         ? $this->option('isolated')
-                        : $this->isolatedCommandExitCode);
+                        : $this->isolatedExitCode);
         }
 
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -69,6 +69,13 @@ class Command extends SymfonyCommand
     protected $isolated = false;
 
     /**
+     * The default exit code for isolated commands.
+     *
+     * @var int
+     */
+    protected $isolatedCommandExitCode = self::SUCCESS;
+
+    /**
      * The console command name aliases.
      *
      * @var array
@@ -192,7 +199,7 @@ class Command extends SymfonyCommand
 
             return (int) (is_numeric($this->option('isolated'))
                         ? $this->option('isolated')
-                        : self::SUCCESS);
+                        : $this->isolatedCommandExitCode);
         }
 
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -62,6 +62,13 @@ class Command extends SymfonyCommand
     protected $hidden = false;
 
     /**
+     * Indicates whether only one instance of the command can run at any given time.
+     *
+     * @var bool
+     */
+    protected $isolated = false;
+
+    /**
      * The console command name aliases.
      *
      * @var array
@@ -140,7 +147,7 @@ class Command extends SymfonyCommand
             null,
             InputOption::VALUE_OPTIONAL,
             'Do not run the command if another instance of the command is already running',
-            false
+            $this->isolated
         ));
     }
 


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/44743 there was merit for marking commands as isolated by default. The work was subsequently changed to an `--isolated` flag to reduce the chances of breakages.

This PR allows the developer to configure the default values:
* `protected $isolated = true;` is equivalent to manually passing `--isolated`
* `protected $isolatedCommandExitCode = 12;` is equivalent to manually passing `--isolated=12`

