### PR TITLE
[10.x] Extract command discovery logic

### DIFF
--- a/src/Illuminate/Foundation/Console/DiscoverCommands.php
+++ b/src/Illuminate/Foundation/Console/DiscoverCommands.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Support\DiscoversClasses;
+use Symfony\Component\Finder\Finder;
+
+class DiscoverCommands extends DiscoversClasses
+{
+    /**
+     * Get all of the commands by searching the given commands directory.
+     *
+     * @param  string  $path
+     * @return array
+     */
+    public static function within($path)
+    {
+        return static::getCommands(
+            (new Finder)->files()->in($path),
+        );
+    }
+
+    /**
+     * Get all of the commands.
+     *
+     * @param  iterable  $commands
+     * @return array
+     */
+    protected static function getCommands($commands)
+    {
+        $discoveredCommands = [];
+
+        foreach (self::discoverClasses($commands) as $command) {
+            if ($command->isSubclassOf(Command::class) &&
+                ! $command->isAbstract()) {
+                $discoveredCommands[] = $command->getName();
+            }
+        }
+
+        return $discoveredCommands;
+    }
+}

--- a/src/Illuminate/Foundation/Support/DiscoversClasses.php
+++ b/src/Illuminate/Foundation/Support/DiscoversClasses.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Foundation\Support;
+
+use ReflectionClass;
+use ReflectionException;
+use SplFileInfo;
+
+abstract class DiscoversClasses
+{
+    /**
+     * Get all of the classes by searching the given directory.
+     *
+     * @param  string  $path
+     * @return array
+     */
+    abstract public static function within($path);
+
+    /**
+     * Get all of the classes from an array of files.
+     *
+     * @param  iterable  $files
+     * @return array
+     */
+    public static function discoverClasses($files)
+    {
+        $discovered = [];
+
+        foreach ($files as $file) {
+            try {
+                $instance = new ReflectionClass(
+                    static::classFromFile($file)
+                );
+            } catch (ReflectionException) {
+                continue;
+            }
+
+            if (! $instance->isInstantiable()) {
+                continue;
+            }
+
+            $discovered[] = $instance;
+        }
+
+        return $discovered;
+    }
+
+    /**
+     * Extract the class name from the given file path.
+     *
+     * @param  \SplFileInfo  $file
+     * @return string
+     */
+    protected static function classFromFile(SplFileInfo $file)
+    {
+        $contents = file_get_contents($file->getRealPath());
+
+        if (! $contents) {
+            return $file->getRealPath();
+        }
+
+        return str($contents)->after('namespace ')->before(";\n")
+            ->append("\\{$file->getFilename()}")
+            ->replaceLast('.php', '')
+            ->toString();
+    }
+}

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -130,7 +130,7 @@ class EventServiceProvider extends ServiceProvider
                     ->reduce(function ($discovered, $directory) {
                         return array_merge_recursive(
                             $discovered,
-                            DiscoverEvents::within($directory, $this->eventDiscoveryBasePath())
+                            DiscoverEvents::within($directory)
                         );
                     }, []);
     }
@@ -145,15 +145,5 @@ class EventServiceProvider extends ServiceProvider
         return [
             $this->app->path('Listeners'),
         ];
-    }
-
-    /**
-     * Get the base path to be used during event discovery.
-     *
-     * @return string
-     */
-    protected function eventDiscoveryBasePath()
-    {
-        return base_path();
     }
 }

--- a/tests/Integration/Foundation/DiscoverCommandsTest.php
+++ b/tests/Integration/Foundation/DiscoverCommandsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Foundation\Console\DiscoverCommands;
+use Illuminate\Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands\CommandOne;
+use Illuminate\Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands\CommandTwo;
+use Orchestra\Testbench\TestCase;
+
+class DiscoverCommandsTest extends TestCase
+{
+    public function testCommandsCanBeDiscovered()
+    {
+        class_alias(CommandOne::class, 'Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands\CommandOne');
+        class_alias(CommandTwo::class, 'Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands\CommandTwo');
+
+        $events = DiscoverCommands::within(__DIR__.'/Fixtures/CommandDiscovery/Commands');
+
+        sort($events);
+
+        $this->assertEquals([
+            CommandOne::class,
+            CommandTwo::class,
+        ], $events);
+    }
+}

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -19,7 +19,7 @@ class DiscoverEventsTest extends TestCase
         class_alias(AbstractListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener');
         class_alias(ListenerInterface::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface');
 
-        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/Listeners', getcwd());
+        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/Listeners');
 
         $this->assertEquals([
             EventOne::class => [
@@ -36,7 +36,7 @@ class DiscoverEventsTest extends TestCase
     {
         class_alias(UnionListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners\UnionListener');
 
-        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/UnionListeners', getcwd());
+        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/UnionListeners');
 
         $this->assertEquals([
             EventOne::class => [

--- a/tests/Integration/Foundation/Fixtures/CommandDiscovery/Commands/CommandOne.php
+++ b/tests/Integration/Foundation/Fixtures/CommandDiscovery/Commands/CommandOne.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands;
+
+use Illuminate\Console\Command;
+
+class CommandOne extends Command
+{
+    protected $signature = 'command-one';
+
+    public function handle()
+    {
+        return self::SUCCESS;
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/CommandDiscovery/Commands/CommandTwo.php
+++ b/tests/Integration/Foundation/Fixtures/CommandDiscovery/Commands/CommandTwo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands;
+
+use Illuminate\Console\Command;
+
+class CommandTwo extends Command
+{
+    protected $signature = 'command-two';
+
+    public function handle()
+    {
+        return self::SUCCESS;
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/CommandDiscovery/Commands/Random.php
+++ b/tests/Integration/Foundation/Fixtures/CommandDiscovery/Commands/Random.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\CommandDiscovery\Commands;
+
+class Random
+{
+}


### PR DESCRIPTION
This PR builds on top of #47327 and extracts the logic within `DiscoverEvents:: classFromFile(...)` into an abstract base class `DiscoversClasses`.

I was in two minds whether this should be an class abstract, or a trait. I made the decision to go with a class abstract, but this can be changed if desired.