### PR TITLE
[10.x] Add arguments to the signed middleware to ignore properties

### DIFF
--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -71,9 +71,10 @@ class ValidateSignature
             array_shift($args);
         }
 
-        $ignore = empty($args)
-            ? property_exists($this, 'except') ? $this->except : $this->ignore
-            : $args;
+        $ignore = array_merge(
+            property_exists($this, 'except') ? $this->except : $this->ignore,
+            $args
+        );
 
         return [$isRelative, $ignore];
     }

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -20,7 +20,6 @@ class ValidateSignature
      * Specify that the URL signature is for a relative URL.
      *
      * @param  array|null  $ignore
-     *
      * @return string
      */
     public static function relative(...$ignore)
@@ -34,7 +33,6 @@ class ValidateSignature
      * Specify that the URL signature is for an absolute URL.
      *
      * @param  array|null  $ignore
-     *
      * @return class-string
      */
     public static function absolute(...$ignore)

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -50,7 +50,7 @@ class ValidateSignature
     {
         [$isRelative, $ignore] = $this->parseArguments($args);
 
-        if ($request->hasValidSignatureWhileIgnoring($ignore, !$isRelative)) {
+        if ($request->hasValidSignatureWhileIgnoring($ignore, ! $isRelative)) {
             return $next($request);
         }
 

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -19,21 +19,29 @@ class ValidateSignature
     /**
      * Specify that the URL signature is for a relative URL.
      *
+     * @param  array|null  $ignore
+     *
      * @return string
      */
-    public static function relative()
+    public static function relative(...$ignore)
     {
-        return static::class.':relative';
+        $args = empty($ignore) ? ['relative'] : ['relative',  ...$ignore];
+
+        return static::class.':'.implode(',', $args);
     }
 
     /**
      * Specify that the URL signature is for an absolute URL.
      *
+     * @param  array|null  $ignore
+     *
      * @return class-string
      */
-    public static function absolute()
+    public static function absolute(...$ignore)
     {
-        return static::class;
+        return empty($ignore)
+            ? static::class
+            : static::class.':'.implode(',', $ignore);
     }
 
     /**

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -305,6 +305,12 @@ class UrlSigningTest extends TestCase
 
         $signature = (string) ValidateSignature::absolute();
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature', $signature);
+
+        $signature = (string) ValidateSignature::relative('foo', 'bar');
+        $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:relative,foo,bar', $signature);
+
+        $signature = (string) ValidateSignature::absolute('foo', 'bar');
+        $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:foo,bar', $signature);
     }
 
     protected function createValidateSignatureMiddleware(array $ignore)

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -306,10 +306,10 @@ class UrlSigningTest extends TestCase
         $signature = (string) ValidateSignature::absolute();
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature', $signature);
 
-        $signature = (string) ValidateSignature::relative('foo', 'bar');
+        $signature = (string) ValidateSignature::relative(['foo', 'bar']);
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:relative,foo,bar', $signature);
 
-        $signature = (string) ValidateSignature::absolute('foo', 'bar');
+        $signature = (string) ValidateSignature::absolute(['foo', 'bar']);
         $this->assertSame('Illuminate\Routing\Middleware\ValidateSignature:foo,bar', $signature);
     }
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -276,6 +276,28 @@ class UrlSigningTest extends TestCase
         }
     }
 
+    public function testSignedMiddlewareIgnoringParameterViaArgumentsWithRelative()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+        })->name('foo')->middleware('signed:relative,ignore');
+
+        $this->assertIsString('https://fake.test'.URL::signedRoute('foo', ['id' => 1, 'ignore' => 'me'], null, false));
+
+        $response = $this->get('/foo/1');
+        $response->assertStatus(403);
+    }
+
+    public function testSignedMiddlewareIgnoringParameterViaArgumentsWithoutRelative()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+        })->name('foo')->middleware('signed:ignore');
+
+        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', ['id' => 1, 'ignore' => 'me'], null, false));
+
+        $response = $this->get('/foo/1');
+        $response->assertStatus(403);
+    }
+
     public function testItCanGenerateMiddlewareDefinitionViaStaticMethod()
     {
         $signature = (string) ValidateSignature::relative();

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -298,6 +298,17 @@ class UrlSigningTest extends TestCase
         $response->assertStatus(403);
     }
 
+    public function testSignedMiddlewareIgnoringParameterViaClassAndArguments()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+        })->name('foo')->middleware(IgnoreParameterMiddleware::relative('test'));
+
+        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', ['id' => 1, 'ignore' => 'me', 'test' => 'bar'], null, false));
+
+        $response = $this->get('/foo/1');
+        $response->assertStatus(403);
+    }
+
     public function testItCanGenerateMiddlewareDefinitionViaStaticMethod()
     {
         $signature = (string) ValidateSignature::relative();
@@ -350,4 +361,9 @@ class RoutableInterfaceStub implements UrlRoutable
     {
         //
     }
+}
+
+class IgnoreParameterMiddleware extends ValidateSignature
+{
+    protected $ignore = ['ignore'];
 }


### PR DESCRIPTION
## Why

Based on this **[tweet](https://twitter.com/ClaudioDekker/status/1655499868326985728)** from Claudio Dekker. This allows passing properties to the `signed` middleware to ignore properties instead of extending it and adding the keys to the `$ignore` property.

Also, this adds the possibility to pass the ignore parameters to the static methods: `relative` and `absolute`.

## Pros of this implementation

- Make the routes file easier to understand
- Remove a lot of 'custom' Middleware files that individually take up a lot of 'visual' space while providing near-zero real value

## Result

### Middleware

```php
// Before
Route::get('foo')->middleware('signed');
Route::get('embed')->middleware(EmbeddableSignedRoute::class);
Route::get('callback')->middleware(SignedRouteWithCallback::class);
Route::get('relative')->middleware('signed');

// After
Route::get('foo')->middleware('signed');
Route::get('embed')->middleware('signed:embed');
Route::get('callback')->middleware('signed:callback');
Route::get('callback')->middleware('signed:callback');
Route::get('relative')->middleware('signed:relative');
Route::get('relative-embed')->middleware('signed:relative,embed');
```

### Static Methods

```php
ValidateSignature::absolute('foo', 'bar'); // 'Illuminate\Routing\Middleware\ValidateSignature:foo,bar'
ValidateSignature::relative('foo', 'bar'); // 'Illuminate\Routing\Middleware\ValidateSignature:relative,foo,bar'
```