### PR TITLE
[10.x] Use container to build `PendingDispatch`

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -24,6 +24,7 @@ trait Dispatchable
      *
      * @param  static  $job
      * @return \Illuminate\Foundation\Bus\PendingDispatch
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected static function makeNewPendingDispatch($job)

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -16,7 +16,21 @@ trait Dispatchable
      */
     public static function dispatch(...$arguments)
     {
-        return new PendingDispatch(new static(...$arguments));
+        return static::makeNewPendingDispatch(new static(...$arguments));
+    }
+
+    /**
+     * Create a new pending dispatch from the container.
+     *
+     * @param  static  $job
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    protected static function makeNewPendingDispatch($job)
+    {
+        return app()->make(PendingDispatch::class, [
+            'job' => $job,
+        ]);
     }
 
     /**
@@ -32,12 +46,12 @@ trait Dispatchable
             $dispatchable = new static(...$arguments);
 
             return value($boolean, $dispatchable)
-                ? new PendingDispatch($dispatchable)
+                ? static::makeNewPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
         return value($boolean)
-            ? new PendingDispatch(new static(...$arguments))
+            ? static::makeNewPendingDispatch(new static(...$arguments))
             : new Fluent;
     }
 
@@ -54,12 +68,12 @@ trait Dispatchable
             $dispatchable = new static(...$arguments);
 
             return ! value($boolean, $dispatchable)
-                ? new PendingDispatch($dispatchable)
+                ? static::makeNewPendingDispatch($dispatchable)
                 : new Fluent;
         }
 
         return ! value($boolean)
-            ? new PendingDispatch(new static(...$arguments))
+            ? static::makeNewPendingDispatch(new static(...$arguments))
             : new Fluent;
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -171,6 +171,7 @@ class UniqueJob extends Job implements ShouldBeUnique
 class JobDispatchingPendingDispatch extends PendingDispatch
 {
     public static $timesCalled = 0;
+
     public function __construct($job)
     {
         parent::__construct($job);


### PR DESCRIPTION
## Problem
There is no way to swap in an implementation of `PendingDispatch` currently aside from duplicating the code and setting it as an alias. This is a challenge, as it means every time there's a tagged release on this repository, the developer needs to check for changes and if so, modify their `PendingDispatch` implementation for parity.

### Why would I ever want to do that?
Working on a rewrite of an application that will have both a beta version and a legacy application in production running simultaneously.

Jobs dispatched from the beta application to the legacy application need to modify the `PendingDispatch@__destruct()` method so that they are dispatched to a separate Horizon database. (See https://github.com/laravel/horizon/pull/1271)

## Solution
Build `PendingDispatch` from the container when needed in `Dispatchable`.

### Alternatives
* Add a protected static variable to Dispatcher that holds the FQCN for PendingDispatch and a static method to change it. Doesn't feel particularly clean to me and conflicts with how most binding is done in the framework.

* Write a `queue()` method on things that need to dispatch to different Horizon Redis database
This would be easier if `Dispatcher@pushCommandToQueue()` were public.

* Write a custom `Dispatchable` implementation
Again, entirely duplicating something that may change with a framework release.