### PR TITLE
[11.x] Added new custom validation Rule::orRule and Rule::anyOf to use the OR operator on the same field

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -12,6 +12,7 @@ use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\OrRule;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
@@ -171,5 +172,16 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
+    }
+
+    /**
+     * Get an orRule constraint builder instance.
+     *
+     * @param  array  $constraints
+     * @return \Illuminate\Validation\Rules\OrRule
+     */
+    public static function orRule(array $rules)
+    {
+        return new OrRule($rules);
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -178,11 +178,11 @@ class Rule
     /**
      * Get an orRule constraint builder instance.
      *
-     * @param $rule
-     * @param $orRule
+     * @param mixed $rule
+     * @param mixed $orRule
      * @return \Illuminate\Validation\Rules\OrRule
      */
-    public static function orRule($rule, $orRule)
+    public static function orRule(mixed $rule, mixed $orRule)
     {
         return new OrRule($rule, $orRule);
     }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -178,8 +178,8 @@ class Rule
     /**
      * Get an orRule constraint builder instance.
      *
-     * @param mixed $rule
-     * @param mixed $orRule
+     * @param  mixed  $rule
+     * @param  mixed  $orRule
      * @return \Illuminate\Validation\Rules\OrRule
      */
     public static function orRule(mixed $rule, mixed $orRule)

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\AnyOf;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -177,11 +178,23 @@ class Rule
     /**
      * Get an orRule constraint builder instance.
      *
-     * @param  array  $rules
+     * @param $rule
+     * @param $orRule
      * @return \Illuminate\Validation\Rules\OrRule
      */
-    public static function orRule(array $rules)
+    public static function orRule($rule, $orRule)
     {
-        return new OrRule($rules);
+        return new OrRule($rule, $orRule);
+    }
+
+    /**
+     * Get an anyOf constraint builder instance.
+     *
+     * @param  array  $rules
+     * @return \Illuminate\Validation\Rules\AnyOf
+     */
+    public static function anyOf(array $rules)
+    {
+        return new AnyOf($rules);
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -177,7 +177,7 @@ class Rule
     /**
      * Get an orRule constraint builder instance.
      *
-     * @param  array  $constraints
+     * @param  array  $rules
      * @return \Illuminate\Validation\Rules\OrRule
      */
     public static function orRule(array $rules)

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -21,9 +21,9 @@ class AnyOf implements ValidationRule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
-     * @param Closure $fail
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure  $fail
      * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -55,6 +55,6 @@ class AnyOf implements Rule
 
         return $message === 'validation.any_of'
             ? ['None of the specified field rules is true.']
-            : $message;
+            : [$message];
     }
 }

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -21,9 +21,10 @@ class AnyOf implements ValidationRule
     /**
      * Determine if the validation rule passes.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
+     * @param string $attribute
+     * @param mixed $value
+     * @param Closure $fail
+     * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -52,14 +53,14 @@ class AnyOf implements ValidationRule
     /**
      * Get the validation error message.
      *
-     * @return array
+     * @return string
      */
-    public function message(): array
+    public function message(): string
     {
         $message = trans('validation.any_of');
 
         return $message === 'validation.any_of'
-            ? ['None of the specified field rules is true.']
-            : [$message];
+            ? 'None of the specified field rules is true.'
+            : $message;
     }
 }

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -21,7 +21,7 @@ class AnyOf implements ValidationRule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
+     * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */
@@ -44,7 +44,7 @@ class AnyOf implements ValidationRule
             }
         }
 
-        if (!$passes) {
+        if (! $passes) {
             $fail($this->message());
         }
     }

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class AnyOf implements Rule
+{
+    public function __construct(protected $rules)
+    {
+    }
+
+    public function passes($attribute, $value)
+    {
+        $attribute = str_replace('.', Str::random(), $attribute);
+
+        foreach ($this->rules as $rule) {
+            $data = [
+                $attribute => $value,
+            ];
+            $rules = [
+                $attribute => $rule,
+            ];
+
+            if (Validator::make($data, $rules)->passes()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function message()
+    {
+        return 'None of the specified field rules is applicable.';
+    }
+}

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 class AnyOf implements Rule
 {
     /**
-     * Create a new any_of validation rule that returns true if any of the rules is true
+     * Create a new any_of validation rule that returns true if any of the rules is true.
      *
      * @return void
      */

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -8,11 +8,24 @@ use Illuminate\Support\Str;
 
 class AnyOf implements Rule
 {
+    /**
+     * Create a new any_of validation rule that returns true if any of the rules is true
+     *
+     * @return void
+     */
     public function __construct(protected $rules)
     {
     }
 
-    public function passes($attribute, $value)
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     *
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
     {
         $attribute = str_replace('.', Str::random(), $attribute);
 
@@ -32,8 +45,17 @@ class AnyOf implements Rule
         return false;
     }
 
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
     public function message()
     {
-        return 'None of the specified field rules is applicable.';
+        $message = trans('validation.any_of');
+
+        return $message === 'validation.any_of'
+            ? ['None of the specified field rules is true.']
+            : $message;
     }
 }

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
-class AnyOf implements Rule
+class AnyOf implements ValidationRule
 {
     /**
      * Create a new any_of validation rule that returns true if any of the rules is true.
@@ -20,13 +21,14 @@ class AnyOf implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param  string  $attribute
+     * @param string $attribute
      * @param  mixed  $value
      * @return bool
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $attribute = str_replace('.', Str::random(), $attribute);
+        $passes = false;
 
         foreach ($this->rules as $rule) {
             $data = [
@@ -37,11 +39,14 @@ class AnyOf implements Rule
             ];
 
             if (Validator::make($data, $rules)->passes()) {
-                return true;
+                $passes = true;
+                break;
             }
         }
 
-        return false;
+        if (!$passes) {
+            $fail($this->message());
+        }
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -45,7 +45,7 @@ class AnyOf implements ValidationRule
             }
         }
 
-        if(!$passes) {
+        if (! $passes) {
             $fail($this->message());
         }
     }

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -13,7 +13,7 @@ class AnyOf implements Rule
      *
      * @return void
      */
-    public function __construct(protected $rules)
+    public function __construct(protected array $rules)
     {
     }
 
@@ -49,7 +49,7 @@ class AnyOf implements Rule
      *
      * @return array
      */
-    public function message()
+    public function message(): array
     {
         $message = trans('validation.any_of');
 

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -45,7 +45,7 @@ class AnyOf implements ValidationRule
             }
         }
 
-        if (! $passes) {
+        if(!$passes) {
             $fail($this->message());
         }
     }

--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -22,7 +22,6 @@ class AnyOf implements Rule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     *
      * @return bool
      */
     public function passes($attribute, $value): bool

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use TypeError;
+
+class OrRule implements Rule
+{
+    public function __construct(protected $rules)
+    {
+        $this->rules = $rules;
+    }
+
+    public function passes($attribute, $value)
+    {
+        $attribute = str_replace('.', Str::random(), $attribute);
+
+        foreach ($this->rules as $rule) {
+            $data = [
+                $attribute => $value,
+            ];
+            $rules = [
+                $attribute => $rule,
+            ];
+
+            if (Validator::make($data, $rules)->passes()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function message()
+    {
+        return 'None of the specified field rules is applicable.';
+    }
+}

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 class OrRule implements Rule
 {
     /**
-     * Create a new or validation rule based on two rules
+     * Create a new or validation rule based on two rules.
      *
      * @return void
      */

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -22,7 +22,6 @@ class OrRule implements Rule
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     *
      * @return bool
      */
     public function passes($attribute, $value): bool

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -5,13 +5,11 @@ namespace Illuminate\Validation\Rules;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
-use TypeError;
 
 class OrRule implements Rule
 {
     public function __construct(protected $rules)
     {
-        $this->rules = $rules;
     }
 
     public function passes($attribute, $value)

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -48,14 +48,14 @@ class OrRule implements ValidationRule
     /**
      * Get the validation error message.
      *
-     * @return array
+     * @return string
      */
-    public function message(): array
+    public function message(): string
     {
         $message = trans('validation.or_rule');
 
         return $message === 'validation.or_rule'
-            ? ['None of the specified field rules is true.']
-            : [$message];
+            ? 'None of the specified field rules is true.'
+            : $message;
     }
 }

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -8,11 +8,24 @@ use Illuminate\Support\Str;
 
 class OrRule implements Rule
 {
-    public function __construct(protected $rule, protected $orRule)
+    /**
+     * Create a new or validation rule based on two rules
+     *
+     * @return void
+     */
+    public function __construct(protected mixed $rule, protected mixed $orRule)
     {
     }
 
-    public function passes($attribute, $value)
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     *
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
     {
         $attribute = str_replace('.', Str::random(), $attribute);
 
@@ -30,8 +43,17 @@ class OrRule implements Rule
             || Validator::make($data, $orRules)->passes();
     }
 
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
     public function message()
     {
-        return 'None of the specified field rules is applicable.';
+        $message = trans('validation.or_rule');
+
+        return $message === 'validation.or_rule'
+            ? ['None of the specified field rules is true.']
+            : $message;
     }
 }

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -47,7 +47,7 @@ class OrRule implements Rule
      *
      * @return array
      */
-    public function message()
+    public function message(): array
     {
         $message = trans('validation.or_rule');
 

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 
 class OrRule implements Rule
 {
-    public function __construct(protected $rules)
+    public function __construct(protected $rule, protected $orRule)
     {
     }
 
@@ -16,20 +16,18 @@ class OrRule implements Rule
     {
         $attribute = str_replace('.', Str::random(), $attribute);
 
-        foreach ($this->rules as $rule) {
-            $data = [
-                $attribute => $value,
-            ];
-            $rules = [
-                $attribute => $rule,
-            ];
+        $data = [
+            $attribute => $value,
+        ];
+        $rules = [
+            $attribute => $this->rule,
+        ];
+        $orRules = [
+            $attribute => $this->orRule,
+        ];
 
-            if (Validator::make($data, $rules)->passes()) {
-                return true;
-            }
-        }
-
-        return false;
+        return Validator::make($data, $rules)->passes()
+            || Validator::make($data, $orRules)->passes();
     }
 
     public function message()

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -29,7 +29,6 @@ class OrRule implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $attribute = str_replace('.', Str::random(), $attribute);
-
         $data = [
             $attribute => $value,
         ];

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -21,9 +21,9 @@ class OrRule implements ValidationRule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
-     * @param Closure $fail
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure  $fail
      * @return void
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
@@ -40,7 +40,7 @@ class OrRule implements ValidationRule
             $attribute => $this->orRule,
         ];
 
-        if(Validator::make($data, $rules)->fails() && Validator::make($data, $orRules)->fails()) {
+        if (Validator::make($data, $rules)->fails() && Validator::make($data, $orRules)->fails()) {
             $fail($this->message());
         }
     }

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -53,6 +53,6 @@ class OrRule implements Rule
 
         return $message === 'validation.or_rule'
             ? ['None of the specified field rules is true.']
-            : $message;
+            : [$message];
     }
 }

--- a/src/Illuminate/Validation/Rules/OrRule.php
+++ b/src/Illuminate/Validation/Rules/OrRule.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
-class OrRule implements Rule
+class OrRule implements ValidationRule
 {
     /**
      * Create a new or validation rule based on two rules.
@@ -20,11 +21,12 @@ class OrRule implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
+     * @param string $attribute
+     * @param mixed $value
+     * @param Closure $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $attribute = str_replace('.', Str::random(), $attribute);
 
@@ -38,8 +40,9 @@ class OrRule implements Rule
             $attribute => $this->orRule,
         ];
 
-        return Validator::make($data, $rules)->passes()
-            || Validator::make($data, $orRules)->passes();
+        if(Validator::make($data, $rules)->fails() && Validator::make($data, $orRules)->fails()) {
+            $fail($this->message());
+        }
     }
 
     /**

--- a/tests/Validation/ValidationAnyOfRuleTest.php
+++ b/tests/Validation/ValidationAnyOfRuleTest.php
@@ -2,7 +2,12 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\AnyOf;
+use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
@@ -16,7 +21,7 @@ class ValidationAnyOfRuleTest extends TestCase
                 'value' => 'Laravel',
             ],
             [
-                'value' => new AnyOf(['string', 'decimal', 'integer']),
+                'value' => new AnyOf(['string', 'decimal:2', 'integer']),
             ]
         );
 
@@ -31,10 +36,34 @@ class ValidationAnyOfRuleTest extends TestCase
                 'value' => ['Laravel', 'Other'],
             ],
             [
-                'value' => new AnyOf(['string', 'decimal', 'integer']),
+                'value' => new AnyOf(['string', 'decimal:2', 'integer']),
             ]
         );
 
         $this->assertFalse($validator->passes());
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
     }
 }

--- a/tests/Validation/ValidationAnyOfRuleTest.php
+++ b/tests/Validation/ValidationAnyOfRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rules\AnyOf;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationAnyOfRuleTest extends TestCase
+{
+    public function testValidationPassesWithCorrectAnyOfRule()
+    {
+        $validator = new Validator(
+            resolve('translator'),
+            [
+                'value' => 'Laravel',
+            ],
+            [
+                'value' => new AnyOf(['string', 'decimal', 'integer']),
+            ]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testValidationFailsWithWrongAnyOfRule()
+    {
+        $validator = new Validator(
+            resolve('translator'),
+            [
+                'value' => ['Laravel', 'Other'],
+            ],
+            [
+                'value' => new AnyOf(['string', 'decimal', 'integer']),
+            ]
+        );
+
+        $this->assertFalse($validator->passes());
+    }
+}

--- a/tests/Validation/ValidationAnyOfRuleTest.php
+++ b/tests/Validation/ValidationAnyOfRuleTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationAnyOfRuleTest extends TestCase
 {
-    public function testValidationPassesWithCorrectAnyOfRule()
+    public function testValidationPassesWithCorrectAnyOfRuleValue()
     {
         $validator = new Validator(
             resolve('translator'),
@@ -28,7 +28,7 @@ class ValidationAnyOfRuleTest extends TestCase
         $this->assertTrue($validator->passes());
     }
 
-    public function testValidationFailsWithWrongAnyOfRule()
+    public function testValidationFailsWithWrongAnyOfRuleValue()
     {
         $validator = new Validator(
             resolve('translator'),

--- a/tests/Validation/ValidationOrRuleTest.php
+++ b/tests/Validation/ValidationOrRuleTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationOrRuleTest extends TestCase
 {
-    public function testValidationPassesWithCorrectOrRule()
+    public function testValidationPassesWithCorrectOrRuleValue()
     {
         $validator = new Validator(
             resolve('translator'),
@@ -28,7 +28,7 @@ class ValidationOrRuleTest extends TestCase
         $this->assertTrue($validator->passes());
     }
 
-    public function testValidationFailsWithWrongOrRule()
+    public function testValidationFailsWithWrongOrRuleValue()
     {
         $validator = new Validator(
             resolve('translator'),

--- a/tests/Validation/ValidationOrRuleTest.php
+++ b/tests/Validation/ValidationOrRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rules\OrRule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationOrRuleTest extends TestCase
+{
+    public function testValidationPassesWithCorrectOrRule()
+    {
+        $validator = new Validator(
+            resolve('translator'),
+            [
+                'name' => 'Taylor Otwell',
+            ],
+            [
+                'name' => new OrRule('starts_with:Otwell', 'ends_with:Otwell'),
+            ]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testValidationFailsWithWrongOrRule()
+    {
+        $validator = new Validator(
+            resolve('translator'),
+            [
+                'name' => 'Thomas Omweri',
+            ],
+            [
+                'name' => new OrRule('starts_with:Otwell', 'ends_with:Otwell'),
+            ]
+        );
+
+        $this->assertFalse($validator->passes());
+    }
+}

--- a/tests/Validation/ValidationOrRuleTest.php
+++ b/tests/Validation/ValidationOrRuleTest.php
@@ -2,7 +2,12 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\OrRule;
+use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
@@ -36,5 +41,29 @@ class ValidationOrRuleTest extends TestCase
         );
 
         $this->assertFalse($validator->passes());
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Sometimes when validating a field, you may wish to use the `or` operator to apply at least one of the specified rules.
Example:
```use Illuminate\Validation\Rule;

$validator = Validator::make($request->all(), [
    'or_field' => [
        Rule::orRule('email', 'min:3'),
    ],
    'any_of_field' => [
        Rule::anyOf([
            Rule::in(['foo', 'bar']),
            'email',
            'min:3',
        ]),
    ],
]);
```