### PR TITLE
[10.x] Flush statics in tests

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -942,7 +942,7 @@ trait EnumeratesValues
      */
     public static function proxy($method)
     {
-        static::$proxies[] = $method;
+        static::$proxies = array_unique([...static::$proxies, $method]);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Signals;
 use Illuminate\Console\View\Components\Line;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Http\Testing\MimeType;
 use Illuminate\Queue\Queue;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Routing\Route;
@@ -77,7 +78,7 @@ abstract class TestCase extends BaseTestCase
     protected $setUpHasRun = false;
 
     /**
-     * Flush any static testing helpers.
+     * Flush framework static values.
      *
      * @var bool
      */
@@ -266,16 +267,17 @@ abstract class TestCase extends BaseTestCase
         Sleep::fake(false);
 
         if ($this->flushStatics) {
-            Str::createUuidsNormally();
-            Str::createRandomStringsNormally();
-            Lottery::determineResultNormally();
+            DateFactory::useDefault();
+            Env::enablePutenv();
             File::$defaultCallback = null;
+            Lottery::determineResultNormally();
+            MimeType::flush();
             Password::$defaultCallback = null;
+            Pluralizer::useLanguage('english');
             ResourceRegistrar::setParameters([]);
             ResourceRegistrar::singularParameters();
-            DateFactory::useDefault();
-            Pluralizer::useLanguage('english');
-            Env::enablePutenv();
+            Str::createRandomStringsNormally();
+            Str::createUuidsNormally();
         }
 
         if ($this->callbackException) {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -28,6 +28,7 @@ use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Component;
+use Illuminate\View\DynamicComponent;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -266,8 +267,8 @@ abstract class TestCase extends BaseTestCase
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();
-        Queue::createPayloadUsing(null);
         HandleExceptions::forgetApp();
+        Queue::createPayloadUsing(null);
         Sleep::fake(false);
 
         if ($this->flushStatics) {
@@ -279,6 +280,8 @@ abstract class TestCase extends BaseTestCase
             MimeType::flush();
             Password::$defaultCallback = null;
             Pluralizer::useLanguage('english');
+            DynamicComponent::forgetCompiler();
+            DynamicComponent::forgetComponentClasses();
             QueueCapsuleManager::flushGlobal();
             ResourceRegistrar::setParameters([]);
             ResourceRegistrar::singularParameters();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -271,7 +271,6 @@ abstract class TestCase extends BaseTestCase
         Sleep::fake(false);
 
         if ($this->flushStatics) {
-            BladeCompiler::flushComponentHashStack();
             DatabaseCapsuleManager::flushGlobal();
             DateFactory::useDefault();
             Env::enablePutenv();

--- a/src/Illuminate/Http/Testing/MimeType.php
+++ b/src/Illuminate/Http/Testing/MimeType.php
@@ -62,4 +62,14 @@ class MimeType
     {
         return Arr::first(self::getMimeTypes()->getExtensions($mimeType));
     }
+
+    /**
+     * Flush the cached instance.
+     *
+     * @return void
+     */
+    public static function flush()
+    {
+        self::$mime = null;
+    }
 }

--- a/src/Illuminate/Support/Traits/CapsuleManagerTrait.php
+++ b/src/Illuminate/Support/Traits/CapsuleManagerTrait.php
@@ -66,4 +66,14 @@ trait CapsuleManagerTrait
     {
         $this->container = $container;
     }
+
+    /**
+     * Flush the global instance.
+     *
+     * @return void
+     */
+    public static function flushGlobal()
+    {
+        static::$instance = null;
+    }
 }

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -169,4 +169,24 @@ EOF;
 
         return static::$compiler;
     }
+
+    /**
+     * Forget the cached compiler.
+     *
+     * @return void
+     */
+    public static function forgetCompiler()
+    {
+        static::$compiler = null;
+    }
+
+    /**
+     * Forget the cached component classes.
+     *
+     * @return void
+     */
+    public static function forgetComponentClasses()
+    {
+        static::$componentClasses = [];
+    }
 }


### PR DESCRIPTION
An opt-in helper to refresh static values that may have been manipulated during a test. This will ensure that one test does not impact another and will hopefully also address some minor memory leakages.

Opt-in for `10.x` so we don't break applications. We could make this the default for `11.x`.

## WIP

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/Foundation/Mix.php#L22

_Note to self: We could probably extract this inline static out to a class static and reset it._

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/Collections/Traits/EnumeratesValues.php#L70

Although these are not reset between tests, they are now ensured to be unique. This means the array will not grow in length during a test run if the proxy is added when the framework boots.

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/Routing/ResourceRegistrar.php#L57

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/Support/ConfigurationUrlParser.php#L14

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php#L16

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/View/Concerns/ManagesLayouts.php#L30-L37

https://github.com/laravel/framework/blob/ffd5b97c743f0b598008686ece6d63a717f09202/src/Illuminate/Macroable/Traits/Macroable.php#L17

## Todo

- [ ] Do we need to put some of these in setUp so that unit tests not using the framework test case do not impact framework tests? Alternatively, extract out to method that could be used their as well `TestCase::flushStatics()` or whatever.