### PR TITLE
[10.x] Adds new method for removing `where` bindings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3641,6 +3641,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Remove the "where" bindings from the current query.
+     *
+     * @return void
+     */
+    public function removeWhereBindings()
+    {
+        unset($this->bindings['where'], $this->wheres);
+    }
+
+    /**
      * Get the raw array of bindings.
      *
      * @return array


### PR DESCRIPTION
This PR allows us to remove all `where` clauses that have been added to the query, I think that method is important because it saves the count of accessing the database, For instance.

> Assume we have 15 users and 5 users only were verified.

## Before this PR gets merged

```PHP
$users = User::query();

if (auth()->user()->email == 'admin@admin.com') {
    // The `$verifiedUsers` variable would have 4 users
    $verifiedUsers = $users->where('id', '!=', 1)
        ->whereNotNull('email_verified_at')
        ->get();
}

// This line is for getting all users
return $users->get();
```

In the previous code, we begin querying the model and then check if the currently authenticated user is an admin then add some `where` clauses. I have discovered here that code affects also on `$users` variable which means that `$users->get()` line would have 4 users also and I want to get all users, so we will have to access the database again to get all users using the next line.

```PHP
$users = User::get();
```

The previous code will execute an additional query, and the solution for that issue is removing all `where` clauses and this is what I have done 😁

## After this PR gets merged

```PHP
$users = User::query();

if (auth()->user()->email == 'admin@admin.com') {
    // The `$verifiedUsers` variable would have 4 users
    $verifiedUsers = $users->where('id', '!=', 1)
        ->whereNotNull('email_verified_at')
        ->get();
}

// This line will remove all `where` clauses
$users->removeWhereBindings();

// This line will return all users without executing additional query 🚀
return $users->get();
```
