### PR TITLE
[10.x] Leverage PDO fetch modes to improve `pluck()` and add `keyBy()`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -780,14 +780,15 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TMapToDictionaryValue
      *
      * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue>  $callback
+     * @param  bool  $keepKeys
      * @return static<TMapToDictionaryKey, array<int, TMapToDictionaryValue>>
      */
-    public function mapToDictionary(callable $callback)
+    public function mapToDictionary(callable $callback, $keepKeys = false)
     {
         $dictionary = [];
 
-        foreach ($this->items as $key => $item) {
-            $pair = $callback($item, $key);
+        foreach ($this->items as $originalKey => $item) {
+            $pair = $callback($item, $originalKey);
 
             $key = key($pair);
 
@@ -797,7 +798,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 $dictionary[$key] = [];
             }
 
-            $dictionary[$key][] = $value;
+            $keepKeys ? $dictionary[$key][$originalKey] = $value : $dictionary[$key][] = $value;
         }
 
         return new static($dictionary);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -120,6 +120,13 @@ class Connection implements ConnectionInterface
     protected $fetchMode = PDO::FETCH_OBJ;
 
     /**
+     * The fetch mode override for $statement->fetchAll() calls.
+     *
+     * @var int|null
+     */
+    protected $fetchAllMode;
+
+    /**
      * The number of active transactions.
      *
      * @var int
@@ -418,6 +425,10 @@ class Connection implements ConnectionInterface
 
             $statement->execute();
 
+            if (! is_null($this->fetchAllMode)) {
+                return $statement->fetchAll($this->fetchAllMode);
+            }
+
             return $statement->fetchAll();
         });
     }
@@ -491,6 +502,32 @@ class Connection implements ConnectionInterface
         while ($record = $statement->fetch()) {
             yield $record;
         }
+    }
+
+    /**
+     * Set the fetch mode override for calling $statement->fetchAll().
+     *
+     * @param  int  $fetchAllMode
+     * @param  bool  $prepend
+     * @return $this
+     */
+    public function setFetchAllMode($fetchAllMode, $prepend = true)
+    {
+        $this->fetchAllMode = $fetchAllMode | ($prepend ? $this->fetchMode : 0);
+
+        return $this;
+    }
+
+    /**
+     * Reset the fetch mode override for calling $statement->fetchAll().
+     *
+     * @return $this
+     */
+    public function resetFetchAllMode()
+    {
+        $this->fetchAllMode = null;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -306,10 +306,12 @@ class BelongsToMany extends Relation
         // parents without having a possibly slow inner loop for every model.
         $dictionary = [];
 
-        foreach ($results as $result) {
+        $isKeyed = ! is_null($this->getBaseQuery()->keyBy);
+
+        foreach ($results as $key => $result) {
             $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
 
-            $dictionary[$value][] = $result;
+            $isKeyed ? $dictionary[$value][$key] = $result : $dictionary[$value][] = $result;
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -237,11 +237,13 @@ class HasManyThrough extends Relation
     {
         $dictionary = [];
 
+        $isKeyed = ! is_null($this->getBaseQuery()->keyBy);
+
         // First we will create a dictionary of models keyed by the foreign key of the
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
-        foreach ($results as $result) {
-            $dictionary[$result->laravel_through_key][] = $result;
+        foreach ($results as $key => $result) {
+            $isKeyed ? $dictionary[$result->laravel_through_key][$key] = $result : $dictionary[$result->laravel_through_key][] = $result;
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -186,7 +186,7 @@ abstract class HasOneOrMany extends Relation
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
             return [$this->getDictionaryKey($result->{$foreign}) => $result];
-        })->all();
+        }, ! is_null($this->getBaseQuery()->keyBy))->all();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3003,7 +3003,7 @@ class Builder implements BuilderContract
     {
         // When the key is null, we only need to fetch one unique column. If a key is given,
         // a combination with PDO:FETCH_COLUMN will result in a neat key/value response.
-        $mode = is_null($key) ? PDO::FETCH_UNIQUE : PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN;
+        $mode = is_null($key) ? PDO::FETCH_COLUMN : PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN;
 
         $queryResult = $this->onceWithColumns(
             is_null($key) ? [$column] : [$key, $column],
@@ -3016,11 +3016,7 @@ class Builder implements BuilderContract
             }
         );
 
-        if (empty($queryResult)) {
-            return collect();
-        }
-
-        return collect(is_null($key) ? array_keys($queryResult) : $queryResult);
+        return collect($queryResult);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3006,7 +3006,7 @@ class Builder implements BuilderContract
         $mode = is_null($key) ? PDO::FETCH_UNIQUE : PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN;
 
         $queryResult = $this->onceWithColumns(
-            is_null($key) ? [$column] : [$column, $key],
+            is_null($key) ? [$column] : [$key, $column],
             function () use ($mode) {
                 return $this->onceWithFetchAllMode($mode, function () {
                     return $this->processor->processSelect(
@@ -3020,7 +3020,7 @@ class Builder implements BuilderContract
             return collect();
         }
 
-        return collect(is_null($key) ? array_keys($queryResult) : array_flip($queryResult));
+        return collect(is_null($key) ? array_keys($queryResult) : $queryResult);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3001,8 +3001,9 @@ class Builder implements BuilderContract
      */
     public function pluck($column, $key = null)
     {
-        // When the key is null, we only need to fetch one unique column. If a key is given,
-        // a combination with PDO:FETCH_COLUMN will result in a neat key/value response.
+        // When the key is null, we only need to fetch one unique column. If a key
+        // is given, a combination of PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN will
+        // result in a neat key/value response.
         $mode = is_null($key) ? PDO::FETCH_COLUMN : PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN;
 
         $queryResult = $this->onceWithColumns(

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3003,7 +3003,7 @@ class Builder implements BuilderContract
     {
         // When the key is null, we only need to fetch one unique column. If a key is given,
         // a combination with PDO:FETCH_COLUMN will result in a neat key/value response.
-        $mode = is_null($key) ? PDO::FETCH_UNIQUE : PDO::FETCH_UNIQUE|PDO::FETCH_COLUMN;
+        $mode = is_null($key) ? PDO::FETCH_UNIQUE : PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN;
 
         $queryResult = $this->onceWithColumns(
             is_null($key) ? [$column] : [$column, $key],

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Contracts\Database\Query\Builder as BaseBuilder;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -59,6 +60,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $related = m::mock(Model::class);
         $related->shouldReceive('newCollection')->passthru();
         $builder->shouldReceive('getModel')->andReturn($related);
+        $builder->shouldReceive('getQuery')->andReturn(m::mock(BaseBuilder::class));
         $related->shouldReceive('qualifyColumn');
         $builder->shouldReceive('join', 'where');
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Contracts\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -289,6 +290,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
+        $builder->shouldReceive('getQuery')->andReturn(m::mock(BaseBuilder::class));
         $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -328,6 +328,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
         $this->related = m::mock(Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
+        $this->builder->shouldReceive('getQuery')->andReturn(m::mock(BaseBuilder::class));
         $this->parent = m::mock(Model::class);
         $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $this->parent->shouldReceive('getAttribute')->with('username')->andReturn('taylor');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2554,16 +2554,16 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPluckMethodGetsCollectionOfColumnValues()
     {
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn([['foo' => 'bar'], ['foo' => 'baz']]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar'], ['foo' => 'baz']])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => [], 'baz' => []]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => [], 'baz' => []])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->pluck('foo');
         $this->assertEquals(['bar', 'baz'], $results->all());
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn([['id' => 1, 'foo' => 'bar'], ['id' => 10, 'foo' => 'baz']]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['id' => 1, 'foo' => 'bar'], ['id' => 10, 'foo' => 'baz']])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => 1, 'baz' => 10]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => 1, 'baz' => 10])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->pluck('foo', 'id');
@@ -2574,8 +2574,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         // Test without glue.
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn([['foo' => 'bar'], ['foo' => 'baz']]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar'], ['foo' => 'baz']])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => [], 'baz' => []]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => [], 'baz' => []])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->implode('foo');
@@ -2583,8 +2583,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         // Test with glue.
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn([['foo' => 'bar'], ['foo' => 'baz']]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar'], ['foo' => 'baz']])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => [], 'baz' => []]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => [], 'baz' => []])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->implode('foo', ',');
@@ -5634,6 +5634,8 @@ SQL;
     {
         $connection = m::mock(ConnectionInterface::class);
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('setFetchAllMode');
+        $connection->shouldReceive('resetFetchAllMode');
 
         return $connection;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2574,8 +2574,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         // Test without glue.
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => [], 'baz' => []]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => [], 'baz' => []])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar', 'baz']);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar', 'baz'])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->implode('foo');
@@ -2583,8 +2583,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
         // Test with glue.
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => [], 'baz' => []]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => [], 'baz' => []])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar', 'baz']);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar', 'baz'])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->implode('foo', ',');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2554,8 +2554,8 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPluckMethodGetsCollectionOfColumnValues()
     {
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => [], 'baz' => []]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => [], 'baz' => []])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar', 'baz']);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar', 'baz'])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->pluck('foo');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2562,8 +2562,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $results->all());
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->andReturn(['bar' => 1, 'baz' => 10]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, ['bar' => 1, 'baz' => 10])->andReturnUsing(function ($query, $results) {
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn([1 => 'bar', 10 => 'baz']);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [1 => 'bar', 10 => 'baz'])->andReturnUsing(function ($query, $results) {
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->pluck('foo', 'id');

--- a/tests/Integration/Database/EloquentKeyByTest.php
+++ b/tests/Integration/Database/EloquentKeyByTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentKeyByTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentKeyByTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->string('address');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('title')->nullable();
+            $table->string('content');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+            $table->string('content');
+        });
+
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+            $table->unsignedInteger('tag_id');
+        });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('tag');
+        });
+
+        DB::table('users')->insert([
+            ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com', 'address' => '5th Avenue'],
+            ['name' => 'Taylor Otwell', 'email' => 'other_taylor@laravel.com', 'address' => '7th Avenue'],
+            ['name' => 'Lortay Wellot', 'email' => 'lortay@laravel.com', 'address' => '4th Street'],
+        ]);
+
+        DB::table('posts')->insert([
+            ['user_id' => 1, 'title' => 'The Post', 'content' => 'Welcome to Laravel!', 'created_at' => '2023-01-04 12:00:00'],
+            ['user_id' => 1, 'title' => 'The Post', 'content' => 'Welcome to the Laravel Ecosystem!', 'created_at' => '2023-03-04 13:00:00'],
+            ['user_id' => 1, 'title' => null, 'content' => 'Lorem Ipsum', 'created_at' => '2023-05-04 14:00:00'],
+            ['user_id' => 1, 'title' => 'A title', 'content' => 'Roses are red', 'created_at' => '2023-07-04 15:00:00'],
+            ['user_id' => 2, 'title' => 'Another title', 'content' => 'Violets are blue', 'created_at' => '2023-09-04 16:00:00'],
+            ['user_id' => 2, 'title' => 'Another title', 'content' => 'Taylor is turquoise', 'created_at' => '2023-11-04 17:00:00'],
+        ]);
+
+        DB::table('tags')->insert([
+            ['tag' => 'A tag'],
+            ['tag' => 'Foo'],
+            ['tag' => 'Bar'],
+        ]);
+
+        DB::table('post_tag')->insert([
+            ['post_id' => 1, 'tag_id' => 1],
+            ['post_id' => 1, 'tag_id' => 2],
+            ['post_id' => 2, 'tag_id' => 1],
+        ]);
+
+        DB::table('comments')->insert([
+            ['post_id' => 2, 'content' => 'This is a comment'],
+        ]);
+    }
+
+    /**
+     * @dataProvider keyByDataProvider
+     */
+    public function testKeyBy($keyBy, $columns, $key, $expected)
+    {
+        $this->assertEquals($expected, json_encode(User::query()->keyBy($keyBy)->get($columns)[$key]));
+    }
+
+    public static function keyByDataProvider()
+    {
+        return [
+            'Key by name with all columns' => ['name', ['*'], 'Lortay Wellot', '{"id":3,"name":"Lortay Wellot","email":"lortay@laravel.com","address":"4th Street"}'],
+            'Key by name with selected columns not including key' => ['name', ['email', 'address'], 'Taylor Otwell', '{"email":"other_taylor@laravel.com","address":"7th Avenue"}'],
+            'Key by name with selected columns including key' => ['name', ['name', 'email', 'address'], 'Taylor Otwell', '{"name":"Taylor Otwell","email":"other_taylor@laravel.com","address":"7th Avenue"}'],
+            'Key by street with selected dot-columns not including key' => ['address', ['users.email'], '5th Avenue', '{"email":"taylor@laravel.com"}'],
+            'Key by street with selected dot-columns including key' => ['address', ['users.address', 'email'], '5th Avenue', '{"address":"5th Avenue","email":"taylor@laravel.com"}'],
+        ];
+    }
+
+    /**
+     * @dataProvider keyByWithSelectDataProvider
+     */
+    public function testKeyByWithSelect($keyBy, $columns, $key, $expected)
+    {
+        $results = User::query()->keyBy($keyBy)->select($columns)->get();
+
+        $this->assertSame($expected, $results[$key]->getAttributes());
+    }
+
+    public static function keyByWithSelectDataProvider()
+    {
+        return [
+            'keyBy column does not become part of the result if not SELECTed' => ['name', ['address'], 'Taylor Otwell', ['address' => '7th Avenue']],
+            'keyBy column becomes part of the result if SELECTed' => ['name', ['name', 'address'], 'Taylor Otwell', ['name' => 'Taylor Otwell', 'address' => '7th Avenue']],
+        ];
+    }
+
+    public function testGroupBySimilarity()
+    {
+        $this->assertSame(
+            Post::query()->groupBy('title')->select(['title', DB::raw('MIN(id) as id')])
+                ->keyBy('title')->get()->toArray(),
+            Post::query()->groupBy('title')->select(['title', DB::raw('MIN(id) as id')])
+                ->get()->keyBy('title')->toArray()
+        );
+    }
+
+    public function testCollectionKeyBySimilarity()
+    {
+        $this->assertSame(
+            User::query()->keyBy('name')->get()->toArray(),
+            User::query()->get()->keyBy('name')->toArray()
+        );
+    }
+
+    public function testHasManyRelation()
+    {
+        $this->assertInstanceOf(
+            Post::class,
+            User::query()->with('posts')->first()->posts['The Post']
+        );
+    }
+
+    public function testHasManyThroughRelation()
+    {
+        $user = User::query()->with('posts', 'comments')->first();
+        $this->assertInstanceOf(Comment::class, $user->comments['This is a comment']);
+        $this->assertInstanceOf(Post::class, $user->posts['The Post']);
+    }
+
+    public function testBelongsToMany()
+    {
+        $this->assertInstanceOf(
+            Tag::class,
+            Post::query()->with('tags')->first()->tags['Foo']
+        );
+    }
+
+    public function testKeyByCustomColumn()
+    {
+        $results = User::query()->with('postsByDate')->first();
+        $this->assertSame(
+            ['2023-01-04', '2023-03-04', '2023-05-04', '2023-07-04'],
+            $results->postsByDate->keys()->toArray()
+        );
+    }
+}
+
+class BaseModel extends Model
+{
+    public $timestamps = false;
+}
+
+class User extends BaseModel
+{
+    public function comments()
+    {
+        return $this->hasManyThrough(Comment::class, Post::class)->keyBy('content');
+    }
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class)->keyBy('title');
+    }
+
+    public function postsByDate()
+    {
+        $cast = match (DB::connection()->getDriverName()) {
+            'mysql', 'sqlite' => 'SUBSTR(created_at, 1, 10)',
+            'pgsql' => 'SUBSTR(CAST(created_at AS varchar), 1, 10)',
+            'sqlsrv' => 'CONVERT(date, created_at)'
+        };
+
+        return $this->hasMany(Post::class)->keyBy(DB::raw($cast));
+    }
+}
+
+class Post extends BaseModel
+{
+    public $timestamps = true;
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class)->keyBy('tag');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class Comment extends BaseModel
+{
+    //
+}
+
+class Tag extends BaseModel
+{
+    //
+}

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -138,6 +139,26 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertEquals(1.5, $rows[1]->wallet_1);
 
         Schema::drop('accounting');
+    }
+
+    /**
+     * @dataProvider keyByDataProvider
+     */
+    public function testKeyBy($keyBy, $columns, $key, $expected)
+    {
+        $record = DB::table('posts')->keyBy($keyBy)->get($columns)[$key];
+        $this->assertEquals($expected, Arr::except((array) $record, 'created_at'));
+    }
+
+    public static function keyByDataProvider()
+    {
+        return [
+            'Key by title with all columns' => ['title', ['*'], 'Foo Post', ['id' => '1', 'title' => 'Foo Post', 'content' => 'Lorem Ipsum.']],
+            'Key by title with selected columns not including key' => ['title', ['id', 'content'], 'Bar Post', ['id' => '2', 'content' => 'Lorem Ipsum.']],
+            'Key by id with selected columns including key' => ['id', ['id', 'content'], 2, ['id' => '2', 'content' => 'Lorem Ipsum.']],
+            'Key by id with selected dot-columns including key' => ['id', ['posts.id', 'posts.content'], 2, ['id' => '2', 'content' => 'Lorem Ipsum.']],
+            'Key by dot-title with selected dot-columns including key' => ['posts.title', ['posts.title', 'posts.content'], 'Foo Post', ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.']],
+        ];
     }
 
     public function testSole()


### PR DESCRIPTION
[PHP's PDO Fetch Modes](https://www.php.net/manual/en/pdostatement.fetchall.php) allow developers to set different response formats for their query results. Currently in Laravel, this fetch mode defaults to `PDO::FETCH_OBJ` which returns the query results as a list (numerically indexed array, so no custom keys) where the values are objects.

By introducing the helper `onceWithFetchAllMode(PDO::FETCH_..., callable)`, queries can now have their response format modified according to the given fetch mode. The new query builder feature `keyBy()` (similar to Collection's `keyBy()` but for the query builder) and a huge simplification to `pluck()` make use of these new fetch modes.

## Feature: `Query\Builder::keyBy()`
Similar to the Collection method `keyBy()` but it acts directly on the query response. Retrieving array items by key is essentially an O(1) (constant time) operation so performance benefits can be found all around. Several examples:
#### 1. Key an array by a column:
```php
$users = User::keyBy('email')->get();
$user = $users['foobar@example.com'] ?? null;
```
#### 2. Key an array by a custom expression:
```php
// Retrieve a user for each day (taking the first 10 characters of the timestamp, which is `2023-01-01`):
$users = User::keyBy(DB::raw('SUBSTR(`created_at`, 1, 10)'));
$janFirstUser = $users['2023-01-01'] ?? null;
// Note: if multiple users have `created_at = 2023-04-01`, the last user with this value will overwrite the previous. This is exactly how `Illuminate\Support\Collection::keyBy()` works as well. The query can obviously be improved with a GROUP BY clause.
```

#### 3. Keying relations:
```php
class Post extends BaseModel
{
    public function tags()
    {
        // Return results keyed by the `tag` column (the name of the tag).
        return $this->belongsToMany(Tag::class)->keyBy('tag');
    }
}
$post = Post::with('tags')->first();
$awesomeTag = $post->tags['awesome'] ?? null;
```
(test cases included)
### Use cases
#### Example 1: creating a local cache of currency objects, which can be quickly retrieved by their iso-code (EUR,USD,BTC etc) array index:
```php
class SomeClass
{
    private $_cache;

    public function get($isoCode)
    {
        return $this->cache()[$isoCode] ?? null;
    }

    protected function cache()
    {
        if (is_null($this->_cache)) {
            $this->_cache = App\Models\Currency::query()->keyBy('iso_code')->get();
        }

        return $this->_cache;
    }
}

$euroCurrency = (new SomeClass)->get('EUR');
```

#### Example 2: any cases where you need to check key existence in a query result
(see Feature no. 3)

#### Example 3: Optimize any cases where `->get()->keyBy(...)` (or similar) is called:
This saves an extra array loop since the result is indexed immediately when it is retrieved from PDO.
```php
// Old:
Country::all()->keyBy('country_code');
// New:
Country::keyBy('country_code')->get();
```

## 2/2 Improvement: `Query\Builder::pluck()`
This PR also improves the speed for Query Builder `pluck()` and removes 80+ lines of code. The usage and functionality remains the same, but it is greatly simplified by using `PDO::FETCH_COLUMN` (when calling `pluck('col')` and `PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN` (when calling `pluck('col', 'id')`). The query result is now exactly the format you expect from the pluck function, so no further modification is necessary.