### PR TITLE
[10.x] Fix incorrect doc type in WorkerOptions

### DIFF
--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -7,7 +7,7 @@ class WorkerOptions
     /**
      * The name of the worker.
      *
-     * @var int
+     * @var string
      */
     public $name;
 


### PR DESCRIPTION
`WorkerOptions::$name` should be a string instead of int