### PR TITLE
[10.x] Allow specifying column type when using `Blueprint@foreignId()` & `Blueprint@foreignIdFor()`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -911,15 +911,16 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned big integer (8-byte) column on the table.
+     * Create a new unsigned integer column on the table.
      *
      * @param  string  $column
+     * @param  string  $type
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function foreignId($column, $type = 'bigInteger')
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
-            'type' => 'bigInteger',
+            'type' => $type,
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,
@@ -931,9 +932,10 @@ class Blueprint
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @param  string|null  $column
+     * @param  string  $integerType
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignIdFor($model, $column = null)
+    public function foreignIdFor($model, $column = null, $integerType = 'bigInteger')
     {
         if (is_string($model)) {
             $model = new $model;
@@ -942,7 +944,7 @@ class Blueprint
         $column = $column ?: $model->getForeignKey();
 
         if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
-            return $this->foreignId($column);
+            return $this->foreignId($column, $integerType);
         }
 
         $modelTraits = class_uses_recursive($model);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -355,6 +355,29 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
+    public function testGenerateRelationshipColumnSpecifyingType()
+    {
+        $map = [
+            'tinyInteger' => 'tinyint',
+            'smallInteger' => 'smallint',
+            'integer' => 'int',
+        ];
+
+        foreach ($map as $eloquentColumnType => $databaseColumnType) {
+            $base = new Blueprint('posts', function ($table) use ($eloquentColumnType) {
+                $table->foreignIdFor('Illuminate\Foundation\Auth\User', null, $eloquentColumnType);
+            });
+
+            $connection = m::mock(Connection::class);
+
+            $blueprint = clone $base;
+
+            $this->assertEquals([
+                "alter table `posts` add `user_id` {$databaseColumnType} unsigned not null",
+            ], $blueprint->toSql($connection, new MySqlGrammar));
+        }
+    }
+
     public function testGenerateRelationshipColumnWithUuidModel()
     {
         require_once __DIR__.'/stubs/EloquentModelUuidStub.php';


### PR DESCRIPTION
If your table has a non-bigint column, the `foreignId()` and `foreignIdFor()` helpers cannot be used because they assume the data type is a bigint.

If I have a migration like this:

```php
return new class extends Migration
{
    public function up(): void
    {
        Schema::create('interests', function (Blueprint $table) {
            $table->unsignedTinyInteger('id')->primary();
            $table->string('name');
        });
        
        Schema::create('users', function (Blueprint $table) {
            $table->id();
            $table->unsignedTinyInteger('interest_id');
            $table->foreign('interest_id')
                ->references('id')
                ->on('interests')
                ->constrained()
                ->nullOnDelete();
        });
    }
}
```

With this change, The second migration could be condensed to:
```php
Schema::create('users', function (Blueprint $table) {
    $table->id();
    $table->foreignId('interest_id', 'tinyInteger')->constrained()->nullOnDelete();
});
```

