### PR TITLE
Respect parents on middleware priority

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -101,6 +101,14 @@ class SortedMiddleware extends Collection
                 yield $interface;
             }
         }
+
+        $parents = @class_parents($stripped);
+
+        if ($parents !== false) {
+            foreach ($parents as $parent) {
+                yield $parent;
+            }
+        }
     }
 
     /**

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -64,4 +64,59 @@ class RoutingSortedMiddlewareTest extends TestCase
         $this->assertEquals(['a', $closure, 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], ['a', $closure, 'b', $closure2, 'foo']))->all());
         $this->assertEquals([$closure, $closure2, 'foo', 'a'], (new SortedMiddleware(['a', 'b'], [$closure, $closure2, 'foo', 'a']))->all());
     }
+
+    public function testItSortsUsingParentsAndContracts()
+    {
+        $priority = [
+            FirstContractStub::class,
+            SecondStub::class,
+            'Third',
+        ];
+
+        $middleware = [
+            'Something',
+            'Something',
+            'Something',
+            'Something',
+            SecondChildStub::class,
+            'Otherthing',
+            FirstStub::class.':api',
+            'Third:foo',
+            FirstStub::class.':foo,bar',
+            'Third',
+            SecondChildStub::class,
+        ];
+
+        $expected = [
+            'Something',
+            FirstStub::class.':api',
+            FirstStub::class.':foo,bar',
+            SecondChildStub::class,
+            'Otherthing',
+            'Third:foo',
+            'Third',
+        ];
+
+        $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
+    }
+}
+
+interface FirstContractStub
+{
+    //
+}
+
+class FirstStub implements FirstContractStub
+{
+    //
+}
+
+class SecondStub
+{
+    //
+}
+
+class SecondChildStub extends SecondStub
+{
+    //
 }


### PR DESCRIPTION
This revisits: https://github.com/laravel/framework/pull/41432

It was previously reverted due to one Nova plugin complaining about a breaking change, but it is simply the correct behavior. When sorting for middleware priority we should consider the parent class as well. For example, if you extend a class that is in the middleware priority list, Laravel should maintain the property priority of the parent class.