### PR TITLE
[10.x] Add a method `assertMethodNotAllowed` to AssertsStatusCodes

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -122,6 +122,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 405 "Method Not Allowed" status code.
+     *
+     * @return $this
+     */
+    public function assertMethodNotAllowed()
+    {
+        return $this->assertStatus(405);
+    }
+
+    /**
      * Assert that the response has a 408 "Request Timeout" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -561,6 +561,24 @@ class TestResponseTest extends TestCase
         $response->assertNotFound();
     }
 
+    public function testAssertMethodNotAllowed()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_METHOD_NOT_ALLOWED)
+        );
+
+        $response->assertMethodNotAllowed();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [405] but received 200.\nFailed asserting that 405 is identical to 200.");
+
+        $response->assertMethodNotAllowed();
+    }
+
     public function testAssertForbidden()
     {
         $statusCode = 500;


### PR DESCRIPTION
This method is useful When we want to make sure an endpoint is not accessible by the other HTTP methods.

```php
$this->get('/')->assertOk();

$this->post('/')->assertMethodNotAllowed();
$this->patch('/')->assertMethodNotAllowed();
$this->put('/')->assertMethodNotAllowed();
$this->delete('/')->assertMethodNotAllowed();
```