### PR TITLE
[9.x] Http client: allow to provide closure to `retryDelay`

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -130,7 +130,7 @@ class PendingRequest
     /**
      * The number of milliseconds to wait between retries.
      *
-     * @var int
+     * @var Closure|int
      */
     protected $retryDelay = 100;
 
@@ -556,12 +556,12 @@ class PendingRequest
      * Specify the number of times the request should be attempted.
      *
      * @param  int  $times
-     * @param  int  $sleepMilliseconds
+     * @param  Closure|int  $sleepMilliseconds
      * @param  callable|null  $when
      * @param  bool  $throw
      * @return $this
      */
-    public function retry(int $times, int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
+    public function retry(int $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
     {
         $this->tries = $times;
         $this->retryDelay = $sleepMilliseconds;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
+use Closure;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
@@ -109,14 +110,14 @@ class PendingRequest
     /**
      * A callback to run when throwing if a server or client error occurs.
      *
-     * @var \Closure
+     * @var Closure
      */
     protected $throwCallback;
 
     /**
      * A callback to check if an exception should be thrown when a server or client error occurs.
      *
-     * @var \Closure
+     * @var Closure
      */
     protected $throwIfCallback;
 
@@ -1093,7 +1094,7 @@ class PendingRequest
     /**
      * Build the before sending handler.
      *
-     * @return \Closure
+     * @return Closure
      */
     public function buildBeforeSendingHandler()
     {
@@ -1107,7 +1108,7 @@ class PendingRequest
     /**
      * Build the recorder handler.
      *
-     * @return \Closure
+     * @return Closure
      */
     public function buildRecorderHandler()
     {
@@ -1130,7 +1131,7 @@ class PendingRequest
     /**
      * Build the stub handler.
      *
-     * @return \Closure
+     * @return Closure
      */
     public function buildStubHandler()
     {
@@ -1167,7 +1168,7 @@ class PendingRequest
      * Get the sink stub handler callback.
      *
      * @param  string  $sink
-     * @return \Closure
+     * @return Closure
      */
     protected function sinkStubHandler($sink)
     {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1573,6 +1573,31 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testRequestsWillBeWaitingSleepMillisecondsReceivedBeforeRetry()
+    {
+        $startTime = microtime(true);
+
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push(['error'], 500)
+                ->push(['error'], 500)
+                ->push(['ok'], 200),
+        ]);
+
+        $this->factory
+            ->retry(3, function ($attempt, $exception) {
+                $this->assertInstanceOf(RequestException::class, $exception);
+
+                return $attempt * 100;
+            }, null, true)
+            ->get('http://foo.com/get');
+
+        $this->factory->assertSentCount(3);
+
+        // Make sure was waited 300ms for the first two attempts
+        $this->assertEqualsWithDelta(0.3, microtime(true) - $startTime, 0.03);
+    }
+
     public function testMiddlewareRunsWhenFaked()
     {
         $this->factory->fake(function (Request $request) {


### PR DESCRIPTION
This possibility has already been implemented [here](https://github.com/laravel/framework/pull/46653) in 10.x. Opening this PR to allow folks still using 9.x to take advantage of this and improve their applications.
