### PR TITLE
[10.x] Allow `Route::whereIn()` to receive an enum

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use BackedEnum;
 use Illuminate\Support\Arr;
 
 trait CreatesRegularExpressionRouteConstraints
@@ -65,11 +66,23 @@ trait CreatesRegularExpressionRouteConstraints
      * Specify that the given route parameters must be one of the given values.
      *
      * @param  array|string  $parameters
-     * @param  array  $values
+     * @param  array|string  $values
      * @return $this
+     * @throws \InvalidArgumentException
      */
-    public function whereIn($parameters, array $values)
+    public function whereIn($parameters, array|string $values)
     {
+        if (is_string($values)) {
+            if (! enum_exists($values)) {
+                throw new \InvalidArgumentException("Enum could not be found to create route constraints.");
+            }
+
+            $values = array_map(
+                fn($case) => $case instanceof BackedEnum ? $case->value : $case->name,
+                [$values, 'cases']()
+            );
+        }
+
         return $this->assignExpressionToParameters($parameters, implode('|', $values));
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -942,6 +942,42 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereInRegistrationWithStringBackedEnum()
+    {
+        $wheres = [
+            'foo' => 'forge|vapor',
+        ];
+
+        $this->router->get('/{foo}')->whereIn(['foo'], RouteRegistrarStringBackedEnum::class);
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereInRegistrationWithIntBackedEnum()
+    {
+        $wheres = [
+            'foo' => '2013|2020',
+        ];
+
+        $this->router->get('/{foo}')->whereIn('foo', RouteRegistrarIntBackedEnum::class);
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereInRegistrationWithUnitEnum()
+    {
+        $wheres = [
+            'foo' => 'FORGE|VAPOR',
+        ];
+
+        $this->router->get('/{foo}')->whereIn('foo', RouteRegistrarUnitEnum::class);
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testGroupWhereNumberRegistrationOnRouteRegistrar()
     {
         $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
@@ -1357,4 +1393,22 @@ class InvokableRouteRegistrarControllerStub
 class RouteRegistrarMiddlewareStub
 {
     //
+}
+
+enum RouteRegistrarStringBackedEnum: string
+{
+    case FORGE = 'forge';
+    case VAPOR = 'vapor';
+}
+
+enum RouteRegistrarIntBackedEnum: int
+{
+    case FORGE = 2013;
+    case VAPOR = 2020;
+}
+
+enum RouteRegistrarUnitEnum
+{
+    case FORGE;
+    case VAPOR;
 }


### PR DESCRIPTION
## What?
Add the ability to specify that a route's parameter must match an enum.

## Why?
Routing is order dependent, which can cause some headaches. Being able to specify that a parameter is of a certain shape is a great way to work around this.

## How to use
Say you have an administrative panel application. You may have some user types in an enum like this:
```php
enum UserType: string
{
    case Admin = 'administrator';
    case VIP = 'vip';
    case FreeTier = 'free_user';
}
```

Let's assume we have an endpoint to get all users of a type. `GET /api/users/{userType}`. We also have an endpoint to fetch any user `GET /api/users/{user:uuid}` so we want to specify the shape too.

### Previously
```php
Route::get('/api/users/{userType}', [UsersController::class, 'index'])->whereIn('userType', ['administrator', 'vip', 'free_user']);
// or
Route::get('/api/users/{userType}', [UsersController::class, 'index'])->whereIn('userType', array_map(UserType $type) => $type->value, UserType::cases());
```

### From this PR
```php
Route::get('/api/users/{userType}', [UsersController::class, 'index'])->whereIn('userType', UserType::class);