### PR TITLE
[9.x] Add whereBelongsToById to EloquentBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -529,7 +529,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship where clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
+     * @param int|\Illuminate\Database\Eloquent\Collection $related
      * @param string $relationshipName
      * @param string $boolean
      * @param bool $not
@@ -570,7 +570,7 @@ trait QueriesRelationships
     /**
      * Add an "BelongsToById" relationship with an "or where" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
+     * @param int|\Illuminate\Database\Eloquent\Collection $related
      * @param string $relationshipName
      * @return $this
      */
@@ -582,7 +582,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
+     * @param int|\Illuminate\Database\Eloquent\Collection $related
      * @param string $relationshipName
      * @param string $boolean
      * @return $this
@@ -595,7 +595,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "or where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
+     * @param int|\Illuminate\Database\Eloquent\Collection $related
      * @param string $relationshipName
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -527,6 +527,84 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a "BelongsToById" relationship where clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @param string $boolean
+     * @param bool $not
+     * @return $this
+     */
+    public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
+    {
+        if (!$related instanceof \Illuminate\Support\Collection) {
+            $relatedCollection = $related->newCollection([$related]);
+        } else {
+            $relatedCollection = $related;
+        }
+
+        if ($relatedCollection->isEmpty()) {
+            throw new InvalidArgumentException('Collection given to whereBelongsTo method may not be empty.');
+        }
+
+        try {
+            $relationship = $this->model->{$relationshipName}();
+        } catch (BadMethodCallException $exception) {
+            throw RelationNotFoundException::make($this->model, $relationshipName);
+        }
+
+        if (!$relationship instanceof BelongsTo) {
+            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
+        }
+
+        $this->whereIn(
+            $relationship->getQualifiedForeignKeyName(),
+            $relatedCollection->toArray(),
+            $boolean,
+            $not
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add an "BelongsToById" relationship with an "or where" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @return $this
+     */
+    public function orWhereBelongsToById($related, $relationshipName)
+    {
+        return $this->whereBelongsToById($related, $relationshipName, 'or');
+    }
+
+    /**
+     * Add a "BelongsToById" relationship with an "where not" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @param string $boolean
+     * @return $this
+     */
+    public function whereNotBelongsToById($related, $relationshipName, $boolean = 'and')
+    {
+        return $this->whereBelongsToById($related, $relationshipName, $boolean, true);
+    }
+
+    /**
+     * Add a "BelongsToById" relationship with an "or where not" clause to the query.
+     *
+     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param string $relationshipName
+     * @return $this
+     */
+    public function orWhereNotBelongsToById($related, $relationshipName)
+    {
+        return $this->whereBelongsToById($related, $relationshipName, 'or', true);
+    }
+
+    /**
      * Add a "belongs to" relationship where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -20,11 +20,11 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\Relation|string $relation
-     * @param string $operator
-     * @param int $count
-     * @param string $boolean
-     * @param \Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      *
      * @throws \RuntimeException
@@ -47,8 +47,8 @@ trait QueriesRelationships
         // the subquery to only run a "where exists" clause instead of this full "count"
         // clause. This will make these queries run much faster compared with a count.
         $method = $this->canUseExistsForExistenceCheck($operator, $count)
-            ? 'getRelationExistenceQuery'
-            : 'getRelationExistenceCountQuery';
+                        ? 'getRelationExistenceQuery'
+                        : 'getRelationExistenceCountQuery';
 
         $hasQuery = $relation->{$method}(
             $relation->getRelated()->newQueryWithoutRelationships(), $this
@@ -71,11 +71,11 @@ trait QueriesRelationships
      *
      * Sets up recursive call to whereHas until we finish the nested relation.
      *
-     * @param string $relations
-     * @param string $operator
-     * @param int $count
-     * @param string $boolean
-     * @param \Closure|null $callback
+     * @param  string  $relations
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
@@ -104,9 +104,9 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param string $relation
-     * @param string $operator
-     * @param int $count
+     * @param  string  $relation
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -117,9 +117,9 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param string $relation
-     * @param string $boolean
-     * @param \Closure|null $callback
+     * @param  string  $relation
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
@@ -130,7 +130,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param string $relation
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orDoesntHave($relation)
@@ -141,10 +141,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param string $relation
-     * @param \Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -157,25 +157,25 @@ trait QueriesRelationships
      *
      * Also load the relationship with same condition.
      *
-     * @param string $relation
-     * @param \Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
-            ->with($callback ? [$relation => fn($query) => $callback($query)] : $relation);
+            ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
     }
 
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param string $relation
-     * @param \Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -186,8 +186,8 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param string $relation
-     * @param \Closure|null $callback
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereDoesntHave($relation, Closure $callback = null)
@@ -198,8 +198,8 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param string $relation
-     * @param \Closure|null $callback
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereDoesntHave($relation, Closure $callback = null)
@@ -210,12 +210,12 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param string $operator
-     * @param int $count
-     * @param string $boolean
-     * @param \Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
@@ -224,7 +224,7 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($relation);
         }
 
-        $types = (array)$types;
+        $types = (array) $types;
 
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
@@ -246,7 +246,7 @@ trait QueriesRelationships
                     }
 
                     $query->where($this->qualifyColumn($relation->getMorphType()), '=', (new $type)->getMorphClass())
-                        ->whereHas($belongsTo, $callback, $operator, $count);
+                                ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }
         }, null, null, $boolean);
@@ -255,8 +255,8 @@ trait QueriesRelationships
     /**
      * Get the BelongsTo relationship for a single polymorphic type.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo $relation
-     * @param string $type
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo  $relation
+     * @param  string  $type
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     protected function getBelongsToRelation(MorphTo $relation, $type)
@@ -277,10 +277,10 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param string $operator
-     * @param int $count
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
@@ -291,10 +291,10 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param string $boolean
-     * @param \Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
@@ -305,8 +305,8 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orDoesntHaveMorph($relation, $types)
@@ -317,11 +317,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param \Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
@@ -332,11 +332,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param \Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
@@ -347,9 +347,9 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param \Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
@@ -360,9 +360,9 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param \Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
@@ -373,10 +373,10 @@ trait QueriesRelationships
     /**
      * Add a basic where clause to a relationship query.
      *
-     * @param string $relation
-     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
-     * @param mixed $operator
-     * @param mixed $value
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
@@ -393,10 +393,10 @@ trait QueriesRelationships
     /**
      * Add an "or where" clause to a relationship query.
      *
-     * @param string $relation
-     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
-     * @param mixed $operator
-     * @param mixed $value
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
@@ -413,11 +413,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
-     * @param mixed $operator
-     * @param mixed $value
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
@@ -430,11 +430,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with an "or where" clause.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param string|array $types
-     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
-     * @param mixed $operator
-     * @param mixed $value
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
@@ -447,8 +447,8 @@ trait QueriesRelationships
     /**
      * Add a morph-to relationship condition to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param \Illuminate\Database\Eloquent\Model|string $model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereMorphedTo($relation, $model, $boolean = 'and')
@@ -460,7 +460,7 @@ trait QueriesRelationships
         if (is_string($model)) {
             $morphMap = Relation::morphMap();
 
-            if (!empty($morphMap) && in_array($model, $morphMap)) {
+            if (! empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
             }
 
@@ -476,8 +476,8 @@ trait QueriesRelationships
     /**
      * Add a not morph-to relationship condition to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param \Illuminate\Database\Eloquent\Model|string $model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereNotMorphedTo($relation, $model, $boolean = 'and')
@@ -489,7 +489,7 @@ trait QueriesRelationships
         if (is_string($model)) {
             $morphMap = Relation::morphMap();
 
-            if (!empty($morphMap) && in_array($model, $morphMap)) {
+            if (! empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
             }
 
@@ -505,8 +505,8 @@ trait QueriesRelationships
     /**
      * Add a morph-to relationship condition to the query with an "or where" clause.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param \Illuminate\Database\Eloquent\Model|string $model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereMorphedTo($relation, $model)
@@ -517,8 +517,8 @@ trait QueriesRelationships
     /**
      * Add a not morph-to relationship condition to the query with an "or where" clause.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
-     * @param \Illuminate\Database\Eloquent\Model|string $model
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereNotMorphedTo($relation, $model)
@@ -529,10 +529,10 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship where clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection $related
-     * @param string $relationshipName
-     * @param string $boolean
-     * @param bool $not
+     * @param  int|\Illuminate\Database\Eloquent\Collection  $related
+     * @param  string  $relationshipName
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
@@ -570,8 +570,8 @@ trait QueriesRelationships
     /**
      * Add an "BelongsToById" relationship with an "or where" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection $related
-     * @param string $relationshipName
+     * @param  int|\Illuminate\Database\Eloquent\Collection  $related
+     * @param  string  $relationshipName
      * @return $this
      */
     public function orWhereBelongsToById($related, $relationshipName)
@@ -582,9 +582,9 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection $related
-     * @param string $relationshipName
-     * @param string $boolean
+     * @param  int|\Illuminate\Database\Eloquent\Collection  $related
+     * @param  string  $relationshipName
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNotBelongsToById($related, $relationshipName, $boolean = 'and')
@@ -595,8 +595,8 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "or where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection $related
-     * @param string $relationshipName
+     * @param  int|\Illuminate\Database\Eloquent\Collection  $related
+     * @param  string  $relationshipName
      * @return $this
      */
     public function orWhereNotBelongsToById($related, $relationshipName)
@@ -607,16 +607,16 @@ trait QueriesRelationships
     /**
      * Add a "belongs to" relationship where clause to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model> $related
-     * @param string|null $relationshipName
-     * @param string $boolean
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related
+     * @param  string|null  $relationshipName
+     * @param  string  $boolean
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
      */
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
     {
-        if (!$related instanceof Collection) {
+        if (! $related instanceof Collection) {
             $relatedCollection = $related->newCollection([$related]);
         } else {
             $relatedCollection = $related;
@@ -638,7 +638,7 @@ trait QueriesRelationships
             throw RelationNotFoundException::make($this->model, $relationshipName);
         }
 
-        if (!$relationship instanceof BelongsTo) {
+        if (! $relationship instanceof BelongsTo) {
             throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
         }
 
@@ -654,8 +654,8 @@ trait QueriesRelationships
     /**
      * Add an "BelongsTo" relationship with an "or where" clause to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Model $related
-     * @param string|null $relationshipName
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string|null  $relationshipName
      * @return $this
      *
      * @throws \RuntimeException
@@ -668,9 +668,9 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include an aggregate value for a relationship.
      *
-     * @param mixed $relations
-     * @param string $column
-     * @param string $function
+     * @param  mixed  $relations
+     * @param  string  $column
+     * @param  string  $function
      * @return $this
      */
     public function withAggregate($relations, $column, $function = null)
@@ -680,7 +680,7 @@ trait QueriesRelationships
         }
 
         if (is_null($this->query->columns)) {
-            $this->query->select([$this->query->from . '.*']);
+            $this->query->select([$this->query->from.'.*']);
         }
 
         $relations = is_array($relations) ? $relations : [$relations];
@@ -759,8 +759,8 @@ trait QueriesRelationships
     /**
      * Get the relation hashed column name for the given column and relation.
      *
-     * @param string $column
-     * @param \Illuminate\Database\Eloquent\Relations\Relationship $relation
+     * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Relations\Relationship  $relation
      * @return string
      */
     protected function getRelationHashedColumn($column, $relation)
@@ -777,7 +777,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to count the relations.
      *
-     * @param mixed $relations
+     * @param  mixed  $relations
      * @return $this
      */
     public function withCount($relations)
@@ -788,8 +788,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the max of the relation's column.
      *
-     * @param string|array $relation
-     * @param string $column
+     * @param  string|array  $relation
+     * @param  string  $column
      * @return $this
      */
     public function withMax($relation, $column)
@@ -800,8 +800,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the min of the relation's column.
      *
-     * @param string|array $relation
-     * @param string $column
+     * @param  string|array  $relation
+     * @param  string  $column
      * @return $this
      */
     public function withMin($relation, $column)
@@ -812,8 +812,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the sum of the relation's column.
      *
-     * @param string|array $relation
-     * @param string $column
+     * @param  string|array  $relation
+     * @param  string  $column
      * @return $this
      */
     public function withSum($relation, $column)
@@ -824,8 +824,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the average of the relation's column.
      *
-     * @param string|array $relation
-     * @param string $column
+     * @param  string|array  $relation
+     * @param  string  $column
      * @return $this
      */
     public function withAvg($relation, $column)
@@ -836,7 +836,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param string|array $relation
+     * @param  string|array  $relation
      * @return $this
      */
     public function withExists($relation)
@@ -847,11 +847,11 @@ trait QueriesRelationships
     /**
      * Add the "has" condition where clause to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $hasQuery
-     * @param \Illuminate\Database\Eloquent\Relations\Relation $relation
-     * @param string $operator
-     * @param int $count
-     * @param string $boolean
+     * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function addHasWhere(Builder $hasQuery, Relation $relation, $operator, $count, $boolean)
@@ -859,14 +859,14 @@ trait QueriesRelationships
         $hasQuery->mergeConstraintsFrom($relation->getQuery());
 
         return $this->canUseExistsForExistenceCheck($operator, $count)
-            ? $this->addWhereExistsQuery($hasQuery->toBase(), $boolean, $operator === '<' && $count === 1)
-            : $this->addWhereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
+                ? $this->addWhereExistsQuery($hasQuery->toBase(), $boolean, $operator === '<' && $count === 1)
+                : $this->addWhereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
     }
 
     /**
      * Merge the where constraints from another query to the current query.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $from
+     * @param  \Illuminate\Database\Eloquent\Builder  $from
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function mergeConstraintsFrom(Builder $from)
@@ -893,17 +893,17 @@ trait QueriesRelationships
     /**
      * Updates the table name for any columns with a new qualified name.
      *
-     * @param array $wheres
-     * @param string $from
-     * @param string $to
+     * @param  array  $wheres
+     * @param  string  $from
+     * @param  string  $to
      * @return array
      */
     protected function requalifyWhereTables(array $wheres, string $from, string $to): array
     {
         return collect($wheres)->map(function ($where) use ($from, $to) {
             return collect($where)->map(function ($value) use ($from, $to) {
-                return is_string($value) && str_starts_with($value, $from . '.')
-                    ? $to . '.' . Str::afterLast($value, '.')
+                return is_string($value) && str_starts_with($value, $from.'.')
+                    ? $to.'.'.Str::afterLast($value, '.')
                     : $value;
             });
         })->toArray();
@@ -912,10 +912,10 @@ trait QueriesRelationships
     /**
      * Add a sub-query count clause to this query.
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param string $operator
-     * @param int $count
-     * @param string $boolean
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
      * @return $this
      */
     protected function addWhereCountQuery(QueryBuilder $query, $operator = '>=', $count = 1, $boolean = 'and')
@@ -923,7 +923,7 @@ trait QueriesRelationships
         $this->query->addBinding($query->getBindings(), 'where');
 
         return $this->where(
-            new Expression('(' . $query->toSql() . ')'),
+            new Expression('('.$query->toSql().')'),
             $operator,
             is_numeric($count) ? new Expression($count) : $count,
             $boolean
@@ -933,7 +933,7 @@ trait QueriesRelationships
     /**
      * Get the "has relation" base query instance.
      *
-     * @param string $relation
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     protected function getRelationWithoutConstraints($relation)
@@ -946,8 +946,8 @@ trait QueriesRelationships
     /**
      * Check if we can run an "exists" query to optimize performance.
      *
-     * @param string $operator
-     * @param int $count
+     * @param  string  $operator
+     * @param  int  $count
      * @return bool
      */
     protected function canUseExistsForExistenceCheck($operator, $count)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -537,7 +537,7 @@ trait QueriesRelationships
      */
     public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
     {
-        if (!$related instanceof \Illuminate\Support\Collection) {
+        if (! $related instanceof \Illuminate\Support\Collection) {
             $relatedCollection = collect([$related]);
         } else {
             $relatedCollection = $related;
@@ -553,7 +553,7 @@ trait QueriesRelationships
             throw RelationNotFoundException::make($this->model, $relationshipName);
         }
 
-        if (!$relationship instanceof BelongsTo) {
+        if (! $relationship instanceof BelongsTo) {
             throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -617,9 +617,9 @@ trait QueriesRelationships
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and', $not = false)
     {
         if (! $related instanceof Collection) {
-            $relatedCollectionOfIds = $related->newCollection([$related])->pluck('id');
+            $relatedCollectionOfIds = $related->newCollection([$related->id]);
         } else {
-            $relatedCollectionOfIds = $related->id;
+            $relatedCollectionOfIds = $related->pluck('id');
 
             $related = $related->first();
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -527,7 +527,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "where id" clause to the query.
+     * Add a "belongs to" relationship with "where id" clause to the query.
      *
      * @param  int|\Illuminate\Database\Eloquent\Collection  $related
      * @param  string  $relationshipName
@@ -568,7 +568,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "or where id" clause to the query.
+     * Add a "belongs to" relationship with "or where id" clause to the query.
      *
      * @param  int|\Illuminate\Database\Eloquent\Collection  $related
      * @param  string  $relationshipName
@@ -580,7 +580,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "where not id" clause to the query.
+     * Add a "belongs to" relationship with "where not id" clause to the query.
      *
      * @param  int|\Illuminate\Database\Eloquent\Collection  $related
      * @param  string  $relationshipName
@@ -593,7 +593,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "or where not id" clause to the query.
+     * Add a "belongs to" relationship with "or where not id" clause to the query.
      *
      * @param  int|\Illuminate\Database\Eloquent\Collection  $related
      * @param  string  $relationshipName
@@ -605,7 +605,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "where" clause to the query.
+     * Add a "belongs to" relationship with "where" clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related
      * @param  string|null  $relationshipName
@@ -632,7 +632,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "or where" clause to the query.
+     * Add a "belongs to" relationship with "or where" clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related
      * @param  string|null  $relationshipName
@@ -646,7 +646,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "where not" clause to the query.
+     * Add a "belongs to" relationship with "where not" clause to the query.
      *
      * @param  int|\Illuminate\Database\Eloquent\Collection  $related
      * @param  string  $relationshipName
@@ -659,7 +659,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "belongs to" relationship "or where not" clause to the query.
+     * Add a "belongs to" relationship with "or where not" clause to the query.
      *
      * @param  int|\Illuminate\Database\Eloquent\Collection  $related
      * @param  string  $relationshipName

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -20,11 +20,11 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\Relation|string $relation
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      *
      * @throws \RuntimeException
@@ -47,8 +47,8 @@ trait QueriesRelationships
         // the subquery to only run a "where exists" clause instead of this full "count"
         // clause. This will make these queries run much faster compared with a count.
         $method = $this->canUseExistsForExistenceCheck($operator, $count)
-                        ? 'getRelationExistenceQuery'
-                        : 'getRelationExistenceCountQuery';
+            ? 'getRelationExistenceQuery'
+            : 'getRelationExistenceCountQuery';
 
         $hasQuery = $relation->{$method}(
             $relation->getRelated()->newQueryWithoutRelationships(), $this
@@ -71,11 +71,11 @@ trait QueriesRelationships
      *
      * Sets up recursive call to whereHas until we finish the nested relation.
      *
-     * @param  string  $relations
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param string $relations
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
@@ -104,9 +104,9 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param  string  $relation
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -117,9 +117,9 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  string  $relation
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param string $relation
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
@@ -130,7 +130,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with an "or".
      *
-     * @param  string  $relation
+     * @param string $relation
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orDoesntHave($relation)
@@ -141,10 +141,10 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -157,25 +157,25 @@ trait QueriesRelationships
      *
      * Also load the relationship with same condition.
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
-            ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+            ->with($callback ? [$relation => fn($query) => $callback($query)] : $relation);
     }
 
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $relation
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
@@ -186,8 +186,8 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param string $relation
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereDoesntHave($relation, Closure $callback = null)
@@ -198,8 +198,8 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param string $relation
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereDoesntHave($relation, Closure $callback = null)
@@ -210,12 +210,12 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
@@ -224,7 +224,7 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($relation);
         }
 
-        $types = (array) $types;
+        $types = (array)$types;
 
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
@@ -246,7 +246,7 @@ trait QueriesRelationships
                     }
 
                     $query->where($this->qualifyColumn($relation->getMorphType()), '=', (new $type)->getMorphClass())
-                                ->whereHas($belongsTo, $callback, $operator, $count);
+                        ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }
         }, null, null, $boolean);
@@ -255,8 +255,8 @@ trait QueriesRelationships
     /**
      * Get the BelongsTo relationship for a single polymorphic type.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo  $relation
-     * @param  string  $type
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo $relation
+     * @param string $type
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     protected function getBelongsToRelation(MorphTo $relation, $type)
@@ -277,10 +277,10 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  string  $operator
-     * @param  int  $count
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
@@ -291,10 +291,10 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param string $boolean
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
@@ -305,8 +305,8 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orDoesntHaveMorph($relation, $types)
@@ -317,11 +317,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
@@ -332,11 +332,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
-     * @param  string  $operator
-     * @param  int  $count
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
+     * @param string $operator
+     * @param int $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
@@ -347,9 +347,9 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
@@ -360,9 +360,9 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|null  $callback
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|null $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
@@ -373,10 +373,10 @@ trait QueriesRelationships
     /**
      * Add a basic where clause to a relationship query.
      *
-     * @param  string  $relation
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param string $relation
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
@@ -393,10 +393,10 @@ trait QueriesRelationships
     /**
      * Add an "or where" clause to a relationship query.
      *
-     * @param  string  $relation
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param string $relation
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
@@ -413,11 +413,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
@@ -430,11 +430,11 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param string|array $types
+     * @param \Closure|string|array|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
@@ -447,8 +447,8 @@ trait QueriesRelationships
     /**
      * Add a morph-to relationship condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereMorphedTo($relation, $model, $boolean = 'and')
@@ -460,7 +460,7 @@ trait QueriesRelationships
         if (is_string($model)) {
             $morphMap = Relation::morphMap();
 
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
+            if (!empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
             }
 
@@ -476,8 +476,8 @@ trait QueriesRelationships
     /**
      * Add a not morph-to relationship condition to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereNotMorphedTo($relation, $model, $boolean = 'and')
@@ -489,7 +489,7 @@ trait QueriesRelationships
         if (is_string($model)) {
             $morphMap = Relation::morphMap();
 
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
+            if (!empty($morphMap) && in_array($model, $morphMap)) {
                 $model = array_search($model, $morphMap, true);
             }
 
@@ -505,8 +505,8 @@ trait QueriesRelationships
     /**
      * Add a morph-to relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereMorphedTo($relation, $model)
@@ -517,8 +517,8 @@ trait QueriesRelationships
     /**
      * Add a not morph-to relationship condition to the query with an "or where" clause.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param \Illuminate\Database\Eloquent\Relations\MorphTo|string $relation
+     * @param \Illuminate\Database\Eloquent\Model|string $model
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereNotMorphedTo($relation, $model)
@@ -529,7 +529,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship where clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @param string $boolean
      * @param bool $not
@@ -538,7 +538,7 @@ trait QueriesRelationships
     public function whereBelongsToById($related, $relationshipName, $boolean = 'and', $not = false)
     {
         if (!$related instanceof \Illuminate\Support\Collection) {
-            $relatedCollection = $related->newCollection([$related]);
+            $relatedCollection = collect([$related]);
         } else {
             $relatedCollection = $related;
         }
@@ -570,7 +570,7 @@ trait QueriesRelationships
     /**
      * Add an "BelongsToById" relationship with an "or where" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @return $this
      */
@@ -582,7 +582,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @param string $boolean
      * @return $this
@@ -595,7 +595,7 @@ trait QueriesRelationships
     /**
      * Add a "BelongsToById" relationship with an "or where not" clause to the query.
      *
-     * @param int|\Illuminate\Database\Eloquent\Collection<int>  $related
+     * @param int|\Illuminate\Database\Eloquent\Collection<int> $related
      * @param string $relationshipName
      * @return $this
      */
@@ -607,16 +607,16 @@ trait QueriesRelationships
     /**
      * Add a "belongs to" relationship where clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>  $related
-     * @param  string|null  $relationshipName
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model> $related
+     * @param string|null $relationshipName
+     * @param string $boolean
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
      */
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
     {
-        if (! $related instanceof Collection) {
+        if (!$related instanceof Collection) {
             $relatedCollection = $related->newCollection([$related]);
         } else {
             $relatedCollection = $related;
@@ -638,7 +638,7 @@ trait QueriesRelationships
             throw RelationNotFoundException::make($this->model, $relationshipName);
         }
 
-        if (! $relationship instanceof BelongsTo) {
+        if (!$relationship instanceof BelongsTo) {
             throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
         }
 
@@ -654,8 +654,8 @@ trait QueriesRelationships
     /**
      * Add an "BelongsTo" relationship with an "or where" clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $related
-     * @param  string|null  $relationshipName
+     * @param \Illuminate\Database\Eloquent\Model $related
+     * @param string|null $relationshipName
      * @return $this
      *
      * @throws \RuntimeException
@@ -668,9 +668,9 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include an aggregate value for a relationship.
      *
-     * @param  mixed  $relations
-     * @param  string  $column
-     * @param  string  $function
+     * @param mixed $relations
+     * @param string $column
+     * @param string $function
      * @return $this
      */
     public function withAggregate($relations, $column, $function = null)
@@ -680,7 +680,7 @@ trait QueriesRelationships
         }
 
         if (is_null($this->query->columns)) {
-            $this->query->select([$this->query->from.'.*']);
+            $this->query->select([$this->query->from . '.*']);
         }
 
         $relations = is_array($relations) ? $relations : [$relations];
@@ -759,8 +759,8 @@ trait QueriesRelationships
     /**
      * Get the relation hashed column name for the given column and relation.
      *
-     * @param  string  $column
-     * @param  \Illuminate\Database\Eloquent\Relations\Relationship  $relation
+     * @param string $column
+     * @param \Illuminate\Database\Eloquent\Relations\Relationship $relation
      * @return string
      */
     protected function getRelationHashedColumn($column, $relation)
@@ -777,7 +777,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to count the relations.
      *
-     * @param  mixed  $relations
+     * @param mixed $relations
      * @return $this
      */
     public function withCount($relations)
@@ -788,8 +788,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the max of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withMax($relation, $column)
@@ -800,8 +800,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the min of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withMin($relation, $column)
@@ -812,8 +812,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the sum of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withSum($relation, $column)
@@ -824,8 +824,8 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the average of the relation's column.
      *
-     * @param  string|array  $relation
-     * @param  string  $column
+     * @param string|array $relation
+     * @param string $column
      * @return $this
      */
     public function withAvg($relation, $column)
@@ -836,7 +836,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param  string|array  $relation
+     * @param string|array $relation
      * @return $this
      */
     public function withExists($relation)
@@ -847,11 +847,11 @@ trait QueriesRelationships
     /**
      * Add the "has" condition where clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Eloquent\Builder $hasQuery
+     * @param \Illuminate\Database\Eloquent\Relations\Relation $relation
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     protected function addHasWhere(Builder $hasQuery, Relation $relation, $operator, $count, $boolean)
@@ -859,14 +859,14 @@ trait QueriesRelationships
         $hasQuery->mergeConstraintsFrom($relation->getQuery());
 
         return $this->canUseExistsForExistenceCheck($operator, $count)
-                ? $this->addWhereExistsQuery($hasQuery->toBase(), $boolean, $operator === '<' && $count === 1)
-                : $this->addWhereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
+            ? $this->addWhereExistsQuery($hasQuery->toBase(), $boolean, $operator === '<' && $count === 1)
+            : $this->addWhereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
     }
 
     /**
      * Merge the where constraints from another query to the current query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $from
+     * @param \Illuminate\Database\Eloquent\Builder $from
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function mergeConstraintsFrom(Builder $from)
@@ -893,17 +893,17 @@ trait QueriesRelationships
     /**
      * Updates the table name for any columns with a new qualified name.
      *
-     * @param  array  $wheres
-     * @param  string  $from
-     * @param  string  $to
+     * @param array $wheres
+     * @param string $from
+     * @param string $to
      * @return array
      */
     protected function requalifyWhereTables(array $wheres, string $from, string $to): array
     {
         return collect($wheres)->map(function ($where) use ($from, $to) {
             return collect($where)->map(function ($value) use ($from, $to) {
-                return is_string($value) && str_starts_with($value, $from.'.')
-                    ? $to.'.'.Str::afterLast($value, '.')
+                return is_string($value) && str_starts_with($value, $from . '.')
+                    ? $to . '.' . Str::afterLast($value, '.')
                     : $value;
             });
         })->toArray();
@@ -912,10 +912,10 @@ trait QueriesRelationships
     /**
      * Add a sub-query count clause to this query.
      *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  string  $operator
-     * @param  int  $count
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param string $operator
+     * @param int $count
+     * @param string $boolean
      * @return $this
      */
     protected function addWhereCountQuery(QueryBuilder $query, $operator = '>=', $count = 1, $boolean = 'and')
@@ -923,7 +923,7 @@ trait QueriesRelationships
         $this->query->addBinding($query->getBindings(), 'where');
 
         return $this->where(
-            new Expression('('.$query->toSql().')'),
+            new Expression('(' . $query->toSql() . ')'),
             $operator,
             is_numeric($count) ? new Expression($count) : $count,
             $boolean
@@ -933,7 +933,7 @@ trait QueriesRelationships
     /**
      * Get the "has relation" base query instance.
      *
-     * @param  string  $relation
+     * @param string $relation
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     protected function getRelationWithoutConstraints($relation)
@@ -946,8 +946,8 @@ trait QueriesRelationships
     /**
      * Check if we can run an "exists" query to optimize performance.
      *
-     * @param  string  $operator
-     * @param  int  $count
+     * @param string $operator
+     * @param int $count
      * @return bool
      */
     protected function canUseExistsForExistenceCheck($operator, $count)

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -35,7 +35,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindMethod()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $builder->setModel($model);
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
@@ -49,7 +49,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindManyMethod()
     {
         // ids are not empty
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model);
@@ -60,7 +60,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz'], $result);
 
         // ids are empty array
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('newCollection')->once()->withNoArgs()->andReturn('emptycollection');
         $model->shouldReceive('getKeyType')->andReturn('int');
@@ -72,7 +72,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('emptycollection', $result);
 
         // ids are empty collection
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('newCollection')->once()->withNoArgs()->andReturn('emptycollection');
         $builder->setModel($model);
@@ -89,7 +89,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $model->shouldReceive('findOrNew')->once()->andReturn('baz');
 
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
@@ -105,7 +105,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $model->shouldReceive('findOrNew')->once()->andReturn(m::mock(Model::class));
 
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
@@ -120,7 +120,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->setModel($model);
@@ -137,7 +137,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKey')->andReturn(1);
         $model->shouldReceive('getKeyType')->andReturn('int');
 
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model]));
@@ -152,7 +152,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKey')->andReturn(1);
         $model->shouldReceive('getKeyType')->andReturn('int');
 
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model]));
@@ -161,7 +161,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindOrMethod()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model);
@@ -171,14 +171,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('first')->with(['column'])->andReturn($model)->once();
         $builder->shouldReceive('first')->andReturn(null)->once();
 
-        $this->assertSame($model, $builder->findOr(1, fn() => 'callback result'));
-        $this->assertSame($model, $builder->findOr(1, ['column'], fn() => 'callback result'));
-        $this->assertSame('callback result', $builder->findOr(2, fn() => 'callback result'));
+        $this->assertSame($model, $builder->findOr(1, fn () => 'callback result'));
+        $this->assertSame($model, $builder->findOr(1, ['column'], fn () => 'callback result'));
+        $this->assertSame('callback result', $builder->findOr(2, fn () => 'callback result'));
     }
 
     public function testFindOrMethodWithMany()
     {
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model1 = $this->getMockModel();
         $model2 = $this->getMockModel();
         $model1->shouldReceive('getKeyType')->andReturn('int');
@@ -190,23 +190,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model1, $model2]))->once();
         $builder->shouldReceive('get')->andReturn(null)->once();
 
-        $result = $builder->findOr([1, 2], fn() => 'callback result');
+        $result = $builder->findOr([1, 2], fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr([1, 2], ['column'], fn() => 'callback result');
+        $result = $builder->findOr([1, 2], ['column'], fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr([1, 2, 3], fn() => 'callback result');
+        $result = $builder->findOr([1, 2, 3], fn () => 'callback result');
         $this->assertSame('callback result', $result);
     }
 
     public function testFindOrMethodWithManyUsingCollection()
     {
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model1 = $this->getMockModel();
         $model2 = $this->getMockModel();
         $model1->shouldReceive('getKeyType')->andReturn('int');
@@ -218,17 +218,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model1, $model2]))->once();
         $builder->shouldReceive('get')->andReturn(null)->once();
 
-        $result = $builder->findOr(new Collection([1, 2]), fn() => 'callback result');
+        $result = $builder->findOr(new Collection([1, 2]), fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr(new Collection([1, 2]), ['column'], fn() => 'callback result');
+        $result = $builder->findOr(new Collection([1, 2]), ['column'], fn () => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr(new Collection([1, 2, 3]), fn() => 'callback result');
+        $result = $builder->findOr(new Collection([1, 2, 3]), fn () => 'callback result');
         $this->assertSame('callback result', $result);
     }
 
@@ -236,7 +236,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $builder->firstOrFail(['column']);
@@ -244,7 +244,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindWithMany()
     {
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
@@ -258,7 +258,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindWithManyUsingCollection()
     {
         $ids = collect([1, 2]);
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
@@ -271,7 +271,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFirstMethod()
     {
-        $builder = m::mock(Builder::class . '[get,take]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('take')->with(1)->andReturnSelf();
         $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
 
@@ -301,7 +301,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
     {
-        $builder = m::mock(Builder::class . '[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('applyScopes')->andReturnSelf();
         $builder->shouldReceive('getModels')->with(['foo'])->andReturn(['bar']);
         $builder->shouldReceive('eagerLoadRelations')->with(['bar'])->andReturn(['bar', 'baz']);
@@ -314,7 +314,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testGetMethodDoesntHydrateEagerRelationsWhenNoResultsAreReturned()
     {
-        $builder = m::mock(Builder::class . '[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('applyScopes')->andReturnSelf();
         $builder->shouldReceive('getModels')->with(['foo'])->andReturn([]);
         $builder->shouldReceive('eagerLoadRelations')->never();
@@ -327,7 +327,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueMethodWithModelFound()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $mockModel = new stdClass;
         $mockModel->name = 'foo';
         $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
@@ -337,7 +337,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueMethodWithModelNotFound()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('first')->with(['name'])->andReturn(null);
 
         $this->assertNull($builder->value('name'));
@@ -345,7 +345,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueOrFailMethodWithModelFound()
     {
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $mockModel = new stdClass;
         $mockModel->name = 'foo';
         $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
@@ -357,7 +357,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->setModel($model);
@@ -368,7 +368,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -391,7 +391,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -411,7 +411,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkCanBeStoppedByReturningFalse()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -433,7 +433,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithCountZero()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk = new Collection([]);
@@ -450,11 +450,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
-        $chunk2 = new Collection([(object)['someIdField' => 10], (object)['someIdField' => 11]]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
         $chunk3 = new Collection([]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
@@ -473,11 +473,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
-        $chunk2 = new Collection([(object)['someIdField' => 10]]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk2 = new Collection([(object) ['someIdField' => 10]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -493,7 +493,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithCountZero()
     {
-        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk = new Collection([]);
@@ -510,7 +510,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
@@ -530,7 +530,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
@@ -548,7 +548,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyIsLazy()
     {
-        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
@@ -559,11 +559,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
-        $chunk2 = new Collection([(object)['someIdField' => 10], (object)['someIdField' => 11]]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
         $chunk3 = new Collection([]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
@@ -572,10 +572,10 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertEquals(
             [
-                (object)['someIdField' => 1],
-                (object)['someIdField' => 2],
-                (object)['someIdField' => 10],
-                (object)['someIdField' => 11],
+                (object) ['someIdField' => 1],
+                (object) ['someIdField' => 2],
+                (object) ['someIdField' => 10],
+                (object) ['someIdField' => 11],
             ],
             $builder->lazyById(2, 'someIdField')->all()
         );
@@ -583,20 +583,20 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
-        $chunk2 = new Collection([(object)['someIdField' => 10]]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk2 = new Collection([(object) ['someIdField' => 10]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
         $this->assertEquals(
             [
-                (object)['someIdField' => 1],
-                (object)['someIdField' => 2],
-                (object)['someIdField' => 10],
+                (object) ['someIdField' => 1],
+                (object) ['someIdField' => 2],
+                (object) ['someIdField' => 10],
             ],
             $builder->lazyById(2, 'someIdField')->all()
         );
@@ -604,17 +604,17 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdIsLazy()
     {
-        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
+        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->once()->andReturn($chunk1);
 
         $this->assertEquals(
             [
-                (object)['someIdField' => 1],
-                (object)['someIdField' => 2],
+                (object) ['someIdField' => 1],
+                (object) ['someIdField' => 2],
             ],
             $builder->lazyById(2, 'someIdField')->take(2)->all()
         );
@@ -719,11 +719,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testGetModelsProperlyHydratesModels()
     {
-        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $records[] = ['name' => 'taylor', 'age' => 26];
         $records[] = ['name' => 'dayle', 'age' => 28];
         $builder->getQuery()->shouldReceive('get')->once()->with(['foo'])->andReturn(new BaseCollection($records));
-        $model = m::mock(Model::class . '[getTable,hydrate]');
+        $model = m::mock(Model::class.'[getTable,hydrate]');
         $model->shouldReceive('getTable')->once()->andReturn('foo_table');
         $builder->setModel($model);
         $model->shouldReceive('hydrate')->once()->with($records)->andReturn(new Collection(['hydrated']));
@@ -734,7 +734,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testEagerLoadRelationsLoadTopLevelRelationships()
     {
-        $builder = m::mock(Builder::class . '[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
         $nop1 = function () {
             //
         };
@@ -750,7 +750,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testEagerLoadRelationsCanBeFlushed()
     {
-        $builder = m::mock(Builder::class . '[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
 
         $builder->setEagerLoads(['foo']);
 
@@ -763,7 +763,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testRelationshipEagerLoadProcess()
     {
-        $builder = m::mock(Builder::class . '[getRelation]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class.'[getRelation]', [$this->getMockQueryBuilder()]);
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
@@ -1778,7 +1778,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', (string)$int);
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', (string) $int);
 
         $builder->whereKey($int);
     }
@@ -1834,7 +1834,8 @@ class DatabaseEloquentBuilderTest extends TestCase
             return $argument === '1';
         }));
 
-        $builder->whereKey(new class extends Model {
+        $builder->whereKey(new class extends Model
+        {
             protected $attributes = ['id' => 1];
         });
     }
@@ -1847,7 +1848,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', (string)$int);
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', (string) $int);
 
         $builder->whereKeyNot($int);
     }
@@ -1917,7 +1918,8 @@ class DatabaseEloquentBuilderTest extends TestCase
             return $argument === '1';
         }));
 
-        $builder->whereKeyNot(new class extends Model {
+        $builder->whereKeyNot(new class extends Model
+        {
             protected $attributes = ['id' => 1];
         });
     }
@@ -2189,8 +2191,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function mockConnectionForModel($model, $database)
     {
-        $grammarClass = 'Illuminate\Database\Query\Grammars\\' . $database . 'Grammar';
-        $processorClass = 'Illuminate\Database\Query\Processors\\' . $database . 'Processor';
+        $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
+        $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
         $grammar = new $grammarClass;
         $processor = new $processorClass;
         $connection = m::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
@@ -2290,7 +2292,7 @@ class EloquentBuilderTestPluckStub
 
     public function __get($key)
     {
-        return 'foo_' . $this->attributes[$key];
+        return 'foo_'.$this->attributes[$key];
     }
 }
 
@@ -2305,7 +2307,7 @@ class EloquentBuilderTestPluckDatesStub extends Model
 
     protected function asDateTime($value)
     {
-        return 'date_' . $value;
+        return 'date_'.$value;
     }
 }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1141,6 +1141,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
 
+        $resultById = $builder->whereBelongsToById($parent->id, 'parent');
+        $this->assertEquals($resultById, $builder);
+
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
@@ -1172,6 +1175,9 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);
+
+        $resultById = $builder->whereBelongsToById($parents->pluck('id'), 'parent');
+        $this->assertEquals($resultById, $builder);
     }
 
     public function testDeleteOverride()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1136,7 +1136,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and', false);
 
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
@@ -1152,7 +1152,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and', false);
 
         $result = $builder->whereBelongsTo($parent, 'parent');
         $this->assertEquals($result, $builder);
@@ -1168,7 +1168,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and', false);
 
         $result = $builder->whereBelongsTo($parents);
         $this->assertEquals($result, $builder);
@@ -1176,7 +1176,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and', false);
 
         $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -35,7 +35,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindMethod()
     {
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $builder->setModel($model);
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
@@ -49,7 +49,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindManyMethod()
     {
         // ids are not empty
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model);
@@ -60,7 +60,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz'], $result);
 
         // ids are empty array
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('newCollection')->once()->withNoArgs()->andReturn('emptycollection');
         $model->shouldReceive('getKeyType')->andReturn('int');
@@ -72,7 +72,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('emptycollection', $result);
 
         // ids are empty collection
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('newCollection')->once()->withNoArgs()->andReturn('emptycollection');
         $builder->setModel($model);
@@ -89,7 +89,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $model->shouldReceive('findOrNew')->once()->andReturn('baz');
 
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
@@ -105,7 +105,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $model->shouldReceive('findOrNew')->once()->andReturn(m::mock(Model::class));
 
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
@@ -120,7 +120,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->setModel($model);
@@ -137,7 +137,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKey')->andReturn(1);
         $model->shouldReceive('getKeyType')->andReturn('int');
 
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model]));
@@ -152,7 +152,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKey')->andReturn(1);
         $model->shouldReceive('getKeyType')->andReturn('int');
 
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model]));
@@ -161,7 +161,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindOrMethod()
     {
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model);
@@ -171,14 +171,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('first')->with(['column'])->andReturn($model)->once();
         $builder->shouldReceive('first')->andReturn(null)->once();
 
-        $this->assertSame($model, $builder->findOr(1, fn () => 'callback result'));
-        $this->assertSame($model, $builder->findOr(1, ['column'], fn () => 'callback result'));
-        $this->assertSame('callback result', $builder->findOr(2, fn () => 'callback result'));
+        $this->assertSame($model, $builder->findOr(1, fn() => 'callback result'));
+        $this->assertSame($model, $builder->findOr(1, ['column'], fn() => 'callback result'));
+        $this->assertSame('callback result', $builder->findOr(2, fn() => 'callback result'));
     }
 
     public function testFindOrMethodWithMany()
     {
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model1 = $this->getMockModel();
         $model2 = $this->getMockModel();
         $model1->shouldReceive('getKeyType')->andReturn('int');
@@ -190,23 +190,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model1, $model2]))->once();
         $builder->shouldReceive('get')->andReturn(null)->once();
 
-        $result = $builder->findOr([1, 2], fn () => 'callback result');
+        $result = $builder->findOr([1, 2], fn() => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr([1, 2], ['column'], fn () => 'callback result');
+        $result = $builder->findOr([1, 2], ['column'], fn() => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr([1, 2, 3], fn () => 'callback result');
+        $result = $builder->findOr([1, 2, 3], fn() => 'callback result');
         $this->assertSame('callback result', $result);
     }
 
     public function testFindOrMethodWithManyUsingCollection()
     {
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model1 = $this->getMockModel();
         $model2 = $this->getMockModel();
         $model1->shouldReceive('getKeyType')->andReturn('int');
@@ -218,17 +218,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model1, $model2]))->once();
         $builder->shouldReceive('get')->andReturn(null)->once();
 
-        $result = $builder->findOr(new Collection([1, 2]), fn () => 'callback result');
+        $result = $builder->findOr(new Collection([1, 2]), fn() => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr(new Collection([1, 2]), ['column'], fn () => 'callback result');
+        $result = $builder->findOr(new Collection([1, 2]), ['column'], fn() => 'callback result');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertSame($model1, $result[0]);
         $this->assertSame($model2, $result[1]);
 
-        $result = $builder->findOr(new Collection([1, 2, 3]), fn () => 'callback result');
+        $result = $builder->findOr(new Collection([1, 2, 3]), fn() => 'callback result');
         $this->assertSame('callback result', $result);
     }
 
@@ -236,7 +236,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $builder->firstOrFail(['column']);
@@ -244,7 +244,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFindWithMany()
     {
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
@@ -258,7 +258,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindWithManyUsingCollection()
     {
         $ids = collect([1, 2]);
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
@@ -271,7 +271,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testFirstMethod()
     {
-        $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get,take]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('take')->with(1)->andReturnSelf();
         $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
 
@@ -301,7 +301,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
     {
-        $builder = m::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('applyScopes')->andReturnSelf();
         $builder->shouldReceive('getModels')->with(['foo'])->andReturn(['bar']);
         $builder->shouldReceive('eagerLoadRelations')->with(['bar'])->andReturn(['bar', 'baz']);
@@ -314,7 +314,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testGetMethodDoesntHydrateEagerRelationsWhenNoResultsAreReturned()
     {
-        $builder = m::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('applyScopes')->andReturnSelf();
         $builder->shouldReceive('getModels')->with(['foo'])->andReturn([]);
         $builder->shouldReceive('eagerLoadRelations')->never();
@@ -327,7 +327,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueMethodWithModelFound()
     {
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $mockModel = new stdClass;
         $mockModel->name = 'foo';
         $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
@@ -337,7 +337,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueMethodWithModelNotFound()
     {
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('first')->with(['name'])->andReturn(null);
 
         $this->assertNull($builder->value('name'));
@@ -345,7 +345,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testValueOrFailMethodWithModelFound()
     {
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $mockModel = new stdClass;
         $mockModel->name = 'foo';
         $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
@@ -357,7 +357,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
-        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[first]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->setModel($model);
@@ -368,7 +368,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -391,7 +391,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -411,7 +411,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkCanBeStoppedByReturningFalse()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk1 = new Collection(['foo1', 'foo2']);
@@ -433,7 +433,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkWithCountZero()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk = new Collection([]);
@@ -450,11 +450,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
+        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
+        $chunk2 = new Collection([(object)['someIdField' => 10], (object)['someIdField' => 11]]);
         $chunk3 = new Collection([]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
@@ -473,11 +473,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = new Collection([(object) ['someIdField' => 10]]);
+        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
+        $chunk2 = new Collection([(object)['someIdField' => 10]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -493,7 +493,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testChunkPaginatesUsingIdWithCountZero()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $chunk = new Collection([]);
@@ -510,7 +510,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
@@ -530,7 +530,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
@@ -548,7 +548,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyIsLazy()
     {
-        $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPage,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
         $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
@@ -559,11 +559,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdWithLastChunkComplete()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
+        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
+        $chunk2 = new Collection([(object)['someIdField' => 10], (object)['someIdField' => 11]]);
         $chunk3 = new Collection([]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
@@ -572,10 +572,10 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertEquals(
             [
-                (object) ['someIdField' => 1],
-                (object) ['someIdField' => 2],
-                (object) ['someIdField' => 10],
-                (object) ['someIdField' => 11],
+                (object)['someIdField' => 1],
+                (object)['someIdField' => 2],
+                (object)['someIdField' => 10],
+                (object)['someIdField' => 11],
             ],
             $builder->lazyById(2, 'someIdField')->all()
         );
@@ -583,20 +583,20 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdWithLastChunkPartial()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = new Collection([(object) ['someIdField' => 10]]);
+        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
+        $chunk2 = new Collection([(object)['someIdField' => 10]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
         $this->assertEquals(
             [
-                (object) ['someIdField' => 1],
-                (object) ['someIdField' => 2],
-                (object) ['someIdField' => 10],
+                (object)['someIdField' => 1],
+                (object)['someIdField' => 2],
+                (object)['someIdField' => 10],
             ],
             $builder->lazyById(2, 'someIdField')->all()
         );
@@ -604,17 +604,17 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testLazyByIdIsLazy()
     {
-        $builder = m::mock(Builder::class.'[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->getQuery()->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
+        $chunk1 = new Collection([(object)['someIdField' => 1], (object)['someIdField' => 2]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->once()->andReturn($chunk1);
 
         $this->assertEquals(
             [
-                (object) ['someIdField' => 1],
-                (object) ['someIdField' => 2],
+                (object)['someIdField' => 1],
+                (object)['someIdField' => 2],
             ],
             $builder->lazyById(2, 'someIdField')->take(2)->all()
         );
@@ -719,11 +719,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testGetModelsProperlyHydratesModels()
     {
-        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[get]', [$this->getMockQueryBuilder()]);
         $records[] = ['name' => 'taylor', 'age' => 26];
         $records[] = ['name' => 'dayle', 'age' => 28];
         $builder->getQuery()->shouldReceive('get')->once()->with(['foo'])->andReturn(new BaseCollection($records));
-        $model = m::mock(Model::class.'[getTable,hydrate]');
+        $model = m::mock(Model::class . '[getTable,hydrate]');
         $model->shouldReceive('getTable')->once()->andReturn('foo_table');
         $builder->setModel($model);
         $model->shouldReceive('hydrate')->once()->with($records)->andReturn(new Collection(['hydrated']));
@@ -734,7 +734,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testEagerLoadRelationsLoadTopLevelRelationships()
     {
-        $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
         $nop1 = function () {
             //
         };
@@ -750,7 +750,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testEagerLoadRelationsCanBeFlushed()
     {
-        $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
 
         $builder->setEagerLoads(['foo']);
 
@@ -763,7 +763,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testRelationshipEagerLoadProcess()
     {
-        $builder = m::mock(Builder::class.'[getRelation]', [$this->getMockQueryBuilder()]);
+        $builder = m::mock(Builder::class . '[getRelation]', [$this->getMockQueryBuilder()]);
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
@@ -1141,6 +1141,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
 
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and', false);
+
         $resultById = $builder->whereBelongsToById($parent->id, 'parent');
         $this->assertEquals($resultById, $builder);
 
@@ -1175,6 +1180,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and', false);
 
         $resultById = $builder->whereBelongsToById($parents->pluck('id'), 'parent');
         $this->assertEquals($resultById, $builder);
@@ -1768,7 +1778,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', (string) $int);
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', (string)$int);
 
         $builder->whereKey($int);
     }
@@ -1824,8 +1834,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             return $argument === '1';
         }));
 
-        $builder->whereKey(new class extends Model
-        {
+        $builder->whereKey(new class extends Model {
             protected $attributes = ['id' => 1];
         });
     }
@@ -1838,7 +1847,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 0;
 
-        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', (string) $int);
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', (string)$int);
 
         $builder->whereKeyNot($int);
     }
@@ -1908,8 +1917,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             return $argument === '1';
         }));
 
-        $builder->whereKeyNot(new class extends Model
-        {
+        $builder->whereKeyNot(new class extends Model {
             protected $attributes = ['id' => 1];
         });
     }
@@ -2181,8 +2189,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function mockConnectionForModel($model, $database)
     {
-        $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
-        $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
+        $grammarClass = 'Illuminate\Database\Query\Grammars\\' . $database . 'Grammar';
+        $processorClass = 'Illuminate\Database\Query\Processors\\' . $database . 'Processor';
         $grammar = new $grammarClass;
         $processor = new $processorClass;
         $connection = m::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
@@ -2282,7 +2290,7 @@ class EloquentBuilderTestPluckStub
 
     public function __get($key)
     {
-        return 'foo_'.$this->attributes[$key];
+        return 'foo_' . $this->attributes[$key];
     }
 }
 
@@ -2297,7 +2305,7 @@ class EloquentBuilderTestPluckDatesStub extends Model
 
     protected function asDateTime($value)
     {
-        return 'date_'.$value;
+        return 'date_' . $value;
     }
 }
 


### PR DESCRIPTION
We need this in case we want to find by relationship id, withouth query the model to reduce mysql queries.
Like filtering the model by relationship in controller from FormRequest, in most efficient way.

This will help also in filtering by relationship when we have only the id, without **query the model** or **use the column name of the relationship**