### PR TITLE
[11.x] Stop magic prefixing

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -531,7 +531,7 @@ class DynamoDbStore implements LockProvider, Store
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+        $this->prefix = $prefix;
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -274,6 +274,6 @@ class MemcachedStore extends TaggableStore implements LockProvider
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+        $this->prefix = $prefix;
     }
 }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -392,7 +392,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+        $this->prefix = $prefix;
     }
 
     /**

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -26,7 +26,7 @@ class CacheMemcachedStoreTest extends TestCase
         $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->willReturn(null);
         $memcache->expects($this->once())->method('getResultCode')->willReturn(1);
-        $store = new MemcachedStore($memcache, 'foo');
+        $store = new MemcachedStore($memcache, 'foo:');
         $this->assertNull($store->get('bar'));
     }
 
@@ -48,7 +48,7 @@ class CacheMemcachedStoreTest extends TestCase
             'fizz', 'buzz', 'norf',
         ]);
         $memcache->expects($this->once())->method('getResultCode')->willReturn(0);
-        $store = new MemcachedStore($memcache, 'foo');
+        $store = new MemcachedStore($memcache, 'foo:');
         $this->assertEquals([
             'foo' => 'fizz',
             'bar' => 'buzz',
@@ -116,9 +116,9 @@ class CacheMemcachedStoreTest extends TestCase
     public function testGetAndSetPrefix()
     {
         $store = new MemcachedStore(new Memcached, 'bar');
-        $this->assertSame('bar:', $store->getPrefix());
+        $this->assertSame('bar', $store->getPrefix());
         $store->setPrefix('foo');
-        $this->assertSame('foo:', $store->getPrefix());
+        $this->assertSame('foo', $store->getPrefix());
         $store->setPrefix(null);
         $this->assertEmpty($store->getPrefix());
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -143,13 +143,13 @@ class CacheRedisStoreTest extends TestCase
         $redis = $this->getRedis();
         $this->assertSame('prefix:', $redis->getPrefix());
         $redis->setPrefix('foo');
-        $this->assertSame('foo:', $redis->getPrefix());
+        $this->assertSame('foo', $redis->getPrefix());
         $redis->setPrefix(null);
         $this->assertEmpty($redis->getPrefix());
     }
 
     protected function getRedis()
     {
-        return new RedisStore(m::mock(Factory::class), 'prefix');
+        return new RedisStore(m::mock(Factory::class), 'prefix:');
     }
 }


### PR DESCRIPTION
Some of the cache stores append a `:` to your the user defined "prefix". I don't really like this behavior and think we should use the exact prefix the developer specifies. The developer can add the `:` on the end of the prefix on their own if they wish.