### PR TITLE
[10.x] Improve Model::toJson error handling

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1650,7 +1650,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $json = json_encode($this->jsonSerialize(), $options);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        if (! ($options & JSON_THROW_ON_ERROR) && json_last_error() !== JSON_ERROR_NONE) {
             throw JsonEncodingException::forModel($this, json_last_error_msg());
         }
 


### PR DESCRIPTION
Fixes an edge-case, where `Model::toJson` can throw an invalid exception. Consider the following code:

```php
// Make a json_encode call that produces an error (JSON_ERROR_UTF8)
json_encode(random_bytes(8)); // [1]

// Make a simple model and encode it into json w/ the JSON_THROW_ON_ERROR flag (no errors at all)
App\Models\User::make([ 'name' => 'Gebril' ])->toJson(JSON_THROW_ON_ERROR);
```

Laravel will currently throw the following invalid exception:

```
Error encoding model [App\Models\User] with ID [] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded
```

Why? Let's take a look at how the `toJson` method is implemented:

```php
public function toJson($options = 0)
{
    $json = json_encode($this->jsonSerialize(), $options); // [2]
        
    if (json_last_error() !== JSON_ERROR_NONE) {
        throw JsonEncodingException::forModel($this, json_last_error_msg());
    }

    return $json;
}
```

This seems pretty standard, `json_encode` call followed by `json_last_error` for error handling. This is what PHP manual says about `json_last_error` though:

```
Returns the last error (if any) occurred during the last JSON encoding/decoding, which did not specify JSON_THROW_ON_ERROR.
```

This means, as soon as we pass the `JSON_THROW_ON_ERROR` flag to the function, the `json_last_error` does not refer to the `json_encode` call `[2]`, but to the previous `json_encode` call without the flag, which would be `[1]` in our example.

This PR fixes this by only doing the error handling if the flag is not included in the function call.





