### PR TITLE
Add Schema::missingColumn()

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -199,6 +199,18 @@ class Builder
     }
 
     /**
+     * Determine if the given table is missing a given column.
+     *
+     * @param  string  $table
+     * @param  string  $column
+     * @return bool
+     */
+    public function missingColumn($table, $column)
+    {
+        return ! $this->hasColumn($table, $column);
+    }
+
+    /**
      * Execute a table builder callback if the given table has a given column.
      *
      * @param  string  $table

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -67,6 +67,18 @@ class DatabaseSchemaBuilderTest extends TestCase
         $this->assertFalse($builder->hasColumns('users', ['id', 'address']));
     }
 
+    public function testTableMissingColumn()
+    {
+        $connection = m::mock(Connection::class);
+        $grammar = m::mock(stdClass::class);
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $builder = m::mock(Builder::class.'[getColumnListing]', [$connection]);
+        $builder->shouldReceive('getColumnListing')->with('users')->twice()->andReturn(['id']);
+
+        $this->assertTrue($builder->missingColumn('users', 'firstname'));
+        $this->assertFalse($builder->missingColumn('users', 'id'));
+    }
+
     public function testGetColumnTypeAddsPrefix()
     {
         $connection = m::mock(Connection::class);


### PR DESCRIPTION
Hi,

The database Schema has a method called `hasColumn()` that allows to check if a table has a column.
This PR adds a `missingColumn()` method that will check that a table does not have a column.

This will allow to write within migrations 

```php
if(Schema::missingColumn('table', 'column')) {
    // Do some migration stuff
}
```

instead of 

```php
if(! Schema::hasColumn('table', 'column')) {
    // Do some migration stuff
}
```

I hope this method get merged because Laravel has this kind of convenience methods that makes the code read better.
PR contains a test of course