### PR TITLE
[10.x] Prevent throw exception when notifiable id not exist

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -137,7 +137,7 @@ class NotificationSender
      */
     protected function sendToNotifiable($notifiable, $id, $notification, $channel)
     {
-        if (! $notification->id) {
+        if (! $notification->id ?? null) {
             $notification->id = $id;
         }
 


### PR DESCRIPTION
This line throws an exception when notifiable is not an object or object without an id attribute, so this merge fixes it.