### PR TITLE
[10.x] Clears resolved instance of Vite when using `withoutVite`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Closure;
 use Illuminate\Foundation\Mix;
 use Illuminate\Foundation\Vite;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\HtmlString;
 use Mockery;
 
@@ -109,6 +110,8 @@ trait InteractsWithContainer
         if ($this->originalVite == null) {
             $this->originalVite = app(Vite::class);
         }
+
+        Facade::clearResolvedInstance(Vite::class);
 
         $this->swap(Vite::class, new class
         {

--- a/tests/Integration/Testing/TestCaseTest.php
+++ b/tests/Integration/Testing/TestCaseTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Testing;
+
+use Illuminate\Support\Facades\Vite;
+use Orchestra\Testbench\TestCase;
+
+class TestCaseTest extends TestCase
+{
+    public function test_without_vite_clear_facade_resolved_instance()
+    {
+        Vite::useScriptTagAttributes([
+            'crossorigin' => 'anonymous',
+        ]);
+
+        $this->withoutVite();
+
+        Vite::asset('foo.png');
+    }
+}


### PR DESCRIPTION
This pull request addresses an issue that may happen when the `Vite` facade gets used before calling `$this->withoutVite()` in your test suite. As example, if the user have the code 

```
// AppServiceProvider@boot method...
Vite::useScriptTagAttributes([
    'crossorigin' => 'anonymous',
]);

// TestCase...
$this->withoutVite();

Vite::asset('foo.png'); // this fails with `Vite manifest not found` as Facade is still working with previous instance of Vite, and not the fake one.
```