### PR TITLE
[10.x] Fix `schedule:list` to display named Jobs

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -81,11 +81,10 @@ class ScheduleListCommand extends Command
             }
 
             if ($event instanceof CallbackEvent) {
-                if (class_exists($description)) {
-                    $command = $description;
-                    $description = '';
-                } else {
-                    $command = 'Closure at: '.$this->getClosureLocation($event);
+                $command = $event->getSummaryForDisplay();
+
+                if ($command === 'Closure' || $command === 'Callback') {
+                    $command = 'Closure at: ' . $this->getClosureLocation($event);
                 }
             }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -84,7 +84,7 @@ class ScheduleListCommand extends Command
                 $command = $event->getSummaryForDisplay();
 
                 if (in_array($command, ['Closure', 'Callback'])) {
-                    $command = 'Closure at: ' . $this->getClosureLocation($event);
+                    $command = 'Closure at: '.$this->getClosureLocation($event);
                 }
             }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -83,7 +83,7 @@ class ScheduleListCommand extends Command
             if ($event instanceof CallbackEvent) {
                 $command = $event->getSummaryForDisplay();
 
-                if ($command === 'Closure' || $command === 'Callback') {
+                if (in_array($command, ['Closure', 'Callback'])) {
                     $command = 'Closure at: ' . $this->getClosureLocation($event);
                 }
             }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ProcessUtils;
 use Orchestra\Testbench\TestCase;
 
@@ -36,6 +37,7 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
         $this->schedule->call(FooCall::class)->everyMinute();
@@ -51,9 +53,10 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  foo-named-job .............. Next Due: 1 minute from now')
             ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
             ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
-            ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
@@ -64,6 +67,7 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
         $this->schedule->call(FooCall::class)->everyMinute();
@@ -77,7 +81,8 @@ class ScheduleListCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
-            ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  foo-named-job .............. Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now')
             ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -133,7 +133,6 @@ class FooParamJob
 {
     public function __construct($param)
     {
-
     }
 }
 

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -37,9 +37,9 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
-        $this->schedule->job(new FooInstanceJob)->everyMinute();
+        $this->schedule->job(new FooParamJob('test'))->everyMinute();
         $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
-        $this->schedule->job(new FooInstanceJob)->name('foo-named-instance-job')->everyMinute();
+        $this->schedule->job(new FooParamJob('test'))->name('foo-named-param-job')->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
         $this->schedule->call(FooCall::class)->everyMinute();
@@ -55,9 +55,9 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
-            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooInstanceJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooParamJob  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  foo-named-job .............. Next Due: 1 minute from now')
-            ->expectsOutput('  * *     * *      *  foo-named-instance-job ..... Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  foo-named-param-job ........ Next Due: 1 minute from now')
             ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
             ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
@@ -71,9 +71,9 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
-        $this->schedule->job(new FooInstanceJob)->everyMinute();
+        $this->schedule->job(new FooParamJob('test'))->everyMinute();
         $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
-        $this->schedule->job(new FooInstanceJob)->name('foo-named-instance-job')->everyMinute();
+        $this->schedule->job(new FooParamJob('test'))->name('foo-named-param-job')->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
         $this->schedule->call(FooCall::class)->everyMinute();
@@ -87,9 +87,9 @@ class ScheduleListCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
-            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooInstanceJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooParamJob  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  foo-named-job .............. Next Due: 1 minute from now')
-            ->expectsOutput('  * *     * *      *  foo-named-instance-job ..... Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  foo-named-param-job ........ Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now')
@@ -130,8 +130,11 @@ class FooJob
 {
 }
 
-class FooInstanceJob
+class FooParamJob
 {
+    public function __construct($param) {
+
+    }
 }
 
 class FooCall

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ProcessUtils;
 use Orchestra\Testbench\TestCase;
 
@@ -132,7 +131,8 @@ class FooJob
 
 class FooParamJob
 {
-    public function __construct($param) {
+    public function __construct($param)
+    {
 
     }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -37,7 +37,9 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->job(new FooInstanceJob)->everyMinute();
         $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
+        $this->schedule->job(new FooInstanceJob)->name('foo-named-instance-job')->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
         $this->schedule->call(FooCall::class)->everyMinute();
@@ -53,7 +55,9 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooInstanceJob  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  foo-named-job .............. Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  foo-named-instance-job ..... Next Due: 1 minute from now')
             ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
             ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
@@ -67,7 +71,9 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->job(new FooInstanceJob)->everyMinute();
         $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
+        $this->schedule->job(new FooInstanceJob)->name('foo-named-instance-job')->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
         $this->schedule->call(FooCall::class)->everyMinute();
@@ -81,7 +87,9 @@ class ScheduleListCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooInstanceJob  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  foo-named-job .............. Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  foo-named-instance-job ..... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now')
@@ -119,6 +127,10 @@ class FooCommand extends Command
 }
 
 class FooJob
+{
+}
+
+class FooInstanceJob
 {
 }
 


### PR DESCRIPTION
## The Issue

I have a project that uses named jobs in the `app/Console/Kernel.php` (similar to https://laravel.com/docs/10.x/scheduling#naming-unique-jobs)

```
class Kernel extends ConsoleKernel
{
    protected function schedule(Schedule $schedule): void
    {
        $schedule->job(new TestJob('hourly'))->name('test-job-hourly')->hourly();
        $schedule->job(new TestJob('daily'))->name('test-job-daily')->daily();
    }
```

The `schedule:test` and `schedule:run` commands display these correctly:

<img width="1225" alt="image" src="https://github.com/laravel/framework/assets/2040842/2c9c71d3-0221-40ed-91a5-cc4bb0d43863">

<img width="1240" alt="image" src="https://github.com/laravel/framework/assets/2040842/fa03ff82-bcba-464d-9431-fe669ade3d3d">


However the `schedule:list` command does not:

<img width="1252" alt="image" src="https://github.com/laravel/framework/assets/2040842/68b0518b-3ae8-4a8b-9bba-1d6639c7ecab">

## This Fix

`->getSummaryForDisplay()` is used by the other commands but not this one, so i have utilised it here while attempting to maintain the extra functionality that was added for Closures and Callbacks.

<img width="1255" alt="image" src="https://github.com/laravel/framework/assets/2040842/ada63092-c898-421d-ad14-ae9113b9da23">

## Testing

* - [x] Added test coverage for instantiated jobs that have parameters, as documented at https://laravel.com/docs/10.x/scheduling#scheduling-queued-jobs but not currently tested
* - [x] Added test coverage for named jobs

## Possible Simplifications

* Share this logic via `->getSummaryForDisplay()` so that all schedule commands  (`schedule:run`, `schedule:list`, `schedule:test`) stay consistent. 
* Adapt `$schedule->call` so that it gives an accurate description from the start, and avoids us having to piece things back together here.
