### PR TITLE
[10.x] Add `Conditionable` and `Macroable` traits to `Sleep`

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -58,19 +58,7 @@ class Sleep
      */
     public function __construct($duration)
     {
-        if (! $duration instanceof DateInterval) {
-            $this->duration = CarbonInterval::microsecond(0);
-
-            $this->pending = $duration;
-        } else {
-            $duration = CarbonInterval::instance($duration);
-
-            if ($duration->totalMicroseconds < 0) {
-                $duration = CarbonInterval::seconds(0);
-            }
-
-            $this->duration = $duration;
-        }
+        $this->duration($duration);
     }
 
     /**
@@ -119,6 +107,32 @@ class Sleep
     public static function sleep($duration)
     {
         return (new static($duration))->seconds();
+    }
+
+    /**
+     * Sleep for the given duration. Replaces any previously defined durations.
+     *
+     * @param  \DateInterval|int|float  $duration
+     * @return $this
+     */
+    public function duration($duration)
+    {
+        if (! $duration instanceof DateInterval) {
+            $this->duration = CarbonInterval::microsecond(0);
+
+            $this->pending = $duration;
+        } else {
+            $duration = CarbonInterval::instance($duration);
+
+            if ($duration->totalMicroseconds < 0) {
+                $duration = CarbonInterval::seconds(0);
+            }
+
+            $this->duration = $duration;
+            $this->pending = null;
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -5,11 +5,16 @@ namespace Illuminate\Support;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use DateInterval;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 
 class Sleep
 {
+    use Conditionable;
+    use Macroable;
+
     /**
      * The total duration to sleep.
      *

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -446,7 +446,7 @@ class SleepTest extends TestCase
         $this->assertSame($sleep->duration->totalMicroseconds, 1234567);
     }
 
-    public function testItCanCreateConditionallyDefineSleepsViaConditionable()
+    public function testItCanCreateConditionallyDefinedDurationsViaConditionable()
     {
         Sleep::fake();
 
@@ -467,5 +467,19 @@ class SleepTest extends TestCase
                 fn (Sleep $sleep) => $sleep->and(3)->milliseconds(),
         );
         $this->assertSame($sleep->duration->totalMicroseconds, 1003000);
+    }
+
+    public function testItCanReplacePreviouslyDefinedDurations()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1)->second();
+        $this->assertSame($sleep->duration->totalMicroseconds, 1000000);
+
+        $sleep->duration(2)->second();
+        $this->assertSame($sleep->duration->totalMicroseconds, 2000000);
+
+        $sleep->duration(500)->milliseconds();
+        $this->assertSame($sleep->duration->totalMicroseconds, 500000);
     }
 }

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -419,26 +419,30 @@ class SleepTest extends TestCase
     {
         Sleep::fake();
 
-        Sleep::macro('orSomeConfiguredAmountOfTime', function (): Sleep {
-            /** @var Sleep $this */
-            return $this->for(1.234)->seconds();
+        Sleep::macro('forSomeConfiguredAmountOfTime', static function () {
+            return Sleep::for(3)->seconds();
         });
 
-        Sleep::macro('andSomeConfiguredAmountOfTime', function (): Sleep {
+        Sleep::macro('useSomeOtherAmountOfTime', function () {
+            /** @var Sleep $this */
+            return $this->duration(1.234)->seconds();
+        });
+
+        Sleep::macro('andSomeMoreGranularControl', function () {
             /** @var Sleep $this */
             return $this->and(567)->microseconds();
         });
 
-        // Sanity check (1 second default)
-        $sleep = Sleep::for(1)->second();
-        $this->assertSame($sleep->duration->totalMicroseconds, 1000000);
+        // A static macro can be referenced
+        $sleep = Sleep::forSomeConfiguredAmountOfTime();
+        $this->assertSame($sleep->duration->totalMicroseconds, 3000000);
 
         // A macro can specify a new duration
-        $sleep = $sleep->orSomeConfiguredAmountOfTime();
+        $sleep = $sleep->useSomeOtherAmountOfTime();
         $this->assertSame($sleep->duration->totalMicroseconds, 1234000);
 
         // A macro can supplement an existing duration
-        $sleep = $sleep->andSomeConfiguredAmountOfTime();
+        $sleep = $sleep->andSomeMoreGranularControl();
         $this->assertSame($sleep->duration->totalMicroseconds, 1234567);
     }
 

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -456,7 +456,7 @@ class SleepTest extends TestCase
                 true,
                 fn (Sleep $sleep) => $sleep->and(2)->milliseconds(),
                 fn (Sleep $sleep) => $sleep->and(3)->milliseconds(),
-        );
+            );
         $this->assertSame($sleep->duration->totalMicroseconds, 1002000);
 
         $sleep = Sleep::for(1)
@@ -465,7 +465,7 @@ class SleepTest extends TestCase
                 false,
                 fn (Sleep $sleep) => $sleep->and(2)->milliseconds(),
                 fn (Sleep $sleep) => $sleep->and(3)->milliseconds(),
-        );
+            );
         $this->assertSame($sleep->duration->totalMicroseconds, 1003000);
     }
 


### PR DESCRIPTION
With the new release of `Sleep` you can easily interface with the sleeping mechanism of PHP, which is great! A few areas we could improve this:

**Conditionables**

One thing it lacks is the ability to conditionally define (or override) the time to sleep (TTS?), which could be easily achieved using the `Illuminate\Support\Conditionable` trait. For a rudimentary example:

```php
Sleep::for(1)->second()
    ->unless(
        $some->status === SomeStatus::PENDING,
        fn (Sleep $sleep) => $sleep->and(500)->milliseconds()
    );
```

**Macros**

Another thing it lacks is the ability to define reusable macros to override or supplement the TTS. This could be very helpful if you application sleeps in various places and you want standardised sleep logic, or wish to leverage a database setting (perhaps user-defined) to control the sleep. For a rudimentary example:

```php
// AppServiceProvider
Sleep::macro('forConfiguredTime', static function () {
    $milliseconds = DB::table('settings')->where('key', 'sleep_after_action')->first()->value ?? 1000; // let's say 3500 ms

    return Sleep::for($milliseconds)->milliseconds();
} );

// Throughout your application:
Sleep::forConfiguredTime(); // e.g. 3500ms
```

**Replacing durations**

To supplement both of the aforementioned features, the ability to replace the previously defined duration would be helpful, so this has been added as well. For example:

```php
$sleep = Sleep::for(1)->second();

// Replace the duration
$sleep->duration(800)->milliseconds();

// $sleep = 800ms not 1s
```

_Happy to rename this to `->set()` or `->replace()` or whatever._

---

While these changes might not seem immediately useful or crucial to all, I foresee them being helpful to people writing elegant sleep rules.
