### PR TITLE
[9.x] Fix `Response@object()` return type docblock

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -85,7 +85,7 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as an object.
      *
-     * @return object|array
+     * @return object|null
      */
     public function object()
     {


### PR DESCRIPTION
`Response@object()` will never return an array. Additionally:

```php
json_encode('', false) === null;
```