### PR TITLE
[10.x] Fix typehint for `EventServiceProvider::$observers` property

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -25,7 +25,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The model observers to register.
      *
-     * @var array<string, array<int, string>>
+     * @var array<string, string|object|array<int, string|object>>
      */
     protected $observers = [];
 


### PR DESCRIPTION
**Issue:**

New typehint was added https://github.com/laravel/framework/commit/d800f9ea313a1e98274dbe547b2dd1ef040a135c which is too strict (only supports array of strings).

![image](https://github.com/laravel/framework/assets/44430471/dfca4c61-6567-4788-b28d-bb1e2c265059)

My syntax is valid (unless string-to-string mapping is now deprecated in which case whoops I missed the memo). AFAICT it's still valid in `HasEvents`:

![image](https://github.com/laravel/framework/assets/44430471/fa3e86bf-1abe-478c-9e11-79b9ecce44aa)

---

Also, while you can't instantiate objects directly in the property declaration, it's still important to define a typehint that supports objects, otherwise the following valid logic would appear invalid in static analysis:

```php
// EventServiceProvider
$model = \App\Models\User::class;
$object = new \App\Observers\UserObserver();

$this->observers[$model] = $object;
```

_I mean, I never use objects in this context, but it's technically valid so it should be typehinted as valid too._