### PR TITLE
[10.x] add prefix and suffix to str random function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -800,9 +800,9 @@ class Str
      * @param  int  $length
      * @return string
      */
-    public static function random($length = 16)
+    public static function random($length = 16, $prefix = '', $suffix = '')
     {
-        return (static::$randomStringFactory ?? function ($length) {
+        return (static::$randomStringFactory ?? function ($length, $prefix, $suffix) {
             $string = '';
 
             while (($len = strlen($string)) < $length) {
@@ -815,8 +815,8 @@ class Str
                 $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
             }
 
-            return $string;
-        })($length);
+            return $prefix . $string . $suffix;
+        })($length, $prefix, $suffix);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -815,7 +815,7 @@ class Str
                 $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
             }
 
-            return $prefix . $string . $suffix;
+            return $prefix.$string.$suffix;
         })($length, $prefix, $suffix);
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -502,6 +502,7 @@ class SupportStrTest extends TestCase
         $randomInteger = random_int(1, 100);
         $this->assertEquals($randomInteger, strlen(Str::random($randomInteger)));
         $this->assertIsString(Str::random());
+        $this->assertEquals($randomInteger + 8, strlen(Str::random($randomInteger, 'foo_', '_bar')));
     }
 
     /** @test */


### PR DESCRIPTION
this pull request aim to add prefix and suffix to Str::random function if needed

```
$random = Str::random(5, 'foo_', '_bar')
```

should output something like this : foo_jndUh_bar

