### PR TITLE
[10.x] Add shorthand for denying as payment required 

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -73,6 +73,16 @@ class AuthorizationException extends Exception
     }
 
     /**
+     * Set the HTTP response status code to 402.
+     *
+     * @return $this
+     */
+    public function asPaymentRequired()
+    {
+        return $this->withStatus(402);
+    }
+
+    /**
      * Set the HTTP response status code to 404.
      *
      * @return $this

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -42,6 +42,18 @@ trait HandlesAuthorization
     }
 
     /**
+     * Deny with a 402 HTTP status code.
+     *
+     * @param  string|null  $message
+     * @param  int|null  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function denyAsPaymentRequired($message = null, $code = null)
+    {
+        return Response::denyWithStatus(402, $message, $code);
+    }
+
+    /**
      * Deny with a 404 HTTP status code.
      *
      * @param  string|null  $message

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -182,16 +182,6 @@ class Response implements Arrayable
     }
 
     /**
-     * Set the HTTP response status code to 404.
-     *
-     * @return $this
-     */
-    public function asNotFound()
-    {
-        return $this->withStatus(404);
-    }
-
-    /**
      * Set the HTTP response status code to 402.
      *
      * @return $this
@@ -199,6 +189,16 @@ class Response implements Arrayable
     public function asPaymentRequired()
     {
         return $this->withStatus(402);
+    }
+
+    /**
+     * Set the HTTP response status code to 404.
+     *
+     * @return $this
+     */
+    public function asNotFound()
+    {
+        return $this->withStatus(404);
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -87,6 +87,18 @@ class Response implements Arrayable
     }
 
     /**
+     * Create a new "deny" Response with a 402 HTTP status code.
+     *
+     * @param  string|null  $message
+     * @param  mixed  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public static function denyAsPaymentRequired($message = null, $code = null)
+    {
+        return static::denyWithStatus(402, $message, $code);
+    }
+
+    /**
      * Create a new "deny" Response with a 404 HTTP status code.
      *
      * @param  string|null  $message
@@ -177,6 +189,16 @@ class Response implements Arrayable
     public function asNotFound()
     {
         return $this->withStatus(404);
+    }
+
+    /**
+     * Set the HTTP response status code to 402.
+     *
+     * @return $this
+     */
+    public function asPaymentRequired()
+    {
+        return $this->withStatus(402);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -29,6 +29,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static array policies()
  * @method static \Illuminate\Auth\Access\Gate setContainer(\Illuminate\Contracts\Container\Container $container)
  * @method static \Illuminate\Auth\Access\Response denyWithStatus(int $status, string|null $message = null, int|null $code = null)
+ * @method static \Illuminate\Auth\Access\Response denyAsPaymentRequired(string|null $message = null, int|null $code = null)
  * @method static \Illuminate\Auth\Access\Response denyAsNotFound(string|null $message = null, int|null $code = null)
  *
  * @see \Illuminate\Auth\Access\Gate

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -63,6 +63,17 @@ class AuthAccessResponseTest extends TestCase
         }
 
         try {
+            Response::deny('foo', 3)->asPaymentRequired()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(402, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->response()->message());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
             Response::deny('foo', 3)->asNotFound()->authorize();
             $this->fail();
         } catch (AuthorizationException $e) {
@@ -111,6 +122,28 @@ class AuthAccessResponseTest extends TestCase
             $this->fail();
         } catch (AuthorizationException $e) {
             $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->response()->message());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
+            Response::denyAsPaymentRequired()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(402, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertNull($e->response()->message());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        try {
+            Response::denyAsNotFound('foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(402, $e->status());
             $this->assertTrue($e->hasStatus());
             $this->assertSame('foo', $e->response()->message());
             $this->assertSame('foo', $e->getMessage());

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -107,6 +107,28 @@ class AuthAccessResponseTest extends TestCase
         }
 
         try {
+            Response::denyAsPaymentRequired()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(402, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertNull($e->response()->message());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        try {
+            Response::denyAsPaymentRequired('foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(402, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->response()->message());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
             Response::denyAsNotFound()->authorize();
             $this->fail();
         } catch (AuthorizationException $e) {
@@ -122,28 +144,6 @@ class AuthAccessResponseTest extends TestCase
             $this->fail();
         } catch (AuthorizationException $e) {
             $this->assertSame(404, $e->status());
-            $this->assertTrue($e->hasStatus());
-            $this->assertSame('foo', $e->response()->message());
-            $this->assertSame('foo', $e->getMessage());
-            $this->assertSame(3, $e->getCode());
-        }
-
-        try {
-            Response::denyAsPaymentRequired()->authorize();
-            $this->fail();
-        } catch (AuthorizationException $e) {
-            $this->assertSame(402, $e->status());
-            $this->assertTrue($e->hasStatus());
-            $this->assertNull($e->response()->message());
-            $this->assertSame('This action is unauthorized.', $e->getMessage());
-            $this->assertSame(0, $e->getCode());
-        }
-
-        try {
-            Response::denyAsNotFound('foo', 3)->authorize();
-            $this->fail();
-        } catch (AuthorizationException $e) {
-            $this->assertSame(402, $e->status());
             $this->assertTrue($e->hasStatus());
             $this->assertSame('foo', $e->response()->message());
             $this->assertSame('foo', $e->getMessage());

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -123,7 +123,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
             public function __invoke()
             {
-                return $this->denyAsNotFound('foo', 3);
+                return $this->denyAsPaymentRequired('foo', 3);
             }
         };
 

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -94,7 +94,6 @@ class AuthHandlesAuthorizationTest extends TestCase
         }
     }
 
-
     public function testItCanDenyAsPaymentRequired()
     {
         $class = new class()

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -94,6 +94,50 @@ class AuthHandlesAuthorizationTest extends TestCase
         }
     }
 
+
+    public function testItCanDenyAsPaymentRequired()
+    {
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyAsPaymentRequired();
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(402, $e->status());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyAsNotFound('foo', 3);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(402, $e->status());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+    }
+
     public function testItCanDenyAsNotFound()
     {
         $class = new class()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

https://github.com/laravel/framework/pull/47269 but now with tests that pass. 😄

This PR adds methods that make it easier to create an authorization exception or access response with `402 Payment Required` HTTP response.
See https://github.com/laravel/framework/pull/45682 for more context on the use case in SaaS applications.

Usually you'd simply pass the status code into `denyWithStatus()`, which works for simple status codes, but gets harder when you can't exactly remember the right status. Of course, you could use `Response::HTTP_PAYMENT_REQUIRED`, but that gets messy when you've already imported the `Illuminate\Auth\Access\Response` class as `Response`. This leads to having to write:

```php
return Response::denyWithStatus(\Illuminate\Http\Response::HTTP_PAYMENT_REQUIRED);
```

This PR enables you to simply write this instead:

```php
return Response::denyAsPaymentRequired();
```

I know it might get out of hand if we add these methods for many more status codes, but I find myself using this specific one a lot in SaaS applications.