### PR TITLE
[10.x] Expose `Js::json()` helper

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -74,7 +74,7 @@ class Js implements Htmlable
             $data = $data->value;
         }
 
-        $json = static::json($data, $flags, $depth);
+        $json = static::encode($data, $flags, $depth);
 
         if (is_string($data)) {
             return "'".substr($json, 1, -1)."'";
@@ -93,7 +93,7 @@ class Js implements Htmlable
      *
      * @throws \JsonException
      */
-    public static function json($data, $flags = 0, $depth = 512)
+    public static function encode($data, $flags = 0, $depth = 512)
     {
         if ($data instanceof Jsonable) {
             return $data->toJson($flags | static::REQUIRED_FLAGS);

--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -74,7 +74,7 @@ class Js implements Htmlable
             $data = $data->value;
         }
 
-        $json = $this->jsonEncode($data, $flags, $depth);
+        $json = static::json($data, $flags, $depth);
 
         if (is_string($data)) {
             return "'".substr($json, 1, -1)."'";
@@ -93,7 +93,7 @@ class Js implements Htmlable
      *
      * @throws \JsonException
      */
-    protected function jsonEncode($data, $flags = 0, $depth = 512)
+    public static function json($data, $flags = 0, $depth = 512)
     {
         if ($data instanceof Jsonable) {
             return $data->toJson($flags | static::REQUIRED_FLAGS);


### PR DESCRIPTION
This solves recurring issues where people would use complex expressions inside the `@json(...)` blade directive, like https://github.com/laravel/framework/pull/46910, https://github.com/laravel/framework/issues/42822, https://github.com/laravel/framework/issues/21068, https://github.com/laravel/framework/issues/46908 and others.

If you ever feel the need to use complex expressions, you should use the `{{ Js::json(...) }}` function and benefit from the preset JSON options as well.

For reference: the `Js::from(...)` exists alongside this function and will echo `JSON.parse(...)` (explicit javascript code), so it is different than `Js::json(...)`. The latter just echoes an agnostic JSON string with some predefined encoding options.