### PR TITLE
[10.x] Remove unnecessary local variable from `Str::remove` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1001,11 +1001,9 @@ class Str
             $search = collect($search)->all();
         }
 
-        $subject = $caseSensitive
+        return $caseSensitive
                     ? str_replace($search, '', $subject)
                     : str_ireplace($search, '', $subject);
-
-        return $subject;
     }
 
     /**


### PR DESCRIPTION
Refactors Str::remove method by removing unnecessary local variable