### PR TITLE
[10.x] Fix inconsistent type hint for `$passwordTimeoutSeconds`

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -48,7 +48,7 @@ class RequirePassword
      * Specify the redirect route and timeout for the middleware.
      *
      * @param  string|null  $redirectToRoute
-     * @param  string|null  $passwordTimeoutSeconds
+     * @param  string|int|null  $passwordTimeoutSeconds
      * @return string
      *
      * @named-arguments-supported


### PR DESCRIPTION
I've updated the type hint to be consistent with the type hint of the middleware's `handle()` method:
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Auth/Middleware/RequirePassword.php#L67

An example that currently results in a static analysis error:
```php
Route::view('/', 'home')->middleware(RequirePassword::using(passwordTimeoutSeconds: 10));

// Parameter $passwordTimeoutSeconds of static method Illuminate\Auth\Middleware\RequirePassword::using()
// expects string|null, int given.
```