### PR TITLE
[10.x] Adds `Lang::whenMissingTranslation`

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,4 +39,12 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
+	
+	/**
+	 * Register a callback to be invoked when the translator detects a missing translation.
+	 *
+	 * @param  callable  $handler
+	 * @return void
+	 */
+	public function whenMissingTranslation($handler);
 }

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,12 +39,12 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
-	
-	/**
-	 * Register a callback to be invoked when the translator detects a missing translation.
-	 *
-	 * @param  callable  $handler
-	 * @return void
-	 */
-	public function whenMissingTranslation($handler);
+
+    /**
+     * Register a callback to be invoked when the translator detects a missing translation.
+     *
+     * @param  callable  $handler
+     * @return void
+     */
+    public function whenMissingTranslation($handler);
 }

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,12 +39,4 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
-
-    /**
-     * Register a callback to be invoked when the translator detects a missing translation.
-     *
-     * @param  callable  $handler
-     * @return void
-     */
-    public function whenMissingTranslation($handler);
 }

--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -29,6 +29,7 @@ namespace Illuminate\Support\Facades;
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
+ * @method static void whenMissingTranslation(callable $handler)
  *
  * @see \Illuminate\Translation\Translator
  */

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -108,11 +108,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function has($key, $locale = null, $fallback = true)
     {
-        if ($missingTranslationHandlers = $this->missingTranslationHandlers) {
-            $this->missingTranslationHandlers = [];
-        }
+        $originalMissingTranslationHandlers = $this->missingTranslationHandlers;
 
-        return tap($this->get($key, [], $locale, $fallback) !== $key, fn () => $this->missingTranslationHandlers = $missingTranslationHandlers);
+        $this->missingTranslationHandlers = [];
+
+        try {
+            return $this->get($key, [], $locale, $fallback) !== $key;
+        } finally {
+            $this->missingTranslationHandlers = $originalMissingTranslationHandlers;
+        }
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -108,8 +108,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function has($key, $locale = null, $fallback = true)
     {
-        // Reset missing translation handlers, so that they are not invoked when using
-        // the `get()` method. They are restored after the `get()` method is called.
         if ($missingTranslationHandlers = $this->missingTranslationHandlers) {
             $this->missingTranslationHandlers = [];
         }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -108,15 +108,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function has($key, $locale = null, $fallback = true)
     {
-		// Reset missing translation handlers, so that they are not invoked when using
-	    // the `get()` method. They are restored after the `get()` method is called.
+        // Reset missing translation handlers, so that they are not invoked when using
+        // the `get()` method. They are restored after the `get()` method is called.
         if ($missingTranslationHandlers = $this->missingTranslationHandlers) {
             $this->missingTranslationHandlers = [];
         }
-	    
-	    $translated = $this->get($key, [], $locale, $fallback);
-		
-	    return tap($translated !== $key, fn () => $this->missingTranslationHandlers = $missingTranslationHandlers);
+
+        $translated = $this->get($key, [], $locale, $fallback);
+
+        return tap($translated !== $key, fn () => $this->missingTranslationHandlers = $missingTranslationHandlers);
     }
 
     /**
@@ -504,13 +504,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         $this->stringableHandlers[$class] = $handler;
     }
-	
-	/**
-	 * Register a callback to be invoked when the translator detects a missing translation.
-	 *
-	 * @param  callable  $handler
-	 * @return void
-	 */
+
+    /**
+     * Register a callback to be invoked when the translator detects a missing translation.
+     *
+     * @param  callable  $handler
+     * @return void
+     */
     public function whenMissingTranslation($handler)
     {
         $this->missingTranslationHandlers[] = $handler;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -112,9 +112,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $this->missingTranslationHandlers = [];
         }
 
-        $translated = $this->get($key, [], $locale, $fallback);
-
-        return tap($translated !== $key, fn () => $this->missingTranslationHandlers = $missingTranslationHandlers);
+        return tap($this->get($key, [], $locale, $fallback) !== $key, fn () => $this->missingTranslationHandlers = $missingTranslationHandlers);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -3,11 +3,9 @@
 namespace Illuminate\Translation;
 
 use Closure;
-use Doctrine\DBAL\Platforms\Keywords\DB2Keywords;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\NamespacedItemResolver;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -66,13 +64,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @var array
      */
     protected $stringableHandlers = [];
-	
-	/**
-	 * All of the registered missing translation handlers.
-	 *
-	 * @var array
-	 */
-	protected $missingTranslationHandlers = [];
+
+    /**
+     * All of the registered missing translation handlers.
+     *
+     * @var array
+     */
+    protected $missingTranslationHandlers = [];
 
     /**
      * Create a new translator instance.
@@ -110,12 +108,12 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function has($key, $locale = null, $fallback = true)
     {
-		if ($missingTranslationHandlers = $this->missingTranslationHandlers) {
-			$this->missingTranslationHandlers = [];
-		}
-		
-        return tap($this->get($key, [], $locale, $fallback) !== $key, function() use ($missingTranslationHandlers) {
-			$this->missingTranslationHandlers = $missingTranslationHandlers;
+        if ($missingTranslationHandlers = $this->missingTranslationHandlers) {
+            $this->missingTranslationHandlers = [];
+        }
+
+        return tap($this->get($key, [], $locale, $fallback) !== $key, function () use ($missingTranslationHandlers) {
+            $this->missingTranslationHandlers = $missingTranslationHandlers;
         });
     }
 
@@ -164,11 +162,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // from the application's language files. Otherwise we can return the line.
         $line = $this->makeReplacements($line ?: $key, $replace);
 
-		foreach($this->missingTranslationHandlers as $missingTranslationHandler) {
-			$missingTranslationHandler($key);
-		}
-		
-		return $line;
+        foreach ($this->missingTranslationHandlers as $missingTranslationHandler) {
+            $missingTranslationHandler($key);
+        }
+
+        return $line;
     }
 
     /**
@@ -504,9 +502,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         $this->stringableHandlers[$class] = $handler;
     }
-	
-	public function whenMissingTranslation($handler)
-	{
-		$this->missingTranslationHandlers[] = $handler;
-	}
+
+    public function whenMissingTranslation($handler)
+    {
+        $this->missingTranslationHandlers[] = $handler;
+    }
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Translation;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
 use Mockery as m;
@@ -76,18 +75,18 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-	    
-		$callbackKey = null;
-		
-	    $t->whenMissingTranslation(function(string $key) use (&$callbackKey) {
-			$callbackKey = $key;
-	    });
-	    
-	    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
-		
-		$this->assertSame('foo::unknown.bar', $callbackKey);
-		
-		$this->assertSame('foo', $t->get('foo::bar.foo'));
+
+        $callbackKey = null;
+
+        $t->whenMissingTranslation(function (string $key) use (&$callbackKey) {
+            $callbackKey = $key;
+        });
+
+        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+
+        $this->assertSame('foo::unknown.bar', $callbackKey);
+
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
     public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -41,7 +41,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertTrue($t->hasForLocale('foo'));
     }
 
-    public function testMissingTranslationHandlersAreNotCalledOnHasMethod()
+    public function testHasMethodDoesNotCallMissingTranslationHandlers()
     {
         $t = new Translator($this->getLoader(), 'en');
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -39,6 +39,11 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
         $this->assertTrue($t->hasForLocale('foo'));
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $this->assertFalse($t->hasForLocale('foo'));
     }
 
     public function testGetMethodMayCallMissingTranslationHandlers()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -40,27 +40,27 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
         $this->assertTrue($t->hasForLocale('foo'));
     }
-	
-	public function testMissingTranslationHandlersAreNotCalledOnHasMethod()
-	{
-		$t = new Translator($this->getLoader(), 'en');
-		
-		$callbackKey = null;
-		
-		$t->whenMissingTranslation(function (string $key) use (&$callbackKey) {
-			$callbackKey = $key;
-		});
-		
-		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
-		$this->assertFalse($t->has('foo'));
-		
-		$this->assertNull($callbackKey);
-		
-		$this->assertSame('foo', $t->get('foo'));
-		
-		$this->assertSame('foo', $callbackKey);
-	}
+
+    public function testMissingTranslationHandlersAreNotCalledOnHasMethod()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+
+        $callbackKey = null;
+
+        $t->whenMissingTranslation(function (string $key) use (&$callbackKey) {
+            $callbackKey = $key;
+        });
+
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $this->assertFalse($t->has('foo'));
+
+        $this->assertNull($callbackKey);
+
+        $this->assertSame('foo', $t->get('foo'));
+
+        $this->assertSame('foo', $callbackKey);
+    }
 
     public function testGetMethodProperlyLoadsAndRetrievesItem()
     {

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -76,7 +76,6 @@ class TranslationTranslatorTest extends TestCase
             $callbackKeys[] = $key;
         });
 
-
         $this->assertFalse($t->has('foo::unknown.bar'));
         $this->assertFalse($t->has('foo::unknown.bar'));
         $this->assertFalse($t->has('foo::unknown.zyo'));

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -39,12 +39,28 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
         $this->assertTrue($t->hasForLocale('foo'));
-
-        $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
-        $this->assertFalse($t->hasForLocale('foo'));
     }
+	
+	public function testMissingTranslationHandlersAreNotCalledOnHasMethod()
+	{
+		$t = new Translator($this->getLoader(), 'en');
+		
+		$callbackKey = null;
+		
+		$t->whenMissingTranslation(function (string $key) use (&$callbackKey) {
+			$callbackKey = $key;
+		});
+		
+		$t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+		$this->assertFalse($t->has('foo'));
+		
+		$this->assertNull($callbackKey);
+		
+		$this->assertSame('foo', $t->get('foo'));
+		
+		$this->assertSame('foo', $callbackKey);
+	}
 
     public function testGetMethodProperlyLoadsAndRetrievesItem()
     {

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Translation;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
 use Mockery as m;
@@ -75,6 +76,18 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+	    
+		$callbackKey = null;
+		
+	    $t->whenMissingTranslation(function(string $key) use (&$callbackKey) {
+			$callbackKey = $key;
+	    });
+	    
+	    $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+		
+		$this->assertSame('foo::unknown.bar', $callbackKey);
+		
+		$this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
     public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()


### PR DESCRIPTION
The original suggestion for this pull request came from https://github.com/laravel/framework/pull/47001. It enables users to report missing translations in their applications in the manner they prefer:

```php
use Illuminate\Support\Facades\Lang;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     */
    public function boot(): void
    {
        Lang::whenMissingTranslation(fn ($key) => logger('Missing translation', ['key' => $key]));
    }
}
```