### PR TITLE
[10.x] Add shouldHashKeys to ThrottleRequests middleware

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -24,7 +24,7 @@ class ThrottleRequests
     protected $limiter;
 
     /**
-     * Key hash preference
+     * Key hash preference.
      *
      * @var bool
      */
@@ -68,7 +68,7 @@ class ThrottleRequests
     }
 
     /**
-     * Specify whether rate limiter keys should be hashed
+     * Specify whether rate limiter keys should be hashed.
      *
      * @param  bool  $shouldHashKeys
      */
@@ -213,6 +213,7 @@ class ThrottleRequests
             return $this->getIdentifier($user->getAuthIdentifier());
         } elseif ($route = $request->route()) {
             $identifier = $route->getDomain().'|'.$request->ip();
+
             return $this->getIdentifier($identifier);
         }
 
@@ -319,7 +320,7 @@ class ThrottleRequests
     }
 
     /**
-     * Returns identifier based on $shouldHashKeys
+     * Returns identifier based on $shouldHashKeys.
      *
      * @param $value
      * @return mixed|string
@@ -328,5 +329,4 @@ class ThrottleRequests
     {
         return self::$shouldHashKeys ? sha1($value) : $value;
     }
-
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -28,7 +28,7 @@ class ThrottleRequests
      *
      * @var bool
      */
-    protected static bool $shouldHashKeys = true;
+    protected static $shouldHashKeys = true;
 
     /**
      * Create a new request throttler.

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -127,7 +127,7 @@ class ThrottleRequests
             $next,
             collect(Arr::wrap($limiterResponse))->map(function ($limit) use ($limiterName) {
                 return (object) [
-                    'key' => self::$shouldHashKeys ? md5($limiterName.$limit->key) : $limiterName.$limit->key,
+                    'key' => self::$shouldHashKeys ? md5($limiterName.$limit->key) : $limiterName.':'.$limit->key,
                     'maxAttempts' => $limit->maxAttempts,
                     'decayMinutes' => $limit->decayMinutes,
                     'responseCallback' => $limit->responseCallback,

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -200,9 +200,9 @@ class ThrottleRequests
     protected function resolveRequestSignature($request)
     {
         if ($user = $request->user()) {
-            return $this->getIdentifier($user->getAuthIdentifier());
+            return $this->formatIdentifier($user->getAuthIdentifier());
         } elseif ($route = $request->route()) {
-            return $this->getIdentifier($route->getDomain().'|'.$request->ip());
+            return $this->formatIdentifier($route->getDomain().'|'.$request->ip());
         }
 
         throw new RuntimeException('Unable to generate the request signature. Route unavailable.');
@@ -308,12 +308,12 @@ class ThrottleRequests
     }
 
     /**
-     * Returns identifier based on $shouldHashKeys.
+     * Format the given identifier based on the configured hashing settings.
      *
-     * @param $value
-     * @return mixed|string
+     * @param  string  $value
+     * @return string
      */
-    private function getIdentifier($value)
+    private function formatIdentifier($value)
     {
         return self::$shouldHashKeys ? sha1($value) : $value;
     }
@@ -322,6 +322,7 @@ class ThrottleRequests
      * Specify whether rate limiter keys should be hashed.
      *
      * @param  bool  $shouldHashKeys
+     * @return void
      */
     public static function shouldHashKeys(bool $shouldHashKeys = true)
     {

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -24,7 +24,7 @@ class ThrottleRequests
     protected $limiter;
 
     /**
-     * Key hash preference.
+     * Indicates if the rate limiter keys should be hashed.
      *
      * @var bool
      */
@@ -65,16 +65,6 @@ class ThrottleRequests
     public static function with($maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
         return static::class.':'.implode(',', func_get_args());
-    }
-
-    /**
-     * Specify whether rate limiter keys should be hashed.
-     *
-     * @param  bool  $shouldHashKeys
-     */
-    public static function shouldHashKeys(bool $shouldHashKeys): void
-    {
-        self::$shouldHashKeys = $shouldHashKeys;
     }
 
     /**
@@ -212,9 +202,7 @@ class ThrottleRequests
         if ($user = $request->user()) {
             return $this->getIdentifier($user->getAuthIdentifier());
         } elseif ($route = $request->route()) {
-            $identifier = $route->getDomain().'|'.$request->ip();
-
-            return $this->getIdentifier($identifier);
+            return $this->getIdentifier($route->getDomain().'|'.$request->ip());
         }
 
         throw new RuntimeException('Unable to generate the request signature. Route unavailable.');
@@ -328,5 +316,15 @@ class ThrottleRequests
     private function getIdentifier($value)
     {
         return self::$shouldHashKeys ? sha1($value) : $value;
+    }
+
+    /**
+     * Specify whether rate limiter keys should be hashed.
+     *
+     * @param  bool  $shouldHashKeys
+     */
+    public static function shouldHashKeys(bool $shouldHashKeys = true)
+    {
+        self::$shouldHashKeys = $shouldHashKeys;
     }
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -28,7 +28,7 @@ class ThrottleRequests
      *
      * @var bool
      */
-    protected static bool $shouldHashKeys = false;
+    protected static bool $shouldHashKeys = true;
 
     /**
      * Create a new request throttler.


### PR DESCRIPTION
This adds ability to have rate limiter keys in a non hashed format. I believe there is no added benefit of having those hashed using `md5` or `sha1` most of the time, and that could not be changed without extending and refactoring current middleware ATM.

Original key:

<img width="495" alt="Screenshot 2023-06-07 at 16 00 24" src="https://github.com/laravel/framework/assets/3708631/2388c94b-2d6b-4ba6-9618-78f920783452">

With `false` as the setting:

<img width="347" alt="Screenshot 2023-06-07 at 15 54 31" src="https://github.com/laravel/framework/assets/3708631/77790299-b519-4389-ac97-7eebbac864f5">

In our case this allows us to have data of rate limit available to outside systems like Grafana etc, without creating some other, duplicate, data.

The default setting would still be `true`, otherwise it could be adjusted in any Service Provider (f.e. `RouteServiceProvider`).

```php
ThrottleRequests::setShouldHashKeys(true);
```

One thing i'm not sure is whether having a static key based setting is reasonable here. Maybe it could be added somewhere in `config/` , but i did not find a reasonable place.

WDYT?

Thanks.