### PR TITLE
[10.x] Allow HTTP pool requests to use the initial pending request as base

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -782,7 +782,9 @@ class PendingRequest
     {
         $results = [];
 
-        $requests = tap(new Pool($this->factory), $callback)->getRequests();
+        $requests = tap(new Pool($this), $callback)->getRequests();
+
+
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -782,7 +782,7 @@ class PendingRequest
     {
         $results = [];
 
-        $requests = tap(new Pool($this->factory), $callback)->getRequests();
+        $requests = tap(new Pool($this), $callback)->getRequests();
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -782,9 +782,7 @@ class PendingRequest
     {
         $results = [];
 
-        $requests = tap(new Pool($this), $callback)->getRequests();
-
-
+        $requests = tap(new Pool($this->factory), $callback)->getRequests();
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -2,19 +2,17 @@
 
 namespace Illuminate\Http\Client;
 
-use GuzzleHttp\Utils;
-
 /**
  * @mixin \Illuminate\Http\Client\Factory
  */
 class Pool
 {
     /**
-     * The factory instance.
+     * The pending request instance.
      *
-     * @var \Illuminate\Http\Client\Factory
+     * @var \Illuminate\Http\Client\PendingRequest
      */
-    protected $factory;
+    protected $pendingRequest;
 
     /**
      * The handler function for the Guzzle client.
@@ -33,18 +31,12 @@ class Pool
     /**
      * Create a new requests pool.
      *
-     * @param  \Illuminate\Http\Client\Factory|null  $factory
+     * @param  \Illuminate\Http\Client\PendingRequest  $pendingRequest
      * @return void
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(PendingRequest $pendingRequest)
     {
-        $this->factory = $factory ?: new Factory();
-
-        if (method_exists(Utils::class, 'chooseHandler')) {
-            $this->handler = Utils::chooseHandler();
-        } else {
-            $this->handler = \GuzzleHttp\choose_handler();
-        }
+        $this->pendingRequest = $pendingRequest;
     }
 
     /**
@@ -65,7 +57,7 @@ class Pool
      */
     protected function asyncRequest()
     {
-        return $this->factory->setHandler($this->handler)->async();
+        return clone $this->pendingRequest->async();
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2279,7 +2279,7 @@ class HttpClientTest extends TestCase
     public function testPoolRequestsInheritBaseUrl()
     {
         $responses = $this->factory->fake()->baseUrl('http://foo.com/')->pool(fn (Pool $pool) => [
-            $pool->get('get')
+            $pool->get('get'),
         ]);
 
         $this->assertEquals('http://foo.com/get', $responses[0]->effectiveUri());


### PR DESCRIPTION
Currently the HTTP pool is set up in a manner which create an entirely new request for each request inside of the pool.

However the initial call to `Http::pool` already instantiates a request which can be used as a base request. It doesn't make sense not to leverage this initial request which is already built up.

```
$responses = Http::pool(fn (Pool $pool) => [
    $pool->get('http://localhost/first'),
    $pool->get('http://localhost/second'),
    $pool->get('http://localhost/third'),
]);
```

By swapping out the factory which is being passed into the pool and ensuring that each pool request clones the existing request originating from the `Http::pool` the configuration from the initial request can be passed on to all pool requests.

This allows for the pool requests to inherit configuration set through methods like:

- `withMiddleware`
- `withOptions`
- `withHeaders`
- `withBasicAuth`
- etc.

In the case of building something like a scraper you would often use this pool to asynchronously fetch a large amount of pages. In such a case it would not make sense to set custom configuration on each separate request while they all share the same base configuration.

Swapping out the factory in favour of a pendingRequest also shouldn't lead to any compatibility issues because the initial pendingRequest get's instantiated through the factory anyways. The only impact this could have is in codebases where a pool would have been instantiated manually but this would mean a factory would also have been instantiated manually. I think that if there are people who utilise the pool without invoking the facade would be extremely minimal.

By cloning the pending request you would also still allow modifications to each individual request with the aforementioned methods if you would like to do that.

There was an earlier PR that this is based on, which came to existence after a Github issue I created. This however got closed without any comment. I modified the code to just use a pending request and altered the tests.

https://github.com/laravel/framework/pull/46931

This would be a good first step as a modification but further requirements also have to be made to the http pool because it is missing some pretty vital things like support for a concurrency limit which a default Guzzle pool does have for obvious reasons.
