### PR TITLE
[10.x] Refactor `HasUuids` and `HasUlids` traits to use a common `ResolveRouteBinding` trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 trait HasUlids
 {
+    use ResolveRouteBinding;
+
     /**
      * Initialize the trait.
      *
@@ -35,29 +37,6 @@ trait HasUlids
     public function newUniqueId()
     {
         return strtolower((string) Str::ulid());
-    }
-
-    /**
-     * Retrieve the model for a bound value.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function resolveRouteBindingQuery($query, $value, $field = null)
-    {
-        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        return parent::resolveRouteBindingQuery($query, $value, $field);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 
 trait HasUlids

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 trait HasUuids
 {
+    use ResolveRouteBinding;
+
     /**
      * Initialize the trait.
      *
@@ -35,29 +37,6 @@ trait HasUuids
     public function newUniqueId()
     {
         return (string) Str::orderedUuid();
-    }
-
-    /**
-     * Retrieve the model for a bound value.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public function resolveRouteBindingQuery($query, $value, $field = null)
-    {
-        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        return parent::resolveRouteBindingQuery($query, $value, $field);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 
 trait HasUuids

--- a/src/Illuminate/Database/Eloquent/Concerns/ResolveRouteBinding.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/ResolveRouteBinding.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Database\Eloquent\Concerns;
+
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/ResolveRouteBinding.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/ResolveRouteBinding.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
+
+trait ResolveRouteBinding
+{
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function resolveRouteBindingQuery($query, $value, $field = null)
+    {
+        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUlid($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        }
+
+        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        }
+
+        return parent::resolveRouteBindingQuery($query, $value, $field);
+    }
+}


### PR DESCRIPTION
This PR includes the `ResolveRouteBinding` trait to avoid code duplication and removes the duplicate `resolveRouteBindingQuery` methods in the `HasUuids` and `HasUlids` traits.
