### PR TITLE
[10.x] Update Kernel::load() to use same `classFromFile` logic as events

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -332,12 +332,15 @@ class Kernel implements KernelContract
         }
 
         $namespace = $this->app->getNamespace();
+        $basePath = $this->app->basePath();
 
-        foreach ((new Finder)->in($paths)->files() as $command) {
-            $command = $namespace.str_replace(
-                ['/', '.php'],
-                ['\\', ''],
-                Str::after($command->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
+        foreach ((new Finder())->in($paths)->files() as $file) {
+            $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+
+            $command = str_replace(
+                [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'],
+                ['\\', $namespace],
+                ucfirst(Str::replaceLast('.php', '', $class)),
             );
 
             if (is_subclass_of($command, Command::class) &&

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -338,7 +338,7 @@ class Kernel implements KernelContract
             $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
 
             $command = str_replace(
-                [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'],
+                [DIRECTORY_SEPARATOR, ucfirst(basename($this->app->path())).'\\'],
                 ['\\', $namespace],
                 ucfirst(Str::replaceLast('.php', '', $class)),
             );


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Closes #47312

Replaces the logic the `Console\Kernel` uses to parse classes from files with the same logic used by Events in `DiscoverEvents::classFromFile()`---this allows commands outside the `App` namespace to be auto-registered if desired.

Thanks!