### PR TITLE
[10.x] Allow update with a closure, passing the previous value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -993,6 +993,10 @@ trait HasAttributes
             $value = $this->castAttributeAsHashedString($key, $value);
         }
 
+        if (! is_null($value) && $value instanceof \Closure) {
+            $value = $value($this->getAttribute($key));
+        }
+
         $this->attributes[$key] = $value;
 
         return $this;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -90,6 +90,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([0 => 'value'], $model->getAttributes());
     }
 
+    public function testSetAttributeWithClosure()
+    {
+        $model = new EloquentModelStub(['foo' => 1]);
+        $model->setAttribute('foo', fn($prev) => $prev + 1);
+
+        $this->assertEquals(['foo' => 2], $model->getAttributes());
+    }
+
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -93,7 +93,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testSetAttributeWithClosure()
     {
         $model = new EloquentModelStub(['foo' => 1]);
-        $model->setAttribute('foo', fn($prev) => $prev + 1);
+        $model->setAttribute('foo', fn ($prev) => $prev + 1);
 
         $this->assertEquals(['foo' => 2], $model->getAttributes());
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Overview

The goal of this PR is to allow for updating Eloquent models via a closure, such as:

```
$model->update([
    'field' => fn ($previous) => $previous . ' appended',
]);
```

In this example, the `$previous` argument to the closure is the previous value of that same field (that was loaded with the model).

### Purpose

I came across wanting this feature as I was exploring using the [spatie/laravel-data](https://github.com/spatie/laravel-data) package to cast eloquent model JSONB fields into DTO value types.

These value types should retain internal consistency so should only be edited via their own methods. Ideally they would be entirely immutable, but this doesn't seem to be currently possible with that package and may be a limitation of PHP.

Anyway, in my example DTO I have a method "add" which changes it's internal state and returns itself:

```
/*
    This is a just an example. Imagine that this is fully hooked up to eloquent $casts etc.
    It saves to a JSON field as e.g { amount: 1000, currency: 'NZD' }
*/
class Money
{
    constructor(protected int $amountCents, protected string $currency)
    {

    }

    public function add(Money $adding): self { ... }

    public function getAmount(): int { ... }

    ...
}
```

To update this field in Laravel 10.x currently I would have to separately update the field, and then call save:
```
$invoice->total = $invoice->total->add(Money::from(2000, 'NZD'));
$invoice->save();
```

With this PR I should be able to do this in one call:
```
$invoice->update([
    'total' => fn ($prev) => $prev->add(Money::from(2000, 'NZD')),
]);
```

### Caveats / Risks etc

- Are there any use-cases where people were legitimately setting fields to have closure values already? If so, then this will break that functionality as we are calling the closure instead of directly setting it. If this is the case then this PR is a no-go.
- I am detecting a Closure with `$value instanceof \Closure`, but I'm not 100% sure if this is the correct method. I tried `is_callable($value)` but that will give false-positives with strings such as 'value' (as this is an internal function)
- This could lead to people introducing race-conditions in their code as the previous value passed to the closure is the existing value loaded on the model and not a fresh database value. e.g This could be used to increment a value, but will have down-sides compared to `->increment()` in some environments.