### PR TITLE
[10.x] Handle Validator strings with regex exploding safely fixes pterodactyl/panel#4360 and pterodactyl/panel#1960

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -99,14 +99,14 @@ class ValidationRuleParser
                     $nextSlash = strpos($rulePart, '/', $nextSlash + 1);
                 } while (substr($rulePart, $nextSlash - 1, 1) === '\\');
 
-                array_push($array, substr($rulePart, 0, $nextSlash + 1));
-
                 $nextPipePos = strpos($rulePart, $seperator, $nextSlash);
-                $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
+                array_push($array, $nextPipePos === false ? substr($rulePart, 0) : substr($rulePart, 0, $nextPipePos));
+
+                $rulePart = $nextPipePos === false ? null : substr($rulePart, $nextPipePos + 1);
             } else {
                 $nextPipePos = strpos($rulePart, $seperator);
                 array_push($array, substr($rulePart, 0, $nextPipePos === false ? null : $nextPipePos));
-                $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
+                $rulePart = $nextPipePos === false ? null : substr($rulePart, $nextPipePos + 1);
             }
         } while ($nextPipePos !== false);
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -78,6 +78,43 @@ class ValidationRuleParser
     }
 
     /**
+     * Explode into an Array while keeping Regex intact.
+     *
+     * @param  string  $seperator
+     * @param  string  $rule
+     * @return array
+     */
+    protected function regexSafeExplode($seperator, $rule)
+    {
+      $array = array();
+      $nextPipePos = 0;
+      $rulePart = $rule;
+    
+      do {
+        if (str_starts_with($rulePart, 'regex:'))
+        {
+          $firstRegexStart = strpos($rulePart, '/');
+          $nextSlash = $firstRegexStart;
+          
+          do {
+            $nextSlash = strpos($rulePart, '/', $nextSlash + 1);
+          } while (substr($rulePart, $nextSlash - 1, 1) === "\\");
+      
+          array_push($array, substr($rulePart, 0, $nextSlash + 1));
+      
+          $nextPipePos = strpos($rulePart, $seperator, $nextSlash);
+          $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
+        } else {
+          $nextPipePos = strpos($rulePart, $seperator);
+          array_push($array, substr($rulePart, 0, $nextPipePos === false ? null : $nextPipePos));
+          $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
+        }
+      } while ($nextPipePos !== false);
+    
+      return $array;
+    }
+
+    /**
      * Explode the explicit rule into an array if necessary.
      *
      * @param  mixed  $rule
@@ -87,7 +124,7 @@ class ValidationRuleParser
     protected function explodeExplicitRule($rule, $attribute)
     {
         if (is_string($rule)) {
-            return explode('|', $rule);
+            return $this->regexSafeExplode('|', $rule);
         }
 
         if (is_object($rule)) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -86,22 +86,21 @@ class ValidationRuleParser
      */
     protected function regexSafeExplode($seperator, $rule)
     {
-        $array = array();
+        $array = [];
         $nextPipePos = 0;
         $rulePart = $rule;
-        
+
         do {
-            if (str_starts_with($rulePart, 'regex:'))
-            {
+            if (str_starts_with($rulePart, 'regex:')) {
                 $firstRegexStart = strpos($rulePart, '/');
                 $nextSlash = $firstRegexStart;
-                
+
                 do {
                     $nextSlash = strpos($rulePart, '/', $nextSlash + 1);
-                } while (substr($rulePart, $nextSlash - 1, 1) === "\\");
-            
+                } while (substr($rulePart, $nextSlash - 1, 1) === '\\');
+
                 array_push($array, substr($rulePart, 0, $nextSlash + 1));
-            
+
                 $nextPipePos = strpos($rulePart, $seperator, $nextSlash);
                 $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
             } else {
@@ -110,7 +109,7 @@ class ValidationRuleParser
                 $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
             }
         } while ($nextPipePos !== false);
-        
+
         return $array;
     }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -86,32 +86,32 @@ class ValidationRuleParser
      */
     protected function regexSafeExplode($seperator, $rule)
     {
-      $array = array();
-      $nextPipePos = 0;
-      $rulePart = $rule;
-    
-      do {
-        if (str_starts_with($rulePart, 'regex:'))
-        {
-          $firstRegexStart = strpos($rulePart, '/');
-          $nextSlash = $firstRegexStart;
-          
-          do {
-            $nextSlash = strpos($rulePart, '/', $nextSlash + 1);
-          } while (substr($rulePart, $nextSlash - 1, 1) === "\\");
-      
-          array_push($array, substr($rulePart, 0, $nextSlash + 1));
-      
-          $nextPipePos = strpos($rulePart, $seperator, $nextSlash);
-          $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
-        } else {
-          $nextPipePos = strpos($rulePart, $seperator);
-          array_push($array, substr($rulePart, 0, $nextPipePos === false ? null : $nextPipePos));
-          $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
-        }
-      } while ($nextPipePos !== false);
-    
-      return $array;
+        $array = array();
+        $nextPipePos = 0;
+        $rulePart = $rule;
+        
+        do {
+            if (str_starts_with($rulePart, 'regex:'))
+            {
+                $firstRegexStart = strpos($rulePart, '/');
+                $nextSlash = $firstRegexStart;
+                
+                do {
+                    $nextSlash = strpos($rulePart, '/', $nextSlash + 1);
+                } while (substr($rulePart, $nextSlash - 1, 1) === "\\");
+            
+                array_push($array, substr($rulePart, 0, $nextSlash + 1));
+            
+                $nextPipePos = strpos($rulePart, $seperator, $nextSlash);
+                $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
+            } else {
+                $nextPipePos = strpos($rulePart, $seperator);
+                array_push($array, substr($rulePart, 0, $nextPipePos === false ? null : $nextPipePos));
+                $rulePart = substr($rulePart, $nextPipePos === false ? null : $nextPipePos + 1);
+            }
+        } while ($nextPipePos !== false);
+        
+        return $array;
     }
 
     /**

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -96,7 +96,7 @@ class ValidationRuleParserTest extends TestCase
         ], $rules);
     }
 
-    public function testExplodeFailsParsingSingleRegexRuleContainingPipe()
+    public function testExplodeProperlyParsesSingleRegexRuleContainingPipe()
     {
         $data = ['items' => [['type' => 'foo']]];
 
@@ -104,8 +104,7 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => 'regex:/^(foo|bar)$/i']
         );
 
-        $this->assertSame('regex:/^(foo', $exploded->rules['items.0.type'][0]);
-        $this->assertSame('bar)$/i', $exploded->rules['items.0.type'][1]);
+        $this->assertSame('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][0]);
     }
 
     public function testExplodeProperlyParsesSingleRegexRuleNotContainingPipe()
@@ -144,7 +143,7 @@ class ValidationRuleParserTest extends TestCase
         $this->assertSame('regex:/^(bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
-    public function testExplodeFailsParsingRegexWithOtherRulesInSingleString()
+    public function testExplodeProperlyParsesRegexWithOtherRulesInSingleString()
     {
         $data = ['items' => [['type' => 'foo']]];
 
@@ -153,8 +152,7 @@ class ValidationRuleParserTest extends TestCase
         );
 
         $this->assertSame('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertSame('regex:/^(foo', $exploded->rules['items.0.type'][1]);
-        $this->assertSame('bar)$/i', $exploded->rules['items.0.type'][2]);
+        $this->assertSame('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
     public function testExplodeGeneratesNestedRules()


### PR DESCRIPTION
Hello everyone :)

i noticed that Validator Strings with regexes that use the OR operator are not correctly handled.
This should fix and handle edgecases correctly as im walking the string and exploding it manually.

Im obviously open for feedback as my PHP got quite rusty.

Sincerely,
Michell