### PR TITLE
[10.x] Add `Arr::mapWithKeys()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -579,17 +579,17 @@ class Arr
      */
     public static function mapWithKeys(array $array, callable $callback)
     {
-	    $result = [];
-	    
-	    foreach ($array as $key => $value) {
-		    $assoc = $callback($value, $key);
-		    
-		    foreach ($assoc as $mapKey => $mapValue) {
-			    $result[$mapKey] = $mapValue;
-		    }
-	    }
-	    
-	    return $result;
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            $assoc = $callback($value, $key);
+
+            foreach ($assoc as $mapKey => $mapValue) {
+                $result[$mapKey] = $mapValue;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -564,6 +564,35 @@ class Arr
     }
 
     /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @template TKey
+     * @template TValue
+     * @template TMapWithKeysKey of array-key
+     * @template TMapWithKeysValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue>  $callback
+     * @return array
+     */
+    public static function mapWithKeys(array $array, callable $callback)
+    {
+	    $result = [];
+	    
+	    foreach ($array as $key => $value) {
+		    $assoc = $callback($value, $key);
+		    
+		    foreach ($assoc as $mapKey => $mapValue) {
+			    $result[$mapKey] = $mapValue;
+		    }
+	    }
+	    
+	    return $result;
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -816,7 +816,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function mapWithKeys(callable $callback)
     {
-	    return new static(Arr::mapWithKeys($this->items, $callback));
+        return new static(Arr::mapWithKeys($this->items, $callback));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -816,17 +816,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function mapWithKeys(callable $callback)
     {
-        $result = [];
-
-        foreach ($this->items as $key => $value) {
-            $assoc = $callback($value, $key);
-
-            foreach ($assoc as $mapKey => $mapValue) {
-                $result[$mapKey] = $mapValue;
-            }
-        }
-
-        return new static($result);
+	    return new static(Arr::mapWithKeys($this->items, $callback));
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -641,6 +641,24 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
+	
+	public function testMapWithKeys()
+	{
+		$data = [
+			['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
+			['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
+			['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
+		];
+		
+		$data = Arr::mapWithKeys($data, function ($pokemon) {
+			return [$pokemon['name'] => $pokemon['type']];
+		});
+		
+		$this->assertEquals(
+			['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
+			$data
+		);
+	}
 
     public function testMapByReference()
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -641,24 +641,24 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
-	
-	public function testMapWithKeys()
-	{
-		$data = [
-			['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
-			['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
-			['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
-		];
-		
-		$data = Arr::mapWithKeys($data, function ($pokemon) {
-			return [$pokemon['name'] => $pokemon['type']];
-		});
-		
-		$this->assertEquals(
-			['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
-			$data
-		);
-	}
+
+    public function testMapWithKeys()
+    {
+        $data = [
+            ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
+            ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
+            ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
+        ];
+
+        $data = Arr::mapWithKeys($data, function ($pokemon) {
+            return [$pokemon['name'] => $pokemon['type']];
+        });
+
+        $this->assertEquals(
+            ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
+            $data
+        );
+    }
 
     public function testMapByReference()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3117,7 +3117,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testMapWithKeys($collection)
     {
-		$data = new $collection([
+        $data = new $collection([
             ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
             ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
             ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3117,7 +3117,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testMapWithKeys($collection)
     {
-        $data = new $collection([
+		$data = new $collection([
             ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
             ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
             ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],


### PR DESCRIPTION
Personally I use the Collection `mapWithKeys()` method a lot. It does happen quite often still that I have just an array and need to return only an array. Converting to a collection, mapping with the keys and converting back to an array does not feel right if we have special `Arr` class for such array-only operations.

This PR adds the `mapWithKeys()` function to the `Arr` class.

```php
public function getSomething(): array
{
    $data = [/** */];

    return Arr::mapWithKeys($data, function($x): array {
       // return [$y => $z]
    });
}
```

Thanks!