### PR TITLE
[10.x] Added colon to UniqueLock key

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -70,6 +70,6 @@ class UniqueLock
                     ? $job->uniqueId()
                     : ($job->uniqueId ?? '');
 
-        return 'laravel_unique_job:'.get_class($job).$uniqueId;
+        return 'laravel_unique_job:'.get_class($job).':'.$uniqueId;
     }
 }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -51,7 +51,7 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(UniqueBroadcastEvent::class);
         Queue::assertPushed(UniqueBroadcastEvent::class);
 
-        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.TestEventUnique::class;
+        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.':'.TestEventUnique::class;
         $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -117,7 +117,7 @@ class JobDispatchingTest extends TestCase
      */
     private function getJobLock($job, $value = null)
     {
-        return $this->app->get(Repository::class)->lock('laravel_unique_job:'.$job.$value, 10)->get();
+        return $this->app->get(Repository::class)->lock('laravel_unique_job:'.$job.':'.$value, 10)->get();
     }
 }
 

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -150,7 +150,7 @@ class UniqueJobTest extends TestCase
 
     protected function getLockKey($job)
     {
-        return 'laravel_unique_job:'.(is_string($job) ? $job : get_class($job));
+        return 'laravel_unique_job:'.(is_string($job) ? $job : get_class($job)).':';
     }
 }
 


### PR DESCRIPTION
When using `ShouldBeUnique` on a job, the `UniqueLock` will create an entry into cache using the class and an optional unique id. These values are glued together without a separator which can cause issues as it may interfere with another class name.

Therefore, I've added a colon to prevent these issues from happening as they would be hard to debug. Note that this separator is also used within the [WithoutOverlapping](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Queue/Middleware/WithoutOverlapping.php#L160) class.

## Example

Imagine we have two jobs named `ImportSizes` and `ImportSize` which are both unique. The `ImportSize` job has an unique id of the size it has been given via the constructor.

Currently, that would give the following results if a size of `s` will be imported:

```
Job "ImportSizes" -> "laravel_unique_job:App\Jobs\ImportSizes"
Job "ImportSize"  -> "laravel_unique_job:App\Jobs\ImportSizes"
                                                            ^--- the size "s"
```

This will give a collision, blocking an import job. By adding a colon after the class name, as classes can't contain these, it will never collide.

```
Job "ImportSizes" -> "laravel_unique_job:App\Jobs\ImportSizes:"
Job "ImportSize"  -> "laravel_unique_job:App\Jobs\ImportSize:s"
                                                             ^--- the size "s"
```
