### PR TITLE
[10.x] Sub-minute Scheduling

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -166,6 +166,8 @@ class Event
     /**
      * The start time of the last event run.
      *
+     * Utilized by sub-minute repeated events.
+     *
      * @var \Illuminate\Support\Carbon|null
      */
     public $lastRun;
@@ -238,11 +240,11 @@ class Event
     }
 
     /**
-     * Determine if the event should repeat.
+     * Determine if the event has been configured to repeat multiple times per minute.
      *
      * @return bool
      */
-    public function shouldRepeat()
+    public function isRepeatable()
     {
         return ! is_null($this->repeatSeconds);
     }
@@ -254,7 +256,7 @@ class Event
      */
     public function shouldRepeatNow()
     {
-        return $this->shouldRepeat()
+        return $this->isRepeatable()
             && $this->lastRun
             && Date::now()->diffInSeconds($this->lastRun) >= $this->repeatSeconds;
     }

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Support\Carbon;
+use InvalidArgumentException;
 
 trait ManagesFrequencies
 {
@@ -67,6 +68,93 @@ trait ManagesFrequencies
         }
 
         return fn () => $now->between($startTime, $endTime);
+    }
+
+    /**
+     * Schedule the event to run every second.
+     *
+     * @return $this
+     */
+    public function everySecond()
+    {
+        return $this->repeatEvery(1);
+    }
+
+    /**
+     * Schedule the event to run every two seconds.
+     *
+     * @return $this
+     */
+    public function everyTwoSeconds()
+    {
+        return $this->repeatEvery(2);
+    }
+
+    /**
+     * Schedule the event to run every five seconds.
+     *
+     * @return $this
+     */
+    public function everyFiveSeconds()
+    {
+        return $this->repeatEvery(5);
+    }
+
+    /**
+     * Schedule the event to run every ten seconds.
+     *
+     * @return $this
+     */
+    public function everyTenSeconds()
+    {
+        return $this->repeatEvery(10);
+    }
+
+    /**
+     * Schedule the event to run every fifteen seconds.
+     *
+     * @return $this
+     */
+    public function everyFifteenSeconds()
+    {
+        return $this->repeatEvery(15);
+    }
+
+    /**
+     * Schedule the event to run every twenty seconds.
+     *
+     * @return $this
+     */
+    public function everyTwentySeconds()
+    {
+        return $this->repeatEvery(20);
+    }
+
+    /**
+     * Schedule the event to run every thirty seconds.
+     *
+     * @return $this
+     */
+    public function everyThirtySeconds()
+    {
+        return $this->repeatEvery(30);
+    }
+
+    /**
+     * Schedule the event to run multiple times per minute.
+     *
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function repeatEvery($seconds)
+    {
+        if (60 % $seconds !== 0) {
+            throw new InvalidArgumentException("The seconds [$seconds] are not evenly divisible by 60.");
+        }
+
+        $this->repeatSeconds = $seconds;
+
+        return $this->everyMinute();
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -146,7 +146,7 @@ trait ManagesFrequencies
      * @param  int  $seconds
      * @return $this
      */
-    public function repeatEvery($seconds)
+    protected function repeatEvery($seconds)
     {
         if (60 % $seconds !== 0) {
             throw new InvalidArgumentException("The seconds [$seconds] are not evenly divisible by 60.");

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -71,6 +71,13 @@ class Schedule
     protected $dispatcher;
 
     /**
+     * The cache of mutex results.
+     *
+     * @var array<string, bool>
+     */
+    protected $mutexCache = [];
+
+    /**
      * Create a new schedule instance.
      *
      * @param  \DateTimeZone|string|null  $timezone
@@ -299,7 +306,7 @@ class Schedule
      */
     public function serverShouldRun(Event $event, DateTimeInterface $time)
     {
-        return $this->schedulingMutex->create($event, $time);
+        return $this->mutexCache[$event->mutexName()] ??= $this->schedulingMutex->create($event, $time);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleInterruptCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleInterruptCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\Facades\Date;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'schedule:interrupt')]
+class ScheduleInterruptCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:interrupt';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Interrupt the current schedule run';
+
+    /**
+     * The cache store implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * Create a new schedule interrupt command.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @return void
+     */
+    public function __construct(Cache $cache)
+    {
+        parent::__construct();
+
+        $this->cache = $cache;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->cache->put('illuminate:schedule:interrupt', true, Date::now()->endOfMinute());
+
+        $this->components->info('Broadcasting schedule interrupt signal.');
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -99,16 +99,16 @@ class ScheduleRunCommand extends Command
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
      * @return void
      */
-    public function handle(Schedule $schedule, Dispatcher $dispatcher, ExceptionHandler $handler, Cache $cache)
+    public function handle(Schedule $schedule, Dispatcher $dispatcher, Cache $cache, ExceptionHandler $handler)
     {
         $this->schedule = $schedule;
         $this->dispatcher = $dispatcher;
-        $this->handler = $handler;
         $this->cache = $cache;
+        $this->handler = $handler;
         $this->phpBinary = Application::phpBinary();
 
         $this->clearInterruptSignal();
@@ -133,8 +133,8 @@ class ScheduleRunCommand extends Command
             $this->eventsRan = true;
         }
 
-        if ($events->contains->shouldRepeat()) {
-            $this->repeatEvents($events->filter->shouldRepeat());
+        if ($events->contains->isRepeatable()) {
+            $this->repeatEvents($events->filter->isRepeatable());
         }
 
         if (! $this->eventsRan) {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -229,27 +229,29 @@ class ScheduleRunCommand extends Command
                     return;
                 }
 
-                if ($event->shouldRepeatNow()) {
-                    $hasEnteredMaintenanceMode = $hasEnteredMaintenanceMode || $this->laravel->isDownForMaintenance();
-
-                    if ($hasEnteredMaintenanceMode && ! $event->runsInMaintenanceMode()) {
-                        continue;
-                    }
-
-                    if (! $event->filtersPass($this->laravel)) {
-                        $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
-
-                        continue;
-                    }
-
-                    if ($event->onOneServer) {
-                        $this->runSingleServerEvent($event);
-                    } else {
-                        $this->runEvent($event);
-                    }
-
-                    $this->eventsRan = true;
+                if (! $event->shouldRepeatNow()) {
+                    continue;
                 }
+
+                $hasEnteredMaintenanceMode = $hasEnteredMaintenanceMode || $this->laravel->isDownForMaintenance();
+
+                if ($hasEnteredMaintenanceMode && ! $event->runsInMaintenanceMode()) {
+                    continue;
+                }
+
+                if (! $event->filtersPass($this->laravel)) {
+                    $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
+
+                    continue;
+                }
+
+                if ($event->onOneServer) {
+                    $this->runSingleServerEvent($event);
+                } else {
+                    $this->runEvent($event);
+                }
+
+                $this->eventsRan = true;
             }
 
             Sleep::usleep(100000);

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Cache\Console\PruneStaleTagsCommand;
 use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
+use Illuminate\Console\Scheduling\ScheduleInterruptCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Console\Scheduling\ScheduleTestCommand;
@@ -151,6 +152,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleClearCache' => ScheduleClearCacheCommand::class,
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
+        'ScheduleInterrupt' => ScheduleInterruptCommand::class,
         'ShowModel' => ShowModelCommand::class,
         'StorageLink' => StorageLinkCommand::class,
         'Up' => UpCommand::class,

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -56,11 +56,14 @@ class SendQueuedMailable
     public function __construct(MailableContract $mailable)
     {
         $this->mailable = $mailable;
-        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
-        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
-        $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
+
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
+        $this->connection = property_exists($mailable, 'connection') ? $mailable->connection : null;
+        $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
+        $this->queue = property_exists($mailable, 'queue') ? $mailable->queue : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
+        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
+        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
     }
 
     /**

--- a/tests/Integration/Console/CommandSchedulingTest.php
+++ b/tests/Integration/Console/CommandSchedulingTest.php
@@ -67,7 +67,8 @@ class CommandSchedulingTest extends TestCase
      */
     public function testExecutionOrder($background, $expected)
     {
-        $event = $this->app->make(Schedule::class)
+        $schedule = $this->app->make(Schedule::class);
+        $event = $schedule
             ->command("test:{$this->id}")
             ->onOneServer()
             ->after(function () {
@@ -82,8 +83,11 @@ class CommandSchedulingTest extends TestCase
         }
 
         // We'll trigger the scheduler three times to simulate multiple servers
+        $this->app->instance(Schedule::class, clone $schedule);
         $this->artisan('schedule:run');
+        $this->app->instance(Schedule::class, clone $schedule);
         $this->artisan('schedule:run');
+        $this->app->instance(Schedule::class, clone $schedule);
         $this->artisan('schedule:run');
 
         if ($background) {

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -90,9 +90,9 @@ class SubMinuteSchedulingTest extends TestCase
 
     public function test_sub_minute_scheduling_can_be_interrupted()
     {
-        $everySecondRuns = 0;
-        $this->schedule->call(function () use (&$everySecondRuns) {
-            $everySecondRuns++;
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
         })->everySecond();
 
         Carbon::setTestNow(now()->startOfMinute());
@@ -111,15 +111,15 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(300);
-        $this->assertEquals(30, $everySecondRuns);
+        $this->assertEquals(30, $runs);
         $this->assertEquals(30, $startedAt->diffInSeconds(now()));
     }
 
     public function test_sub_minute_events_stop_for_the_rest_of_the_minute_once_maintenance_mode_is_enabled()
     {
-        $everySecondRuns = 0;
-        $this->schedule->call(function () use (&$everySecondRuns) {
-            $everySecondRuns++;
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
         })->everySecond();
 
         Config::set('app.maintenance.driver', 'cache');
@@ -143,14 +143,14 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(30, $everySecondRuns);
+        $this->assertEquals(30, $runs);
     }
 
     public function test_sub_minute_events_can_be_run_in_maintenance_mode()
     {
-        $everySecondRuns = 0;
-        $this->schedule->call(function () use (&$everySecondRuns) {
-            $everySecondRuns++;
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
         })->everySecond()->evenInMaintenanceMode();
 
         Config::set('app.maintenance.driver', 'cache');
@@ -170,14 +170,14 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(60, $everySecondRuns);
+        $this->assertEquals(60, $runs);
     }
 
     public function test_sub_minute_scheduling_respects_filters()
     {
-        $everySecondRuns = 0;
-        $this->schedule->call(function () use (&$everySecondRuns) {
-            $everySecondRuns++;
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
         })->everySecond()->when(fn () => now()->second % 2 === 0);
 
         Carbon::setTestNow(now()->startOfMinute());
@@ -188,14 +188,14 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [Callback]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(30, $everySecondRuns);
+        $this->assertEquals(30, $runs);
     }
 
     public function test_sub_minute_scheduling_can_run_on_one_server()
     {
-        $everySecondRuns = 0;
-        $this->schedule->call(function () use (&$everySecondRuns) {
-            $everySecondRuns++;
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
         })->everySecond()->name('test')->onOneServer();
 
         $startedAt = now()->startOfMinute();
@@ -208,7 +208,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Running [test]');
 
         Sleep::assertSleptTimes(600);
-        $this->assertEquals(60, $everySecondRuns);
+        $this->assertEquals(60, $runs);
 
         // Fake a second server running at the same minute.
         Carbon::setTestNow($startedAt);
@@ -218,7 +218,7 @@ class SubMinuteSchedulingTest extends TestCase
             ->expectsOutputToContain('Skipping [test]');
 
         Sleep::assertSleptTimes(1200);
-        $this->assertEquals(60, $everySecondRuns);
+        $this->assertEquals(60, $runs);
     }
 
     public static function frequencyProvider()

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Sleep;
+use Orchestra\Testbench\TestCase;
+
+class SubMinuteSchedulingTest extends TestCase
+{
+    protected Schedule $schedule;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->schedule = $this->app->make(Schedule::class);
+    }
+
+    public function test_it_doesnt_wait_for_sub_minute_events_when_nothing_is_scheduled()
+    {
+        Carbon::setTestNow(now()->startOfMinute());
+        Sleep::fake();
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('No scheduled commands are ready to run.');
+
+        Sleep::assertNeverSlept();
+    }
+
+    public function test_it_doesnt_wait_for_sub_minute_events_when_none_are_scheduled()
+    {
+        $this->schedule
+            ->call(fn () => true)
+            ->everyMinute();
+
+        Carbon::setTestNow(now()->startOfMinute());
+        Sleep::fake();
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertNeverSlept();
+    }
+
+    /** @dataProvider frequencyProvider */
+    public function test_it_runs_sub_minute_callbacks($frequency, $expectedRuns)
+    {
+        $runs = 0;
+        $this->schedule->call(function () use (&$runs) {
+            $runs++;
+        })->{$frequency}();
+
+        Carbon::setTestNow(now()->startOfMinute());
+        Sleep::fake();
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals($expectedRuns, $runs);
+    }
+
+    public function test_it_runs_multiple_sub_minute_callbacks()
+    {
+        $everySecondRuns = 0;
+        $this->schedule->call(function () use (&$everySecondRuns) {
+            $everySecondRuns++;
+        })->everySecond();
+
+        $everyThirtySecondsRuns = 0;
+        $this->schedule->call(function () use (&$everyThirtySecondsRuns) {
+            $everyThirtySecondsRuns++;
+        })->everyThirtySeconds();
+
+        Carbon::setTestNow(now()->startOfMinute());
+        Sleep::fake();
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(60, $everySecondRuns);
+        $this->assertEquals(2, $everyThirtySecondsRuns);
+    }
+
+    public function test_sub_minute_scheduling_can_be_interrupted()
+    {
+        $everySecondRuns = 0;
+        $this->schedule->call(function () use (&$everySecondRuns) {
+            $everySecondRuns++;
+        })->everySecond();
+
+        Carbon::setTestNow(now()->startOfMinute());
+        $startedAt = now();
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
+            Carbon::setTestNow(now()->add($duration));
+
+            if (now()->diffInSeconds($startedAt) >= 30) {
+                $this->artisan('schedule:interrupt')
+                    ->expectsOutputToContain('Broadcasting schedule interrupt signal.');
+            }
+        });
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(300);
+        $this->assertEquals(30, $everySecondRuns);
+        $this->assertEquals(30, $startedAt->diffInSeconds(now()));
+    }
+
+    public function test_sub_minute_events_stop_for_the_rest_of_the_minute_once_maintenance_mode_is_enabled()
+    {
+        $everySecondRuns = 0;
+        $this->schedule->call(function () use (&$everySecondRuns) {
+            $everySecondRuns++;
+        })->everySecond();
+
+        Config::set('app.maintenance.driver', 'cache');
+        Config::set('app.maintenance.store', 'array');
+        Carbon::setTestNow(now()->startOfMinute());
+        $startedAt = now();
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
+            Carbon::setTestNow(now()->add($duration));
+
+            if (now()->diffInSeconds($startedAt) >= 30 && ! $this->app->isDownForMaintenance()) {
+                $this->artisan('down');
+            }
+
+            if (now()->diffInSeconds($startedAt) >= 40 && $this->app->isDownForMaintenance()) {
+                $this->artisan('up');
+            }
+        });
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(30, $everySecondRuns);
+    }
+
+    public function test_sub_minute_events_can_be_run_in_maintenance_mode()
+    {
+        $everySecondRuns = 0;
+        $this->schedule->call(function () use (&$everySecondRuns) {
+            $everySecondRuns++;
+        })->everySecond()->evenInMaintenanceMode();
+
+        Config::set('app.maintenance.driver', 'cache');
+        Config::set('app.maintenance.store', 'array');
+        Carbon::setTestNow(now()->startOfMinute());
+        $startedAt = now();
+        Sleep::fake();
+        Sleep::whenFakingSleep(function ($duration) use ($startedAt) {
+            Carbon::setTestNow(now()->add($duration));
+
+            if (now()->diffInSeconds($startedAt) >= 30 && ! $this->app->isDownForMaintenance()) {
+                $this->artisan('down');
+            }
+        });
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(60, $everySecondRuns);
+    }
+
+    public function test_sub_minute_scheduling_respects_filters()
+    {
+        $everySecondRuns = 0;
+        $this->schedule->call(function () use (&$everySecondRuns) {
+            $everySecondRuns++;
+        })->everySecond()->when(fn () => now()->second % 2 === 0);
+
+        Carbon::setTestNow(now()->startOfMinute());
+        Sleep::fake();
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [Callback]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(30, $everySecondRuns);
+    }
+
+    public function test_sub_minute_scheduling_can_run_on_one_server()
+    {
+        $everySecondRuns = 0;
+        $this->schedule->call(function () use (&$everySecondRuns) {
+            $everySecondRuns++;
+        })->everySecond()->name('test')->onOneServer();
+
+        $startedAt = now()->startOfMinute();
+        Carbon::setTestNow($startedAt);
+        Sleep::fake();
+        Sleep::whenFakingSleep(fn ($duration) => Carbon::setTestNow(now()->add($duration)));
+
+        $this->app->instance(Schedule::class, clone $this->schedule);
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Running [test]');
+
+        Sleep::assertSleptTimes(600);
+        $this->assertEquals(60, $everySecondRuns);
+
+        // Fake a second server running at the same minute.
+        Carbon::setTestNow($startedAt);
+
+        $this->app->instance(Schedule::class, clone $this->schedule);
+        $this->artisan('schedule:run')
+            ->expectsOutputToContain('Skipping [test]');
+
+        Sleep::assertSleptTimes(1200);
+        $this->assertEquals(60, $everySecondRuns);
+    }
+
+    public static function frequencyProvider()
+    {
+        return [
+            'everySecond' => ['everySecond', 60],
+            'everyTwoSeconds' => ['everyTwoSeconds', 30],
+            'everyFiveSeconds' => ['everyFiveSeconds', 12],
+            'everyTenSeconds' => ['everyTenSeconds', 6],
+            'everyFifteenSeconds' => ['everyFifteenSeconds', 4],
+            'everyTwentySeconds' => ['everyTwentySeconds', 3],
+            'everyThirtySeconds' => ['everyThirtySeconds', 2],
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to schedule tasks with a sub-minute frequencies.

### Example

```php
$schedule->job(new UpdateLeaderboard)->everyFiveSeconds();
```

The new frequency options are:

* `everySecond`
* `everyTwoSeconds`
* `everyFiveSeconds`
* `everyTenSeconds`
* `everyFifteenSeconds`
* `everyTwentySeconds`
* `everyThirtySeconds`

### How it works

The `schedule:run` Artisan command has been modified to continue running until the end of the minute when the current minute has events with sub-minute frequency.

![image](https://github.com/laravel/framework/assets/4977161/b082d94c-b830-4ede-a1db-7c0b0651253b)

### Caveats

1. It's possible for slow-running tasks to prevent subsequent tasks from starting on time. This can be avoided by ensuring slow tasks run in the background or are queued.
2. The sub-minute frequency must be evenly divisible into 60 seconds because every minute is effectively a clean slate. Each task will be run at the start of the minute regardless of when it was last run in the previous minute. This also means it's possible for a task to repeat faster than the configured time if the task was delayed in the previous minute.
3. If a task is configured to only run on one server, each occurrence for the minute will run on the same server.
4. ~~If a condition (e.g. using the `when` method) prevents a sub-minute task from running at the beginning of a minute, it won't be run at all during that minute.~~ Solved!
5. If maintenance mode prevents a task from running at any time during the minute, the task will not be run for the remainder of the minute, even if maintenance mode is disabled. This ensures that the task will be run with a fresh application instance after maintenance mode has been re-enabled. Note that it is possible for maintenance mode to be enabled and then disabled while a long-running foreground task is also running, in which case the `schedule:run` command won't know this occurred and will continue processing tasks. The `schedule:interrupt` command can be used in these scenarios to ensure no further jobs are processed for the current minute, but will include those configured to run in maintenance mode.

### Interrupting the execution (e.g. when deploying new code)

The `schedule:run` command is typically called by your system's cron daemon. When deploying new code, you may need to interrupt the currently-running command. This can be done with the `schedule:interrupt` command:

```sh
php artisan schedule:interrupt
```

This works similarly to the `queue:restart` command, which uses the cache to pass a signal value to the running process that will be checked on the next loop. The schedule will continue when your cron daemon next calls `schedule:run`.

I went with "interrupt" over "restart" or "stop" because neither felt quite right with the way the command will be stopped and then *potentially* started again in the next minute.