### PR TITLE
Adding missing "MustVerifyEmail" contract

### DIFF
--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -8,13 +8,15 @@ use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Auth\MustVerifyEmail as MustVerifyEmailContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 
 class User extends Model implements
     AuthenticatableContract,
     AuthorizableContract,
-    CanResetPasswordContract
+    CanResetPasswordContract,
+    MustVerifyEmailContract
 {
     use Authenticatable, Authorizable, CanResetPassword, MustVerifyEmail;
 }


### PR DESCRIPTION
When running Larastan it complained that the User model was not implementing `Illuminate\Contracts\Auth\MustVerifyEmail`.

```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Http/Controllers/Auth/VerifyEmailController.php                                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  23     Parameter #1 $user of class Illuminate\Auth\Events\Verified constructor expects Illuminate\Contracts\Auth\MustVerifyEmail, App\Models\User|null given.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
 ```

This PR looks to add the contract so that Phpstan is happy again.