### PR TITLE
[10.x] Allow passing an array of `$times` in `PendingRequest::retry()`

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -124,7 +124,7 @@ class PendingRequest
     /**
      * The number of times to try the request.
      *
-     * @var int
+     * @var int|array
      */
     protected $tries = 1;
 
@@ -556,13 +556,13 @@ class PendingRequest
     /**
      * Specify the number of times the request should be attempted.
      *
-     * @param  int  $times
+     * @param  int|array  $times
      * @param  Closure|int  $sleepMilliseconds
      * @param  callable|null  $when
      * @param  bool  $throw
      * @return $this
      */
-    public function retry(int $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
+    public function retry(int|array $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
     {
         $this->tries = $times;
         $this->retryDelay = $sleepMilliseconds;


### PR DESCRIPTION
Inspired by #46653 this PR adds the ability to pass an array for the `$times` parameter in the `PendingRequest::retry()` method, which in turn allows us to pass an array to then `Http::retry()` method.

The `PendingRequest::retry()` method uses the `retry()` helper function which already allows its `$times` parameter to be an array and implement a retry and backoff strategy.

[Documentation PR](https://github.com/laravel/docs/pull/8819)