### PR TITLE
[10.x] "Can" validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -32,6 +32,7 @@ return [
         'string' => 'The :attribute field must be between :min and :max characters.',
     ],
     'boolean' => 'The :attribute field must be true or false.',
+    'can' => 'The :attribute field contains a unauthorized value.',
     'confirmed' => 'The :attribute field confirmation does not match.',
     'current_password' => 'The password is incorrect.',
     'date' => 'The :attribute field must be a valid date.',

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -32,7 +32,7 @@ return [
         'string' => 'The :attribute field must be between :min and :max characters.',
     ],
     'boolean' => 'The :attribute field must be true or false.',
-    'can' => 'The :attribute field contains a unauthorized value.',
+    'can' => 'The :attribute field contains an unauthorized value.',
     'confirmed' => 'The :attribute field confirmation does not match.',
     'current_password' => 'The password is incorrect.',
     'date' => 'The :attribute field must be a valid date.',

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\Can;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -19,6 +20,18 @@ use Illuminate\Validation\Rules\Unique;
 class Rule
 {
     use Macroable;
+
+    /**
+     * Get a can constraint builder instance.
+     *
+     * @param  string  $ability
+     * @param  mixed  ...$arguments
+     * @return \Illuminate\Validation\Rules\Can
+     */
+    public static function can($ability, ...$arguments)
+    {
+        return new Can($ability, $arguments);
+    }
 
     /**
      * Create a new conditional rule set.

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -59,7 +59,7 @@ class Can implements Rule
         $message = trans('validation.can');
 
         return $message === 'validation.can'
-            ? ['The :attribute field contains a unauthorized value.']
+            ? ['The :attribute field contains an unauthorized value.']
             : $message;
     }
 }

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Gate;
+
+class Can implements Rule
+{
+    /**
+     * The gate ability.
+     *
+     * @var string
+     */
+    protected $ability;
+
+    /**
+     * The gate arguments.
+     *
+     * @var array
+     */
+    protected $arguments;
+
+    /**
+     * Constructor.
+     *
+     * @param  string  $ability
+     * @param  mixed  $arguments
+     */
+    public function __construct($ability, array $arguments = [])
+    {
+        $this->ability = $ability;
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $arguments = $this->arguments;
+
+        $model = array_shift($arguments);
+
+        return Gate::allows($this->ability, array_filter([$model, ...$arguments, $value]));
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        $message = trans('validation.can');
+
+        return $message === 'validation.can'
+            ? ['The :attribute field contains a unauthorized value.']
+            : $message;
+    }
+}

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -8,14 +8,14 @@ use Illuminate\Support\Facades\Gate;
 class Can implements Rule
 {
     /**
-     * The gate ability.
+     * The ability to check.
      *
      * @var string
      */
     protected $ability;
 
     /**
-     * The gate arguments.
+     * The arguments to pass to the authorization check.
      *
      * @var array
      */

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -25,7 +25,7 @@ class Can implements Rule
      * Constructor.
      *
      * @param  string  $ability
-     * @param  mixed  $arguments
+     * @param  array  $arguments
      */
     public function __construct($ability, array $arguments = [])
     {

--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\Can;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ValidationRuleCanTest extends TestCase
+{
+    protected $container;
+    protected $user;
+    protected $router;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = new stdClass;
+
+        Container::setInstance($this->container = new Container);
+
+        $this->container->singleton(GateContract::class, function () {
+            return new Gate($this->container, function () {
+                return $this->user;
+            });
+        });
+
+        $this->container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($this->container);
+
+        (new ValidationServiceProvider($this->container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+
+    public function testValidationFails()
+    {
+        $this->gate()->define('update-company', function ($user, $value) {
+            $this->assertEquals('1', $value);
+
+            return false;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['company' => '1'],
+            ['company' => new Can('update-company')]
+        );
+
+        $this->assertTrue($v->fails());
+    }
+
+    public function testValidationPasses()
+    {
+        $this->gate()->define('update-company', function ($user, $class, $model, $value) {
+            $this->assertEquals(\App\Models\Company::class, $class);
+            $this->assertInstanceOf(stdClass::class, $model);
+            $this->assertEquals('1', $value);
+
+            return true;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['company' => '1'],
+            ['company' => new Can('update-company', [\App\Models\Company::class, new stdClass])]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
+    /**
+     * Get the Gate instance from the container.
+     *
+     * @return \Illuminate\Auth\Access\Gate
+     */
+    protected function gate()
+    {
+        return $this->container->make(GateContract::class);
+    }
+}


### PR DESCRIPTION
### Description

This PR implements a new "can" validation rule (accessible via the `Rule::can` method). 

It provides a way to authorize an ability for a given form field.

### Usage

Given the following `PostPolicy` that ensures only admins can change a blog post's author:

```php
class PostPolicy
{
    // ...
    
    public function updateAuthor(User $user, Post $post)
    {
        return $user->isAdmin();
    }
}
```

And a `PostRequest` that allows the user to change the author if it's present, we can validate that the user has the ability to do so using the `Rule::can()` method:

```php
use App\Models\Post;

class PostRequest extends FormRequest
{
    public function rules()
    {
        return [
            'author' => Rule::can('update-author', Post::class, $this->route('post')),
            'title' => '...',
            'body' => '...',
        ];
    }
}
```

This allows us to move this validation from the controller and into the form request:

```diff
public function update(PostRequest $request, Post $post)
{
    // ...

-    if ($request->filled('author') && $request->user()->can('update-author', $post)) {
+    if ($request->filled('author')) {
        $post->author()->associate($request->author);
    }
}
```

### Notes

The validation rule will always include the submitted field's value in the authorization method, but it will be pushed to the end when given more arguments, allowing developers to send their own values to authorization methods that will take precedence. This offers compatibility to raw Gate definitions, as well as model policies.

For the example below, we don't provide any additional arguments in the `Rule::can()` method after the ability, so the second argument in the gate definition's callback is the field's value:

```php
Gate::define('update-something', function (User $user, $fieldValue) {
    // ...
});
```

```php
public function rules()
{
    return [
        'field' => Rule::can('update-something'),
    ];
}
```

Using the same example, if we add new arguments into the `Rule::can()` method, the `$fieldValue` will be last:

```php
public function rules()
{
    return [
        'field' => Rule::can('update-something', 'foo', 'bar'),
    ];
}
```

```php
Gate::define('update-something', function (User $user, $foo, $bar, $fieldValue) {
    // ...
});
```

Let me know if you have any issues or concerns with this PR. No hard feelings on closure ❤️ 

Thanks for your time!