### PR TITLE
[10.x] Replace goto structure by while loop inside retry helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -240,24 +240,23 @@ if (! function_exists('retry')) {
             $times = count($times) + 1;
         }
 
-        beginning:
-        $attempts++;
-        $times--;
+        while (true) {
+            $attempts++;
+            $times--;
 
-        try {
-            return $callback($attempts);
-        } catch (Exception $e) {
-            if ($times < 1 || ($when && ! $when($e))) {
-                throw $e;
+            try {
+                return $callback($attempts);
+            } catch (Exception $e) {
+                if ($times < 1 || ($when && ! $when($e))) {
+                    throw $e;
+                }
+
+                $sleepMilliseconds = $backoff[$attempts - 1] ?? $sleepMilliseconds;
+
+                if ($sleepMilliseconds) {
+                    Sleep::usleep(value($sleepMilliseconds, $attempts, $e) * 1000);
+                }
             }
-
-            $sleepMilliseconds = $backoff[$attempts - 1] ?? $sleepMilliseconds;
-
-            if ($sleepMilliseconds) {
-                Sleep::usleep(value($sleepMilliseconds, $attempts, $e) * 1000);
-            }
-
-            goto beginning;
         }
     }
 }


### PR DESCRIPTION
Since **goto** structure is considered to be kind of "deprecated", some people wish **to avoid using it** (me as well).

Seeing no reason to use it when we have loops