### PR TITLE
[10.x] add model() method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -426,7 +426,7 @@ trait InteractsWithInput
      * Retrieve input from the request as a model if it is present.
      *
      * @param  string|null  $key
-     * @param  string $className
+     * @param  string  $className
      * @return \Illuminate\Database\Eloquent\Model|null
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
@@ -419,6 +421,17 @@ trait InteractsWithInput
     public function collect($key = null)
     {
         return collect(is_array($key) ? $this->only($key) : $this->input($key));
+    }
+
+    public function model($key, $class) {
+        throw_if(
+            ! is_subclass_of($class, Model::class),
+            new \InvalidArgumentException("{$class} must be an instance of ".Model::class)
+        );
+        
+        $value = $this->input($key);
+
+        return app($class)->resolveRouteBinding($value) ?? throw (new ModelNotFoundException)->setModel($class, $value);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -423,15 +423,29 @@ trait InteractsWithInput
         return collect(is_array($key) ? $this->only($key) : $this->input($key));
     }
 
-    public function model($key, $class) {
+    /**
+     * Retrieve input from the request as a model if it is present.
+     *
+     * @param  string|null  $key
+     * @param  string       $class
+     * @return \Illuminate\Database\Eloquent\Model|null
+     * @throws \InvalidArgumentException
+     */
+    public function model($key, $className)
+    {
         throw_if(
-            ! is_subclass_of($class, Model::class),
-            new \InvalidArgumentException("{$class} must be an instance of ".Model::class)
+            ! is_subclass_of($className, Model::class),
+            new \InvalidArgumentException("{$className} must be an instance of ".Model::class)
         );
-        
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
         $value = $this->input($key);
 
-        return app($class)->resolveRouteBinding($value) ?? throw (new ModelNotFoundException)->setModel($class, $value);
+        return $value
+            ? (new $className)->resolveRouteBinding($value)
+            : null;
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
@@ -427,8 +426,9 @@ trait InteractsWithInput
      * Retrieve input from the request as a model if it is present.
      *
      * @param  string|null  $key
-     * @param  string       $class
+     * @param  string $className
      * @return \Illuminate\Database\Eloquent\Model|null
+     *
      * @throws \InvalidArgumentException
      */
     public function model($key, $className)

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -318,18 +318,18 @@ PHP);
             })->middleware(['web']);
         });
 
-        $response = $this->getJson("/user?user={$user->id}");
+        $response = $this->getJson('/user?user={$user->id}');
         $response->assertOk();
         $response->assertJson([
             [
                 'id' => $user->id,
                 'name' => $user->name,
-            ]
+            ],
         ]);
 
-        $response = $this->getJson("/user?user=foobar");
+        $response = $this->getJson('/user?user=foobar');
         $response->assertOk();
-        $response->assertJson([ null ]);
+        $response->assertJson([null]);
     }
 }
 

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -307,7 +307,7 @@ PHP);
         $response->assertJsonFragment(['id' => $tag->id]);
     }
 
-    public function testRequestMethodFunction()
+    public function testRequestModelFunction()
     {
         $user = ImplicitBindingUser::create(['name' => 'Foo']);
 

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -165,25 +165,6 @@ PHP);
         $response->assertNotFound();
     }
 
-    public function testImplicitRouteBindingsViaQueryParameter()
-    {
-        $user = ImplicitBindingUser::create(['name' => 'Dries']);
-        $post = ImplicitBindingPost::create(['user_id' => 2]);
-        $this->assertEmpty($user->posts);
-
-        config(['app.key' => str_repeat('a', 32)]);
-
-        Route::scopeBindings()->group(function () {
-            Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser $user, ImplicitBindingPost $post) {
-                return [$user, $post];
-            })->middleware(['web']);
-        });
-
-        $response = $this->getJson("/user/{$user->id}/post/{$post->id}");
-
-        $response->assertNotFound();
-    }
-
     public function testEnforceScopingImplicitRouteBindingsWithTrashedAndChildWithNoSoftDeleteTrait()
     {
         $user = ImplicitBindingUser::create(['name' => 'Dries']);
@@ -347,7 +328,8 @@ PHP);
         ]);
 
         $response = $this->getJson("/user?user=foobar");
-        $response->assertNotFound();
+        $response->assertOk();
+        $response->assertJson([ null ]);
     }
 }
 


### PR DESCRIPTION
This pull request adds a new method `model()` to the `InteractsWithInput` trait.
The `model()` method allows developers to conveniently retrieve a model instance based on a given key and class from the request object.

The model method takes two parameters: `$key` represents the input key to retrieve the value from, and `$className` represents the class name of the model. It performs the following steps:

 * Validates that the provided `$className` is a subclass of the Model class. If not, it throws an \InvalidArgumentException.
 * Retrieves the value from the input using the provided `$key`.
 * Resolves an instance of the `$className`
 * Invokes the resolveRouteBinding method on the resolved instance, passing the retrieved value, to retrieve the model instance.
 * Returns the retrieved model instance if found or null.

The addition of the model method simplifies the process of retrieving models provided as query parameter from the request object, reducing boilerplate code and enhancing developer productivity. It promotes clean and concise code by encapsulating the logic of retrieving and resolving model instances within the framework itself.

This feature does not break any existing features or backward compatibility as it is a non-intrusive addition to an existing trait within the Laravel framework. It adheres to the existing coding standards and conventions.

Benefits to end users:

 * Simplifies the retrieval of model instances from the request object.
 * Reduces code duplication and boilerplate when working with models.
 * Enhances developer productivity and readability of code.

How to use:

```php
$model = $request->model('foobar', Post::class) ?? new Post;
dump($model);
```