### PR TITLE
[10.x] Speed-up slow tests

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -802,6 +802,7 @@ class Str
      */
     public static function random($length = 16)
     {
+
         return (static::$randomStringFactory ?? function ($length) {
             $string = '';
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -802,7 +802,6 @@ class Str
      */
     public static function random($length = 16)
     {
-
         return (static::$randomStringFactory ?? function ($length) {
             $string = '';
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1380,7 +1380,7 @@ class HttpClientTest extends TestCase
             '*' => $factory->response(['error'], 403),
         ]);
 
-        $response = $factory->retry(2, 1000, null, false)->get('http://foo.com/get');
+        $response = $factory->retry(2, 10, null, false)->get('http://foo.com/get');
 
         $this->assertTrue($response->failed());
 

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -85,7 +85,7 @@ class EloquentPrunableTest extends DatabaseTestCase
         $count = (new PrunableWithCustomPruneMethodTestModel)->pruneAll(10);
 
         $this->assertEquals(10, $count);
-        $this->assertTrue((bool) PrunableWithCustomPruneMethodTestModel::first()->pruned);
+        $this->assertTrue((bool) PrunableWithCustomPruneMethodTestModel::orderBy('id')->first()->pruned);
         $this->assertFalse((bool) PrunableWithCustomPruneMethodTestModel::orderBy('id', 'desc')->first()->pruned);
         $this->assertEquals(50, PrunableWithCustomPruneMethodTestModel::count());
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -508,13 +508,12 @@ class SupportStrTest extends TestCase
     public function TestWhetherTheNumberOfGeneratedCharactersIsEquallyDistributed()
     {
         $results = [];
-        // take 6.200.000 samples, because there are 62 different characters
-        for ($i = 0; $i < 620000; $i++) {
-            $random = Str::random(1);
-            $results[$random] = ($results[$random] ?? 0) + 1;
+        // Generate a string with a length of 620,000 since there are 62 different characters.
+        foreach (str_split(Str::random(620000)) as $char) {
+            $results[$char] = ($results[$char] ?? 0) + 1;
         }
 
-        // each character should occur 100.000 times with a variance of 5%.
+        // Each character should occur 10,000 times with a variance of 5%.
         foreach ($results as $result) {
             $this->assertEqualsWithDelta(10000, $result, 500);
         }


### PR DESCRIPTION
This improves some tests that were running slowly because they either did something inefficiently or used way too many test data.

(the first commit is meant to be a whitespace so I can benchmark the tests before and after)