### PR TITLE
[10.x] Throw timeoutException instead of maxAttemptsExceededException when a job times out

### DIFF
--- a/src/Illuminate/Queue/TimeoutExceededException.php
+++ b/src/Illuminate/Queue/TimeoutExceededException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Queue;
+
+class TimeoutExceededException extends MaxAttemptsExceededException
+{
+    //
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -213,7 +213,7 @@ class Worker
         pcntl_signal(SIGALRM, function () use ($job, $options) {
             if ($job) {
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
-                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->maxAttemptsExceededException($job)
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->timoutExceededException($job)
                 );
 
                 $this->markJobAsFailedIfWillExceedMaxExceptions(
@@ -778,7 +778,20 @@ class Worker
     protected function maxAttemptsExceededException($job)
     {
         return new MaxAttemptsExceededException(
-            $job->resolveName().' has been attempted too many times or run too long. The job may have previously timed out.'
+            $job->resolveName().' has been attempted too many times.'
+        );
+    }
+
+    /**
+     * Create an instance of TimeoutExceededException.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return \Illuminate\Queue\TimeoutExceededException
+     */
+    protected function timoutExceededException($job)
+    {
+        return new TimeoutExceededException(
+            $job->resolveName().' has timed out and was terminated.'
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -791,7 +791,7 @@ class Worker
     protected function timoutExceededException($job)
     {
         return new TimeoutExceededException(
-            $job->resolveName().' has timed out and was terminated.'
+            $job->resolveName().' has timed out.'
         );
     }
 


### PR DESCRIPTION
Currently, both when a job times out and when the max attempts are exceeded for a job the maxAttemptsExceeded exception is thrown. This makes debugging job timeouts difficult. This PR adds a new exception that is thrown when the SIGALRM signal is fired.

