### PR TITLE
Revert "[10.x] Fix inconsistentcy between `report` and `render` methods"

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -373,8 +373,6 @@ class Handler implements ExceptionHandlerContract
      */
     public function render($request, Throwable $e)
     {
-        $e = $this->prepareException($this->mapException($e));
-
         if (method_exists($e, 'render') && $response = $e->render($request)) {
             return Router::toResponse($request, $response);
         }
@@ -382,6 +380,8 @@ class Handler implements ExceptionHandlerContract
         if ($e instanceof Responsable) {
             return $e->toResponse($request);
         }
+
+        $e = $this->prepareException($this->mapException($e));
 
         if ($response = $this->renderViaCallbacks($request, $e)) {
             return $response;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -195,17 +195,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My responsable exception response"}', $response);
     }
 
-    public function testReturnsCustomResponseFromMappedException()
-    {
-        $this->handler->map(function (RuntimeException $e) {
-            return new ResponsableException();
-        });
-
-        $response = $this->handler->render($this->request, new RuntimeException)->getContent();
-
-        $this->assertSame('{"response":"My responsable exception response"}', $response);
-    }
-
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);


### PR DESCRIPTION
Reverts laravel/framework#47201