### PR TITLE
Add whereBelongsById to EloquentBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -527,6 +527,84 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a "BelongsToById" relationship where clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @param string $boolean
+     * @param bool $not
+     * @return $this
+     */
+    public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
+    {
+        if (!$related instanceof \Illuminate\Support\Collection) {
+            $relatedCollection = $related->newCollection([$related]);
+        } else {
+            $relatedCollection = $related;
+        }
+
+        if ($relatedCollection->isEmpty()) {
+            throw new InvalidArgumentException('Collection given to whereBelongsTo method may not be empty.');
+        }
+
+        try {
+            $relationship = $this->model->{$relationshipName}();
+        } catch (BadMethodCallException $exception) {
+            throw RelationNotFoundException::make($this->model, $relationshipName);
+        }
+
+        if (!$relationship instanceof BelongsTo) {
+            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
+        }
+
+        $this->whereIn(
+            $relationship->getQualifiedForeignKeyName(),
+            $relatedCollection->toArray(),
+            $boolean,
+            $not
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add an "BelongsToById" relationship with an "or where" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @return $this
+     */
+    public function orWhereBelongsToById($related, $relationshipName)
+    {
+        return $this->whereBelongsToById($related, $relationshipName, 'or');
+    }
+
+    /**
+     * Add a "BelongsToById" relationship with an "where not" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @param string $boolean
+     * @return $this
+     */
+    public function whereNotBelongsToById($related, $relationshipName, $boolean = 'and')
+    {
+        return $this->whereBelongsToById($related, $relationshipName, $boolean, true);
+    }
+
+    /**
+     * Add a "BelongsToById" relationship with an "or where not" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @return $this
+     */
+    public function orWhereNotBelongsToById($related, $relationshipName)
+    {
+        return $this->whereBelongsToById($related, $relationshipName, 'or', true);
+    }
+
+    /**
      * Add a "belongs to" relationship where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -20,11 +20,11 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\Relation|string $relation
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      *
      * @throws \RuntimeException
@@ -47,8 +47,8 @@ trait QueriesRelationships
         // the subquery to only run a "where exists" clause instead of this full "count"
         // clause. This will make these queries run much faster compared with a count.
         $method = $this->canUseExistsForExistenceCheck($operator, $count)
-                        ? 'getRelationExistenceQuery'
-                        : 'getRelationExistenceCountQuery';
+            ? 'getRelationExistenceQuery'
+            : 'getRelationExistenceCountQuery';
 
         $hasQuery = $relation->{$method}(
             $relation->getRelated()->newQueryWithoutRelationships(), $this
@@ -71,11 +71,11 @@ trait QueriesRelationships
      *
      * Sets up recursive call to whereHas until we finish the nested relation.
      *
-     * @param  string  $relations
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param string $relations
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
@@ -104,9 +104,9 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param  string  $relation
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -117,9 +117,9 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  string  $relation
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param string $relation
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
@@ -130,7 +130,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param  string  $relation
+     * @param string $relation
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orDoesntHave($relation)
@@ -141,10 +141,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -157,25 +157,25 @@ trait QueriesRelationships
      *
      * Also load the relationship with same condition.
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
-            ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+            ->with($callback ? [$relation => fn($query) => $callback($query)] : $relation);
     }
 
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -186,8 +186,8 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param string $relation
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereDoesntHave($relation, Closure $callback = null)
@@ -198,8 +198,8 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param string $relation
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereDoesntHave($relation, Closure $callback = null)
@@ -210,12 +210,12 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
@@ -224,7 +224,7 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($relation);
         }
 
-        $types = (array) $types;
+        $types = (array)$types;
 
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
@@ -246,7 +246,7 @@ trait QueriesRelationships
                     }
 
                     $query->where($this->qualifyColumn($relation->getMorphType()), '=', (new $type)->getMorphClass())
-                                ->whereHas($belongsTo, $callback, $operator, $count);
+                        ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }
         }, null, null, $boolean);
@@ -255,8 +255,8 @@ trait QueriesRelationships
     /**
      * Get the BelongsTo relationship for a single polymorphic type.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo  $relation
-     * @param  string  $type
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo $relation
+     * @param string $type
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     protected function getBelongsToRelation(MorphTo $relation, $type)
@@ -277,10 +277,10 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  string  $operator
-     * @param  int  $count
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
@@ -291,10 +291,10 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
@@ -305,8 +305,8 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orDoesntHaveMorph($relation, $types)
@@ -317,11 +317,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
@@ -332,11 +332,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
@@ -347,9 +347,9 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
@@ -360,9 +360,9 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
@@ -373,10 +373,10 @@ trait QueriesRelationships
     /**
      * Add a basic where clause to a relationship query.
      *
-     * @param  string  $relation
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param string $relation
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
@@ -393,10 +393,10 @@ trait QueriesRelationships
     /**
      * Add an "or where" clause to a relationship query.
      *
-     * @param  string  $relation
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param string $relation
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
@@ -413,11 +413,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
@@ -430,11 +430,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
@@ -447,8 +447,8 @@ trait QueriesRelationships
     /**
      * Add a morph-to relationship condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereMorphedTo($relation, $model, $boolean = 'and')
@@ -460,7 +460,7 @@ trait QueriesRelationships
         if (is_string($model)) {
             $morphMap = Relation::morphMap();
 
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
+            if (!empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
             }
 
@@ -476,8 +476,8 @@ trait QueriesRelationships
     /**
      * Add a not morph-to relationship condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereNotMorphedTo($relation, $model, $boolean = 'and')
@@ -489,7 +489,7 @@ trait QueriesRelationships
         if (is_string($model)) {
             $morphMap = Relation::morphMap();
 
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
+            if (!empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
             }
 
@@ -505,8 +505,8 @@ trait QueriesRelationships
     /**
      * Add a morph-to relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereMorphedTo($relation, $model)
@@ -517,8 +517,8 @@ trait QueriesRelationships
     /**
      * Add a not morph-to relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereNotMorphedTo($relation, $model)
@@ -529,7 +529,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship where clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @param string $boolean
      * @param bool $not
@@ -538,7 +538,7 @@ trait QueriesRelationships
     public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
     {
         if (!$related instanceof \Illuminate\Support\Collection) {
-            $relatedCollection = $related->newCollection([$related]);
+            $relatedCollection = collect([$related]);
         } else {
             $relatedCollection = $related;
         }
@@ -570,7 +570,7 @@ trait QueriesRelationships
     /**
      * Add an "BelongsToById" relationship with an "or where" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @return $this
      */
@@ -582,7 +582,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @param string $boolean
      * @return $this
@@ -595,7 +595,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "or where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @return $this
      */
@@ -607,16 +607,16 @@ trait QueriesRelationships
     /**
      * Add a "belongs to" relationship where clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related
-     * @param  string|null  $relationshipName
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model> $related
+     * @param string|null $relationshipName
+     * @param string $boolean
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
      */
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
     {
-        if (! $related instanceof Collection) {
+        if (!$related instanceof Collection) {
             $relatedCollection = $related->newCollection([$related]);
         } else {
             $relatedCollection = $related;
@@ -638,7 +638,7 @@ trait QueriesRelationships
             throw RelationNotFoundException::make($this->model, $relationshipName);
         }
 
-        if (! $relationship instanceof BelongsTo) {
+        if (!$relationship instanceof BelongsTo) {
             throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
         }
 
@@ -654,8 +654,8 @@ trait QueriesRelationships
     /**
      * Add an "BelongsTo" relationship with an "or where" clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $related
-     * @param  string|null  $relationshipName
+     * @param \Illuminate\Database\Eloquent\Model $related
+     * @param string|null $relationshipName
      * @return $this
      *
      * @throws \RuntimeException
@@ -668,9 +668,9 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include an aggregate value for a relationship.
      *
-     * @param  mixed  $relations
-     * @param  string  $column
-     * @param  string  $function
+     * @param mixed $relations
+     * @param string $column
+     * @param string $function
      * @return $this
      */
     public function withAggregate($relations, $column, $function = null)
@@ -680,7 +680,7 @@ trait QueriesRelationships
         }
 
         if (is_null($this->query->columns)) {
-            $this->query->select([$this->query->from.'.*']);
+            $this->query->select([$this->query->from . '.*']);
         }
 
         $relations = is_array($relations) ? $relations : [$relations];
@@ -759,8 +759,8 @@ trait QueriesRelationships
     /**
      * Get the relation hashed column name for the given column and relation.
      *
-     * @param  string  $column
-     * @param  \Illuminate\Database\Eloquent\Relations\Relationship  $relation
+     * @param string $column
+     * @param \Illuminate\Database\Eloquent\Relations\Relationship $relation
      * @return string
      */
     protected function getRelationHashedColumn($column, $relation)
@@ -777,7 +777,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to count the relations.
      *
-     * @param  mixed  $relations
+     * @param mixed $relations
      * @return $this
      */
     public function withCount($relations)
@@ -788,8 +788,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the max of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withMax($relation, $column)
@@ -800,8 +800,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the min of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withMin($relation, $column)
@@ -812,8 +812,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the sum of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withSum($relation, $column)
@@ -824,8 +824,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the average of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withAvg($relation, $column)
@@ -836,7 +836,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param  string|array  $relation
+     * @param string|array $relation
      * @return $this
      */
     public function withExists($relation)
@@ -847,11 +847,11 @@ trait QueriesRelationships
     /**
      * Add the "has" condition where clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Eloquent\Builder $hasQuery
+     * @param \Illuminate\Database\Eloquent\Relations\Relation $relation
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function addHasWhere(Builder $hasQuery, Relation $relation, $operator, $count, $boolean)
@@ -859,14 +859,14 @@ trait QueriesRelationships
         $hasQuery->mergeConstraintsFrom($relation->getQuery());
 
         return $this->canUseExistsForExistenceCheck($operator, $count)
-                ? $this->addWhereExistsQuery($hasQuery->toBase(), $boolean, $operator === '<' && $count === 1)
-                : $this->addWhereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
+            ? $this->addWhereExistsQuery($hasQuery->toBase(), $boolean, $operator === '<' && $count === 1)
+            : $this->addWhereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
     }
 
     /**
      * Merge the where constraints from another query to the current query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $from
+     * @param \Illuminate\Database\Eloquent\Builder $from
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function mergeConstraintsFrom(Builder $from)
@@ -893,17 +893,17 @@ trait QueriesRelationships
     /**
      * Updates the table name for any columns with a new qualified name.
      *
-     * @param  array  $wheres
-     * @param  string  $from
-     * @param  string  $to
+     * @param array $wheres
+     * @param string $from
+     * @param string $to
      * @return array
      */
     protected function requalifyWhereTables(array $wheres, string $from, string $to): array
     {
         return collect($wheres)->map(function ($where) use ($from, $to) {
             return collect($where)->map(function ($value) use ($from, $to) {
-                return is_string($value) && str_starts_with($value, $from.'.')
-                    ? $to.'.'.Str::afterLast($value, '.')
+                return is_string($value) && str_starts_with($value, $from . '.')
+                    ? $to . '.' . Str::afterLast($value, '.')
                     : $value;
             });
         })->toArray();
@@ -912,10 +912,10 @@ trait QueriesRelationships
     /**
      * Add a sub-query count clause to this query.
      *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
      * @return $this
      */
     protected function addWhereCountQuery(QueryBuilder $query, $operator = '>=', $count = 1, $boolean = 'and')
@@ -923,7 +923,7 @@ trait QueriesRelationships
         $this->query->addBinding($query->getBindings(), 'where');
 
         return $this->where(
-            new Expression('('.$query->toSql().')'),
+            new Expression('(' . $query->toSql() . ')'),
             $operator,
             is_numeric($count) ? new Expression($count) : $count,
             $boolean
@@ -933,7 +933,7 @@ trait QueriesRelationships
     /**
      * Get the "has relation" base query instance.
      *
-     * @param  string  $relation
+     * @param string $relation
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     protected function getRelationWithoutConstraints($relation)
@@ -946,8 +946,8 @@ trait QueriesRelationships
     /**
      * Check if we can run an "exists" query to optimize performance.
      *
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $operator
+     * @param int $count
      * @return bool
      */
     protected function canUseExistsForExistenceCheck($operator, $count)

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1141,6 +1141,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
 
+        $resultById = $builder->whereBelongsToById($parent->id, 'parent');
+        $this->assertEquals($resultById, $builder);
+
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
@@ -1172,6 +1175,9 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);
+
+        $resultById = $builder->whereBelongsToById($parents->pluck('id'), 'parent');
+        $this->assertEquals($resultById, $builder);
     }
 
     public function testDeleteOverride()


### PR DESCRIPTION
We need this in case we want to find by relationship id, withouth query the model to reduce mysql queries.
Like filtering the model by relationship in controller from FormRequest, in most efficient way.