### PR TITLE
[10.x] Prevent missing translations using `Translator::preventMissingTranslations()`

### DIFF
--- a/src/Illuminate/Translation/MissingTranslationViolationException.php
+++ b/src/Illuminate/Translation/MissingTranslationViolationException.php
@@ -6,23 +6,23 @@ use RuntimeException;
 
 class MissingTranslationViolationException extends RuntimeException
 {
-	/**
-	 * The key of the missing translation.
-	 *
-	 * @var string
-	 */
-	public $key;
-	
-	/**
-	 * Create a new exception instance.
-	 *
-	 * @param string $key
-	 * @return static
-	 */
-	public function __construct($key)
-	{
-		parent::__construct("Attempted to retrieve missing translation [{$key}].");
-		
-		$this->key = $key;
-	}
+    /**
+     * The key of the missing translation.
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  string  $key
+     * @return static
+     */
+    public function __construct($key)
+    {
+        parent::__construct("Attempted to retrieve missing translation [{$key}].");
+
+        $this->key = $key;
+    }
 }

--- a/src/Illuminate/Translation/MissingTranslationViolationException.php
+++ b/src/Illuminate/Translation/MissingTranslationViolationException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Translation;
+
+use RuntimeException;
+
+class MissingTranslationViolationException extends RuntimeException
+{
+	/**
+	 * The key of the missing translation.
+	 *
+	 * @var string
+	 */
+	public $key;
+	
+	/**
+	 * Create a new exception instance.
+	 *
+	 * @param string $key
+	 * @return static
+	 */
+	public function __construct($key)
+	{
+		parent::__construct("Attempted to retrieve missing translation [{$key}].");
+		
+		$this->key = $key;
+	}
+}

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -14,473 +14,546 @@ use InvalidArgumentException;
 
 class Translator extends NamespacedItemResolver implements TranslatorContract
 {
-    use Macroable, ReflectsClosures;
-
-    /**
-     * The loader implementation.
-     *
-     * @var \Illuminate\Contracts\Translation\Loader
-     */
-    protected $loader;
-
-    /**
-     * The default locale being used by the translator.
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
-     * The fallback locale used by the translator.
-     *
-     * @var string
-     */
-    protected $fallback;
-
-    /**
-     * The array of loaded translation groups.
-     *
-     * @var array
-     */
-    protected $loaded = [];
-
-    /**
-     * The message selector.
-     *
-     * @var \Illuminate\Translation\MessageSelector
-     */
-    protected $selector;
-
-    /**
-     * The callable that should be invoked to determine applicable locales.
-     *
-     * @var callable
-     */
-    protected $determineLocalesUsing;
-
-    /**
-     * The custom rendering callbacks for stringable objects.
-     *
-     * @var array
-     */
-    protected $stringableHandlers = [];
-
-    /**
-     * Create a new translator instance.
-     *
-     * @param  \Illuminate\Contracts\Translation\Loader  $loader
-     * @param  string  $locale
-     * @return void
-     */
-    public function __construct(Loader $loader, $locale)
-    {
-        $this->loader = $loader;
-
-        $this->setLocale($locale);
-    }
-
-    /**
-     * Determine if a translation exists for a given locale.
-     *
-     * @param  string  $key
-     * @param  string|null  $locale
-     * @return bool
-     */
-    public function hasForLocale($key, $locale = null)
-    {
-        return $this->has($key, $locale, false);
-    }
-
-    /**
-     * Determine if a translation exists.
-     *
-     * @param  string  $key
-     * @param  string|null  $locale
-     * @param  bool  $fallback
-     * @return bool
-     */
-    public function has($key, $locale = null, $fallback = true)
-    {
-        return $this->get($key, [], $locale, $fallback) !== $key;
-    }
-
-    /**
-     * Get the translation for the given key.
-     *
-     * @param  string  $key
-     * @param  array  $replace
-     * @param  string|null  $locale
-     * @param  bool  $fallback
-     * @return string|array
-     */
-    public function get($key, array $replace = [], $locale = null, $fallback = true)
-    {
-        $locale = $locale ?: $this->locale;
-
-        // For JSON translations, there is only one file per locale, so we will simply load
-        // that file and then we will be ready to check the array for the key. These are
-        // only one level deep so we do not need to do any fancy searching through it.
-        $this->load('*', '*', $locale);
-
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
-
-        // If we can't find a translation for the JSON key, we will attempt to translate it
-        // using the typical translation file. This way developers can always just use a
-        // helper such as __ instead of having to pick between trans or __ with views.
-        if (! isset($line)) {
-            [$namespace, $group, $item] = $this->parseKey($key);
-
-            // Here we will get the locale that should be used for the language line. If one
-            // was not passed, we will use the default locales which was given to us when
-            // the translator was instantiated. Then, we can load the lines and return.
-            $locales = $fallback ? $this->localeArray($locale) : [$locale];
-
-            foreach ($locales as $locale) {
-                if (! is_null($line = $this->getLine(
-                    $namespace, $group, $locale, $item, $replace
-                ))) {
-                    return $line;
-                }
-            }
-        }
-
-        // If the line doesn't exist, we will return back the key which was requested as
-        // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
-    }
-
-    /**
-     * Get a translation according to an integer value.
-     *
-     * @param  string  $key
-     * @param  \Countable|int|array  $number
-     * @param  array  $replace
-     * @param  string|null  $locale
-     * @return string
-     */
-    public function choice($key, $number, array $replace = [], $locale = null)
-    {
-        $line = $this->get(
-            $key, $replace, $locale = $this->localeForChoice($locale)
-        );
-
-        // If the given "number" is actually an array or countable we will simply count the
-        // number of elements in an instance. This allows developers to pass an array of
-        // items without having to count it on their end first which gives bad syntax.
-        if (is_countable($number)) {
-            $number = count($number);
-        }
-
-        $replace['count'] = $number;
-
-        return $this->makeReplacements(
-            $this->getSelector()->choose($line, $number, $locale), $replace
-        );
-    }
-
-    /**
-     * Get the proper locale for a choice operation.
-     *
-     * @param  string|null  $locale
-     * @return string
-     */
-    protected function localeForChoice($locale)
-    {
-        return $locale ?: $this->locale ?: $this->fallback;
-    }
-
-    /**
-     * Retrieve a language line out the loaded array.
-     *
-     * @param  string  $namespace
-     * @param  string  $group
-     * @param  string  $locale
-     * @param  string  $item
-     * @param  array  $replace
-     * @return string|array|null
-     */
-    protected function getLine($namespace, $group, $locale, $item, array $replace)
-    {
-        $this->load($namespace, $group, $locale);
-
-        $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
-
-        if (is_string($line)) {
-            return $this->makeReplacements($line, $replace);
-        } elseif (is_array($line) && count($line) > 0) {
-            array_walk_recursive($line, function (&$value, $key) use ($replace) {
-                $value = $this->makeReplacements($value, $replace);
-            });
-
-            return $line;
-        }
-    }
-
-    /**
-     * Make the place-holder replacements on a line.
-     *
-     * @param  string  $line
-     * @param  array  $replace
-     * @return string
-     */
-    protected function makeReplacements($line, array $replace)
-    {
-        if (empty($replace)) {
-            return $line;
-        }
-
-        $shouldReplace = [];
-
-        foreach ($replace as $key => $value) {
-            if (is_object($value) && isset($this->stringableHandlers[get_class($value)])) {
-                $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
-            }
-
-            $shouldReplace[':'.Str::ucfirst($key ?? '')] = Str::ucfirst($value ?? '');
-            $shouldReplace[':'.Str::upper($key ?? '')] = Str::upper($value ?? '');
-            $shouldReplace[':'.$key] = $value;
-        }
-
-        return strtr($line, $shouldReplace);
-    }
-
-    /**
-     * Add translation lines to the given locale.
-     *
-     * @param  array  $lines
-     * @param  string  $locale
-     * @param  string  $namespace
-     * @return void
-     */
-    public function addLines(array $lines, $locale, $namespace = '*')
-    {
-        foreach ($lines as $key => $value) {
-            [$group, $item] = explode('.', $key, 2);
-
-            Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
-        }
-    }
-
-    /**
-     * Load the specified language group.
-     *
-     * @param  string  $namespace
-     * @param  string  $group
-     * @param  string  $locale
-     * @return void
-     */
-    public function load($namespace, $group, $locale)
-    {
-        if ($this->isLoaded($namespace, $group, $locale)) {
-            return;
-        }
-
-        // The loader is responsible for returning the array of language lines for the
-        // given namespace, group, and locale. We'll set the lines in this array of
-        // lines that have already been loaded so that we can easily access them.
-        $lines = $this->loader->load($locale, $group, $namespace);
-
-        $this->loaded[$namespace][$group][$locale] = $lines;
-    }
-
-    /**
-     * Determine if the given group has been loaded.
-     *
-     * @param  string  $namespace
-     * @param  string  $group
-     * @param  string  $locale
-     * @return bool
-     */
-    protected function isLoaded($namespace, $group, $locale)
-    {
-        return isset($this->loaded[$namespace][$group][$locale]);
-    }
-
-    /**
-     * Add a new namespace to the loader.
-     *
-     * @param  string  $namespace
-     * @param  string  $hint
-     * @return void
-     */
-    public function addNamespace($namespace, $hint)
-    {
-        $this->loader->addNamespace($namespace, $hint);
-    }
-
-    /**
-     * Add a new JSON path to the loader.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function addJsonPath($path)
-    {
-        $this->loader->addJsonPath($path);
-    }
-
-    /**
-     * Parse a key into namespace, group, and item.
-     *
-     * @param  string  $key
-     * @return array
-     */
-    public function parseKey($key)
-    {
-        $segments = parent::parseKey($key);
-
-        if (is_null($segments[0])) {
-            $segments[0] = '*';
-        }
-
-        return $segments;
-    }
-
-    /**
-     * Get the array of locales to be checked.
-     *
-     * @param  string|null  $locale
-     * @return array
-     */
-    protected function localeArray($locale)
-    {
-        $locales = array_filter([$locale ?: $this->locale, $this->fallback]);
-
-        return call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
-    }
-
-    /**
-     * Specify a callback that should be invoked to determined the applicable locale array.
-     *
-     * @param  callable  $callback
-     * @return void
-     */
-    public function determineLocalesUsing($callback)
-    {
-        $this->determineLocalesUsing = $callback;
-    }
-
-    /**
-     * Get the message selector instance.
-     *
-     * @return \Illuminate\Translation\MessageSelector
-     */
-    public function getSelector()
-    {
-        if (! isset($this->selector)) {
-            $this->selector = new MessageSelector;
-        }
-
-        return $this->selector;
-    }
-
-    /**
-     * Set the message selector instance.
-     *
-     * @param  \Illuminate\Translation\MessageSelector  $selector
-     * @return void
-     */
-    public function setSelector(MessageSelector $selector)
-    {
-        $this->selector = $selector;
-    }
-
-    /**
-     * Get the language line loader implementation.
-     *
-     * @return \Illuminate\Contracts\Translation\Loader
-     */
-    public function getLoader()
-    {
-        return $this->loader;
-    }
-
-    /**
-     * Get the default locale being used.
-     *
-     * @return string
-     */
-    public function locale()
-    {
-        return $this->getLocale();
-    }
-
-    /**
-     * Get the default locale being used.
-     *
-     * @return string
-     */
-    public function getLocale()
-    {
-        return $this->locale;
-    }
-
-    /**
-     * Set the default locale.
-     *
-     * @param  string  $locale
-     * @return void
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function setLocale($locale)
-    {
-        if (Str::contains($locale, ['/', '\\'])) {
-            throw new InvalidArgumentException('Invalid characters present in locale.');
-        }
-
-        $this->locale = $locale;
-    }
-
-    /**
-     * Get the fallback locale being used.
-     *
-     * @return string
-     */
-    public function getFallback()
-    {
-        return $this->fallback;
-    }
-
-    /**
-     * Set the fallback locale being used.
-     *
-     * @param  string  $fallback
-     * @return void
-     */
-    public function setFallback($fallback)
-    {
-        $this->fallback = $fallback;
-    }
-
-    /**
-     * Set the loaded translation groups.
-     *
-     * @param  array  $loaded
-     * @return void
-     */
-    public function setLoaded(array $loaded)
-    {
-        $this->loaded = $loaded;
-    }
-
-    /**
-     * Add a handler to be executed in order to format a given class to a string during translation replacements.
-     *
-     * @param  callable|string  $class
-     * @param  callable|null  $handler
-     * @return void
-     */
-    public function stringable($class, $handler = null)
-    {
-        if ($class instanceof Closure) {
-            [$class, $handler] = [
-                $this->firstClosureParameterType($class),
-                $class,
-            ];
-        }
-
-        $this->stringableHandlers[$class] = $handler;
-    }
+	use Macroable, ReflectsClosures;
+	
+	/**
+	 * The loader implementation.
+	 *
+	 * @var \Illuminate\Contracts\Translation\Loader
+	 */
+	protected $loader;
+	
+	/**
+	 * The default locale being used by the translator.
+	 *
+	 * @var string
+	 */
+	protected $locale;
+	
+	/**
+	 * The fallback locale used by the translator.
+	 *
+	 * @var string
+	 */
+	protected $fallback;
+	
+	/**
+	 * The array of loaded translation groups.
+	 *
+	 * @var array
+	 */
+	protected $loaded = [];
+	
+	/**
+	 * The message selector.
+	 *
+	 * @var \Illuminate\Translation\MessageSelector
+	 */
+	protected $selector;
+	
+	/**
+	 * The callable that should be invoked to determine applicable locales.
+	 *
+	 * @var callable
+	 */
+	protected $determineLocalesUsing;
+	
+	/**
+	 * The custom rendering callbacks for stringable objects.
+	 *
+	 * @var array
+	 */
+	protected $stringableHandlers = [];
+	
+	/**
+	 * Indicates if an exception should be thrown instead of silently returning the translation key.
+	 *
+	 * @var bool
+	 */
+	protected static $shouldPreventMissingTranslations = false;
+	
+	/**
+	 * The callback that is responsible for handling missing translation violations.
+	 *
+	 * @var callable|null
+	 */
+	protected static $missingTranslationViolationCallback;
+	
+	
+	/**
+	 * Create a new translator instance.
+	 *
+	 * @param \Illuminate\Contracts\Translation\Loader $loader
+	 * @param string $locale
+	 * @return void
+	 */
+	public function __construct(Loader $loader, $locale)
+	{
+		$this->loader = $loader;
+		
+		$this->setLocale($locale);
+	}
+	
+	/**
+	 * Prevent missing translations from being silently returned.
+	 *
+	 * @param bool $value
+	 * @return void
+	 */
+	public static function preventMissingTranslations($value = true)
+	{
+		static::$shouldPreventMissingTranslations = $value;
+	}
+	
+	/**
+	 * Register a callback that is responsible for handling missing translation violations.
+	 *
+	 * @param callable|null $callback
+	 * @return void
+	 */
+	public static function handleMissingTranslationViolationUsing(?callable $callback)
+	{
+		static::$missingTranslationViolationCallback = $callback;
+	}
+	
+	/**
+	 * Determine if missing translations are prevented.
+	 *
+	 * @return bool
+	 */
+	public static function preventsMissingTranslations()
+	{
+		return static::$shouldPreventMissingTranslations;
+	}
+	
+	/**
+	 * Determine if a translation exists for a given locale.
+	 *
+	 * @param string $key
+	 * @param string|null $locale
+	 * @return bool
+	 */
+	public function hasForLocale($key, $locale = null)
+	{
+		return $this->has($key, $locale, false);
+	}
+	
+	/**
+	 * Determine if a translation exists.
+	 *
+	 * @param string $key
+	 * @param string|null $locale
+	 * @param bool $fallback
+	 * @return bool
+	 */
+	public function has($key, $locale = null, $fallback = true)
+	{
+		if ( $preventsMissingTranslations = static::preventsMissingTranslations() ) {
+			static::preventMissingTranslations(false);
+		}
+		
+		return tap($this->get($key, [], $locale, $fallback) !== $key, function () use ($preventsMissingTranslations) {
+			static::preventMissingTranslations($preventsMissingTranslations);
+		});
+	}
+	
+	/**
+	 * Get the translation for the given key.
+	 *
+	 * @param string $key
+	 * @param array $replace
+	 * @param string|null $locale
+	 * @param bool $fallback
+	 * @return string|array
+	 */
+	public function get($key, array $replace = [], $locale = null, $fallback = true)
+	{
+		$locale = $locale ?: $this->locale;
+		
+		// For JSON translations, there is only one file per locale, so we will simply load
+		// that file and then we will be ready to check the array for the key. These are
+		// only one level deep so we do not need to do any fancy searching through it.
+		$this->load('*', '*', $locale);
+		
+		$line = $this->loaded['*']['*'][$locale][$key]??null;
+		
+		// If we can't find a translation for the JSON key, we will attempt to translate it
+		// using the typical translation file. This way developers can always just use a
+		// helper such as __ instead of having to pick between trans or __ with views.
+		if ( !isset($line) ) {
+			[
+				$namespace,
+				$group,
+				$item,
+			] = $this->parseKey($key);
+			
+			// Here we will get the locale that should be used for the language line. If one
+			// was not passed, we will use the default locales which was given to us when
+			// the translator was instantiated. Then, we can load the lines and return.
+			$locales = $fallback ? $this->localeArray($locale) : [$locale];
+			
+			foreach ($locales as $locale) {
+				if ( !is_null($line = $this->getLine($namespace, $group, $locale, $item, $replace)) ) {
+					return $line;
+				}
+			}
+		}
+		
+		// If the line doesn't exist, we will return back the key which was requested as
+		// that will be quick to spot in the UI if language keys are wrong or missing
+		// from the application's language files. Otherwise we can return the line.
+		$line = $this->makeReplacements($line ?: $key, $replace);
+		
+		if ( static::preventsMissingTranslations() ) {
+			if ( static::$missingTranslationViolationCallback ) {
+				call_user_func(static::$missingTranslationViolationCallback, $key);
+			} else {
+				throw new MissingTranslationViolationException($key);
+			}
+		}
+		
+		return $line;
+	}
+	
+	/**
+	 * Get a translation according to an integer value.
+	 *
+	 * @param string $key
+	 * @param \Countable|int|array $number
+	 * @param array $replace
+	 * @param string|null $locale
+	 * @return string
+	 */
+	public function choice($key, $number, array $replace = [], $locale = null)
+	{
+		$line = $this->get($key, $replace, $locale = $this->localeForChoice($locale));
+		
+		// If the given "number" is actually an array or countable we will simply count the
+		// number of elements in an instance. This allows developers to pass an array of
+		// items without having to count it on their end first which gives bad syntax.
+		if ( is_countable($number) ) {
+			$number = count($number);
+		}
+		
+		$replace['count'] = $number;
+		
+		return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
+	}
+	
+	/**
+	 * Get the proper locale for a choice operation.
+	 *
+	 * @param string|null $locale
+	 * @return string
+	 */
+	protected function localeForChoice($locale)
+	{
+		return $locale ?: $this->locale ?: $this->fallback;
+	}
+	
+	/**
+	 * Retrieve a language line out the loaded array.
+	 *
+	 * @param string $namespace
+	 * @param string $group
+	 * @param string $locale
+	 * @param string $item
+	 * @param array $replace
+	 * @return string|array|null
+	 */
+	protected function getLine($namespace, $group, $locale, $item, array $replace)
+	{
+		$this->load($namespace, $group, $locale);
+		
+		$line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
+		
+		if ( is_string($line) ) {
+			return $this->makeReplacements($line, $replace);
+		} elseif ( is_array($line) && count($line) > 0 ) {
+			array_walk_recursive($line, function (&$value, $key) use ($replace) {
+				$value = $this->makeReplacements($value, $replace);
+			});
+			
+			return $line;
+		}
+	}
+	
+	/**
+	 * Make the place-holder replacements on a line.
+	 *
+	 * @param string $line
+	 * @param array $replace
+	 * @return string
+	 */
+	protected function makeReplacements($line, array $replace)
+	{
+		if ( empty($replace) ) {
+			return $line;
+		}
+		
+		$shouldReplace = [];
+		
+		foreach ($replace as $key => $value) {
+			if ( is_object($value) && isset($this->stringableHandlers[get_class($value)]) ) {
+				$value = call_user_func($this->stringableHandlers[get_class($value)], $value);
+			}
+			
+			$shouldReplace[':' . Str::ucfirst($key??'')] = Str::ucfirst($value??'');
+			$shouldReplace[':' . Str::upper($key??'')] = Str::upper($value??'');
+			$shouldReplace[':' . $key] = $value;
+		}
+		
+		return strtr($line, $shouldReplace);
+	}
+	
+	/**
+	 * Add translation lines to the given locale.
+	 *
+	 * @param array $lines
+	 * @param string $locale
+	 * @param string $namespace
+	 * @return void
+	 */
+	public function addLines(array $lines, $locale, $namespace = '*')
+	{
+		foreach ($lines as $key => $value) {
+			[
+				$group,
+				$item,
+			] = explode('.', $key, 2);
+			
+			Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
+		}
+	}
+	
+	/**
+	 * Load the specified language group.
+	 *
+	 * @param string $namespace
+	 * @param string $group
+	 * @param string $locale
+	 * @return void
+	 */
+	public function load($namespace, $group, $locale)
+	{
+		if ( $this->isLoaded($namespace, $group, $locale) ) {
+			return;
+		}
+		
+		// The loader is responsible for returning the array of language lines for the
+		// given namespace, group, and locale. We'll set the lines in this array of
+		// lines that have already been loaded so that we can easily access them.
+		$lines = $this->loader->load($locale, $group, $namespace);
+		
+		$this->loaded[$namespace][$group][$locale] = $lines;
+	}
+	
+	/**
+	 * Determine if the given group has been loaded.
+	 *
+	 * @param string $namespace
+	 * @param string $group
+	 * @param string $locale
+	 * @return bool
+	 */
+	protected function isLoaded($namespace, $group, $locale)
+	{
+		return isset($this->loaded[$namespace][$group][$locale]);
+	}
+	
+	/**
+	 * Add a new namespace to the loader.
+	 *
+	 * @param string $namespace
+	 * @param string $hint
+	 * @return void
+	 */
+	public function addNamespace($namespace, $hint)
+	{
+		$this->loader->addNamespace($namespace, $hint);
+	}
+	
+	/**
+	 * Add a new JSON path to the loader.
+	 *
+	 * @param string $path
+	 * @return void
+	 */
+	public function addJsonPath($path)
+	{
+		$this->loader->addJsonPath($path);
+	}
+	
+	/**
+	 * Parse a key into namespace, group, and item.
+	 *
+	 * @param string $key
+	 * @return array
+	 */
+	public function parseKey($key)
+	{
+		$segments = parent::parseKey($key);
+		
+		if ( is_null($segments[0]) ) {
+			$segments[0] = '*';
+		}
+		
+		return $segments;
+	}
+	
+	/**
+	 * Get the array of locales to be checked.
+	 *
+	 * @param string|null $locale
+	 * @return array
+	 */
+	protected function localeArray($locale)
+	{
+		$locales = array_filter([
+			$locale ?: $this->locale,
+			$this->fallback,
+		]);
+		
+		return call_user_func($this->determineLocalesUsing ?: fn() => $locales, $locales);
+	}
+	
+	/**
+	 * Specify a callback that should be invoked to determined the applicable locale array.
+	 *
+	 * @param callable $callback
+	 * @return void
+	 */
+	public function determineLocalesUsing($callback)
+	{
+		$this->determineLocalesUsing = $callback;
+	}
+	
+	/**
+	 * Get the message selector instance.
+	 *
+	 * @return \Illuminate\Translation\MessageSelector
+	 */
+	public function getSelector()
+	{
+		if ( !isset($this->selector) ) {
+			$this->selector = new MessageSelector;
+		}
+		
+		return $this->selector;
+	}
+	
+	/**
+	 * Set the message selector instance.
+	 *
+	 * @param \Illuminate\Translation\MessageSelector $selector
+	 * @return void
+	 */
+	public function setSelector(MessageSelector $selector)
+	{
+		$this->selector = $selector;
+	}
+	
+	/**
+	 * Get the language line loader implementation.
+	 *
+	 * @return \Illuminate\Contracts\Translation\Loader
+	 */
+	public function getLoader()
+	{
+		return $this->loader;
+	}
+	
+	/**
+	 * Get the default locale being used.
+	 *
+	 * @return string
+	 */
+	public function locale()
+	{
+		return $this->getLocale();
+	}
+	
+	/**
+	 * Get the default locale being used.
+	 *
+	 * @return string
+	 */
+	public function getLocale()
+	{
+		return $this->locale;
+	}
+	
+	/**
+	 * Set the default locale.
+	 *
+	 * @param string $locale
+	 * @return void
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function setLocale($locale)
+	{
+		if ( Str::contains($locale, [
+			'/',
+			'\\',
+		]) ) {
+			throw new InvalidArgumentException('Invalid characters present in locale.');
+		}
+		
+		$this->locale = $locale;
+	}
+	
+	/**
+	 * Get the fallback locale being used.
+	 *
+	 * @return string
+	 */
+	public function getFallback()
+	{
+		return $this->fallback;
+	}
+	
+	/**
+	 * Set the fallback locale being used.
+	 *
+	 * @param string $fallback
+	 * @return void
+	 */
+	public function setFallback($fallback)
+	{
+		$this->fallback = $fallback;
+	}
+	
+	/**
+	 * Set the loaded translation groups.
+	 *
+	 * @param array $loaded
+	 * @return void
+	 */
+	public function setLoaded(array $loaded)
+	{
+		$this->loaded = $loaded;
+	}
+	
+	/**
+	 * Add a handler to be executed in order to format a given class to a string during translation replacements.
+	 *
+	 * @param callable|string $class
+	 * @param callable|null $handler
+	 * @return void
+	 */
+	public function stringable($class, $handler = null)
+	{
+		if ( $class instanceof Closure ) {
+			[
+				$class,
+				$handler,
+			] = [
+				$this->firstClosureParameterType($class),
+				$class,
+			];
+		}
+		
+		$this->stringableHandlers[$class] = $handler;
+	}
 }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -14,546 +14,545 @@ use InvalidArgumentException;
 
 class Translator extends NamespacedItemResolver implements TranslatorContract
 {
-	use Macroable, ReflectsClosures;
-	
-	/**
-	 * The loader implementation.
-	 *
-	 * @var \Illuminate\Contracts\Translation\Loader
-	 */
-	protected $loader;
-	
-	/**
-	 * The default locale being used by the translator.
-	 *
-	 * @var string
-	 */
-	protected $locale;
-	
-	/**
-	 * The fallback locale used by the translator.
-	 *
-	 * @var string
-	 */
-	protected $fallback;
-	
-	/**
-	 * The array of loaded translation groups.
-	 *
-	 * @var array
-	 */
-	protected $loaded = [];
-	
-	/**
-	 * The message selector.
-	 *
-	 * @var \Illuminate\Translation\MessageSelector
-	 */
-	protected $selector;
-	
-	/**
-	 * The callable that should be invoked to determine applicable locales.
-	 *
-	 * @var callable
-	 */
-	protected $determineLocalesUsing;
-	
-	/**
-	 * The custom rendering callbacks for stringable objects.
-	 *
-	 * @var array
-	 */
-	protected $stringableHandlers = [];
-	
-	/**
-	 * Indicates if an exception should be thrown instead of silently returning the translation key.
-	 *
-	 * @var bool
-	 */
-	protected static $shouldPreventMissingTranslations = false;
-	
-	/**
-	 * The callback that is responsible for handling missing translation violations.
-	 *
-	 * @var callable|null
-	 */
-	protected static $missingTranslationViolationCallback;
-	
-	
-	/**
-	 * Create a new translator instance.
-	 *
-	 * @param \Illuminate\Contracts\Translation\Loader $loader
-	 * @param string $locale
-	 * @return void
-	 */
-	public function __construct(Loader $loader, $locale)
-	{
-		$this->loader = $loader;
-		
-		$this->setLocale($locale);
-	}
-	
-	/**
-	 * Prevent missing translations from being silently returned.
-	 *
-	 * @param bool $value
-	 * @return void
-	 */
-	public static function preventMissingTranslations($value = true)
-	{
-		static::$shouldPreventMissingTranslations = $value;
-	}
-	
-	/**
-	 * Register a callback that is responsible for handling missing translation violations.
-	 *
-	 * @param callable|null $callback
-	 * @return void
-	 */
-	public static function handleMissingTranslationViolationUsing(?callable $callback)
-	{
-		static::$missingTranslationViolationCallback = $callback;
-	}
-	
-	/**
-	 * Determine if missing translations are prevented.
-	 *
-	 * @return bool
-	 */
-	public static function preventsMissingTranslations()
-	{
-		return static::$shouldPreventMissingTranslations;
-	}
-	
-	/**
-	 * Determine if a translation exists for a given locale.
-	 *
-	 * @param string $key
-	 * @param string|null $locale
-	 * @return bool
-	 */
-	public function hasForLocale($key, $locale = null)
-	{
-		return $this->has($key, $locale, false);
-	}
-	
-	/**
-	 * Determine if a translation exists.
-	 *
-	 * @param string $key
-	 * @param string|null $locale
-	 * @param bool $fallback
-	 * @return bool
-	 */
-	public function has($key, $locale = null, $fallback = true)
-	{
-		if ( $preventsMissingTranslations = static::preventsMissingTranslations() ) {
-			static::preventMissingTranslations(false);
-		}
-		
-		return tap($this->get($key, [], $locale, $fallback) !== $key, function () use ($preventsMissingTranslations) {
-			static::preventMissingTranslations($preventsMissingTranslations);
-		});
-	}
-	
-	/**
-	 * Get the translation for the given key.
-	 *
-	 * @param string $key
-	 * @param array $replace
-	 * @param string|null $locale
-	 * @param bool $fallback
-	 * @return string|array
-	 */
-	public function get($key, array $replace = [], $locale = null, $fallback = true)
-	{
-		$locale = $locale ?: $this->locale;
-		
-		// For JSON translations, there is only one file per locale, so we will simply load
-		// that file and then we will be ready to check the array for the key. These are
-		// only one level deep so we do not need to do any fancy searching through it.
-		$this->load('*', '*', $locale);
-		
-		$line = $this->loaded['*']['*'][$locale][$key]??null;
-		
-		// If we can't find a translation for the JSON key, we will attempt to translate it
-		// using the typical translation file. This way developers can always just use a
-		// helper such as __ instead of having to pick between trans or __ with views.
-		if ( !isset($line) ) {
-			[
-				$namespace,
-				$group,
-				$item,
-			] = $this->parseKey($key);
-			
-			// Here we will get the locale that should be used for the language line. If one
-			// was not passed, we will use the default locales which was given to us when
-			// the translator was instantiated. Then, we can load the lines and return.
-			$locales = $fallback ? $this->localeArray($locale) : [$locale];
-			
-			foreach ($locales as $locale) {
-				if ( !is_null($line = $this->getLine($namespace, $group, $locale, $item, $replace)) ) {
-					return $line;
-				}
-			}
-		}
-		
-		// If the line doesn't exist, we will return back the key which was requested as
-		// that will be quick to spot in the UI if language keys are wrong or missing
-		// from the application's language files. Otherwise we can return the line.
-		$line = $this->makeReplacements($line ?: $key, $replace);
-		
-		if ( static::preventsMissingTranslations() ) {
-			if ( static::$missingTranslationViolationCallback ) {
-				call_user_func(static::$missingTranslationViolationCallback, $key);
-			} else {
-				throw new MissingTranslationViolationException($key);
-			}
-		}
-		
-		return $line;
-	}
-	
-	/**
-	 * Get a translation according to an integer value.
-	 *
-	 * @param string $key
-	 * @param \Countable|int|array $number
-	 * @param array $replace
-	 * @param string|null $locale
-	 * @return string
-	 */
-	public function choice($key, $number, array $replace = [], $locale = null)
-	{
-		$line = $this->get($key, $replace, $locale = $this->localeForChoice($locale));
-		
-		// If the given "number" is actually an array or countable we will simply count the
-		// number of elements in an instance. This allows developers to pass an array of
-		// items without having to count it on their end first which gives bad syntax.
-		if ( is_countable($number) ) {
-			$number = count($number);
-		}
-		
-		$replace['count'] = $number;
-		
-		return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
-	}
-	
-	/**
-	 * Get the proper locale for a choice operation.
-	 *
-	 * @param string|null $locale
-	 * @return string
-	 */
-	protected function localeForChoice($locale)
-	{
-		return $locale ?: $this->locale ?: $this->fallback;
-	}
-	
-	/**
-	 * Retrieve a language line out the loaded array.
-	 *
-	 * @param string $namespace
-	 * @param string $group
-	 * @param string $locale
-	 * @param string $item
-	 * @param array $replace
-	 * @return string|array|null
-	 */
-	protected function getLine($namespace, $group, $locale, $item, array $replace)
-	{
-		$this->load($namespace, $group, $locale);
-		
-		$line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
-		
-		if ( is_string($line) ) {
-			return $this->makeReplacements($line, $replace);
-		} elseif ( is_array($line) && count($line) > 0 ) {
-			array_walk_recursive($line, function (&$value, $key) use ($replace) {
-				$value = $this->makeReplacements($value, $replace);
-			});
-			
-			return $line;
-		}
-	}
-	
-	/**
-	 * Make the place-holder replacements on a line.
-	 *
-	 * @param string $line
-	 * @param array $replace
-	 * @return string
-	 */
-	protected function makeReplacements($line, array $replace)
-	{
-		if ( empty($replace) ) {
-			return $line;
-		}
-		
-		$shouldReplace = [];
-		
-		foreach ($replace as $key => $value) {
-			if ( is_object($value) && isset($this->stringableHandlers[get_class($value)]) ) {
-				$value = call_user_func($this->stringableHandlers[get_class($value)], $value);
-			}
-			
-			$shouldReplace[':' . Str::ucfirst($key??'')] = Str::ucfirst($value??'');
-			$shouldReplace[':' . Str::upper($key??'')] = Str::upper($value??'');
-			$shouldReplace[':' . $key] = $value;
-		}
-		
-		return strtr($line, $shouldReplace);
-	}
-	
-	/**
-	 * Add translation lines to the given locale.
-	 *
-	 * @param array $lines
-	 * @param string $locale
-	 * @param string $namespace
-	 * @return void
-	 */
-	public function addLines(array $lines, $locale, $namespace = '*')
-	{
-		foreach ($lines as $key => $value) {
-			[
-				$group,
-				$item,
-			] = explode('.', $key, 2);
-			
-			Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
-		}
-	}
-	
-	/**
-	 * Load the specified language group.
-	 *
-	 * @param string $namespace
-	 * @param string $group
-	 * @param string $locale
-	 * @return void
-	 */
-	public function load($namespace, $group, $locale)
-	{
-		if ( $this->isLoaded($namespace, $group, $locale) ) {
-			return;
-		}
-		
-		// The loader is responsible for returning the array of language lines for the
-		// given namespace, group, and locale. We'll set the lines in this array of
-		// lines that have already been loaded so that we can easily access them.
-		$lines = $this->loader->load($locale, $group, $namespace);
-		
-		$this->loaded[$namespace][$group][$locale] = $lines;
-	}
-	
-	/**
-	 * Determine if the given group has been loaded.
-	 *
-	 * @param string $namespace
-	 * @param string $group
-	 * @param string $locale
-	 * @return bool
-	 */
-	protected function isLoaded($namespace, $group, $locale)
-	{
-		return isset($this->loaded[$namespace][$group][$locale]);
-	}
-	
-	/**
-	 * Add a new namespace to the loader.
-	 *
-	 * @param string $namespace
-	 * @param string $hint
-	 * @return void
-	 */
-	public function addNamespace($namespace, $hint)
-	{
-		$this->loader->addNamespace($namespace, $hint);
-	}
-	
-	/**
-	 * Add a new JSON path to the loader.
-	 *
-	 * @param string $path
-	 * @return void
-	 */
-	public function addJsonPath($path)
-	{
-		$this->loader->addJsonPath($path);
-	}
-	
-	/**
-	 * Parse a key into namespace, group, and item.
-	 *
-	 * @param string $key
-	 * @return array
-	 */
-	public function parseKey($key)
-	{
-		$segments = parent::parseKey($key);
-		
-		if ( is_null($segments[0]) ) {
-			$segments[0] = '*';
-		}
-		
-		return $segments;
-	}
-	
-	/**
-	 * Get the array of locales to be checked.
-	 *
-	 * @param string|null $locale
-	 * @return array
-	 */
-	protected function localeArray($locale)
-	{
-		$locales = array_filter([
-			$locale ?: $this->locale,
-			$this->fallback,
-		]);
-		
-		return call_user_func($this->determineLocalesUsing ?: fn() => $locales, $locales);
-	}
-	
-	/**
-	 * Specify a callback that should be invoked to determined the applicable locale array.
-	 *
-	 * @param callable $callback
-	 * @return void
-	 */
-	public function determineLocalesUsing($callback)
-	{
-		$this->determineLocalesUsing = $callback;
-	}
-	
-	/**
-	 * Get the message selector instance.
-	 *
-	 * @return \Illuminate\Translation\MessageSelector
-	 */
-	public function getSelector()
-	{
-		if ( !isset($this->selector) ) {
-			$this->selector = new MessageSelector;
-		}
-		
-		return $this->selector;
-	}
-	
-	/**
-	 * Set the message selector instance.
-	 *
-	 * @param \Illuminate\Translation\MessageSelector $selector
-	 * @return void
-	 */
-	public function setSelector(MessageSelector $selector)
-	{
-		$this->selector = $selector;
-	}
-	
-	/**
-	 * Get the language line loader implementation.
-	 *
-	 * @return \Illuminate\Contracts\Translation\Loader
-	 */
-	public function getLoader()
-	{
-		return $this->loader;
-	}
-	
-	/**
-	 * Get the default locale being used.
-	 *
-	 * @return string
-	 */
-	public function locale()
-	{
-		return $this->getLocale();
-	}
-	
-	/**
-	 * Get the default locale being used.
-	 *
-	 * @return string
-	 */
-	public function getLocale()
-	{
-		return $this->locale;
-	}
-	
-	/**
-	 * Set the default locale.
-	 *
-	 * @param string $locale
-	 * @return void
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	public function setLocale($locale)
-	{
-		if ( Str::contains($locale, [
-			'/',
-			'\\',
-		]) ) {
-			throw new InvalidArgumentException('Invalid characters present in locale.');
-		}
-		
-		$this->locale = $locale;
-	}
-	
-	/**
-	 * Get the fallback locale being used.
-	 *
-	 * @return string
-	 */
-	public function getFallback()
-	{
-		return $this->fallback;
-	}
-	
-	/**
-	 * Set the fallback locale being used.
-	 *
-	 * @param string $fallback
-	 * @return void
-	 */
-	public function setFallback($fallback)
-	{
-		$this->fallback = $fallback;
-	}
-	
-	/**
-	 * Set the loaded translation groups.
-	 *
-	 * @param array $loaded
-	 * @return void
-	 */
-	public function setLoaded(array $loaded)
-	{
-		$this->loaded = $loaded;
-	}
-	
-	/**
-	 * Add a handler to be executed in order to format a given class to a string during translation replacements.
-	 *
-	 * @param callable|string $class
-	 * @param callable|null $handler
-	 * @return void
-	 */
-	public function stringable($class, $handler = null)
-	{
-		if ( $class instanceof Closure ) {
-			[
-				$class,
-				$handler,
-			] = [
-				$this->firstClosureParameterType($class),
-				$class,
-			];
-		}
-		
-		$this->stringableHandlers[$class] = $handler;
-	}
+    use Macroable, ReflectsClosures;
+
+    /**
+     * The loader implementation.
+     *
+     * @var \Illuminate\Contracts\Translation\Loader
+     */
+    protected $loader;
+
+    /**
+     * The default locale being used by the translator.
+     *
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * The fallback locale used by the translator.
+     *
+     * @var string
+     */
+    protected $fallback;
+
+    /**
+     * The array of loaded translation groups.
+     *
+     * @var array
+     */
+    protected $loaded = [];
+
+    /**
+     * The message selector.
+     *
+     * @var \Illuminate\Translation\MessageSelector
+     */
+    protected $selector;
+
+    /**
+     * The callable that should be invoked to determine applicable locales.
+     *
+     * @var callable
+     */
+    protected $determineLocalesUsing;
+
+    /**
+     * The custom rendering callbacks for stringable objects.
+     *
+     * @var array
+     */
+    protected $stringableHandlers = [];
+
+    /**
+     * Indicates if an exception should be thrown instead of silently returning the translation key.
+     *
+     * @var bool
+     */
+    protected static $shouldPreventMissingTranslations = false;
+
+    /**
+     * The callback that is responsible for handling missing translation violations.
+     *
+     * @var callable|null
+     */
+    protected static $missingTranslationViolationCallback;
+
+    /**
+     * Create a new translator instance.
+     *
+     * @param  \Illuminate\Contracts\Translation\Loader  $loader
+     * @param  string  $locale
+     * @return void
+     */
+    public function __construct(Loader $loader, $locale)
+    {
+        $this->loader = $loader;
+
+        $this->setLocale($locale);
+    }
+
+    /**
+     * Prevent missing translations from being silently returned.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventMissingTranslations($value = true)
+    {
+        static::$shouldPreventMissingTranslations = $value;
+    }
+
+    /**
+     * Register a callback that is responsible for handling missing translation violations.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public static function handleMissingTranslationViolationUsing(?callable $callback)
+    {
+        static::$missingTranslationViolationCallback = $callback;
+    }
+
+    /**
+     * Determine if missing translations are prevented.
+     *
+     * @return bool
+     */
+    public static function preventsMissingTranslations()
+    {
+        return static::$shouldPreventMissingTranslations;
+    }
+
+    /**
+     * Determine if a translation exists for a given locale.
+     *
+     * @param  string  $key
+     * @param  string|null  $locale
+     * @return bool
+     */
+    public function hasForLocale($key, $locale = null)
+    {
+        return $this->has($key, $locale, false);
+    }
+
+    /**
+     * Determine if a translation exists.
+     *
+     * @param  string  $key
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return bool
+     */
+    public function has($key, $locale = null, $fallback = true)
+    {
+        if ($preventsMissingTranslations = static::preventsMissingTranslations()) {
+            static::preventMissingTranslations(false);
+        }
+
+        return tap($this->get($key, [], $locale, $fallback) !== $key, function () use ($preventsMissingTranslations) {
+            static::preventMissingTranslations($preventsMissingTranslations);
+        });
+    }
+
+    /**
+     * Get the translation for the given key.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return string|array
+     */
+    public function get($key, array $replace = [], $locale = null, $fallback = true)
+    {
+        $locale = $locale ?: $this->locale;
+
+        // For JSON translations, there is only one file per locale, so we will simply load
+        // that file and then we will be ready to check the array for the key. These are
+        // only one level deep so we do not need to do any fancy searching through it.
+        $this->load('*', '*', $locale);
+
+        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+
+        // If we can't find a translation for the JSON key, we will attempt to translate it
+        // using the typical translation file. This way developers can always just use a
+        // helper such as __ instead of having to pick between trans or __ with views.
+        if (! isset($line)) {
+            [
+                $namespace,
+                $group,
+                $item,
+            ] = $this->parseKey($key);
+
+            // Here we will get the locale that should be used for the language line. If one
+            // was not passed, we will use the default locales which was given to us when
+            // the translator was instantiated. Then, we can load the lines and return.
+            $locales = $fallback ? $this->localeArray($locale) : [$locale];
+
+            foreach ($locales as $locale) {
+                if (! is_null($line = $this->getLine($namespace, $group, $locale, $item, $replace))) {
+                    return $line;
+                }
+            }
+        }
+
+        // If the line doesn't exist, we will return back the key which was requested as
+        // that will be quick to spot in the UI if language keys are wrong or missing
+        // from the application's language files. Otherwise we can return the line.
+        $line = $this->makeReplacements($line ?: $key, $replace);
+
+        if (static::preventsMissingTranslations()) {
+            if (static::$missingTranslationViolationCallback) {
+                call_user_func(static::$missingTranslationViolationCallback, $key);
+            } else {
+                throw new MissingTranslationViolationException($key);
+            }
+        }
+
+        return $line;
+    }
+
+    /**
+     * Get a translation according to an integer value.
+     *
+     * @param  string  $key
+     * @param  \Countable|int|array  $number
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @return string
+     */
+    public function choice($key, $number, array $replace = [], $locale = null)
+    {
+        $line = $this->get($key, $replace, $locale = $this->localeForChoice($locale));
+
+        // If the given "number" is actually an array or countable we will simply count the
+        // number of elements in an instance. This allows developers to pass an array of
+        // items without having to count it on their end first which gives bad syntax.
+        if (is_countable($number)) {
+            $number = count($number);
+        }
+
+        $replace['count'] = $number;
+
+        return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
+    }
+
+    /**
+     * Get the proper locale for a choice operation.
+     *
+     * @param  string|null  $locale
+     * @return string
+     */
+    protected function localeForChoice($locale)
+    {
+        return $locale ?: $this->locale ?: $this->fallback;
+    }
+
+    /**
+     * Retrieve a language line out the loaded array.
+     *
+     * @param  string  $namespace
+     * @param  string  $group
+     * @param  string  $locale
+     * @param  string  $item
+     * @param  array  $replace
+     * @return string|array|null
+     */
+    protected function getLine($namespace, $group, $locale, $item, array $replace)
+    {
+        $this->load($namespace, $group, $locale);
+
+        $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
+
+        if (is_string($line)) {
+            return $this->makeReplacements($line, $replace);
+        } elseif (is_array($line) && count($line) > 0) {
+            array_walk_recursive($line, function (&$value, $key) use ($replace) {
+                $value = $this->makeReplacements($value, $replace);
+            });
+
+            return $line;
+        }
+    }
+
+    /**
+     * Make the place-holder replacements on a line.
+     *
+     * @param  string  $line
+     * @param  array  $replace
+     * @return string
+     */
+    protected function makeReplacements($line, array $replace)
+    {
+        if (empty($replace)) {
+            return $line;
+        }
+
+        $shouldReplace = [];
+
+        foreach ($replace as $key => $value) {
+            if (is_object($value) && isset($this->stringableHandlers[get_class($value)])) {
+                $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
+            }
+
+            $shouldReplace[':'.Str::ucfirst($key ?? '')] = Str::ucfirst($value ?? '');
+            $shouldReplace[':'.Str::upper($key ?? '')] = Str::upper($value ?? '');
+            $shouldReplace[':'.$key] = $value;
+        }
+
+        return strtr($line, $shouldReplace);
+    }
+
+    /**
+     * Add translation lines to the given locale.
+     *
+     * @param  array  $lines
+     * @param  string  $locale
+     * @param  string  $namespace
+     * @return void
+     */
+    public function addLines(array $lines, $locale, $namespace = '*')
+    {
+        foreach ($lines as $key => $value) {
+            [
+                $group,
+                $item,
+            ] = explode('.', $key, 2);
+
+            Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
+        }
+    }
+
+    /**
+     * Load the specified language group.
+     *
+     * @param  string  $namespace
+     * @param  string  $group
+     * @param  string  $locale
+     * @return void
+     */
+    public function load($namespace, $group, $locale)
+    {
+        if ($this->isLoaded($namespace, $group, $locale)) {
+            return;
+        }
+
+        // The loader is responsible for returning the array of language lines for the
+        // given namespace, group, and locale. We'll set the lines in this array of
+        // lines that have already been loaded so that we can easily access them.
+        $lines = $this->loader->load($locale, $group, $namespace);
+
+        $this->loaded[$namespace][$group][$locale] = $lines;
+    }
+
+    /**
+     * Determine if the given group has been loaded.
+     *
+     * @param  string  $namespace
+     * @param  string  $group
+     * @param  string  $locale
+     * @return bool
+     */
+    protected function isLoaded($namespace, $group, $locale)
+    {
+        return isset($this->loaded[$namespace][$group][$locale]);
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $namespace
+     * @param  string  $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint)
+    {
+        $this->loader->addNamespace($namespace, $hint);
+    }
+
+    /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJsonPath($path)
+    {
+        $this->loader->addJsonPath($path);
+    }
+
+    /**
+     * Parse a key into namespace, group, and item.
+     *
+     * @param  string  $key
+     * @return array
+     */
+    public function parseKey($key)
+    {
+        $segments = parent::parseKey($key);
+
+        if (is_null($segments[0])) {
+            $segments[0] = '*';
+        }
+
+        return $segments;
+    }
+
+    /**
+     * Get the array of locales to be checked.
+     *
+     * @param  string|null  $locale
+     * @return array
+     */
+    protected function localeArray($locale)
+    {
+        $locales = array_filter([
+            $locale ?: $this->locale,
+            $this->fallback,
+        ]);
+
+        return call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+    }
+
+    /**
+     * Specify a callback that should be invoked to determined the applicable locale array.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public function determineLocalesUsing($callback)
+    {
+        $this->determineLocalesUsing = $callback;
+    }
+
+    /**
+     * Get the message selector instance.
+     *
+     * @return \Illuminate\Translation\MessageSelector
+     */
+    public function getSelector()
+    {
+        if (! isset($this->selector)) {
+            $this->selector = new MessageSelector;
+        }
+
+        return $this->selector;
+    }
+
+    /**
+     * Set the message selector instance.
+     *
+     * @param  \Illuminate\Translation\MessageSelector  $selector
+     * @return void
+     */
+    public function setSelector(MessageSelector $selector)
+    {
+        $this->selector = $selector;
+    }
+
+    /**
+     * Get the language line loader implementation.
+     *
+     * @return \Illuminate\Contracts\Translation\Loader
+     */
+    public function getLoader()
+    {
+        return $this->loader;
+    }
+
+    /**
+     * Get the default locale being used.
+     *
+     * @return string
+     */
+    public function locale()
+    {
+        return $this->getLocale();
+    }
+
+    /**
+     * Get the default locale being used.
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * Set the default locale.
+     *
+     * @param  string  $locale
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setLocale($locale)
+    {
+        if (Str::contains($locale, [
+            '/',
+            '\\',
+        ])) {
+            throw new InvalidArgumentException('Invalid characters present in locale.');
+        }
+
+        $this->locale = $locale;
+    }
+
+    /**
+     * Get the fallback locale being used.
+     *
+     * @return string
+     */
+    public function getFallback()
+    {
+        return $this->fallback;
+    }
+
+    /**
+     * Set the fallback locale being used.
+     *
+     * @param  string  $fallback
+     * @return void
+     */
+    public function setFallback($fallback)
+    {
+        $this->fallback = $fallback;
+    }
+
+    /**
+     * Set the loaded translation groups.
+     *
+     * @param  array  $loaded
+     * @return void
+     */
+    public function setLoaded(array $loaded)
+    {
+        $this->loaded = $loaded;
+    }
+
+    /**
+     * Add a handler to be executed in order to format a given class to a string during translation replacements.
+     *
+     * @param  callable|string  $class
+     * @param  callable|null  $handler
+     * @return void
+     */
+    public function stringable($class, $handler = null)
+    {
+        if ($class instanceof Closure) {
+            [
+                $class,
+                $handler,
+            ] = [
+                $this->firstClosureParameterType($class),
+                $class,
+            ];
+        }
+
+        $this->stringableHandlers[$class] = $handler;
+    }
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -6,263 +6,389 @@ use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Translation\MessageSelector;
+use Illuminate\Translation\MissingTranslationViolationException;
 use Illuminate\Translation\Translator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class TranslationTranslatorTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
-    public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
-    {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
-        $this->assertFalse($t->has('foo', 'bar'));
-
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
-        $this->assertTrue($t->has('foo', 'bar'));
-
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
-        $this->assertTrue($t->hasForLocale('foo', 'bar'));
-
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
-        $this->assertFalse($t->hasForLocale('foo', 'bar'));
-
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
-        $this->assertTrue($t->hasForLocale('foo'));
-
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
-        $this->assertFalse($t->hasForLocale('foo'));
-    }
-
-    public function testGetMethodProperlyLoadsAndRetrievesItem()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
-        $this->assertEquals(['tree bar', 'breeze bar'], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
-        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
-    }
-
-    public function testGetMethodProperlyLoadsAndRetrievesArrayItem()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo', 'beep' => ['rock' => 'tree :foo']]]);
-        $this->assertEquals(['foo' => 'foo', 'baz' => 'breeze bar', 'qux' => ['tree bar', 'breeze bar', 'beep' => ['rock' => 'tree bar']]], $t->get('foo::bar', ['foo' => 'bar'], 'en'));
-        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
-    }
-
-    public function testGetMethodForNonExistingReturnsSameKey()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
-        $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-    }
-
-    public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze <p>test</p>']);
-        $this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
-    }
-
-    public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
-    {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :0 :Foo :BAR']);
-        $this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', ['john', 'foo' => 'bar', 'bar' => 'foo'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
-    }
-
-    public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
-        $this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
-        $this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
-    }
-
-    public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->setFallback('lv');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
-        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
-    }
-
-    public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
-        $this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
-    }
-
-    public function testChoiceMethodProperlyLoadsAndRetrievesItem()
-    {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
-        $t->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
-
-        $t->choice('foo', 10, ['replace']);
-    }
-
-    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
-    {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
-        $t->setSelector($selector = m::mock(MessageSelector::class));
-        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
-
-        $values = ['foo', 'bar', 'baz'];
-        $t->choice('foo', $values, ['replace']);
-
-        $values = new Collection(['foo', 'bar', 'baz']);
-        $t->choice('foo', $values, ['replace']);
-    }
-
-    public function testGetJson()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
-        $this->assertSame('one', $t->get('foo'));
-    }
-
-    public function testGetJsonReplaces()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
-        $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
-    }
-
-    public function testGetJsonHasAtomicReplacements()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['Hello :foo!' => 'Hello :foo!']);
-        $this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
-    }
-
-    public function testGetJsonReplacesForAssociativeInput()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
-        $this->assertSame('bar eye see', $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
-    }
-
-    public function testGetJsonPreservesOrder()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
-        $this->assertSame('Greetings David', $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
-    }
-
-    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
-        $this->assertSame('one', $t->get('foo.bar'));
-    }
-
-    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
-        $this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
-    }
-
-    public function testGetJsonForNonExistingReturnsSameKey()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
-        $this->assertSame('Foo that bar', $t->get('Foo that bar'));
-    }
-
-    public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
-    }
-
-    public function testEmptyFallbacks()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-        $this->assertSame('foo ', $t->get('foo :message', ['message' => null]));
-    }
-
-    public function testGetJsonReplacesWithStringable()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()
-            ->shouldReceive('load')
-            ->once()
-            ->with('en', '*', '*')
-            ->andReturn(['test' => 'the date is :date']);
-
-        $date = Carbon::createFromTimestamp(0);
-
-        $this->assertSame(
-            'the date is 1970-01-01 00:00:00',
-            $t->get('test', ['date' => $date])
-        );
-
-        $t->stringable(function (\Illuminate\Support\Carbon $carbon) {
-            return $carbon->format('jS M Y');
-        });
-        $this->assertSame(
-            'the date is 1st Jan 1970',
-            $t->get('test', ['date' => $date])
-        );
-    }
-
-    public function testDetermineLocalesUsingMethod()
-    {
-        $t = new Translator($this->getLoader(), 'en');
-        $t->determineLocalesUsing(function ($locales) {
-            $this->assertSame(['en'], $locales);
-
-            return ['en', 'lz'];
-        });
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('lz', 'foo', '*')->andReturn([]);
-        $this->assertSame('foo', $t->get('foo'));
-    }
-
-    protected function getLoader()
-    {
-        return m::mock(Loader::class);
-    }
+	protected function tearDown(): void
+	{
+		m::close();
+	}
+	
+	public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
+	{
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+		])->getMock();
+		$t->expects($this->once())->method('get')
+			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
+		$this->assertFalse($t->has('foo', 'bar'));
+		
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+			'sp',
+		])->getMock();
+		$t->expects($this->once())->method('get')
+			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
+		$this->assertTrue($t->has('foo', 'bar'));
+		
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+		])->getMock();
+		$t->expects($this->once())->method('get')
+			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
+		$this->assertTrue($t->hasForLocale('foo', 'bar'));
+		
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+		])->getMock();
+		$t->expects($this->once())->method('get')
+			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
+		$this->assertFalse($t->hasForLocale('foo', 'bar'));
+		
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
+		$this->assertTrue($t->hasForLocale('foo'));
+		
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+		$this->assertFalse($t->hasForLocale('foo'));
+	}
+	
+	public function testGetMethodProperlyLoadsAndRetrievesItem()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
+			'foo' => 'foo',
+			'baz' => 'breeze :foo',
+			'qux' => [
+				'tree :foo',
+				'breeze :foo',
+			],
+		]);
+		$this->assertEquals([
+			'tree bar',
+			'breeze bar',
+		], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
+		$this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+		$this->assertSame('foo', $t->get('foo::bar.foo'));
+	}
+	
+	public function testGetMethodProperlyLoadsAndRetrievesArrayItem()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
+			'foo' => 'foo',
+			'baz' => 'breeze :foo',
+			'qux' => [
+				'tree :foo',
+				'breeze :foo',
+				'beep' => ['rock' => 'tree :foo'],
+			],
+		]);
+		$this->assertEquals([
+			'foo' => 'foo',
+			'baz' => 'breeze bar',
+			'qux' => [
+				'tree bar',
+				'breeze bar',
+				'beep' => ['rock' => 'tree bar'],
+			],
+		], $t->get('foo::bar', ['foo' => 'bar'], 'en'));
+		$this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+		$this->assertSame('foo', $t->get('foo::bar.foo'));
+	}
+	
+	public function testGetMethodForNonExistingReturnsSameKey()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
+			'foo' => 'foo',
+			'baz' => 'breeze :foo',
+			'qux' => [
+				'tree :foo',
+				'breeze :foo',
+			],
+		]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
+		$this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
+		$this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
+		$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+		
+		Translator::preventMissingTranslations(true);
+		
+		try {
+			$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+			
+			$this->fail('Expected exception was not thrown');
+		} catch (MissingTranslationViolationException $e) {
+			$this->assertSame('Attempted to retrieve missing translation [foo::unknown.bar].', $e->getMessage());
+		}
+		
+		Translator::preventMissingTranslations(false);
+		
+		$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+		
+		$callbackKey = null;
+		
+		Translator::preventMissingTranslations();
+		
+		Translator::handleMissingTranslationViolationUsing(function (string $key) use (&$callbackKey) {
+			$callbackKey = $key;
+		});
+		
+		$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+		
+		$this->assertSame('foo::unknown.bar', $callbackKey);
+	}
+	
+	public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')
+			->andReturn(['bar' => 'breeze <p>test</p>']);
+		$this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
+	}
+	
+	public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
+	{
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+		])->getMock();
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
+			'foo' => 'foo',
+			'baz' => 'breeze :0 :Foo :BAR',
+		]);
+		$this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', [
+			'john',
+			'foo' => 'bar',
+			'bar' => 'foo',
+		], 'en'));
+		$this->assertSame('foo', $t->get('foo::bar.foo'));
+	}
+	
+	public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
+			'foo' => 'foo',
+			'baz' => 'breeze :foo :foobar',
+		]);
+		$this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', [
+			'foo' => 'bar',
+			'foobar' => 'taylor',
+		], 'en'));
+		$this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', [
+			'foo' => 'foo bar baz',
+			'foobar' => 'taylor',
+		], 'en'));
+		$this->assertSame('foo', $t->get('foo::bar.foo'));
+	}
+	
+	public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->setFallback('lv');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn([
+			'foo' => 'foo',
+			'baz' => 'breeze :foo',
+		]);
+		$this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+		$this->assertSame('foo', $t->get('foo::bar.foo'));
+	}
+	
+	public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
+		$this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
+	}
+	
+	public function testChoiceMethodProperlyLoadsAndRetrievesItem()
+	{
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+		])->getMock();
+		$t->expects($this->once())->method('get')
+			->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+		$t->setSelector($selector = m::mock(MessageSelector::class));
+		$selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
+		
+		$t->choice('foo', 10, ['replace']);
+	}
+	
+	public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
+	{
+		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
+			$this->getLoader(),
+			'en',
+		])->getMock();
+		$t->expects($this->exactly(2))->method('get')
+			->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+		$t->setSelector($selector = m::mock(MessageSelector::class));
+		$selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
+		
+		$values = [
+			'foo',
+			'bar',
+			'baz',
+		];
+		$t->choice('foo', $values, ['replace']);
+		
+		$values = new Collection([
+			'foo',
+			'bar',
+			'baz',
+		]);
+		$t->choice('foo', $values, ['replace']);
+	}
+	
+	public function testGetJson()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
+		$this->assertSame('one', $t->get('foo'));
+	}
+	
+	public function testGetJsonReplaces()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
+			->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+		$this->assertSame('bar onetwo three', $t->get('foo :i:c :u', [
+			'i' => 'one',
+			'c' => 'two',
+			'u' => 'three',
+		]));
+	}
+	
+	public function testGetJsonHasAtomicReplacements()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
+			->andReturn(['Hello :foo!' => 'Hello :foo!']);
+		$this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', [
+			'foo' => 'baz:bar',
+			'bar' => 'abcdef',
+		]));
+	}
+	
+	public function testGetJsonReplacesForAssociativeInput()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
+		$this->assertSame('bar eye see', $t->get('foo :i :c', [
+			'i' => 'eye',
+			'c' => 'see',
+		]));
+	}
+	
+	public function testGetJsonPreservesOrder()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
+			->andReturn(['to :name I give :greeting' => ':greeting :name']);
+		$this->assertSame('Greetings David', $t->get('to :name I give :greeting', [
+			'name' => 'David',
+			'greeting' => 'Greetings',
+		]));
+	}
+	
+	public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
+		$this->assertSame('one', $t->get('foo.bar'));
+	}
+	
+	public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
+		$this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
+	}
+	
+	public function testGetJsonForNonExistingReturnsSameKey()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
+		$this->assertSame('Foo that bar', $t->get('Foo that bar'));
+	}
+	
+	public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+		$this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
+	}
+	
+	public function testEmptyFallbacks()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+		$this->assertSame('foo ', $t->get('foo :message', ['message' => null]));
+	}
+	
+	public function testGetJsonReplacesWithStringable()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
+			->andReturn(['test' => 'the date is :date']);
+		
+		$date = Carbon::createFromTimestamp(0);
+		
+		$this->assertSame('the date is 1970-01-01 00:00:00', $t->get('test', ['date' => $date]));
+		
+		$t->stringable(function (\Illuminate\Support\Carbon $carbon) {
+			return $carbon->format('jS M Y');
+		});
+		$this->assertSame('the date is 1st Jan 1970', $t->get('test', ['date' => $date]));
+	}
+	
+	public function testDetermineLocalesUsingMethod()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		$t->determineLocalesUsing(function ($locales) {
+			$this->assertSame(['en'], $locales);
+			
+			return [
+				'en',
+				'lz',
+			];
+		});
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('lz', 'foo', '*')->andReturn([]);
+		$this->assertSame('foo', $t->get('foo'));
+	}
+	
+	protected function getLoader()
+	{
+		return m::mock(Loader::class);
+	}
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -15,6 +15,10 @@ class TranslationTranslatorTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+	    
+Translator::handleMissingTranslationViolationUsing(function (string $key): void {
+    report("Missing translation detected for key [{$key}].");
+});
     }
 
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
@@ -75,32 +79,32 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-	    
-	    Translator::preventMissingTranslations(true);
-	    
-	    try {
-		    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-		    
-		    $this->fail('Expected exception was not thrown');
-	    } catch (MissingTranslationViolationException $e) {
-		    $this->assertSame('Attempted to retrieve missing translation [foo::unknown.bar].', $e->getMessage());
-	    }
-	    
-	    Translator::preventMissingTranslations(false);
-	    
-	    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-	    
-	    $callbackKey = null;
-	    
-	    Translator::preventMissingTranslations();
-	    
-	    Translator::handleMissingTranslationViolationUsing(function (string $key) use (&$callbackKey) {
-		    $callbackKey = $key;
-	    });
-	    
-	    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-	    
-	    $this->assertSame('foo::unknown.bar', $callbackKey);
+
+        Translator::preventMissingTranslations(true);
+
+        try {
+            $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+
+            $this->fail('Expected exception was not thrown');
+        } catch (MissingTranslationViolationException $e) {
+            $this->assertSame('Attempted to retrieve missing translation [foo::unknown.bar].', $e->getMessage());
+        }
+
+        Translator::preventMissingTranslations(false);
+
+        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+
+        $callbackKey = null;
+
+        Translator::preventMissingTranslations();
+
+        Translator::handleMissingTranslationViolationUsing(function (string $key) use (&$callbackKey) {
+            $callbackKey = $key;
+        });
+
+        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+
+        $this->assertSame('foo::unknown.bar', $callbackKey);
     }
 
     public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -6,389 +6,289 @@ use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Translation\MessageSelector;
-use Illuminate\Translation\MissingTranslationViolationException;
 use Illuminate\Translation\Translator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class TranslationTranslatorTest extends TestCase
 {
-	protected function tearDown(): void
-	{
-		m::close();
-	}
-	
-	public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
-	{
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-		])->getMock();
-		$t->expects($this->once())->method('get')
-			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
-		$this->assertFalse($t->has('foo', 'bar'));
-		
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-			'sp',
-		])->getMock();
-		$t->expects($this->once())->method('get')
-			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
-		$this->assertTrue($t->has('foo', 'bar'));
-		
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-		])->getMock();
-		$t->expects($this->once())->method('get')
-			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
-		$this->assertTrue($t->hasForLocale('foo', 'bar'));
-		
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-		])->getMock();
-		$t->expects($this->once())->method('get')
-			->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
-		$this->assertFalse($t->hasForLocale('foo', 'bar'));
-		
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
-		$this->assertTrue($t->hasForLocale('foo'));
-		
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
-		$this->assertFalse($t->hasForLocale('foo'));
-	}
-	
-	public function testGetMethodProperlyLoadsAndRetrievesItem()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
-			'foo' => 'foo',
-			'baz' => 'breeze :foo',
-			'qux' => [
-				'tree :foo',
-				'breeze :foo',
-			],
-		]);
-		$this->assertEquals([
-			'tree bar',
-			'breeze bar',
-		], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
-		$this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-		$this->assertSame('foo', $t->get('foo::bar.foo'));
-	}
-	
-	public function testGetMethodProperlyLoadsAndRetrievesArrayItem()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
-			'foo' => 'foo',
-			'baz' => 'breeze :foo',
-			'qux' => [
-				'tree :foo',
-				'breeze :foo',
-				'beep' => ['rock' => 'tree :foo'],
-			],
-		]);
-		$this->assertEquals([
-			'foo' => 'foo',
-			'baz' => 'breeze bar',
-			'qux' => [
-				'tree bar',
-				'breeze bar',
-				'beep' => ['rock' => 'tree bar'],
-			],
-		], $t->get('foo::bar', ['foo' => 'bar'], 'en'));
-		$this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-		$this->assertSame('foo', $t->get('foo::bar.foo'));
-	}
-	
-	public function testGetMethodForNonExistingReturnsSameKey()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
-			'foo' => 'foo',
-			'baz' => 'breeze :foo',
-			'qux' => [
-				'tree :foo',
-				'breeze :foo',
-			],
-		]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
-		$this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
-		$this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
-		$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-		
-		Translator::preventMissingTranslations(true);
-		
-		try {
-			$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-			
-			$this->fail('Expected exception was not thrown');
-		} catch (MissingTranslationViolationException $e) {
-			$this->assertSame('Attempted to retrieve missing translation [foo::unknown.bar].', $e->getMessage());
-		}
-		
-		Translator::preventMissingTranslations(false);
-		
-		$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-		
-		$callbackKey = null;
-		
-		Translator::preventMissingTranslations();
-		
-		Translator::handleMissingTranslationViolationUsing(function (string $key) use (&$callbackKey) {
-			$callbackKey = $key;
-		});
-		
-		$this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-		
-		$this->assertSame('foo::unknown.bar', $callbackKey);
-	}
-	
-	public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')
-			->andReturn(['bar' => 'breeze <p>test</p>']);
-		$this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
-	}
-	
-	public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
-	{
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-		])->getMock();
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
-			'foo' => 'foo',
-			'baz' => 'breeze :0 :Foo :BAR',
-		]);
-		$this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', [
-			'john',
-			'foo' => 'bar',
-			'bar' => 'foo',
-		], 'en'));
-		$this->assertSame('foo', $t->get('foo::bar.foo'));
-	}
-	
-	public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([
-			'foo' => 'foo',
-			'baz' => 'breeze :foo :foobar',
-		]);
-		$this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', [
-			'foo' => 'bar',
-			'foobar' => 'taylor',
-		], 'en'));
-		$this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', [
-			'foo' => 'foo bar baz',
-			'foobar' => 'taylor',
-		], 'en'));
-		$this->assertSame('foo', $t->get('foo::bar.foo'));
-	}
-	
-	public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->setFallback('lv');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn([
-			'foo' => 'foo',
-			'baz' => 'breeze :foo',
-		]);
-		$this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-		$this->assertSame('foo', $t->get('foo::bar.foo'));
-	}
-	
-	public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
-		$this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
-	}
-	
-	public function testChoiceMethodProperlyLoadsAndRetrievesItem()
-	{
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-		])->getMock();
-		$t->expects($this->once())->method('get')
-			->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
-		$t->setSelector($selector = m::mock(MessageSelector::class));
-		$selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
-		
-		$t->choice('foo', 10, ['replace']);
-	}
-	
-	public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
-	{
-		$t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([
-			$this->getLoader(),
-			'en',
-		])->getMock();
-		$t->expects($this->exactly(2))->method('get')
-			->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
-		$t->setSelector($selector = m::mock(MessageSelector::class));
-		$selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
-		
-		$values = [
-			'foo',
-			'bar',
-			'baz',
-		];
-		$t->choice('foo', $values, ['replace']);
-		
-		$values = new Collection([
-			'foo',
-			'bar',
-			'baz',
-		]);
-		$t->choice('foo', $values, ['replace']);
-	}
-	
-	public function testGetJson()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
-		$this->assertSame('one', $t->get('foo'));
-	}
-	
-	public function testGetJsonReplaces()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
-			->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
-		$this->assertSame('bar onetwo three', $t->get('foo :i:c :u', [
-			'i' => 'one',
-			'c' => 'two',
-			'u' => 'three',
-		]));
-	}
-	
-	public function testGetJsonHasAtomicReplacements()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
-			->andReturn(['Hello :foo!' => 'Hello :foo!']);
-		$this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', [
-			'foo' => 'baz:bar',
-			'bar' => 'abcdef',
-		]));
-	}
-	
-	public function testGetJsonReplacesForAssociativeInput()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
-		$this->assertSame('bar eye see', $t->get('foo :i :c', [
-			'i' => 'eye',
-			'c' => 'see',
-		]));
-	}
-	
-	public function testGetJsonPreservesOrder()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
-			->andReturn(['to :name I give :greeting' => ':greeting :name']);
-		$this->assertSame('Greetings David', $t->get('to :name I give :greeting', [
-			'name' => 'David',
-			'greeting' => 'Greetings',
-		]));
-	}
-	
-	public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
-		$this->assertSame('one', $t->get('foo.bar'));
-	}
-	
-	public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
-		$this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
-	}
-	
-	public function testGetJsonForNonExistingReturnsSameKey()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
-		$this->assertSame('Foo that bar', $t->get('Foo that bar'));
-	}
-	
-	public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-		$this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
-	}
-	
-	public function testEmptyFallbacks()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-		$this->assertSame('foo ', $t->get('foo :message', ['message' => null]));
-	}
-	
-	public function testGetJsonReplacesWithStringable()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')
-			->andReturn(['test' => 'the date is :date']);
-		
-		$date = Carbon::createFromTimestamp(0);
-		
-		$this->assertSame('the date is 1970-01-01 00:00:00', $t->get('test', ['date' => $date]));
-		
-		$t->stringable(function (\Illuminate\Support\Carbon $carbon) {
-			return $carbon->format('jS M Y');
-		});
-		$this->assertSame('the date is 1st Jan 1970', $t->get('test', ['date' => $date]));
-	}
-	
-	public function testDetermineLocalesUsingMethod()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		$t->determineLocalesUsing(function ($locales) {
-			$this->assertSame(['en'], $locales);
-			
-			return [
-				'en',
-				'lz',
-			];
-		});
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('lz', 'foo', '*')->andReturn([]);
-		$this->assertSame('foo', $t->get('foo'));
-	}
-	
-	protected function getLoader()
-	{
-		return m::mock(Loader::class);
-	}
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
+        $this->assertFalse($t->has('foo', 'bar'));
+
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
+        $this->assertTrue($t->has('foo', 'bar'));
+
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
+        $this->assertTrue($t->hasForLocale('foo', 'bar'));
+
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
+        $this->assertFalse($t->hasForLocale('foo', 'bar'));
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
+        $this->assertTrue($t->hasForLocale('foo'));
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $this->assertFalse($t->hasForLocale('foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
+        $this->assertEquals(['tree bar', 'breeze bar'], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesArrayItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo', 'beep' => ['rock' => 'tree :foo']]]);
+        $this->assertEquals(['foo' => 'foo', 'baz' => 'breeze bar', 'qux' => ['tree bar', 'breeze bar', 'beep' => ['rock' => 'tree bar']]], $t->get('foo::bar', ['foo' => 'bar'], 'en'));
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodForNonExistingReturnsSameKey()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
+        $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+	    
+	    Translator::preventMissingTranslations(true);
+	    
+	    try {
+		    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+		    
+		    $this->fail('Expected exception was not thrown');
+	    } catch (MissingTranslationViolationException $e) {
+		    $this->assertSame('Attempted to retrieve missing translation [foo::unknown.bar].', $e->getMessage());
+	    }
+	    
+	    Translator::preventMissingTranslations(false);
+	    
+	    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+	    
+	    $callbackKey = null;
+	    
+	    Translator::preventMissingTranslations();
+	    
+	    Translator::handleMissingTranslationViolationUsing(function (string $key) use (&$callbackKey) {
+		    $callbackKey = $key;
+	    });
+	    
+	    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+	    
+	    $this->assertSame('foo::unknown.bar', $callbackKey);
+    }
+
+    public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze <p>test</p>']);
+        $this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :0 :Foo :BAR']);
+        $this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', ['john', 'foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
+        $this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setFallback('lv');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
+    }
+
+    public function testChoiceMethodProperlyLoadsAndRetrievesItem()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
+
+        $t->choice('foo', 10, ['replace']);
+    }
+
+    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
+
+        $values = ['foo', 'bar', 'baz'];
+        $t->choice('foo', $values, ['replace']);
+
+        $values = new Collection(['foo', 'bar', 'baz']);
+        $t->choice('foo', $values, ['replace']);
+    }
+
+    public function testGetJson()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
+        $this->assertSame('one', $t->get('foo'));
+    }
+
+    public function testGetJsonReplaces()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+        $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
+    }
+
+    public function testGetJsonHasAtomicReplacements()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['Hello :foo!' => 'Hello :foo!']);
+        $this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
+    }
+
+    public function testGetJsonReplacesForAssociativeInput()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
+        $this->assertSame('bar eye see', $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
+    }
+
+    public function testGetJsonPreservesOrder()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
+        $this->assertSame('Greetings David', $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
+    }
+
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
+        $this->assertSame('one', $t->get('foo.bar'));
+    }
+
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
+        $this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
+    }
+
+    public function testGetJsonForNonExistingReturnsSameKey()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
+        $this->assertSame('Foo that bar', $t->get('Foo that bar'));
+    }
+
+    public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
+    }
+
+    public function testEmptyFallbacks()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $this->assertSame('foo ', $t->get('foo :message', ['message' => null]));
+    }
+
+    public function testGetJsonReplacesWithStringable()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()
+            ->shouldReceive('load')
+            ->once()
+            ->with('en', '*', '*')
+            ->andReturn(['test' => 'the date is :date']);
+
+        $date = Carbon::createFromTimestamp(0);
+
+        $this->assertSame(
+            'the date is 1970-01-01 00:00:00',
+            $t->get('test', ['date' => $date])
+        );
+
+        $t->stringable(function (\Illuminate\Support\Carbon $carbon) {
+            return $carbon->format('jS M Y');
+        });
+        $this->assertSame(
+            'the date is 1st Jan 1970',
+            $t->get('test', ['date' => $date])
+        );
+    }
+
+    public function testDetermineLocalesUsingMethod()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->determineLocalesUsing(function ($locales) {
+            $this->assertSame(['en'], $locales);
+
+            return ['en', 'lz'];
+        });
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lz', 'foo', '*')->andReturn([]);
+        $this->assertSame('foo', $t->get('foo'));
+    }
+
+    protected function getLoader()
+    {
+        return m::mock(Loader::class);
+    }
 }


### PR DESCRIPTION
This PR adds a warning system to the `Translator` class, that will allow developers to throw exceptions when a missing translation is detected, similar to the already existing Eloquent strict modes. You can also provide a custom callback for when a missing translation is detected, which is very useful for e.g. production environments, where you don't want to throw an exception, but only be informed immediately. 

Enable missing translations like this:
```php
use Illuminate\Translation\Translator;

Translator::preventMissingTranslations(app()->isLocal());
```

Report violations using a custom callback:

```php
Translator::handleMissingTranslationViolationUsing(function (string $key): void {
    report("Missing translation detected for key [{$key}].");
});
```

Thanks!
