### PR TITLE
[10.x] Fix docblock

### DIFF
--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -94,7 +94,7 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
      * Create a pending potentially translated string.
      *
      * @param  string  $attribute
-     * @param  ?string  $message
+     * @param  string|null  $message
      * @return \Illuminate\Translation\PotentiallyTranslatedString
      */
     protected function pendingPotentiallyTranslatedString($attribute, $message)


### PR DESCRIPTION
We had uniformed these from `?string` to `string|null` (see #45677)