### PR TITLE
fixed bug when function wrapped around definition of related factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -471,7 +471,7 @@ abstract class Factory
         return collect($definition)
             ->map($evaluateRelations = function ($attribute) {
                 if ($attribute instanceof self) {
-                    $attribute = $this->getRandomRecycledModel($attribute->modelName())
+                    $attribute = $this->getRandomRecycledModel($attribute->modelName())?->getKey()
                         ?? $attribute->recycle($this->recycle)->create()->getKey();
                 } elseif ($attribute instanceof Model) {
                     $attribute = $attribute->getKey();

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -898,7 +898,7 @@ class FactoryTestCommentFactory extends Factory
         return [
             'commentable_id' => FactoryTestPostFactory::new(),
             'commentable_type' => FactoryTestPost::class,
-            'user_id' => FactoryTestUserFactory::new(),
+            'user_id' => fn() => FactoryTestUserFactory::new(),
             'body' => $this->faker->name(),
         ];
     }


### PR DESCRIPTION
This fixes a bug which arises when a factory instance is wrapped by a closure within a factory definition, combined with recyclable models.
Then a recyclable model gets retrieved, but is never converted to its key.
This causes an error because the INSERT statement tries to insert the entire model as json instead of simply its key, e.g.:
```
SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '{"id":2,"external_id":"1","name":"Abel","email":"admin2@tcc.test","role":"super-admin","status":"offline","status_confirmed_at":' for column 'user_id' at row 1 (SQL: insert into `text_messages` (`text_conversation_id`, `user_id`, `direction`, `subject`, `body`, `service_data`, `updated_at`, `created_at`) values (50, {"id":2,"external_id":"1","name":"Abel","email":"admin2@tcc.test","role":"super-admin","status":"offline","status_confirmed_at":null,"conversation_info":null,"administration_id":1,"google_refresh_token":null,"worker_sid":null,"notification_preferences":null,"home_screen_settings":null,"created_at":"2023-05-17T12:52:25.000000Z","updated_at":"2023-05-17T12:52:25.000000Z","deleted_at":null,"last_name":"Jacobs","full_name":"Abel Jacobs","pivot":{"company_id":1,"user_id":2}}, OUT, Labore excepturi et quod provident nulla., <html><head><title>In ipsam eos saepe.</title></head><body><form action="example.org" method="POST"><label for="username">aliquam</label><input type="text" id="username"><label for="password">harum</label><input type="password" id="password"></form><div id="37470"><div id="77081"></div><div id="52460"></div></div></body></html>
, [], 2023-05-17 14:52:26, 2023-05-17 14:52:26))
```
