### PR TITLE
[10.x] Wrap response preparation in events

### DIFF
--- a/src/Illuminate/Routing/Events/PreparingResponse.php
+++ b/src/Illuminate/Routing/Events/PreparingResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class PreparingResponse
+{
+    /**
+     * The request instance.
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    public $request;
+
+    /**
+     * The response instance.
+     *
+     * @var mixed
+     */
+    public $response;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  mixed  $response
+     * @return void
+     */
+    public function __construct($request, $response)
+    {
+        $this->request = $request;
+
+        $this->response = $response;
+    }
+}

--- a/src/Illuminate/Routing/Events/PreparingResponse.php
+++ b/src/Illuminate/Routing/Events/PreparingResponse.php
@@ -28,7 +28,6 @@ class PreparingResponse
     public function __construct($request, $response)
     {
         $this->request = $request;
-
         $this->response = $response;
     }
 }

--- a/src/Illuminate/Routing/Events/ResponsePrepared.php
+++ b/src/Illuminate/Routing/Events/ResponsePrepared.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class ResponsePrepared
+{
+    /**
+     * The request instance.
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    public $request;
+
+    /**
+     * The response instance.
+     *
+     * @var \Symfony\Component\HttpFoundation\Response
+     */
+    public $response;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @return void
+     */
+    public function __construct($request, $response)
+    {
+        $this->request = $request;
+
+        $this->response = $response;
+    }
+}
+
+
+

--- a/src/Illuminate/Routing/Events/ResponsePrepared.php
+++ b/src/Illuminate/Routing/Events/ResponsePrepared.php
@@ -32,6 +32,3 @@ class ResponsePrepared
         $this->response = $response;
     }
 }
-
-
-

--- a/src/Illuminate/Routing/Events/ResponsePrepared.php
+++ b/src/Illuminate/Routing/Events/ResponsePrepared.php
@@ -28,7 +28,6 @@ class ResponsePrepared
     public function __construct($request, $response)
     {
         $this->request = $request;
-
         $this->response = $response;
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Events\PreparingResponse;
+use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Events\Routing;
 use Illuminate\Support\Arr;
@@ -871,7 +873,11 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function prepareResponse($request, $response)
     {
-        return static::toResponse($request, $response);
+        $this->events->dispatch(new PreparingResponse($request, $response));
+
+        return tap(static::toResponse($request, $response), function ($response) use ($request) {
+            $this->events->dispatch(new ResponsePrepared($request, $response));
+        });
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -23,6 +23,8 @@ use Illuminate\Routing\Contracts\CallableDispatcher as CallableDispatcherContrac
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\ControllerDispatcher;
+use Illuminate\Routing\Events\PreparingResponse;
+use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Routing\Events\Routing;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -2169,11 +2171,45 @@ class RoutingRouteTest extends TestCase
         ], $route->middleware());
     }
 
-    protected function getRouter()
+    public function testItDispatchesEventsWhilePreparingRequest()
     {
+        $events = new Dispatcher;
+        $preparing = [];
+        $prepared = [];
+        $events->listen(PreparingResponse::class, function ($event) use (&$preparing) {
+            $preparing[] = $event;
+        });
+        $events->listen(ResponsePrepared::class, function ($event) use (&$prepared) {
+            $prepared[] = $event;
+        });
         $container = new Container;
+        $container->instance(Dispatcher::class, $events);
+        $router = $this->getRouter($container);
+        $router->get('foo/bar', function () {
+            return 'hello';
+        });
+        $request = Request::create('foo/bar', 'GET');
 
-        $router = new Router(new Dispatcher, $container);
+        $response = $router->dispatch($request);
+
+        $this->assertSame('hello', $response->getContent());
+        $this->assertCount(2, $preparing);
+        $this->assertSame($request, $preparing[0]->request);
+        $this->assertSame('hello', $preparing[0]->response);
+        $this->assertSame($request, $preparing[1]->request);
+        $this->assertSame($response, $preparing[1]->response);
+        $this->assertCount(2, $prepared);
+        $this->assertSame($request, $prepared[0]->request);
+        $this->assertSame($response, $prepared[0]->response);
+        $this->assertSame($request, $prepared[1]->request);
+        $this->assertSame($response, $prepared[1]->response);
+    }
+
+    protected function getRouter($container = null)
+    {
+        $container ??= new Container;
+
+        $router = new Router($container->make(Dispatcher::class), $container);
 
         $container->singleton(Registrar::class, function () use ($router) {
             return $router;


### PR DESCRIPTION
This enables user-land implementations of https://github.com/laravel/framework/pull/45603 without actually bringing the feature to the framework.

For example:

```php
public function boot(): void
{
    $logQueries = false;

    Event::listen(PreparingResponse::class, function () use (&$logQueries) {
        $logQueries = true;
    });

    Event::listen(ResponsePrepared::class, function () use (&$logQueries) {
        $logQueries = false;
    });

    DB::listen(function (QueryExecuted $event) use (&$logQueries) {
        if ($logQueries) {
            // log in production, throw locally.
        }
    });
}
```