### PR TITLE
[10.x] Allow no-cache headers to return untouched response with bypass option

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -49,6 +49,13 @@ class SetCacheHeaders
             $options = $this->parseOptions($options);
         }
 
+        if (isset($options['bypass'])) {
+            if ($request->isNoCache() && $options['bypass'] === 'no-cache') {
+                return $response;
+            }
+            unset($options['bypass']);
+        }
+
         if (isset($options['etag']) && $options['etag'] === true) {
             $options['etag'] = $response->getEtag() ?? md5($response->getContent());
         }

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -57,6 +57,30 @@ class CacheTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
+    public function testDoNotSetHeaderWhenBypassAndRequestCacheControlNoCache()
+    {
+        $request = new Request;
+        $request->headers->set('Cache-Control', 'no-cache');
+
+        $response = (new Cache)->handle($request, function () {
+            return new Response('Hello Laravel');
+        }, 'max_age=120;s_maxage=60;bypass=no-cache');
+
+        $this->assertNull($response->getMaxAge());
+    }
+
+    public function testDoNotSetHeaderWhenBypassAndRequestPragmaNoCache()
+    {
+        $request = new Request;
+        $request->headers->set('Pragma', 'no-cache');
+
+        $response = (new Cache)->handle($request, function () {
+            return new Response('Hello Laravel');
+        }, 'max_age=120;s_maxage=60;bypass=no-cache');
+
+        $this->assertNull($response->getMaxAge());
+    }
+
     public function testSetHeaderToFileEvenWithNoContent()
     {
         $response = (new Cache)->handle(new Request, function () {
@@ -158,5 +182,38 @@ class CacheTest extends TestCase
         }, "last_modified=$time;");
 
         $this->assertSame($time, $response->getLastModified()->getTimestamp());
+    }
+
+    public function testAddHeadersWhenRequestCacheControlNoCacheWithoutBypass()
+    {
+        $request = new Request;
+        $request->headers->set('Cache-Control', 'no-cache');
+
+        $response = (new Cache)->handle($request, function () {
+            return new Response('Hello Laravel');
+        }, 'max_age=120;s_maxage=60');
+
+        $this->assertNotNull($response->getMaxAge());
+    }
+
+    public function testAddHeadersWhenRequestPragmaNoCacheWithoutBypass()
+    {
+        $request = new Request;
+        $request->headers->set('Pragma', 'no-cache');
+
+        $response = (new Cache)->handle($request, function () {
+            return new Response('Hello Laravel');
+        }, 'max_age=120;s_maxage=60');
+
+        $this->assertNotNull($response->getMaxAge());
+    }
+
+    public function testAddHeadersWhenBypassWithoutRequestNoCache()
+    {
+        $response = (new Cache)->handle(new Request, function () {
+            return new Response('Hello Laravel');
+        }, 'max_age=120;s_maxage=60;bypass=no-cache');
+
+        $this->assertNotNull($response->getMaxAge());
     }
 }


### PR DESCRIPTION
Follow up from #46986

We're trying to find a way to completely bypass cached responses, including not setting any cache headers, by utilizing the `Cache-Control: no-cache` or `Pragma: no-cache` headers.

After reading [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#force_reload) on caching, I realized it might not be preferred behavior to simply return untouched responses when providing any `no-cache` header, so I opted for a `bypass` option which only responds to `no-cache` for now.
This way there are no breaking changes for people who rely on the existing behavior.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
