### PR TITLE
[10.x] Add Carbon `dd()` and `dump()` methods 

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support;
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Illuminate\Support\Traits\Conditionable;
-use Symfony\Component\VarDumper\VarDumper;
 
 class Carbon extends BaseCarbon
 {
@@ -19,27 +18,27 @@ class Carbon extends BaseCarbon
         BaseCarbon::setTestNow($testNow);
         BaseCarbonImmutable::setTestNow($testNow);
     }
-	
-	/**
-	 * Dump the instance and end the script.
-	 *
-	 * @param  mixed  ...$args
-	 * @return never
-	 */
-	public function dd(...$args)
-	{
-		dd($this, ...$args);
-	}
-	
-	/**
-	 * Dump the instance.
-	 *
-	 * @return $this
-	 */
-	public function dump()
-	{
-		dump($this);
-		
-		return $this;
-	}
+
+    /**
+     * Dump the instance and end the script.
+     *
+     * @param  mixed  ...$args
+     * @return never
+     */
+    public function dd(...$args)
+    {
+        dd($this, ...$args);
+    }
+
+    /**
+     * Dump the instance.
+     *
+     * @return $this
+     */
+    public function dump()
+    {
+        dump($this);
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Illuminate\Support\Traits\Conditionable;
+use Symfony\Component\VarDumper\VarDumper;
 
 class Carbon extends BaseCarbon
 {
@@ -18,4 +19,27 @@ class Carbon extends BaseCarbon
         BaseCarbon::setTestNow($testNow);
         BaseCarbonImmutable::setTestNow($testNow);
     }
+	
+	/**
+	 * Dump the instance and end the script.
+	 *
+	 * @param  mixed  ...$args
+	 * @return never
+	 */
+	public function dd(...$args)
+	{
+		dd($this, ...$args);
+	}
+	
+	/**
+	 * Dump the instance.
+	 *
+	 * @return $this
+	 */
+	public function dump()
+	{
+		dump($this);
+		
+		return $this;
+	}
 }


### PR DESCRIPTION
This PR adds a `dd()` and `dump()` method to the Carbon instance, allowing people to more easily dump their Carbon instances. This is similar to the methods found on many other places in the framework.

```php
now()->dd();

now()->dump();
```

Thanks!