### PR TITLE
[10.x] @attributes() Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -14,7 +14,8 @@ use InvalidArgumentException;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
-    use Concerns\CompilesAuthorizations,
+    use Concerns\CompilesAttributes,
+        Concerns\CompilesAuthorizations,
         Concerns\CompilesClasses,
         Concerns\CompilesComments,
         Concerns\CompilesComponents,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAttributes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAttributes.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesAttributes
+{
+    /**
+     * Compile the attributes statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileAttributes($expression)
+    {
+        $expression = is_null($expression) ? '([])' : $expression;
+
+        return "<?php echo (new \Illuminate\View\ComponentAttributeBag)$expression; ?>";
+    }
+}

--- a/tests/View/Blade/BladeAttributesTest.php
+++ b/tests/View/Blade/BladeAttributesTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeAttributesTest extends AbstractBladeTestCase
+{
+    public function testAttributesAreCompiled()
+    {
+        $string = "<form @attributes(['id' => 'contactform', 'class' => 'bg-red', 'action' => '/contact', 'method' => 'POST', 'name' => false])></form>";
+        $expected = "<form <?php echo (new \Illuminate\View\ComponentAttributeBag)(['id' => 'contactform', 'class' => 'bg-red', 'action' => '/contact', 'method' => 'POST', 'name' => false]); ?>></form>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Useful when attributes come from the backend, for example with Statamic the form attributes come from the backend. With this we can just pass them through like:
```
<form @attributes($form['attrs'])>
```
Instead of manually setting them:
```
<form action="{{ $form['attrs']['action'] }}" method="{{ $form['attrs']['method'] }}">
```