### PR TITLE
[10.x] fix migration creator to validated existing migration class

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -94,7 +94,11 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        try {
+            $this->writeMigration($name, $table, $create);
+        }catch (\InvalidArgumentException $e) {
+            $this->components->error($e->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
While the new migrations class now are anonymous classes
the method ensureMigrationDoesntAlreadyExist doesn't validate anymore the class name

Added error message to console ex:
ERROR  A CreateUsersTable class already exists. 
before it was showing an exception

