### PR TITLE
[10.x] Add `searchStrict` method to Collection class

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1100,6 +1100,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Search the collection for a given value using strict comparison and return the corresponding key if found.
+     *
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
+     * @return TKey|bool
+     */
+    public function searchStrict($value)
+    {
+        return $this->search($value, true);
+    }
+
+    /**
      * Get and remove the first N items from the collection.
      *
      * @param  int  $count


### PR DESCRIPTION
This pull request adds a new method searchStrict to the collection class that allows users to search for a value in the collection using strict comparison. The method simply calls the existing search method with the second argument set to true.