### PR TITLE
Lumen does not have the now() helper.

### DIFF
--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Carbon;
 
 class RedisTagSet extends TagSet
 {
@@ -16,7 +17,7 @@ class RedisTagSet extends TagSet
      */
     public function addEntry(string $key, int $ttl = 0, $updateWhen = null)
     {
-        $ttl = $ttl > 0 ? now()->addSeconds($ttl)->getTimestamp() : -1;
+        $ttl = $ttl > 0 ? Carbon::now()->addSeconds($ttl)->getTimestamp() : -1;
 
         foreach ($this->tagIds() as $tagKey) {
             if ($updateWhen) {
@@ -72,7 +73,7 @@ class RedisTagSet extends TagSet
     {
         $this->store->connection()->pipeline(function ($pipe) {
             foreach ($this->tagIds() as $tagKey) {
-                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, now()->getTimestamp());
+                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, Carbon::now()->getTimestamp());
             }
         });
     }


### PR DESCRIPTION
Fixes 'Call to undefined function Illuminate\Cache\now()'.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
