### PR TITLE
[10.x] Add `withQueryParameters` to the HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -345,6 +345,21 @@ class PendingRequest
     }
 
     /**
+     * Set the given query parameters in the request URI.
+     *
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function withQueryParameters(array $parameters)
+    {
+        return tap($this, function () use ($parameters) {
+            $this->options = array_merge_recursive($this->options, [
+                'query' => $parameters,
+            ]);
+        });
+    }
+
+    /**
      * Specify the request's content type.
      *
      * @param  string  $contentType
@@ -473,21 +488,6 @@ class PendingRequest
         return tap($this, function () use ($cookies, $domain) {
             $this->options = array_merge_recursive($this->options, [
                 'cookies' => CookieJar::fromArray($cookies, $domain),
-            ]);
-        });
-    }
-
-    /**
-     * Set the given query parameters in the request URI.
-     *
-     * @param  array  $parameters
-     * @return $this
-     */
-    public function withQueryParameters(array $parameters)
-    {
-        return tap($this, function () use ($parameters) {
-            $this->options = array_merge_recursive($this->options, [
-                'query' => $parameters,
             ]);
         });
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -478,6 +478,21 @@ class PendingRequest
     }
 
     /**
+     * Set the given query parameters in the request URI.
+     *
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function withQueryParameters(array $parameters)
+    {
+        return tap($this, function () use ($parameters) {
+            $this->options = array_merge_recursive($this->options, [
+                'query' => $parameters,
+            ]);
+        });
+    }
+
+    /**
      * Specify the maximum number of redirects to allow.
      *
      * @param  int  $max

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -735,6 +735,19 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testWithArrayQueryParameters()
+    {
+        $this->factory->fake();
+
+        $this->factory->withQueryParameters(
+            ['foo' => ['bar', 'baz']],
+        )->get('https://laravel.com');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'https://laravel.com?foo%5B0%5D=bar&foo%5B1%5D=baz';
+        });
+    }
+
     public function testWithQueryParametersAllowsAddingMoreOnRequest()
     {
         $this->factory->fake();
@@ -742,6 +755,23 @@ class HttpClientTest extends TestCase
         $this->factory->withQueryParameters(
             ['foo' => 'bar']
         )->get('https://laravel.com', [
+            'baz' => 'qux',
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'https://laravel.com?foo=bar&baz=qux';
+        });
+    }
+
+    public function testWithQueryParametersAllowsOverridingParameterOnRequest()
+    {
+        $this->factory->fake();
+
+        $this->factory->withQueryParameters([
+            'foo' => 'bar',
+            'baz' => 'baz',
+        ])->get('https://laravel.com', [
+            // Override the previously set value
             'baz' => 'qux',
         ]);
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -722,6 +722,34 @@ class HttpClientTest extends TestCase
         $this->assertSame('https://laravel.com', $responseCookie['Domain']);
     }
 
+    public function testWithQueryParameters()
+    {
+        $this->factory->fake();
+
+        $this->factory->withQueryParameters(
+            ['foo' => 'bar']
+        )->get('https://laravel.com');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'https://laravel.com?foo=bar';
+        });
+    }
+
+    public function testWithQueryParametersAllowsAddingMoreOnRequest()
+    {
+        $this->factory->fake();
+
+        $this->factory->withQueryParameters(
+            ['foo' => 'bar']
+        )->get('https://laravel.com', [
+            'baz' => 'qux',
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'https://laravel.com?foo=bar&baz=qux';
+        });
+    }
+
     public function testGetWithArrayQueryParam()
     {
         $this->factory->fake();


### PR DESCRIPTION
Some APIs require some query parameters to be always set. For example auth token (even though this isn't a great practice).

With this new helper, we can create a macro with the query parameter always set.

Example:

```php
        Http::macro('convertKit', fn() => Http::timeout(5)
            ->retry(3, 100)
            ->withOptions([
                'query' => [
                    'api_secret' => config('services.convertkit.api_secret'),
                ],
            ])
            ->baseUrl('https://api.convertkit.com/v3/')
            ->acceptJson());
```

can become:

```php
        Http::macro('convertKit', fn() => Http::timeout(5)
            ->retry(3, 100)
            ->withQueryParameters([
                'api_secret' => config('services.convertkit.api_secret'),
            ])
            ->baseUrl('https://api.convertkit.com/v3/')
            ->acceptJson());
```