### PR TITLE
[10.x] Add error handling and ensure re-enabling of foreign key constraints

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -422,12 +422,10 @@ class Builder
         $this->disableForeignKeyConstraints();
 
         try {
-            $result = $callback();
+            return $callback();
         } finally {
             $this->enableForeignKeyConstraints();
         }
-
-        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -421,9 +421,11 @@ class Builder
     {
         $this->disableForeignKeyConstraints();
 
-        $result = $callback();
-
-        $this->enableForeignKeyConstraints();
+        try {
+            $result = $callback();
+        } finally {
+            $this->enableForeignKeyConstraints();
+        }
 
         return $result;
     }


### PR DESCRIPTION
This pull request enhances the ``withoutForeignKeyConstraints`` method to handle exceptions and ensure proper re-enabling of foreign key constraints. Previously, if an exception occurred within the callback function, the foreign key constraints would not be re-enabled, leading to potential issues. 

The changes introduced a try-finally block, allowing for proper error handling. The foreign key constraints are disabled before executing the callback, and regardless of whether an exception is thrown or not, they are always re-enabled using the ``enableForeignKeyConstraints`` method.