### PR TITLE
Change visibility of `path` method in FileStore.php

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -338,7 +338,7 @@ class FileStore implements Store, LockProvider
      * @param  string  $key
      * @return string
      */
-    protected function path($key)
+    public function path($key)
     {
         $parts = array_slice(str_split($hash = sha1($key), 2), 0, 2);
 


### PR DESCRIPTION
This make us able to get the full path of a cache file like below:

```
/path/to/laravel/storage/framework/cache/data/27/fb/27fbb4c8ca2df6879d95b589df7f3a49f63ef05f
```
