### PR TITLE
[10.x] Allow serialization of NotificationSent

### DIFF
--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -46,14 +46,10 @@ class MessageSent
     {
         $hasAttachments = collect($this->message->getAttachments())->isNotEmpty();
 
-        return $hasAttachments ? [
-            'sent' => base64_encode(serialize($this->sent)),
-            'data' => base64_encode(serialize($this->data)),
-            'hasAttachments' => true,
-        ] : [
+        return [
             'sent' => $this->sent,
-            'data' => $this->data,
-            'hasAttachments' => false,
+            'data' => $hasAttachments ? base64_encode(serialize($this->data)) : $this->data,
+            'hasAttachments' => $hasAttachments,
         ];
     }
 
@@ -65,13 +61,10 @@ class MessageSent
      */
     public function __unserialize(array $data)
     {
-        if (isset($data['hasAttachments']) && $data['hasAttachments'] === true) {
-            $this->sent = unserialize(base64_decode($data['sent']));
-            $this->data = unserialize(base64_decode($data['data']));
-        } else {
-            $this->sent = $data['sent'];
-            $this->data = $data['data'];
-        }
+        $this->sent = $data['sent'];
+        $this->data = (($data['hasAttachments'] ?? false) === true)
+            ? unserialize(base64_decode($data['data']))
+            : $data['data'];
     }
 
     /**

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -62,6 +62,7 @@ class MessageSent
     public function __unserialize(array $data)
     {
         $this->sent = $data['sent'];
+
         $this->data = (($data['hasAttachments'] ?? false) === true)
             ? unserialize(base64_decode($data['data']))
             : $data['data'];

--- a/src/Illuminate/Mail/SentMessage.php
+++ b/src/Illuminate/Mail/SentMessage.php
@@ -51,4 +51,32 @@ class SentMessage
     {
         return $this->forwardCallTo($this->sentMessage, $method, $parameters);
     }
+
+    /**
+     * Get the serializable representation of the object.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $hasAttachments = collect($this->sentMessage->getOriginalMessage()->getAttachments())->isNotEmpty();
+
+        return [
+            'hasAttachments' => $hasAttachments,
+            'sentMessage' => $hasAttachments ? base64_encode(serialize($this->sentMessage)) : $this->sentMessage,
+        ];
+    }
+
+    /**
+     * Marshal the object from its serialized data.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function __unserialize(array $data)
+    {
+        $hasAttachments = (isset($data['hasAttachments']) && $data['hasAttachments'] === true);
+
+        $this->sentMessage = $hasAttachments ? unserialize(base64_decode($data['sentMessage'])) : $data['sentMessage'];
+    }
 }

--- a/src/Illuminate/Mail/SentMessage.php
+++ b/src/Illuminate/Mail/SentMessage.php
@@ -75,7 +75,7 @@ class SentMessage
      */
     public function __unserialize(array $data)
     {
-        $hasAttachments = (isset($data['hasAttachments']) && $data['hasAttachments'] === true);
+        $hasAttachments = ($data['hasAttachments'] ?? false) === true;
 
         $this->sentMessage = $hasAttachments ? unserialize(base64_decode($data['sentMessage'])) : $data['sentMessage'];
     }

--- a/tests/Integration/Mail/Fixtures/blank_document.pdf
+++ b/tests/Integration/Mail/Fixtures/blank_document.pdf
@@ -1,0 +1,57 @@
+%PDF-1.4
+%׃כיב
+1 0 obj
+<</Title (blank document)
+/Producer (Skia/PDF m116 Google Docs Renderer)>>
+endobj
+3 0 obj
+<</ca 1
+/BM /Normal>>
+endobj
+4 0 obj
+<</Length 84>> stream
+1 0 0 -1 0 792 cm
+q
+.75 0 0 .75 0 0 cm
+1 1 1 RG 1 1 1 rg
+/G3 gs
+0 0 816 1056 re
+f
+Q
+
+endstream
+endobj
+2 0 obj
+<</Type /Page
+/Resources <</ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/ExtGState <</G3 3 0 R>>>>
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+/StructParents 0
+/Parent 5 0 R>>
+endobj
+5 0 obj
+<</Type /Pages
+/Count 1
+/Kids [2 0 R]>>
+endobj
+6 0 obj
+<</Type /Catalog
+/Pages 5 0 R>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000274 00000 n 
+0000000105 00000 n 
+0000000142 00000 n 
+0000000462 00000 n 
+0000000517 00000 n 
+trailer
+<</Size 7
+/Root 6 0 R
+/Info 1 0 R>>
+startxref
+564
+%%EOF

--- a/tests/Integration/Mail/SentMessageMailTest.php
+++ b/tests/Integration/Mail/SentMessageMailTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Mail;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class SentMessageMailTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('sent_message_users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+    }
+
+    public function testDispatchesNotificationSent()
+    {
+        $notificationWasSent = false;
+
+        $user = SentMessageUser::create();
+
+        Event::listen(
+            NotificationSent::class,
+            function(NotificationSent $notification) use (&$notificationWasSent, $user) {
+                $notificationWasSent = true;
+                /**
+                 * Confirm that NotificationSent can be serialized/unserialized as
+                 * will happen if the listener implements ShouldQueue.
+                 */
+                /** @var NotificationSent $afterSerialization */
+                $afterSerialization = unserialize(serialize($notification));
+
+                $this->assertTrue($user->is($afterSerialization->notifiable));
+
+                $this->assertEqualsCanonicalizing($notification->notification, $afterSerialization->notification);
+        });
+
+        $user->notify(new SentMessageMailNotification());
+
+        $this->assertTrue($notificationWasSent);
+    }
+}
+
+class SentMessageUser extends Model
+{
+    use Notifiable;
+
+    public $timestamps = false;
+}
+
+
+class SentMessageMailNotification extends Notification
+{
+    public function via(): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->line('Example notification with attachment.')
+            ->attach(__DIR__ . '/Fixtures/blank_document.pdf', [
+                'as' => 'blank_document.pdf',
+                'mime' => 'application/pdf',
+            ]);
+    }
+}


### PR DESCRIPTION
To close https://github.com/laravel/framework/issues/47372

- [x] Serialize SentMessage
- [x] Do not double serialize/encode SentMessage within MessageSent
- [x] Test serializing/unserializing SentMessage
- [x] ~~Test serializing/unserializing MessageSent~~ This is covered adequately by serializing MessageSent, but can add another test if requested.

MessageSent handily serializes and unserializes the raw message data (contained within SentMessage, which relies on Symfony's SentMessage class).

Since Illuminate's SentMessage is common to both MessageSent and NotificationSent, I thought it would make sense to move the base64 encoding/decoding and serialization of Symfony's SentMessage to Laravel's SentMessage class.

BTW, these names are confusing as hell to talk about, let alone work on. 😆 