### PR TITLE
[10.x] Database Expressions that are conditions

### DIFF
--- a/src/Illuminate/Contracts/Database/Query/ConditionExpression.php
+++ b/src/Illuminate/Contracts/Database/Query/ConditionExpression.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Query;
+
+interface ConditionExpression extends Expression
+{
+
+}

--- a/src/Illuminate/Contracts/Database/Query/ConditionExpression.php
+++ b/src/Illuminate/Contracts/Database/Query/ConditionExpression.php
@@ -4,5 +4,4 @@ namespace Illuminate\Contracts\Database\Query;
 
 interface ConditionExpression extends Expression
 {
-
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -754,15 +754,15 @@ class Builder implements BuilderContract
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-		// If the column is a condition expression, we can skip the normal handling
-		// of parameters. Such a value indicates that the column contains a where
-		// condition that can be directly embedded into the query.
-		if ($column instanceof ConditionExpression) {
-			$type = 'Expression';
-			$this->wheres[] = compact('type', 'column', 'boolean');
+        // If the column is a condition expression, we can skip the normal handling
+        // of parameters. Such a value indicates that the column contains a where
+        // condition that can be directly embedded into the query.
+        if ($column instanceof ConditionExpression) {
+            $type = 'Expression';
+            $this->wheres[] = compact('type', 'column', 'boolean');
 
-			return $this;
-		}
+            return $this;
+        }
 
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
@@ -2094,15 +2094,15 @@ class Builder implements BuilderContract
     {
         $type = 'Basic';
 
-		// If the column is a condition expression, we can skip the normal handling
-		// of parameters. Such a value indicates that the column contains a having
-		// condition that can be directly embedded into the query.
-		if ($column instanceof ConditionExpression) {
-			$type = 'Expression';
-			$this->havings[] = compact('type', 'column', 'boolean');
+        // If the column is a condition expression, we can skip the normal handling
+        // of parameters. Such a value indicates that the column contains a having
+        // condition that can be directly embedded into the query.
+        if ($column instanceof ConditionExpression) {
+            $type = 'Expression';
+            $this->havings[] = compact('type', 'column', 'boolean');
 
-			return $this;
-		}
+            return $this;
+        }
 
         // Here we will make some assumptions about the operator. If only 2 values are
         // passed to the method, we will assume that the operator is an equals sign

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -7,6 +7,7 @@ use Carbon\CarbonPeriod;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
+use Illuminate\Contracts\Database\Query\ConditionExpression;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
@@ -753,6 +754,16 @@ class Builder implements BuilderContract
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+		// If the column is a condition expression, we can skip the normal handling
+		// of parameters. Such a value indicates that the column contains a where
+		// condition that can be directly embedded into the query.
+		if ($column instanceof ConditionExpression) {
+			$type = 'Expression';
+			$this->wheres[] = compact('type', 'column', 'boolean');
+
+			return $this;
+		}
+
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.
@@ -2082,6 +2093,16 @@ class Builder implements BuilderContract
     public function having($column, $operator = null, $value = null, $boolean = 'and')
     {
         $type = 'Basic';
+
+		// If the column is a condition expression, we can skip the normal handling
+		// of parameters. Such a value indicates that the column contains a having
+		// condition that can be directly embedded into the query.
+		if ($column instanceof ConditionExpression) {
+			$type = 'Expression';
+			$this->havings[] = compact('type', 'column', 'boolean');
+
+			return $this;
+		}
 
         // Here we will make some assumptions about the operator. If only 2 values are
         // passed to the method, we will assume that the operator is an equals sign

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -754,11 +754,9 @@ class Builder implements BuilderContract
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        // If the column is a condition expression, we can skip the normal handling
-        // of parameters. Such a value indicates that the column contains a where
-        // condition that can be directly embedded into the query.
         if ($column instanceof ConditionExpression) {
             $type = 'Expression';
+
             $this->wheres[] = compact('type', 'column', 'boolean');
 
             return $this;
@@ -2094,11 +2092,9 @@ class Builder implements BuilderContract
     {
         $type = 'Basic';
 
-        // If the column is a condition expression, we can skip the normal handling
-        // of parameters. Such a value indicates that the column contains a having
-        // condition that can be directly embedded into the query.
         if ($column instanceof ConditionExpression) {
             $type = 'Expression';
+
             $this->havings[] = compact('type', 'column', 'boolean');
 
             return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -707,6 +707,18 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a clause based on an expression.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    public function whereExpression(Builder $query, $where)
+    {
+        return $where['column']->getValue($this);
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -752,6 +764,8 @@ class Grammar extends BaseGrammar
             return $this->compileHavingNotNull($having);
         } elseif ($having['type'] === 'bit') {
             return $this->compileHavingBit($having);
+        } elseif ($having['type'] === 'Expression') {
+            return $this->compileHavingExpression($having);
         } elseif ($having['type'] === 'Nested') {
             return $this->compileNestedHavings($having);
         }
@@ -832,6 +846,17 @@ class Grammar extends BaseGrammar
         $parameter = $this->parameter($having['value']);
 
         return '('.$column.' '.$having['operator'].' '.$parameter.') != 0';
+    }
+
+    /**
+     * Compile a having clause involving an expression.
+     *
+     * @param  array  $having
+     * @return string
+     */
+    protected function compileHavingExpression($having)
+    {
+        return $having['column']->getValue($this);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1838,7 +1838,8 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having(
-            new class() implements ConditionExpression {
+            new class() implements ConditionExpression
+            {
                 public function getValue(\Illuminate\Database\Grammar $grammar)
                 {
                     return '1 = 1';
@@ -1847,7 +1848,7 @@ class DatabaseQueryBuilderTest extends TestCase
         );
         $this->assertSame('select * from "users" having 1 = 1', $builder->toSql());
         $this->assertSame([], $builder->getBindings());
-   }
+    }
 
     public function testHavingShortcut()
     {
@@ -5096,7 +5097,8 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where(
-            new class() implements ConditionExpression {
+            new class() implements ConditionExpression
+            {
                 public function getValue(\Illuminate\Database\Grammar $grammar)
                 {
                     return '1 = 1';

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use BadMethodCallException;
 use Closure;
 use DateTime;
+use Illuminate\Contracts\Database\Query\ConditionExpression;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
@@ -1832,6 +1833,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select(['category', new Raw('count(*) as "total"')])->from('item')->where('department', '=', 'popular')->groupBy('category')->havingNotNull('total');
         $this->assertSame('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" is not null', $builder->toSql());
     }
+
+    public function testHavingExpression()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->having(
+            new class() implements ConditionExpression {
+                public function getValue(\Illuminate\Database\Grammar $grammar)
+                {
+                    return '1 = 1';
+                }
+            }
+        );
+        $this->assertSame('select * from "users" having 1 = 1', $builder->toSql());
+        $this->assertSame([], $builder->getBindings());
+   }
 
     public function testHavingShortcut()
     {
@@ -5074,6 +5090,21 @@ SQL;
             'cursorName' => $cursorName,
             'parameters' => ['created_at', 'id'],
         ]), $result);
+    }
+
+    public function testWhereExpression()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->where(
+            new class() implements ConditionExpression {
+                public function getValue(\Illuminate\Database\Grammar $grammar)
+                {
+                    return '1 = 1';
+                }
+            }
+        );
+        $this->assertSame('select * from "orders" where 1 = 1', $builder->toSql());
+        $this->assertSame([], $builder->getBindings());
     }
 
     public function testWhereRowValues()


### PR DESCRIPTION
With #46558 merged, the database expressions could now support more extended use cases: A common thing for database drivers or users is to extend the query builder to support new `whereXyz()` methods. But these are not database-agnostic. 

I've created a new interface (`ConditionExpression`) to indicate expressions that will be transformed into an entire database condition. These can be passed to `where` and `having`:
```php
/** @see https://github.com/tpetry/laravel-query-expressions/blob/main/src/Operator/Comparison/DistinctFrom.php */
$query->where(new DistinctFrom('type', new Value('pending')))
```

Expressions built on the new interface will be handled differently by `WHERE` and `HAVING`. At the moment, an expression passed as a single parameter to `where` will result in a SQL string that is no longer the intended use-case. By changing the query builder very minimal to handle `ConditionExpression` different, those conditions can be embedded into the SQL query correctly:
```sql
-- expression using the Expression interface
WHERE (type IS DISTINCT FROM 'pending') IS NULL

-- expression using the ConditionExpression interface
WHERE (type IS DISTINCT FROM 'pending')
```


But this approach is much more compelling if you consider more complex use cases. For example, geographical operations or statistical queries require many transformations on columns and values. These are hard to generalize, and you must fall back to raw parts. Some spaghetti code often insecurely interpolates those raw strings when complex customization is used.

With condition expressions, you can safely composite multiple objects to form the condition you want to have. Complex dynamic query-building logic can be transformed into parsers that return a single object that can be used with Laravel: 
```php
$condition = createDBCondition($request);
// returns:
// new LessThan(
//   new GeoDistance('location', new GeoPoint(-39.08677, 58.64465, srid: 4326), srid: 4326),
//   new Value(50),
// );

$query->where(condition);
```