### PR TITLE
[10.x] Add `Conditionable` trait to `Sleep` class

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -5,11 +5,14 @@ namespace Illuminate\Support;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use DateInterval;
+use Illuminate\Support\Traits\Conditionable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 
 class Sleep
 {
+    use Conditionable;
+
     /**
      * The total duration to sleep.
      *

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -414,4 +414,27 @@ class SleepTest extends TestCase
             $this->assertSame("The expected sleep was found [0] times instead of [1].\nFailed asserting that 0 is identical to 1.", $e->getMessage());
         }
     }
+
+    public function testItCanCreateConditionallyDefinedDurationsViaConditionable()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1)
+            ->second()
+            ->when(
+                true,
+                fn (Sleep $sleep) => $sleep->and(2)->milliseconds(),
+                fn (Sleep $sleep) => $sleep->and(3)->milliseconds(),
+            );
+        $this->assertSame($sleep->duration->totalMicroseconds, 1002000);
+
+        $sleep = Sleep::for(1)
+            ->second()
+            ->when(
+                false,
+                fn (Sleep $sleep) => $sleep->and(2)->milliseconds(),
+                fn (Sleep $sleep) => $sleep->and(3)->milliseconds(),
+            );
+        $this->assertSame($sleep->duration->totalMicroseconds, 1003000);
+    }
 }


### PR DESCRIPTION
From https://github.com/laravel/framework/pull/47092

This PR adds the Conditionable trait to the Sleep class. Example:

```php
Sleep::for(1)->second()
    ->unless(
        $some->status === SomeStatus::PENDING,
        fn (Sleep $sleep) => $sleep->and(500)->milliseconds()
    );
```