### PR TITLE
[9.x] mb_strwidth deprecate warning fix

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -490,7 +490,7 @@ class Str
      */
     public static function limit($value, $limit = 100, $end = '...')
     {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+        if (mb_strwidth($value ?? '', 'UTF-8') <= $limit) {
             return $value;
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -470,6 +470,8 @@ class SupportStrTest extends TestCase
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
+
+        $this->assertSame(null, Str::limit(null));
     }
 
     public function testLength()


### PR DESCRIPTION
When passing a null value to Str::limit log this error:

`
mb_strwidth(): Passing null to parameter #1 ($string) of type string is deprecated in /app/vendor/laravel/framework/src/Illuminate/Support/Str.php on line 493
`