### PR TITLE
Add Arr methods to support csv/array conversions.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -858,6 +858,30 @@ class Arr
     }
 
     /**
+     * Convert a string of comma separated values into an array.
+     *
+     * @param  string  $string
+     * @param  string  $delimiter
+     * @return array
+     */
+    public static function fromCsv(string $string, string $delimiter = ',')
+    {
+        return array_map('trim', explode($delimiter, $string));
+    }
+
+    /**
+     * Convert an array into a string of comma separated values.
+     *
+     * @param  array  $array
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function toCsv(array $array, string $delimiter = ',')
+    {
+        return implode($delimiter, $array);
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1196,4 +1196,44 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testFromCsv()
+    {
+        $csvString = 'apple, banana, orange';
+        $expectedArray = ['apple', 'banana', 'orange'];
+
+        $result = Arr::fromCsv($csvString);
+
+        $this->assertEquals($expectedArray, $result);
+    }
+
+    public function testFromCsvWithCustomDelimiter()
+    {
+        $csvString = 'apple;banana;orange';
+        $expectedArray = ['apple', 'banana', 'orange'];
+
+        $result = Arr::fromCsv($csvString, ';');
+
+        $this->assertEquals($expectedArray, $result);
+    }
+
+    public function testToCsv()
+    {
+        $array = ['apple', 'banana', 'orange'];
+        $expectedCsvString = 'apple,banana,orange';
+
+        $result = Arr::toCsv($array);
+
+        $this->assertEquals($expectedCsvString, $result);
+    }
+
+    public function testToCsvWithCustomDelimiter()
+    {
+        $array = ['apple', 'banana', 'orange'];
+        $expectedCsvString = 'apple;banana;orange';
+
+        $result = Arr::toCsv($array, ';');
+
+        $this->assertEquals($expectedCsvString, $result);
+    }
 }


### PR DESCRIPTION
This adds convenient Arr::fromCsv() and Arr::toCsv() methods to convert strings of csv to an array and likewise, array to a csv string.

Example of current flow:

```php
$csv = 'apple, banana, orange';

$fruits = explode(',', $csv);
$fruits = array_map('trim', $fruits); // ['apple', 'banana', 'orange']
```

```php
$fruits = ['apple', 'banana', 'orange'];
$fruits = implode(',', $fruits); // 'apple,banana,orange'
```

New flow:

```php
Arr::fromCsv('apple, banana, orange'); // ['apple', 'banana', 'orange']
Arr::toCsv(['apple', 'banana', 'orange']); // 'apple,banana,orange'
```

This additional method will not affect current users and eases the development flow when converting data between array and csv. Tests are included.