### PR TITLE
[10.x] Avoid duplicates in visible/hidden on merge

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -77,7 +77,7 @@ trait HidesAttributes
         $this->hidden = array_diff($this->hidden, $attributes);
 
         if (! empty($this->visible)) {
-            $this->visible = array_merge($this->visible, $attributes);
+            $this->visible = array_unique(array_merge($this->visible, $attributes));
         }
 
         return $this;
@@ -103,9 +103,9 @@ trait HidesAttributes
      */
     public function makeHidden($attributes)
     {
-        $this->hidden = array_merge(
+        $this->hidden = array_unique(array_merge(
             $this->hidden, is_array($attributes) ? $attributes : func_get_args()
-        );
+        ));
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -77,7 +77,7 @@ trait HidesAttributes
         $this->hidden = array_diff($this->hidden, $attributes);
 
         if (! empty($this->visible)) {
-            $this->visible = array_unique(array_merge($this->visible, $attributes));
+            $this->visible = array_values(array_unique(array_merge($this->visible, $attributes)));
         }
 
         return $this;
@@ -103,9 +103,9 @@ trait HidesAttributes
      */
     public function makeHidden($attributes)
     {
-        $this->hidden = array_unique(array_merge(
+        $this->hidden = array_values(array_unique(array_merge(
             $this->hidden, is_array($attributes) ? $attributes : func_get_args()
-        ));
+        )));
 
         return $this;
     }


### PR DESCRIPTION
A model's `$visible` or `$hidden` array should not contain duplicates if we try to merge attributes that are already present.