### PR TITLE
[10.x] Fix typo in HasGlobalScopes PHPdoc tag

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -72,8 +72,7 @@ trait HasGlobalScopes
     /**
      * Set the current global scopes.
      *
-     * @params array  $scopes
-     *
+     * @param  array  $scopes
      * @return void
      */
     public static function setAllGlobalScopes($scopes)


### PR DESCRIPTION
Fix a minor typo in the PHPdoc introduced in #46922.

This breaks using Doctrine Annotations with the `Model` class, as the `@params` tag is not excluded by default and thus the library tries to autoload a class called `params`.