### PR TITLE
[10.x] Remove session on authenticatable deletion v2

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -173,7 +173,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             }
         }
 
-        if(is_null($this->user)) {
+        if (is_null($this->user)) {
             $this->clearUserDataFromStorage();
         }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -173,6 +173,10 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             }
         }
 
+        if(is_null($this->user)) {
+            $this->clearUserDataFromStorage();
+        }
+
         return $this->user;
     }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -262,6 +262,9 @@ class AuthGuardTest extends TestCase
         $this->expectExceptionMessage('Unauthenticated.');
 
         $guard = $this->getGuard();
+        $guard->setCookieJar($cookies = m::mock(CookieJar::class));
+        $cookies->shouldReceive('unqueue')->once();
+        $guard->getSession()->shouldReceive('remove')->once();
         $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
 
         $guard->authenticate();
@@ -313,6 +316,9 @@ class AuthGuardTest extends TestCase
     public function testNullIsReturnedForUserIfNoUserFound()
     {
         $mock = $this->getGuard();
+        $mock->setCookieJar($cookies = m::mock(CookieJar::class));
+        $cookies->shouldReceive('unqueue')->once();
+        $mock->getSession()->shouldReceive('remove')->once();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(null);
         $this->assertNull($mock->user());
     }


### PR DESCRIPTION
(same as https://github.com/laravel/framework/pull/47139 but fixed the tests)

Hello!

So, if somehow in your application you delete the authenticatable (lets say from the users table) without clearing the session and the user still has the cookie, because of 
` if (! is_null($id) && $this->user = $this->provider->retrieveById($id)) {
            $this->fireAuthenticatedEvent($this->user);
}`

Every @can directive every Auth check (anything that uses the Auth::user) will cause for a db query spamming the database since the user is never set. On top of that if you do any auth checks in your application with Auth::id() it doesn't return null because of
`return $this->user()
                    ? $this->user()->getAuthIdentifier()
                    : $this->session->get($this->getName());`

Which is kind of a security issue. Not sure if it is only in my codebase but I thought it would be safer to open this PR to make you aware of the issue!

Thanks for your time