### PR TITLE
Clear session from storage if no recaller can be found

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -173,7 +173,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             }
         }
 
-        if(is_null($this->user)) {
+        if (is_null($this->user)) {
             $this->clearUserDataFromStorage();
         }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -173,6 +173,10 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             }
         }
 
+        if(is_null($this->user)) {
+            $this->clearUserDataFromStorage();
+        }
+
         return $this->user;
     }
 


### PR DESCRIPTION
Hello!

So, if somehow in your application you delete the authenticatable (lets say from the users table) without clearing the session and the user still has the cookie, because of 
` if (! is_null($id) && $this->user = $this->provider->retrieveById($id)) {
            $this->fireAuthenticatedEvent($this->user);
}`

Every @can directive every Auth check (anything that uses the Auth::user) will cause for a db query spamming the database since the user is never set. On top of that if you do any auth checks in your application with Auth::id() it doesn't return null because of
`return $this->user()
                    ? $this->user()->getAuthIdentifier()
                    : $this->session->get($this->getName());`

Which is kind of a security issue. Not sure if it is only in my codebase but I thought it would be safer to open this PR to make you aware of the issue!

Thanks for your time