### PR TITLE
[10.x] Raise visibility of Mailable prepareMailableForDelivery()

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1581,7 +1581,7 @@ class Mailable implements MailableContract, Renderable
      *
      * @return void
      */
-    private function prepareMailableForDelivery()
+    protected function prepareMailableForDelivery()
     {
         if (method_exists($this, 'build')) {
             Container::getInstance()->call([$this, 'build']);


### PR DESCRIPTION
This PR raises visibility of `Mailable` `prepareMailableForDelivery()` method to protected. Since the introduction of the new mailable syntax in #44462, overriding `send()` method in child classes is not as straightforward as before since `prepareMailableForDelivery()` has private visibility. Our use-case for overriding `send()` is to change the mailer configuration on-the-fly before sending the mail.