### PR TITLE
[10.x] Remove redundant code 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1976,8 +1976,6 @@ class Builder implements BuilderContract
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasGlobalMacro($method->name)) {
-                $method->setAccessible(true);
-
                 static::macro($method->name, $method->invoke($mixin));
             }
         }


### PR DESCRIPTION
In PHP 8.1, the `ReflectionMethod::setAccessible()` method is no longer required for invoking methods using reflection. Therefore, the line `$method->setAccessible(true);` can be safely removed.