### PR TITLE
[10.x] Use `carbon::now()` to get current timestamp in `takeUntilTimeout` lazycollection-method

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1726,6 +1726,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     protected function now()
     {
-        return time();
+        return Carbon::now()->timestamp;
     }
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -7,6 +7,7 @@ use Closure;
 use DateTimeInterface;
 use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -7,7 +7,6 @@ use Closure;
 use DateTimeInterface;
 use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -17,8 +17,7 @@
         "php": "^8.1",
         "illuminate/conditionable": "^10.0",
         "illuminate/contracts": "^10.0",
-        "illuminate/macroable": "^10.0",
-        "illuminate/support": "^10.0"
+        "illuminate/macroable": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -17,7 +17,8 @@
         "php": "^8.1",
         "illuminate/conditionable": "^10.0",
         "illuminate/contracts": "^10.0",
-        "illuminate/macroable": "^10.0"
+        "illuminate/macroable": "^10.0",
+        "illuminate/support": "^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When you set the current time to a date in the future using `setTestNow` carbon method, and your code uses the `takeUntilTimeout` method on a `LazyCollection`, then the no items of the lazy collection will be taken, while it should take items.

```php
User::factory()->count(10)->create();

Carbon::setTestNow(now()->addYear());

$users = User::lazy()->takeUntilTimeout(now()->addMinute())->all();
// will be empty while that should not be the case
```