### PR TITLE
[10.x] Allow configuration set on `PendingRequest` to carry over to `Pool` requests

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -352,7 +352,7 @@ class Factory
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */
-    protected function newPendingRequest()
+    public function newPendingRequest()
     {
         return new PendingRequest($this);
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -64,13 +63,6 @@ class Factory
     protected $preventStrayRequests = false;
 
     /**
-     * The middleware callables added by users that will handle requests.
-     *
-     * @var \Illuminate\Support\Collection
-     */
-    protected $middleware;
-
-    /**
      * Create a new factory instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
@@ -81,7 +73,6 @@ class Factory
         $this->dispatcher = $dispatcher;
 
         $this->stubCallbacks = collect();
-        $this->middleware = collect();
     }
 
     /**
@@ -374,29 +365,6 @@ class Factory
     public function getDispatcher()
     {
         return $this->dispatcher;
-    }
-
-    /**
-     * Add new middleware the client handler stack.
-     *
-     * @param  callable  $middleware
-     * @return $this
-     */
-    public function withMiddleware(callable $middleware)
-    {
-        $this->middleware->push($middleware);
-
-        return $this;
-    }
-
-    /**
-     * Get middleware to be applied to the client handler stack.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function getMiddleware(): Collection
-    {
-        return $this->middleware;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -7,8 +7,8 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -63,6 +64,13 @@ class Factory
     protected $preventStrayRequests = false;
 
     /**
+     * The middleware callables added by users that will handle requests.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $middleware;
+
+    /**
      * Create a new factory instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
@@ -73,6 +81,7 @@ class Factory
         $this->dispatcher = $dispatcher;
 
         $this->stubCallbacks = collect();
+        $this->middleware = collect();
     }
 
     /**
@@ -365,6 +374,29 @@ class Factory
     public function getDispatcher()
     {
         return $this->dispatcher;
+    }
+
+    /**
+     * Add new middleware the client handler stack.
+     *
+     * @param  callable  $middleware
+     * @return $this
+     */
+    public function withMiddleware(callable $middleware)
+    {
+        $this->middleware->push($middleware);
+
+        return $this;
+    }
+
+    /**
+     * Get middleware to be applied to the client handler stack.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getMiddleware(): Collection
+    {
+        return $this->middleware;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -220,7 +220,7 @@ class PendingRequest
     public function __construct(Factory $factory = null)
     {
         $this->factory = $factory;
-        $this->middleware = $factory->getMiddleware();
+        $this->middleware = collect();
 
         $this->asJson();
 
@@ -781,7 +781,7 @@ class PendingRequest
     {
         $results = [];
 
-        $requests = tap(new Pool($this->factory), $callback)->getRequests();
+        $requests = tap(new Pool($this->factory, $this->buildHandlerStack()), $callback)->getRequests();
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -781,7 +781,8 @@ class PendingRequest
     {
         $results = [];
 
-        $requests = tap(new Pool($this->factory, $this->buildHandlerStack()), $callback)->getRequests();
+        $handlerStack = $this->buildHandlerStack();
+        $requests = tap(new Pool($this->factory, $handlerStack), $callback)->getRequests();
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
@@ -220,7 +221,7 @@ class PendingRequest
     public function __construct(Factory $factory = null)
     {
         $this->factory = $factory;
-        $this->middleware = collect();
+        $this->middleware = new Collection;
 
         $this->asJson();
 
@@ -781,8 +782,7 @@ class PendingRequest
     {
         $results = [];
 
-        $handlerStack = $this->buildHandlerStack();
-        $requests = tap(new Pool($this->factory, $handlerStack), $callback)->getRequests();
+        $requests = tap(new Pool(pendingRequest: $this), $callback)->getRequests();
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -16,7 +16,6 @@ use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
@@ -221,7 +220,7 @@ class PendingRequest
     public function __construct(Factory $factory = null)
     {
         $this->factory = $factory;
-        $this->middleware = new Collection;
+        $this->middleware = $factory->getMiddleware();
 
         $this->asJson();
 

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -10,18 +10,11 @@ use GuzzleHttp\Utils;
 class Pool
 {
     /**
-     * The pending request that is cloned for each async request.
+     * The PendingRequest that is a basis for each pooled request.
      *
      * @var \Illuminate\Http\Client\PendingRequest
      */
     protected $pendingRequest;
-
-    /**
-     * The handler function for the Guzzle client.
-     *
-     * @var callable
-     */
-    protected $handler;
 
     /**
      * The pool of requests.
@@ -47,6 +40,11 @@ class Pool
         $this->pendingRequest = $pendingRequest;
     }
 
+    /**
+     * Create a default handler for the Factory.
+     *
+     * @return callable
+     */
     protected function getDefaultHandler(): callable
     {
         if (method_exists(Utils::class, 'chooseHandler')) {

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -34,17 +34,22 @@ class Pool
      * Create a new requests pool.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
+     * @param  callable|null  $handler
      * @return void
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(Factory $factory = null, ?callable $handler = null)
     {
         $this->factory = $factory ?: new Factory();
+        $this->handler = $handler ?: $this->getDefaultHandler();
+    }
 
+    protected function getDefaultHandler(): callable
+    {
         if (method_exists(Utils::class, 'chooseHandler')) {
-            $this->handler = Utils::chooseHandler();
-        } else {
-            $this->handler = \GuzzleHttp\choose_handler();
+            return Utils::chooseHandler();
         }
+
+        return \GuzzleHttp\choose_handler();
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2283,7 +2283,7 @@ class HttpClientTest extends TestCase
         });
     }
 
-    public function testWithHeaders()
+    public function testPoolRespectsWithHeaders()
     {
         $this->factory->fake();
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2247,7 +2247,7 @@ class HttpClientTest extends TestCase
 
         $middleware = Middleware::history($history);
 
-        $responses = $this->factory->withMiddleware($middleware)->pool(fn (Pool $pool) => [
+        $this->factory->withMiddleware($middleware)->pool(fn (Pool $pool) => [
             $pool->post('https://example.com', ['hyped-for' => 'laravel-movie']),
         ]);
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2266,7 +2266,7 @@ class HttpClientTest extends TestCase
                 },
             ])
             ->pool(fn (Pool $pool) => [
-                $pool->get('https://example.com')
+                $pool->get('https://example.com'),
             ]);
 
         $this->assertTrue($onStatsFunctionCalled);
@@ -2276,7 +2276,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->baseUrl('http://foo.com/')->pool(fn(Pool $pool) => $pool->get('get'));
+        $this->factory->baseUrl('http://foo.com/')->pool(fn (Pool $pool) => $pool->get('get'));
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/get';
@@ -2291,7 +2291,7 @@ class HttpClientTest extends TestCase
             'X-Test-Header' => 'foo',
             'X-Test-ArrayHeader' => ['bar', 'baz'],
         ])->pool(fn (Pool $pool) => [
-            $pool->post('http://foo.com/json', ['name' => 'Taylor'])
+            $pool->post('http://foo.com/json', ['name' => 'Taylor']),
         ]);
 
         $this->factory->assertSent(function (Request $request) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Http;
 
-use Closure;
 use Exception;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -29,7 +28,6 @@ use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use Closure;
 use Exception;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -28,6 +29,7 @@ use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;
 
@@ -2239,5 +2241,18 @@ class HttpClientTest extends TestCase
             ->handlerStats();
 
         $this->assertTrue($onStatsFunctionCalled);
+    }
+
+    public function testMiddlewareIsPoolable()
+    {
+        $history = [];
+
+        $middleware = Middleware::history($history);
+
+        $responses = $this->factory->withMiddleware($middleware)->pool(fn (Pool $pool) => [
+            $pool->post('https://example.com', ['hyped-for' => 'laravel-movie']),
+        ]);
+
+        $this->assertCount(1, $history);
     }
 }


### PR DESCRIPTION
To resolve https://github.com/laravel/framework/issues/46923.

The following code:
```php
Http::withMiddleware(MyRequestMiddleware::class)->pool(fn(Pool $pool) => [
    $pool->get('https://laravel.com'),
    $pool->get('https://laracasts.com'),
]);

Http::withHeaders([
    'This-Header' => 'Does Not Get Passed'
])->pool(fn ($pool) => [$pool->get('https://laravel.com')]);
```

Does not apply theMyRequestMiddleware to the pooled request. Nor does it pass forward headers.

This PR instead swaps Pool to use `PendingRequest` instead of `Http\Client\Factory` as the basis for making requests.

Now, rather than having to apply these additional properties to each array item in the `pool()` closure, you can write something like this:

```php
use Illuminate\Support\Facades\Http;
use Illuminate\Http\Client\Pool;

Http::baseUrl('https://laravel-news.com')
    ->withUserAgent('Laravel News Fetcher')
    ->withHeaders([
        'Accept' => 'text/html',
    ])
    ->pool(fn(Pool $pool) => [
        $pool->get('/blog'), // https://laravel-news.com/blog
        $pool->get('/category/packages'), // https://laravel-news.com/category/packages
    ]);
```