### PR TITLE
[10.x] Clean ‍‍`check` method in `Argon2IdHasher`

### DIFF
--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -22,11 +22,7 @@ class Argon2IdHasher extends ArgonHasher
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }
 
-        if (is_null($hashedValue) || strlen($hashedValue) === 0) {
-            return false;
-        }
-
-        return password_verify($value, $hashedValue);
+        return parent::check($value, $hashedValue, $options);
     }
 
     /**


### PR DESCRIPTION
## Whats changed?
In `AbstractHasher` class the `check` method is:
```php
// AbstractHasher.php

public function check($value, $hashedValue, array $options = [])
    {
        if (is_null($hashedValue) || strlen($hashedValue) === 0) {
            return false;
        }

        return password_verify($value, $hashedValue);
    }
```` 

And in ‍‍`Argon2IdHasher`, which is a child class of `AbstractHasher` class, the `check` method is:
```php
// Argon2IdHasher.php

public function check($value, $hashedValue, array $options = [])
    {
        if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2id') {
            throw new RuntimeException('This password does not use the Argon2id algorithm.');
        }

        if (is_null($hashedValue) || strlen($hashedValue) === 0) {
            return false;
        }

        return password_verify($value, $hashedValue);
    }


```

So, we can use the `parent::check` method in `Argon2IdHasher` class for check the value like other hasher classes:
```php
// Argon2IdHasher.php

public function check($value, $hashedValue, array $options = [])
    {
        if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2id') {
            throw new RuntimeException('This password does not use the Argon2id algorithm.');
        }

        return parent::check($value, $hashedValue, $options);
    }


```


* Clean `check` method in `Argon2IdHasher.php` 
* Successful tests in `HasherTest.php`
* #47236