### PR TITLE
[10.x] Report exception after job timeout occurred

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -223,6 +223,8 @@ class Worker
                 $this->markJobAsFailedIfItShouldFailOnTimeout(
                     $job->getConnectionName(), $job, $e
                 );
+
+                $this->exceptions->report($e);
             }
 
             $this->kill(static::EXIT_ERROR, $options);


### PR DESCRIPTION
As i explained in #47068, TimeoutExceededException only occurs in the JobFailed event when the job fails.
Consider that I set 5 attempts to the job and timeout occurred on the first and second attempt. After that the worker is killed and there is no way to know the timeout exception occured.
I think it is necessary to report this exception or send a special event