### PR TITLE
[10.x] Adds time rewind/forward

### DIFF
--- a/src/Illuminate/Support/At.php
+++ b/src/Illuminate/Support/At.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Exception;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Traits\Macroable;
+
+/**
+ * @property-read static $next
+ * @property-read static $prev
+ * @property-read static $previous
+ *
+ * @property-read static $startOf
+ *
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $second
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $seconds
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $minute
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $minutes
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $hour
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $hours
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $day
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $days
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $week
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $weeks
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $month
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $months
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $year
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $years
+ *
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $monday
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $tuesday
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $wednesday
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $thursday
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $friday
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $saturday
+ * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $sunday
+ */
+class At
+{
+    use Macroable;
+
+    /**
+     * The default timezone to use.
+     *
+     * @var \DateTimeZone|string|null
+     */
+    protected $tz = null;
+
+    /**
+     * How much to forward or rewind the moment.
+     *
+     * @var int
+     */
+    protected $amount = 1;
+
+    /**
+     * If it should rewind to the start of the given unit.
+     *
+     * @var bool
+     */
+    protected $start = false;
+
+    /**
+     * Create a new At instance.
+     *
+     * @param  \DateTimeZone|string|null  $tz
+     * @return void
+     */
+    public function __construct($tz = null)
+    {
+        $this->tz = $tz;
+    }
+
+    /**
+     * Find the next moment of time.
+     *
+     * @param  int  $amount
+     * @return $this
+     */
+    public function next($amount = 1)
+    {
+         $this->amount = $amount;
+
+         return $this;
+    }
+
+    /**
+     * Find the previous moment of time.
+     *
+     * @param  int  $amount
+     * @return $this
+     */
+    public function prev($amount = 1)
+    {
+         return $this->next(abs($amount) * -1);
+    }
+
+    /**
+     * Return the current moment.
+     *
+     * @return Carbon
+     */
+    public function now()
+    {
+        return Date::now($this->tz);
+    }
+
+    /**
+     * Returns the next or previous day of month.
+     *
+     * @param  int  $day
+     * @return \Illuminate\Support\Carbon|\DateTimeInterface
+     */
+    public function nthOfMonth($day)
+    {
+        return $this->now()
+            ->startOfMonth()
+            ->addUnit('month', $this->amount)
+            ->setUnitNoOverflow('day', abs($day), 'month')
+            ->setTimeFrom()
+            ->when($this->start)->startOfDay();
+    }
+
+    /**
+     * Modify the day of the week of the moment.
+     *
+     * @param  int  $dayOfWeek
+     * @return Carbon
+     */
+    protected function modifyDayOfWeek($dayOfWeek)
+    {
+        $moment = $this->now();
+
+        match ($this->amount <=> 0) {
+            -1 => $moment->previous($dayOfWeek),
+            1 => $moment->next($dayOfWeek),
+        };
+
+        return $moment->setTimeFrom()->when($this->start)->startOfDay();
+    }
+
+    /**
+     * Dynamically get a moment.
+     *
+     * @param  string  $name
+     * @return  $this
+     *
+     * @throws \Exception
+     */
+    public function __get(string $name)
+    {
+        if ($name === 'startOf') {
+            $this->start = true;
+
+            return $this;
+        }
+
+        return match ($name) {
+            'next' => $this->next(),
+            'prev',
+            'previous' => $this->prev(),
+            'second',
+            'seconds' => $this->now()->addUnit('second', $this->amount)->when($this->start)->startOfSecond(),
+            'minute',
+            'minutes' => $this->now()->addUnit('minute', $this->amount)->when($this->start)->startOfMinute(),
+            'hour',
+            'hours' => $this->now()->addUnit('hour', $this->amount)->when($this->start)->startOfHour(),
+            'day',
+            'days' => $this->now()->addUnit('day', $this->amount)->when($this->start)->startOfDay(),
+            'week',
+            'weeks' => $this->now()->addUnit('week', $this->amount)->when($this->start)->startOfWeek(),
+            'month',
+            'months' => $this->now()->addUnit('month', $this->amount)->when($this->start)->startOfMonth(),
+            'year',
+            'years' => $this->now()->addUnit('year', $this->amount)->when($this->start)->startOfYear(),
+            'monday' => $this->modifyDayOfWeek(Carbon::MONDAY),
+            'tuesday' => $this->modifyDayOfWeek(Carbon::TUESDAY),
+            'wednesday' => $this->modifyDayOfWeek(Carbon::WEDNESDAY),
+            'thursday' => $this->modifyDayOfWeek(Carbon::THURSDAY),
+            'friday' => $this->modifyDayOfWeek(Carbon::FRIDAY),
+            'saturday' => $this->modifyDayOfWeek(Carbon::SATURDAY),
+            'sunday' => $this->modifyDayOfWeek(Carbon::SUNDAY),
+            default => throw new Exception('Unable to access undefined property on '.__CLASS__.': '.$name)
+        };
+    }
+}

--- a/src/Illuminate/Support/At.php
+++ b/src/Illuminate/Support/At.php
@@ -10,9 +10,7 @@ use Illuminate\Support\Traits\Macroable;
  * @property-read static $next
  * @property-read static $prev
  * @property-read static $previous
- *
  * @property-read static $startOf
- *
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $second
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $seconds
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $minute
@@ -27,7 +25,6 @@ use Illuminate\Support\Traits\Macroable;
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $months
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $year
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $years
- *
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $monday
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $tuesday
  * @property-read \Illuminate\Support\Carbon|\DateTimeInterface $wednesday
@@ -80,9 +77,9 @@ class At
      */
     public function next($amount = 1)
     {
-         $this->amount = $amount;
+        $this->amount = $amount;
 
-         return $this;
+        return $this;
     }
 
     /**
@@ -93,7 +90,7 @@ class At
      */
     public function prev($amount = 1)
     {
-         return $this->next(abs($amount) * -1);
+        return $this->next(abs($amount) * -1);
     }
 
     /**
@@ -144,7 +141,7 @@ class At
      * Dynamically get a moment.
      *
      * @param  string  $name
-     * @return  $this
+     * @return $this
      *
      * @throws \Exception
      */

--- a/src/Illuminate/Support/At.php
+++ b/src/Illuminate/Support/At.php
@@ -136,7 +136,7 @@ class At
      */
     protected function edgeTime($time, $unit)
     {
-        return match($this->start) {
+        return match ($this->start) {
             1 => $time->startOf($unit),
             -1 => $time->endOf($unit),
             default => $time
@@ -159,7 +159,7 @@ class At
             ->addUnit('month', $this->amount)
             ->setUnitNoOverflow('day', abs($day), 'month')
             ->setTimeFrom($now)
-            ->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'day'));
+            ->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'day'));
     }
 
     /**
@@ -177,7 +177,7 @@ class At
             ->addUnit('month', $this->amount)
             ->setUnitNoOverflow('day', $now->day, 'month')
             ->setTimeFrom($now)
-            ->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'month'));
+            ->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'month'));
     }
 
     /**
@@ -195,7 +195,7 @@ class At
             1 => $now->next($dayOfWeek),
         };
 
-        return $now->setTimeFrom()->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'day'));
+        return $now->setTimeFrom()->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'day'));
     }
 
     /**
@@ -215,19 +215,19 @@ class At
             'prev',
             'previous' => $this->prev(),
             'second',
-            'seconds' => $this->now()->addUnit('second', $this->amount)->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'second')),
+            'seconds' => $this->now()->addUnit('second', $this->amount)->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'second')),
             'minute',
-            'minutes' => $this->now()->addUnit('minute', $this->amount)->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'minute')),
+            'minutes' => $this->now()->addUnit('minute', $this->amount)->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'minute')),
             'hour',
-            'hours' => $this->now()->addUnit('hour', $this->amount)->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'hour')),
+            'hours' => $this->now()->addUnit('hour', $this->amount)->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'hour')),
             'day',
-            'days' => $this->now()->addUnit('day', $this->amount)->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'day')),
+            'days' => $this->now()->addUnit('day', $this->amount)->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'day')),
             'week',
-            'weeks' => $this->now()->addUnit('week', $this->amount)->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'week')),
+            'weeks' => $this->now()->addUnit('week', $this->amount)->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'week')),
             'month',
             'months' => $this->addMonth(),
             'year',
-            'years' => $this->now()->addUnit('year', $this->amount)->when($this->start !== 0, fn($time) => $this->edgeTime($time, 'year')),
+            'years' => $this->now()->addUnit('year', $this->amount)->when($this->start !== 0, fn ($time) => $this->edgeTime($time, 'year')),
             'monday' => $this->modifyDayOfWeek(Carbon::MONDAY),
             'tuesday' => $this->modifyDayOfWeek(Carbon::TUESDAY),
             'wednesday' => $this->modifyDayOfWeek(Carbon::WEDNESDAY),

--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -187,6 +187,17 @@ class DateFactory
     }
 
     /**
+     * Finds the next or previous moment in time.
+     *
+     * @param  \DateTimeZone|string|null  $tz
+     * @return \Illuminate\Support\At
+     */
+    public static function at($tz = null)
+    {
+        return new At($tz);
+    }
+
+    /**
      * Handle dynamic calls to generate dates.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -84,6 +84,7 @@ use Illuminate\Support\DateFactory;
  * @method static void useStrictMode($strictModeEnabled = true)
  * @method static void useYearsOverflow($yearsOverflow = true)
  * @method static \Illuminate\Support\Carbon yesterday($tz = null)
+ * @method static \Illuminate\Support\At at($tz = null)
  *
  * @see \Illuminate\Support\DateFactory
  */

--- a/tests/Support/SupportAtTest.php
+++ b/tests/Support/SupportAtTest.php
@@ -8,14 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 class SupportAtTest extends TestCase
 {
-    /** @var \Illuminate\Support\At */
-    protected $at;
-
     protected function setUp(): void
     {
         Carbon::setTestNow('2020-01-01 19:30:05.168');
-
-        $this->at = new At();
     }
 
     protected function tearDown(): void
@@ -25,40 +20,40 @@ class SupportAtTest extends TestCase
 
     public function testUnits(): void
     {
-        $this->assertEquals('2020-01-01 19:30:06', $this->at->next->second);
-        $this->assertEquals('2020-01-01 19:30:15', $this->at->next(10)->seconds);
-        $this->assertEquals('2020-01-01 19:30:04', $this->at->prev->second);
-        $this->assertEquals('2020-01-01 19:29:55', $this->at->prev(10)->seconds);
+        $this->assertEquals('2020-01-01 19:30:06', At::next()->second);
+        $this->assertEquals('2020-01-01 19:30:15', At::next(10)->seconds);
+        $this->assertEquals('2020-01-01 19:30:04', At::prev()->second);
+        $this->assertEquals('2020-01-01 19:29:55', At::prev(10)->seconds);
 
-        $this->assertEquals('2020-01-01 19:31:05', $this->at->next->minute);
-        $this->assertEquals('2020-01-01 19:40:05', $this->at->next(10)->minutes);
-        $this->assertEquals('2020-01-01 19:29:05', $this->at->prev->minute);
-        $this->assertEquals('2020-01-01 19:20:05', $this->at->prev(10)->minutes);
+        $this->assertEquals('2020-01-01 19:31:05', At::next()->minute);
+        $this->assertEquals('2020-01-01 19:40:05', At::next(10)->minutes);
+        $this->assertEquals('2020-01-01 19:29:05', At::prev()->minute);
+        $this->assertEquals('2020-01-01 19:20:05', At::prev(10)->minutes);
 
-        $this->assertEquals('2020-01-01 20:30:05', $this->at->next->hour);
-        $this->assertEquals('2020-01-02 05:30:05', $this->at->next(10)->hours);
-        $this->assertEquals('2020-01-01 18:30:05', $this->at->prev->hour);
-        $this->assertEquals('2020-01-01 09:30:05', $this->at->prev(10)->hours);
+        $this->assertEquals('2020-01-01 20:30:05', At::next()->hour);
+        $this->assertEquals('2020-01-02 05:30:05', At::next(10)->hours);
+        $this->assertEquals('2020-01-01 18:30:05', At::prev()->hour);
+        $this->assertEquals('2020-01-01 09:30:05', At::prev(10)->hours);
 
-        $this->assertEquals('2020-01-02 19:30:05', $this->at->next->day);
-        $this->assertEquals('2020-01-11 19:30:05', $this->at->next(10)->days);
-        $this->assertEquals('2019-12-31 19:30:05', $this->at->prev->day);
-        $this->assertEquals('2019-12-22 19:30:05', $this->at->prev(10)->days);
+        $this->assertEquals('2020-01-02 19:30:05', At::next()->day);
+        $this->assertEquals('2020-01-11 19:30:05', At::next(10)->days);
+        $this->assertEquals('2019-12-31 19:30:05', At::prev()->day);
+        $this->assertEquals('2019-12-22 19:30:05', At::prev(10)->days);
 
-        $this->assertEquals('2020-01-08 19:30:05', $this->at->next->week);
-        $this->assertEquals('2020-03-11 19:30:05', $this->at->next(10)->weeks);
-        $this->assertEquals('2019-12-25 19:30:05', $this->at->prev->week);
-        $this->assertEquals('2019-10-23 19:30:05', $this->at->prev(10)->weeks);
+        $this->assertEquals('2020-01-08 19:30:05', At::next()->week);
+        $this->assertEquals('2020-03-11 19:30:05', At::next(10)->weeks);
+        $this->assertEquals('2019-12-25 19:30:05', At::prev()->week);
+        $this->assertEquals('2019-10-23 19:30:05', At::prev(10)->weeks);
 
-        $this->assertEquals('2020-02-01 19:30:05', $this->at->next->month);
-        $this->assertEquals('2020-11-01 19:30:05', $this->at->next(10)->months);
-        $this->assertEquals('2019-12-01 19:30:05', $this->at->prev->month);
-        $this->assertEquals('2019-03-01 19:30:05', $this->at->prev(10)->months);
+        $this->assertEquals('2020-02-01 19:30:05', At::next()->month);
+        $this->assertEquals('2020-11-01 19:30:05', At::next(10)->months);
+        $this->assertEquals('2019-12-01 19:30:05', At::prev()->month);
+        $this->assertEquals('2019-03-01 19:30:05', At::prev(10)->months);
 
-        $this->assertEquals('2021-01-01 19:30:05', $this->at->next->year);
-        $this->assertEquals('2030-01-01 19:30:05', $this->at->next(10)->years);
-        $this->assertEquals('2019-01-01 19:30:05', $this->at->prev->year);
-        $this->assertEquals('2010-01-01 19:30:05', $this->at->prev(10)->years);
+        $this->assertEquals('2021-01-01 19:30:05', At::next()->year);
+        $this->assertEquals('2030-01-01 19:30:05', At::next(10)->years);
+        $this->assertEquals('2019-01-01 19:30:05', At::prev()->year);
+        $this->assertEquals('2010-01-01 19:30:05', At::prev(10)->years);
     }
 
     /**
@@ -66,8 +61,8 @@ class SupportAtTest extends TestCase
      */
     public function testDayOfWeek($name, $next, $prev)
     {
-        $this->assertEquals($next, $this->at->next->{$name}, "The day $name is not the next.");
-        $this->assertEquals($prev, $this->at->prev->{$name}, "The day $name is not the previous.");
+        $this->assertEquals($next, At::next()->{$name}, "The day $name is not the next.");
+        $this->assertEquals($prev, At::prev()->{$name}, "The day $name is not the previous.");
     }
 
     public static function dayOfWeeks()
@@ -85,36 +80,69 @@ class SupportAtTest extends TestCase
 
     public function testNthOfMonth()
     {
-        $this->assertEquals('2020-02-01 19:30:05', $this->at->next->nthOfMonth(1));
-        $this->assertEquals('2019-12-01 19:30:05', $this->at->prev->nthOfMonth(1));
+        $this->assertEquals('2020-02-01 19:30:05', At::next()->nthOfMonth(1));
+        $this->assertEquals('2019-12-01 19:30:05', At::prev()->nthOfMonth(1));
 
-        $this->assertEquals('2021-01-30 19:30:05', $this->at->next(12)->nthOfMonth(30));
-        $this->assertEquals('2021-02-28 19:30:05', $this->at->next(13)->nthOfMonth(30));
-        $this->assertEquals('2019-01-30 19:30:05', $this->at->prev(12)->nthOfMonth(30));
-        $this->assertEquals('2018-12-30 19:30:05', $this->at->prev(13)->nthOfMonth(30));
+        $this->assertEquals('2021-01-30 19:30:05', At::next(12)->nthOfMonth(30));
+        $this->assertEquals('2021-02-28 19:30:05', At::next(13)->nthOfMonth(30));
+        $this->assertEquals('2019-01-30 19:30:05', At::prev(12)->nthOfMonth(30));
+        $this->assertEquals('2018-12-30 19:30:05', At::prev(13)->nthOfMonth(30));
+        $this->assertEquals('2018-12-31 19:30:05', At::prev(13)->nthOfMonth(99));
 
-        // This test if it can find the last day of february when the date overflows.
+        $this->assertEquals('2020-02-01 19:30:05', At::next()->nthOfMonth(1));
+        $this->assertEquals('2019-12-01 19:30:05', At::prev()->nthOfMonth(1));
+
+        $this->assertEquals('2021-01-30 19:30:05', At::next(12)->nthOfMonth(30));
+        $this->assertEquals('2021-02-28 19:30:05', At::next(13)->nthOfMonth(30));
+        $this->assertEquals('2019-01-30 19:30:05', At::prev(12)->nthOfMonth(30));
+        $this->assertEquals('2018-12-30 19:30:05', At::prev(13)->nthOfMonth(30));
+        $this->assertEquals('2018-12-31 19:30:05', At::prev(13)->nthOfMonth(99));
+    }
+
+    public function testNthOfMonthDoesNotOverflowInFebruary()
+    {
+        Carbon::setTestNow('2019-10-31 19:30:05');
+
+        $this->assertEquals('2020-02-29 19:30:05', At::next(4)->month);
+
         Carbon::setTestNow('2020-01-30 19:30:05');
 
-        $this->assertEquals('2020-02-01 19:30:05', $this->at->next->nthOfMonth(1));
-        $this->assertEquals('2019-12-01 19:30:05', $this->at->prev->nthOfMonth(1));
+        $this->assertEquals('2020-02-29 19:30:05', At::next()->month);
 
-        $this->assertEquals('2021-01-30 19:30:05', $this->at->next(12)->nthOfMonth(30));
-        $this->assertEquals('2021-02-28 19:30:05', $this->at->next(13)->nthOfMonth(30));
-        $this->assertEquals('2019-01-30 19:30:05', $this->at->prev(12)->nthOfMonth(30));
-        $this->assertEquals('2018-12-30 19:30:05', $this->at->prev(13)->nthOfMonth(30));
+        $this->assertEquals('2020-02-29 19:30:05', At::next()->nthOfMonth(30));
+        $this->assertEquals('2020-02-29 19:30:05', At::next()->nthOfMonth(99));
+
+        Carbon::setTestNow('2020-03-31 19:30:05');
+
+        $this->assertEquals('2020-02-29 19:30:05', At::prev()->month);
+
+        $this->assertEquals('2020-02-29 19:30:05', At::prev()->nthOfMonth(30));
+        $this->assertEquals('2020-02-29 19:30:05', At::prev()->nthOfMonth(99));
+
+        Carbon::setTestNow('2020-06-30 19:30:05');
+
+        $this->assertEquals('2020-02-29 19:30:05', At::prev(4)->month);
     }
 
     public function testStartOf()
     {
-        $this->at->startOf;
+        $this->assertEquals('2020-01-01 19:30:06', At::next()->startOf->second);
+        $this->assertEquals('2020-01-01 19:31:00', At::next()->startOf->minute);
+        $this->assertEquals('2020-01-01 20:00:00', At::next()->startOf->hour);
+        $this->assertEquals('2020-01-02 00:00:00', At::next()->startOf->day);
+        $this->assertEquals('2020-01-06 00:00:00', At::next()->startOf->week);
+        $this->assertEquals('2020-02-01 00:00:00', At::next()->startOf->month);
+        $this->assertEquals('2021-01-01 00:00:00', At::next()->startOf->year);
+    }
 
-        $this->assertEquals('2020-01-01 19:30:06', $this->at->next->second);
-        $this->assertEquals('2020-01-01 19:31:00', $this->at->next->minute);
-        $this->assertEquals('2020-01-01 20:00:00', $this->at->next->hour);
-        $this->assertEquals('2020-01-02 00:00:00', $this->at->next->day);
-        $this->assertEquals('2020-01-06 00:00:00', $this->at->next->week);
-        $this->assertEquals('2020-02-01 00:00:00', $this->at->next->month);
-        $this->assertEquals('2021-01-01 00:00:00', $this->at->next->year);
+    public function testEndOf()
+    {
+        $this->assertEquals('2020-01-01T19:30:06.999999Z', At::next()->endOf->second->toJSON());
+        $this->assertEquals('2020-01-01T19:31:59.999999Z', At::next()->endOf->minute->toJSON());
+        $this->assertEquals('2020-01-01T20:59:59.999999Z', At::next()->endOf->hour->toJSON());
+        $this->assertEquals('2020-01-02T23:59:59.999999Z', At::next()->endOf->day->toJSON());
+        $this->assertEquals('2020-01-12T23:59:59.999999Z', At::next()->endOf->week->toJSON());
+        $this->assertEquals('2020-02-29T23:59:59.999999Z', At::next()->endOf->month->toJSON());
+        $this->assertEquals('2021-12-31T23:59:59.999999Z', At::next()->endOf->year->toJSON());
     }
 }

--- a/tests/Support/SupportAtTest.php
+++ b/tests/Support/SupportAtTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\At;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class SupportAtTest extends TestCase
+{
+    /** @var \Illuminate\Support\At */
+    protected $at;
+
+    protected function setUp(): void
+    {
+        Carbon::setTestNow('2020-01-01 19:30:05.168');
+
+        $this->at = new At();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+    }
+
+    public function testUnits(): void
+    {
+        $this->assertEquals('2020-01-01 19:30:06', $this->at->next->second);
+        $this->assertEquals('2020-01-01 19:30:15', $this->at->next(10)->seconds);
+        $this->assertEquals('2020-01-01 19:30:04', $this->at->prev->second);
+        $this->assertEquals('2020-01-01 19:29:55', $this->at->prev(10)->seconds);
+
+        $this->assertEquals('2020-01-01 19:31:05', $this->at->next->minute);
+        $this->assertEquals('2020-01-01 19:40:05', $this->at->next(10)->minutes);
+        $this->assertEquals('2020-01-01 19:29:05', $this->at->prev->minute);
+        $this->assertEquals('2020-01-01 19:20:05', $this->at->prev(10)->minutes);
+
+        $this->assertEquals('2020-01-01 20:30:05', $this->at->next->hour);
+        $this->assertEquals('2020-01-02 05:30:05', $this->at->next(10)->hours);
+        $this->assertEquals('2020-01-01 18:30:05', $this->at->prev->hour);
+        $this->assertEquals('2020-01-01 09:30:05', $this->at->prev(10)->hours);
+
+        $this->assertEquals('2020-01-02 19:30:05', $this->at->next->day);
+        $this->assertEquals('2020-01-11 19:30:05', $this->at->next(10)->days);
+        $this->assertEquals('2019-12-31 19:30:05', $this->at->prev->day);
+        $this->assertEquals('2019-12-22 19:30:05', $this->at->prev(10)->days);
+
+        $this->assertEquals('2020-01-08 19:30:05', $this->at->next->week);
+        $this->assertEquals('2020-03-11 19:30:05', $this->at->next(10)->weeks);
+        $this->assertEquals('2019-12-25 19:30:05', $this->at->prev->week);
+        $this->assertEquals('2019-10-23 19:30:05', $this->at->prev(10)->weeks);
+
+        $this->assertEquals('2020-02-01 19:30:05', $this->at->next->month);
+        $this->assertEquals('2020-11-01 19:30:05', $this->at->next(10)->months);
+        $this->assertEquals('2019-12-01 19:30:05', $this->at->prev->month);
+        $this->assertEquals('2019-03-01 19:30:05', $this->at->prev(10)->months);
+
+        $this->assertEquals('2021-01-01 19:30:05', $this->at->next->year);
+        $this->assertEquals('2030-01-01 19:30:05', $this->at->next(10)->years);
+        $this->assertEquals('2019-01-01 19:30:05', $this->at->prev->year);
+        $this->assertEquals('2010-01-01 19:30:05', $this->at->prev(10)->years);
+    }
+
+    /**
+     * @dataProvider dayOfWeeks
+     */
+    public function testDayOfWeek($name, $next, $prev)
+    {
+        $this->assertEquals($next, $this->at->next->{$name}, "The day $name is not the next.");
+        $this->assertEquals($prev, $this->at->prev->{$name}, "The day $name is not the previous.");
+    }
+
+    public static function dayOfWeeks()
+    {
+        return [
+            ['monday', '2020-01-06 19:30:05', '2019-12-30 19:30:05'],
+            ['tuesday', '2020-01-07 19:30:05', '2019-12-31 19:30:05'],
+            ['wednesday', '2020-01-08 19:30:05', '2019-12-25 19:30:05'],
+            ['thursday', '2020-01-02 19:30:05', '2019-12-26 19:30:05'],
+            ['friday', '2020-01-03 19:30:05', '2019-12-27 19:30:05'],
+            ['saturday', '2020-01-04 19:30:05', '2019-12-28 19:30:05'],
+            ['sunday', '2020-01-05 19:30:05', '2019-12-29 19:30:05'],
+        ];
+    }
+
+    public function testNthOfMonth()
+    {
+        $this->assertEquals('2020-02-01 19:30:05', $this->at->next->nthOfMonth(1));
+        $this->assertEquals('2019-12-01 19:30:05', $this->at->prev->nthOfMonth(1));
+
+        $this->assertEquals('2021-01-30 19:30:05', $this->at->next(12)->nthOfMonth(30));
+        $this->assertEquals('2021-02-28 19:30:05', $this->at->next(13)->nthOfMonth(30));
+        $this->assertEquals('2019-01-30 19:30:05', $this->at->prev(12)->nthOfMonth(30));
+        $this->assertEquals('2018-12-30 19:30:05', $this->at->prev(13)->nthOfMonth(30));
+
+        // This test if it can find the last day of february when the date overflows.
+        Carbon::setTestNow('2020-01-30 19:30:05');
+
+        $this->assertEquals('2020-02-01 19:30:05', $this->at->next->nthOfMonth(1));
+        $this->assertEquals('2019-12-01 19:30:05', $this->at->prev->nthOfMonth(1));
+
+        $this->assertEquals('2021-01-30 19:30:05', $this->at->next(12)->nthOfMonth(30));
+        $this->assertEquals('2021-02-28 19:30:05', $this->at->next(13)->nthOfMonth(30));
+        $this->assertEquals('2019-01-30 19:30:05', $this->at->prev(12)->nthOfMonth(30));
+        $this->assertEquals('2018-12-30 19:30:05', $this->at->prev(13)->nthOfMonth(30));
+    }
+
+    public function testStartOf()
+    {
+        $this->at->startOf;
+
+        $this->assertEquals('2020-01-01 19:30:06', $this->at->next->second);
+        $this->assertEquals('2020-01-01 19:31:00', $this->at->next->minute);
+        $this->assertEquals('2020-01-01 20:00:00', $this->at->next->hour);
+        $this->assertEquals('2020-01-02 00:00:00', $this->at->next->day);
+        $this->assertEquals('2020-01-06 00:00:00', $this->at->next->week);
+        $this->assertEquals('2020-02-01 00:00:00', $this->at->next->month);
+        $this->assertEquals('2021-01-01 00:00:00', $this->at->next->year);
+    }
+}


### PR DESCRIPTION
## What?

A _smol_ helper to find the next or previous moment of time from the `DateFactory`. Its purpose is to simplify these operations, which to me are relatively common and require lengthy lines and calculations.

For example, let's try to get the next 30th of a month in january. 

```php
use Illuminate\Support\At;

// Today: 2020-01-01 12:13:14

// Find the next 30th without overflowing
At::next()->nthOfMonth(30); // 2020-02-29 12:13:14
```

Without the helper, you're bound to start _course-correcting_ the date to your needs.

```php
use Illuminate\Support\Facades\Date;

$date = Date::now()->setDay(30);

if ($date->isSameMonth()) {
    $date->addMonthNoOverflow();
}

if ($date->month === 2) {
    $date->setDay($date->daysInMonth)->setTimeFrom();
}

// ...
```

## How?

This helper works in three scenarios:

- Adding or subtracting a unit of time, from seconds to years.
- Advancing or rewinding to a day of week, like thursday.
- Advancing or rewinding to a day of month, like 30th, without accidental overflow.

Here are some notable examples:

```php
use Illuminate\Support\At;

// Now: 2020-01-01 12:13:14

// Units of time
At::prev(5)->months; // 2019-07-01 12:13:14
At::next()->year // 2021-01-01 12:13:14

// Day of Week
At::prev()->sunday //  2019-12-29 12:13:14

// Day of Month
At::next()->nthOfMonth(1) //  2020-02-01 12:13:14
```

All of these methods can _edged_ to their respective start or end with `startOf` and `endOf`, respectively.

```php
use Illuminate\Support\At;

// Now: 2020-01-01 12:13:14

At::next()->startOf->year; // 2021-01-01 00:00:00
```

## Other approaches

I decided strongly to set it outside the `DateFactory` class for two reasons:

- It depends strongly on Carbon.
- I force the dev to start with either `next()` or `prev()`.