### PR TITLE
[11.x] Fix missing parameters in `intersectUsing` method

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -638,7 +638,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  callable(TValue, TValue): int  $callback
      * @return static
      */
-    public function intersectUsing()
+    public function intersectUsing($items, callable $callback)
     {
         return $this->passthru('intersectUsing', func_get_args());
     }


### PR DESCRIPTION
This PR addresses an issue in the `intersectUsing` method where the necessary parameters, `$items` and `$callback`, were missing. The function has been updated to include these parameters, ensuring its proper functionality.