### PR TITLE
[10.x] Pluralisation typo in queue:clear command output

### DIFF
--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Queue\ClearableQueue;
+use Illuminate\Support\Str;
 use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -52,8 +53,9 @@ class ClearCommand extends Command
 
         if ($queue instanceof ClearableQueue) {
             $count = $queue->clear($queueName);
+            $jobLabel = Str::plural('job', $count);
 
-            $this->components->info('Cleared '.$count.' jobs from the ['.$queueName.'] queue');
+            $this->components->info('Cleared '.$count.' '.$jobLabel.' from the ['.$queueName.'] queue');
         } else {
             $this->components->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
         }

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -54,7 +54,7 @@ class ClearCommand extends Command
         if ($queue instanceof ClearableQueue) {
             $count = $queue->clear($queueName);
 
-            $this->components->info('Cleared '.Str::plural('job', $count).' '.$jobLabel.' from the ['.$queueName.'] queue');
+            $this->components->info('Cleared '.$count.' '.Str::plural('job', $count).' from the ['.$queueName.'] queue');
         } else {
             $this->components->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
         }

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -53,9 +53,8 @@ class ClearCommand extends Command
 
         if ($queue instanceof ClearableQueue) {
             $count = $queue->clear($queueName);
-            $jobLabel = Str::plural('job', $count);
 
-            $this->components->info('Cleared '.$count.' '.$jobLabel.' from the ['.$queueName.'] queue');
+            $this->components->info('Cleared '.Str::plural('job', $count).' '.$jobLabel.' from the ['.$queueName.'] queue');
         } else {
             $this->components->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
         }


### PR DESCRIPTION
When only 1 job was cleared from the queue, it previously showed:
`Cleared 1 jobs from the [default] queue.`

Now:
`Cleared 1 job from the [default] queue.`