### PR TITLE
[10.x] Remove `return` from channelRoutes method

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -112,7 +112,7 @@ class BroadcastManager implements FactoryContract
      */
     public function channelRoutes(array $attributes = null)
     {
-        return $this->routes($attributes);
+        $this->routes($attributes);
     }
 
     /**


### PR DESCRIPTION
There is no need to return, because channelRoutes method is void return type.