### PR TITLE
Cast array bindings as JSON

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3705,7 +3705,11 @@ class Builder implements BuilderContract
      */
     public function castBinding($value)
     {
-        return $value instanceof BackedEnum ? $value->value : $value;
+        return match (true) {
+            $value instanceof BackedEnum => $value->value,
+            is_array($value) => json_encode($value),
+            default => $value
+        };
     }
 
     /**


### PR DESCRIPTION
This PR makes it possible to insert array values as JSON, providing the convenience of not needing to manually cast array values with `json_encode()`.

```php
DB::table('users')->insert([
    'name' => 'Newton Job'
    'meta' => [ 'key' => 'value']
]);

DB::insert("insert into users (name, meta) values (?, ?)", [
    'Newton Job',
    ['key' => 'value']
]);
```

Related to https://github.com/laravel/framework/pull/46711, however, this PR takes advantage of the `castBinding` method on the query `Builder` to achieve this in a similar fashion as Enums.