### PR TITLE
[10.x] Display queue runtime in human readable format

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -251,7 +251,7 @@ class WorkCommand extends Command
     }
 
     /**
-     * Given a start time, Format the total run time for human readability.
+     * Given a start time, format the total run time for human readability.
      *
      * @param  float  $startTime
      * @return string

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Carbon\CarbonInterval;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
@@ -216,7 +217,7 @@ class WorkCommand extends Command
             return $this->output->writeln(' <fg=yellow;options=bold>RUNNING</>');
         }
 
-        $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2).'ms';
+        $runTime = $this->resolveRunTime();
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
             $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
@@ -286,5 +287,21 @@ class WorkCommand extends Command
     protected function downForMaintenance()
     {
         return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
+    }
+
+    /**
+     * Format the worked runtime for human readability.
+     *
+     * @return string
+     */
+    protected function resolveRunTime()
+    {
+        $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2);
+
+        if ($runTime > 1) {
+            return CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true);
+        }
+
+        return $runTime.'ms';
     }
 }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -298,7 +298,7 @@ class WorkCommand extends Command
     {
         $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2);
 
-        if ($runTime > 1) {
+        if ($runTime > 1000) {
             return CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true);
         }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -217,7 +217,7 @@ class WorkCommand extends Command
             return $this->output->writeln(' <fg=yellow;options=bold>RUNNING</>');
         }
 
-        $runTime = $this->resolveRunTime();
+        $runTime = $this->formatRunTime($this->latestStartedAt);
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
             $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
@@ -248,6 +248,21 @@ class WorkCommand extends Command
         }
 
         return Carbon::now();
+    }
+
+    /**
+     * Given a start time, Format the total run time for human readability.
+     *
+     * @param  float  $startTime
+     * @return string
+     */
+    protected function formatRunTime($startTime)
+    {
+        $runTime = (microtime(true) - $startTime) * 1000;
+
+        return $runTime > 1000
+            ? CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true)
+            : number_format($runTime, 2).'ms';
     }
 
     /**
@@ -287,21 +302,5 @@ class WorkCommand extends Command
     protected function downForMaintenance()
     {
         return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
-    }
-
-    /**
-     * Format the worked runtime for human readability.
-     *
-     * @return string
-     */
-    protected function resolveRunTime()
-    {
-        $runTime = (microtime(true) - $this->latestStartedAt) * 1000;
-
-        if ($runTime > 1000) {
-            return CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true);
-        }
-
-        return number_format($runTime, 2).'ms';
     }
 }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -296,12 +296,12 @@ class WorkCommand extends Command
      */
     protected function resolveRunTime()
     {
-        $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2);
+        $runTime = (microtime(true) - $this->latestStartedAt) * 1000;
 
         if ($runTime > 1000) {
             return CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true);
         }
 
-        return $runTime.'ms';
+        return number_format($runTime, 2).'ms';
     }
 }


### PR DESCRIPTION
Currently, queue runtime is displayed in milliseconds (`ms` suffix), which is fine in many scenarios where tasks are short-lived and it is clear how long a job ran.

For longer running tasks, beyond say 10 seconds (`10,000.00ms`), the runtime is not so easily parseable.

I have had queued jobs that run for `828,320.11ms`, which is difficult to reason about at a glance.

This PR introduces formatting of the runtime to human-readable notation for runtimes exceeding 1sec (`1,000ms`);

```bash
# Before
2023-05-25 23:35:26 App\Jobs\SomeLongRunningTask .......... 828,420.11ms DONE
# After
2023-05-25 23:35:26 App\Jobs\SomeLongRunningTask ............... 13m 48s DONE
```
