### PR TITLE
[10.x] Remove workarounds for old Guzzle versions

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -12,7 +12,6 @@ parameters:
     - "#Class [a-zA-Z0-9\\\\_]+ not found.#"
     - "#has invalid type#"
     - "#should always throw an exception or terminate script execution#"
-    - "#Function GuzzleHttp\\\\Psr7#"
     - "#Instantiated class [a-zA-Z0-9\\\\_]+ not found.#"
     - "#Unsafe usage of new static#"
   excludePaths:

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
@@ -93,9 +94,7 @@ class Factory
 
         $response = new Psr7Response($status, $headers, $body);
 
-        return class_exists(\GuzzleHttp\Promise\Create::class)
-            ? \GuzzleHttp\Promise\Create::promiseFor($response)
-            : \GuzzleHttp\Promise\promise_for($response);
+        return Create::promiseFor($response);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -39,12 +39,7 @@ class Pool
     public function __construct(Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory();
-
-        if (method_exists(Utils::class, 'chooseHandler')) {
-            $this->handler = Utils::chooseHandler();
-        } else {
-            $this->handler = \GuzzleHttp\choose_handler();
-        }
+        $this->handler = Utils::chooseHandler();
     }
 
     /**

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Client;
 
+use GuzzleHttp\Psr7\Message;
+
 class RequestException extends HttpClientException
 {
     /**
@@ -34,9 +36,7 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = class_exists(\GuzzleHttp\Psr7\Message::class)
-            ? \GuzzleHttp\Psr7\Message::bodySummary($response->toPsrResponse())
-            : \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
+        $summary = Message::bodySummary($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }


### PR DESCRIPTION
We already require Guzzle `^7.5`, which means all the newer (like 3 or 4 years old at this point) class methods are necessarily available.