### PR TITLE
[10.x] Adds timestamp retrieval as Carbon instance from UUID/ULID

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -5,6 +5,10 @@ namespace Illuminate\Support;
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Illuminate\Support\Traits\Conditionable;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
+use Ramsey\Uuid\Exception\UnsupportedOperationException;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Uid\Ulid;
 
 class Carbon extends BaseCarbon
 {
@@ -17,6 +21,31 @@ class Carbon extends BaseCarbon
     {
         BaseCarbon::setTestNow($testNow);
         BaseCarbonImmutable::setTestNow($testNow);
+    }
+
+    /**
+     * Creates a Carbon instance from the ULID or UUID.
+     *
+     * Returns "null" if there is no timestamp, or "false" if the UID is invalid.
+     *
+     * @param  \Ramsey\Uuid\Uuid|\Symfony\Component\Uid\Ulid|string  $uid
+     * @return \Illuminate\Support\Carbon|null|false
+     */
+    public static function createFromUid($uid)
+    {
+        if (Ulid::isValid($uid)) {
+            return static::createFromInterface(Ulid::fromString($uid)->getDateTime());
+        }
+
+        try {
+            $date = Uuid::fromString($uid)->getDateTime();
+        } catch (InvalidUuidStringException) {
+            return false;
+        } catch (UnsupportedOperationException) {
+            return null;
+        }
+
+        return static::createFromInterface($date);
     }
 
     /**

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -5,8 +5,6 @@ namespace Illuminate\Support;
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Illuminate\Support\Traits\Conditionable;
-use Ramsey\Uuid\Exception\InvalidUuidStringException;
-use Ramsey\Uuid\Exception\UnsupportedOperationException;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Uid\Ulid;
 
@@ -24,28 +22,16 @@ class Carbon extends BaseCarbon
     }
 
     /**
-     * Creates a Carbon instance from the ULID or UUID.
+     * Create a Carbon instance from a given ordered UUID or ULID.
      *
-     * Returns "null" if there is no timestamp, or "false" if the UID is invalid.
-     *
-     * @param  \Ramsey\Uuid\Uuid|\Symfony\Component\Uid\Ulid|string  $uid
-     * @return \Illuminate\Support\Carbon|null|false
+     * @param  \Ramsey\Uuid\Uuid|\Symfony\Component\Uid\Ulid|string  $id
+     * @return \Illuminate\Support\Carbon
      */
-    public static function createFromUid($uid)
+    public static function createFromId($id)
     {
-        if (Ulid::isValid($uid)) {
-            return static::createFromInterface(Ulid::fromString($uid)->getDateTime());
-        }
-
-        try {
-            $date = Uuid::fromString($uid)->getDateTime();
-        } catch (InvalidUuidStringException) {
-            return false;
-        } catch (UnsupportedOperationException) {
-            return null;
-        }
-
-        return static::createFromInterface($date);
+        return Ulid::isValid($id)
+            ? static::createFromInterface(Ulid::fromString($id)->getDateTime())
+            : static::createFromInterface(Uuid::fromString($id)->getDateTime());
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -21,6 +21,7 @@ use Illuminate\Support\DateFactory;
  * @method static \Illuminate\Support\Carbon createFromTimestamp($timestamp, $tz = null)
  * @method static \Illuminate\Support\Carbon createFromTimestampMs($timestamp, $tz = null)
  * @method static \Illuminate\Support\Carbon createFromTimestampUTC($timestamp)
+ * @method static \Illuminate\Support\Carbon|false|null createFromUid($uid)
  * @method static \Illuminate\Support\Carbon createMidnightDate($year = null, $month = null, $day = null, $tz = null)
  * @method static \Illuminate\Support\Carbon|false createSafe($year = null, $month = null, $day = null, $hour = null, $minute = null, $second = null, $tz = null)
  * @method static void disableHumanDiffOption($humanDiffOption)

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -21,7 +21,7 @@ use Illuminate\Support\DateFactory;
  * @method static \Illuminate\Support\Carbon createFromTimestamp($timestamp, $tz = null)
  * @method static \Illuminate\Support\Carbon createFromTimestampMs($timestamp, $tz = null)
  * @method static \Illuminate\Support\Carbon createFromTimestampUTC($timestamp)
- * @method static \Illuminate\Support\Carbon|false|null createFromUid($uid)
+ * @method static \Illuminate\Support\Carbon createFromId($id)
  * @method static \Illuminate\Support\Carbon createMidnightDate($year = null, $month = null, $day = null, $tz = null)
  * @method static \Illuminate\Support\Carbon|false createSafe($year = null, $month = null, $day = null, $hour = null, $minute = null, $second = null, $tz = null)
  * @method static void disableHumanDiffOption($humanDiffOption)

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -126,39 +126,19 @@ class SupportCarbonTest extends TestCase
 
     public function testCreateFromUid()
     {
-        $ulid = Carbon::createFromUid('01DXH9C4P0ED4AGJJP9CRKQ55C');
+        $ulid = Carbon::createFromId('01DXH9C4P0ED4AGJJP9CRKQ55C');
         $this->assertEquals('2020-01-01 19:30:00.000000', $ulid->toDateTimeString('microsecond'));
 
-        $uuidv1 = Carbon::createFromUid('71513cb4-f071-11ed-a0cf-325096b39f47');
+        $uuidv1 = Carbon::createFromId('71513cb4-f071-11ed-a0cf-325096b39f47');
         $this->assertEquals('2023-05-12 03:02:34.147346', $uuidv1->toDateTimeString('microsecond'));
 
-        $uuidv2 = Carbon::createFromUid('000003e8-f072-21ed-9200-325096b39f47');
+        $uuidv2 = Carbon::createFromId('000003e8-f072-21ed-9200-325096b39f47');
         $this->assertEquals('2023-05-12 03:06:33.529139', $uuidv2->toDateTimeString('microsecond'));
 
-        // NS: af3aca1d-a6aa-33ec-abe5-88dfb02ed276
-        // Name: Laravel
-        $this->assertNull(Carbon::createFromUid('44d5a9b3-f302-35b3-bc7c-94c9f3e57053'));
-
-        $this->assertNull(Carbon::createFromUid('2732c3ce-43c7-4f33-9008-44828906c3f3'));
-
-        // NS: af3aca1d-a6aa-33ec-abe5-88dfb02ed276
-        // Name: Laravel
-        $this->assertNull(Carbon::createFromUid('c75e7122-25af-5f33-b8a0-6c1ba7848f94'));
-
-        $uuidv6 = Carbon::createFromUid('1edf0746-5d1c-6ce8-88ad-e0cb4effa035');
+        $uuidv6 = Carbon::createFromId('1edf0746-5d1c-6ce8-88ad-e0cb4effa035');
         $this->assertEquals('2023-05-12 03:23:43.347428', $uuidv6->toDateTimeString('microsecond'));
 
-        $uuidv7 = Carbon::createFromUid('01880dfa-2825-72e4-acbb-b1e4981cf8af');
+        $uuidv7 = Carbon::createFromId('01880dfa-2825-72e4-acbb-b1e4981cf8af');
         $this->assertEquals('2023-05-12 03:21:18.117000', $uuidv7->toDateTimeString('microsecond'));
-
-        $this->assertNull(Carbon::createFromUid('d036e1a9-81a7-8dff-8eed-acfd28116c84'));
-
-        $this->assertFalse(Carbon::createFromUid(''));
-
-        $this->assertNull(Carbon::createFromUid('00000000-0000-0000-0000-000000000000'));
-
-        $this->assertNull(Carbon::createFromUid('ffffffff-ffff-ffff-ffff-ffffffffffff'));
-
-        $this->assertFalse(Carbon::createFromUid('invalid'));
     }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -123,4 +123,42 @@ class SupportCarbonTest extends TestCase
         $this->assertTrue(Carbon::now()->when(null, fn (Carbon $carbon) => $carbon->addDays(1))->isToday());
         $this->assertTrue(Carbon::now()->when(true, fn (Carbon $carbon) => $carbon->addDays(1))->isTomorrow());
     }
+
+    public function testCreateFromUid()
+    {
+        $ulid = Carbon::createFromUid('01DXH9C4P0ED4AGJJP9CRKQ55C');
+        $this->assertEquals('2020-01-01 19:30:00.000000', $ulid->toDateTimeString('microsecond'));
+
+        $uuidv1 = Carbon::createFromUid('71513cb4-f071-11ed-a0cf-325096b39f47');
+        $this->assertEquals('2023-05-12 03:02:34.147346', $uuidv1->toDateTimeString('microsecond'));
+
+        $uuidv2 = Carbon::createFromUid('000003e8-f072-21ed-9200-325096b39f47');
+        $this->assertEquals('2023-05-12 03:06:33.529139', $uuidv2->toDateTimeString('microsecond'));
+
+        // NS: af3aca1d-a6aa-33ec-abe5-88dfb02ed276
+        // Name: Laravel
+        $this->assertNull(Carbon::createFromUid('44d5a9b3-f302-35b3-bc7c-94c9f3e57053'));
+
+        $this->assertNull(Carbon::createFromUid('2732c3ce-43c7-4f33-9008-44828906c3f3'));
+
+        // NS: af3aca1d-a6aa-33ec-abe5-88dfb02ed276
+        // Name: Laravel
+        $this->assertNull(Carbon::createFromUid('c75e7122-25af-5f33-b8a0-6c1ba7848f94'));
+
+        $uuidv6 = Carbon::createFromUid('1edf0746-5d1c-6ce8-88ad-e0cb4effa035');
+        $this->assertEquals('2023-05-12 03:23:43.347428', $uuidv6->toDateTimeString('microsecond'));
+
+        $uuidv7 = Carbon::createFromUid('01880dfa-2825-72e4-acbb-b1e4981cf8af');
+        $this->assertEquals('2023-05-12 03:21:18.117000', $uuidv7->toDateTimeString('microsecond'));
+
+        $this->assertNull(Carbon::createFromUid('d036e1a9-81a7-8dff-8eed-acfd28116c84'));
+
+        $this->assertFalse(Carbon::createFromUid(''));
+
+        $this->assertNull(Carbon::createFromUid('00000000-0000-0000-0000-000000000000'));
+
+        $this->assertNull(Carbon::createFromUid('ffffffff-ffff-ffff-ffff-ffffffffffff'));
+
+        $this->assertFalse(Carbon::createFromUid('invalid'));
+    }
 }


### PR DESCRIPTION
# What?

Extracts the timestamp from an UUID (v1, v2, v6, v7) or ULID into a Carbon instance.

```php
use Illuminate\Support\Facades\Date;

// Dates from ULID
$date = Date::createFromUid('01H06ZMA15EBJASEXHWJC1SY5F');

// Dates from UUID
$date = Date::createFromUid('01880dfa-2825-72e4-acbb-b1e4981cf8af');
```

Returns `null` the UID has no timestamp, or `false` if the UID is invalid. This allows to check both cases:

```php
$date = Date::createFromUid($uid);

if (is_null($date)) {
    return 'The UID is invalid';
} elseif (!$date) {
    return 'The UID has no timestamp';
}

return $date;
```

# Why?

It saves the step to detect an incoming UID, transform into a UUID/ULID, and then extracting the date, and then transform it into Carbon, all that inside a try-catch if the UID is invalid or has no timestamp.

```php
use Illuminate\Http\Request;
use Illuminate\Support\Str;
use Illuminate\Support\Facades\Date;
use Ramsey\Uuid\Uuid;
use Symfony\Component\Uid\Ulid;

// Before
public function date(Request $request)
{
    $uid = $request->uid;
    
    if (Str::isUlid($uid)) {
        return Date::make(Ulid::fromString($uid)->getDateTime()));
    }
    
    try {
        return Date::make(Uuid::fromString($uid)->getDateTime());
    } catch (\Throwable) {
        return null;
    }
}
```