### PR TITLE
[10.x] Return response from mail notification channel

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -46,7 +46,7 @@ class MailChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return void
+     * @return \Illuminate\Mail\SentMessage|null
      */
     public function send($notifiable, Notification $notification)
     {
@@ -61,7 +61,7 @@ class MailChannel
             return $message->send($this->mailer);
         }
 
-        $this->mailer->mailer($message->mailer ?? null)->send(
+        return $this->mailer->mailer($message->mailer ?? null)->send(
             $this->buildView($message),
             array_merge($message->data(), $this->additionalMessageData($notification)),
             $this->messageBuilder($notifiable, $notification, $message)


### PR DESCRIPTION
# What is the problem?

Currently, there is no way to read the response from the `mail` notification channel because the `MailChannel` does not return the mailer response.

This response is utilized by the `NotificationSender` on line 148:

```php
$response = $this->manager->driver($channel)->send($notifiable, $notification);

$this->events->dispatch(
    new NotificationSent($notifiable, $notification, $channel, $response)
);
```

Thus, when listening to the `NotificationSent` event, the `response` property is always `null`.

This issue only occurs with the `mail` channel. Other default channels like `broadcast` or `database` work correctly.
