### PR TITLE
[10.x] Add `actionIf` into SimpleMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -258,6 +258,24 @@ class SimpleMessage
     }
 
     /**
+     * Configure the "call to action" button if the given condition is true.
+     *
+     * @param  bool  $condition
+     * @param  string  $text
+     * @param  string  $url
+     * @return $this
+     */
+    public function actionIf($condition, $text, $url)
+    {
+        if ($condition) {
+            $this->actionText = $text;
+            $this->actionUrl = $url;
+        }
+
+        return $this;
+    }
+
+    /**
      * Set the name of the mailer that should send the notification.
      *
      * @param  string  $mailer


### PR DESCRIPTION
Imagine you want to send email and you want to display a button but with a condition, you may use some if condition and it's a awful. But you can use `actionIf` to display button without if condition into mail message:

```php
// Before
$message = (new MailMessage)
                ->greeting('Hello!')
                ->line('One of your invoices has been paid!');

if ($user->isTeacher()) {
    $message->action('View wallet', $walletRoute);
}
if ($user->isStudent()) {
    $message->action('Go to Course', $courseUrl);
}
$message->line();

// After
return (new MailMessage)
                ->greeting('Hello!')
                ->line('One of your invoices has been paid!')
                ->actionIf($user->isTeacher(), 'View wallet', $walletRoute)
                ->actionIf($user->isStudent(), 'Go to Course', $courseUrl)
                ->line('Thank you for using our application!');
```

Now think you have 5 condition 💣