### PR TITLE
[10.x] Enable use of non global morph mappings for MorphTo & related

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -297,9 +297,9 @@ trait HasRelationships
      */
     protected function morphEagerTo($name, $type, $id, $ownerKey, $mappings)
     {
-        return $this->newMorphTo(
-            $this->newQuery()->setEagerLoads([]), $this, $id, $ownerKey, $type, $name, $mappings
-        );
+        return tap($this->newMorphTo(
+            $this->newQuery()->setEagerLoads([]), $this, $id, $ownerKey, $type, $name
+        ), fn($it) => $it->setMappings($mappings));
     }
 
     /**
@@ -319,9 +319,9 @@ trait HasRelationships
             static::getActualClassNameForMorph($target, $mappings)
         );
 
-        return $this->newMorphTo(
-            $instance->newQuery(), $this, $id, $ownerKey ?? $instance->getKeyName(), $type, $name, $mappings
-        );
+        return tap($this->newMorphTo(
+            $instance->newQuery(), $this, $id, $ownerKey ?? $instance->getKeyName(), $type, $name
+        ), fn($it) => $it->setMappings($mappings));
     }
 
     /**
@@ -336,9 +336,9 @@ trait HasRelationships
      * @param  array|null  $mappings
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $mappings)
+    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
     {
-        return new MorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation, $mappings);
+        return new MorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -299,7 +299,7 @@ trait HasRelationships
     {
         return tap($this->newMorphTo(
             $this->newQuery()->setEagerLoads([]), $this, $id, $ownerKey, $type, $name
-        ), fn($it) => $it->setMappings($mappings));
+        ), fn ($it) => $it->setMappings($mappings));
     }
 
     /**
@@ -321,7 +321,7 @@ trait HasRelationships
 
         return tap($this->newMorphTo(
             $instance->newQuery(), $this, $id, $ownerKey ?? $instance->getKeyName(), $type, $name
-        ), fn($it) => $it->setMappings($mappings));
+        ), fn ($it) => $it->setMappings($mappings));
     }
 
     /**
@@ -333,7 +333,6 @@ trait HasRelationships
      * @param  string  $ownerKey
      * @param  string  $type
      * @param  string  $relation
-     * @param  array|null  $mappings
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -221,9 +221,15 @@ trait QueriesRelationships
     public function hasMorph($relation, $types, $mappings = null, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
     {
         if (is_string($mappings)) {
-            if($boolean != 'and') $callback = $boolean;
-            if($count != 1) $boolean = $count;
-            if($operator != '>=') $count = $operator;
+            if ($boolean != 'and') {
+                $callback = $boolean;
+            }
+            if ($count != 1) {
+                $boolean = $count;
+            }
+            if ($operator != '>=') {
+                $count = $operator;
+            }
             $operator = $mappings;
             $mappings = null;
         }
@@ -294,7 +300,9 @@ trait QueriesRelationships
     public function orHasMorph($relation, $types, $mappings = null, $operator = '>=', $count = 1)
     {
         if (is_string($mappings)) {
-            if($operator != '>=') $count = $operator;
+            if ($operator != '>=') {
+                $count = $operator;
+            }
             $operator = $mappings;
             $mappings = null;
         }
@@ -313,7 +321,9 @@ trait QueriesRelationships
     public function doesntHaveMorph($relation, $types, $mappings = null, $boolean = 'and', Closure $callback = null)
     {
         if(is_string($mappings)) {
-            if($boolean != 'and') $callback = $boolean;
+            if ($boolean != 'and') {
+                $callback = $boolean;
+            }
             $boolean = $mappings;
             $mappings = null;
         }
@@ -345,12 +355,16 @@ trait QueriesRelationships
     public function whereHasMorph($relation, $types, $mappings = null, Closure $callback = null, $operator = '>=', $count = 1)
     {
         if($mappings instanceof Closure) {
-            if($operator != ">=") $count = $operator;
-            if($callback != null) $operator = $callback;
+            if ($operator != ">=") {
+                $count = $operator;
+            }
+            if ($callback != null) {
+                $operator = $callback;
+            }
             $callback = $mappings;
             $mappings = null;
         }
-        return $this->hasMorph($relation, $types, $mappings, $operator, $count,'and', $callback);
+        return $this->hasMorph($relation, $types, $mappings, $operator, $count, 'and', $callback);
     }
 
     /**
@@ -366,11 +380,16 @@ trait QueriesRelationships
     public function orWhereHasMorph($relation, $types, $mappings, Closure $callback = null, $operator = '>=', $count = 1)
     {
         if($mappings instanceof Closure) {
-            if($operator != ">=") $count = $operator;
-            if($callback != null) $operator = $callback;
+            if ($operator != ">=") {
+                $count = $operator;
+            }
+            if ($callback != null) {
+                $operator = $callback;
+            }
             $callback = $mappings;
             $mappings = null;
         }
+
         return $this->hasMorph($relation, $types, $mappings, $operator, $count, 'or', $callback);
     }
 
@@ -388,6 +407,7 @@ trait QueriesRelationships
             $callback = $mappings;
             $mappings = null;
         }
+
         return $this->doesntHaveMorph($relation, $types, $mappings, 'and', $callback);
     }
 
@@ -405,6 +425,7 @@ trait QueriesRelationships
             $callback = $mappings;
             $mappings = null;
         }
+
         return $this->doesntHaveMorph($relation, $types, $mappings, 'or', $callback);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -218,8 +218,16 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function hasMorph($relation, $types, $mappings = null, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
     {
+        if (is_string($mappings)) {
+            if($boolean != 'and') $callback = $boolean;
+            if($count != 1) $boolean = $count;
+            if($operator != '>=') $count = $operator;
+            $operator = $mappings;
+            $mappings = null;
+        }
+
         if (is_string($relation)) {
             $relation = $this->getRelationWithoutConstraints($relation);
         }
@@ -231,7 +239,7 @@ trait QueriesRelationships
         }
 
         foreach ($types as &$type) {
-            $type = Relation::getMorphedModel($type) ?? $type;
+            $type = Relation::getMorphedModel($type, $mappings) ?? $type;
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
@@ -283,9 +291,14 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
+    public function orHasMorph($relation, $types, $mappings = null, $operator = '>=', $count = 1)
     {
-        return $this->hasMorph($relation, $types, $operator, $count, 'or');
+        if (is_string($mappings)) {
+            if($operator != '>=') $count = $operator;
+            $operator = $mappings;
+            $mappings = null;
+        }
+        return $this->hasMorph($relation, $types, $mappings, $operator, $count, 'or');
     }
 
     /**
@@ -297,9 +310,14 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
+    public function doesntHaveMorph($relation, $types, $mappings = null, $boolean = 'and', Closure $callback = null)
     {
-        return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
+        if(is_string($mappings)) {
+            if($boolean != 'and') $callback = $boolean;
+            $boolean = $mappings;
+            $mappings = null;
+        }
+        return $this->hasMorph($relation, $types, $mappings, '<', 1, $boolean, $callback);
     }
 
     /**
@@ -309,9 +327,9 @@ trait QueriesRelationships
      * @param  string|array  $types
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orDoesntHaveMorph($relation, $types)
+    public function orDoesntHaveMorph($relation, $types, $mappings = null)
     {
-        return $this->doesntHaveMorph($relation, $types, 'or');
+        return $this->doesntHaveMorph($relation, $types, $mappings, 'or');
     }
 
     /**
@@ -324,9 +342,15 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHasMorph($relation, $types, $mappings = null, Closure $callback = null, $operator = '>=', $count = 1)
     {
-        return $this->hasMorph($relation, $types, $operator, $count, 'and', $callback);
+        if($mappings instanceof Closure) {
+            if($operator != ">=") $count = $operator;
+            if($callback != null) $operator = $callback;
+            $callback = $mappings;
+            $mappings = null;
+        }
+        return $this->hasMorph($relation, $types, $mappings, $operator, $count,'and', $callback);
     }
 
     /**
@@ -339,9 +363,15 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHasMorph($relation, $types, $mappings, Closure $callback = null, $operator = '>=', $count = 1)
     {
-        return $this->hasMorph($relation, $types, $operator, $count, 'or', $callback);
+        if($mappings instanceof Closure) {
+            if($operator != ">=") $count = $operator;
+            if($callback != null) $operator = $callback;
+            $callback = $mappings;
+            $mappings = null;
+        }
+        return $this->hasMorph($relation, $types, $mappings, $operator, $count, 'or', $callback);
     }
 
     /**
@@ -352,9 +382,13 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function whereDoesntHaveMorph($relation, $types, $mappings, Closure $callback = null)
     {
-        return $this->doesntHaveMorph($relation, $types, 'and', $callback);
+        if ($mappings instanceof Closure) {
+            $callback = $mappings;
+            $mappings = null;
+        }
+        return $this->doesntHaveMorph($relation, $types, $mappings, 'and', $callback);
     }
 
     /**
@@ -365,9 +399,13 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function orWhereDoesntHaveMorph($relation, $types, $mappings, Closure $callback = null)
     {
-        return $this->doesntHaveMorph($relation, $types, 'or', $callback);
+        if ($mappings instanceof Closure) {
+            $callback = $mappings;
+            $mappings = null;
+        }
+        return $this->doesntHaveMorph($relation, $types, $mappings, 'or', $callback);
     }
 
     /**
@@ -451,8 +489,14 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model|string|null  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereMorphedTo($relation, $model, $boolean = 'and')
+    public function whereMorphedTo($relation, $model, $mappings = null, $boolean = 'and')
     {
+        // migrate old usages of boolean to support custom mappings
+        if (is_string($mappings)) {
+            $boolean = $mappings;
+            $mappings = null;
+        }
+
         if (is_string($relation)) {
             $relation = $this->getRelationWithoutConstraints($relation);
         }
@@ -462,7 +506,7 @@ trait QueriesRelationships
         }
 
         if (is_string($model)) {
-            $morphMap = Relation::morphMap();
+            $morphMap = $mappings ?: Relation::morphMap();
 
             if (! empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
@@ -484,14 +528,20 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereNotMorphedTo($relation, $model, $boolean = 'and')
+    public function whereNotMorphedTo($relation, $model, $mappings = null, $boolean = 'and')
     {
+        // migrate old usages of boolean to support custom mappings
+        if (is_string($mappings)) {
+            $boolean = $mappings;
+            $mappings = null;
+        }
+
         if (is_string($relation)) {
             $relation = $this->getRelationWithoutConstraints($relation);
         }
 
         if (is_string($model)) {
-            $morphMap = Relation::morphMap();
+            $morphMap = $mappings ?: Relation::morphMap();
 
             if (! empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
@@ -513,9 +563,9 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model|string|null  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereMorphedTo($relation, $model)
+    public function orWhereMorphedTo($relation, $model, $mappings = null)
     {
-        return $this->whereMorphedTo($relation, $model, 'or');
+        return $this->whereMorphedTo($relation, $model, $mappings, 'or');
     }
 
     /**
@@ -525,9 +575,9 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereNotMorphedTo($relation, $model)
+    public function orWhereNotMorphedTo($relation, $model, $mappings = null)
     {
-        return $this->whereNotMorphedTo($relation, $model, 'or');
+        return $this->whereNotMorphedTo($relation, $model, $mappings, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -25,7 +25,7 @@ class MorphTo extends BelongsTo
      *
      * @var array
      */
-    protected $mappings;
+    private $mappings;
 
     /**
      * The models whose relations are being eager loaded.
@@ -80,10 +80,9 @@ class MorphTo extends BelongsTo
      * @param  string  $relation
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $mappings = null)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
     {
         $this->morphType = $type;
-        $this->mappings = $mappings;
 
         parent::__construct($query, $parent, $foreignKey, $ownerKey, $relation);
     }
@@ -97,6 +96,15 @@ class MorphTo extends BelongsTo
     public function addEagerConstraints(array $models)
     {
         $this->buildDictionary($this->models = Collection::make($models));
+    }
+
+    /**
+     * Set custom mappings. When set these replace the global morph mappings.
+     *
+     * @return void
+     */
+    public function setMappings(array|null $mappings) {
+        $this->mappings = $mappings;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -103,7 +103,8 @@ class MorphTo extends BelongsTo
      *
      * @return void
      */
-    public function setMappings(array|null $mappings) {
+    public function setMappings(array|null $mappings)
+    {
         $this->mappings = $mappings;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -20,6 +20,14 @@ class MorphTo extends BelongsTo
     protected $morphType;
 
     /**
+     * Custom mappings for this polymorphic relationship.
+     * Use of this will override the global morph mappings.
+     *
+     * @var array
+     */
+    protected $mappings;
+
+    /**
      * The models whose relations are being eager loaded.
      *
      * @var \Illuminate\Database\Eloquent\Collection
@@ -72,9 +80,10 @@ class MorphTo extends BelongsTo
      * @param  string  $relation
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $mappings = null)
     {
         $this->morphType = $type;
+        $this->mappings = $mappings;
 
         parent::__construct($query, $parent, $foreignKey, $ownerKey, $relation);
     }
@@ -181,7 +190,7 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        $class = Model::getActualClassNameForMorph($type);
+        $class = Model::getActualClassNameForMorph($type, $this->mappings);
 
         return tap(new $class, function ($instance) {
             if (! $instance->getConnectionName()) {

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -496,9 +496,9 @@ abstract class Relation implements BuilderContract
      * @param  string  $alias
      * @return string|null
      */
-    public static function getMorphedModel($alias)
+    public static function getMorphedModel($alias, $mapping = null)
     {
-        return static::$morphMap[$alias] ?? null;
+        return ($mapping??static::$morphMap)[$alias] ?? null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -493,12 +493,16 @@ abstract class Relation implements BuilderContract
     /**
      * Get the model associated with a custom polymorphic type.
      *
+     * If mapping are not passed in manually, this function will use the global
+     * mappings provided by Relation::morphMap()
+     *
      * @param  string  $alias
+     * @param  array  $mapping
      * @return string|null
      */
     public static function getMorphedModel($alias, $mapping = null)
     {
-        return ($mapping??static::$morphMap)[$alias] ?? null;
+        return ($mapping ?? static::$morphMap)[$alias] ?? null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -352,9 +352,9 @@ class CustomPost extends Post
             $relationName, $inverse);
     }
 
-    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $mappings)
+    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
     {
-        return new CustomMorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation, $mappings);
+        return new CustomMorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation);
     }
 }
 

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -352,9 +352,9 @@ class CustomPost extends Post
             $relationName, $inverse);
     }
 
-    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
+    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $mappings)
     {
-        return new CustomMorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation);
+        return new CustomMorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation, $mappings);
     }
 }
 


### PR DESCRIPTION
In certain cases it is useful to have morph mappings that are disconnected from the global mappings - eg working in a db structure where the same custom key means a different class in different tables (thank you external provider).

I have added an option to pass custom mappings to the morph methods I could find which will then override the global mapping for that segment of the query/relationship rather then having to set and unset the global mapping state.