### PR TITLE
[10.x] Add `ModelPruning` event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Database\Events\ModelPruning;
 use Illuminate\Database\Events\ModelsPruned;
 use LogicException;
 
@@ -48,6 +49,8 @@ trait Prunable
      */
     public function prune()
     {
+        event(new ModelPruning($this));
+
         $this->pruning();
 
         return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))

--- a/src/Illuminate/Database/Events/ModelPruning.php
+++ b/src/Illuminate/Database/Events/ModelPruning.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Events;
 class ModelPruning
 {
     /**
-     * The model that was pruned.
+     * The model being pruned.
      *
      * @var string
      */

--- a/src/Illuminate/Database/Events/ModelPruning.php
+++ b/src/Illuminate/Database/Events/ModelPruning.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class ModelPruning
+{
+    /**
+     * The model that was pruned.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $model
+     * @return void
+     */
+    public function __construct($model)
+    {
+        $this->model = $model;
+    }
+}

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Events\ModelPruning;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Event;
@@ -57,6 +58,7 @@ class EloquentPrunableTest extends DatabaseTestCase
         $this->assertEquals(3500, PrunableTestModel::count());
 
         Event::assertDispatched(ModelsPruned::class, 2);
+        Event::assertDispatched(ModelPruning::class, 1500);
     }
 
     public function testPrunesSoftDeletedRecords()
@@ -76,6 +78,7 @@ class EloquentPrunableTest extends DatabaseTestCase
         $this->assertEquals(2000, PrunableSoftDeleteTestModel::withTrashed()->count());
 
         Event::assertDispatched(ModelsPruned::class, 3);
+        Event::assertDispatched(ModelPruning::class, 3000);
     }
 
     public function testPruneWithCustomPruneMethod()
@@ -96,6 +99,7 @@ class EloquentPrunableTest extends DatabaseTestCase
         $this->assertEquals(5000, PrunableWithCustomPruneMethodTestModel::count());
 
         Event::assertDispatched(ModelsPruned::class, 1);
+        Event::assertDispatched(ModelPruning::class, 1000);
     }
 }
 


### PR DESCRIPTION
This pull request adds the `ModelPruning` event, allowing for the firing of an event before model pruning takes place.

When marking models as `Prunable`, you may also define a pruning method on the model. This method will be called before the model is deleted. This method can be useful for deleting any additional resources associated with the model, such as stored files, before the model is permanently removed from the database:

Now you can use a listener to handle the pruning logic instead of implementing a pruning method in the model.

Separating the pruning logic into a listener helps keep the model class cleaner and focused on its core responsibilities. By extracting the pruning-related logic into a separate listener, the model class remains more concise and maintains a clear separation of concerns. The listener can handle any additional actions, such as deleting associated files or updating related records, without cluttering the model code. This approach improves the readability, maintainability, and testability of the model class.

``` php

namespace App\Listeners;

use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Database\Events\ModelsPruning;

class PruneModelListener implements ShouldQueue
{
    /**
     * Handle the event.
     *
     * @param  \Illuminate\Database\Events\ModelPruning  $event
     * @return void
     */
    public function handle(ModelPruning $event)
    {
        $model = $event->model;

        // Perform your pruning logic here
        // For example, delete additional resources associated with the model

        // Example: Delete associated files
        // deleteAssociatedFiles($model);
    }
}
```