### PR TITLE
[10.x] HasCasts returning false instead of true

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -864,7 +864,7 @@ trait HasAttributes
             $convertedCastType = 'immutable_custom_datetime';
         } elseif ($this->isDecimalCast($castType)) {
             $convertedCastType = 'decimal';
-        } elseif ($this->isClassInstance($castType)){
+        } elseif ($this->isClassInstance($castType)) {
             $convertedCastType = $castType;
         } else {
             $convertedCastType = trim(strtolower($castType));

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -864,6 +864,8 @@ trait HasAttributes
             $convertedCastType = 'immutable_custom_datetime';
         } elseif ($this->isDecimalCast($castType)) {
             $convertedCastType = 'decimal';
+        } elseif ($this->isClassInstance($castType)){
+            $convertedCastType = $castType;
         } else {
             $convertedCastType = trim(strtolower($castType));
         }
@@ -933,6 +935,17 @@ trait HasAttributes
     protected function isDecimalCast($cast)
     {
         return str_starts_with($cast, 'decimal:');
+    }
+
+    /**
+     * Determine if the cast type is a class-string.
+     *
+     * @param  string  $cast
+     * @return bool
+     */
+    protected function isClassInstance($cast)
+    {
+        return class_exists($cast);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -864,7 +864,7 @@ trait HasAttributes
             $convertedCastType = 'immutable_custom_datetime';
         } elseif ($this->isDecimalCast($castType)) {
             $convertedCastType = 'decimal';
-        } elseif ($this->isClassInstance($castType)) {
+        } elseif (class_exists($castType)) {
             $convertedCastType = $castType;
         } else {
             $convertedCastType = trim(strtolower($castType));
@@ -935,17 +935,6 @@ trait HasAttributes
     protected function isDecimalCast($cast)
     {
         return str_starts_with($cast, 'decimal:');
-    }
-
-    /**
-     * Determine if the cast type is a class-string.
-     *
-     * @param  string  $cast
-     * @return bool
-     */
-    protected function isClassInstance($cast)
-    {
-        return class_exists($cast);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -349,6 +349,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('asEnumArrayObjectAttribute'));
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testHasCastsOnEnumAttribute()
+    {
+        $model = new EloquentModelEnumCastingStub();
+        $this->assertTrue($model->hasCast('enumAttribute' , StringStatus::class));
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
@@ -3051,6 +3060,11 @@ class EloquentModelCastingStub extends Model
     {
         return $date->format('Y-m-d H:i:s');
     }
+}
+
+class EloquentModelEnumCastingStub extends Model
+{
+    protected $casts = ['enumAttribute' => StringStatus::class];
 }
 
 class EloquentModelDynamicHiddenStub extends Model

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -355,7 +355,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testHasCastsOnEnumAttribute()
     {
         $model = new EloquentModelEnumCastingStub();
-        $this->assertTrue($model->hasCast('enumAttribute' , StringStatus::class));
+        $this->assertTrue($model->hasCast('enumAttribute', StringStatus::class));
     }
 
     public function testCleanAttributes()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -343,9 +343,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('asEnumArrayObjectAttribute'));
     }
 
-    /**
-     * @requires PHP >= 8.1
-     */
     public function testHasCastsOnEnumAttribute()
     {
         $model = new EloquentModelEnumCastingStub();


### PR DESCRIPTION
In current casting implementation, when class is used as a cast type, hasCast is returning false, as it is falling back to else in case class-string is given, which in turn trims it & makes it lowercase. That means f.e. App\Enums\StatusEnum becomes app\enums\statusenum, which in hasCasts function is case-sensitive compared with actual class and is therefore returning false instead of true. 

This PR offers a simple fix which checks if provided string is a class instance & if it is, it returns it as is from getCastType function. 

Steps to reproduce:
1. Create model with enum cast
2. Try calling $model->hasCast('enum',Enum::class) -> expected true, false received