### PR TITLE
[10.x] Fix mapped renderable exception handling

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -373,6 +373,8 @@ class Handler implements ExceptionHandlerContract
      */
     public function render($request, Throwable $e)
     {
+        $e = $this->mapException($e);
+
         if (method_exists($e, 'render') && $response = $e->render($request)) {
             return Router::toResponse($request, $response);
         }
@@ -381,7 +383,7 @@ class Handler implements ExceptionHandlerContract
             return $e->toResponse($request);
         }
 
-        $e = $this->prepareException($this->mapException($e));
+        $e = $this->prepareException($e);
 
         if ($response = $this->renderViaCallbacks($request, $e)) {
             return $response;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -195,6 +195,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"My renderable exception response"}', $response);
     }
 
+    public function testReturnsResponseFromMappedRenderableException()
+    {
+        $this->handler->map(RuntimeException::class, RenderableException::class);
+
+        $response = $this->handler->render($this->request, new RuntimeException)->getContent();
+
+        $this->assertSame('{"response":"My renderable exception response"}', $response);
+    }
+
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
     {
         $response = $this->handler->render($this->request, new ResponsableException)->getContent();

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -190,7 +190,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testReturnsResponseFromRenderableException()
     {
-        $response = $this->handler->render($this->request, new RenderableException)->getContent();
+        $response = $this->handler->render(Request::create('/'), new RenderableException)->getContent();
 
         $this->assertSame('{"response":"My renderable exception response"}', $response);
     }
@@ -199,7 +199,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $this->handler->map(RuntimeException::class, RenderableException::class);
 
-        $response = $this->handler->render($this->request, new RuntimeException)->getContent();
+        $response = $this->handler->render(Request::create('/'), new RuntimeException)->getContent();
 
         $this->assertSame('{"response":"My renderable exception response"}', $response);
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -188,6 +188,13 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame('{"response":"The CustomRenderer response"}', $response);
     }
 
+    public function testReturnsResponseFromRenderableException()
+    {
+        $response = $this->handler->render($this->request, new RenderableException)->getContent();
+
+        $this->assertSame('{"response":"My renderable exception response"}', $response);
+    }
+
     public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
     {
         $response = $this->handler->render($this->request, new ResponsableException)->getContent();
@@ -447,6 +454,14 @@ class UnReportableException extends Exception
     public function report()
     {
         return false;
+    }
+}
+
+class RenderableException extends Exception
+{
+    public function render($request)
+    {
+        return response()->json(['response' => 'My renderable exception response']);
     }
 }
 


### PR DESCRIPTION
In my previous PR #47201, I tries to fix the handling of mapped exceptions with a `render` hook. The PR was reverted due to a significant mistake I made by moving the `mapException` method together with `prepareException`, which I should not have touched. As it was reported by RobertBoes that change breaks exception rendering on the extended internal exceptions. I sincerely apologize for that.

In this PR I have fixed issue from #47201 and also added a missing test for renderable exceptions.

---

Let me describe the progrem again. When we have a custom exception that defines `report` and `render` hooks, only the `report` hook works while the `render` hook is never called. For instance:

```php
class Handler extends ExceptionHandler
{
    public function register(): void
    {
        $this->map(RuntimeException::class, AppException::class);
    }
}

class AppException extends Exception
{
    public function report()
    {
        app('sentry')->report($this->getPrevious());
    }

    public function render()
    {
        return new JsonResponse(['message' => 'Something went wrong.']);
    }
}

throw new RuntimeException;

// 👌 The `report` method is called.

// ❌ The `render` method is ignored.
```

With this change both methods `report` and `render` will map the exception at the beginning and handle it correctly:

```php
class Handler
{
    public function report(Throwable $e)
    {
        $e = $this->mapException($e);

        // ...
    }

    public function render($request, Throwable $e)
    {
        $e = $this->mapException($e);

        // ...
    }
}
```
