### PR TITLE
[10.x] Add Support\Str methods for inserting substrings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -459,9 +459,9 @@ class Str
     /**
      * Insert a substring at a given position in the string.
      *
-     * @param string $subject
-     * @param string $insert
-     * @param int $position
+     * @param  string  $subject
+     * @param  string  $insert
+     * @param  int  $position
      * @return string
      */
     public static function insert($subject, $insert, $position)
@@ -475,9 +475,9 @@ class Str
     /**
      * Insert a substring after the first occurrence of a given value in the string.
      *
-     * @param string $subject
-     * @param string $pattern
-     * @param string $insert
+     * @param  string  $subject
+     * @param  string  $pattern
+     * @param  string  $insert
      * @return string
      */
     public static function insertAfterMatch($subject, $pattern, $insert)
@@ -494,14 +494,14 @@ class Str
     /**
      * Insert a substring after the first occurrence of a given substring in a string.
      *
-     * @param string $subject
-     * @param string $find
-     * @param string $insert
+     * @param  string  $subject
+     * @param  string  $find
+     * @param  string  $insert
      * @return string
      */
     public static function insertAfter($subject, $find, $insert)
     {
-        if (!static::contains($subject, $find)) {
+        if (! static::contains($subject, $find)) {
             return $subject;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -457,6 +457,61 @@ class Str
     }
 
     /**
+     * Insert a substring at a given position in the string.
+     *
+     * @param string $subject
+     * @param string $insert
+     * @param int $position
+     * @return string
+     */
+    public static function insert($subject, $insert, $position)
+    {
+        $start = static::substr($subject, 0, $position);
+        $end = static::substr($subject, $position, static::length($subject));
+
+        return $start.$insert.$end;
+    }
+
+    /**
+     * Insert a substring after the first occurrence of a given value in the string.
+     *
+     * @param string $subject
+     * @param string $pattern
+     * @param string $insert
+     * @return string
+     */
+    public static function insertAfterMatch($subject, $pattern, $insert)
+    {
+        $match = static::match($pattern, $subject);
+
+        if (empty($match)) {
+            return $subject;
+        }
+
+        return static::insert($subject, $insert, strlen($match));
+    }
+
+    /**
+     * Insert a substring after the first occurrence of a given substring in a string.
+     *
+     * @param string $subject
+     * @param string $find
+     * @param string $insert
+     * @return string
+     */
+    public static function insertAfter($subject, $find, $insert)
+    {
+        if (!static::contains($subject, $find)) {
+            return $subject;
+        }
+
+        $before = static::before($subject, $find);
+        $after = static::after($subject, $find);
+
+        return $before.$find.$insert.$after;
+    }
+
+    /**
      * Determine if a given string is a valid ULID.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1119,6 +1119,32 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(strlen(Str::password()) === 32);
     }
+
+    public function testItCanInsertStrings()
+    {
+        $initial = 'HelloWorld';
+        $this->assertSame('HelloWorld', Str::insert($initial, '', 0));
+        $this->assertSame('Hello World', Str::insert($initial, ' ', 5));
+        $this->assertSame('Hello--World', Str::insert($initial, '--', 5));
+    }
+
+    public function testItCanInsertStringsAfterMatch()
+    {
+        $initial = 'HelloWorld';
+        $this->assertSame('HelloWorld', Str::insertAfterMatch($initial, '/(Missing)/', '@@'));
+        $this->assertSame('Hello World', Str::insertAfterMatch($initial, '/(Hello)/', ' '));
+        $this->assertSame('H-elloWorld', Str::insertAfterMatch($initial, '/^(H)/', '-'));
+        $this->assertSame('HelloWorld--', Str::insertAfterMatch($initial, '/(.+World)$/', '--'));
+    }
+
+    public function testItCanInsertStringsAfterASubstring()
+    {
+        $initial = 'HelloWorld';
+        $this->assertSame('HelloWorld', Str::insertAfter($initial, 'Missing', '@@@'));
+        $this->assertSame('Hello World', Str::insertAfter($initial, 'Hello', ' '));
+        $this->assertSame('H-elloWorld', Str::insertAfter($initial, 'H', '-'));
+        $this->assertSame('HelloWorld--', Str::insertAfter($initial, 'World', '--'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
### Summary

This PR adds several helper methods to the `Support\Str` helper class for inserting substrings into a given string.  All methods include full unit tests as well as comment docblocks.

These methods provide an enhanced developer experience as it makes inserting a substring at a particular point within a string trivial and eliminates the need to do any calculations (i.e. position to insert, location of substring to insert after, etc.).

This does not break any features as it only introduces new features and does not modify any existing code.

### Additional Methods

- `insert()` - inserts a string at the specified position in the given string.
- `insertAfterMatch()` - inserts a string after the specified pattern match.
- `insertAfter()` - inserts a string after the specified substring.

### Examples

```php
$new = Str::insert('HelloWorld', '--', 5); //returns 'Hello--World'
$new = Str::insertAfterMatch('HelloWorld', '/(Hello)/', ' '); // returns 'Hello World'
$new = Str::insertAfter('HelloWorld', 'H', '_'); // returns 'H_elloWorld'
```
As far as making building web applications easier - consider the following use case:

```php
// the identifier in the database is UA-1001, but we want to
// allow the user to provide the identifier without a dash for ease of entry:

$providedIdentifier = 'UA1001';
$actualIdentifier = Str::insertAfter($providedIdentifier, 'UA', '-'); 
$userExists = User::where('identifier', $actualIdentifier)->exists();
```

I believe these additional methods will enhance the overall developer experience and provide value to the overall Laravel framework.