### PR TITLE
[10.x] Fix when() true when Str::of($str)->isEmpty() === true

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Traits;
 
 use Closure;
 use Illuminate\Support\HigherOrderWhenProxy;
+use Illuminate\Support\Stringable;
 
 trait Conditionable
 {
@@ -30,7 +31,13 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition($value);
         }
 
-        if ($value) {
+        if (
+            (
+                $value instanceof Stringable
+                && $value->isNotEmpty()
+            )
+            || $value
+        ) {
             return $callback($this, $value) ?? $this;
         } elseif ($default) {
             return $default($this, $value) ?? $this;

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -631,6 +632,18 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_factory_can_conditionally_execute_code()
     {
         FactoryTestUserFactory::new()
+            ->when(Str::of('a'), function () {
+                $this->assertTrue(true);
+            })
+            ->when(Str::of('0'), function () {
+                $this->assertTrue(true);
+            })
+            ->when(Str::of('1'), function () {
+                $this->assertTrue(true);
+            })
+            ->when(Str::of(''), function () {
+                $this->fail('Unreachable code that has somehow been reached.');
+            })
             ->when(true, function () {
                 $this->assertTrue(true);
             })


### PR DESCRIPTION
```php
User::query()
        ->when($request->input('search'), function ($query) {
            $query->where('name', 'like', '%' . $request->input('search') . '%');
        })
        ->get()
;
```

if search empty `''` or `NULL` when() alway return true
I think when() should return false when Stringable::isEmpty() === true

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
