### PR TITLE
[11.x] Omit `render()` method in Blade components

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -3,13 +3,13 @@
 namespace Illuminate\View;
 
 use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\View as ViewContract;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 use Illuminate\Support\Str;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Contracts\View\View as ViewContract;
 
 abstract class Component
 {

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -6,10 +6,10 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
-use Illuminate\Support\Str;
 
 abstract class Component
 {

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -3,12 +3,13 @@
 namespace Illuminate\View;
 
 use Closure;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Contracts\View\View as ViewContract;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
+use Illuminate\Support\Str;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\View as ViewContract;
 
 abstract class Component
 {
@@ -80,7 +81,20 @@ abstract class Component
      *
      * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
-    abstract public function render();
+    public function render()
+    {
+        return view('components.'.$this->resolveViewName());
+    }
+
+    /**
+     * Resolve the Blade view that should be used when rendering the component.
+     *
+     * @return string
+     */
+    protected function resolveViewName()
+    {
+        return $this->componentName ?: Str::kebab(class_basename(get_class($this)));
+    }
 
     /**
      * Resolve the component instance with the given data.

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -411,7 +411,6 @@ class TestHtmlableReturningViewComponent extends Component
     }
 }
 
-
 class TestMissingRenderComponent extends Component
 {
     public $title;

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -268,6 +268,16 @@ class ComponentTest extends TestCase
         Component::forgetFactory();
         $this->assertNotSame($this->viewFactory, $getFactory($inline));
     }
+
+    public function testViewWithMissingRenderMethodGetReturned()
+    {
+        $view = m::mock(View::class);
+        $this->viewFactory->shouldReceive('make')->once()->with('components.test-missing-render-component', [], [])->andReturn($view);
+
+        $component = new TestMissingRenderComponent();
+
+        $this->assertSame($view, $component->resolveView());
+    }
 }
 
 class TestInlineViewComponent extends Component
@@ -398,5 +408,16 @@ class TestHtmlableReturningViewComponent extends Component
     public function render()
     {
         return new HtmlString("<p>Hello {$this->title}</p>");
+    }
+}
+
+
+class TestMissingRenderComponent extends Component
+{
+    public $title;
+
+    public function __construct($title = 'foo')
+    {
+        $this->title = $title;
     }
 }


### PR DESCRIPTION
Currently, the `render()` method is required on a blade component. ~95% of the time, I never change the `render()` method view on a rendered blade view component. In Livewire, you can omit the `render()` method, and this PR accomplishes the same action.

This will automatically attempt to resolve a view located at `components.x` and also works on nested components. Users may continue to write their own `render()` methods for complex customization.

I don't believe this is a breaking change - but I went ahead and targeted `11.x` in case developers write any customization on render in the core component class.

Before:
```php
<?php

namespace App\View\Components;

use Illuminate\View\Component;

class Alert extends Component
{
    public function render()
    {
        return view('components.alert');
    }
}
```

After:
```php
<?php

namespace App\View\Components;

use Illuminate\View\Component;

class Alert extends Component
{
    //
}
```

Other considerations - throw a good exception message when the blade view doesn't exist (making it clear we couldn't automatically resolve the view)?