### PR TITLE
[10.x] Improve `Envelope` constructor

### DIFF
--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -110,7 +110,7 @@ class Envelope
      */
     protected function normalizeAddresses($addresses)
     {
-        return collect($addresses)->map(function ($address) {
+        return collect(Arr::wrap($addresses))->map(function ($address) {
             return is_string($address) ? new Address($address) : $address;
         })->all();
     }

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -139,7 +139,7 @@ class Envelope
     public function to(Address|array|string $address, $name = null)
     {
         $this->to = array_merge($this->to, $this->normalizeAddresses(
-            is_string($name) ? [new Address($address, $name)] : Arr::wrap($address),
+            is_string($name) ? [new Address($address, $name)] : $address,
         ));
 
         return $this;
@@ -155,7 +155,7 @@ class Envelope
     public function cc(Address|array|string $address, $name = null)
     {
         $this->cc = array_merge($this->cc, $this->normalizeAddresses(
-            is_string($name) ? [new Address($address, $name)] : Arr::wrap($address),
+            is_string($name) ? [new Address($address, $name)] : $address,
         ));
 
         return $this;
@@ -171,7 +171,7 @@ class Envelope
     public function bcc(Address|array|string $address, $name = null)
     {
         $this->bcc = array_merge($this->bcc, $this->normalizeAddresses(
-            is_string($name) ? [new Address($address, $name)] : Arr::wrap($address),
+            is_string($name) ? [new Address($address, $name)] : $address,
         ));
 
         return $this;
@@ -187,7 +187,7 @@ class Envelope
     public function replyTo(Address|array|string $address, $name = null)
     {
         $this->replyTo = array_merge($this->replyTo, $this->normalizeAddresses(
-            is_string($name) ? [new Address($address, $name)] : Arr::wrap($address),
+            is_string($name) ? [new Address($address, $name)] : $address,
         ));
 
         return $this;

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -77,10 +77,10 @@ class Envelope
      * Create a new message envelope instance.
      *
      * @param  \Illuminate\Mail\Mailables\Address|string|null  $from
-     * @param  array  $to
-     * @param  array  $cc
-     * @param  array  $bcc
-     * @param  array  $replyTo
+     * @param  \Illuminate\Mail\Mailables\Address|string|array  $to
+     * @param  \Illuminate\Mail\Mailables\Address|string|array  $cc
+     * @param  \Illuminate\Mail\Mailables\Address|string|array  $bcc
+     * @param  \Illuminate\Mail\Mailables\Address|string|array  $replyTo
      * @param  string|null  $subject
      * @param  array  $tags
      * @param  array  $metadata
@@ -103,9 +103,9 @@ class Envelope
     }
 
     /**
-     * Normalize the given array of addresses.
+     * Normalize the given address(es).
      *
-     * @param  array  $addresses
+     * @param  \Illuminate\Mail\Mailables\Address|string|array  $addresses
      * @return array
      */
     protected function normalizeAddresses($addresses)


### PR DESCRIPTION
Currently when constructing an `Envelope`, the `to`, `cc`, `bcc` and `replyTo` parameter values should only be an array of `string`s or `Address`es, unlike the dedicated methods `->to()`, `->cc()`, etc., which additionally can accept a single `string` or  `Address`.

Adding `Arr::wrap()` in `normalizeAddresses()` rectifies this and simplifies the logic of the dedicated methods by removing its call there.

A revised example as per the docs:

```php
new Envelope(
    from: new Address('jeffrey@example.com', 'Jeffrey Way'),
    replyTo: new Address('taylor@example.com', 'Taylor Otwell'),
    subject: 'Order Shipped',
);
```