### PR TITLE
[10.x] Patch - Added missing validation keys

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -181,4 +181,12 @@ return [
 
     'attributes' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Summarized message from ValidationException
+    |--------------------------------------------------------------------------
+    */
+    'The given data was invalid.' => 'The given data was invalid.',
+    '(and :count more error)' => '(and :count more error)',
+    '(and :count more errors)' => '(and :count more errors)',
 ];


### PR DESCRIPTION
## Patch for 10.x

From "ValidationError" it is using 2 translation keys:

- The given data was invalid.
- (and :count more error|errors)

Which haven't been added to the `validation.php` translation file. So as of now, I believe these 2 texts would result in English all the time.

This would be helpful from userland, they can search & update their translated texts quickly without reading the `ValidationException` code and add the needful translation keys.

Please let me know if I need to change the key to snake_case instead.

Thanks ✌️ 