### PR TITLE
[9.x] Fix PHPStan description of Closure returning a union type

### DIFF
--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -113,8 +113,8 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
 // assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->lazy([
 //     'string' => 'string',
 // ]));
-assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->lazy());
-assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->lazy([
+assertType('Closure(): (Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model)', $factory->lazy());
+assertType('Closure(): (Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model)', $factory->lazy([
     'string' => 'string',
 ]));
 


### PR DESCRIPTION
I changed `Closure` and `callable` type description in PHPStan 1.10.16 to be compatible with what you can write in PHPDoc (https://phpstan.org/writing-php-code/phpdoc-types#callables). Union types need to be put in parentheses, because without them `callable(): string|null` means `(callable(): string)|null`.

This breaks tests in `laravel/framework` so I'm sending a PR to fix them.

I wasn't sure which branch to pick. I chose 9.x because I figured it'll get merged to 10.x too (where the same issue is present).

Cheers 👍 