### PR TITLE
[10.x] Removed unnecessary condition in migrate:status command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -96,7 +96,7 @@ class StatusCommand extends BaseCommand
                         if (in_array($migrationName, $ran)) {
                             $status = '['.$batches[$migrationName].'] <fg=green;options=bold>Ran</>';
                         } else {
-                            $status =  '<fg=yellow;options=bold>Pending</>';
+                            $status = '<fg=yellow;options=bold>Pending</>';
                         }
 
                         return [$migrationName, $status];

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -93,12 +93,10 @@ class StatusCommand extends BaseCommand
                     ->map(function ($migration) use ($ran, $batches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
 
-                        $status = in_array($migrationName, $ran)
-                            ? '<fg=green;options=bold>Ran</>'
-                            : '<fg=yellow;options=bold>Pending</>';
-
                         if (in_array($migrationName, $ran)) {
-                            $status = '['.$batches[$migrationName].'] '.$status;
+                            $status = '['.$batches[$migrationName].'] <fg=green;options=bold>Ran</>';
+                        } else {
+                            $status =  '<fg=yellow;options=bold>Pending</>';
                         }
 
                         return [$migrationName, $status];


### PR DESCRIPTION
The `in_array($migrationName, $ran)` is redundant. I am aware that this also could be solved like below. But I decided against it because of my follow up PR https://github.com/laravel/framework/pull/47397.

```php
$status = in_array($migrationName, $ran)
    ?  '['.$batches[$migrationName].'] <fg=green;options=bold>Ran</>'
    :  '<fg=yellow;options=bold>Pending</>';
```