### PR TITLE
[10.x] Add multiple exceptions support for the `rescue` helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -743,6 +743,10 @@ if (! function_exists('rescue')) {
                 report($e);
             }
 
+            if (is_array($rescue)) {
+                $rescue = $rescue[get_class($e)] ?? $rescue[0] ?? null;
+            }
+
             return value($rescue, $e);
         }
     }

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -7,6 +7,7 @@ use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use LogicException;
 use Orchestra\Testbench\TestCase;
 
 class FoundationHelpersTest extends TestCase
@@ -49,6 +50,31 @@ class FoundationHelpersTest extends TestCase
             rescue(function () use ($testClass) {
                 $testClass->test([]);
             }, 'rescued!')
+        );
+
+        $this->assertEquals(
+            'rescued!',
+            rescue(function () {
+                throw new Exception();
+            }, [
+                Exception::class => function () {
+                    return 'rescued!';
+                }
+            ])
+        );
+
+        $this->assertEquals(
+            'last resort!',
+            rescue(function () {
+                throw new LogicException();
+            }, [
+                Exception::class => function () {
+                    return 'rescued!';
+                },
+                function () {
+                    return 'last resort!';
+                }
+            ])
         );
     }
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -59,7 +59,7 @@ class FoundationHelpersTest extends TestCase
             }, [
                 Exception::class => function () {
                     return 'rescued!';
-                }
+                },
             ])
         );
 
@@ -73,7 +73,7 @@ class FoundationHelpersTest extends TestCase
                 },
                 function () {
                     return 'last resort!';
-                }
+                },
             ])
         );
     }


### PR DESCRIPTION
Sometimes you have a case where more than one exception can be thrown and you want to perform a certain action for each case. Currently it is not possible to do this with the `rescue` function.

For example you wan't to perform a simple action.

```php
try {
    $user = User::query()->findByEmail($email);
} catch (ModelNotFoundException $e) {
    // Do something when model is not found.
} catch (UnauthorizedException $e){
    // Do something when the current user is unauthorized.
}
```

With the added implementation to support multiple exceptions we can now do this to with rescue!

```php
$user = rescue(
    fn () => User::query()->findByEmail($email),
    [
        ModelNotFoundException::class => function (Throwable $e) {
            // Do something when model is not found.
        },
        UnauthorizedException::class => function (Throwable $e) {
            // Do something when the current user is unauthorized.
        },
        function () {
            // This block of code will be executed when non of the above exceptions match.
        }
    ]
);
```

As you can see we have added a third array item without a key. This will be executed as our last resort. This is not mandatory and can be omitted if desired. 