### PR TITLE
[10.x] Fixes missing output on `ProcessFailedException` exception

### DIFF
--- a/src/Illuminate/Process/Exceptions/ProcessFailedException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessFailedException.php
@@ -29,11 +29,11 @@ class ProcessFailedException extends RuntimeException
             $result->exitCode(),
         );
 
-        if  (! empty($result->output())) {
+        if (! empty($result->output())) {
             $error .= sprintf("\n\nOutput:\n================\n%s", $result->output());
         }
 
-        if  (! empty($result->errorOutput())) {
+        if (! empty($result->errorOutput())) {
             $error .= sprintf("\n\nError Output:\n================\n%s", $result->errorOutput());
         }
 

--- a/src/Illuminate/Process/Exceptions/ProcessFailedException.php
+++ b/src/Illuminate/Process/Exceptions/ProcessFailedException.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Process\Exceptions;
 
 use Illuminate\Contracts\Process\ProcessResult;
-use Symfony\Component\Console\Exception\RuntimeException;
+use RuntimeException;
 
 class ProcessFailedException extends RuntimeException
 {
@@ -24,9 +24,19 @@ class ProcessFailedException extends RuntimeException
     {
         $this->result = $result;
 
-        parent::__construct(
-            sprintf('The process "%s" failed.', $result->command()),
-            $result->exitCode() ?? 1,
+        $error = sprintf('The command "%s" failed.'."\n\nExit Code: %s",
+            $result->command(),
+            $result->exitCode(),
         );
+
+        if  (! empty($result->output())) {
+            $error .= sprintf("\n\nOutput:\n================\n%s", $result->output());
+        }
+
+        if  (! empty($result->errorOutput())) {
+            $error .= sprintf("\n\nError Output:\n================\n%s", $result->errorOutput());
+        }
+
+        parent::__construct($error, $result->exitCode() ?? 1);
     }
 }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -424,17 +424,129 @@ class ProcessTest extends TestCase
         $this->assertEquals("Hello World\n", $result->errorOutput());
     }
 
-    public function testRealProcessesCanThrow()
+    public function testFakeProcessesCanThrowWithoutOutput()
+    {
+        $this->expectException(ProcessFailedException::class);
+        $this->expectExceptionMessage(<<<'EOT'
+            The command "exit 1;" failed.
+
+            Exit Code: 1
+            EOT
+        );
+
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result(exitCode: 1));
+        $result = $factory->path(__DIR__)->run('exit 1;');
+
+        $result->throw();
+    }
+
+    public function testRealProcessesCanThrowWithoutOutput()
     {
         if (windows_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage('The process "echo "Hello World" >&2; exit 1;" failed.');
+        $this->expectExceptionMessage(<<<'EOT'
+            The command "exit 1;" failed.
+
+            Exit Code: 1
+            EOT
+        );
+
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run('exit 1;');
+
+        $result->throw();
+    }
+
+    public function testFakeProcessesCanThrowWithErrorOutput()
+    {
+        $this->expectException(ProcessFailedException::class);
+        $this->expectExceptionMessage(<<<'EOT'
+            The command "echo "Hello World" >&2; exit 1;" failed.
+
+            Exit Code: 1
+
+            Error Output:
+            ================
+            Hello World
+            EOT
+        );
+
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result(errorOutput: 'Hello World', exitCode: 1));
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
+
+        $result->throw();
+    }
+
+    public function testRealProcessesCanThrowWithErrorOutput()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $this->expectException(ProcessFailedException::class);
+        $this->expectExceptionMessage(<<<'EOT'
+            The command "echo "Hello World" >&2; exit 1;" failed.
+
+            Exit Code: 1
+
+            Error Output:
+            ================
+            Hello World
+            EOT
+        );
 
         $factory = new Factory;
         $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
+
+        $result->throw();
+    }
+
+    public function testFakeProcessesCanThrowWithOutput()
+    {
+        $this->expectException(ProcessFailedException::class);
+        $this->expectExceptionMessage(<<<'EOT'
+            The command "echo "Hello World" >&1; exit 1;" failed.
+
+            Exit Code: 1
+
+            Output:
+            ================
+            Hello World
+            EOT
+        );
+
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result(output: 'Hello World', exitCode: 1));
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&1; exit 1;');
+
+        $result->throw();
+    }
+
+    public function testRealProcessesCanThrowWithOutput()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $this->expectException(ProcessFailedException::class);
+        $this->expectExceptionMessage(<<<'EOT'
+            The command "echo "Hello World" >&1; exit 1;" failed.
+
+            Exit Code: 1
+
+            Output:
+            ================
+            Hello World
+            EOT
+        );
+
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&1; exit 1;');
 
         $result->throw();
     }


### PR DESCRIPTION
This pull request adds the process's output to the `ProcessFailedException`'s error message. Similar to what Symfony does to their own `ProcessFailedException` exception.

Note that, this pull request also changes the class extended by `ProcessFailedException` - as for sure, by mistake we were extending the `RuntimeException` of the console component.

Fixes: https://github.com/laravel/framework/issues/47281.