### PR TITLE
[10.x] Added parameters to timezone validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2292,8 +2292,8 @@ trait ValidatesAttributes
     public function validateTimezone($attribute, $value, $parameters = [])
     {
         return in_array($value, timezone_identifiers_list(
-            constant(DateTimeZone::class.'::'.Str::upper($parameters[0] ?? 'all')),
-            Str::upper($parameters[1] ?? '')
+            constant(DateTimeZone::class.'::'.Str::upper($parameters[0] ?? 'ALL')),
+            isset($parameters[1]) ? Str::upper($parameters[1]) : null,
         ), true);
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -313,8 +313,7 @@ trait ValidatesAttributes
      *
      * @param  string  $format
      * @param  string  $value
-     *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     protected function getDateTimeWithOptionalFormat($format, $value)
     {
@@ -329,8 +328,7 @@ trait ValidatesAttributes
      * Get a DateTime instance from a string with no format.
      *
      * @param  string  $value
-     *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     protected function getDateTime($value)
     {
@@ -2288,14 +2286,14 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array<string, null|string> $parameters
+     * @param  array<string, null|string>  $parameters
      * @return bool
      */
     public function validateTimezone($attribute, $value, $parameters)
     {
         return in_array($value, timezone_identifiers_list(
-            constant(DateTimeZone::class . '::' . Str::upper($parameters[0] ?? 'all')),
-                Str::upper($parameters[1] ?? '')
+            constant(DateTimeZone::class.'::'.Str::upper($parameters[0] ?? 'all')),
+            Str::upper($parameters[1] ?? '')
         ), true);
     }
 
@@ -2409,10 +2407,9 @@ trait ValidatesAttributes
      * @param  mixed  $first
      * @param  mixed  $second
      * @param  string  $operator
-     *
      * @return bool
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function compare($first, $second, $operator)
     {
@@ -2449,10 +2446,9 @@ trait ValidatesAttributes
      * @param  int  $count
      * @param  array<int, int|string>  $parameters
      * @param  string  $rule
-     *
      * @return void
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function requireParameterCount($count, $parameters, $rule)
     {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -7,6 +7,7 @@ use Brick\Math\BigNumber;
 use Brick\Math\Exception\MathException as BrickMathException;
 use DateTime;
 use DateTimeInterface;
+use DateTimeZone;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
 use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
@@ -312,7 +313,8 @@ trait ValidatesAttributes
      *
      * @param  string  $format
      * @param  string  $value
-     * @return \DateTime|null
+     *
+     * @return DateTime|null
      */
     protected function getDateTimeWithOptionalFormat($format, $value)
     {
@@ -327,7 +329,8 @@ trait ValidatesAttributes
      * Get a DateTime instance from a string with no format.
      *
      * @param  string  $value
-     * @return \DateTime|null
+     *
+     * @return DateTime|null
      */
     protected function getDateTime($value)
     {
@@ -2285,11 +2288,15 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<string, null|string> $parameters
      * @return bool
      */
-    public function validateTimezone($attribute, $value)
+    public function validateTimezone($attribute, $value, $parameters)
     {
-        return in_array($value, timezone_identifiers_list(), true);
+        return in_array($value, timezone_identifiers_list(
+            constant(DateTimeZone::class . '::' . Str::upper($parameters[0] ?? 'all')),
+                Str::upper($parameters[1] ?? '')
+        ), true);
     }
 
     /**
@@ -2402,9 +2409,10 @@ trait ValidatesAttributes
      * @param  mixed  $first
      * @param  mixed  $second
      * @param  string  $operator
+     *
      * @return bool
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected function compare($first, $second, $operator)
     {
@@ -2441,9 +2449,10 @@ trait ValidatesAttributes
      * @param  int  $count
      * @param  array<int, int|string>  $parameters
      * @param  string  $rule
+     *
      * @return void
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function requireParameterCount($count, $parameters, $rule)
     {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2289,7 +2289,7 @@ trait ValidatesAttributes
      * @param  array<string, null|string>  $parameters
      * @return bool
      */
-    public function validateTimezone($attribute, $value, $parameters)
+    public function validateTimezone($attribute, $value, $parameters = [])
     {
         return in_array($value, timezone_identifiers_list(
             constant(DateTimeZone::class.'::'.Str::upper($parameters[0] ?? 'all')),

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4712,6 +4712,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => 'Europe/Kyiv'], ['foo' => 'Timezone']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => 'africa/windhoek'], ['foo' => 'Timezone']);
         $this->assertFalse($v->passes());
 
@@ -4722,6 +4728,488 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAfricaOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Africa']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'America/New_York'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'africa/windhoek'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Africa']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAmericaOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'America/New_York'], ['foo' => 'Timezone:America']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'america/new_york'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:America']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAntarcticaOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Antarctica/Mawson'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'antarctica/mawson'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Antarctica']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithArcticOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Arctic/Longyearbyen'], ['foo' => 'Timezone:Arctic']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'arctic/longyearbyen'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Arctic']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAsiaOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Asia/Tokyo'], ['foo' => 'Timezone:Asia']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'asia/tokyo'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Asia']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAtlanticOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Atlantic/Cape_Verde'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'atlantic/cape_verde'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Atlantic']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAustraliaOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Australia/Sydney'], ['foo' => 'Timezone:Australia']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'australia/sydney'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Australia']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithEuropeOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kyiv'], ['foo' => 'Timezone:Europe']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'europe/kyiv'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Europe']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithIndianOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Indian/Christmas'], ['foo' => 'Timezone:Indian']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'indian/christmas'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Indian']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithPacificOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Pacific/Fiji'], ['foo' => 'Timezone:Pacific']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'pacific/fiji'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Pacific']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithUTCOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:UTC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'utc'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:UTC']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAllOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:All']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:All']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Indian/Christmas'], ['foo' => 'Timezone:All']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kyiv'], ['foo' => 'Timezone:All']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'indian/christmas'], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:All']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithAllWithBCOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Indian/Christmas'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kyiv'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'indian/christmas'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:All_with_BC']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateTimezoneWithPerCountryOptionWithoutSpecifyingCountry()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone:Per_country,IN']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Cairo'], ['foo' => 'Timezone:Per_country,CA']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'UTC'], ['foo' => 'Timezone:Per_country,GB']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:Per_country,NA']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kiev'], ['foo' => 'Timezone:Per_country,UA']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kyiv'], ['foo' => 'Timezone:Per_country,UA']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Europe/Kyiv'], ['foo' => 'Timezone:Per_country,ua']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'utc'], ['foo' => 'Timezone:Per_country,GB']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone:Per_country,GB']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone:Per_country,GB']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone:Per_country,GB']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
## The problem that I've got
IANA has officially changed the Ukraine's timezone from Ukraine/Kiev to Ukraine/Kyiv in 2022b version of tzdata. But some systems still use the old versions of tzdata. And timezone validations are started to fail.

## Ways to resolve
To resolve that problem in my project I've created custom validation rule for timezones that is actually a copy of current timezone validation but with a parameter DateTimeZone::ALL_WITH_BC that returns all timezones list with a Backward Compatibility. So all old timezone names will be accepted with this parameter.

## What I have changed in the PR
I have modified current timezone validation to accept parameters that could be passed to timezone_identifiers_list method. It could be useful also for those projects that are designed to work only in specific country. So developers can accept the timezones from the only country.

```php
'timezone' // works as before
'timezone:Africa' // accepts only Africans timezones
'timezone:All' // works the same as without any parameters
'timezone:All_with_BC' // accepts timezones with Backward Compatibility (Europe/Kiev will be accepted)
'timezone:Per_country,US' // accepts only US timezones
```