### PR TITLE
[10.x] avoid duplicates in fillable/guarded on merge

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -63,7 +63,7 @@ trait GuardsAttributes
      */
     public function mergeFillable(array $fillable)
     {
-        $this->fillable = array_merge($this->fillable, $fillable);
+        $this->fillable = array_values(array_unique(array_merge($this->fillable, $fillable)));
 
         return $this;
     }
@@ -101,7 +101,7 @@ trait GuardsAttributes
      */
     public function mergeGuarded(array $guarded)
     {
-        $this->guarded = array_merge($this->guarded, $guarded);
+        $this->guarded = array_values(array_unique(array_merge($this->guarded, $guarded)));
 
         return $this;
     }


### PR DESCRIPTION
A model's `$fillable` or `$guarded` array should not contain duplicates if we try to merge attributes that are already present.

This is a follow-up for #47264 which was merged and published in Laravel v10.13.0