### PR TITLE
[10.x] Add `whenIsMatch` method to Stringable class

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1019,6 +1019,19 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Execute the given callback if the string matches a given pattern.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsMatch($pattern, $callback, $default = null)
+    {
+        return $this->when($this->isMatch($pattern), $callback, $default);
+    }
+
+    /**
      * Execute the given callback if the string is 7 bit ASCII.
      *
      * @param  callable  $callback


### PR DESCRIPTION
This pull request adds a new method called whenIsMatch to the Stringable class. This method allows you to easily check if a string matches a given regular expression pattern and execute a callback function if it does, or return a default value if it doesn't.