### PR TITLE
[10.x] Allow headers to be replaced on the HTTP client.

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -394,6 +394,19 @@ class PendingRequest
     }
 
     /**
+     * Replace the given headers for the request.
+     *
+     * @param  array  $headers
+     * @return $this
+     */
+    public function replaceHeaders(array $headers)
+    {
+        return tap($this, function () use ($headers) {
+            $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers);
+        });
+    }
+
+    /**
      * Specify the basic authentication username and password for the request.
      *
      * @param  string  $username

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -394,7 +394,7 @@ class PendingRequest
     }
 
     /**
-     * Replace the given headers for the request.
+     * Replace the given headers on the request.
      *
      * @param  array  $headers
      * @return $this

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -401,9 +401,9 @@ class PendingRequest
      */
     public function replaceHeaders(array $headers)
     {
-        return tap($this, function () use ($headers) {
-            $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers);
-        });
+        $this->options['headers'] = array_merge($this->options['headers'] ?? [], $headers);
+
+        return $this;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -861,6 +861,54 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testItMergesMultipleHeaders()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+        ])->withHeaders([
+            'X-Test-Header' => 'bar',
+        ])->withHeaders([
+            'X-Test-Header' => ['baz', 'qux'],
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders(['X-Test-Header' => ['foo', 'bar', 'baz', 'qux']]);
+        });
+    }
+
+    public function testItCanReplaceHeaders()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+        ])->replaceHeaders([
+            'X-Test-Header' => 'baz',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders(['X-Test-Header' => ['baz']]);
+        });
+    }
+
+    public function testItCanReplaceHeadersWhenNoHeadersYetSet()
+    {
+        $this->factory->fake();
+
+        $this->factory->replaceHeaders([
+            'X-Test-Header' => 'baz',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders(['X-Test-Header' => ['baz']]);
+        });
+    }
+
     public function testExceptionAccessorOnSuccess()
     {
         $resp = new Response(new Psr7Response());


### PR DESCRIPTION
This PR allows headers to be replaced when working with a Pending HTTP Request.

`withHeaders` does a recursive merge, which I feel is the expected behaviour, however it may be useful to replace the headers.

Fixes #47313