### PR TITLE
handle circular dependency exception

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -972,14 +972,14 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($dependencies as $dependency) {
-            $dependencyName = $dependency->getName();
+            $dependencyName = Util::getParameterClassName($dependency);
             // Check if the dependency has already been injected
             if (in_array($dependencyName, $existingDependencies)) {
-                $className = $dependency->getDeclaringClass()->getName();
-                $fileName = $dependency->getDeclaringClass()->getFileName();
-                throw new CircularDependencyException(sprintf('Circular dependency detected in class  %s defined in file %s', $className, $fileName));
+                throw new CircularDependencyException(sprintf('Circular dependency detected in class %s', end($existingDependencies)));
             } else {
-                $existingDependencies[] = $dependencyName;
+                if (! is_null($dependencyName)) {
+                    $existingDependencies[] = $dependencyName;
+                }
                 // If the dependency has an override for this particular build we will use
                 // that instead as the value. Otherwise, we will continue with this run
                 // of resolutions and let reflection attempt to determine the result.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -909,13 +909,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @param  string  $abstract
      * @param  array  $parameters
+     * @param  array  $abstractDependencies
      * @return mixed
      */
-    public function make($abstract, array $parameters = [])
+    public function make($abstract, array $parameters = [], array $abstractDependencies = [])
     {
         $this->loadDeferredProviderIfNeeded($abstract = $this->getAlias($abstract));
 
-        return parent::make($abstract, $parameters);
+        return parent::make($abstract, $parameters, $abstractDependencies);
     }
 
     /**
@@ -924,13 +925,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  string  $abstract
      * @param  array  $parameters
      * @param  bool  $raiseEvents
+     * @param  array  $abstractDependencies
      * @return mixed
      */
-    protected function resolve($abstract, $parameters = [], $raiseEvents = true)
+    protected function resolve($abstract, $parameters = [], $raiseEvents = true, array $abstractDependencies = [])
     {
         $this->loadDeferredProviderIfNeeded($abstract = $this->getAlias($abstract));
 
-        return parent::resolve($abstract, $parameters, $raiseEvents);
+        return parent::resolve($abstract, $parameters, $raiseEvents, $abstractDependencies);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Container;
 use Illuminate\Container\Container;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\CircularDependencyException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use stdClass;
@@ -680,13 +681,22 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationStub::class, $result);
     }
 
-    // public function testContainerCanCatchCircularDependency()
-    // {
-    //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
+     public function testContainerCanCatchCircularDependency()
+     {
+         $this->expectException(CircularDependencyException::class);
 
-    //     $container = new Container;
-    //     $container->get(CircularAStub::class);
-    // }
+         $container = new Container;
+         $container->get(CircularAStub::class);
+     }
+
+    public function testCircularDependencyExceptionMessage()
+    {
+        $this->expectException(CircularDependencyException::class);
+        $this->expectExceptionMessage('Circular dependency detected in class Illuminate\Tests\Container\CircularCStub');
+
+        $container = new Container;
+        $container->get(CircularCStub::class);
+    }
 }
 
 class CircularAStub


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**This PR is to handle circular dependency exception. It also prevents memory leak issue on dev machine**

                                            Current Situation

 When you have objects in your code that are directly dependent on each other, and are injected via constructor, the final result is SERVER ERROR, because of the infinite loop. This also leads to memory leak in the application.

 **Example** 

AuthController injects AuthService
<img width="631" alt="Screenshot 2023-05-29 at 3 28 43 AM" src="https://github.com/laravel/framework/assets/6876434/ac178d74-5ca7-46c9-b845-60aead6628e9">


AuthService injects AuthController
<img width="649" alt="Screenshot 2023-05-29 at 3 28 21 AM" src="https://github.com/laravel/framework/assets/6876434/384a3441-95b5-411a-b075-04c5737ed6b6">



The error output in dev machine console: 

<img width="1008" alt="Screenshot 2023-05-28 at 2 32 12 AM" src="https://github.com/laravel/framework/assets/6876434/69373e16-10bb-485d-8755-b37235f5a211">




                                          After the Fix

The exception is rightly handled, also the developer knows to refactor the code.

![Screenshot 2023-05-29 at 3 29 53 AM](https://github.com/laravel/framework/assets/6876434/c3b9995a-8269-4475-905c-ae3f3ec640ab)






