### PR TITLE
[10.x] reconnect when redis throws connection lost error

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -530,7 +530,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return parent::command($method, $parameters);
         } catch (RedisException $e) {
-            foreach (['went away', 'socket', 'read error on connection'] as $errorMessage) {
+            foreach (['went away', 'socket', 'read error on connection', 'Connection lost'] as $errorMessage) {
                 if (str_contains($e->getMessage(), $errorMessage)) {
                     $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
 


### PR DESCRIPTION
reference to issue https://github.com/laravel/framework/issues/41651, and adds a match for 'Connection lost' to trigger a Redis reconnection.