### PR TITLE
[10.x] Add the ability to extend the generic types for DatabaseNotificationCollection

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -3,7 +3,14 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Notifications\DatabaseNotification;
 
+/**
+ * @template TKey of array-key
+ * @template TModel of DatabaseNotification
+ *
+ * @extends Collection<TKey, TModel>
+ */
 class DatabaseNotificationCollection extends Collection
 {
     /**

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -9,7 +9,7 @@ use Illuminate\Notifications\DatabaseNotification;
  * @template TKey of array-key
  * @template TModel of DatabaseNotification
  *
- * @extends Collection<TKey, TModel>
+ * @extends \Illuminate\Database\Eloquent\Collection<TKey, TModel>
  */
 class DatabaseNotificationCollection extends Collection
 {

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Notifications\DatabaseNotification;
 
 /**
  * @template TKey of array-key

--- a/types/Database/Eloquent/DatabaseNotificationCollection.php
+++ b/types/Database/Eloquent/DatabaseNotificationCollection.php
@@ -26,6 +26,5 @@ class CustomNotificationCollection extends DatabaseNotificationCollection
 $databaseNotificationsCollection = DatabaseNotification::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Notifications\DatabaseNotification>', $databaseNotificationsCollection);
 
-
 $customNotificationsCollection = CustomNotification::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, CustomNotification>', $customNotificationsCollection);

--- a/types/Database/Eloquent/DatabaseNotificationCollection.php
+++ b/types/Database/Eloquent/DatabaseNotificationCollection.php
@@ -1,13 +1,14 @@
 <?php
 
-use function PHPStan\Testing\assertType;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\DatabaseNotificationCollection;
+
+use function PHPStan\Testing\assertType;
 
 class CustomNotification extends DatabaseNotification
 {
     /**
-     * @param array<int, CustomNotification> $models
+     * @param  array<int, CustomNotification>  $models
      */
     public function newCollection(array $models = []): CustomNotificationCollection
     {

--- a/types/Database/Eloquent/DatabaseNotificationCollection.php
+++ b/types/Database/Eloquent/DatabaseNotificationCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Notifications\DatabaseNotificationCollection;
+
+class CustomNotification extends DatabaseNotification
+{
+    /**
+     * @param array<int, CustomNotification> $models
+     */
+    public function newCollection(array $models = []): CustomNotificationCollection
+    {
+        return new CustomNotificationCollection($models);
+    }
+}
+
+/**
+ * @extends DatabaseNotificationCollection<int, CustomNotification>
+ */
+class CustomNotificationCollection extends DatabaseNotificationCollection
+{
+}
+
+$databaseNotificationsCollection = DatabaseNotification::all();
+assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Notifications\DatabaseNotification>', $databaseNotificationsCollection);
+
+
+$customNotificationsCollection = CustomNotification::all();
+assertType('Illuminate\Database\Eloquent\Collection<int, CustomNotification>', $customNotificationsCollection);

--- a/types/Notifications/DatabaseNotificationCollection.php
+++ b/types/Notifications/DatabaseNotificationCollection.php
@@ -7,13 +7,7 @@ use function PHPStan\Testing\assertType;
 
 class CustomNotification extends DatabaseNotification
 {
-    /**
-     * @param  array<int, CustomNotification>  $models
-     */
-    public function newCollection(array $models = []): CustomNotificationCollection
-    {
-        return new CustomNotificationCollection($models);
-    }
+    //
 }
 
 /**
@@ -21,6 +15,7 @@ class CustomNotification extends DatabaseNotification
  */
 class CustomNotificationCollection extends DatabaseNotificationCollection
 {
+    //
 }
 
 $databaseNotificationsCollection = DatabaseNotification::all();


### PR DESCRIPTION
In my project in currently extending the `DatabaseNotification` and `DatabaseNotificationCollection` to add on top of the existing Laravel notifications.

However, when extending the `DatabaseNotificationCollection` with my own custom one, I'm getting errors, since I'm unable to provide a `TKey` and a `TModel` to the `DatabaseNotificationCollection` (like I would be able to do if I were instead extending the `Illuminate\Database\Eloquent\Collection` class.

Adding this markup makes it possible to add the following to my own Collection:

```
/**
 * @extends DatabaseNotificationCollection<int, Notification>
 */
class NotificationCollection extends DatabaseNotificationCollection
```

While without it gives me the following error in PHPStan:

`Class App\Collections\NotificationCollection @extends tag contains incompatible type Illuminate\Notifications\DatabaseNotificationCollection&iterable<int, App\Models\Notification>.`