### PR TITLE
[10.x] Cache ViewName::normalize result for performance

### DIFF
--- a/src/Illuminate/View/ViewName.php
+++ b/src/Illuminate/View/ViewName.php
@@ -4,13 +4,20 @@ namespace Illuminate\View;
 
 class ViewName
 {
+    private static array $cache = [];
+
+    public static function normalize($name)
+    {
+        return static::$cache[$name] ??= static::_normalize($name);
+    }
+
     /**
      * Normalize the given view name.
      *
      * @param  string  $name
      * @return string
      */
-    public static function normalize($name)
+    public static function _normalize($name)
     {
         $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
 


### PR DESCRIPTION
When lots for namespaced views are used repetitively this can end up contributing to a significant chunk of time.

We've seen cases where 17k+ views have been loaded and this has totalled 2s+ of runtime.

The result is constant so no risk is involved.

