### PR TITLE
Add whereBelongsById to EloquentBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -527,6 +527,84 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a "BelongsToById" relationship where clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @param string $boolean
+     * @param bool $not
+     * @return $this
+     */
+    public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
+    {
+        if (!$related instanceof \Illuminate\Support\Collection) {
+            $relatedCollection = $related->newCollection([$related]);
+        } else {
+            $relatedCollection = $related;
+        }
+
+        if ($relatedCollection->isEmpty()) {
+            throw new InvalidArgumentException('Collection given to whereBelongsTo method may not be empty.');
+        }
+
+        try {
+            $relationship = $this->model->{$relationshipName}();
+        } catch (BadMethodCallException $exception) {
+            throw RelationNotFoundException::make($this->model, $relationshipName);
+        }
+
+        if (!$relationship instanceof BelongsTo) {
+            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
+        }
+
+        $this->whereIn(
+            $relationship->getQualifiedForeignKeyName(),
+            $relatedCollection->toArray(),
+            $boolean,
+            $not
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add an "BelongsToById" relationship with an "or where" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @return $this
+     */
+    public function orWhereBelongsToById($related, $relationshipName)
+    {
+        return $this->whereBelongsToById($related, $relationshipName, 'or');
+    }
+
+    /**
+     * Add a "BelongsToById" relationship with an "where not" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @param string $boolean
+     * @return $this
+     */
+    public function whereNotBelongsToById($related, $relationshipName, $boolean = 'and')
+    {
+        return $this->whereBelongsToById($related, $relationshipName, $boolean, true);
+    }
+
+    /**
+     * Add a "BelongsToById" relationship with an "or where not" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @return $this
+     */
+    public function orWhereNotBelongsToById($related, $relationshipName)
+    {
+        return $this->whereBelongsToById($related, $relationshipName, 'or', true);
+    }
+
+    /**
      * Add a "belongs to" relationship where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1141,6 +1141,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
 
+        $resultById = $builder->whereBelongsToById($parent->id, 'parent');
+        $this->assertEquals($resultById, $builder);
+
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
@@ -1172,6 +1175,9 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);
+
+        $resultById = $builder->whereBelongsToById($parents->pluck('id'), 'parent');
+        $this->assertEquals($resultById, $builder);
     }
 
     public function testDeleteOverride()


### PR DESCRIPTION
We need this in case we want to find by relationship id, withouth query the model to reduce mysql queries.
Like filtering the model by relationship in controller from FormRequest, in most efficient way.