### PR TITLE
[10.x] Add new error messages for detecting lost connections

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -63,6 +63,8 @@ trait DetectsLostConnections
             'Reason: Server is in script upgrade mode. Only administrator can connect at this time.',
             'Unknown $curl_error_code: 77',
             'SSL: Handshake timed out',
+            'SQLSTATE[08006] [7] SSL error: sslv3 alert unexpected message',
+            'SQLSTATE[08006] [7] unrecognized SSL error code:',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
Ever since I moved from AWS Aurora to using AWS RDS Proxy, which (similar to pgbouncer) is essential to not overload the primary database with connection, I sporadically see these messages. This affects scheduled tasks, worker, HTTP requests; it's across the whole board.

This happened across different PHP versions (7.4, 8.2) and different
docker base OS images, as well as different Laravel version (8.x, 10.x).

---
The message for
`SQLSTATE[08006] [7] unrecognized SSL error code:`
is actually
`SQLSTATE[08006] [7] unrecognized SSL error code: 6`
but I figured this minor error code shouldn't be relevant.

I also saw other messages starting with `SQLSTATE[08006] [7]`, so maybe there's a case for just adding this prefix, but I guess no one knows if this would really apply to all of such messages.