### PR TITLE
[10.x] Add `hour` method to `Sleep` class

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -134,6 +134,28 @@ class Sleep
     }
 
     /**
+     * Sleep for the given number of hours.
+     *
+     * @return $this
+     */
+    public function hours()
+    {
+        $this->duration->add('hours', $this->pullPending());
+
+        return $this;
+    }
+
+    /**
+     * Sleep for one hour.
+     *
+     * @return $this
+     */
+    public function hour()
+    {
+        return $this->hours();
+    }
+
+    /**
      * Sleep for the given number of minutes.
      *
      * @return $this

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -49,6 +49,24 @@ class SleepTest extends TestCase
         $this->assertEqualsWithDelta(0, $end - $start, 0.03);
     }
 
+    public function testItCanSpecifyHours()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1.5)->hours();
+
+        $this->assertSame($sleep->duration->totalMicroseconds, 5_400_000_000);
+    }
+
+    public function testItCanSpecifyHour()
+    {
+        Sleep::fake();
+
+        $sleep = Sleep::for(1)->hour();
+
+        $this->assertSame($sleep->duration->totalMicroseconds, 3_600_000_000);
+    }
+
     public function testItCanSpecifyMinutes()
     {
         Sleep::fake();


### PR DESCRIPTION
In this PR, Add a new `Hour` method in `Sleep` class to calculate sleep time in hours.

* Add `Hour` and `Hours` methods in `Sleep.php`
* Add tests in `SleepTest.php`