### PR TITLE
[10.x] Improve Sleep assertions

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -359,7 +359,7 @@ class Sleep
      */
     public static function assertNeverSlept()
     {
-        return static::assertInsomniac();
+        return static::assertSleptTimes(0);
     }
 
     /**
@@ -369,6 +369,10 @@ class Sleep
      */
     public static function assertInsomniac()
     {
+        if (static::$sequence === []) {
+            PHPUnit::assertTrue(true);
+        }
+
         foreach (static::$sequence as $duration) {
             PHPUnit::assertSame(0, $duration->totalMicroseconds, vsprintf('Unexpected sleep duration of [%s] found.', [
                 $duration->cascade()->forHumans([

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -305,6 +305,38 @@ class SleepTest extends TestCase
         }
     }
 
+    public function testAssertNeverSlept()
+    {
+        Sleep::fake();
+
+        Sleep::assertNeverSlept();
+
+        Sleep::for(1)->seconds();
+
+        try {
+            Sleep::assertNeverSlept();
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Expected [0] sleeps but found [1].\nFailed asserting that 1 is identical to 0.", $e->getMessage());
+        }
+    }
+
+    public function testAssertNeverAgainstZeroSecondSleep()
+    {
+        Sleep::fake();
+
+        Sleep::assertNeverSlept();
+
+        Sleep::for(0)->seconds();
+
+        try {
+            Sleep::assertNeverSlept();
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Expected [0] sleeps but found [1].\nFailed asserting that 1 is identical to 0.", $e->getMessage());
+        }
+    }
+
     public function testItCanAssertNoSleepingOccurred()
     {
         Sleep::fake();


### PR DESCRIPTION
`Sleep::assertNeverSlept()` is now an alias for `Sleep::assertSleptTimes(0)`.

`Sleep::assertInsomniac()` is different. It may be used to check that a calculated time slept for zero time.

Example:

Where `active_at` is already in the past.

```php
Sleep::until($post->active_at);

// --- //

Sleep::assertSleptTimes(1); // passes
Sleep::assertInsomniac(); // passes
```

