### PR TITLE
[10.x] feat: add an progressbar that handles an keyed array

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -280,6 +280,38 @@ trait InteractsWithIO
     }
 
     /**
+     * Execute a given callback while advancing a progress bar.
+     *
+     * @param  iterable|int  $totalSteps
+     * @param  \Closure  $callback
+     * @return mixed|void
+     */
+    public function withProgressBarWithKeys($totalSteps, Closure $callback)
+    {
+        $bar = $this->output->createProgressBar(
+            is_iterable($totalSteps) ? count($totalSteps) : $totalSteps
+        );
+
+        $bar->start();
+
+        if (is_iterable($totalSteps)) {
+            foreach ($totalSteps as $key => $value) {
+                $callback($key, $value, $bar);
+
+                $bar->advance();
+            }
+        } else {
+            $callback($bar);
+        }
+
+        $bar->finish();
+
+        if (is_iterable($totalSteps)) {
+            return $totalSteps;
+        }
+    }
+
+    /**
      * Write a string as information output.
      *
      * @param  string  $string


### PR DESCRIPTION
When I wanted to use the progressBar in the console I couldn't use an keyed array, the workaround would be to not make my array keyed and give an array as value wich then is keyed. However I would like to use the progressBar without this workaround and make it so it gives the key, value back.
