### PR TITLE
[9.x] Send along value to InvalidPayloadException

### DIFF
--- a/src/Illuminate/Queue/InvalidPayloadException.php
+++ b/src/Illuminate/Queue/InvalidPayloadException.php
@@ -7,13 +7,23 @@ use InvalidArgumentException;
 class InvalidPayloadException extends InvalidArgumentException
 {
     /**
+     * The attempted value being encoded.
+     *
+     * @var mixed
+     */
+    public $value;
+
+    /**
      * Create a new exception instance.
      *
      * @param  string|null  $message
+     * @param  mixed  $value
      * @return void
      */
-    public function __construct($message = null)
+    public function __construct($message = null, $value = null)
     {
         parent::__construct($message ?: json_last_error());
+
+        $this->value = $value;
     }
 }

--- a/src/Illuminate/Queue/InvalidPayloadException.php
+++ b/src/Illuminate/Queue/InvalidPayloadException.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 class InvalidPayloadException extends InvalidArgumentException
 {
     /**
-     * The attempted value being encoded.
+     * The value that failed to decode.
      *
      * @var mixed
      */

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -102,11 +102,11 @@ abstract class Queue
             $job = CallQueuedClosure::create($job);
         }
 
-        $payload = json_encode($this->createPayloadArray($job, $queue, $data), \JSON_UNESCAPED_UNICODE);
+        $payload = json_encode($value = $this->createPayloadArray($job, $queue, $data), \JSON_UNESCAPED_UNICODE);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidPayloadException(
-                'Unable to JSON encode payload. Error code: '.json_last_error()
+                'Unable to JSON encode payload. Error code: '.json_last_error(), $value
             );
         }
 


### PR DESCRIPTION
This PR will send along the value that's being attempted to encode with the `InvalidPayloadException` that's thrown if there's an error. This hopefully gives more insight when debugging why the payload is invalid.