### PR TITLE
Remove unnecessary usage of collection mapping in the Inspiring class

### DIFF
--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -55,9 +55,7 @@ class Inspiring
      */
     public static function quote()
     {
-        return static::quotes()
-            ->map(fn ($quote) => static::formatForConsole($quote))
-            ->random();
+        return static::formatForConsole(static::quotes()->random());
     }
 
     /**


### PR DESCRIPTION
The usage of collection mapping seems to be unnecessary.
The current code is traversing the whole collection, maps each quote to it's pretty console formatted equivalent, and then picks a random quote.


Since formatting all quotes is not necessary, I suggest to pick a random quote from collection using `static::quotes()-> random()` and then formatting that specific quote.