### PR TITLE
[10.x] Adds InteractsWithModelEvents trait to TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithModelEvents.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithModelEvents.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Event;
+
+trait InteractsWithModelEvents
+{
+    /**
+     * Fakes all internals events for the given model.
+     *
+     * @param  array|class-string|\Illuminate\Database\Eloquent\Model  $models
+     * @param  string[]|null  $events
+     * @return void
+     */
+    protected function fakeModelEvents($models, $events = null)
+    {
+        $allEvents = [
+            'retrieved', 'creating', 'created',
+            'updating', 'updated', 'saving',
+            'saved', 'restoring', 'restored',
+            'replicating', 'deleting', 'deleted',
+            'forceDeleting', 'forceDeleted',
+        ];
+
+        $events ??= $allEvents;
+
+        foreach (Arr::wrap($models) as $model) {
+            $model = is_object($model) ? get_class($model) : $model;
+
+            $events = collect($events)->map(fn ($event) => "eloquent.$event: $model")->all();
+
+            Event::fake($events);
+        }
+    }
+
+    /**
+     * Assert if a model event was dispatched based on a truth-test callback.
+     *
+     * @param  array|class-string|\Illuminate\Database\Eloquent\Model  $models
+     * @param  string[]  $events
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    protected function assertModelEventDispatched($models, $events, $callback = null)
+    {
+        foreach (Arr::wrap($models) as $model) {
+            $model = is_object($model) ? get_class($model) : $model;
+
+            $events = collect($events)
+                ->map(fn ($event) => "eloquent.$event: $model")
+                ->each(fn ($event) => Event::assertDispatched($event, $callback));
+        }
+    }
+
+    /**
+     * Assert if a model event was not dispatched based on a truth-test callback.
+     *
+     * @param  array|class-string|\Illuminate\Database\Eloquent\Model  $models
+     * @param  string[]  $events
+     * @param  callable|null  $callback
+     * @return void
+     */
+    protected function assertModelEventNotDispatched($models, array $events, $callback = null)
+    {
+        foreach (Arr::wrap($models) as $model) {
+            $model = is_object($model) ? $model::class : $model;
+
+            $events = collect($events)->map(fn ($event) => "eloquent.$event: $model")->all();
+
+            Event::assertNotDispatched($events, $callback);
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,6 +29,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithExceptionHandling,
         Concerns\InteractsWithSession,
         Concerns\InteractsWithTime,
+        Concerns\InteractsWithModelEvents,
         Concerns\InteractsWithViews;
 
     /**


### PR DESCRIPTION
This is how we want to test our model events:

```php
   $this->fakeModelEvents(User::class);

   $this->postJson('/users', $validFormData);

   $this->assertModelEventDispatched(User::class, 'created');
    
    // or more advanced:
   $this->assertModelEventDispatched(User::class, 'created', function ($event, $user) {
       return $user->email_verified === 0;
   });
```
- We make sure that only the listeners for the User model events fall asleep since sometimes we want other models to continue firing events.

- This way we can make sure that no one in the future replaces model saving with a query that does not fire events. like below:
```php
DB:table('users')->insert(...);
```

- We can also make sure that saving is done quietly:

```php
   $this->assertModelEventNotDispatched(User::class, 'created');
```
