### PR TITLE
[10.x] Adds UUID version check to validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -23,8 +23,10 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
 use InvalidArgumentException;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Throwable;
 use ValueError;
 
 trait ValidatesAttributes
@@ -2344,15 +2346,28 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is a valid UUID.
+     * Validate that an attribute is a valid UUID, or UUID versions.
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
      * @return bool
      */
-    public function validateUuid($attribute, $value)
+    public function validateUuid($attribute, $value, $parameters)
     {
-        return Str::isUuid($value);
+        if (! Str::isUuid($value)) {
+            return false;
+        }
+
+        if (empty($parameters)) {
+            return true;
+        }
+
+        try {
+            return in_array(Uuid::fromString($value)->getFields()->getVersion(), $parameters);
+        } catch (Throwable) {
+            return false;
+        }
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7290,6 +7290,32 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
+    public function testValidateUuidWithVersion()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['v4' => '7292af02-6804-4d46-86ca-479ce7d59347'], ['v1' => 'uuid:4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['v4' => '7292af02-6804-4d46-86ca-479ce7d59347'], ['v4' => 'uuid:4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['v4' => '7292af02-6804-4d46-86ca-479ce7d59347'], ['v4' => 'uuid:1,4,2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['v4' => '7292af02-6804-4d46-86ca-479ce7d59347'], ['v4' => 'uuid:1,2']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['invalid' => '7292af02-6804-4d46-86ca-479ce7d59347'], ['invalid' => 'uuid:0']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['invalid' => '7292af02-6804-0d46-86ca-479ce7d59347'], ['invalid' => 'uuid:0']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['invalid' => '7292af02-6804-0d46-86ca-479ce7d59347'], ['invalid' => 'uuid:null']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateWithValidAscii()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
# What?

Extends the UUID validator rule to constraints by versions. Useful to filter UUID to comply with specific properties (like totally random, or timestamps).

```php
use Illuminate\Http\Request;

public function createId(Request $request)
{
    $request->validate([
        'user' => 'uuid:7'
    ]);
    
    // ...
}
```

## How?

It will _parse_ the UUID and retrieve the valid version instead of just checking the 13th character. This way it makes difficult to _fake_ a version by just changing this character.