### PR TITLE
[10.x] Allow passing an array with values to the filled() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -148,7 +148,7 @@ if (! function_exists('filled')) {
      */
     function filled($value)
     {
-        $values = is_array($value) ? $value : func_get_args();
+        $values = Arr::wrap($value);
 
         if (empty($values)) {
             return false;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -150,6 +150,10 @@ if (! function_exists('filled')) {
     {
         $values = is_array($value) ? $value : func_get_args();
 
+        if (empty($values)) {
+            return false;
+        }
+
         foreach ($values as $value) {
             if (blank($value)) {
                 return false;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -148,7 +148,15 @@ if (! function_exists('filled')) {
      */
     function filled($value)
     {
-        return ! blank($value);
+        $values = is_array($value) ? $value : func_get_args();
+
+        foreach ($values as $value) {
+            if (blank($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -107,6 +107,25 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(filled($object));
     }
 
+    public function testFilledMultiple()
+    {
+        $this->assertFalse(filled([null]));
+        $this->assertFalse(filled(['']));
+        $this->assertFalse(filled(['  ']));
+        $this->assertTrue(filled([10]));
+        $this->assertTrue(filled([true]));
+        $this->assertTrue(filled([false]));
+        $this->assertTrue(filled([0]));
+        $this->assertTrue(filled([0.0]));
+
+        $object = new SupportTestCountable();
+        $this->assertFalse(filled([$object]));
+
+        $this->assertFalse(filled([null, '', '  ']));
+        $this->assertTrue(filled([10, true, false, 0, 0.0]));
+        $this->assertFalse(filled([10, true, false, 0, 0.0, null, '', '  ']));
+    }
+
     public function testValue()
     {
         $callable = new class

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -121,6 +121,8 @@ class SupportHelpersTest extends TestCase
         $object = new SupportTestCountable();
         $this->assertFalse(filled([$object]));
 
+        $this->assertFalse(filled([]));
+        $this->assertFalse(filled([[]]));
         $this->assertFalse(filled([null, '', '  ']));
         $this->assertTrue(filled([10, true, false, 0, 0.0]));
         $this->assertFalse(filled([10, true, false, 0, 0.0, null, '', '  ']));


### PR DESCRIPTION
This PR will allow you to pass an array of values to the _filled()_ helper method.
The same principle is already applied to the _filled()_ helper method in [Illuminate/Http/Concerns/InteractsWithInput](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Http/Concerns/InteractsWithInput.php#L142).

Instead of this:
```
@if (filled($var1) && filled($var2) && filled($var3))
@endif
```

You would be able to do this:
```
@if (filled([$var1, $var2, $var3]))
@endif
```

I know there are other ways to accomplish the same thing, but this seems like a nice little papercut and an opportunity to streamline both methods.

This might however cause a new confusion with the inverse method of _filled()_, namely _blank()_, where currently one value is allowed.

Thanks for taking the time to review this PR.
I'd appreciate any feedback.