### PR TITLE
Fix artisan `make:listener` command from overriding existing listeners by default

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -82,17 +82,6 @@ class ListenerMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName);
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace


### PR DESCRIPTION
I accidentally ran make:listener with same class name twice and got surprised when same file was created and all of my changes to the original were gone.

One of the solutions is to remove `alreadyExists` method from `ListenerMakeCommand.php`.
CommandGenerator class will call it's original alreadyExists method which works just fine.