### PR TITLE
[10.x] Add test with array for `assertViewHas` method

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -188,6 +188,16 @@ class TestResponseTest extends TestCase
         $response->assertViewHas('foos', $actual->concat([new TestModel(['id' => 3])]));
     }
 
+    public function testAssertViewHasWithArray()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertViewHas(['foo' => 'bar']);
+    }
+
     public function testAssertViewMissing()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
When you are using `assertViewHas` method, if pass array for `key` parameter they fire `assertViewHasAll` method!
There is no tests about this!