### PR TITLE
[10.x] Add url support for mail config

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -12,6 +12,7 @@ use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Mail\Transport\SesV2Transport;
 use Illuminate\Support\Arr;
+use Illuminate\Support\ConfigurationUrlParser;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
@@ -446,9 +447,17 @@ class MailManager implements FactoryContract
         // Here we will check if the "driver" key exists and if it does we will use
         // the entire mail configuration file as the "driver" config in order to
         // provide "BC" for any Laravel <= 6.x style mail configuration files.
-        return $this->app['config']['mail.driver']
+        $config = $this->app['config']['mail.driver']
             ? $this->app['config']['mail']
             : $this->app['config']["mail.mailers.{$name}"];
+
+        if (isset($config['url'])) {
+            $config = (new ConfigurationUrlParser)->parseConfiguration($config);
+            $config['transport'] = $config['driver'];
+            unset($config['driver']);
+        }
+
+        return $config;
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -452,9 +452,9 @@ class MailManager implements FactoryContract
             : $this->app['config']["mail.mailers.{$name}"];
 
         if (isset($config['url'])) {
-            $config = (new ConfigurationUrlParser)->parseConfiguration($config);
-            $config['transport'] = $config['driver'];
-            unset($config['driver']);
+            $config = array_merge($config, (new ConfigurationUrlParser)->parseConfiguration($config));
+
+            $config['transport'] = Arr::pull($config, 'driver');
         }
 
         return $config;

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Mail;
 
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 
 class MailManagerTest extends TestCase
 {
@@ -25,6 +26,22 @@ class MailManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Unsupported mail transport [{$transport}]");
         $this->app['mail.manager']->mailer('custom_smtp');
+    }
+
+    public function testMailUrlConfig()
+    {
+        $this->app['config']->set('mail.mailers.smtp_url', [
+            'url' => 'smtp://usr:pwd@127.0.0.2:5876'
+        ]);
+
+        $mailer = $this->app['mail.manager']->mailer('smtp_url');
+        $transport = $mailer->getSymfonyTransport();
+
+        $this->assertInstanceOf(EsmtpTransport::class, $transport);
+        $this->assertSame('usr', $transport->getUsername());
+        $this->assertSame('pwd', $transport->getPassword());
+        $this->assertSame('127.0.0.2', $transport->getStream()->getHost());
+        $this->assertSame(5876, $transport->getStream()->getPort());
     }
 
     public static function emptyTransportConfigDataProvider()

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -31,7 +31,7 @@ class MailManagerTest extends TestCase
     public function testMailUrlConfig()
     {
         $this->app['config']->set('mail.mailers.smtp_url', [
-            'url' => 'smtp://usr:pwd@127.0.0.2:5876'
+            'url' => 'smtp://usr:pwd@127.0.0.2:5876',
         ]);
 
         $mailer = $this->app['mail.manager']->mailer('smtp_url');


### PR DESCRIPTION
This PR add support for mail url via `ConfigurationUrlParser`. The resulting `driver` key is assigned to `transport` for compability with mail config.