### PR TITLE
refactoring Console GeneratorCommand class

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -223,17 +223,18 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     {
         $model = ltrim($model, '\\/');
 
-        $model = str_replace('/', '\\', $model);
+        $model = str_replace(DIRECTORY_SEPARATOR, '\\', $model);
 
         $rootNamespace = $this->rootNamespace();
 
-        if (Str::startsWith($model, $rootNamespace)) {
-            return $model;
+        $qualifiedModel = $model;
+
+        if (!Str::startsWith($model, $rootNamespace)) {
+            $modelNamespace = is_dir(app_path('Models')) ? 'Models' : '';
+            $qualifiedModel = $rootNamespace . $modelNamespace . '\\' . $model;
         }
 
-        return is_dir(app_path('Models'))
-                    ? $rootNamespace.'Models\\'.$model
-                    : $rootNamespace.$model;
+        return $qualifiedModel;
     }
 
     /**


### PR DESCRIPTION
1. The code currently modifies the $model variable in place several times. While this is not necessarily a problem, it can make the code harder to follow. Consider using separate variables for the modified versions of $model, rather than overwriting it each time.
2. using the DIRECTORY_SEPARATOR constant. This can make the code more portable between different operating systems.
3. it returns only a string instead of an array or a string, since the is_dir() check is only needed to determine the namespace to 