### PR TITLE
[10.x] Add `defaultProviders` method to Facade class

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\DefaultProviders;
 use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\Fake;
@@ -310,6 +311,14 @@ abstract class Facade
             'View' => View::class,
             'Vite' => Vite::class,
         ]);
+    }
+
+    /**
+     * Get the application default providers.
+     */
+    public static function defaultProviders()
+    {
+        return new DefaultProviders();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -316,9 +316,9 @@ abstract class Facade
     /**
      * Get the application default providers.
      */
-    public static function defaultProviders()
+    public static function defaultProviders(?array $providers = null)
     {
-        return new DefaultProviders;
+        return new DefaultProviders($providers);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -318,7 +318,7 @@ abstract class Facade
      */
     public static function defaultProviders()
     {
-        return new DefaultProviders();
+        return new DefaultProviders;
     }
 
     /**


### PR DESCRIPTION
This PR simplify and harmonize usage of `DefaultProviders` class inside config file _(like `defaultAliases`)_.

As `Illuminate\Support\Facades\Facade` is already used in `app.php`, we can now instantiate `DefaultProvider` directly from Facade like:

```php
'providers' => Facade::defaultProviders()
    ->merge([
        App\Providers\AppServiceProvider::class,
        App\Providers\AuthServiceProvider::class,
        App\Providers\EventServiceProvider::class,
        App\Providers\RouteServiceProvider::class,
        // other providers ...
    ])->toArray(),
```

Instead of using traditional constructor
```php
'providers' => (new \Illuminate\Support\DefaultProviders)
    ->merge([
        App\Providers\AppServiceProvider::class,
        App\Providers\AuthServiceProvider::class,
        App\Providers\EventServiceProvider::class,
        App\Providers\RouteServiceProvider::class,
        // other providers ...
  ])->toArray(),
```