### PR TITLE
[10.x] Narrow down array type for `$attributes` in `CastsAttributes`

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -16,7 +16,7 @@ interface CastsAttributes
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
      * @param  mixed  $value
-     * @param  array  $attributes
+     * @param  array<string, mixed>  $attributes
      * @return TGet|null
      */
     public function get(Model $model, string $key, mixed $value, array $attributes);
@@ -27,7 +27,7 @@ interface CastsAttributes
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
      * @param  TSet|null  $value
-     * @param  array  $attributes
+     * @param  array<string, mixed>  $attributes
      * @return mixed
      */
     public function set(Model $model, string $key, mixed $value, array $attributes);


### PR DESCRIPTION
[The documentation contains an example](https://laravel.com/docs/10.x/eloquent-mutators#custom-casts) with an `array<string, mixed>` type hint for `$attributes`, which is more specific than `array`, as type hinted in the source. However, if I wanted to use the more specific type hint from the example in my application, PHPStan reports the following:

```
Parameter #4 $attributes (array<string, mixed>) of method App\Casts\MyCast::get() should be contravariant with parameter $attributes (array) of method Illuminate\Contracts\Database\Eloquent\CastsAttributes<App\Value\MyValueObject,string>::get()
```

So I propose to update the type hint in the source to be consistent with the example in the documentation. Thanks!

Edit: [the `make:cast` stub](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Console/stubs/cast.stub) also uses the `array<string, mixed>` type hint.