### PR TITLE
[10.x] fix Str docblocks

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -423,7 +423,7 @@ class Str
     /**
      * Determine if a given string is valid JSON.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isJson($value)
@@ -444,7 +444,7 @@ class Str
     /**
      * Determine if a given string is a valid UUID.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isUuid($value)
@@ -459,7 +459,7 @@ class Str
     /**
      * Determine if a given string is a valid ULID.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isUlid($value)
@@ -632,7 +632,7 @@ class Str
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern
-     * @param  string  $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isMatch($pattern, $value)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -105,7 +105,7 @@ class Str
     /**
      * Transliterate a UTF-8 value to ASCII.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  string  $language
      * @return string
      */
@@ -131,7 +131,7 @@ class Str
      * Get the portion of a string before the first occurrence of a given value.
      *
      * @param  string  $subject
-     * @param  string  $search
+     * @param  mixed  $search
      * @return string
      */
     public static function before($subject, $search)
@@ -288,7 +288,7 @@ class Str
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|iterable<string>  $needles
+     * @param  string|iterable<mixed>  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
@@ -309,8 +309,8 @@ class Str
     /**
      * Extracts an excerpt from text that matches the first instance of a phrase.
      *
-     * @param  string  $text
-     * @param  string  $phrase
+     * @param  mixed  $text
+     * @param  mixed  $phrase
      * @param  array  $options
      * @return string|null
      */
@@ -372,8 +372,8 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|iterable<string>  $pattern
-     * @param  string  $value
+     * @param  string|iterable<mixed>  $pattern
+     * @param  mixed  $value
      * @return bool
      */
     public static function is($pattern, $value)
@@ -412,7 +412,7 @@ class Str
     /**
      * Determine if a given string is 7 bit ASCII.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isAscii($value)
@@ -942,7 +942,7 @@ class Str
     /**
      * Replace the first occurrence of a given value in the string.
      *
-     * @param  string  $search
+     * @param  mixed  $search
      * @param  string  $replace
      * @param  string  $subject
      * @return string
@@ -1158,7 +1158,7 @@ class Str
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|iterable<string>  $needles
+     * @param  string|iterable<mixed>  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -288,7 +288,7 @@ class Str
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|iterable<mixed>  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
@@ -309,8 +309,8 @@ class Str
     /**
      * Extracts an excerpt from text that matches the first instance of a phrase.
      *
-     * @param  mixed  $text
-     * @param  mixed  $phrase
+     * @param  string  $text
+     * @param  string  $phrase
      * @param  array  $options
      * @return string|null
      */
@@ -1158,7 +1158,7 @@ class Str
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|iterable<mixed>  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)


### PR DESCRIPTION
Noticed some docblocks specify string as their typehint, but also check if the input is string (or coerce to a string).