### PR TITLE
[10.x] Add `JSON_UNESCAPED_UNICODE` flag to the encode method 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -23,7 +23,7 @@ class Json
      */
     public static function encode(mixed $value): mixed
     {
-        return isset(static::$encoder) ? (static::$encoder)($value) : json_encode($value);
+        return isset(static::$encoder) ? (static::$encoder)($value) : json_encode($value, JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
Hi,

This pull request aims to enhance the readability of data stored in the database when using `notifications`, the `array` and `collection` casts. Currently, when a notification message or data containing `UTF-8` characters is stored in the database, it gets encoded as a Unicode escape sequence (\u***), which can be difficult to read and interpret.
