### PR TITLE
[10.x] `Model@isDirty()` should evaluate to false in saved event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1175,13 +1175,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function finishSave(array $options)
     {
-        $this->fireModelEvent('saved', false);
-
-        if ($this->isDirty() && ($options['touch'] ?? true)) {
-            $this->touchOwners();
-        }
+        $wasDirty = $this->isDirty();
 
         $this->syncOriginal();
+
+        $this->fireModelEvent('saved', false);
+
+        if ($wasDirty && ($options['touch'] ?? true)) {
+            $this->touchOwners();
+        }
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -94,6 +94,26 @@ class EloquentModelTest extends DatabaseTestCase
         $user->save();
         $this->assertFalse($user->wasChanged());
     }
+
+    public function testIsNotDirtyOnSaved()
+    {
+        $user = TestModel2::create([
+            'name' => 'Soren Kierkegaard', 'title' => 'Either/Or',
+        ]);
+
+        TestModel1::saving(function(TestModel2 $model) {
+            $this->assertTrue($model->isDirty('title'));
+            $this->assertFalse($model->wasChanged('title'));
+        });
+        TestModel1::saved(function(TestModel2 $model) {
+            $this->assertFalse($model->isDirty('title'));
+            $this->assertTrue($model->wasChanged('title'));
+        });
+
+        $user->title = 'Fear And Trembling';
+
+        $user->save();
+    }
 }
 
 class TestModel1 extends Model

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -101,11 +101,11 @@ class EloquentModelTest extends DatabaseTestCase
             'name' => 'Soren Kierkegaard', 'title' => 'Either/Or',
         ]);
 
-        TestModel1::saving(function(TestModel2 $model) {
+        TestModel1::saving(function (TestModel2 $model) {
             $this->assertTrue($model->isDirty('title'));
             $this->assertFalse($model->wasChanged('title'));
         });
-        TestModel1::saved(function(TestModel2 $model) {
+        TestModel1::saved(function (TestModel2 $model) {
             $this->assertFalse($model->isDirty('title'));
             $this->assertTrue($model->wasChanged('title'));
         });


### PR DESCRIPTION
Prompted by discussion https://github.com/laravel/framework/discussions/40182
