### PR TITLE
[10.x] Add `assertNotAcceptable` method to AssertsStatusCodes

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -132,6 +132,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 406 "Not Acceptable" status code.
+     *
+     * @return $this
+     */
+    public function assertNotAcceptable()
+    {
+        return $this->assertStatus(406);
+    }
+
+    /**
      * Assert that the response has a 408 "Request Timeout" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -579,6 +579,25 @@ class TestResponseTest extends TestCase
         $response->assertMethodNotAllowed();
     }
 
+    public function testAssertNotAcceptable()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_NOT_ACCEPTABLE)
+        );
+
+        $response->assertNotAcceptable();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [406] but received 200.\nFailed asserting that 406 is identical to 200.");
+
+        $response->assertNotAcceptable();
+        $this->fail();
+    }
+
     public function testAssertForbidden()
     {
         $statusCode = 500;


### PR DESCRIPTION
The new `assertNotAcceptable` method added to the `AssertsStatusCodes` class.

``` php
$response = $this->get('/api/my-endpoint');
$response->assertNotAcceptable();
```