### PR TITLE
[10.x] Remove isset from pusher method in BroadcastManager

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -297,7 +297,7 @@ class BroadcastManager implements FactoryContract
             $config['secret'],
             $config['app_id'],
             $config['options'] ?? [],
-            isset($config['client_options']) && ! empty($config['client_options'])
+            ! empty($config['client_options'])
                     ? new GuzzleClient($config['client_options'])
                     : null,
         );


### PR DESCRIPTION
Condition is unnecessary because it is checked by `! empty($config['client_options'])`