### PR TITLE
[10.x] Add Query::toBoundSql method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2618,6 +2618,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the SQL representation of the query with bindings
+     */
+    public function toBoundSql(): string
+    {
+        $bindings = collect($this->getBindings())
+            ->map(fn(string|float|int|null $binding) => is_string($binding) ? "'" . $binding . "'" : $binding)->all();
+
+        return Str::replaceArray('?' , $bindings, $this->toSql());
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5607,6 +5607,13 @@ SQL;
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
+    public function testToBoundSql()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = \'foo\'', $builder->toBoundSql());
+    }
+
     public function testCloneWithout()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR allows user to get full SQL query with bindings
`User::query()->where('email', 'foo')->where('age', 10)->toBoundSql(); // select * from `users` where email = 'foo' and age=10;`
