### PR TITLE
[10.x] Support drop stored procedures in `migrate:fresh` command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -45,6 +45,7 @@ class FreshCommand extends Command
             '--database' => $database,
             '--drop-views' => $this->option('drop-views'),
             '--drop-types' => $this->option('drop-types'),
+            '--drop-procedures' => $this->option('drop-procedures'),
             '--force' => true,
         ])) == 0);
 
@@ -108,6 +109,7 @@ class FreshCommand extends Command
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
             ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
+            ['drop-procedures', null, InputOption::VALUE_NONE, 'Drop all tables and procedures'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -45,6 +45,12 @@ class WipeCommand extends Command
             $this->components->info('Dropped all views successfully.');
         }
 
+        if ($this->option('drop-procedures')) {
+            $this->dropAllProcedures($database);
+
+            $this->components->info('Dropped all procedures successfully.');
+        }
+
         $this->dropAllTables($database);
 
         $this->components->info('Dropped all tables successfully.');
@@ -98,6 +104,19 @@ class WipeCommand extends Command
     }
 
     /**
+     * Drop all of the database procedures.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    protected function dropAllProcedures($database)
+    {
+        $this->laravel['db']->connection($database)
+            ->getSchemaBuilder()
+            ->dropAllProcedures();
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array
@@ -108,6 +127,7 @@ class WipeCommand extends Command
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
             ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
+            ['drop-procedures', null, InputOption::VALUE_NONE, 'Drop all tables and procedures'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];
     }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -362,6 +362,18 @@ class Builder
     }
 
     /**
+     * Drop all stored procedures from the database.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function dropAllProcedures()
+    {
+        throw new LogicException('This database driver does not support dropping all procedures.');
+    }
+
+    /**
      * Get all of the table names for the database.
      *
      * @return array

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -162,6 +162,17 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the SQL needed to retrieve all stored procedure names.
+     *
+     * @return string
+     */
+    public function compileGetAllProcedures($schemaName)
+    {
+        return "SELECT routine_schema, routine_name FROM information_schema.routines WHERE routine_type = 'PROCEDURE'
+         and routine_schema = '$schemaName'";
+    }
+
+    /**
      * Compile the blueprint's added column definitions.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -511,6 +511,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to drop stored procedure.
+     *
+     * @param  string  $procedure
+     * @return string
+     */
+    public function compileDropProcedure($procedure)
+    {
+        return 'drop procedure '.$this->wrapValue($procedure);
+    }
+
+    /**
      * Compile the SQL needed to retrieve all table names.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -373,6 +373,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to drop all stored procedures.
+     *
+     * @param  array  $procedures
+     * @return string
+     */
+    public function compileDropAllProcedures($procedures)
+    {
+        return 'drop procedure '.implode(',', $this->escapeNames($procedures)).' cascade';
+    }
+
+    /**
      * Compile the SQL needed to retrieve all table names.
      *
      * @param  string|array  $searchPath

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -478,6 +478,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to drop all stored procedures.
+     *
+     * @param  array  $procedures
+     * @return string
+     */
+    public function compileDropAllProcedures($procedures)
+    {
+        return 'drop procedure '.implode(',', $this->wrapArray($procedures));
+    }
+
+    /**
      * Compile the SQL needed to retrieve all table names.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -115,6 +115,27 @@ class MySqlBuilder extends Builder
     }
 
     /**
+     * Drop all procedures from the database.
+     *
+     * @return void
+     */
+    public function dropAllProcedures()
+    {
+        $procedures = $this->getAllProcedures();
+
+        if (empty($procedures)) {
+            return;
+        }
+
+        foreach ($procedures as $row) {
+            $row = (array) $row;
+            $this->connection->statement(
+                $this->grammar->compileDropProcedure($row['ROUTINE_NAME'])
+            );
+        }
+    }
+
+    /**
      * Get all of the table names for the database.
      *
      * @return array
@@ -135,6 +156,18 @@ class MySqlBuilder extends Builder
     {
         return $this->connection->select(
             $this->grammar->compileGetAllViews()
+        );
+    }
+
+    /**
+     * Get all of the procedures names for the database.
+     *
+     * @return array
+     */
+    public function getAllProcedures()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllProcedures($this->connection->getDatabaseName())
         );
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -283,7 +283,7 @@ class PostgresBuilder extends Builder
     }
 
     /**
-     * Get database schema
+     * Get database schema.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -53,6 +53,30 @@ class SqlServerBuilder extends Builder
     }
 
     /**
+     * Drop all procedures from the database.
+     *
+     * @return void
+     */
+    public function dropAllProcedures()
+    {
+        $procedures = [];
+
+        foreach ($this->getAllProcedures() as $row) {
+            $row = (array) $row;
+
+            $procedures[] = $row['routine_name'];
+        }
+
+        if (empty($procedures)) {
+            return;
+        }
+
+        $this->connection->statement(
+            $this->grammar->compileDropAllProcedures($procedures)
+        );
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return array
@@ -74,5 +98,27 @@ class SqlServerBuilder extends Builder
         return $this->connection->select(
             $this->grammar->compileGetAllViews()
         );
+    }
+
+    /**
+     * Get all of the procedures names for the database.
+     *
+     * @return array
+     */
+    public function getAllProcedures()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllProcedures($this->getSchema())
+        );
+    }
+
+    /**
+     * Get database schema
+     *
+     * @return string
+     */
+    protected function getSchema()
+    {
+        return $this->connection->getConfig('schema') ?: 'dbo';
     }
 }

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -113,7 +113,7 @@ class SqlServerBuilder extends Builder
     }
 
     /**
-     * Get database schema
+     * Get database schema.
      *
      * @return string
      */

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1411,6 +1411,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('drop view `alpha`,`beta`,`gamma`', $statement);
     }
 
+    public function testDropProceduresEscapesTableNames()
+    {
+        $statement = $this->getGrammar()->compileDropProcedure('alpha');
+
+        $this->assertSame('drop procedure `alpha`', $statement);
+    }
+
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1172,6 +1172,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('drop view "alpha","beta","gamma" cascade', $statement);
     }
 
+    public function testDropAllProceduresEscapesTableNames()
+    {
+        $statement = $this->getGrammar()->compileDropAllProcedures(['alpha', 'beta', 'gamma']);
+
+        $this->assertSame('drop procedure "alpha","beta","gamma" cascade', $statement);
+    }
+
     public function testDropAllTypesEscapesTableNames()
     {
         $statement = $this->getGrammar()->compileDropAllTypes(['alpha', 'beta', 'gamma']);

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -971,6 +971,13 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         );
     }
 
+    public function testDropAllProceduresEscapesTableNames()
+    {
+        $statement = $this->getGrammar()->compileDropAllProcedures(['alpha', 'beta', 'gamma']);
+
+        $this->assertSame('drop procedure "alpha","beta","gamma"', $statement);
+    }
+
     protected function getConnection()
     {
         return m::mock(Connection::class);


### PR DESCRIPTION
Sometimes, we have to create migrations with stored procedures and when running `migrate:fresh`, they aren't dropped. With this PR, we can dropped them by adding `--drop-procedures` argument when running `migrate:fresh` command