### PR TITLE
[10.x] Add test for `assertViewHasAll` method

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -198,6 +198,18 @@ class TestResponseTest extends TestCase
         $response->assertViewHas(['foo' => 'bar']);
     }
 
+    public function testAssertViewHasAll()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertViewHasAll([
+            'foo' => 'bar'
+        ]);
+    }
+
     public function testAssertViewMissing()
     {
         $response = $this->makeMockResponse([

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -206,7 +206,7 @@ class TestResponseTest extends TestCase
         ]);
 
         $response->assertViewHasAll([
-            'foo' => 'bar'
+            'foo' => 'bar',
         ]);
     }
 


### PR DESCRIPTION
There is no test for the `assertViewHasAll` method in TestResponse class!
Coverage: 90%

The failed test is not about my changes!