### PR TITLE
[10.x] Add `whenAggregated` method to `ConditionallyLoadsAttributes` trait

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -301,7 +301,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a relationship with average value if it exists.
+     * Retrieve a relationship average value if it exists.
      *
      * @param  string  $relationship
      * @param  string  $column

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -301,23 +301,24 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a relationship average value if it exists.
+     * Retrieve a relationship aggregated value if it exists.
      *
      * @param  string  $relationship
      * @param  string  $column
+     * @param  string  $aggregate
      * @param  mixed  $value
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenAveraged($relationship, $column, $value = null, $default = null)
+    public function whenAggregated($relationship, $column, $aggregate, $value = null, $default = null)
     {
-        $attribute = (string) Str::of($relationship)->snake()->append('_avg_')->finish($column);
+        $attribute = (string) Str::of($relationship)->snake()->append('_')->append($aggregate)->append('_')->finish($column);
 
         if (! isset($this->resource->getAttributes()[$attribute])) {
             return value($default);
         }
 
-        if (func_num_args() === 2) {
+        if (func_num_args() === 3) {
             return $this->resource->{$attribute};
         }
 

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -301,6 +301,34 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve a relationship with average value if it exists.
+     *
+     * @param  string  $relationship
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    public function whenAveraged($relationship, $column, $value = null, $default = null)
+    {
+        $attribute = (string) Str::of($relationship)->snake()->append('_avg_')->finish($column);
+
+        if (! isset($this->resource->getAttributes()[$attribute])) {
+            return value($default);
+        }
+
+        if (func_num_args() === 2) {
+            return $this->resource->{$attribute};
+        }
+
+        if ($this->resource->{$attribute} === null) {
+            return;
+        }
+
+        return value($value, $this->resource->{$attribute});
+    }
+
+    /**
      * Execute a callback if the given pivot table has been loaded.
      *
      * @param  string  $table

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipAggregates.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipAggregates.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithOptionalRelationshipAggregates extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'average_rating' => $this->whenAggregated('comments', 'rating', 'avg'),
+            'minimum_rating' => $this->whenAggregated('comments', 'rating', 'min'),
+            'maximum_rating' => $this->whenAggregated('comments', 'rating', 'max', fn ($avg) => "$avg ratings", 'Default Value'),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -35,6 +35,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalHasAttrib
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipAggregates;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipCounts;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithoutWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
@@ -445,6 +446,65 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'author' => ['name' => 'jrrmartin'],
                 'author_name' => 'jrrmartin',
+            ],
+        ]);
+    }
+
+    public function testResourcesMayLoadOptionalRelationshipAggregates()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+                'comments_avg_rating' => 3.8,
+                'comments_min_rating' => 2,
+                'comments_max_rating' => 5
+            ]);
+
+            return new PostResourceWithOptionalRelationshipAggregates($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'title' => 'Test Title',
+                'average_rating' => 3.8,
+                'minimum_rating' => 2,
+                'maximum_rating' => "5 ratings",
+            ],
+        ]);
+    }
+
+    public function testResourcesMayHaveOptionalRelationshipAggregates()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ]);
+
+            return new PostResourceWithOptionalRelationshipAggregates($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'title' => 'Test Title',
+                'average_rating' => null,
+                'minimum_rating' => null,
+                'maximum_rating' => "Default Value",
             ],
         ]);
     }


### PR DESCRIPTION
This PR introduces a new method, `whenAveraged()`, to the `ConditionallyLoadsAttributes` trait. This function is designed to work similarly to `whenCounted()`, but retrieves a relationship's column average value if it exists, expanding upon the trait's conditional loading capabilities.

Eloquent example with [withAvg](https://laravel.com/docs/10.x/eloquent-relationships#other-aggregate-functions)
```php
$endpoints = $currentSite
            ->endpoints()
            ->withAvg('checks', 'response_time')
            ->get();
```

Eloquent Resource example with additional conditional relationship (`whenAveraged`)
```php
public function toArray($request)
{
    return [
       'response_time_avg' => $this->whenAveraged('checks', 'response_time'),
    ];
}
```

The `whenAveraged()` method takes in a relationship, a column name, an optional value, and an optional default value. It generates an attribute name by appending the string '_avg_' to the snake-cased version of the relationship name, followed by the column name. If this attribute does not exist in the resource's attributes, it returns the default value (or null if no default is provided).

This new method is particularly useful when dealing with large datasets where you want to conditionally load averages. It provides a convenient and readable way to handle such scenarios directly in the resource class, expanding upon the conditional loading capabilities of `whenCounted()`.