### PR TITLE
[9.x] Fixes usage of `Redis::many()` with empty array

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -74,6 +74,10 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function many(array $keys)
     {
+       if (count($keys) === 0) {
+            return [];
+        }
+
         $results = [];
 
         $values = $this->connection()->mget(array_map(function ($key) {

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -74,7 +74,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function many(array $keys)
     {
-       if (count($keys) === 0) {
+        if (count($keys) === 0) {
             return [];
         }
 

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -45,4 +45,24 @@ class RedisStoreTest extends TestCase
         $this->assertTrue($result);
         $this->assertNan(Cache::store('redis')->get('foo'));
     }
+
+    public function testItMultipleItemsCanBeSetAndRetrieved()
+    {
+        $store = Cache::store('redis');
+        $result = $store->put('foo', 'bar', 10);
+        $resultMany = $store->putMany([
+            'fizz' => 'buz',
+            'quz' => 'baz',
+        ], 10);
+        $this->assertTrue($result);
+        $this->assertTrue($resultMany);
+        $this->assertEquals([
+            'foo' => 'bar',
+            'fizz' => 'buz',
+            'quz' => 'baz',
+            'norf' => null,
+        ], $store->many(['foo', 'fizz', 'quz', 'norf']));
+
+        $this->assertEquals([], $store->many([]));
+    }
 }


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/framework/issues/47298, by backporting https://github.com/laravel/framework/pull/46998/files to Laravel 9.