### PR TITLE
[10.x] Add job timeout occurred event

### DIFF
--- a/src/Illuminate/Queue/Events/JobTimedOut.php
+++ b/src/Illuminate/Queue/Events/JobTimedOut.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue\Events;
 
-class JobTimeoutOccurred
+class JobTimedOut
 {
     /**
      * The connection name.

--- a/src/Illuminate/Queue/Events/JobTimeoutOccurred.php
+++ b/src/Illuminate/Queue/Events/JobTimeoutOccurred.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Events;
 
 class JobTimeoutOccurred
 {
-     /**
+    /**
      * The connection name.
      *
      * @var string

--- a/src/Illuminate/Queue/Events/JobTimeoutOccurred.php
+++ b/src/Illuminate/Queue/Events/JobTimeoutOccurred.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobTimeoutOccurred
+{
+     /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->job = $job;
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
+use Illuminate\Queue\Events\JobTimeoutOccurred;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -223,6 +224,10 @@ class Worker
                 $this->markJobAsFailedIfItShouldFailOnTimeout(
                     $job->getConnectionName(), $job, $e
                 );
+
+                $this->events->dispatch(new JobTimeoutOccurred(
+                    $job->getConnectionName(), $job
+                ));
             }
 
             $this->kill(static::EXIT_ERROR, $options);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -13,7 +13,7 @@ use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
-use Illuminate\Queue\Events\JobTimeoutOccurred;
+use Illuminate\Queue\Events\JobTimedOut;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -225,7 +225,7 @@ class Worker
                     $job->getConnectionName(), $job, $e
                 );
 
-                $this->events->dispatch(new JobTimeoutOccurred(
+                $this->events->dispatch(new JobTimedOut(
                     $job->getConnectionName(), $job
                 ));
             }


### PR DESCRIPTION
No event is dispatched when timeout occurss, so there is no way for external packages to know about it. With this pr, this is possible