### PR TITLE
Add support for setting BackedEnum as column default value

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -309,6 +309,10 @@ abstract class Grammar extends BaseGrammar
             return $this->getValue($value);
         }
 
+        if ($value instanceof \BackedEnum) {
+            return "'" . (string) $value->value . "'";
+        }
+
         return is_bool($value)
                     ? "'".(int) $value."'"
                     : "'".(string) $value."'";


### PR DESCRIPTION
This will allow using `BackedEnum` values as column default values. If we have an enum class like this,
```php
enum Status: string
{
    case ACTIVE = 'active';
    case INACTIVE = 'inactive';
}
```

Currently, we can do this in migration files,
```php
$table->string('status')->default(Status::ACTIVE->value);
```
Which looks a bit ugly. Changes in this PR will allow us to do this instead,
```php
$table->string('status')->default(Status::ACTIVE);
```