### PR TITLE
[10.x] File failed job storage driver

### DIFF
--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+use DateTimeInterface;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Date;
+
+class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider
+{
+    /**
+     * The path at which the failed job file should be stored.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Create a new database failed job provider.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Log a failed job into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @param  \Throwable  $exception
+     * @return int|null
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        $id = json_decode($payload, true)['uuid'];
+
+        $jobs = $this->read();
+
+        $jobs[] = [
+            'id' => $id,
+            'connection' => $connection,
+            'queue' => $queue,
+            'payload' => $payload,
+            'exception' => (string) mb_convert_encoding($exception, 'UTF-8'),
+            'failed_at' => Date::now()->getTimestamp(),
+        ];
+
+        $this->write($jobs);
+    }
+
+    /**
+     * Get a list of all of the failed jobs.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->read();
+    }
+
+    /**
+     * Get a single failed job.
+     *
+     * @param  mixed  $id
+     * @return object|null
+     */
+    public function find($id)
+    {
+        return collect($this->read())
+            ->first(fn ($job) => $job->id === $id);
+    }
+
+    /**
+     * Delete a single failed job from storage.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function forget($id)
+    {
+        $this->write(collect($this->read())->reject(fn ($job) => $job->id === $id)->values()->all());
+    }
+
+    /**
+     * Flush all of the failed jobs from storage.
+     *
+     * @param  int|null  $hours
+     * @return void
+     */
+    public function flush($hours = null)
+    {
+        $this->prune(Date::now()->subHours($hours ?: 0));
+    }
+
+    /**
+     * Prune all of the entries older than the given date.
+     *
+     * @param  \DateTimeInterface  $before
+     * @return int
+     */
+    public function prune(DateTimeInterface $before)
+    {
+        $jobs = $this->read();
+
+        $deleted = 0;
+
+        $prunedJobs = collect($jobs)->reject(function ($job) use (&$deleted) {
+            return $job->failed_at <= $before->getTimestamp();
+        })->values()->all();
+
+        $this->write($prunedJobs);
+
+        return count($jobs) - count($prunedJobs);
+    }
+
+    public function read()
+    {
+        if (! file_exists($this->path.'/failed-jobs.json')) {
+            return [];
+        }
+
+        $content = file_get_contents($this->path.'/failed-jobs.json');
+
+        if (empty(trim($content))) {
+            return [];
+        }
+
+        $content = json_decode($content);
+
+        return is_array($content) ? $content : [];
+    }
+
+    public function write(array $jobs)
+    {
+        file_put_contents(
+            $this->path.'/failed-jobs.json',
+            json_encode($jobs, JSON_PRETTY_PRINT)
+        );
+    }
+}

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -130,11 +130,11 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
      */
     protected function read()
     {
-        if (! file_exists($this->path.'/failed-jobs.json')) {
+        if (! file_exists($this->path)) {
             return [];
         }
 
-        $content = file_get_contents($this->path.'/failed-jobs.json');
+        $content = file_get_contents($this->path);
 
         if (empty(trim($content))) {
             return [];
@@ -154,7 +154,7 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
     protected function write(array $jobs)
     {
         file_put_contents(
-            $this->path.'/failed-jobs.json',
+            $this->path,
             json_encode($jobs, JSON_PRETTY_PRINT)
         );
     }

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -114,9 +114,7 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
     {
         $jobs = $this->read();
 
-        $deleted = 0;
-
-        $this->write($prunedJobs = collect($jobs)->reject(function ($job) use ($before, &$deleted) {
+        $this->write($prunedJobs = collect($jobs)->reject(function ($job) use ($before) {
             return $job->failed_at_timestamp <= $before->getTimestamp();
         })->values()->all());
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -253,7 +253,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
 
             if (isset($config['driver']) && $config['driver'] === 'file') {
                 return new FileFailedJobProvider(
-                    $config['path'] ?? $this->app->storagePath('framework/failed-jobs.json')
+                    $config['path'] ?? $this->app->storagePath('framework/failed-jobs.json'),
+                    $config['limit'] ?? 100,
                 );
             } elseif (isset($config['driver']) && $config['driver'] === 'dynamodb') {
                 return $this->dynamoFailedJobProvider($config);

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -253,7 +253,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
 
             if (isset($config['driver']) && $config['driver'] === 'file') {
                 return new FileFailedJobProvider(
-                    $config['path'] ?? $this->app->storagePath('framework/failed-jobs.json'),
+                    $config['path'] ?? $this->app->storagePath('framework/cache/failed-jobs.json'),
                     $config['limit'] ?? 100,
                 );
             } elseif (isset($config['driver']) && $config['driver'] === 'dynamodb') {

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\Connectors\SyncConnector;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
+use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
@@ -250,7 +251,9 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return new NullFailedJobProvider;
             }
 
-            if (isset($config['driver']) && $config['driver'] === 'dynamodb') {
+            if (isset($config['driver']) && $config['driver'] === 'file') {
+                return new FileFailedJobProvider($config['path']);
+            } elseif (isset($config['driver']) && $config['driver'] === 'dynamodb') {
                 return $this->dynamoFailedJobProvider($config);
             } elseif (isset($config['driver']) && $config['driver'] === 'database-uuids') {
                 return $this->databaseUuidFailedJobProvider($config);

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -252,7 +252,9 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             }
 
             if (isset($config['driver']) && $config['driver'] === 'file') {
-                return new FileFailedJobProvider($config['path']);
+                return new FileFailedJobProvider(
+                    $config['path'] ?? $this->app->storagePath('framework/failed-jobs.json')
+                );
             } elseif (isset($config['driver']) && $config['driver'] === 'dynamodb') {
                 return $this->dynamoFailedJobProvider($config);
             } elseif (isset($config['driver']) && $config['driver'] === 'database-uuids') {

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Exception;
+use Illuminate\Queue\Failed\FileFailedJobProvider;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+
+class FileFailedJobProviderTest extends TestCase
+{
+    protected $path;
+
+    protected $provider;
+
+    protected function setUp(): void
+    {
+        $this->path = @tempnam('tmp', 'file_failed_job_provider_test');
+        $this->provider = new FileFailedJobProvider($this->path);
+    }
+
+    public function testCanLogFailedJobs()
+    {
+        [$uuid, $exception] = $this->logFailedJob();
+
+        $failedJobs = $this->provider->all();
+
+        $this->assertEquals([
+            (object) [
+                'id' => $uuid,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuid]),
+                'exception' => (string) mb_convert_encoding($exception, 'UTF-8'),
+                'failed_at' => $failedJobs[0]->failed_at,
+                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
+            ],
+        ], $failedJobs);
+    }
+
+    public function testCanRetrieveAllFailedJobs()
+    {
+        [$uuidOne, $exceptionOne] = $this->logFailedJob();
+        [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
+
+        $failedJobs = $this->provider->all();
+
+        $this->assertEquals([
+            (object) [
+                'id' => $uuidOne,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidOne]),
+                'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
+                'failed_at' => $failedJobs[0]->failed_at,
+                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
+            ],
+            (object) [
+                'id' => $uuidTwo,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidTwo]),
+                'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
+                'failed_at' => $failedJobs[1]->failed_at,
+                'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
+            ],
+        ], $failedJobs);
+    }
+
+    public function testCanFindFailedJobs()
+    {
+        [$uuid, $exception] = $this->logFailedJob();
+
+        $failedJob = $this->provider->find($uuid);
+
+        $this->assertEquals((object) [
+            'id' => $uuid,
+            'connection' => 'connection',
+            'queue' => 'queue',
+            'payload' => json_encode(['uuid' => (string) $uuid]),
+            'exception' => (string) mb_convert_encoding($exception, 'UTF-8'),
+            'failed_at' => $failedJob->failed_at,
+            'failed_at_timestamp' => $failedJob->failed_at_timestamp,
+        ], $failedJob);
+    }
+
+    public function testNullIsReturnedIfJobNotFound()
+    {
+        $uuid = Str::uuid();
+
+        $failedJob = $this->provider->find($uuid);
+
+        $this->assertNull($failedJob);
+    }
+
+    public function testCanForgetFailedJobs()
+    {
+        [$uuid] = $this->logFailedJob();
+
+        $this->provider->forget($uuid);
+
+        $failedJob = $this->provider->find($uuid);
+
+        $this->assertNull($failedJob);
+    }
+
+    public function testCanFlushFailedJobs()
+    {
+        $this->logFailedJob();
+        $this->logFailedJob();
+
+        $this->provider->flush();
+
+        $failedJobs = $this->provider->all();
+
+        $this->assertEmpty($failedJobs);
+    }
+
+    public function testCanPruneFailedJobs()
+    {
+        $this->logFailedJob();
+        $this->logFailedJob();
+
+        $this->provider->prune(now()->addDay(1));
+        $failedJobs = $this->provider->all();
+        $this->assertEmpty($failedJobs);
+
+        $this->logFailedJob();
+        $this->logFailedJob();
+
+        $this->provider->prune(now()->subDay(1));
+        $failedJobs = $this->provider->all();
+        $this->assertCount(2, $failedJobs);
+    }
+
+    public function testEmptyFailedJobsByDefault()
+    {
+        $failedJobs = $this->provider->all();
+
+        $this->assertEmpty($failedJobs);
+    }
+
+    public function logFailedJob()
+    {
+        $uuid = Str::uuid();
+
+        $exception = new Exception("Something went wrong at job [{$uuid}].");
+
+        $this->provider->log('connection', 'queue', json_encode(['uuid' => (string) $uuid]), $exception);
+
+        return [(string) $uuid, $exception];
+    }
+}

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -47,15 +47,6 @@ class FileFailedJobProviderTest extends TestCase
 
         $this->assertEquals([
             (object) [
-                'id' => $uuidOne,
-                'connection' => 'connection',
-                'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuidOne]),
-                'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
-                'failed_at' => $failedJobs[0]->failed_at,
-                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
-            ],
-            (object) [
                 'id' => $uuidTwo,
                 'connection' => 'connection',
                 'queue' => 'queue',
@@ -63,6 +54,15 @@ class FileFailedJobProviderTest extends TestCase
                 'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
                 'failed_at' => $failedJobs[1]->failed_at,
                 'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
+            ],
+            (object) [
+                'id' => $uuidOne,
+                'connection' => 'connection',
+                'queue' => 'queue',
+                'payload' => json_encode(['uuid' => $uuidOne]),
+                'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
+                'failed_at' => $failedJobs[0]->failed_at,
+                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
             ],
         ], $failedJobs);
     }


### PR DESCRIPTION
A simple, file-based failed job storage driver for local development and exploration when first installing the framework.

Not intended for production usage.