### PR TITLE
Fix for potential negative values in pendingJobs count in job batching

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -241,11 +241,11 @@ class Batch implements Arrayable, JsonSerializable
     {
         $counts = $this->decrementPendingJobs($jobId);
 
-        if ($counts->pendingJobs === 0) {
+        if ($counts->pendingJobs <= 0) {
             $this->repository->markAsFinished($this->id);
         }
 
-        if ($counts->pendingJobs === 0 && $this->hasThenCallbacks()) {
+        if ($counts->pendingJobs <= 0 && $this->hasThenCallbacks()) {
             $batch = $this->fresh();
 
             collect($this->options['then'])->each(function ($handler) use ($batch) {


### PR DESCRIPTION
Overview of the issue:
There's a potential issue in the job batching system where the count of pending jobs can mistakenly become negative due to concurrency issues or repeated job execution. This could lead to batches never getting marked as 'finished' and 'then' callbacks not getting invoked.

Proposed Solution:
This PR changes the conditions for marking a batch of jobs as 'finished' and for invoking 'then' callbacks. These actions are now taken when the number of pending jobs is less than or equal to zero, not just exactly zero.

Benefits to End Users:
This change will make the job batching system more robust against unexpected scenarios like race conditions that might lead to the pending jobs count going negative. It will ensure that batches are marked as 'finished' and 'then' callbacks are invoked as expected even if such issues occur.

Backward Compatibility:
This change does not break any existing features. It merely extends the conditions under which a batch of jobs is considered 'finished' and 'then' callbacks are invoked. Existing applications using the job batching system should continue to function as expected without any modifications.

Ease of Building Web Applications:
By making the job batching system more robust, this change makes it easier for developers to build web applications that heavily rely on Laravel's queue system without having to worry about unusual scenarios like the pending jobs count going negative.