### PR TITLE
[11.x] Handle circular dependency exception

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -960,8 +960,8 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve all of the dependencies from the ReflectionParameters.
      *
-     * @param \ReflectionParameter[] $dependencies
-     * @param array $existingDependencies
+     * @param  \ReflectionParameter[] $dependencies
+     * @param  array $existingDependencies
      * @return array
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
@@ -977,7 +977,7 @@ class Container implements ArrayAccess, ContainerContract
             if (in_array($dependencyName, $existingDependencies)) {
                 throw new CircularDependencyException(sprintf('Circular dependency detected in class %s', end($existingDependencies)));
             } else {
-                if (!is_null($dependencyName)) {
+                if (! is_null($dependencyName)) {
                     $existingDependencies[] = $dependencyName;
                 }
                 // If the dependency has an override for this particular build we will use

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -722,13 +722,14 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string|callable  $abstract
      * @param  array  $parameters
+     * @param  array  $abstractDependencies
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function make($abstract, array $parameters = [])
+    public function make($abstract, array $parameters = [], array $abstractDependencies = [])
     {
-        return $this->resolve($abstract, $parameters);
+        return $this->resolve($abstract, $parameters, true, $abstractDependencies);
     }
 
     /**
@@ -755,12 +756,13 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string|callable  $abstract
      * @param  array  $parameters
      * @param  bool  $raiseEvents
+     * @param  array  $abstractDependencies
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \Illuminate\Contracts\Container\CircularDependencyException
      */
-    protected function resolve($abstract, $parameters = [], $raiseEvents = true)
+    protected function resolve($abstract, $parameters = [], $raiseEvents = true, $abstractDependencies = [])
     {
         $abstract = $this->getAlias($abstract);
 
@@ -792,7 +794,7 @@ class Container implements ArrayAccess, ContainerContract
         // the binding. This will instantiate the types, as well as resolve any of
         // its "nested" dependencies recursively until all have gotten resolved.
         if ($this->isBuildable($concrete, $abstract)) {
-            $object = $this->build($concrete);
+            $object = $this->build($concrete, $abstractDependencies);
         } else {
             $object = $this->make($concrete);
         }
@@ -896,12 +898,13 @@ class Container implements ArrayAccess, ContainerContract
      * Instantiate a concrete instance of the given type.
      *
      * @param  \Closure|string  $concrete
+     * @param  array  $existingDependencies
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \Illuminate\Contracts\Container\CircularDependencyException
      */
-    public function build($concrete)
+    public function build($concrete, $existingDependencies = [])
     {
         // If the concrete type is actually a Closure, we will just execute it and
         // hand back the results of the functions, which allows functions to be
@@ -942,7 +945,7 @@ class Container implements ArrayAccess, ContainerContract
         // dependency instances and then use the reflection instances to make a
         // new instance of this class, injecting the created dependencies in.
         try {
-            $instances = $this->resolveDependencies($dependencies);
+            $instances = $this->resolveDependencies($dependencies, $existingDependencies);
         } catch (BindingResolutionException $e) {
             array_pop($this->buildStack);
 
@@ -957,36 +960,47 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve all of the dependencies from the ReflectionParameters.
      *
-     * @param  \ReflectionParameter[]  $dependencies
+     * @param \ReflectionParameter[] $dependencies
+     * @param array $existingDependencies
      * @return array
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\CircularDependencyException
      */
-    protected function resolveDependencies(array $dependencies)
+    protected function resolveDependencies(array $dependencies, array $existingDependencies = [])
     {
         $results = [];
 
         foreach ($dependencies as $dependency) {
-            // If the dependency has an override for this particular build we will use
-            // that instead as the value. Otherwise, we will continue with this run
-            // of resolutions and let reflection attempt to determine the result.
-            if ($this->hasParameterOverride($dependency)) {
-                $results[] = $this->getParameterOverride($dependency);
-
-                continue;
-            }
-
-            // If the class is null, it means the dependency is a string or some other
-            // primitive type which we can not resolve since it is not a class and
-            // we will just bomb out with an error since we have no-where to go.
-            $result = is_null(Util::getParameterClassName($dependency))
-                            ? $this->resolvePrimitive($dependency)
-                            : $this->resolveClass($dependency);
-
-            if ($dependency->isVariadic()) {
-                $results = array_merge($results, $result);
+            $dependencyName = Util::getParameterClassName($dependency);
+            // Check if the dependency has already been injected
+            if (in_array($dependencyName, $existingDependencies)) {
+                throw new CircularDependencyException(sprintf('Circular dependency detected in class %s', end($existingDependencies)));
             } else {
-                $results[] = $result;
+                if (!is_null($dependencyName)) {
+                    $existingDependencies[] = $dependencyName;
+                }
+                // If the dependency has an override for this particular build we will use
+                // that instead as the value. Otherwise, we will continue with this run
+                // of resolutions and let reflection attempt to determine the result.
+                if ($this->hasParameterOverride($dependency)) {
+                    $results[] = $this->getParameterOverride($dependency);
+
+                    continue;
+                }
+
+                // If the class is null, it means the dependency is a string or some other
+                // primitive type which we can not resolve since it is not a class and
+                // we will just bomb out with an error since we have no-where to go.
+                $result = is_null(Util::getParameterClassName($dependency))
+                    ? $this->resolvePrimitive($dependency)
+                    : $this->resolveClass($dependency, $existingDependencies);
+
+                if ($dependency->isVariadic()) {
+                    $results = array_merge($results, $result);
+                } else {
+                    $results[] = $result;
+                }
             }
         }
 
@@ -1056,16 +1070,17 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve a class based dependency from the container.
      *
      * @param  \ReflectionParameter  $parameter
+     * @param  array  $existingDependencies
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function resolveClass(ReflectionParameter $parameter)
+    protected function resolveClass(ReflectionParameter $parameter, array $existingDependencies = [])
     {
         try {
             return $parameter->isVariadic()
                         ? $this->resolveVariadicClass($parameter)
-                        : $this->make(Util::getParameterClassName($parameter));
+                        : $this->make(Util::getParameterClassName($parameter), [], $existingDependencies);
         }
 
         // If we can not resolve the class instance, we will check to see if the value

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -960,8 +960,8 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve all of the dependencies from the ReflectionParameters.
      *
-     * @param  \ReflectionParameter[] $dependencies
-     * @param  array $existingDependencies
+     * @param  \ReflectionParameter[]  $dependencies
+     * @param  array  $existingDependencies
      * @return array
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
@@ -972,13 +972,14 @@ class Container implements ArrayAccess, ContainerContract
         $results = [];
 
         foreach ($dependencies as $dependency) {
-            $dependencyName = Util::getParameterClassName($dependency);
+            $dependencyClassName = Util::getParameterClassName($dependency);
+            $dependencyName = $dependency->getName();
             // Check if the dependency has already been injected
-            if (in_array($dependencyName, $existingDependencies)) {
-                throw new CircularDependencyException(sprintf('Circular dependency detected in class %s', end($existingDependencies)));
+            if (isset($existingDependencies[$dependencyClassName])) {
+                throw new CircularDependencyException(sprintf('Circular dependency detected in class %s', $dependencyClassName));
             } else {
-                if (! is_null($dependencyName)) {
-                    $existingDependencies[] = $dependencyName;
+                if (! is_null($dependencyClassName)) {
+                    $existingDependencies[$dependencyClassName] = $dependencyName;
                 }
                 // If the dependency has an override for this particular build we will use
                 // that instead as the value. Otherwise, we will continue with this run

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -909,13 +909,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @param  string  $abstract
      * @param  array  $parameters
+     * @param  array  $abstractDependencies
      * @return mixed
      */
-    public function make($abstract, array $parameters = [])
+    public function make($abstract, array $parameters = [], array $abstractDependencies = [])
     {
         $this->loadDeferredProviderIfNeeded($abstract = $this->getAlias($abstract));
 
-        return parent::make($abstract, $parameters);
+        return parent::make($abstract, $parameters, $abstractDependencies);
     }
 
     /**
@@ -924,13 +925,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  string  $abstract
      * @param  array  $parameters
      * @param  bool  $raiseEvents
+     * @param  array  $abstractDependencies
      * @return mixed
      */
-    protected function resolve($abstract, $parameters = [], $raiseEvents = true)
+    protected function resolve($abstract, $parameters = [], $raiseEvents = true, $abstractDependencies = [])
     {
         $this->loadDeferredProviderIfNeeded($abstract = $this->getAlias($abstract));
 
-        return parent::resolve($abstract, $parameters, $raiseEvents);
+        return parent::resolve($abstract, $parameters, $raiseEvents, $abstractDependencies);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Container;
 use Illuminate\Container\Container;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\CircularDependencyException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use stdClass;
@@ -680,13 +681,22 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationStub::class, $result);
     }
 
-    // public function testContainerCanCatchCircularDependency()
-    // {
-    //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
+     public function testContainerCanCatchCircularDependency()
+     {
+         $this->expectException(CircularDependencyException::class);
 
-    //     $container = new Container;
-    //     $container->get(CircularAStub::class);
-    // }
+         $container = new Container;
+         $container->get(CircularAStub::class);
+     }
+
+    public function testCircularDependencyExceptionMessage()
+    {
+        $this->expectException(CircularDependencyException::class);
+        $this->expectExceptionMessage('Circular dependency detected in class Illuminate\Tests\Container\CircularCStub');
+
+        $container = new Container;
+        $container->make(CircularCStub::class);
+    }
 }
 
 class CircularAStub

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -692,7 +692,7 @@ class ContainerTest extends TestCase
     public function testCircularDependencyExceptionMessage()
     {
         $this->expectException(CircularDependencyException::class);
-        $this->expectExceptionMessage('Circular dependency detected in class Illuminate\Tests\Container\CircularCStub');
+        $this->expectExceptionMessage('Circular dependency detected in class Illuminate\Tests\Container\CircularAStub');
 
         $container = new Container;
         $container->make(CircularCStub::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**This PR is to handle circular dependency exception. It also prevents memory leak issue on dev machine**

                                            Current Situation

 When you have objects in your code that are directly dependent on each other, and are injected via constructor, the final result is SERVER ERROR, because of the infinite loop. This also leads to memory leak in the application.

 **Example** 

AuthController injects AuthService
<img width="631" alt="Screenshot 2023-05-29 at 3 28 43 AM" src="https://github.com/laravel/framework/assets/6876434/ac178d74-5ca7-46c9-b845-60aead6628e9">


AuthService injects AuthController
<img width="649" alt="Screenshot 2023-05-29 at 3 28 21 AM" src="https://github.com/laravel/framework/assets/6876434/384a3441-95b5-411a-b075-04c5737ed6b6">



The error output in dev machine console: 

<img width="1008" alt="Screenshot 2023-05-28 at 2 32 12 AM" src="https://github.com/laravel/framework/assets/6876434/69373e16-10bb-485d-8755-b37235f5a211">




                                          After the Fix

The exception is rightly handled, also the developer knows to refactor the code.

![Screenshot 2023-05-29 at 3 29 53 AM](https://github.com/laravel/framework/assets/6876434/c3b9995a-8269-4475-905c-ae3f3ec640ab)






