### PR TITLE
[10.x] Add `forceCreateQuietly` method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1018,6 +1018,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Save a new model instance with mass assignment, without raising model events.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model|$this
+     */
+    public function forceCreateQuietly(array $attributes)
+    {
+        return Model::withoutEvents(fn () => $this->forceCreate($attributes));
+    }
+
+    /**
      * Update records in the database.
      *
      * @param  array  $values


### PR DESCRIPTION
The method provides a convenient way to save a new model instance while ensuring that model events are not triggered during the process.