### PR TITLE
[10.x] Replace paths with proper namespaces when autoloading commands & events

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -331,13 +331,16 @@ class Kernel implements KernelContract
             return;
         }
 
-        $namespace = $this->app->getNamespace();
+        $namespaces = Arr::get(
+            json_decode(file_get_contents($this->app->basePath('composer.json')), true),
+            'autoload.psr-4',
+        );
 
         foreach ((new Finder)->in($paths)->files() as $command) {
-            $command = $namespace.str_replace(
-                ['/', '.php'],
-                ['\\', ''],
-                Str::after($command->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
+            $command = str_replace(
+                [...array_values($namespaces), '/', '.php'],
+                [...array_keys($namespaces), '\\', ''],
+                Str::after($command->getRealPath(), realpath(base_path()).DIRECTORY_SEPARATOR)
             );
 
             if (is_subclass_of($command, Command::class) &&

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -8,8 +8,11 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\namespaces\app\Listener as AppListener;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\namespaces\domain\Listener as DomainListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners\UnionListener;
 use Orchestra\Testbench\TestCase;
+use ReflectionClass;
 
 class DiscoverEventsTest extends TestCase
 {
@@ -44,6 +47,34 @@ class DiscoverEventsTest extends TestCase
             ],
             EventTwo::class => [
                 UnionListener::class.'@handle',
+            ],
+        ], $events);
+    }
+
+    public function testEventsCanBeDiscoveredInDifferentNamespaces()
+    {
+        (new ReflectionClass(DiscoverEvents::class))
+            ->getProperty('namespaces')
+            ->setValue([
+                'App\\' => 'tests/Integration/Foundation/Fixtures/EventDiscovery/namespaces/app/',
+                'Domain\\' => 'tests/Integration/Foundation/Fixtures/EventDiscovery/namespaces/domain/',
+            ]);
+
+        class_alias(AppListener::class, 'App\Listener');
+        class_alias(DomainListener::class, 'Domain\Listener');
+
+        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/namespaces', getcwd());
+
+        $this->assertEqualsCanonicalizing([
+            EventOne::class => [
+                AppListener::class.'@handle',
+                AppListener::class.'@handleEventOne',
+                DomainListener::class.'@handle',
+                DomainListener::class.'@handleEventOne',
+            ],
+            EventTwo::class => [
+                AppListener::class.'@handleEventTwo',
+                DomainListener::class.'@handleEventTwo',
             ],
         ], $events);
     }

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/namespaces/app/Listener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/namespaces/app/Listener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\namespaces\app;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
+
+class Listener
+{
+    public function handle(EventOne $event)
+    {
+        //
+    }
+
+    public function handleEventOne(EventOne $event)
+    {
+        //
+    }
+
+    public function handleEventTwo(EventTwo $event)
+    {
+        //
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/namespaces/domain/Listener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/namespaces/domain/Listener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\namespaces\domain;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
+
+class Listener
+{
+    public function handle(EventOne $event)
+    {
+        //
+    }
+
+    public function handleEventOne(EventOne $event)
+    {
+        //
+    }
+
+    public function handleEventTwo(EventTwo $event)
+    {
+        //
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!


Fixes #47377, command autoloading now uses the composer autoload classmap to resolve the class instead of parsing the filename and trying to make assumptions that work for everyone.


Thanks!



