### PR TITLE
[9.x] Fix schema:dump command - Use old .dump file name if it exists

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -102,7 +102,7 @@ class DumpCommand extends Command
     }
 
     /**
-     * Get the path to the to be stored schema for the given connection.
+     * Get the path to the stored schema for the given connection.
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @return string


### PR DESCRIPTION
Version 9.50 introduced a new schema dump-file name with the following PR:
#45805. ( [src/Illuminate/Database/Console/DumpCommand.php](https://github.com/laravel/framework/pull/45805/files#diff-68cddf764fafe83042244527f3269a08f693b857ede34814b8b40f4db5ddd866L97) ).

This behavior creates an additional `mysql-schema.sql` file alongside the existing `mysql-schema.dump` file, which may cause failures in existing project toolchains (this happened to us).

The migrate command already checks for the existence of a `mysql-schema.dump` file and will use it instead of the `.sql` file if it is present. [Relevant Code](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Console/Migrations/MigrateCommand.php#L269)

This Pull Request implements the same logic for the `schema:dump` command.

This improvement will assist developers with existing `mysql-schema.dump` files by eliminating the need to modify their current toolchains.
