### PR TITLE
[10.x] Add support for custom values on FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -123,6 +123,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->messages(), $this->attributes()
         )->stopOnFirstFailure($this->stopOnFirstFailure);
 
+        if (method_exists($validator, 'addCustomValues')) {
+            $validator->addCustomValues($this->customValues());
+        }
+
         if ($this->isPrecognitive()) {
             $validator->setRules(
                 $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders())
@@ -248,6 +252,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @return array
      */
     public function attributes()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom values for validator errors.
+     *
+     * @return array
+     */
+    public function customValues()
     {
         return [];
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -221,7 +221,7 @@ class FoundationFormRequestTest extends TestCase
         $translator->addLines(['validation.required_if' => ':value'], 'en');
 
         $container = new Container;
-        $container->instance(\Illuminate\Contracts\Validation\Factory::class, (new \Illuminate\Validation\Factory($translator)));
+        $container->instance(\Illuminate\Contracts\Validation\Factory::class, new \Illuminate\Validation\Factory($translator));
         $request->setContainer($container)->setRedirector($this->createMockRedirector($request));
 
         $this->expectException(ValidationException::class);


### PR DESCRIPTION
In the `validator` class used by the `FormRequest` validation, there is a feature called `customValues`, which allows for value substitutions to occur in form error messages. For example, Given a model with an `id` and `name` property, we can define the following validation rules:
```php
return [
'id'         => ['required'],
'other_data' => ['required_if:id,1'], 
]
``` 
An error message for these rules may look like: `Property other data is required when id is 1`

From a users perspective, this message is not all that desirable, as the user may not know what id 1 is referencing (imagine an update form context).

A better alternative would be something like: `Property other data is required when model is Foo`.  (Name of the model is Foo)

In the `FormRequest` class, the id attribute name can be changed via the `attributes` method:
```php
public function attributes()
{
    return [
        'id' => 'model',
    ];
}
```

However, currently there is no method that allows for easily setting customValues on the validator via a `FormRequest`. This PR adds a helper method `customValues` that allows those to be set. Ex:

```php
public function customValues()
{
    return ['id' => [1 => 'Foo']];
}
```

The data returned from the `customValues` function is a list key-value pairs, with keys being the properties to replace, and the value being another array that maps the value given to its new value. In the example given, when property `id` has a value of 1, that property will be shown as `Foo` in the validation message