### PR TITLE
[10.x] add ability to set broadcast event backoff method

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -60,7 +60,7 @@ class BroadcastEvent implements ShouldQueue
         $this->event = $event;
         $this->tries = property_exists($event, 'tries') ? $event->tries : null;
         $this->timeout = property_exists($event, 'timeout') ? $event->timeout : null;
-        $this->backoff = property_exists($event, 'backoff') ? $event->backoff : null;
+        $this->backoff = method_exists($event, 'backoff') ? $event->backoff() : ($event->backoff ?? null);
         $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
         $this->maxExceptions = property_exists($event, 'maxExceptions') ? $event->maxExceptions : null;
     }


### PR DESCRIPTION
This PR enables setting broadcast event backoff using method

```php
class BroadcastTestEvent implements ShouldBroadcast
{
    use Dispatchable, InteractsWithSockets, SerializesModels;

    public int $tries = 2;
    
    public function backoff()
    {
       return 5;
    }
}
```
