### PR TITLE
[10.x] Fix typo `except` method in BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -90,7 +90,7 @@ class BusFake implements Fake, QueueingDispatcher
      * Specify the jobs that should be dispatched instead of faked.
      *
      * @param  array|string  $jobsToDispatch
-     * @return void
+     * @return $this
      */
     public function except($jobsToDispatch)
     {


### PR DESCRIPTION
Contracts added in a separate PR.