### PR TITLE
[10.x] Add authorization to resource routes

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class ResourceRegistrar
@@ -620,6 +621,12 @@ class ResourceRegistrar
             $action['middleware'] = $options['middleware'];
         }
 
+        if (isset($options['abilities'])) {
+            foreach ($this->getAbilityMiddleware($resource, $method, $options['abilities']) as $abilityMiddleware) {
+                $action['middleware'][] = $abilityMiddleware;
+            }
+        }
+
         if (isset($options['excluded_middleware'])) {
             $action['excluded_middleware'] = $options['excluded_middleware'];
         }
@@ -633,6 +640,33 @@ class ResourceRegistrar
         }
 
         return $action;
+    }
+
+    /**
+     * Compose the ability middleware for a resource route.
+     *
+     * @param  string  $resource
+     * @param  string  $method
+     * @param  array  $abilities
+     * @return array
+     */
+    protected function getAbilityMiddleware($resource, $method, $abilities = [])
+    {
+        if (! isset($abilities[$method])) {
+            return [];
+        }
+
+        $middleware = [];
+
+        foreach (Arr::wrap($abilities[$method]) as $ability) {
+            if (! str_starts_with($ability, 'can:')) {
+                $ability = "can:$ability,$resource";
+            }
+
+            $middleware[] = $ability;
+        }
+
+        return $middleware;
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -8,6 +8,10 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Tests\Routing\fixtures\Models\FooModel;
+use Illuminate\Tests\Routing\fixtures\Models\PartialFooModel;
+use Illuminate\Tests\Routing\fixtures\Policies\FooModelPolicy;
+use Illuminate\Tests\Routing\fixtures\Policies\PartialFooModelPolicy;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -156,6 +160,256 @@ class RouteRegistrarTest extends TestCase
         foreach ($this->router->getRoutes() as $route) {
             $this->assertTrue($route->allowsTrashedBindings());
         }
+    }
+
+    public function testResourceAuthorized()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize();
+
+        $this->assertEquals([
+            'can:viewAny,users',
+        ], $this->router->getRoutes()->getByName('users.index')->middleware());
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.edit')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.update')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingMethods()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(['show', 'edit', 'destroy']);
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.edit')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.index')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.create')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.update')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingMethodsAsArray()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(['show', 'edit', 'destroy']);
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.edit')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.index')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.create')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.update')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingAbilities()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize('view', 'create', 'delete');
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.index')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.edit')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.update')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingAbilitiesAsArray()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(['view', 'create', 'delete']);
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.index')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.edit')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.update')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingModelWithFullPolicy()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(FooModel::class);
+
+        $this->assertEquals([
+            'can:viewAny,users',
+        ], $this->router->getRoutes()->getByName('users.index')->middleware());
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.edit')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.update')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingFullPolicy()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(FooModelPolicy::class);
+
+        $this->assertEquals([
+            'can:viewAny,users',
+        ], $this->router->getRoutes()->getByName('users.index')->middleware());
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.edit')->middleware());
+
+        $this->assertEquals([
+            'can:update,users',
+        ], $this->router->getRoutes()->getByName('users.update')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingModelWithPartialPolicy()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(PartialFooModel::class);
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.index')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.edit')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.update')->middleware());
+    }
+
+    public function testResourceAuthorizedUsingPartialPolicy()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->authorize(PartialFooModelPolicy::class);
+
+        $this->assertEquals([
+            'can:view,users',
+        ], $this->router->getRoutes()->getByName('users.show')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.create')->middleware());
+
+        $this->assertEquals([
+            'can:create,users',
+        ], $this->router->getRoutes()->getByName('users.store')->middleware());
+
+        $this->assertEquals([
+            'can:delete,users',
+        ], $this->router->getRoutes()->getByName('users.destroy')->middleware());
+
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.index')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.edit')->middleware());
+        $this->assertEmpty($this->router->getRoutes()->getByName('users.update')->middleware());
     }
 
     public function testFallbackRoute()

--- a/tests/Routing/fixtures/Models/FooModel.php
+++ b/tests/Routing/fixtures/Models/FooModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Routing\fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FooModel extends Model
+{
+}

--- a/tests/Routing/fixtures/Models/PartialFooModel.php
+++ b/tests/Routing/fixtures/Models/PartialFooModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Routing\fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PartialFooModel extends Model
+{
+}

--- a/tests/Routing/fixtures/Policies/FooModelPolicy.php
+++ b/tests/Routing/fixtures/Policies/FooModelPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Routing\fixtures\Policies;
+
+class FooModelPolicy
+{
+    public function viewAny($user)
+    {
+        return true;
+    }
+
+    public function view($user)
+    {
+        return true;
+    }
+
+    public function create($user)
+    {
+        return true;
+    }
+
+    public function update($user)
+    {
+        return true;
+    }
+
+    public function delete($user)
+    {
+        return true;
+    }
+}

--- a/tests/Routing/fixtures/Policies/PartialFooModelPolicy.php
+++ b/tests/Routing/fixtures/Policies/PartialFooModelPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Routing\fixtures\Policies;
+
+class PartialFooModelPolicy
+{
+    public function view($user)
+    {
+        return true;
+    }
+
+    public function create($user)
+    {
+        return true;
+    }
+
+    public function delete($user)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
I was inspired to create this PR after watching [Laravel Security Through Examples: Missing Authorisation](https://laracasts.com/series/laravel-security-through-examples/episodes/2) – specifically 13 minutes 22 seconds in – where it is noted by @valorin that you currently cannot define authorization for resources in your routes file.

I searched through the discussions and found #45396 which proposes a new `authorize()` method on `PendingResourceRegistration` so that developers may specify a variety of abilities to be checked via the `Illuminate\Auth\Middleware\Authorize` middleware. This PR is based off of that suggestion and aims to provide developers with an intuitive API and allow them to define authorization for their resources.

**Known abilities**: `viewAny`, `view`, `create`, `update`, `delete`

## Todo
Argument Type | Example | Done
-- | -- | -- |
All abilities | `->authorize()` | ✅ |
Model | `->authorize(Post::class)` | ✅ |
Policy Class | `->authorize(PostPolicy::class)` | ✅ |
methods (as strings) | `->authorize('show', 'edit', 'destroy')` | ✅ |
methods (as array) | `->authorize(['show', 'edit', 'destroy'])` | ✅ |
abilities (as strings) | `->authorize('create', 'update', 'delete')` | ✅ |
abilities (as array) | `->authorize(['create', 'update', 'delete'])` | ✅ |


## Examples

```php
// Via model
Route::resource('post', [PostController::class])
    ->authorize(Post::class);

// Via policy
Route::resource('post', [PostController::class])
    ->authorize(PostPolicy::class);

// Via methods
Route::resource('post', [PostController::class])
    ->authorize('show', 'edit', 'destroy');

// Via methods as an array
Route::resource('post', [PostController::class])
    ->authorize(['show', 'edit', 'destroy']);

// Via specific abilities
Route::resource('post', [PostController::class])
    ->authorize('create', 'update', 'delete');

// Via specific abilities, as an array
Route::resource('post', [PostController::class])
    ->authorize(['create', 'update', 'delete']);

// If the developer does not provide any arguments,
// we default to all known abilities
Route::resource('post', [PostController::class])
    ->authorize();
```