### PR TITLE
[10.x] Add missing methods to `AssertsStatusCodes`

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -72,6 +72,36 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 304 "Not Modified" status code.
+     *
+     * @return $this
+     */
+    public function assertNotModified()
+    {
+        return $this->assertStatus(304);
+    }
+
+    /**
+     * Assert that the response has a 307 "Temporary Redirect" status code.
+     *
+     * @return $this
+     */
+    public function assertTemporaryRedirect()
+    {
+        return $this->assertStatus(307);
+    }
+
+    /**
+     * Assert that the response has a 308 "Permanent Redirect" status code.
+     *
+     * @return $this
+     */
+    public function assertPermanentRedirect()
+    {
+        return $this->assertStatus(308);
+    }
+
+    /**
      * Assert that the response has a 400 "Bad Request" status code.
      *
      * @return $this
@@ -129,6 +159,16 @@ trait AssertsStatusCodes
     public function assertMethodNotAllowed()
     {
         return $this->assertStatus(405);
+    }
+
+    /**
+     * Assert that the response has a 406 "Not Acceptable" status code.
+     *
+     * @return $this
+     */
+    public function assertNotAcceptable()
+    {
+        return $this->assertStatus(406);
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -579,6 +579,25 @@ class TestResponseTest extends TestCase
         $response->assertMethodNotAllowed();
     }
 
+    public function testAssertNotAcceptable()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_NOT_ACCEPTABLE)
+        );
+
+        $response->assertNotAcceptable();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [406] but received 200.\nFailed asserting that 406 is identical to 200.");
+
+        $response->assertNotAcceptable();
+        $this->fail();
+    }
+
     public function testAssertForbidden()
     {
         $statusCode = 500;
@@ -703,6 +722,63 @@ class TestResponseTest extends TestCase
         $this->expectExceptionMessage("Expected response status code [302] but received 200.\nFailed asserting that 302 is identical to 200.");
 
         $response->assertFound();
+        $this->fail();
+    }
+
+    public function testAssertNotModified()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_NOT_MODIFIED)
+        );
+
+        $response->assertNotModified();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [304] but received 200.\nFailed asserting that 304 is identical to 200.");
+
+        $response->assertNotModified();
+        $this->fail();
+    }
+
+    public function testAssertTemporaryRedirect()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_TEMPORARY_REDIRECT)
+        );
+
+        $response->assertTemporaryRedirect();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [307] but received 200.\nFailed asserting that 307 is identical to 200.");
+
+        $response->assertTemporaryRedirect();
+        $this->fail();
+    }
+
+    public function testAssertPermanentRedirect()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_PERMANENTLY_REDIRECT)
+        );
+
+        $response->assertPermanentRedirect();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [308] but received 200.\nFailed asserting that 308 is identical to 200.");
+
+        $response->assertPermanentRedirect();
         $this->fail();
     }
 


### PR DESCRIPTION
Adds missing assertion methods.