### PR TITLE
[10.x] 'set authentication guard' middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/SetAuthenticationGuard.php
+++ b/src/Illuminate/Auth/Middleware/SetAuthenticationGuard.php
@@ -30,7 +30,7 @@ class SetAuthenticationGuard
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  string $guard
+     * @param  string  $guard
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle($request, Closure $next, string $guard)

--- a/src/Illuminate/Auth/Middleware/SetAuthenticationGuard.php
+++ b/src/Illuminate/Auth/Middleware/SetAuthenticationGuard.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Auth\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\Factory as Auth;
+
+class SetAuthenticationGuard
+{
+    /**
+     * The authentication factory instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $auth;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @return void
+     */
+    public function __construct(Auth $auth)
+    {
+        $this->auth = $auth;
+    }
+
+    /**
+     * Handle the given request and get the response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string $guard
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle($request, Closure $next, string $guard)
+    {
+        $response = $next($request);
+
+        $this->auth->shouldUse($guard);
+
+        return $response;
+    }
+}

--- a/tests/Auth/SetAuthenticationGuardMiddlewareTest.php
+++ b/tests/Auth/SetAuthenticationGuardMiddlewareTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Auth\Middleware\SetAuthenticationGuard;
+use Illuminate\Auth\RequestGuard;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class SetAuthenticationGuardMiddlewareTest extends TestCase
+{
+    protected $auth;
+
+    protected function setUp(): void
+    {
+        $container = Container::setInstance(new Container);
+
+        $this->auth = new AuthManager($container);
+
+        $container->singleton('config', function () {
+            return $this->createConfig();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+
+        Container::setInstance(null);
+    }
+
+    public function testSetDefaultGuardOfAuth()
+    {
+        $default = $this->registerAuthDriver('default');
+        $secondary = $this->registerAuthDriver('secondary');
+
+        $this->assertSame($default, $this->auth->guard());
+
+        $this->setAuthenticationGuard('secondary');
+
+        $this->assertSame($secondary, $this->auth->guard());
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'auth' => [
+                'defaults' => ['guard' => 'default'],
+                'guards' => [
+                    'default' => ['driver' => 'default'],
+                    'secondary' => ['driver' => 'secondary'],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Create and register a new auth driver with the auth manager.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Auth\RequestGuard
+     */
+    protected function registerAuthDriver($name)
+    {
+        $driver = new RequestGuard(
+            fn () => new stdClass,
+            m::mock(Request::class),
+            m::mock(EloquentUserProvider::class)
+        );
+
+        $this->auth->extend($name, fn () => $driver);
+
+        return $driver;
+    }
+    /**
+     * Call the "set authentication guard" middleware with the given guard.
+     *
+     * @param  string  $guard
+     * @return void
+     */
+    protected function setAuthenticationGuard($guard)
+    {
+        $request = m::mock(Request::class);
+
+        $nextParam = null;
+
+        $next = function ($param) use (&$nextParam) {
+            $nextParam = $param;
+        };
+
+        (new SetAuthenticationGuard($this->auth))->handle($request, $next, $guard);
+
+        $this->assertSame($request, $nextParam);
+    }
+}


### PR DESCRIPTION
In the `config/auth.php` file, the default authentication guard is defined. But currently, the framework does not provide an easy way to define that a route uses a different guard. It only currently does this when you use the 'authenticate' middleware. Sometimes a route is accessible by both guests and authenticated users, so the 'authenticate' middleware can not be used. If an authenticated user is present you want to customize the page/content/... based on that user. To get that working, you have to provide the guard name everywhere you access the auth user.

```php
// Assume the default authentication guard is 'web'

Route::('some-route-that-can-be-accessed-by-both-guests-and-authenticated-users', function () {
    // A user might be authenticated, but not using the default 'web' authentication guard
    
    // That means the following will always be null even if a user is correctly authenticated
    // because it uses that default 'web' authentication guard
    if (auth()->user()) {
        // This will never be executed even if an authenticated user is present ...
    }

     // To fix that, you have to explicitly set the authentication guard
    if (auth('foo')->user()) {
        // This now works if an authenticated user is present ...
    }

    // This also causes issues when working with gates.
    // The gate will immediately fail even if an authenticated user is present
    Gate::authorize('view', $project);
    // To fix that, you have to manually provide the authenticated user
    Gate::forUser(auth('foo')->user())->authorize('view', $project);
});
```

This PR fixes that by middleware that allows you to set the guard on a route using middleware.
```php
// Assume the default authentication guard is 'web'

Route::('some-route-that-can-be-accessed-by-both-guests-and-authenticated-users', function () {
    // Now you don't have to provide the correct guard name everywhere
    dump(auth()->user());

    // And you don't have to explicitly provide the user using the 'forUser' method
    Gate::authorize('view', $project);
})->middleware('guard:foo');
```
In this example I use a 'guard' alias for the middleware, which I would add to the Laravel skeleton if this PR is merged.