### PR TITLE
[10.x] Allows Enum casts to be used together with an accessor

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -706,6 +706,12 @@ trait HasAttributes
         } else {
             $value = $this->mutateAttribute($key, $value);
         }
+        
+        if ($this->isEnumCastable($key)) {
+            $value = $this->getEnumCastableAttributeValue($key, $value);
+
+            return $this->getStorableEnumValue($value);
+        }
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
     }
@@ -1585,6 +1591,10 @@ trait HasAttributes
         $castType = $this->parseCasterClass($casts[$key]);
 
         if (in_array($castType, static::$primitiveCastTypes)) {
+            return false;
+        }
+        
+        if (enum_exists($castType)) {
             return false;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -706,7 +706,7 @@ trait HasAttributes
         } else {
             $value = $this->mutateAttribute($key, $value);
         }
-        
+
         if ($this->isEnumCastable($key)) {
             $value = $this->getEnumCastableAttributeValue($key, $value);
 
@@ -1593,7 +1593,7 @@ trait HasAttributes
         if (in_array($castType, static::$primitiveCastTypes)) {
             return false;
         }
-        
+
         if (enum_exists($castType)) {
             return false;
         }


### PR DESCRIPTION
This PR addresses an issue where using an Enum cast and an accessor for the same field causes the ``attributesToArray`` method to throw a ``Cannot instantiate enum error``. The issue seems to stem from the ``resolveCasterClass`` method in ``HasAttributes.php`` where the Enum case is incorrectly treated. ( #47012 )

Steps to reproduce:
```php
enum ProductStatus: string
{
    case ACTIVE = 'active';
    case PAUSED = 'paused'; 
    case OFFLINE = 'offline'; 
}

class Product extends Eloquent
{
    protected $table = 'products';
    protected $casts = [
        'status' => ProductStatus::class,
    ];

    protected function status(): Attribute
    {
        return Attribute::get(fn ($value) => 'offline' ?? $value);
    }
}

Product::find(1)->attributesToArray(); // <-- Cannot instantiate enum error occurs here
```

After the PR all of these cases will work and output a valid enum ``offline`` string when used with ``attributesToArray``:

```php
   protected function status(): Attribute
   {
        return Attribute::get(fn ($value) => $this->castAttribute('status', 'offline' ?? $value));
    }
```

```php
    protected function status(): Attribute
    {
        return Attribute::get(fn ($value) => 'offline' ?? $value);
    }
```

```php
    public function getStatusAttribute()
    {
        return ProductStatus::OFFLINE;
    }
```

```php
    public function getStatusAttribute()
    {
        return 'offline';
    }
```

