### PR TITLE
Fix "Return value must be of type string, null returned"

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -8,10 +8,8 @@ class HtmlString implements Htmlable
 {
     /**
      * The HTML string.
-     *
-     * @var string
      */
-    protected $html;
+    protected string $html;
 
     /**
      * Create a new HTML string instance.
@@ -19,7 +17,7 @@ class HtmlString implements Htmlable
      * @param  string  $html
      * @return void
      */
-    public function __construct($html = '')
+    public function __construct(string $html = '')
     {
         $this->html = $html;
     }


### PR DESCRIPTION
> Illuminate\Support\HtmlString::__toString(): Return value must be of type string, null returned

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The above `TypeError` was thrown in our project. These changes fixes it.