### PR TITLE
always call the $missingAttributeViolationCallback if preventsAccessingMissingAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -464,14 +464,15 @@ trait HasAttributes
      */
     protected function throwMissingAttributeExceptionIfApplicable($key)
     {
-        if ($this->exists &&
-            ! $this->wasRecentlyCreated &&
-            static::preventsAccessingMissingAttributes()) {
+        if (static::preventsAccessingMissingAttributes()) {
+
             if (isset(static::$missingAttributeViolationCallback)) {
                 return call_user_func(static::$missingAttributeViolationCallback, $this, $key);
             }
 
-            throw new MissingAttributeException($this, $key);
+            if ($this->exists && ! $this->wasRecentlyCreated) {
+                throw new MissingAttributeException($this, $key);
+            }
         }
 
         return null;


### PR DESCRIPTION
This change brings `throwMissingAttributeExceptionIfApplicable` into alignment with `handleLazyLoadingViolation` by always executing the callback if its defined.

The purpose for this change is to allow the end-user to be in control and determine whether or not they care about accessing missing attributes in ALL circumstances. My original description and reproduction steps are in https://github.com/laravel/framework/issues/47109

The only risk I see from this change is that it will cause people who have defined a `missingAttributeViolationCallback` to potentially start getting more calls to it if they have issues in their code when they are accessing missing attributes.

The specific instance where I got burned from this was;

1. Using Jetstream
2. Added an `enum` columns to my `users` table with a default value (and not having defined that in the User.php $attributes array) called `type`
3. Registered an Event Listener on the `Login` event in `EventServiceProvider` and tried accessing an the `type` attribute expecting it would be there since I have `Model::preventAccessingMissingAttributes();` and no error was thrown. 

My expectation when defining `Model::preventAccessingMissingAttributes();` is that it would do **it in all circumstances**   so as to force me to ensure I've hardened my code with either with defaults values in $attributes or to rehydrate my models explicitly. 

I think this is a good compromise rather than introducing a breaking change for people. That said, the downside of this change is that people will still be burned by this unless they know about the 'hidden behaviour' of registering this callback. 

Also I appreciate any feedback if there's anything wrong with what I've submitting, I think I've done everything to align with expectations for submitting a PR.