### PR TITLE
[10.x] Allow to override an existing DBAL types in DatabaseManager

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -265,6 +265,8 @@ class DatabaseManager implements ConnectionResolverInterface
 
         if (! Type::hasType($name)) {
             Type::addType($name, $class);
+        } else {
+            Type::overrideType($name, $class);
         }
 
         $this->doctrineTypes[$name] = [$type, $class];


### PR DESCRIPTION
As I was reading the [documentation](https://laravel.com/docs/10.x/migrations#modifying-columns-on-sqlite), I came across the section that illustrates how we can easily register custom types for DBAL in the ``database.php`` file:

```php
'dbal' => [
    'types' => [
        'timestamp' => TimestampType::class,
    ],
],
```

At present, ``DatabaseManager`` does not support extending / overriding an existing DBAL types via the ``database.php`` configuration file. This pull request aims to bridge this gap by allowing this.


e.g. I wanted to extend ``boolean`` type so I could add support for "UNSIGNED" when doing ``change`` in my migrations.

```php
use Doctrine\DBAL\Platforms\AbstractPlatform;
use Doctrine\DBAL\Types\BooleanType;

class Boolean extends BooleanType
{
    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
    {
        $unsigned = !empty($column['unsigned']) ? ' UNSIGNED' : '';

        return parent::getSQLDeclaration($column, $platform) . $unsigned;
    }
}
```