### PR TITLE
[10.x] Throws an exception in case of passing an invalid key name 🐛

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -615,9 +615,17 @@ class Route
      * @param  string  $key
      * @param  mixed  $value
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function defaults($key, $value)
     {
+        if(!in_array($key, $this->parameterNames())) {
+            throw new InvalidArgumentException(
+                \sprintf('The given [%s] argument key is invalid', $key)
+            );
+        }
+
         $this->defaults[$key] = $value;
 
         return $this;


### PR DESCRIPTION
I was working on a project and I needed to set a default value for an optional parameter, so I used the `defaults` route method, but I found an unexpected approach. I found that this method set the given value to whatever key I pass, knowing that this key maybe not exist in the route parameters. So, this PR solves this issue by throwing an exception in case we pass an invalid key.