### PR TITLE
[10.x] `WithoutRelations` Attribute

### DIFF
--- a/src/Illuminate/Queue/Attributes/WithoutRelations.php
+++ b/src/Illuminate/Queue/Attributes/WithoutRelations.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class WithoutRelations
+{
+    public function __construct(public readonly array $exclude = ['*'])
+    {
+        //
+    }
+}


### PR DESCRIPTION
This just acts a short-hand for calling `withoutRelations()` (and `unsetRelation()`) with serializable jobs/event listeners.

```php
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\Attributes\WithoutRelations;
use Illuminate\Queue\SerializesModels;
use App\Models\User;
use App\Models\Group;

class CreateUserGroupPermissions implements ShouldQueue
{
    use SerializesModels;

    private readonly User $user;

    private readonly Group $group;

    public function __construct(
        User $user,
        Group $group,
        private readonly array $permissions = ['read', 'write', 'comment']
    )
    {
        $this->user = $user->withoutRelations();
        $this->group = (clone $group)->unsetRelation('user');
    }

    public function handle(): void
    {
        collect($this->permissions)->each(fn ($permission) => doSomethingElse($this-group, $this->user, $permission));
    }
}
```

can now become

```php
public function __construct(
        #[WithoutRelations]
        private readonly User $user,
        #[WithoutRelations(['user'])]
        private readonly Group $group,
        private readonly array $permissions = ['read', 'write', 'comment']
    )
    {
    }
```

This is to improve developer experience, as I find developers tend to either forget to the unset relations before storing them, and when they do, the constructor promotion tends to get ugly where we cannot set `readonly`.