### PR TITLE
[10.x] Add missing typehint to cache repository contract

### DIFF
--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -71,7 +71,7 @@ interface Repository extends CacheInterface
      * @template TCacheValue
      *
      * @param  string  $key
-     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -71,7 +71,7 @@ interface Repository extends CacheInterface
      * @template TCacheValue
      *
      * @param  string  $key
-     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \DateTimeInterface|\DateInterval|\Closure|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */


### PR DESCRIPTION
Cache repositories support dynamically configuring the TTL when 'remembering' a value, but the interface currently doesn't make this clear. The following works just fine, but the IDE complains because `\Closure` isn't allowed according to the docs

```php
use Illuminate\Contracts\Cache\Repository;
use Lcobucci\JWT\UnencryptedToken;

function getOrCreateJwt(Repository $cache)
{
    return $cache->remember(
       'my-jwt-token',
       fn (UnencryptedToken $token) => $token->claims()->get(RegisteredClaims::EXPIRATION_TIME),
       fn () => $this->generateJwtToken(),
    );
}
```
