### PR TITLE
Add 'ContainsSubstring' validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/ContainsSubstring,php
+++ b/src/Illuminate/Validation/Rules/ContainsSubstring,php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class ContainsSubstring extends Rule
+{
+    /**
+     * @var
+     */
+    protected $substring;
+
+    /**
+     * @param $substring
+     */
+    public function __construct($substring)
+    {
+        $this->substring = $substring;
+    }
+
+    /**
+     * @param $attribute
+     * @param $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        return str_contains($value, $this->substring);
+    }
+
+    /**
+     * @return string
+     */
+    public function message(): string
+    {
+        return "The :attribute must contain the substring '{$this->substring}'.";
+    }
+}


### PR DESCRIPTION
This commit introduces a new validation rule called 'ContainsSubstring' to the 'Validation\Rules' namespace. The rule allows developers to validate if a given string contains a specific substring.

The 'ContainsSubstring' rule can be used in Laravel's validation system to ensure that a field or input contains a required substring. It provides flexibility in validating input based on custom substring requirements.

Example usage:

```php
use Illuminate\Validation\Rule;
use App\Validation\Rules\ContainsSubstring;

$request->validate([ 'title' => ['required', new ContainsSubstring('example')],]);

```

Here's an example of a test case for the ContainsSubstring validation rule:

```php
use Illuminate\Validation\Rules\ContainsSubstring;
use Illuminate\Validation\Validator;
use PHPUnit\Framework\TestCase;

class ContainsSubstringTest extends TestCase
{
    /** @test */
    public function passes_validation_when_string_contains_substring()
    {
        $rule = new ContainsSubstring('example');

        $validator = new Validator(
            $this->getMockedTranslator(),
            ['attribute' => 'Lorem ipsum example dolor sit met],
            ['attribute' => $rule]
        );

        $this->assertTrue($validator->passes());
    }

    /** @test */
    public function fails_validation_when_string_does_not_contain_substring()
    {
        $rule = new ContainsSubstring('example');

        $validator = new Validator(
            $this->getMockedTranslator(),
            ['attribute' => 'Lorem ipsum dolor sit met],
            ['attribute' => $rule]
        );

        $this->assertFalse($validator->passes());
    }

    private function getMockedTranslator()
    {
        $translator = $this->getMockBuilder('Illuminate\Contracts\Translation\Translator')
            ->disableOriginalConstructor()
            ->getMock();

        $translator->method('trans')
            ->willReturnArgument(0);

        return $translator;
    }
}
