### PR TITLE
[10.x] Provide testing hooks

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -316,7 +316,6 @@ class Sleep
         static::$fake = $value;
 
         static::$sequence = [];
-
         static::$fakeSleepCallbacks = [];
     }
 

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -14,6 +14,13 @@ class Sleep
     use Macroable;
 
     /**
+     * The fake sleep callbacks.
+     *
+     * @var array
+     */
+    public static $fakeSleepCallbacks = [];
+
+    /**
      * The total duration to sleep.
      *
      * @var \Carbon\CarbonInterval
@@ -252,6 +259,10 @@ class Sleep
         if (static::$fake) {
             static::$sequence[] = $this->duration;
 
+            foreach (static::$fakeSleepCallbacks as $callback) {
+                $callback($this->duration);
+            }
+
             return;
         }
 
@@ -305,6 +316,8 @@ class Sleep
         static::$fake = $value;
 
         static::$sequence = [];
+
+        static::$fakeSleepCallbacks = [];
     }
 
     /**
@@ -434,5 +447,16 @@ class Sleep
     public function unless($condition)
     {
         return $this->when(! value($condition, $this));
+    }
+
+    /**
+     * Run a callback when faking sleep within a test.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function whenFakingSleep($callback)
+    {
+        static::$fakeSleepCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -449,7 +449,7 @@ class Sleep
     }
 
     /**
-     * Run a callback when faking sleep within a test.
+     * Specify a callback that should be invoked when faking sleep within a test.
      *
      * @param  callable  $callback
      * @return void

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Carbon\CarbonInterval;
+use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Sleep;
 use PHPUnit\Framework\AssertionFailedError;
@@ -500,5 +501,40 @@ class SleepTest extends TestCase
         Sleep::assertSlept(fn () => true, 3);
         Sleep::for(1)->second()->unless(fn () => false);
         Sleep::assertSlept(fn () => true, 4);
+    }
+
+    public function testItCanRegisterCallbacksToRunInTests()
+    {
+        $countA = 0;
+        $countB = 0;
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use (&$countA) {
+            $countA += $duration->totalMilliseconds;
+        });
+        Sleep::whenFakingSleep(function ($duration) use (&$countB) {
+            $countB += $duration->totalMilliseconds;
+        });
+
+        Sleep::for(1)->millisecond();
+        Sleep::for(2)->millisecond();
+
+        Sleep::assertSequence([
+            Sleep::for(1)->millisecond(),
+            Sleep::for(2)->millisecond(),
+        ]);
+
+        $this->assertSame(3, $countA);
+        $this->assertSame(3, $countB);
+    }
+
+    public function testItDoesntRunCallbacksWhenNotFaking()
+    {
+        Sleep::whenFakingSleep(function () {
+            throw new Exception('Should not run without faking.');
+        });
+
+        Sleep::for(1)->millisecond();
+
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
This PR allows developers to register callbacks to execute when sleeping in tests.

Given the following implementation:

```php
$timeout = now()->addMinute();

do {
    if (Work:attempt()) {
        return;
    }

    Sleep::for(100)->milliseconds();
} while (now()->isAfter($timeout));
```

When we "fake" sleeping in our tests, the loop will likely do millions of loops, as it doesn't actually pause the code. To test this code we need to be able to progress the `now()` value. 

Introducing `Sleep::whenFakingSleep($callback);`

```php
$this->freezeTime();
Sleep::fake();
Sleep::whenFakingSleep(fn (Interval $duration) => $this->travel(
    $duration->totalMilliseconds
)->milliseconds());

// run test code.

Sleep::assertSlept();
```

This solution is inspired by @michaeldyrynda's real-world use case.