### PR TITLE
[10.x] Add tests for order of validation error messages in json files

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -102,6 +102,88 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('post name is required', $v->errors()->all()[0]);
     }
 
+    public function testNestedErrorMessagesAreRetrievedFromJsonFileOrderDetailedFirst()
+    {
+        $localeFileContent = '
+        {
+            "validation.custom": {
+                "users.*.posts.*.name": {
+                    "required": "post name is required"
+                },
+                "users.*.name": {
+                    "required": "user name is required"
+                }
+            }
+        }
+        ';
+        $messages = json_decode($localeFileContent, true);
+
+        $loader = new ArrayLoader();
+        $loader->addMessages('en', '*', $messages, '*');
+
+        $trans = new Translator($loader, 'en');
+
+        $v = new Validator($trans, [
+            'users' => [
+                [
+                    'name' => 'Taylor Otwell',
+                    'posts' => [
+                        [
+                            'name' => '',
+                        ],
+                    ],
+                ],
+            ],
+        ], [
+            'users.*.name' => ['required'],
+            'users.*.posts.*.name' => ['required'],
+        ]);
+
+        $this->assertFalse($v->passes());
+        $this->assertSame('post name is required', $v->errors()->all()[0]);
+    }
+
+    public function testNestedErrorMessagesAreRetrievedFromJsonFileOrderDetailedLast()
+    {
+        $localeFileContent = '
+        {
+            "validation.custom": {
+                "users.*.name": {
+                    "required": "user name is required"
+                },
+                "users.*.posts.*.name": {
+                    "required": "post name is required"
+                }
+            }
+        }
+        ';
+        $messages = json_decode($localeFileContent, true);
+
+        $loader = new ArrayLoader();
+        $loader->addMessages('en', '*', $messages, '*');
+
+        $trans = new Translator($loader, 'en');
+
+        $v = new Validator($trans, [
+            'users' => [
+                [
+                    'name' => 'Taylor Otwell',
+                    'posts' => [
+                        [
+                            'name' => '',
+                        ],
+                    ],
+                ],
+            ],
+        ], [
+            'users.*.name' => ['required'],
+            'users.*.posts.*.name' => ['required'],
+        ]);
+
+        $this->assertFalse($v->passes());
+        $this->assertSame('post name is required', $v->errors()->all()[0]);
+    }
+
     public function testSometimesWorksOnNestedArrays()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR adds tests to ensure the localisation of validation error messages is working properly.

It reveals the following bug: Placing the localisation string in a different order result in a different output

It is possible to fix this problem of the framework in the laravel application itself, but according to the clean code principles (https://clean-code-developer.com/grades/grade-1-red/#Root_Cause_Analysis) it would be better to fix the root problem.

Currently this PR is WIP and does not fix the issue