### PR TITLE
[10.x] Add test for `withTrashed` method in Routing

### DIFF
--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -136,6 +136,13 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
     }
 
+    public function testGetRouteWithTrashed()
+    {
+        $route = $this->router->get('users', [RouteRegistrarControllerStub::class, 'index'])->withTrashed();
+
+        $this->assertTrue($route->allowsTrashedBindings());
+    }
+    
     public function testCanRegisterGetRouteWithClosureAction()
     {
         $this->router->middleware('get-middleware')->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -142,7 +142,22 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertTrue($route->allowsTrashedBindings());
     }
-    
+
+    public function testResourceWithTrashed()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->only(['index', 'destroy'])
+            ->withTrashed([
+                'index',
+                'destroy',
+            ]);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertTrue($route->allowsTrashedBindings());
+        }
+    }
+
     public function testCanRegisterGetRouteWithClosureAction()
     {
         $this->router->middleware('get-middleware')->get('users', function () {


### PR DESCRIPTION
There is no tests for withTrashed method in Routing.