### PR TITLE
[10.x] Add new error message "SSL: Handshake timed out" handling to PDO Dete…

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -62,6 +62,7 @@ trait DetectsLostConnections
             'SSL: Operation timed out',
             'Reason: Server is in script upgrade mode. Only administrator can connect at this time.',
             'Unknown $curl_error_code: 77',
+            'SSL: Handshake timed out',
         ]);
     }
 }


### PR DESCRIPTION
…cts Lost Connections

After upgrading Laravel from 9 to 10.13.2 and PHP from 8.1 to 8.2 I started to see some strange errors in logs. They might happen 1  per 1-2 hours only in Scheduled commands. 

I'm using Vapor and base image of docker php8.2. Using RDS cluster. 

Adding new error messages to detect connection was lost helped me to fix issue.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
