### PR TITLE
[10.x] Add 'hashed' cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
@@ -104,6 +105,7 @@ trait HasAttributes
         'encrypted:json',
         'encrypted:object',
         'float',
+        'hashed',
         'immutable_date',
         'immutable_datetime',
         'immutable_custom_datetime',
@@ -985,6 +987,10 @@ trait HasAttributes
             $value = $this->castAttributeAsEncryptedString($key, $value);
         }
 
+        if (! is_null($value) && $this->hasCast($key, 'hashed')) {
+            $value = $this->castAttributeAsHashedString($key, $value);
+        }
+
         $this->attributes[$key] = $value;
 
         return $this;
@@ -1291,6 +1297,18 @@ trait HasAttributes
     public static function encryptUsing($encrypter)
     {
         static::$encrypter = $encrypter;
+    }
+
+    /**
+     * Cast the given attribute to a hashed string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function castAttributeAsHashedString($key, $value)
+    {
+        return Hash::needsRehash($value) ? Hash::make($value) : $value;;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1308,7 +1308,7 @@ trait HasAttributes
      */
     protected function castAttributeAsHashedString($key, $value)
     {
-        return Hash::needsRehash($value) ? Hash::make($value) : $value;;
+        return Hash::needsRehash($value) ? Hash::make($value) : $value;
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -2,19 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Hashing\Hasher;
-use Illuminate\Database\Eloquent\Casts\ArrayObject;
-use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
-use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Hashing\AbstractHasher;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
-use stdClass;
 
 class EloquentModelHashedCastingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Database\Eloquent\Casts\ArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Hashing\AbstractHasher;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use stdClass;
+
+class EloquentModelHashedCastingTest extends DatabaseTestCase
+{
+    protected $hasher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->hasher = $this->mock(Hasher::class);
+        Hash::swap($this->hasher);
+    }
+
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('hashed_casts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('password')->nullable();
+        });
+    }
+
+    public function testHashed()
+    {
+        $this->hasher->expects('needsRehash')
+            ->with('this is a password')
+            ->andReturnTrue();
+
+        $this->hasher->expects('make')
+            ->with('this is a password')
+            ->andReturn('hashed-password');
+
+        $subject = HashedCast::create([
+            'password' => 'this is a password',
+        ]);
+
+        $this->assertSame('hashed-password', $subject->password);
+        $this->assertDatabaseHas('hashed_casts', [
+            'id' => $subject->id,
+            'password' => 'hashed-password',
+        ]);
+    }
+
+    public function testNotHashedIfAlreadyHashed()
+    {
+        $this->hasher->expects('needsRehash')
+            ->with('already-hashed-password')
+            ->andReturnFalse();
+
+        $subject = HashedCast::create([
+            'password' => 'already-hashed-password',
+        ]);
+
+        $this->assertSame('already-hashed-password', $subject->password);
+        $this->assertDatabaseHas('hashed_casts', [
+            'id' => $subject->id,
+            'password' => 'already-hashed-password',
+        ]);
+    }
+
+    public function testNotHashedIfNull()
+    {
+        $subject = HashedCast::create([
+            'password' => null,
+        ]);
+
+        $this->assertNull($subject->password);
+        $this->assertDatabaseHas('hashed_casts', [
+            'id' => $subject->id,
+            'password' => null,
+        ]);
+    }
+}
+
+class HashedCast extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public $casts = [
+        'password' => 'hashed',
+    ];
+}


### PR DESCRIPTION
The `encrypted` cast exists, but a cast that hashes a value does not exist yet. In a lot of applications (even Laravel's default application), the user model has a password. I think it makes sense to have a `hashed` cast that ensures the password (or some other attribute's value) is always hashed before being saved in the database.

Example:
```php
public $casts = [
    'password' => 'hashed',
];
```