### PR TITLE
[10.x] Allow the fill method on models to accept an additional 'except' parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -247,12 +247,12 @@ trait GuardsAttributes
      */
     protected function fillableFromArray(array $attributes, array|string $except = [])
     {
-        $except = !is_array($except) ? [$except] : $except;
+        $except = ! is_array($except) ? [$except] : $except;
 
-        if(!empty($except)){
+        if (! empty($except)) {
             $attributes = array_filter(
                 $attributes,
-                static fn ($key) => !in_array($key, $except, true),
+                static fn ($key) => ! in_array($key, $except, true),
                 ARRAY_FILTER_USE_KEY
             );
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -242,10 +242,21 @@ trait GuardsAttributes
      * Get the fillable attributes of a given array.
      *
      * @param  array  $attributes
+     * @param  array|string  $except
      * @return array
      */
-    protected function fillableFromArray(array $attributes)
+    protected function fillableFromArray(array $attributes, array|string $except = [])
     {
+        $except = !is_array($except) ? [$except] : $except;
+
+        if(!empty($except)){
+            $attributes = array_filter(
+                $attributes,
+                static fn ($key) => !in_array($key, $except, true),
+                ARRAY_FILTER_USE_KEY
+            );
+        }
+
         if (count($this->getFillable()) > 0 && ! static::$unguarded) {
             return array_intersect_key($attributes, array_flip($this->getFillable()));
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -501,15 +501,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Fill the model with an array of attributes.
      *
      * @param  array  $attributes
+     * @param  array|string  $except
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\MassAssignmentException
      */
-    public function fill(array $attributes)
+    public function fill(array $attributes, array|string $except = [])
     {
         $totallyGuarded = $this->totallyGuarded();
 
-        $fillable = $this->fillableFromArray($attributes);
+        $fillable = $this->fillableFromArray($attributes, $except);
 
         foreach ($fillable as $key => $value) {
             // The developers may choose to place some attributes in the "fillable" array

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1272,6 +1272,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model->fill(['name' => 'foo', 'age' => 'bar']);
         $this->assertSame('foo', $model->name);
         $this->assertSame('bar', $model->age);
+
+        $model = new EloquentModelStub;
+        $model->fillable(['name', 'age']);
+        $model->fill(['name' => 'foo', 'age' => 'bar', 'except' => 'baz'], 'except');
+        $model->fill(['name' => 'foo', 'age' => 'bar', 'except' => 'baz', 'except2' => 'baz'], ['except', 'except2']);
+        $this->assertSame('foo', $model->name);
+        $this->assertSame('bar', $model->age);
     }
 
     public function testQualifyColumn()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1275,8 +1275,13 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model = new EloquentModelStub;
         $model->fillable(['name', 'age']);
-        $model->fill(['name' => 'foo', 'age' => 'bar', 'except' => 'baz'], 'except');
-        $model->fill(['name' => 'foo', 'age' => 'bar', 'except' => 'baz', 'except2' => 'baz'], ['except', 'except2']);
+        $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz']);
+        $this->expectException(MassAssignmentException::class);
+
+        $model = new EloquentModelStub;
+        $model->fillable(['name', 'age']);
+        $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz'], 'address');
+        $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz', 'number' => 123], ['address', 'number']);
         $this->assertSame('foo', $model->name);
         $this->assertSame('bar', $model->age);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1274,16 +1274,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('bar', $model->age);
 
         $model = new EloquentModelStub;
-        $model->fillable(['name', 'age']);
-        $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz']);
-        $this->expectException(MassAssignmentException::class);
-
-        $model = new EloquentModelStub;
-        $model->fillable(['name', 'age']);
+        $model->guard([]);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz'], 'address');
-        $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz', 'number' => 123], ['address', 'number']);
         $this->assertSame('foo', $model->name);
         $this->assertSame('bar', $model->age);
+        $this->assertNull($model->address);
+
+        $model = new EloquentModelStub;
+        $model->guard([]);
+        $model->fill(['name' => 'foo', 'age' => 'bar', 'address' => 'baz', 'phone' => 123], ['address', 'phone']);
+        $this->assertSame('foo', $model->name);
+        $this->assertSame('bar', $model->age);
+        $this->assertNull($model->address);
+        $this->assertNull($model->phone);
     }
 
     public function testQualifyColumn()


### PR DESCRIPTION
Ran into a situation where i thought this might be helpful. It allows 1 key as string or multiple keys as array.

Since its an optional parameter it won't break anything that already exists.

Example:

```php

class Model
{
    protected $guarded = [];
}

class SomeController
{
    public function update(Request $request, Model $model)
    {
        $validated = $request->validate([
            'name' => 'required|string',
            'category' => 'required|string',
            'something_outside_model' => 'required|string',
        ]);

        $model->fill($validated, ['something_outside_model'])->save();
    }
}
```