### PR TITLE
[10.x] `Hash::isHashed($value)`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1310,7 +1310,7 @@ trait HasAttributes
      */
     protected function castAttributeAsHashedString($key, $value)
     {
-        return $value !== null && password_get_info($value)['algo'] === null ? Hash::make($value) : $value;
+        return $value !== null && ! Hash::isHashed($value) ? Hash::make($value) : $value;
     }
 
     /**

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -89,7 +89,7 @@ class HashManager extends Manager implements Hasher
     }
 
     /**
-     * Check if a value is already hashed.
+     * Determine if a given string is already hashed.
      *
      * @param  string  $value
      * @return bool

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -96,7 +96,7 @@ class HashManager extends Manager implements Hasher
      */
     public function isHashed($value)
     {
-        return password_get_info($value)['algo'] === null;
+        return password_get_info($value)['algo'] !== null;
     }
 
     /**

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -89,6 +89,17 @@ class HashManager extends Manager implements Hasher
     }
 
     /**
+     * Check if a value is already hashed.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public function isHashed($value)
+    {
+        return password_get_info($value)['algo'] === null;
+    }
+
+    /**
      * Get the default driver name.
      *
      * @return string

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Hashing;
 use Illuminate\Hashing\Argon2IdHasher;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
+use Illuminate\Support\Facades\Hash;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -39,6 +40,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['rounds' => 1]));
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
+        $this->assertTrue(Hash::isHashed($value));
     }
 
     public function testBasicArgon2iHashing()
@@ -50,6 +52,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2i', password_get_info($value)['algoName']);
+        $this->assertTrue(Hash::isHashed($value));
     }
 
     public function testBasicArgon2idHashing()
@@ -61,6 +64,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
+        $this->assertTrue(Hash::isHashed($value));
     }
 
     /**

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -116,4 +116,9 @@ class HasherTest extends TestCase
         $bcryptHashed = $bcryptHasher->make('password');
         (new Argon2IdHasher(['verify' => true]))->check('password', $bcryptHashed);
     }
+
+    public function testIsHashedWithNonHashedValue()
+    {
+        $this->assertFalse($this->hashManager->isHashed('foo'));
+    }
 }

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Hashing;
 
-use Illuminate\Container\Container;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
 use Illuminate\Hashing\Argon2IdHasher;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
@@ -15,7 +15,7 @@ class HasherTest extends TestCase
 {
     public $hashManager;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -2,15 +2,29 @@
 
 namespace Illuminate\Tests\Hashing;
 
+use Illuminate\Container\Container;
+use Illuminate\Config\Repository as Config;
 use Illuminate\Hashing\Argon2IdHasher;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
-use Illuminate\Support\Facades\Hash;
+use Illuminate\Hashing\HashManager;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class HasherTest extends TestCase
 {
+    public $hashManager;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $container = Container::setInstance(new Container);
+        $container->singleton('config', fn () => new Config());
+
+        $this->hashManager = new HashManager($container);
+    }
+
     public function testEmptyHashedValueReturnsFalse()
     {
         $hasher = new BcryptHasher();
@@ -40,7 +54,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['rounds' => 1]));
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
-        $this->assertTrue(Hash::isHashed($value));
+        $this->assertTrue($this->hashManager->isHashed($value));
     }
 
     public function testBasicArgon2iHashing()
@@ -52,7 +66,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2i', password_get_info($value)['algoName']);
-        $this->assertTrue(Hash::isHashed($value));
+        $this->assertTrue($this->hashManager->isHashed($value));
     }
 
     public function testBasicArgon2idHashing()
@@ -64,7 +78,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
-        $this->assertTrue(Hash::isHashed($value));
+        $this->assertTrue($this->hashManager->isHashed($value));
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelHashedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelHashedCastingTest.php
@@ -30,6 +30,10 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
 
     public function testHashed()
     {
+        $this->hasher->expects('isHashed')
+            ->with('this is a password')
+            ->andReturnFalse();
+
         $this->hasher->expects('make')
             ->with('this is a password')
             ->andReturn('hashed-password');
@@ -47,14 +51,18 @@ class EloquentModelHashedCastingTest extends DatabaseTestCase
 
     public function testNotHashedIfAlreadyHashed()
     {
+        $this->hasher->expects('isHashed')
+            ->with('already-hashed-password')
+            ->andReturnTrue();
+
         $subject = HashedCast::create([
-            'password' => $hashedPassword = '$argon2i$v=19$m=65536,t=4,p=1$RHFPR1Zjc1p5cUVXTVJEcg$ooJoZb7NOa3r35WeeDRvnFwBTfaqlbbo1WcdJP5nPp8',
+            'password' => 'already-hashed-password',
         ]);
 
-        $this->assertSame($hashedPassword, $subject->password);
+        $this->assertSame('already-hashed-password', $subject->password);
         $this->assertDatabaseHas('hashed_casts', [
             'id' => $subject->id,
-            'password' => $hashedPassword,
+            'password' => 'already-hashed-password',
         ]);
     }
 


### PR DESCRIPTION
Inspired by a comment of @valorin on a previous PR of mine https://github.com/laravel/framework/pull/47029#discussion_r1191687989, so the check can be mocked for testing and overwritten if the dev wishes to use a 3rd party hashing algorithm