### PR TITLE
[10.x] Add `Macroable` trait to `Sleep` class

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
-use Carbon\Exceptions\InvalidCastException;
 use DateInterval;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -113,7 +113,7 @@ class Sleep
      * @param  \DateInterval|int|float  $duration
      * @return $this
      */
-    public function duration($duration)
+    protected function duration($duration)
     {
         if (! $duration instanceof DateInterval) {
             $this->duration = CarbonInterval::microsecond(0);

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -4,12 +4,16 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Carbon\Exceptions\InvalidCastException;
 use DateInterval;
+use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 
 class Sleep
 {
+    use Macroable;
+
     /**
      * The total duration to sleep.
      *
@@ -53,19 +57,7 @@ class Sleep
      */
     public function __construct($duration)
     {
-        if (! $duration instanceof DateInterval) {
-            $this->duration = CarbonInterval::microsecond(0);
-
-            $this->pending = $duration;
-        } else {
-            $duration = CarbonInterval::instance($duration);
-
-            if ($duration->totalMicroseconds < 0) {
-                $duration = CarbonInterval::seconds(0);
-            }
-
-            $this->duration = $duration;
-        }
+        $this->duration($duration);
     }
 
     /**
@@ -114,6 +106,32 @@ class Sleep
     public static function sleep($duration)
     {
         return (new static($duration))->seconds();
+    }
+
+    /**
+     * Sleep for the given duration. Replaces any previously defined duration.
+     *
+     * @param  \DateInterval|int|float  $duration
+     * @return $this
+     */
+    public function duration($duration)
+    {
+        if (! $duration instanceof DateInterval) {
+            $this->duration = CarbonInterval::microsecond(0);
+
+            $this->pending = $duration;
+        } else {
+            $duration = CarbonInterval::instance($duration);
+
+            if ($duration->totalMicroseconds < 0) {
+                $duration = CarbonInterval::seconds(0);
+            }
+
+            $this->duration = $duration;
+            $this->pending = null;
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -414,4 +414,49 @@ class SleepTest extends TestCase
             $this->assertSame("The expected sleep was found [0] times instead of [1].\nFailed asserting that 0 is identical to 1.", $e->getMessage());
         }
     }
+
+    public function testItCanCreateMacrosViaMacroable()
+    {
+        Sleep::fake();
+
+        Sleep::macro('forSomeConfiguredAmountOfTime', static function () {
+            return Sleep::for(3)->seconds();
+        });
+
+        Sleep::macro('useSomeOtherAmountOfTime', function () {
+            /** @var Sleep $this */
+            return $this->duration(1.234)->seconds();
+        });
+
+        Sleep::macro('andSomeMoreGranularControl', function () {
+            /** @var Sleep $this */
+            return $this->and(567)->microseconds();
+        });
+
+        // A static macro can be referenced
+        $sleep = Sleep::forSomeConfiguredAmountOfTime();
+        $this->assertSame($sleep->duration->totalMicroseconds, 3000000);
+
+        // A macro can specify a new duration
+        $sleep = $sleep->useSomeOtherAmountOfTime();
+        $this->assertSame($sleep->duration->totalMicroseconds, 1234000);
+
+        // A macro can supplement an existing duration
+        $sleep = $sleep->andSomeMoreGranularControl();
+        $this->assertSame($sleep->duration->totalMicroseconds, 1234567);
+    }
+
+    public function testItCanReplacePreviouslyDefinedDurations()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1)->second();
+        $this->assertSame($sleep->duration->totalMicroseconds, 1000000);
+
+        $sleep->duration(2)->second();
+        $this->assertSame($sleep->duration->totalMicroseconds, 2000000);
+
+        $sleep->duration(500)->milliseconds();
+        $this->assertSame($sleep->duration->totalMicroseconds, 500000);
+    }
 }

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -450,13 +450,17 @@ class SleepTest extends TestCase
     {
         Sleep::fake();
 
+        Sleep::macro('setDuration', function ($duration) {
+            return $this->duration($duration);
+        });
+
         $sleep = Sleep::for(1)->second();
         $this->assertSame($sleep->duration->totalMicroseconds, 1000000);
 
-        $sleep->duration(2)->second();
+        $sleep->setDuration(2)->second();
         $this->assertSame($sleep->duration->totalMicroseconds, 2000000);
 
-        $sleep->duration(500)->milliseconds();
+        $sleep->setDuration(500)->milliseconds();
         $this->assertSame($sleep->duration->totalMicroseconds, 500000);
     }
 }


### PR DESCRIPTION
From https://github.com/laravel/framework/pull/47092

This PR adds the Macroable trait to the Sleep class. Example:


```php
// AppServiceProvider
Sleep::macro('forConfiguredTime', static function () {
    $milliseconds = DB::table('settings')->where('key', 'sleep_after_action')->first()->value ?? 1000; // let's say 3500 ms

    return Sleep::for($milliseconds)->milliseconds();
} );

// Throughout your application:
Sleep::forConfiguredTime(); // e.g. 3500ms

// Or
Sleep::for(1)->second()->orMyCustomMacroAmountOfTime();
```

A helpful subfeature for this facility would be the ability to define a replacement duration. Example:


```php
$sleep = Sleep::for(1)->second();

// Replace the duration
$sleep->duration(800)->milliseconds();

// $sleep = 800ms not 1s
```