### PR TITLE
[10.x] Vite customization using config

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -90,6 +90,13 @@ class Vite implements Htmlable
      */
     protected static $manifests = [];
 
+    public function __construct()
+    {
+        $this->hotFile = config('vite.hotFile');
+        $this->buildDirectory = config('vite.buildDirectory', $this->buildDirectory);
+        $this->manifestFilename = config('vite.manifestFilename', $this->manifestFilename);
+    }
+
     /**
      * Get the preloaded assets.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The methods `useHotFile`, `useBuildDirectory`, and `useManifestFilename` for customizing Vite are very convenient, and I use them often. 
However, I don't like having to write the same code in multiple blade files every time I use Vite. 
Therefore, I made it so that these settings can be written in the config file.