### PR TITLE
Revert "[10.x] Update Kernel::load() to use same `classFromFile` logic as events"

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -332,15 +332,12 @@ class Kernel implements KernelContract
         }
 
         $namespace = $this->app->getNamespace();
-        $basePath = $this->app->basePath();
 
-        foreach ((new Finder())->in($paths)->files() as $file) {
-            $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
-
-            $command = str_replace(
-                [DIRECTORY_SEPARATOR, ucfirst(basename($this->app->path())).'\\'],
-                ['\\', $namespace],
-                ucfirst(Str::replaceLast('.php', '', $class)),
+        foreach ((new Finder)->in($paths)->files() as $command) {
+            $command = $namespace.str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                Str::after($command->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
             );
 
             if (is_subclass_of($command, Command::class) &&


### PR DESCRIPTION
Reverts laravel/framework#47327