### PR TITLE
[10.x] Add method in JsonResource to cast to array

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -253,4 +253,15 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     {
         return $this->resolve(Container::getInstance()->make('request'));
     }
+
+    /**
+     * Cast nested resources to an array.
+     *
+     * @return array
+     * @throws \JsonException
+     */
+    public function castToArray(): array
+    {
+        return json_decode($this->toJson(), true, 512, JSON_THROW_ON_ERROR);
+    }
 }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -258,6 +258,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Cast nested resources to an array.
      *
      * @return array
+     *
      * @throws \JsonException
      */
     public function castToArray(): array


### PR DESCRIPTION
This PR is to add a method to JsonResource class to recursively cast the resource to an array.

I find it useful with my use case when I want to use the same data format for API responses and emails/PDF:

Usage:

`$data = (new MyResource($object))->castToArray()`

or 

`$data = MyResource::collection($collection)->castToArray()`
