### PR TITLE
Redis transaction is not closed when PSR-6 cache is used in combination with Redis store

### DIFF
--- a/tests/Integration/Cache/Fixtures/Unserializable.php
+++ b/tests/Integration/Cache/Fixtures/Unserializable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache\Fixtures;
+
+use Exception;
+
+class Unserializable
+{
+    public function __sleep()
+    {
+        throw new Exception('Not serializable');
+    }
+}

--- a/tests/Integration/Cache/Psr6RedisTest.php
+++ b/tests/Integration/Cache/Psr6RedisTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Tests\Integration\Cache\Fixtures\Unserializable;
+use Orchestra\Testbench\TestCase;
+
+class Psr6RedisTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+    }
+
+    /**
+     * @dataProvider redisClientDataProvider
+     */
+    public function testTransctionIsClosedOnException($redisClient)
+    {
+        $this->app['config']['cache.default'] = 'redis';
+        $this->app['config']['database.redis.client'] = $redisClient;
+
+        $cache = $this->app->make('cache.psr6');
+
+        $item = $cache->getItem('foo');
+
+        $item->set(new Unserializable());
+        $item->expiresAfter(60);
+
+        $cache->save($item);
+
+        Cache::store('redis')->get('foo');
+    }
+
+    /**
+     * @return array
+     */
+    public static function redisClientDataProvider()
+    {
+        return [
+            ['predis'],
+            ['phpredis'],
+        ];
+    }
+}


### PR DESCRIPTION
I've created a test case addressing a case where the PSR-6 adapter in combination with the Redis store leads to the Redis transaction not being closed.

The problem is that if exception is thrown as part of `$cache->save($item);` then `Symfony\Component\Cache\Adapter\Psr16Adapter` eats the exception leading to the transaction not being closed in `Illuminate\Cache\RedisStore:putMany()` (`$this->connection()->exec();` is never called). This later leads to read failures as Redis is returning an object that can't be unserialized.

I don't know what would be the best way to fix this, thus I'm seeking guidance here.
