### PR TITLE
[10.x] add `ExcludesPaths` middleware trait

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -5,7 +5,14 @@ namespace Illuminate\Foundation\Http\Middleware\Concerns;
 trait ExcludesPaths
 {
     /**
-     * Get the URIs that should be accessible even when maintenance mode is enabled.
+     * The URIs that should be excluded.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [];
+
+    /**
+     * Get the URIs that should be excluded.
      *
      * @return array
      */
@@ -15,7 +22,7 @@ trait ExcludesPaths
     }
 
     /**
-     * Determine if the request has a URI that should be accessible in maintenance mode.
+     * Determine if the request has a URI that should be exclued.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return bool

--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware\Concerns;
+
+trait ExcludesPaths
+{
+    /**
+     * Get the URIs that should be accessible even when maintenance mode is enabled.
+     *
+     * @return array
+     */
+    public function getExcludedPaths()
+    {
+        return $this->except;
+    }
+
+    /**
+     * Determine if the request has a URI that should be accessible in maintenance mode.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function inExceptArray($request)
+    {
+        foreach ($this->getExcludedPaths() as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -22,7 +22,7 @@ trait ExcludesPaths
     }
 
     /**
-     * Determine if the request has a URI that should be exclued.
+     * Determine if the request has a URI that should be excluded.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return bool

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -5,10 +5,13 @@ namespace Illuminate\Foundation\Http\Middleware;
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
+use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PreventRequestsDuringMaintenance
 {
+    use ExcludesPaths;
+
     /**
      * The application implementation.
      *
@@ -104,27 +107,6 @@ class PreventRequestsDuringMaintenance
     }
 
     /**
-     * Determine if the request has a URI that should be accessible in maintenance mode.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    protected function inExceptArray($request)
-    {
-        foreach ($this->getExcludedPaths() as $except) {
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if ($request->fullUrlIs($except) || $request->is($except)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Redirect the user back to the root of the application with a maintenance mode bypass cookie.
      *
      * @param  string  $secret
@@ -152,15 +134,5 @@ class PreventRequestsDuringMaintenance
         }
 
         return $headers;
-    }
-
-    /**
-     * Get the URIs that should be accessible even when maintenance mode is enabled.
-     *
-     * @return array
-     */
-    public function getExcludedPaths()
-    {
-        return $this->except;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -20,13 +20,6 @@ class PreventRequestsDuringMaintenance
     protected $app;
 
     /**
-     * The URIs that should be accessible while maintenance mode is enabled.
-     *
-     * @var array<int, string>
-     */
-    protected $except = [];
-
-    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -9,13 +9,15 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\HttpFoundation\Cookie;
 
 class VerifyCsrfToken
 {
-    use InteractsWithTime;
+    use InteractsWithTime,
+        ExcludesPaths;
 
     /**
      * The application instance.
@@ -104,27 +106,6 @@ class VerifyCsrfToken
     protected function runningUnitTests()
     {
         return $this->app->runningInConsole() && $this->app->runningUnitTests();
-    }
-
-    /**
-     * Determine if the request has a URI that should pass through CSRF verification.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    protected function inExceptArray($request)
-    {
-        foreach ($this->except as $except) {
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if ($request->fullUrlIs($except) || $request->is($except)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -34,13 +34,6 @@ class VerifyCsrfToken
     protected $encrypter;
 
     /**
-     * The URIs that should be excluded from CSRF verification.
-     *
-     * @var array<int, string>
-     */
-    protected $except = [];
-
-    /**
      * Indicates whether the XSRF-TOKEN cookie should be set on the response.
      *
      * @var bool


### PR DESCRIPTION
The `PreventRequestsDuringMaintenance` and `VerifyCsrfToken` middleware both have code related to excluding certain paths/urls/routes. This PR extracts that code to a dedicated trait, which removes duplicate code from the framework and also makes it possible for applications to use that trait on project-specific middleware that needs the same behavior.