### PR TITLE
[9.x] Document some more return types (removes Symfony 6.3 deprecation notices)

### DIFF
--- a/src/Illuminate/Console/BufferedConsoleOutput.php
+++ b/src/Illuminate/Console/BufferedConsoleOutput.php
@@ -27,6 +27,8 @@ class BufferedConsoleOutput extends ConsoleOutput
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     protected function doWrite(string $message, bool $newline)
     {

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -39,6 +39,8 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function write(string|iterable $messages, bool $newline = false, int $options = 0)
     {
@@ -49,6 +51,8 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function writeln(string|iterable $messages, int $type = self::OUTPUT_NORMAL)
     {
@@ -59,6 +63,8 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function newLine(int $count = 1)
     {

--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -14,6 +14,8 @@ class QuestionHelper extends SymfonyQuestionHelper
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     protected function writePrompt(OutputInterface $output, Question $question)
     {

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -11,6 +11,8 @@ class TimestampType extends Type implements PhpDateTimeMappingType
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
@@ -87,6 +89,8 @@ class TimestampType extends Type implements PhpDateTimeMappingType
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -46,6 +46,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function setId(string $id)
     {
@@ -62,6 +64,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function setName(string $name)
     {
@@ -90,6 +94,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function save()
     {
@@ -114,6 +120,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function set(string $name, mixed $value)
     {
@@ -130,6 +138,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function replace(array $attributes)
     {
@@ -146,6 +156,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function clear()
     {
@@ -162,6 +174,8 @@ class SymfonySessionDecorator implements SessionInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function registerBag(SessionBagInterface $bag)
     {


### PR DESCRIPTION
In Symfony 6.3, we've added PHPdoc return types to all methods.

I've run the type patch utility on this repository, to make sure all return types are also defined by Laravel to avoid indirect deprecation notices. I'm not sure about your policy regarding adding return types, so some of these might be turned into a real PHP return type.