### PR TITLE
[10.x] QueriesRelationships new method withCountWhereHas added

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -712,6 +712,21 @@ trait QueriesRelationships
     }
 
     /**
+     * Add subselect queries to count the relations if they are not null.
+     *
+     * @param $relation
+     * @param Closure|null $callback
+     * @param string $operator
+     * @param int $count
+     * @return Builder
+     */
+    public  function  withCountWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1): Builder
+    {
+        return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
+            ->withCount($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+    }
+
+    /**
      * Add subselect queries to include the max of the relation's column.
      *
      * @param  string|array  $relation

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -720,7 +720,7 @@ trait QueriesRelationships
      * @param int $count
      * @return Builder
      */
-    public  function  withCountWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1): Builder
+    public  function  withCountWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
             ->withCount($callback ? [$relation => fn ($query) => $callback($query)] : $relation);

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -715,12 +715,12 @@ trait QueriesRelationships
      * Add subselect queries to count the relations if they are not null.
      *
      * @param $relation
-     * @param Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return Builder
      */
-    public  function  withCountWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function withCountWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
             ->withCount($callback ? [$relation => fn ($query) => $callback($query)] : $relation);


### PR DESCRIPTION
Description:

This pull request introduces a new method, withCountWhereHas, to the Builder class. The method allows for subselect queries to count relations when they are not null, eliminating the need to duplicate the callback for whereHas and withCount when used together.

Changes Made
* Added the withCountWhereHas method to the Builder class.
* The method combines the functionality of whereHas and withCount in a single method call.
* The provided callback is automatically applied to the subquery for count constraints.
```
$condition=function($query){
    $query->where('name','like','%a%');
};
\App\Models\Post::query()
    ->whereHas('tags',$condition=function($query){
        $query->where('name','like','%a%');
    })
    ->withCount('tags',$condition)
    ->get();

```
if this PR is merged then we can write like this 
```
//with callback 
$callback=function($query){
    $query->where('name','like','%a%');
};
\App\Models\Post::query()
    ->withCountWhereHas('tags',$callback)
    ->get();


//without callback 
\App\Models\Post::query()
    ->withCountWhereHas('tags')
    ->get();

```


Benefits:
* Reduces code duplication and improves code readability.
* Provides a more streamlined and concise syntax for querying relationships with count constraints.
