### PR TITLE
[10.x] Add type hint for `assertJsonIsArray` & `assertJsonIsObject`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -894,7 +894,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given key is a JSON array.
      *
-     * @param string|null $key
+     * @param  string|null  $key
      * @return $this
      */
     public function assertJsonIsArray($key = null)

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -915,7 +915,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given key is a JSON object.
      *
-     * @param $key
+     * @param  string|null  $key
      * @return $this
      */
     public function assertJsonIsObject($key = null)

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -894,7 +894,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given key is a JSON array.
      *
-     * @param $key
+     * @param string|null $key
      * @return $this
      */
     public function assertJsonIsArray($key = null)


### PR DESCRIPTION
Add missing type-hint for `assertJsonIsArray` & `assertJsonIsObject`