### PR TITLE
[10.x] Add increment and decrement methods to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1752,4 +1752,36 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Increases the value of a given key.
+     *
+     * @return void
+     *
+     * @throws ItemNotNumericException
+     */
+    public function increment(string $key, int $amount = 1)
+    {
+        if ($this->has($key) && !is_numeric($this->get($key))) {
+            throw ItemNotNumericException::forIncrement($key);
+        }
+
+        $this->put($key, $this->get($key) + $amount);
+    }
+
+    /**
+     * Decreases the value of a given key.
+     *
+     * @return void
+     *
+     * @throws ItemNotNumericException
+     */
+    public function decrement(string $key, int $amount = 1)
+    {
+        if ($this->has($key) && !is_numeric($this->get($key))) {
+            throw ItemNotNumericException::forDecrement($key);
+        }
+
+        $this->put($key, $this->get($key) - $amount);
+    }
 }

--- a/src/Illuminate/Collections/ItemNotNumericException.php
+++ b/src/Illuminate/Collections/ItemNotNumericException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Support;
+
+use InvalidArgumentException;
+
+class ItemNotNumericException extends InvalidArgumentException
+{
+    public static function forIncrement(string $key)
+    {
+        return new static("Cannot increment non-numeric collection item: {$key}!");
+    }
+
+    public static function forDecrement(string $key)
+    {
+        return new static("Cannot decrement non-numeric collection item: {$key}!");
+    }
+}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\ItemNotFoundException;
+use Illuminate\Support\ItemNotNumericException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
 use Illuminate\Support\Str;
@@ -5563,6 +5564,48 @@ class SupportCollectionTest extends TestCase
             'foo.1' => 'baz',
             'foo.baz' => 'boom',
         ], $data->all());
+    }
+
+    public function testIncrement()
+    {
+        $c = new Collection([
+            'total' => 0,
+            'is_test' => true,
+        ]);
+
+        $c->increment('total');
+        $this->assertSame(1, $c->get('total'));
+
+        $c->increment('total', 10);
+        $this->assertSame(11, $c->get('total'));
+
+        // It's also possible to introduce a new item...
+        $c->increment('overall', 1);
+        $this->assertSame(1, $c->get('overall'));
+
+        $this->expectException(ItemNotNumericException::class);
+        $c->increment('is_test', 10);
+    }
+
+    public function testDecrement()
+    {
+        $c = new Collection([
+            'total' => 0,
+            'is_test' => true,
+        ]);
+
+        $c->decrement('total');
+        $this->assertSame(-1, $c->get('total'));
+
+        $c->decrement('total', 10);
+        $this->assertSame(-11, $c->get('total'));
+
+        // It's also possible to introduce a new item...
+        $c->decrement('overall', 1);
+        $this->assertSame(-1, $c->get('overall'));
+
+        $this->expectException(ItemNotNumericException::class);
+        $c->decrement('is_test', 10);
     }
 
     /**


### PR DESCRIPTION
Increasing and decreasing a value in a Laravel Collection is kind of a pain and exhausting.

Now instead of doing this:
```php
$collection = collect(['total' => 0]);
$collection->put('total', $collection->get('total') + 1);
```

We can do this:
```php
$collection = collect(['total' => 0]);
$collection->increment('total');
```

The same works for `decrement`.