### PR TITLE
Add support for combining inputs

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -380,6 +380,24 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Combine the values of the given keys into a single string.
+     *
+     * @param  array  $keys
+     * @param  string  $delimiter
+     * @return string
+     */
+    public function combine(array $keys, $delimiter = '')
+    {
+        $values = [];
+
+        foreach ($keys as $key) {
+            $values[] = $this->get($key);
+        }
+
+        return implode($delimiter, $values);
+    }
+
+    /**
      * This method belongs to Symfony HttpFoundation and is not usually needed when using Laravel.
      *
      * Instead, you may use the "input" method.


### PR DESCRIPTION
This PR adds support for combining inputs as one input.

I found myself struggling to combine input of a form as one string. As shown in the example below, the user can enter a verification code that is divided up in multiple form inputs. To combine the inputted code, you need to write a lot of additional code.

![image](https://github.com/laravel/framework/assets/58806240/207a1029-8643-4f5b-93fd-3b93a815d7fe)

That's where the combine() function comes in handy. You can combine the function as one code.

```php
$code = $request->combine(['first_digit', 'second_digit', 'third_digit', 'fourth_digit', 'fifth_digit', 'sixth_digit']);
```

There are countless other use cases where this is extremely useful

```php
$full_name = $request->combine(['first_name', 'last_name']);

$phone_number = $request->combine(['country_code', 'number']);
        
$email = $request->combine(['username', 'domain']);

```

The delimiter can be used to distinguish values as shown in the examples below
```php
$address = $request->combine(['street_1', 'street_2', 'city', 'state', 'zip_code', 'country'], ',');

$url = $request->combine(['domain', 'page'], '/');

$search_query = $request->combine(['title', 'author', 'publisher'], ' ');
```