### PR TITLE
Bug ShowModelCommand not guessing policy

### DIFF
--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -106,10 +106,8 @@ class ShowModelCommand extends DatabaseInspectionCommand
      */
     protected function getPolicy($model)
     {
-        return collect(Gate::policies())
-            ->filter(fn ($policy, $modelClass) => $modelClass === get_class($model))
-            ->values()
-            ->first();
+        $policy = Gate::getPolicyFor($model::class);
+        return $policy ? $policy::class : '';
     }
 
     /**

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -108,7 +108,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $policy = Gate::getPolicyFor($model::class);
 
-        return $policy ? $policy::class : '';
+        return $policy ? $policy::class : null;
     }
 
     /**

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -107,6 +107,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     protected function getPolicy($model)
     {
         $policy = Gate::getPolicyFor($model::class);
+
         return $policy ? $policy::class : '';
     }
 


### PR DESCRIPTION
Currently the command defines it`s own method for resolving policies, which does not take into account the Policy guessing feature of Laravel. I suggest we reuse Gate own method for this.
