### PR TITLE
[10.x] Implement __set_state() to Illuminate\Support\Js

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -147,18 +147,18 @@ class Js implements Htmlable
     {
         return $this->toHtml();
     }
-    
+
     /**
      * Restores a class instance from cached data.
      *
      * @param  array  $state
-     *
      * @return static
      */
     public static function __set_state($state)
     {
         $instance = new static(null);
         $instance->js = $state['js'];
+
         return $instance;
     }
 }

--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -147,4 +147,18 @@ class Js implements Htmlable
     {
         return $this->toHtml();
     }
+    
+    /**
+     * Restores a class instance from cached data.
+     *
+     * @param  array  $state
+     *
+     * @return static
+     */
+    public static function __set_state($state)
+    {
+        $instance = new static(null);
+        $instance->js = $state['js'];
+        return $instance;
+    }
 }

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -130,7 +130,7 @@ class SupportJsTest extends TestCase
         $this->assertSame('2', (string) Js::from(IntBackedEnum::TWO));
         $this->assertSame("'Hello world'", (string) Js::from(StringBackedEnum::HELLO_WORLD));
     }
-    
+
     public function testSetState()
     {
         $this->assertEquals(

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -130,4 +130,12 @@ class SupportJsTest extends TestCase
         $this->assertSame('2', (string) Js::from(IntBackedEnum::TWO));
         $this->assertSame("'Hello world'", (string) Js::from(StringBackedEnum::HELLO_WORLD));
     }
+    
+    public function testSetState()
+    {
+        $this->assertEquals(
+            "JSON.parse('[1,2,3]')",
+            (string) Js::__set_state(['js' => "JSON.parse('[1,2,3]')"])
+        );
+    }
 }


### PR DESCRIPTION
This allows the use of `Js` instances within cached contents, such as cached routes.

Fixes #47251.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
