### PR TITLE
Ensure cached class cast is actually in expected shape

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1137,7 +1137,7 @@ trait HasAttributes
         if ($caster instanceof CastsInboundAttributes || ! is_object($value)) {
             unset($this->classCastCache[$key]);
         } else {
-            $this->classCastCache[$key] = $value;
+            $this->classCastCache[$key] = $this->normalizeCacheableClassCastableAttribute($key, $value, $caster);
         }
     }
 
@@ -1750,6 +1750,23 @@ trait HasAttributes
                 )
             );
         }
+    }
+
+    /**
+     * Normalize the cacheable class cast value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  mixed  $caster
+     * @return array
+     */
+    protected function normalizeCacheableClassCastableAttribute($key, $value, $caster)
+    {
+        $casted = $caster->get(
+            $this, $key, $value, $this->attributes
+        );
+
+        return $value == $casted ? $value : $casted;
     }
 
     /**


### PR DESCRIPTION
This is a (rudimentary?) take on https://github.com/laravel/framework/issues/46744

---

When defining attribute casts, the framework is able to handle value objects and simple lists (array, collection) fluently.
Imagine now the powerful combination: a cast to handle **a collection of value objects**.
A custom cast class seems like a good fit for this. Here's a slim implementation:

```php
class ValueObjectCollectionCaster implements CastsAttributes
{
    public function get($model, $key, $value, $attributes)
    {
        return (new Collection($json_decode($attributes[$key], true)))->map(function ($item) {
            return new ValueObject($item);
        });
    }

    public function set($model, $key, $value, $attributes)
    {
        return json_encode($value);
    }
}
```

Because the `set()` method is directly encoding the value into a JSON string, I should be able to pass any encodable value to it:

```php
$model->items = ['foo', 'bar'];
$model->items = [new ValueObject('foo'), new ValueObject('bar')];

$model->items = collect(['foo', 'bar']);
$model->items = collect([new ValueObject('foo'), new ValueObject('bar')]);
```

But these yield very different results. I figured that the **class cast cache** is causing trouble. More specifically this part:

https://github.com/laravel/framework/blob/ddbbb2b50388721fe63312bb4469cae13163fd36/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1129-L1133

It seems that, upon setting the value, the original value gets cached if it's an object. The array example behaves fine. It never makes it into the cache. But the collection gets cached as-is without its items being casted to value objects. Subsequent retrievals of the attribute then results in an uncasted value.