### PR TITLE
Hide dev commands on production environments

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Cache\Console\PruneStaleTagsCommand;
+use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
@@ -236,6 +237,12 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
                 $this->{$method}();
             } else {
                 $this->app->singleton($command);
+            }
+
+            if ($this->app->environment('production') && array_key_exists($commandName, $this->devCommands)) {
+                $this->app->afterResolving($command, function (Command $command) {
+                    $command->setHidden();
+                });
             }
         }
 


### PR DESCRIPTION
On production environments, I always find myself looking through the extensive list of commands just to find the one command that I need at that moment. A large part of the commands offered by the framework are for development purposes only. Why not hide them on production environments?

The hidden commands can still be used, but they won't be disturbing the developer.

Not sure how to unit test this, since the `list` command is not part of the framework. Any guidance is appreciated.