### PR TITLE
[10.x] Fixes singleton and api singletons creatable|destryoable|only|except combinations

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -249,13 +249,17 @@ class ResourceRegistrar
             $methods = array_diff($methods, (array) $options['except']);
         }
 
+        if (isset($options['apiSingleton'])) {
+            $methods = array_diff($methods, ['create', 'edit']);
+        }
+
         if (isset($options['creatable'])) {
             $methods = isset($options['apiSingleton'])
                             ? array_merge(['store', 'destroy'], $methods)
                             : array_merge(['create', 'store', 'destroy'], $methods);
 
             return $this->getResourceMethods(
-                $methods, array_values(Arr::except($options, ['creatable']))
+                $methods, Arr::except($options, ['creatable'])
             );
         }
 
@@ -263,11 +267,11 @@ class ResourceRegistrar
             $methods = array_merge(['destroy'], $methods);
 
             return $this->getResourceMethods(
-                $methods, array_values(Arr::except($options, ['destroyable']))
+                $methods, Arr::except($options, ['destroyable'])
             );
         }
 
-        return $methods;
+        return array_values($methods);
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class ResourceRegistrar
@@ -149,6 +148,12 @@ class ResourceRegistrar
 
         $defaults = $this->singletonResourceDefaults;
 
+        if (isset($options['creatable'])) {
+            $defaults = array_merge($defaults, ['create', 'store', 'destroy']);
+        } elseif (isset($options['destroyable'])) {
+            $defaults = array_merge($defaults, ['destroy']);
+        }
+
         $collection = new RouteCollection;
 
         $resourceMethods = $this->getResourceMethods($defaults, $options);
@@ -247,28 +252,6 @@ class ResourceRegistrar
 
         if (isset($options['except'])) {
             $methods = array_diff($methods, (array) $options['except']);
-        }
-
-        if (isset($options['apiSingleton'])) {
-            $methods = array_diff($methods, ['create', 'edit']);
-        }
-
-        if (isset($options['creatable'])) {
-            $methods = isset($options['apiSingleton'])
-                            ? array_merge(['store', 'destroy'], $methods)
-                            : array_merge(['create', 'store', 'destroy'], $methods);
-
-            return $this->getResourceMethods(
-                $methods, Arr::except($options, ['creatable'])
-            );
-        }
-
-        if (isset($options['destroyable'])) {
-            $methods = array_merge(['destroy'], $methods);
-
-            return $this->getResourceMethods(
-                $methods, Arr::except($options, ['destroyable'])
-            );
         }
 
         return array_values($methods);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -427,16 +427,17 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function apiSingleton($name, $controller, array $options = [])
     {
-        $only = ['show', 'update', 'destroy'];
-
-        if (isset($options['except'])) {
-            $only = array_diff($only, (array) $options['except']);
+        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
+            $registrar = $this->container->make(ResourceRegistrar::class);
+        } else {
+            $registrar = new ResourceRegistrar($this);
         }
 
-        return $this->singleton($name, $controller, array_merge([
-            'only' => $only,
-            'apiSingleton' => true,
-        ], $options));
+        return new PendingSingletonResourceRegistration(
+            $registrar, $name, $controller, array_merge([
+                'apiSingleton' => true,
+            ], $options),
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -427,17 +427,15 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function apiSingleton($name, $controller, array $options = [])
     {
-        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
-            $registrar = $this->container->make(ResourceRegistrar::class);
-        } else {
-            $registrar = new ResourceRegistrar($this);
+        $only = ['store', 'show', 'update', 'destroy'];
+
+        if (isset($options['except'])) {
+            $only = array_diff($only, (array) $options['except']);
         }
 
-        return new PendingSingletonResourceRegistration(
-            $registrar, $name, $controller, array_merge([
-                'apiSingleton' => true,
-            ], $options),
-        );
+        return $this->singleton($name, $controller, array_merge([
+            'only' => $only,
+        ], $options));
     }
 
     /**

--- a/tests/Integration/Routing/RouteSingletonTest.php
+++ b/tests/Integration/Routing/RouteSingletonTest.php
@@ -116,7 +116,7 @@ class RouteSingletonTest extends TestCase
 
     public function testDestroyableSingleton()
     {
-        Route::singleton('avatar', SingletonTestController::class)->destroyable();
+        Route::singleton('avatar', CreatableSingletonTestController::class)->destroyable();
 
         $this->assertSame('http://localhost/avatar', route('avatar.show'));
         $response = $this->get('/avatar');

--- a/tests/Integration/Routing/RouteSingletonTest.php
+++ b/tests/Integration/Routing/RouteSingletonTest.php
@@ -191,6 +191,32 @@ class RouteSingletonTest extends TestCase
         $this->assertEquals(405, $response->getStatusCode());
     }
 
+    public function testCreatableDestroyableSingletonOnlyExceptTest()
+    {
+        Route::singleton('avatar', SingletonTestController::class)->creatable()->destroyable()->only(['show'])->except(['destroy']);
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
     public function testApiSingleton()
     {
         Route::apiSingleton('avatar', SingletonTestController::class);
@@ -344,6 +370,32 @@ class RouteSingletonTest extends TestCase
 
         $response = $this->patch('/avatar');
         $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    public function testCreatableDestroyableApiSingletonOnlyExceptTest()
+    {
+        Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable()->destroyable()->only(['show'])->except(['destroy']);
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
 
         $response = $this->delete('/avatar');
         $this->assertEquals(405, $response->getStatusCode());

--- a/tests/Integration/Routing/RouteSingletonTest.php
+++ b/tests/Integration/Routing/RouteSingletonTest.php
@@ -259,7 +259,7 @@ class RouteSingletonTest extends TestCase
         $this->assertEquals(405, $response->getStatusCode());
 
         $response = $this->get('/avatar/create');
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
 
         $response = $this->post('/avatar');
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/Integration/Routing/RouteSingletonTest.php
+++ b/tests/Integration/Routing/RouteSingletonTest.php
@@ -62,9 +62,61 @@ class RouteSingletonTest extends TestCase
         $this->assertSame('singleton destroy', $response->getContent());
     }
 
+    public function testCreatableSingletonOnly()
+    {
+        Route::singleton('avatar', CreatableSingletonTestController::class)->creatable()->only('show');
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    public function testCreatableSingletonExcept()
+    {
+        Route::singleton('avatar', CreatableSingletonTestController::class)->creatable()->except('show');
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     public function testDestroyableSingleton()
     {
-        Route::singleton('avatar', CreatableSingletonTestController::class)->destroyable();
+        Route::singleton('avatar', SingletonTestController::class)->destroyable();
 
         $this->assertSame('http://localhost/avatar', route('avatar.show'));
         $response = $this->get('/avatar');
@@ -87,6 +139,58 @@ class RouteSingletonTest extends TestCase
         $this->assertSame('singleton destroy', $response->getContent());
     }
 
+    public function testDestroyableSingletonOnly()
+    {
+        Route::singleton('avatar', SingletonTestController::class)->destroyable()->only('destroy');
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testDestroyableSingletonExcept()
+    {
+        Route::singleton('avatar', SingletonTestController::class)->destroyable()->except('destroy');
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
     public function testApiSingleton()
     {
         Route::apiSingleton('avatar', SingletonTestController::class);
@@ -94,8 +198,8 @@ class RouteSingletonTest extends TestCase
         $response = $this->get('/avatar/create');
         $this->assertEquals(404, $response->getStatusCode());
 
-        $response = $this->post('/avatar/store');
-        $this->assertEquals(404, $response->getStatusCode());
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
 
         $this->assertSame('http://localhost/avatar', route('avatar.update'));
         $response = $this->put('/avatar');
@@ -121,6 +225,58 @@ class RouteSingletonTest extends TestCase
         $this->assertSame('singleton update', $response->getContent());
     }
 
+    public function testCreatableApiSingletonOnly()
+    {
+        Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable()->only(['create', 'store']);
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    public function testCreatableApiSingletonExcept()
+    {
+        Route::apiSingleton('avatar', CreatableSingletonTestController::class)->creatable()->except(['create', 'store']);
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     public function testDestroyableApiSingleton()
     {
         Route::apiSingleton('avatar', CreatableSingletonTestController::class)->destroyable();
@@ -139,6 +295,58 @@ class RouteSingletonTest extends TestCase
         $response = $this->delete('/avatar');
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertSame('singleton destroy', $response->getContent());
+    }
+
+    public function testDestroyableApiSingletonOnly()
+    {
+        Route::apiSingleton('avatar', CreatableSingletonTestController::class)->destroyable()->only(['destroy']);
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testDestroyableApiSingletonExcept()
+    {
+        Route::apiSingleton('avatar', CreatableSingletonTestController::class)->destroyable()->except(['destroy', 'show']);
+
+        $response = $this->get('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/create');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->post('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
+
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(404, $response->getStatusCode());
+
+        $response = $this->put('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->patch('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->delete('/avatar');
+        $this->assertEquals(405, $response->getStatusCode());
     }
 
     public function testSingletonOnly()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -592,6 +592,19 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
+    public function testCanLimitAndExcludeMethodsOnRegisteredResource()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->only('index', 'show', 'destroy')
+                     ->except('destroy');
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
     public function testCanSetShallowOptionOnRegisteredResource()
     {
         $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->shallow();

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1101,6 +1101,155 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals([], $this->router->getMiddlewareGroups());
     }
 
+    public function testCanRegisterSingleton()
+    {
+        $this->router->singleton('user', RouteRegistrarControllerStub::class);
+
+        $this->assertCount(3, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+    }
+
+    public function testCanRegisterApiSingleton()
+    {
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class);
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+    }
+
+    public function testCanRegisterCreatableSingleton()
+    {
+        $this->router->singleton('user', RouteRegistrarControllerStub::class)->creatable();
+
+        $this->assertCount(6, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.create'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.store'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.destroy'));
+    }
+
+    public function testCanRegisterCreatableApiSingleton()
+    {
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class)->creatable();
+
+        $this->assertCount(4, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.store'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.destroy'));
+    }
+
+    public function testSingletonCreatableNotDestroyable()
+    {
+        $this->router->singleton('user', RouteRegistrarControllerStub::class)
+            ->creatable()
+            ->except('destroy');
+
+        $this->assertCount(5, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.create'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.store'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.destroy'));
+    }
+
+    public function testApiSingletonCreatableNotDestroyable()
+    {
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class)
+            ->creatable()
+            ->except('destroy');
+
+        $this->assertCount(3, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.store'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.destroy'));
+    }
+
+    public function testSingletonCanBeDestroyable()
+    {
+        $this->router->singleton('user', RouteRegistrarControllerStub::class)
+            ->destroyable();
+
+        $this->assertCount(4, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.destroy'));
+    }
+
+    public function testApiSingletonCanBeDestroyable()
+    {
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class)
+            ->destroyable();
+
+        $this->assertCount(3, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.destroy'));
+    }
+
+    public function testSingletonCanBeOnlyCreatable()
+    {
+        $this->router->singleton('user', RouteRegistrarControllerStub::class)
+            ->creatable()
+            ->only('create', 'store');
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.create'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.store'));
+    }
+
+    public function testApiSingletonCanBeOnlyCreatable()
+    {
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class)
+            ->creatable()
+            ->only('store');
+
+        $this->assertCount(1, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.store'));
+    }
+
+    public function testSingletonDoesntAllowIncludingUnsupportedMethods()
+    {
+        $this->router->singleton('post', RouteRegistrarControllerStub::class)
+            ->only('index', 'store', 'create', 'destroy');
+
+        $this->assertCount(0, $this->router->getRoutes());
+
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class)
+            ->only('index', 'store', 'create', 'destroy');
+
+        $this->assertCount(0, $this->router->getRoutes());
+    }
+
+    public function testApiSingletonCanIncludeAnySingletonMethods()
+    {
+        // This matches the behavior of the apiResource method.
+        $this->router->apiSingleton('user', RouteRegistrarControllerStub::class)
+            ->only('edit');
+
+        $this->assertCount(1, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.edit'));
+    }
+
     /**
      * Get the last route registered with the router.
      *


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/framework/issues/47088, and the usage of `creatable` or `destroyable` Singleton Resources when combined with options such as `only` or `except`.

@jessarcher Can you let know what do you think about this, before I deliver it to Taylor? Thanks!