### PR TITLE
 [10.x] Remove redundant 'setAccessible' methods

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -196,9 +196,7 @@ class ScheduleListCommand extends Command
      */
     private function getClosureLocation(CallbackEvent $event)
     {
-        $callback = tap((new ReflectionClass($event))->getProperty('callback'))
-                        ->setAccessible(true)
-                        ->getValue($event);
+        $callback = (new ReflectionClass($event))->getProperty('callback')->getValue($event);
 
         if ($callback instanceof Closure) {
             $function = new ReflectionFunction($callback);

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -108,8 +108,6 @@ abstract class Component
             ->getParentClass()
             ->getProperty('questionHelper');
 
-        $property->setAccessible(true);
-
         $currentHelper = $property->isInitialized($this->output)
             ? $property->getValue($this->output)
             : new SymfonyQuestionHelper();

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1976,8 +1976,6 @@ class Builder implements BuilderContract
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasGlobalMacro($method->name)) {
-                $method->setAccessible(true);
-
                 static::macro($method->name, $method->invoke($mixin));
             }
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2227,7 +2227,6 @@ trait HasAttributes
 
             if ($returnType instanceof ReflectionNamedType &&
                 $returnType->getName() === Attribute::class) {
-
                 if (is_callable($method->invoke($instance)->get)) {
                     return true;
                 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2227,7 +2227,6 @@ trait HasAttributes
 
             if ($returnType instanceof ReflectionNamedType &&
                 $returnType->getName() === Attribute::class) {
-                $method->setAccessible(true);
 
                 if (is_callable($method->invoke($instance)->get)) {
                     return true;

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -45,7 +45,6 @@ trait Macroable
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasMacro($method->name)) {
-                $method->setAccessible(true);
                 static::macro($method->name, $method->invoke($mixin));
             }
         }

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -27,8 +27,6 @@ trait SerializesModels
                 continue;
             }
 
-            $property->setAccessible(true);
-
             if (! $property->isInitialized($this)) {
                 continue;
             }
@@ -82,8 +80,6 @@ trait SerializesModels
                 continue;
             }
 
-            $property->setAccessible(true);
-
             $property->setValue(
                 $this, $this->getRestoredPropertyValue($values[$name])
             );
@@ -98,8 +94,6 @@ trait SerializesModels
      */
     protected function getPropertyValue(ReflectionProperty $property)
     {
-        $property->setAccessible(true);
-
         return $property->getValue($this);
     }
 }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1657,8 +1657,6 @@ class TestResponse implements ArrayAccess
     {
         $property = new ReflectionProperty($exception, 'message');
 
-        $property->setAccessible(true);
-
         $property->setValue(
             $exception,
             $exception->getMessage().PHP_EOL.PHP_EOL.$message.PHP_EOL

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -217,7 +217,6 @@ class CookieTest extends TestCase
     private function getQueuedPropertyValue(CookieJar $cookieJar)
     {
         $property = (new ReflectionObject($cookieJar))->getProperty('queued');
-        $property->setAccessible(true);
 
         return $property->getValue($cookieJar);
     }

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -90,9 +90,7 @@ class DatabaseConnectionFactoryTest extends TestCase
     {
         $connection = $this->db->getConnection();
         $pdo = new ReflectionProperty(get_class($connection), 'pdo');
-        $pdo->setAccessible(true);
         $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
-        $readPdo->setAccessible(true);
 
         $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
@@ -102,9 +100,7 @@ class DatabaseConnectionFactoryTest extends TestCase
     {
         $connection = $this->db->getConnection('read_write');
         $pdo = new ReflectionProperty(get_class($connection), 'pdo');
-        $pdo->setAccessible(true);
         $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
-        $readPdo->setAccessible(true);
 
         $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -412,7 +412,6 @@ class DatabaseConnectionTest extends TestCase
     public function testRunMethodRetriesOnFailure()
     {
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
-        $method->setAccessible(true);
 
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
@@ -429,7 +428,6 @@ class DatabaseConnectionTest extends TestCase
         $this->expectExceptionMessage('(Connection: conn, SQL: ) (Connection: , SQL: )');
 
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
-        $method->setAccessible(true);
 
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['beginTransaction'])->getMock();
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -497,7 +497,6 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $class = new ReflectionClass($factory);
         $prop = $class->getProperty('count');
-        $prop->setAccessible(true);
         $value = $prop->getValue($factory);
 
         $this->assertSame(3, $value);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1159,7 +1159,6 @@ class DatabaseEloquentModelTest extends TestCase
 
         $class = new ReflectionClass($model);
         $method = $class->getMethod('getArrayableRelations');
-        $method->setAccessible(true);
 
         $model->setRelation('foo', ['bar']);
         $model->setRelation('bam', ['boom']);

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -22,13 +22,13 @@ class DatabaseMySqlSchemaStateTest extends TestCase
 
         // test connectionString
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
-        $connString = tap($method)->setAccessible(true)->invoke($schemaState);
+        $connString = $method->invoke($schemaState);
 
         self::assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
         $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
-        $variables = tap($method)->setAccessible(true)->invoke($schemaState, $dbConfig);
+        $variables = $method->invoke($schemaState, $dbConfig);
 
         self::assertEquals($expectedVariables, $variables);
     }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -31,7 +31,7 @@ class HandleExceptionsTest extends TestCase
         $this->handleExceptions = new HandleExceptions();
 
         with(new ReflectionClass($this->handleExceptions), function ($reflection) {
-            $property = tap($reflection->getProperty('app'))->setAccessible(true);
+            $property = $reflection->getProperty('app');
 
             $property->setValue(
                 $this->handleExceptions,
@@ -324,7 +324,7 @@ class HandleExceptionsTest extends TestCase
     public function testForgetApp()
     {
         $appResolver = fn () => with(new ReflectionClass($this->handleExceptions), function ($reflection) {
-            $property = tap($reflection->getProperty('app'))->setAccessible(true);
+            $property = $reflection->getProperty('app');
 
             return $property->getValue($this->handleExceptions);
         });
@@ -339,7 +339,7 @@ class HandleExceptionsTest extends TestCase
     public function testHandlerForgetsPreviousApp()
     {
         $appResolver = fn () => with(new ReflectionClass($this->handleExceptions), function ($reflection) {
-            $property = tap($reflection->getProperty('app'))->setAccessible(true);
+            $property = $reflection->getProperty('app');
 
             return $property->getValue($this->handleExceptions);
         });

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -121,7 +121,6 @@ class CliDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('isCompiledViewFile');
-        $method->setAccessible(true);
         $isCompiledViewFile = $method->invoke($dumper, $file);
 
         $this->assertFalse($isCompiledViewFile);
@@ -140,7 +139,6 @@ class CliDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('isCompiledViewFile');
-        $method->setAccessible(true);
         $isCompiledViewFile = $method->invoke($dumper, $file);
 
         $this->assertTrue($isCompiledViewFile);
@@ -160,7 +158,6 @@ class CliDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('getOriginalFileForCompiledView');
-        $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
     }
@@ -179,7 +176,6 @@ class CliDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('getOriginalFileForCompiledView');
-        $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
     }

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -116,7 +116,6 @@ class HtmlDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('isCompiledViewFile');
-        $method->setAccessible(true);
         $isCompiledViewFile = $method->invoke($dumper, $file);
 
         $this->assertFalse($isCompiledViewFile);
@@ -133,7 +132,6 @@ class HtmlDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('isCompiledViewFile');
-        $method->setAccessible(true);
         $isCompiledViewFile = $method->invoke($dumper, $file);
 
         $this->assertTrue($isCompiledViewFile);
@@ -151,7 +149,6 @@ class HtmlDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('getOriginalFileForCompiledView');
-        $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
     }
@@ -168,7 +165,6 @@ class HtmlDumperTest extends TestCase
 
         $reflection = new ReflectionClass($dumper);
         $method = $reflection->getMethod('getOriginalFileForCompiledView');
-        $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
     }

--- a/tests/Foundation/Testing/BootTraitsTest.php
+++ b/tests/Foundation/Testing/BootTraitsTest.php
@@ -36,12 +36,12 @@ class BootTraitsTest extends TestCase
         $testCase = new TestCaseWithTrait('foo');
 
         $method = new ReflectionMethod($testCase, 'setUpTraits');
-        tap($method)->setAccessible(true)->invoke($testCase);
+        $method->invoke($testCase);
 
         $this->assertTrue($testCase->setUp);
 
         $method = new ReflectionMethod($testCase, 'callBeforeApplicationDestroyedCallbacks');
-        tap($method)->setAccessible(true)->invoke($testCase);
+        $method->invoke($testCase);
 
         $this->assertTrue($testCase->tearDown);
     }

--- a/tests/Foundation/Testing/DatabaseMigrationsTest.php
+++ b/tests/Foundation/Testing/DatabaseMigrationsTest.php
@@ -38,8 +38,6 @@ class DatabaseMigrationsTest extends TestCase
             $methodName
         );
 
-        $migrateFreshUsingReflection->setAccessible(true);
-
         return $migrateFreshUsingReflection;
     }
 

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -38,8 +38,6 @@ class RefreshDatabaseTest extends TestCase
             $methodName
         );
 
-        $migrateFreshUsingReflection->setAccessible(true);
-
         return $migrateFreshUsingReflection;
     }
 

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -22,8 +22,6 @@ class CanConfigureMigrationCommandsTest extends TestCase
             $methodName
         );
 
-        $migrateFreshUsingReflection->setAccessible(true);
-
         return $migrateFreshUsingReflection;
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -78,7 +78,6 @@ class JobDispatchingTest extends TestCase
     {
         // get initial terminatingCallbacks
         $terminatingCallbacksReflectionProperty = (new \ReflectionObject($this->app))->getProperty('terminatingCallbacks');
-        $terminatingCallbacksReflectionProperty->setAccessible(true);
         $startTerminatingCallbacks = $terminatingCallbacksReflectionProperty->getValue($this->app);
 
         UniqueJob::dispatchAfterResponse('test');

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -123,7 +123,6 @@ class LogManagerTest extends TestCase
         $this->assertFalse($handlers[0]->getBubble());
 
         $url = new ReflectionProperty(get_class($handlers[0]), 'url');
-        $url->setAccessible(true);
         $this->assertSame('php://stderr', $url->getValue($handlers[0]));
 
         $config->set('logging.channels.logentries', [
@@ -139,7 +138,6 @@ class LogManagerTest extends TestCase
         $handlers = $logger->getLogger()->getHandlers();
 
         $logToken = new ReflectionProperty(get_class($handlers[0]), 'logToken');
-        $logToken->setAccessible(true);
 
         $this->assertInstanceOf(LogEntriesHandler::class, $handlers[0]);
         $this->assertSame('123456789', $logToken->getValue($handlers[0]));
@@ -182,7 +180,6 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
-        $dateFormat->setAccessible(true);
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -243,7 +240,6 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(PsrLogMessageProcessor::class, $processors[1]);
 
         $removeUsedContextFields = new ReflectionProperty(get_class($processors[1]), 'removeUsedContextFields');
-        $removeUsedContextFields->setAccessible(true);
 
         $this->assertTrue($removeUsedContextFields->getValue($processors[1]));
     }
@@ -324,7 +320,6 @@ class LogManagerTest extends TestCase
         $this->assertEmpty($logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
-        $dateFormat->setAccessible(true);
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -370,7 +365,6 @@ class LogManagerTest extends TestCase
         $this->assertEmpty($logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
-        $dateFormat->setAccessible(true);
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -414,7 +408,6 @@ class LogManagerTest extends TestCase
         $this->assertEmpty($logger->getLogger()->getProcessors());
 
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
-        $dateFormat->setAccessible(true);
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -447,7 +440,6 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(StreamHandler::class, $handler);
 
         $url = new ReflectionProperty(get_class($handler), 'url');
-        $url->setAccessible(true);
 
         $this->assertSame(storage_path('logs/on-demand.log'), $url->getValue($handler));
     }
@@ -483,7 +475,6 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(UidProcessor::class, $processor);
 
         $url = new ReflectionProperty(get_class($handler), 'url');
-        $url->setAccessible(true);
 
         $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
     }
@@ -516,11 +507,9 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(FingersCrossedHandler::class, $expectedFingersCrossedHandler);
 
         $activationStrategyProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'activationStrategy');
-        $activationStrategyProp->setAccessible(true);
         $activationStrategyValue = $activationStrategyProp->getValue($expectedFingersCrossedHandler);
 
         $actionLevelProp = new ReflectionProperty(get_class($activationStrategyValue), 'actionLevel');
-        $actionLevelProp->setAccessible(true);
         $actionLevelValue = $actionLevelProp->getValue($activationStrategyValue);
 
         $this->assertEquals(Level::Critical, $actionLevelValue);
@@ -529,7 +518,6 @@ class LogManagerTest extends TestCase
             $expectedStreamHandler = $expectedFingersCrossedHandler->getHandler();
         } else {
             $handlerProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'handler');
-            $handlerProp->setAccessible(true);
             $expectedStreamHandler = $handlerProp->getValue($expectedFingersCrossedHandler);
         }
         $this->assertInstanceOf(StreamHandler::class, $expectedStreamHandler);
@@ -560,7 +548,6 @@ class LogManagerTest extends TestCase
         $expectedFingersCrossedHandler = $handlers[0];
 
         $stopBufferingProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'stopBuffering');
-        $stopBufferingProp->setAccessible(true);
         $stopBufferingValue = $stopBufferingProp->getValue($expectedFingersCrossedHandler);
 
         $this->assertTrue($stopBufferingValue);
@@ -591,7 +578,6 @@ class LogManagerTest extends TestCase
         $expectedFingersCrossedHandler = $handlers[0];
 
         $stopBufferingProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'stopBuffering');
-        $stopBufferingProp->setAccessible(true);
         $stopBufferingValue = $stopBufferingProp->getValue($expectedFingersCrossedHandler);
 
         $this->assertFalse($stopBufferingValue);
@@ -718,7 +704,6 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(LineFormatter::class, $formatter);
 
         $format = new ReflectionProperty(get_class($formatter), 'format');
-        $format->setAccessible(true);
 
         $this->assertEquals(
             '[%datetime%] %channel%.%level_name%: %message% %context% %extra%',

--- a/tests/Mail/MailableAlternativeSyntaxTest.php
+++ b/tests/Mail/MailableAlternativeSyntaxTest.php
@@ -31,7 +31,6 @@ class MailableAlternativeSyntaxTest extends TestCase
 
         $reflection = new ReflectionClass($mailable);
         $method = $reflection->getMethod('prepareMailableForDelivery');
-        $method->setAccessible(true);
         $method->invoke($mailable);
 
         $this->assertEquals('test-view', $mailable->view);

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -103,7 +103,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $class = new ReflectionClass(Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
-        $createPayload->setAccessible(true);
         $createPayload->invokeArgs($queue, [
             $job,
             'queue-name',
@@ -118,7 +117,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $class = new ReflectionClass(Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
-        $createPayload->setAccessible(true);
         $createPayload->invokeArgs($queue, [
             ["\xc3\x28"],
             'queue-name',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -606,7 +606,6 @@ class SupportCollectionTest extends TestCase
 
         $class = new ReflectionClass($collection);
         $method = $class->getMethod('getArrayableItems');
-        $method->setAccessible(true);
 
         $items = new TestArrayableObject;
         $array = $method->invokeArgs($data, [$items]);

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -17,7 +17,6 @@ class SupportFluentTest extends TestCase
 
         $refl = new ReflectionObject($fluent);
         $attributes = $refl->getProperty('attributes');
-        $attributes->setAccessible(true);
 
         $this->assertEquals($array, $attributes->getValue($fluent));
         $this->assertEquals($array, $fluent->getAttributes());
@@ -30,7 +29,6 @@ class SupportFluentTest extends TestCase
 
         $refl = new ReflectionObject($fluent);
         $attributes = $refl->getProperty('attributes');
-        $attributes->setAccessible(true);
 
         $this->assertEquals($array, $attributes->getValue($fluent));
         $this->assertEquals($array, $fluent->getAttributes());
@@ -43,7 +41,6 @@ class SupportFluentTest extends TestCase
 
         $refl = new ReflectionObject($fluent);
         $attributes = $refl->getProperty('attributes');
-        $attributes->setAccessible(true);
 
         $this->assertEquals($array, $attributes->getValue($fluent));
         $this->assertEquals($array, $fluent->getAttributes());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -340,7 +340,6 @@ class SupportStrTest extends TestCase
     {
         $reflection = new ReflectionClass(Str::class);
         $property = $reflection->getProperty('snakeCache');
-        $property->setAccessible(true);
 
         Str::flushCache();
         $this->assertEmpty($property->getValue());

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -73,7 +73,7 @@ class TestDatabasesTest extends TestCase
         };
 
         $method = new ReflectionMethod($instance, 'switchToDatabase');
-        tap($method)->setAccessible(true)->invoke($instance, $database);
+        $method->invoke($instance, $database);
     }
 
     public static function databaseUrls()


### PR DESCRIPTION
The `setAccessible()` method has had no effect (i.e. is redundant) as of PHP 8.1

Laravel 10 has a minimum requirement of PHP 8.1, therefore officially dropping the requirement to retain these methods.

This PR simply removes all instances of `->setAccessible(true)` from all `ReflectionProperty` and `ReflectionMethod` objects throughout the `src/` and `tests/` directories.

Sources: 

`ReflectionMethod::setAccessible()`: https://www.php.net/manual/en/reflectionmethod.setaccessible.php

> Note: As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default. 

`ReflectionProperty::setAccessible()`: https://www.php.net/manual/en/reflectionproperty.setaccessible.php
 
> Note: As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. 