### PR TITLE
Name attributes on slots

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -552,8 +552,7 @@ class ComponentTagCompiler
             }
 
             // If the name was given as a simple string, we will wrap it in quotes as if it was bound for convenience...
-            if ((isset($matches['inlineName']) && ! empty($matches['inlineName'])) ||
-                (isset($matches['name']) && ! empty($matches['name']))) {
+            if (! empty($matches['inlineName']) || ! empty($matches['name'])) {
                 $name = "'{$name}'";
             }
 
@@ -562,9 +561,8 @@ class ComponentTagCompiler
             $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
 
             // If an inline name was provided and a name or bound name was *also* provided, we will assume the name should be an attribute...
-            if (isset($matches['inlineName']) && (isset($matches['name']) || isset($matches['boundName'])) &&
-                ! empty($matches['inlineName']) && (! empty($matches['name']) || ! empty($matches['boundName']))) {
-                $attributes = isset($matches['name']) && ! empty($matches['name'])
+            if (! empty($matches['inlineName']) && (! empty($matches['name']) || ! empty($matches['boundName']))) {
+                $attributes = ! empty($matches['name'])
                     ? array_merge($attributes, $this->getAttributesFromAttributeString('name='.$matches['name']))
                     : array_merge($attributes, $this->getAttributesFromAttributeString(':name='.$matches['boundName']));
             }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -505,8 +505,8 @@ class ComponentTagCompiler
                 \s*
                 x[\-\:]slot
                 (?:\:(?<inlineName>\w+(?:-\w+)*))?
-                (?:\s+\:name=(?<boundName>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
                 (?:\s+name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
+                (?:\s+\:name=(?<boundName>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
                 (?<attributes>
                     (?:
                         \s+

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -122,6 +122,39 @@ class BladeTest extends TestCase
 <div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
+    public function test_name_attribute_can_be_used_if_using_short_slot_names()
+    {
+        $content = Blade::render('<x-input-with-slot>
+    <x-slot:input name="my_form_field" class="text-input-lg" data-test="data">Test</x-slot:input>
+</x-input-with-slot>');
+
+        $this->assertSame('<div>
+    <input type="text" class="input text-input-lg" data-test="data" name="my_form_field" />
+</div>', trim($content));
+    }
+
+    public function test_name_attribute_cant_be_used_if_not_using_short_slot_names()
+    {
+        $content = Blade::render('<x-input-with-slot>
+    <x-slot name="input" class="text-input-lg" data-test="data">Test</x-slot>
+</x-input-with-slot>');
+
+        $this->assertSame('<div>
+    <input type="text" class="input text-input-lg" data-test="data" />
+</div>', trim($content));
+    }
+
+    public function test_bound_name_attribute_can_be_used_if_using_short_slot_names()
+    {
+        $content = Blade::render('<x-input-with-slot>
+    <x-slot:input :name="\'my_form_field\'" class="text-input-lg" data-test="data">Test</x-slot:input>
+</x-input-with-slot>');
+
+        $this->assertSame('<div>
+    <input type="text" class="input text-input-lg" data-test="data" name="my_form_field" />
+</div>', trim($content));
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -155,6 +155,17 @@ class BladeTest extends TestCase
 </div>', trim($content));
     }
 
+    public function test_bound_name_attribute_can_be_used_if_using_short_slot_names_and_not_first_attribute()
+    {
+        $content = Blade::render('<x-input-with-slot>
+    <x-slot:input class="text-input-lg" :name="\'my_form_field\'" data-test="data">Test</x-slot:input>
+</x-input-with-slot>');
+
+        $this->assertSame('<div>
+    <input type="text" class="input text-input-lg" name="my_form_field" data-test="data" />
+</div>', trim($content));
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);

--- a/tests/Integration/View/templates/components/input-with-slot.blade.php
+++ b/tests/Integration/View/templates/components/input-with-slot.blade.php
@@ -1,0 +1,7 @@
+@props([
+    'input'
+])
+
+<div>
+    <input type="text" {{ $input->attributes->class('input') }} />
+</div>


### PR DESCRIPTION
Fix for https://github.com/laravel/framework/issues/47057

If an inline name is provided, we will assume any additional name attribute should be proxied into the slot attributes.