### PR TITLE
Testing: configure max amount of redirects to follow

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -43,7 +43,7 @@ trait MakesHttpRequests
     /**
      * Indicates whether redirects should be followed.
      *
-     * @var int
+     * @var int|null
      */
     protected $followRedirects = null;
 
@@ -263,7 +263,7 @@ trait MakesHttpRequests
     /**
      * Automatically follow any redirects returned from the response.
      *
-     * @param  int  $max
+     * @param  int|null  $max
      * @return $this
      */
     public function followingRedirects($max = null)

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -164,6 +164,28 @@ class MakesHttpRequestsTest extends TestCase
             ->assertSee('OK');
     }
 
+    public function testFollowingRedirectsWithMax()
+    {
+        $router = $this->app->make(Registrar::class);
+        $url = $this->app->make(UrlGenerator::class);
+
+        $router->get('from', function () use ($url) {
+            return new RedirectResponse($url->to('via'));
+        });
+
+        $router->get('via', function () use ($url) {
+            return new RedirectResponse($url->to('to'));
+        });
+
+        $router->get('to', function () {
+            return 'OK';
+        });
+
+        $this->followingRedirects(1)
+            ->get('from')
+            ->assertRedirect('to');
+    }
+
     public function testFollowingRedirectsTerminatesInExpectedOrder()
     {
         $router = $this->app->make(Registrar::class);


### PR DESCRIPTION
This PR extends the `followingRedirects()` and `followRedirects($response)` methods to accept an additional maximum amount of hops. 

This way:
- the expected amount of redirects can be asserted more easily;
- the intermediary responses (e.g. their URLs) can be examined if needed.

Given that the parameters are optional and the property is protected I don't think this would be a breaking change.
I chose a (way too) high maximum value if no amount was provided to mimic the current behavior of following redirects indefinitely. Other takes are possible of course so feel free to comment or adjust.

