### PR TITLE
[10.x] ViewComposerMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewComposerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewComposerMakeCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:view-composer')]
+class ViewComposerMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:view-composer';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new view composer class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'ViewComposer';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/view-composer.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\View\Composers';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the view composer already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/view-composer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-composer.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\View\View;
+
+class {{ class }}
+{
+    public function compose(View $view): void
+    {
+        // $view->with('foo', 'bar');
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -74,6 +74,7 @@ use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Console\ViewCacheCommand;
 use Illuminate\Foundation\Console\ViewClearCommand;
+use Illuminate\Foundation\Console\ViewComposerMakeCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Queue\Console\BatchesTableCommand;
 use Illuminate\Queue\Console\ClearCommand as QueueClearCommand;
@@ -191,6 +192,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueTable' => TableCommand::class,
         'QueueBatchesTable' => BatchesTableCommand::class,
         'RequestMake' => RequestMakeCommand::class,
+        'ViewComposerMake' => ViewComposerMakeCommand::class,
         'ResourceMake' => ResourceMakeCommand::class,
         'RuleMake' => RuleMakeCommand::class,
         'ScopeMake' => ScopeMakeCommand::class,
@@ -669,6 +671,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(RequestMakeCommand::class, function ($app) {
             return new RequestMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerViewComposerMakeCommand()
+    {
+        $this->app->singleton(ViewComposerMakeCommand::class, function ($app) {
+            return new ViewComposerMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
I don’t know why this command hasn’t existed yet, but I often use the view composer class and often look at the documentation for how it should look and where it’s best to store it, the command will immediately create a class in app/View/Composers

`php artisan make:view-composer`
