### PR TITLE
[10.x] Add possibility to "supplement" class for make:model command

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -162,9 +162,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         $path = $this->getPath($name);
 
-        // Next, We will check to see if the class already exists. If it does, we don't want
-        // to create the class and overwrite the user's code. So, we will bail out so the
-        // code is untouched. Otherwise, we will continue generating this class' files.
+        // Next, We will check to see if the class already exists. If it does and is not supplementable,
+        // we don't want to create the class and overwrite the user's code. So, we will bail out so the
+        // code is untouched. If the class is supplementable, we don`t touch one but keep processing options.
+        // Otherwise, we will continue generating this class' files.
         if ((! $this->hasOption('force') ||
              ! $this->option('force')) &&
              $this->alreadyExists($this->getNameInput())) {

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Contracts\Console\Supplementable;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -167,6 +168,15 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         if ((! $this->hasOption('force') ||
              ! $this->option('force')) &&
              $this->alreadyExists($this->getNameInput())) {
+            if (
+                $this instanceof Supplementable
+                && $this->didReceiveOptions($this->input)
+            ) {
+                $this->components->info($this->type.' has been supplemented.');
+
+                return null;
+            }
+
             $this->components->error($this->type.' already exists.');
 
             return false;

--- a/src/Illuminate/Contracts/Console/Supplementable.php
+++ b/src/Illuminate/Contracts/Console/Supplementable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Console;
+
+interface Supplementable
+{
+    //
+}

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Console\Supplementable;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -11,7 +12,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:model')]
-class ModelMakeCommand extends GeneratorCommand
+class ModelMakeCommand extends GeneratorCommand implements Supplementable
 {
     use CreatesMatchingTest;
 


### PR DESCRIPTION
This feature allows developers to **"supplement" (update)** the class. For now it`s considered to work only for `make:model` command, however potentially it may be used for another commands in the future.

The idea is that if developer didn't add for some reason some options during `make:model` command, one is forced then to execute separately, for instance, `make:request` , `make:migration`, `make:seeder` etc., which is pretty annoying.

### Explanation:
So, if you have previously created model called `Something`, you are unable to execute `make:model` for this model and generate all related stuff anymore. This PR makes you feel free to do it (**obviously, without touching the code inside model**).

### Example

### Before

![image](https://github.com/laravel/framework/assets/72033639/e3355d4d-1f63-47a7-a700-a2ca4b8388ac)

### After

![image](https://github.com/laravel/framework/assets/72033639/9c2fd29f-78e9-4a5e-8a39-63d291f8177c)

### My opinion
This is a small but pretty nice feature I`d personally love to have and use. I hope someone else will find it useful :)