### PR TITLE
[10.x] `forceCreate` on `MorphOne` result in a NULL _type column

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -345,9 +345,9 @@ abstract class HasOneOrMany extends Relation
      */
     public function forceCreate(array $attributes = [])
     {
-        $attributes[$this->getForeignKeyName()] = $this->getParentKey();
-
-        return $this->related->forceCreate($attributes);
+        return $this->related->unguarded(function () use ($attributes) {
+            return $this->create($attributes);
+        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -316,12 +316,16 @@ class DatabaseEloquentHasManyTest extends TestCase
 
     protected function expectForceCreatedModel($relation, $attributes)
     {
-        $attributes[$relation->getForeignKeyName()] = $relation->getParentKey();
-
         $model = m::mock(Model::class);
         $model->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
 
-        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($model);
+        $relation->getRelated()->shouldReceive('unguarded')->once()->andReturnUsing(function ($callback) {
+            return $callback();
+        });
+
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with($attributes)->andReturn($model);
+        $model->shouldReceive('setAttribute')->once()->with($relation->getForeignKeyName(), $relation->getParentKey());
+        $model->shouldReceive('save')->once()->andReturn(true);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -103,6 +103,8 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
 
         $this->assertNotNull($state);
         $this->assertSame(MorphOneOfManyTestProduct::class, $product->current_state->stateful_type);
+        $this->assertSame($state->stateful_type, $product->getMorphClass());
+        $this->assertSame($state->stateful_id, $product->getKey());
     }
 
     public function testExists()

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -211,7 +211,7 @@ class MorphOneOfManyTestProduct extends Eloquent
 
     public function states()
     {
-        return $this->morphMany(MorphOneOfManyTestState::class, 'stateful');
+        return $this->morphOne(MorphOneOfManyTestState::class, 'stateful');
     }
 
     public function current_state()


### PR DESCRIPTION
### Description

This PR fixes an inconsistent behavior with the `morphOne` relation. When having a `morphOne` scenario, calling `forceCreate` on the `MorphOne` instance results in a `NULL` *_type column if it's a `nullableMorph`, or an error otherwise. The `create` method, in contrast, works correctly.

### How to reproduce

1. Create the table and the model that hold the morph
```php
Schema::create('roots', function (Blueprint $table) {
    $table->id();
    $table->string('root_name');
    $table->nullableMorphs('rootable');
    $table->timestamps();
});
```

```php
class Root extends Model
{
    public function rootable(): MorphTo
    {
        return $this->morphTo();
    }
}
```

2. Create the table and the model that uses the morph

```php
Schema::create('leaves', function (Blueprint $table) {
    $table->id();
    $table->string('name');
    $table->timestamps();
});
```

```php
class Leaf extends Model
{
    public function root(): MorphOne
    {
        return $this->morphOne(Root::class, 'rootable');
    }
}
```

3. Now try to forceCreate

```php
$leaf = Leaf::find(1);
if(empty($leaf)) {
  $leaf = Leaf::forceCreate([
    'name' => 'Hi'
  ]);
}

$leaf->root()->forceCreate([
  'root_name' => 'Hello'
]);
```
This will result in a row in the `roots` table with:
- rootable_id = 1
- rootable_type = NULL

### Why this wasn't spotted in the tests

The test file that should have spotted this issue contains a typo. 
The row that instantiates the morph uses `morphMany` instead of `morphOne` -> [Permalink to the row](https://github.com/laravel/framework/blob/245e891e3ab17132a2aaeb6c1e32b80ec5426c68/tests/Database/DatabaseEloquentMorphOneOfManyTest.php#L214)

### How this PR solves the problem

The `forceCreate` method proxies the request to the related `forceCreate` method. I've changed this behavior by unguarding the related and proxying the request to the `create` method. 

Test files have been updated accordingly.