### PR TITLE
[10.x] Additional string helpers for longerThan, shorterThan, and pregReplace

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -495,6 +495,22 @@ class Str
     }
 
     /**
+     * Returns if the string length is equal to a value.  Optional parameter to
+     * remove leading and trailing whitespace.
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  boolean $trimWhitespace
+     * @return boolean
+     */
+    public static function lengthEqualTo($value, $length, $trimWhitespace)
+    {
+        return $trimWhitespace ?
+            Str::of($value)->trim()->length() == $length :
+            Str::of($value)->length() == $length;
+    }
+
+    /**
      * Limit the number of characters in a string.
      *
      * @param  string  $value
@@ -509,6 +525,22 @@ class Str
         }
 
         return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+    }
+
+    /**
+     * Check if a string is longer than a given length.  Optional parameter to
+     * trim leading and trailing white space.
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  boolean  $trimWhitespace
+     * @return boolean
+     */
+    public static function longerThan($value, $length, $trimWhitespace = false)
+    {
+        return $trimWhitespace ?
+            Str::of($value)->trim()->length() > $length :
+            Str::of($value)->length() > $length;
     }
 
     /**
@@ -759,6 +791,31 @@ class Str
         $lastWord = array_pop($parts);
 
         return implode('', $parts).self::plural($lastWord, $count);
+    }
+
+    /**
+     * Replace the given value in the given string.
+     *
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $pattern
+     * @param  string|iterable<string>  $replace
+     * @return string
+     */
+    public static function pregReplace($search, $pattern, $replace)
+    {
+        if ($search instanceof Traversable) {
+            $search = collect($search)->all();
+        }
+
+        if ($pattern instanceof Traversable) {
+            $pattern = collect($pattern)->all();
+        }
+
+        if ($replace instanceof Traversable) {
+            $replace = collect($replace)->all();
+        }
+
+        return preg_replace($pattern, $replace, $search);
     }
 
     /**
@@ -1070,6 +1127,22 @@ class Str
         $collapsed = static::replace(['-', '_', ' '], '_', implode('_', $parts));
 
         return implode(' ', array_filter(explode('_', $collapsed)));
+    }
+
+    /**
+     * Check if a string is shorter than a given length.  Optional parameter to
+     * trim leading and trailing white space.
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  boolean  $trimWhitespace
+     * @return  boolean
+     */
+    public static function shorterThan($value, $length, $trimWhitespace = false)
+    {
+        return $trimWhitespace ?
+            Str::of($value)->trim()->length() < $length :
+            Str::of($value)->length() < $length;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -396,6 +396,21 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Check if a string is longer than a given length.  Optional parameter to
+     * trim leading and trailing white space.
+     *
+     * @param  int  $length
+     * @param  boolean  $trimWhitespace
+     * @return boolean
+     */
+    public function longerThan($length, $trimWhitespace = false)
+    {
+        return $trimWhitespace ?
+            Str::of($this->value)->trim()->length() > $length :
+            Str::of($this->value)->length() > $length;
+    }
+
+    /**
      * Convert the given string to lower-case.
      *
      * @return static
@@ -563,6 +578,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function pluralStudly($count = 2)
     {
         return new static(Str::pluralStudly($this->value, $count));
+    }
+
+    /**
+     * Replace the given value in the given string.
+     *
+     * @param  string|iterable<string>  $pattern
+     * @param  string|iterable<string>  $replace
+     * @return string
+     */
+    public function pregReplace($pattern, $replace)
+    {
+        return new static(preg_replace($pattern, $replace, $this->value));
     }
 
     /**
@@ -746,6 +773,21 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function headline()
     {
         return new static(Str::headline($this->value));
+    }
+
+    /**
+     * Check if a string is shorter than a given length.  Optional parameter to
+     * trim leading and trailing white space.
+     *
+     * @param  int  $length
+     * @param  boolean  $trimWhitespace
+     * @return  boolean
+     */
+    public function shorterThan($length, $trimWhitespace = false)
+    {
+        return $trimWhitespace ?
+            Str::of($this->value)->trim()->length() < $length :
+            Str::of($this->value)->length() < $length;
     }
 
     /**

--- a/tests/Support/StringableObjectStub.php
+++ b/tests/Support/StringableObjectStub.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+class StringableObjectStub
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
 
+use Illuminate\Tests\Support\StringableObjectStub;
+
 class SupportStrTest extends TestCase
 {
     public function testStringCanBeLimitedByWords()
@@ -173,9 +175,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('[...]is a beautiful morn[...]', Str::excerpt('This is a beautiful morning', 'beautiful', ['omission' => '[...]', 'radius' => 5]));
         $this->assertSame(
             'This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
-            Str::excerpt('This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
+            Str::excerpt(
+                'This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?',
+                'very',
                 ['omission' => '[...]'],
-            ));
+            )
+        );
 
         $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
         $this->assertSame('...ayl...', Str::excerpt('taylor', 'Y', ['radius' => 1]));
@@ -494,6 +499,30 @@ class SupportStrTest extends TestCase
     {
         $this->assertEquals(11, Str::length('foo bar baz'));
         $this->assertEquals(11, Str::length('foo bar baz', 'UTF-8'));
+    }
+
+    public function testLongerThan()
+    {
+        $this->assertTrue(Str::longerThan("Laravel", 3));
+        $this->assertTrue(Str::longerThan("    Laravel    ", 3, true));
+        $this->assertFalse(Str::longerThan("Laravel", 30));
+        $this->assertFalse(Str::longerThan("    Laravel    ", 30, true));
+    }
+
+    public function testShorterThan()
+    {
+        $this->assertTrue(Str::shorterThan("Laravel", 30));
+        $this->assertTrue(Str::shorterThan("    Laravel    ", 30, true));
+        $this->assertFalse(Str::shorterThan("Laravel", 3));
+        $this->assertFalse(Str::shorterThan("    Laravel    ", 3, true));
+    }
+
+    public function testPregReplace()
+    {
+        $this->assertEquals("1234", Str::pregReplace("1234abc", "/[a-zA-Z]/", ""));
+        $this->assertEquals("abc", Str::pregReplace("1234abc", "/[0-9]/", ""));
+        $this->assertNotEquals("1234", Str::pregReplace("1234abc", "/[0-9]/", ""));
+        $this->assertNotEquals("abc", Str::pregReplace("1234abc", "/[a-zA-Z]/", ""));
     }
 
     public function testRandom()
@@ -1118,20 +1147,5 @@ class SupportStrTest extends TestCase
     public function testPasswordCreation()
     {
         $this->assertTrue(strlen(Str::password()) === 32);
-    }
-}
-
-class StringableObjectStub
-{
-    private $value;
-
-    public function __construct($value)
-    {
-        $this->value = $value;
-    }
-
-    public function __toString()
-    {
-        return $this->value;
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -8,6 +8,8 @@ use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
+use Illuminate\Tests\Support\StringableObjectStub;
+
 class SupportStringableTest extends TestCase
 {
     /**
@@ -267,7 +269,8 @@ class SupportStringableTest extends TestCase
             'Iron Man',
             (string) $this->stringable('Tony')->whenNotExactly('Tony Stark', function ($stringable) {
                 return 'Iron Man';
-            }));
+            })
+        );
 
         $this->assertSame(
             'Swing and a miss...!',
@@ -275,7 +278,8 @@ class SupportStringableTest extends TestCase
                 return 'Iron Man';
             }, function ($stringable) {
                 return 'Swing and a miss...!';
-            }));
+            })
+        );
     }
 
     public function testWhenIs()
@@ -468,12 +472,14 @@ class SupportStringableTest extends TestCase
             return $stringable->append($value)->append('true');
         }));
 
-        $this->assertSame('unless true fallbacks to default with value 1',
+        $this->assertSame(
+            'unless true fallbacks to default with value 1',
             (string) $this->stringable('unless true ')->unless(1, function ($stringable, $value) {
                 return $stringable->append($value);
             }, function ($stringable, $value) {
                 return $stringable->append('fallbacks to default with value ')->append($value);
-            }));
+            })
+        );
     }
 
     public function testUnlessFalsy()
@@ -482,12 +488,14 @@ class SupportStringableTest extends TestCase
             return $stringable->append($value);
         }));
 
-        $this->assertSame('gets the value 0',
+        $this->assertSame(
+            'gets the value 0',
             (string) $this->stringable('gets the value ')->unless(0, function ($stringable, $value) {
                 return $stringable->append($value);
             }, function ($stringable) {
                 return $stringable->append('fallbacks to default');
-            }));
+            })
+        );
     }
 
     public function testTrimmedOnlyWhereNecessary()
@@ -787,6 +795,30 @@ class SupportStringableTest extends TestCase
         $this->assertSame('laravel-php-framework', (string) $this->stringable('LaravelPhpFramework')->kebab());
     }
 
+    public function testLongerThan()
+    {
+        $this->assertTrue($this->stringable("Laravel")->longerThan(3));
+        $this->assertTrue($this->stringable("    Laravel    ")->longerThan(3, true));
+        $this->assertFalse($this->stringable("Laravel")->longerThan(30));
+        $this->assertFalse($this->stringable("    Laravel    ")->longerThan(30, true));
+    }
+
+    public function testShorterThan()
+    {
+        $this->assertTrue($this->stringable("Laravel")->shorterThan(30));
+        $this->assertTrue($this->stringable("    Laravel    ")->shorterThan(30, true));
+        $this->assertFalse($this->stringable("Laravel")->shorterThan(3));
+        $this->assertFalse($this->stringable("    Laravel    ")->shorterThan(3, true));
+    }
+
+    public function testPregReplace()
+    {
+        $this->assertEquals("1234", $this->stringable("1234abc")->pregReplace("/[a-zA-Z]/", ""));
+        $this->assertEquals("abc", $this->stringable("1234abc")->pregReplace("/[0-9]/", ""));
+        $this->assertNotEquals("1234", $this->stringable("1234abc")->pregReplace("/[0-9]/", ""));
+        $this->assertNotEquals("abc", $this->stringable("1234abc")->pregReplace("/[a-zA-Z]/", ""));
+    }
+
     public function testLower()
     {
         $this->assertSame('foo bar baz', (string) $this->stringable('FOO BAR BAZ')->lower());
@@ -801,7 +833,8 @@ class SupportStringableTest extends TestCase
 
     public function testLimit()
     {
-        $this->assertSame('Laravel is...',
+        $this->assertSame(
+            'Laravel is...',
             (string) $this->stringable('Laravel is a free, open source PHP web application framework.')->limit(10)
         );
         $this->assertSame('这是一...', (string) $this->stringable('这是一段中文')->limit(6));


### PR DESCRIPTION
Additional string helpers and methods to the Stringable object to support

- longerThan
- shorterThan
- pregReplace

I have found these useful where I want to keep everything very fluent without needing temporary variables or switching coding modalities.

I also ran into some testing issues when testing the Stringable object with a missing class.  This has been broken into a separate file to allow for independent testing of `tests/Support/SupportStrTest.php` and `tests/Support/SupportStringableTest.php`.