### PR TITLE
[10.x] `hasAttached()` model factory method without pivot data

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -588,12 +588,17 @@ abstract class Factory
      * Define an attached relationship for the model.
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $factory
-     * @param  (callable(): array<string, mixed>)|array<string, mixed>  $pivot
+     * @param  (callable(): array<string, mixed>)|array<string, mixed>|string  $pivot
      * @param  string|null  $relationship
      * @return static
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
+        if ($relationship === null && is_string($pivot)) {
+            $relationship = $pivot;
+            $pivot = [];
+        }
+
         return $this->newInstance([
             'has' => $this->has->concat([new BelongsToManyRelationship(
                 $factory,

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -356,6 +356,25 @@ class DatabaseEloquentFactoryTest extends TestCase
         unset($_SERVER['__test.role.creating-role'], $_SERVER['__test.role.creating-user']);
     }
 
+    public function test_belongs_to_many_relationship_with_relationship_name_in_pivot_parameter()
+    {
+        FactoryTestUserFactory::times(3)
+            ->hasAttached(
+                FactoryTestRoleFactory::times(3)->afterCreating(function ($role, $user) {
+                    $_SERVER['__test.role.creating-role'] = $role;
+                    $_SERVER['__test.role.creating-user'] = $user;
+                }),
+                'roles'
+            )
+            ->create();
+
+        $this->assertCount(9, FactoryTestRole::all());
+
+        $user = FactoryTestUser::latest()->first();
+
+        $this->assertCount(3, $user->roles);
+    }
+
     public function test_belongs_to_many_relationship_related_models_set_on_instance_when_touching_owner()
     {
         $user = FactoryTestUserFactory::new()->create();


### PR DESCRIPTION
In a lot of cases, a belongstomany-relationship does not have any extra pivot columns beside the foreign keys. But when using the `hasAttached()` method on a model factory, you still have to provide an empty array as a second parameter. That seems a bit unnecessary.
```php
Company::factory()
    ->hasAttached(User::factory()->count(2), [], 'users')
    ->create();
```
This PR fixes that, so you can provide the relationship name as the second parameter value if you do not have any pivot data. It's a small DX improvement that has been used in other parts of the framework if I'm not mistaken.
```php
Company::factory()
    ->hasAttached(User::factory()->count(2), 'users')
    ->create();
```