### PR TITLE
[10.x] Use `Arr::mapWithKeys` directly

### DIFF
--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Support\Arr;
+
 trait RetrievesMultipleKeys
 {
     /**
@@ -16,9 +18,9 @@ trait RetrievesMultipleKeys
     {
         $return = [];
 
-        $keys = collect($keys)->mapWithKeys(function ($value, $key) {
+        $keys = Arr::mapWithKeys($keys, function ($value, $key) {
             return [is_string($key) ? $key : $value => is_string($key) ? $value : null];
-        })->all();
+        });
 
         foreach ($keys as $key => $default) {
             $return[$key] = $this->get($key, $default);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -474,9 +474,7 @@ class Arr
      */
     public static function prependKeysWith($array, $prependWith)
     {
-        return Collection::make($array)->mapWithKeys(function ($item, $key) use ($prependWith) {
-            return [$prependWith.$key => $item];
-        })->all();
+        return Arr::mapWithKeys($array, fn ($item, $key) => [$prependWith.$key => $item]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1836,9 +1836,9 @@ trait HasAttributes
             );
         }
 
-        return collect($this->original)->mapWithKeys(function ($value, $key) {
+        return Arr::mapWithKeys($this->original, function ($value, $key) {
             return [$key => $this->transformModelValue($key, $value)];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Relations\Concerns;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 
 trait InteractsWithPivotTable
@@ -149,13 +150,13 @@ trait InteractsWithPivotTable
      */
     protected function formatRecordsList(array $records)
     {
-        return collect($records)->mapWithKeys(function ($attributes, $id) {
+        return Arr::mapWithKeys($records, function ($attributes, $id) {
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }
 
             return [$id => $attributes];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
@@ -596,11 +597,11 @@ trait MakesHttpRequests
      */
     protected function transformHeadersToServerVars(array $headers)
     {
-        return collect(array_merge($this->defaultHeaders, $headers))->mapWithKeys(function ($value, $name) {
+        return Arr::mapWithKeys(array_merge($this->defaultHeaders, $headers), function ($value, $name) {
             $name = strtr(strtoupper($name), '-', '_');
 
             return [$this->formatServerHeaderKey($name) => $value];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -154,9 +154,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function getUrlRange($start, $end)
     {
-        return collect(range($start, $end))->mapWithKeys(function ($page) {
-            return [$page => $this->url($page)];
-        })->all();
+        return Arr::mapWithKeys(range($start, $end), fn ($page) => [$page => $this->url($page)]);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1123,11 +1123,9 @@ class Validator implements ValidatorContract
      */
     public function getRulesWithoutPlaceholders()
     {
-        return collect($this->rules)
-            ->mapWithKeys(fn ($value, $key) => [
-                str_replace($this->dotPlaceholder, '\\.', $key) => $value,
-            ])
-            ->all();
+        return Arr::mapWithKeys($this->rules, fn ($value, $key) => [
+            str_replace($this->dotPlaceholder, '\\.', $key) => $value,
+        ]);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a refactoring that replaces the usage of `collect($array)->mapWithKeys()->all()` with direct usage of the Arr::mapWithKeys method in the Laravel Arr class. 

The `Arr::mapWithKeys` method, recently added to Laravel's Arr class, provides the same functionality as mapWithKeys in the Collection class but allows us to work directly with arrays without the need for intermediate collection objects.

This refactoring improves the codebase by eliminating the conversion from array to collection and back to an array. The code becomes more concise, easier to read, and avoids unnecessary overhead.

Please review the changes and ensure they have been applied correctly and have not introduced any regressions or breaking changes. Your feedback and suggestions are welcome.

If this change is approved, we can proceed with identifying and replacing similar occurrences throughout the codebase. This will result in more streamlined and efficient code, improving maintainability and performance.
