### PR TITLE
[11.x] Prefix Rate Limiter cache key

### DIFF
--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static void clear(string $key)
  * @method static int availableIn(string $key)
  * @method static string cleanRateLimiterKey(string $key)
+ * @method static string getKey(string $key)
  *
  * @see \Illuminate\Cache\RateLimiter
  */

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -17,8 +17,8 @@ class CacheRateLimiterTest extends TestCase
     public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(1);
-        $cache->shouldReceive('has')->once()->with('key:timer')->andReturn(true);
+        $cache->shouldReceive('get')->once()->with('laravel_rate_limiter:key', 0)->andReturn(1);
+        $cache->shouldReceive('has')->once()->with('laravel_rate_limiter:key:timer')->andReturn(true);
         $cache->shouldReceive('add')->never();
         $rateLimiter = new RateLimiter($cache);
 
@@ -28,9 +28,9 @@ class CacheRateLimiterTest extends TestCase
     public function testHitProperlyIncrementsAttemptCount()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
-        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(true);
-        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
+        $cache->shouldReceive('add')->once()->with('laravel_rate_limiter:key:timer', m::type('int'), 1)->andReturn(true);
+        $cache->shouldReceive('add')->once()->with('laravel_rate_limiter:key', 0, 1)->andReturn(true);
+        $cache->shouldReceive('increment')->once()->with('laravel_rate_limiter:key')->andReturn(1);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
@@ -39,10 +39,10 @@ class CacheRateLimiterTest extends TestCase
     public function testHitHasNoMemoryLeak()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
-        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(false);
-        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
-        $cache->shouldReceive('put')->once()->with('key', 1, 1);
+        $cache->shouldReceive('add')->once()->with('laravel_rate_limiter:key:timer', m::type('int'), 1)->andReturn(true);
+        $cache->shouldReceive('add')->once()->with('laravel_rate_limiter:key', 0, 1)->andReturn(false);
+        $cache->shouldReceive('increment')->once()->with('laravel_rate_limiter:key')->andReturn(1);
+        $cache->shouldReceive('put')->once()->with('laravel_rate_limiter:key', 1, 1);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
@@ -51,7 +51,7 @@ class CacheRateLimiterTest extends TestCase
     public function testRetriesLeftReturnsCorrectCount()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(3);
+        $cache->shouldReceive('get')->once()->with('laravel_rate_limiter:key', 0)->andReturn(3);
         $rateLimiter = new RateLimiter($cache);
 
         $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
@@ -60,8 +60,8 @@ class CacheRateLimiterTest extends TestCase
     public function testClearClearsTheCacheKeys()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('forget')->once()->with('key');
-        $cache->shouldReceive('forget')->once()->with('key:timer');
+        $cache->shouldReceive('forget')->once()->with('laravel_rate_limiter:key');
+        $cache->shouldReceive('forget')->once()->with('laravel_rate_limiter:key:timer');
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->clear('key');
@@ -80,10 +80,10 @@ class CacheRateLimiterTest extends TestCase
     public function testAttemptsCallbackReturnsTrue()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(0);
-        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1);
-        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturns(1);
-        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
+        $cache->shouldReceive('get')->once()->with('laravel_rate_limiter:key', 0)->andReturn(0);
+        $cache->shouldReceive('add')->once()->with('laravel_rate_limiter:key:timer', m::type('int'), 1);
+        $cache->shouldReceive('add')->once()->with('laravel_rate_limiter:key', 0, 1)->andReturns(1);
+        $cache->shouldReceive('increment')->once()->with('laravel_rate_limiter:key')->andReturn(1);
 
         $executed = false;
 
@@ -98,10 +98,10 @@ class CacheRateLimiterTest extends TestCase
     public function testAttemptsCallbackReturnsCallbackReturn()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->times(6)->with('key', 0)->andReturn(0);
-        $cache->shouldReceive('add')->times(6)->with('key:timer', m::type('int'), 1);
-        $cache->shouldReceive('add')->times(6)->with('key', 0, 1)->andReturns(1);
-        $cache->shouldReceive('increment')->times(6)->with('key')->andReturn(1);
+        $cache->shouldReceive('get')->times(6)->with('laravel_rate_limiter:key', 0)->andReturn(0);
+        $cache->shouldReceive('add')->times(6)->with('laravel_rate_limiter:key:timer', m::type('int'), 1);
+        $cache->shouldReceive('add')->times(6)->with('laravel_rate_limiter:key', 0, 1)->andReturns(1);
+        $cache->shouldReceive('increment')->times(6)->with('laravel_rate_limiter:key')->andReturn(1);
 
         $rateLimiter = new RateLimiter($cache);
 
@@ -133,8 +133,8 @@ class CacheRateLimiterTest extends TestCase
     public function testAttemptsCallbackReturnsFalse()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(2);
-        $cache->shouldReceive('has')->once()->with('key:timer')->andReturn(true);
+        $cache->shouldReceive('get')->once()->with('laravel_rate_limiter:key', 0)->andReturn(2);
+        $cache->shouldReceive('has')->once()->with('laravel_rate_limiter:key:timer')->andReturn(true);
 
         $executed = false;
 
@@ -149,8 +149,8 @@ class CacheRateLimiterTest extends TestCase
     public function testKeysAreSanitizedFromUnicodeCharacters()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('john', 0)->andReturn(1);
-        $cache->shouldReceive('has')->once()->with('john:timer')->andReturn(true);
+        $cache->shouldReceive('get')->once()->with('laravel_rate_limiter:john', 0)->andReturn(1);
+        $cache->shouldReceive('has')->once()->with('laravel_rate_limiter:john:timer')->andReturn(true);
         $cache->shouldReceive('add')->never();
         $rateLimiter = new RateLimiter($cache);
 
@@ -163,10 +163,10 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter = new RateLimiter($cache);
 
         $key = "john'doe";
-        $cleanedKey = $rateLimiter->cleanRateLimiterKey($key);
+        $cleanedAndPrefixedKey = 'laravel_rate_limiter:'.$rateLimiter->cleanRateLimiterKey($key);
 
-        $cache->shouldReceive('get')->once()->with($cleanedKey, 0)->andReturn(1);
-        $cache->shouldReceive('has')->once()->with("$cleanedKey:timer")->andReturn(true);
+        $cache->shouldReceive('get')->once()->with($cleanedAndPrefixedKey, 0)->andReturn(1);
+        $cache->shouldReceive('has')->once()->with("$cleanedAndPrefixedKey:timer")->andReturn(true);
         $cache->shouldReceive('add')->never();
 
         $this->assertTrue($rateLimiter->tooManyAttempts($key, 1));


### PR DESCRIPTION
This PR adds a `laravel_rate_limiter:` prefix to Rate Limiter cache key, similar to the [UniqueLock](https://github.com/laravel/framework/blob/6e7c0ab8cb3f8a444dccd1e1b6302fa4c5a8a5c8/src/Illuminate/Bus/UniqueLock.php#L73) and [WithoutOverlapping](https://github.com/laravel/framework/blob/6e7c0ab8cb3f8a444dccd1e1b6302fa4c5a8a5c8/src/Illuminate/Queue/Middleware/WithoutOverlapping.php#L39) classes.

Our project has a helper method that rate limits an API call. We cache the API response so that when the rate limiter key has been hit too many times, we return the cached result. Unfortunately, we first made the mistake of using the same key for the Rate Limiter and caching. It's easy to fix, but I thought it would be nice if this problem wouldn't happen in the first place and probably save a future developer some time :)

Though unlikely, I didn't target Laravel 10 as others might have some custom code built around the key.