### PR TITLE
[11.x] Improve API error handling

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -489,7 +489,7 @@ class Handler implements ExceptionHandlerContract
     {
         $redirectTo = $exception->redirectTo() ?? (Router::has('login') ? route('login') : null);
 
-        return $this->shouldReturnJson($request, $exception) || !$redirectTo;
+        return $this->shouldReturnJson($request, $exception) || !$redirectTo
                     ? response()->json(['message' => $exception->getMessage()], 401)
                     : redirect()->guest($redirectTo);
     }
@@ -525,7 +525,7 @@ class Handler implements ExceptionHandlerContract
 
         return $redirectTo
             ? $this->invalidRedirect($request, $exception, $redirectTo)
-            : $this->invalidJson($request, $e);
+            : $this->invalidJson($request, $exception);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -486,9 +486,11 @@ class Handler implements ExceptionHandlerContract
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        return $this->shouldReturnJson($request, $exception)
+        $redirectTo = $exception->redirectTo() ?? (Router::has('login') ? route('login') : null);
+
+        return $this->shouldReturnJson($request, $exception) || !$redirectTo;
                     ? response()->json(['message' => $exception->getMessage()], 401)
-                    : redirect()->guest($exception->redirectTo() ?? route('login'));
+                    : redirect()->guest($redirectTo);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -490,7 +490,7 @@ class Handler implements ExceptionHandlerContract
     {
         $redirectTo = $exception->redirectTo() ?? (Route::has('login') ? route('login') : null);
 
-        return $this->shouldReturnJson($request, $exception) || !$redirectTo
+        return $this->shouldReturnJson($request, $exception) || ! $redirectTo
                     ? response()->json(['message' => $exception->getMessage()], 401)
                     : redirect()->guest($redirectTo);
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -18,6 +18,7 @@ use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Router;
@@ -523,10 +524,18 @@ class Handler implements ExceptionHandlerContract
         $redirectTo = $exception->redirectTo ?? url()->getPreviousUrlFromSession();
 
         return $redirectTo
-            ? redirect($redirectTo)
-                ->withInput(Arr::except($request->input(), $this->dontFlash))
-                ->withErrors($exception->errors(), $request->input('_error_bag', $exception->errorBag))
+            ? $this->invalidRedirect($request, $exception, $redirectTo)
             : $this->invalidJson($request, $e);
+    }
+
+    /**
+     * Convert a validation exception into a redirect response.
+     */
+    protected function invalidRedirect(Request $request, ValidationException $exception, string $redirectTo): Response
+    {
+        return redirect($redirectTo)
+                ->withInput(Arr::except($request->input(), $this->dontFlash))
+                ->withErrors($exception->errors(), $request->input('_error_bag', $exception->errorBag));
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -520,9 +520,13 @@ class Handler implements ExceptionHandlerContract
      */
     protected function invalid($request, ValidationException $exception)
     {
-        return redirect($exception->redirectTo ?? url()->previous())
-                    ->withInput(Arr::except($request->input(), $this->dontFlash))
-                    ->withErrors($exception->errors(), $request->input('_error_bag', $exception->errorBag));
+        $redirectTo = $exception->redirectTo ?? url()->getPreviousUrlFromSession();
+
+        return $redirectTo
+            ? redirect($redirectTo)
+                ->withInput(Arr::except($request->input(), $this->dontFlash))
+                ->withErrors($exception->errors(), $request->input('_error_bag', $exception->errorBag))
+            : $this->invalidJson($request, $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -517,7 +517,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Validation\ValidationException  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function invalid($request, ValidationException $exception)
     {
@@ -531,7 +531,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Convert a validation exception into a redirect response.
      */
-    protected function invalidRedirect(Request $request, ValidationException $exception, string $redirectTo): Response
+    protected function invalidRedirect(Request $request, ValidationException $exception, string $redirectTo): RedirectResponse
     {
         return redirect($redirectTo)
                 ->withInput(Arr::except($request->input(), $this->dontFlash))

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -518,7 +518,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Validation\ValidationException  $exception
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
     protected function invalid($request, ValidationException $exception)
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -25,6 +25,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;
@@ -487,7 +488,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        $redirectTo = $exception->redirectTo() ?? (Router::has('login') ? route('login') : null);
+        $redirectTo = $exception->redirectTo() ?? (Route::has('login') ? route('login') : null);
 
         return $this->shouldReturnJson($request, $exception) || !$redirectTo
                     ? response()->json(['message' => $exception->getMessage()], 401)

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -185,7 +185,7 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @return string|null
      */
-    protected function getPreviousUrlFromSession()
+    public function getPreviousUrlFromSession()
     {
         $session = $this->getSession();
 

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -158,7 +158,7 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
     public function testUnauthenticatedWebUsersAreRedirectedToLogin()
     {
         Route::get('test-route', fn () => throw new AuthenticationException);
-        Route::get('login', fn() => ':)')->name('login');
+        Route::get('login', fn () => ':)')->name('login');
 
         $this->get('test-route')
             ->assertStatus(302)
@@ -181,7 +181,7 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         Route::get('test-route', fn () => throw new AuthenticationException);
 
         // They should receive JSON even if redirect to `login` is possible.
-        Route::get('login', fn() => ':)')->name('login');
+        Route::get('login', fn () => ':)')->name('login');
 
         $this->getJson('test-route')
             ->assertStatus(401)

--- a/tests/Integration/Http/Middleware/HandleCorsTest.php
+++ b/tests/Integration/Http/Middleware/HandleCorsTest.php
@@ -248,7 +248,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
         $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
-        $this->assertEquals(302, $crawler->getStatusCode());
+        $this->assertEquals(422, $crawler->getStatusCode());
     }
 
     protected function addWebRoutes(Router $router)


### PR DESCRIPTION
I've come across two common issues when working with API backends and testing the endpoints in browser or just not knowing to specify the `Accept: application/json` header. Most projects work around this by adding some middleware that either adds the header to all incoming API requests or sets a `forceJson` flag on their custom request.

This PR proposes to remedy these issues by taking a "only redirect if there's a reasonable redirect target" approach.

## Unauthenticated user

When hitting an endpoint that requires authentication, but failing the auth, user should receive an authentication error. Instead they receive a 500 error with `Route [login] not defined.` message.

**Proposed solution:** only redirect to `route('login')` if the route exists. Otherwise fall back to JSON response.

**Backwards compatibility?** Technically it is a breaking change, but I can't imagine a legit scenario where someone would rely on their auth errors being redirected to non-existant route, catching the particular error and doing some useful reporting with it.

## Validation error

When getting some request params wrong, users should see validation errors. Instead users that are hitting the endpoint in their browserse receive a redirect to `/`. Because no "previous" route exists and even if it did, Laravel wouldn't know it as the session is not enabled on API routes.

**Proposed solution:** only redirect to "previous" route if it exists in the session. Do not use `url()->previous()` as

- falling back to `url('/')` for all validation errors is unlikely to be useful in real usecases (although common in automated tests)
- redirecting to referrer would be useless as they wouldn't receive the error bag or error code in any way

**Backwards compatibility?** 

1. This will require to update web (non-json) validation tests that expect a `302` redirect now. Two options:
    - Expect `422` instead of `302`, i.e. change `assertRedirect` or `assertStatus(302)` to `assertInvalid` or `assertStatus(422)`.
    - Set up the session with the previous URL as it would be in a real life workflow. Add `session()->setPreviousUrl($prevUrl);` to the test before hitting the endpoint that should redirect you back.
2. This would also break the workflow if someone has set their index page as a dedicated error displayer. I don't know if someone actually does that. There are multiple ways to restore the previous behaviour, e.g. overriding the handler's `invalid` method or catching the exceptions in handler (and maybe just specifying `->redirectTo('/')` on them which is still respected). 