### PR TITLE
Adds expressive logging helper methods

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -461,6 +461,90 @@ if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
     }
 }
 
+if (! function_exists('emergency')) {
+    /**
+     * Write a emergency level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function emergency($message, $context = [])
+    {
+        app('log')->emergency($message, $context);
+    }
+}
+
+if (! function_exists('alert')) {
+    /**
+     * Write a alert level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function alert($message, $context = [])
+    {
+        app('log')->alert($message, $context);
+    }
+}
+
+if (! function_exists('critical')) {
+    /**
+     * Write a critical level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function critical($message, $context = [])
+    {
+        app('log')->critical($message, $context);
+    }
+}
+
+if (! function_exists('error')) {
+    /**
+     * Write a error level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function error($message, $context = [])
+    {
+        app('log')->error($message, $context);
+    }
+}
+
+if (! function_exists('warning')) {
+    /**
+     * Write a warning level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function warning($message, $context = [])
+    {
+        app('log')->warning($message, $context);
+    }
+}
+
+if (! function_exists('notice')) {
+    /**
+     * Write a notice level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function notice($message, $context = [])
+    {
+        app('log')->notice($message, $context);
+    }
+}
+
 if (! function_exists('info')) {
     /**
      * Write some information to the log.
@@ -472,6 +556,20 @@ if (! function_exists('info')) {
     function info($message, $context = [])
     {
         app('log')->info($message, $context);
+    }
+}
+
+if (! function_exists('debug')) {
+    /**
+     * Write a debug level message to the log.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    function debug($message, $context = [])
+    {
+        app('log')->debug($message, $context);
     }
 }
 


### PR DESCRIPTION
This pull request adds new helper functions for logging purposes. Laravel already provides a ``` info($message) ```  helper but I felt that we were missing the same for ```emergency, alert, critical, error, warning, notice,``` and  ```debug``` level messages. Although the ```logger($message)``` helper can be used to log ``` debug ``` level messages, an explicit ```debug($message)``` helper could be more expressive.

**Examples**
```php
emergency($message, []) 
//Write an emergency level message to the log

alert($message, []) 
//Write an alert level message to the log

critical($message, []) 
//Write a critical level message to the log

error($message, []) 
//Write a error level message to the log

warning($message, []) 
//Write a warning level message to the log

notice($message, []) 
//Write a notice level message to the log

debug($message, []) 
//Write a debug level message to the log
```

Thanks.