### PR TITLE
[10.x] Fix error in pull method when handling array and add pullMany method for array keys support

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -185,9 +185,32 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function pull($key, $default = null)
     {
+        if (is_array($key)) {
+            return $this->pullMany($key,$default);
+        }
+
         return tap($this->get($key, $default), function () use ($key) {
             $this->forget($key);
         });
+    }
+
+    /**
+     * Retrieve multiple items from the cache and delete them.
+     *
+     * @template TCacheValue
+     *
+     * @param  list<string>  $keys
+     * @param  TCacheValue|(\Closure(): TCacheValue)  $default
+     * @return array<string, (TCacheValue is null ? mixed : TCacheValue)>
+     */
+    public function pullMany(array $keys, $default = null): array
+    {
+        $values = [];
+        foreach ($keys as $key) {
+            $values[$key] = $this->pull($key,$default);
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -20,6 +20,7 @@ namespace Illuminate\Support\Facades;
  * @method static array many(array $keys)
  * @method static iterable getMultiple(iterable $keys, mixed $default = null)
  * @method static mixed pull(array|string $key, mixed|\Closure $default = null)
+ * @method static array pullMany(array $keys, mixed|\Closure $default = null)
  * @method static bool put(array|string $key, mixed $value, \DateTimeInterface|\DateInterval|int|null $ttl = null)
  * @method static bool set(string $key, mixed $value, null|int|\DateInterval $ttl = null)
  * @method static bool putMany(array $values, \DateTimeInterface|\DateInterval|int|null $ttl = null)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -351,6 +351,38 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->deleteMultiple(['a-key', 'a-second-key']));
     }
 
+    public function testPullingMultipleKeys()
+    {
+        $repo = $this->getRepository();
+        $cacheData = [
+            'the-first-key' => 'the-first-value',
+            'the-second-key' => 'the-second-value',
+        ];
+
+        foreach ($cacheData as $key => $value) {
+            $repo->getStore()->shouldReceive('get')->once()->with($key)->andReturn($value);
+            $repo->getStore()->shouldReceive('forget')->once()->with($key)->andReturn(true);
+        }
+
+        $this->assertEquals($cacheData, $repo->pull(array_keys($cacheData)));
+    }
+
+    public function testPullManyMethodWithArrayOfKeys()
+    {
+        $repo = $this->getRepository();
+        $cacheData = [
+            'the-first-key' => 'the-first-value',
+            'the-second-key' => 'the-second-value',
+        ];
+
+        foreach ($cacheData as $key => $value) {
+            $repo->getStore()->shouldReceive('get')->once()->with($key)->andReturn($value);
+            $repo->getStore()->shouldReceive('forget')->once()->with($key)->andReturn(true);
+        }
+
+        $this->assertEquals($cacheData, $repo->pullMany(array_keys($cacheData)));
+    }
+
     public function testAllTagsArePassedToTaggableStore()
     {
         $store = m::mock(ArrayStore::class);


### PR DESCRIPTION
### Description

This PR fixes the error in the cache `pull` method when handling arrays and adds a new `pullMany` method to support array keys.

### Changes

- Fixed the error in the `pull` method with array keys
- Added a new `pullMany` method for better handling of array keys
- Added test cases to ensure the proper functioning of both the improved `pull` method and the new `pullMany` method

### Error Image Example

<img width="1338" alt="Screenshot 2023-05-23 at 08 19 51" src="https://github.com/laravel/framework/assets/113529280/71e477af-a488-4a83-9efc-ecb0a4d64cab">

**the values with keys 'key1' and 'key2' still persist in the cache store.**

<img width="1099" alt="Screenshot 2023-05-23 at 08 21 13" src="https://github.com/laravel/framework/assets/113529280/96fe1194-f03d-48b6-b640-720151cc1052">


### How to reproduce the error

Use the following code snippet to reproduce the error prior to this PR:

1. Execute the following code to store two values in the cache:

```php
   use Illuminate\Support\Facades\Cache;

   Cache::put('key1', 'value1', 60);
   Cache::put('key2', 'value2', 60);
```
2. Next, attempt to use an array of keys with the pull method. This would cause an error:
```php
$pulledValues = Cache::pull(['key1', 'key2']); // This will cause an error before the fix
```
3. Before the fix, the error would look like this: 
```
[
    "key1" => "value1",
    "key2" => "value2",
  ]
<warning> WARNING </warning> Array to string conversion in vendor/laravel/framework/src/Illuminate/Cache/RedisStore.php on line 223.
```
4. Additionally, even after encountering this error, the cache remains unchanged, i.e., the values with keys 'key1' and 'key2' still persist in the cache store.

### How Has This Been Tested?

- PHPUnit tests have been added to test the modified `pull` method and the new `pullMany` method
- All existing tests passed, ensuring that no existing functionality was adversely affected by these changes

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
- [x] I have added tests to cover my changes.
