### PR TITLE
[10.x] Input data decryption middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/DecryptInputValues.php
+++ b/src/Illuminate/Foundation/Http/Middleware/DecryptInputValues.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+
+class DecryptInputValues
+{
+    public function __construct(protected EncrypterContract $encrypter)
+    {
+    }
+
+    public function handle($request, Closure $next, ...$inputKeys)
+    {
+        $request->merge(
+            $request->collect($inputKeys ?: null)->map(function ($inputValue) {
+                try {
+                    $inputValue = $this->encrypter->decrypt($inputValue, false);
+                } catch (DecryptException) {
+                    $inputValue = null;
+                }
+
+                return $inputValue;
+            })->all()
+        );
+
+        return $next($request);
+    }
+}

--- a/tests/Foundation/Http/Middleware/DecryptInputValuesTest.php
+++ b/tests/Foundation/Http/Middleware/DecryptInputValuesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Http\Middleware\DecryptInputValues;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class DecryptInputValuesTest extends TestCase
+{
+    protected Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container;
+        $this->container->singleton(EncrypterContract::class, function () {
+            return new Encrypter(str_repeat('a', 16));
+        });
+    }
+
+    public function testDecryptsEncryptedValue()
+    {
+        $encrypter = $this->container->make(EncrypterContract::class);
+        $message = 'bar';
+
+        $this->container->make(DecryptInputValues::class)->handle(
+            Request::create('/test', 'GET', ['foo' => $encrypter->encrypt($message, false)]),
+            function (Request $request) use ($message) {
+                $this->assertSame($message, $request->get('foo'));
+            });
+    }
+
+    public function testConvertsImproperlyDecryptedValueToNull()
+    {
+        $this->container->make(DecryptInputValues::class)->handle(
+            Request::create('/test', 'GET', ['foo' => 'bar']),
+            function (Request $request) {
+                $this->assertNull($request->get('foo'));
+            });
+    }
+}


### PR DESCRIPTION
An easy way to get already decrypted data from a request in your controller or validator.

I use this middleware when working on a stateless API. This way you can safely pass data between requests without storing temporary or intermediate data in the database.

```
curl --location 'http://localhost/api/test' \
--form 'message="eyJpdiI6InJjK2hCN01oQi9yMTNqaHozTWVHb1E9PSIsInZhbHVlIjoieGRuSitUa01VNWFTQkZhV3BzRnhvZz09IiwibWFjIjoiMTI2MGRhZTkyZjU4ZjZkZmRhZmYzZTVjYjFjZTQ4OThmYzUwODc2N2Y1MTg4ZWZlOGRkYjY2ZTI2Mjg2Y2E4MiIsInRhZyI6IiJ9="' \
--form 'string="value"'
```
```
Route::post('/test', function (\Illuminate\Http\Request $request) {
    $request->dd();
})->middleware(\Illuminate\Foundation\Http\Middleware\DecryptInputValues::class.':message');
```
```
array:2 [
  "message" => "secret value"
  "string" => "value"
]
```

