### PR TITLE
[10.x] Add missing 'attachMany' method to 'MailMessage' class

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -263,6 +263,25 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
+     * Attach multiple files to the message.
+     *
+     * @param  array<string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment|array>  $files
+     * @return $this
+     */
+    public function attachMany($files)
+    {
+        foreach ($files as $file => $options) {
+            if (is_int($file)) {
+                $this->attach($options);
+            } else {
+                $this->attach($file, $options);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Attach in-memory data as an attachment.
      *
      * @param  string  $data

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -314,4 +314,49 @@ class NotificationMailMessageTest extends TestCase
             ],
         ], $mailMessage->rawAttachments[0]);
     }
+
+    public function testItAttachesManyFiles()
+    {
+        $mailMessage = new MailMessage();
+        $attachable = new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'bar', 'foo.jpg')->withMime('image/png');
+            }
+        };
+
+        $mailMessage->attachMany([
+            $attachable,
+            '/path/to/forge.svg',
+            '/path/to/vapor.svg' => [
+                'as' => 'Logo.svg',
+                'mime' => 'image/svg+xml',
+            ],
+        ]);
+
+        $this->assertSame([
+            [
+                'data' => 'bar',
+                'name' => 'foo.jpg',
+                'options' => [
+                    'mime' => 'image/png',
+                ],
+            ],
+        ], $mailMessage->rawAttachments);
+
+        $this->assertSame([
+            [
+                'file' => '/path/to/forge.svg',
+                'options' => [],
+            ],
+            [
+                'file' => '/path/to/vapor.svg',
+                'options' => [
+                    'as' => 'Logo.svg',
+                    'mime' => 'image/svg+xml',
+                ],
+            ],
+        ], $mailMessage->attachments);
+    }
 }


### PR DESCRIPTION
**Type:** Bug fix

**Issue:** The `attachMany` method on the `Illuminate\Notifications\Messages\MailMessage`  is documented as a method that is available, however it does not exist. Either the method needs to be added to `laravel/framework` or the method needs to be removed from `laravel/docs`.

![image](https://github.com/laravel/framework/assets/44430471/6fc147aa-c329-4fc5-99f0-760043b50b2e)

**Documentation:** https://laravel.com/docs/10.x/notifications#mail-attachments

**Related PRs:**

- `attachMany` docs added to `Illuminate\Notifications\Messages\MailMessage` in https://github.com/laravel/docs/pull/8085/files
- `attachMany` method added to `Illuminate\Mail\Mailable` in https://github.com/laravel/framework/pull/43080
