### PR TITLE
[10.x] Bug in reset() with string path

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -332,7 +332,7 @@ class Migrator
             return [];
         }
 
-        return tap($this->resetMigrations($migrations, $paths, $pretend), function () {
+        return tap($this->resetMigrations($migrations, (array) $paths, $pretend), function () {
             if ($this->output) {
                 $this->output->writeln('');
             }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -332,7 +332,7 @@ class Migrator
             return [];
         }
 
-        return tap($this->resetMigrations($migrations, (array) $paths, $pretend), function () {
+        return tap($this->resetMigrations($migrations, Arr::wrap($paths), $pretend), function () {
             if ($this->output) {
                 $this->output->writeln('');
             }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -156,7 +156,20 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue(str_contains($rolledBack[1], 'users'));
     }
 
-    public function testMigrationsCanBeReset()
+    public function testMigrationsCanBeResetUsingAnString()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $rolledBack = $this->migrator->reset(__DIR__.'/migrations/one');
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+
+        $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
+        $this->assertTrue(str_contains($rolledBack[1], 'users'));
+    }
+
+    public function testMigrationsCanBeResetUsingAnArray()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);
         $this->assertTrue($this->db->schema()->hasTable('users'));


### PR DESCRIPTION
#### Report

Related class: `Illuminate\Database\Migrations\Migrator`

The `reset()` method interface hints at a string for the `$paths` argument, which is accurate to marry up with the `rollback()` interface.

```php
/**
 * Rolls all of the currently applied migrations back.
 *
 * @param  array|string  $paths
 * @param  bool  $pretend
 * @return array
 */
public function reset($paths = [], $pretend = false);
```

However passing a string to this method fails:

```php
// Eg:
$migrator->reset(base_path('database/migrations'));
```

#### Actual

Exception is thrown.

```php
In Migrator.php line 346:

  Illuminate\Database\Migrations\Migrator::resetMigrations(): Argument #2 ($paths) must be of type array, string given, called in ~\vendor\laravel\framework\src\Illuminate\Database\Migrations\Migrator.php on line 331
```

#### Expect

Happy path.


#### Proposal

Use an internal type cast/check at the first instance the variable is used.

Have a great day.