### PR TITLE
[10.x] Add Conditional Sleeps

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
-use Closure;
 use DateInterval;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -416,14 +415,12 @@ class Sleep
     /**
      * Only sleep when the condition is true.
      *
-     * @param (\Closure($this): bool)|bool $condition
+     * @param  (\Closure($this): bool)|bool $condition
      * @return $this
      */
     public function when($condition)
     {
-        $condition = $condition instanceof Closure ? $condition($this) : $condition;
-
-        $this->shouldSleep = (bool) $condition;
+        $this->shouldSleep = (bool) value($condition, $this);
 
         return $this;
     }
@@ -431,13 +428,11 @@ class Sleep
     /**
      * Always sleep unless the condition is true.
      *
-     * @param (\Closure($this): bool)|bool $condition
+     * @param  (\Closure($this): bool)|bool $condition
      * @return $this
      */
     public function unless($condition)
     {
-        $condition = $condition instanceof Closure ? $condition($this) : $condition;
-
-        return $this->when(! $condition);
+        return $this->when(! value($condition, $this));
     }
 }

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -414,7 +414,7 @@ class Sleep
     }
 
     /**
-     * Only sleep when the condition is true
+     * Only sleep when the condition is true.
      *
      * @param (\Closure($this): bool)|bool $condition
      * @return $this
@@ -429,7 +429,7 @@ class Sleep
     }
 
     /**
-     * Always sleep unless the condition is true
+     * Always sleep unless the condition is true.
      *
      * @param (\Closure($this): bool)|bool $condition
      * @return $this

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -426,7 +426,7 @@ class Sleep
     }
 
     /**
-     * Always sleep unless the condition is true.
+     * Don't sleep when the condition is true.
      *
      * @param  (\Closure($this): bool)|bool $condition
      * @return $this

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Closure;
 use DateInterval;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -410,5 +411,33 @@ class Sleep
         $this->shouldSleep = false;
 
         return $this;
+    }
+
+    /**
+     * Only sleep when the condition is true
+     *
+     * @param (\Closure($this): bool)|bool $condition
+     * @return $this
+     */
+    public function when($condition)
+    {
+        $condition = $condition instanceof Closure ? $condition($this) : $condition;
+
+        $this->shouldSleep = (bool) $condition;
+
+        return $this;
+    }
+
+    /**
+     * Always sleep unless the condition is true
+     *
+     * @param (\Closure($this): bool)|bool $condition
+     * @return $this
+     */
+    public function unless($condition)
+    {
+        $condition = $condition instanceof Closure ? $condition($this) : $condition;
+
+        return $this->when(! $condition);
     }
 }

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -413,7 +413,7 @@ class Sleep
     }
 
     /**
-     * Only sleep when the condition is true.
+     * Only sleep when the given condition is true.
      *
      * @param  (\Closure($this): bool)|bool $condition
      * @return $this
@@ -426,7 +426,7 @@ class Sleep
     }
 
     /**
-     * Don't sleep when the condition is true.
+     * Don't sleep when the given condition is true.
      *
      * @param  (\Closure($this): bool)|bool $condition
      * @return $this

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -463,4 +463,42 @@ class SleepTest extends TestCase
         $sleep->setDuration(500)->milliseconds();
         $this->assertSame($sleep->duration->totalMicroseconds, 500000);
     }
+
+    public function testItCanSleepConditionallyWhen()
+    {
+        Sleep::fake();
+
+        // Control test
+        Sleep::assertSlept(fn () => true, 0);
+        Sleep::for(1)->second();
+        Sleep::assertSlept(fn () => true, 1);
+        Sleep::fake();
+        Sleep::assertSlept(fn () => true, 0);
+
+        // Reset
+        Sleep::fake();
+
+        // Will not sleep if `when()` yields `false`
+        Sleep::for(1)->second()->when(false);
+        Sleep::for(1)->second()->when(fn () => false);
+
+        // Will not sleep if `unless()` yields `true`
+        Sleep::for(1)->second()->unless(true);
+        Sleep::for(1)->second()->unless(fn () => true);
+
+        // Finish 'do not sleep' tests - assert no sleeping occurred
+        Sleep::assertSlept(fn () => true, 0);
+
+        // Will sleep if `when()` yields `true`
+        Sleep::for(1)->second()->when(true);
+        Sleep::assertSlept(fn () => true, 1);
+        Sleep::for(1)->second()->when(fn () => true);
+        Sleep::assertSlept(fn () => true, 2);
+
+        // Will sleep if `unless()` yields `false`
+        Sleep::for(1)->second()->unless(false);
+        Sleep::assertSlept(fn () => true, 3);
+        Sleep::for(1)->second()->unless(fn () => false);
+        Sleep::assertSlept(fn () => true, 4);
+    }
 }


### PR DESCRIPTION
This PR is spun off from https://github.com/laravel/framework/pull/47100 and implements the interface that @nunomaduro suggested:

```php
Sleep::for(1)->second()->unless($task->completed());
// or
Sleep::for(1)->second()->when($task->pending());
```

It also supports a `Closure` condition (bool return type)

```php
Sleep::for(1)->second()->unless(fn () => $task->completed());
// or
Sleep::for(1)->second()->when(fn () => $task->pending());
```

If the `Closure` support is unwanted then I'll get rid of it 🤷 