### PR TITLE
[10.x] Fix inconsistentcy between `report` and `render` methods

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -373,6 +373,8 @@ class Handler implements ExceptionHandlerContract
      */
     public function render($request, Throwable $e)
     {
+        $e = $this->prepareException($this->mapException($e));
+
         if (method_exists($e, 'render') && $response = $e->render($request)) {
             return Router::toResponse($request, $response);
         }
@@ -380,8 +382,6 @@ class Handler implements ExceptionHandlerContract
         if ($e instanceof Responsable) {
             return $e->toResponse($request);
         }
-
-        $e = $this->prepareException($this->mapException($e));
 
         if ($response = $this->renderViaCallbacks($request, $e)) {
             return $response;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -195,6 +195,17 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My responsable exception response"}', $response);
     }
 
+    public function testReturnsCustomResponseFromMappedException()
+    {
+        $this->handler->map(function (RuntimeException $e) {
+            return new ResponsableException();
+        });
+
+        $response = $this->handler->render($this->request, new RuntimeException)->getContent();
+
+        $this->assertSame('{"response":"My responsable exception response"}', $response);
+    }
+
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);


### PR DESCRIPTION
# What is the problem?

If `ExceptionA` implements a `render` method and `ExceptionB` is mapped to `ExceptionA` in `ExceptionHandler`, the `render` hook **will not be called**. This is because `ExceptionHandler` calls the `render` hook after the exception mapping. However, with the `report` method, it works fine because it maps the exception before calling the `report` hook.

```php
class Handler extends ExceptionHandler
{
    public function register(): void
    {
        $this->map(RuntimeException::class, AppException::class);
    }
}


class AppException extends Exception
{
    public function report()
    {
        app('sentry')->report($this->getPrevious());
    }

    public function render()
    {
      return new JsonResponse(['message' => 'Something went wrong.']);
    }
}

throw new RuntimeException('Test exception');

// 👌 The `report` method is called on the mapped `AppException` instance.

// ❌ The `render` method is ignored and the default error response is returned.
```

# Solution

Move `mapException` to the top of the `render` method.