### PR TITLE
Renamed ambiguous `Eloquent Builder` function param

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -284,15 +284,15 @@ class Builder implements BuilderContract
      * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @param  string  $boolean
+     * @param  string  $logicalOperator
      * @return $this
      */
-    public function where($column, $operator = null, $value = null, $boolean = 'and')
+    public function where($column, $operator = null, $value = null, $logicalOperator = 'and')
     {
         if ($column instanceof Closure && is_null($operator)) {
             $column($query = $this->model->newQueryWithoutRelationships());
 
-            $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
+            $this->query->addNestedWhereQuery($query->getQuery(), $logicalOperator);
         } else {
             $this->query->where(...func_get_args());
         }


### PR DESCRIPTION
I have renamed the param of  the Eloquent builder `where` function from `$boolean = "and"` to be  `$logicalOperator= "and"`.
Because it was ambiguous before and me my self didn't find the  use of the param before cuz I didn't understand it, until I figured out what it stands for after digging into the Framework code, then I decided to use it and it did help me a lot and reduced a lot of code. 
