### PR TITLE
[11.x] Allow `TestResponse` to accept `Illuminate\Http\Request`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -570,7 +570,7 @@ trait MakesHttpRequests
             $response = $this->followRedirects($response);
         }
 
-        return static::$latestResponse = $this->createTestResponse($response);
+        return static::$latestResponse = $this->createTestResponse($response, $request);
     }
 
     /**
@@ -692,11 +692,12 @@ trait MakesHttpRequests
      * Create the test response instance from the given response.
      *
      * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Testing\TestResponse
      */
-    protected function createTestResponse($response)
+    protected function createTestResponse($response, $request)
     {
-        return tap(TestResponse::fromBaseResponse($response), function ($response) {
+        return tap(TestResponse::fromBaseResponse($response, $request), function ($response) {
             $response->withExceptions(
                 $this->app->bound(LoggedExceptionCollection::class)
                     ? $this->app->make(LoggedExceptionCollection::class)

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -38,7 +38,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * The request to delegate to.
+     * The original request for the response.
      *
      * @var \Illuminate\Http\Request|null
      */

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -38,6 +38,13 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * The request to delegate to.
+     *
+     * @var \Illuminate\Http\Request|null
+     */
+    public readonly ?Request $baseRequest;
+
+    /**
      * The response to delegate to.
      *
      * @var \Illuminate\Http\Response
@@ -62,11 +69,13 @@ class TestResponse implements ArrayAccess
      * Create a new test response instance.
      *
      * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Request|null  $request
      * @return void
      */
-    public function __construct($response)
+    public function __construct($response, $request = null)
     {
         $this->baseResponse = $response;
+        $this->baseRequest = $request;
         $this->exceptions = new Collection;
     }
 
@@ -74,11 +83,12 @@ class TestResponse implements ArrayAccess
      * Create a new TestResponse from another response.
      *
      * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Request|null  $request
      * @return static
      */
-    public static function fromBaseResponse($response)
+    public static function fromBaseResponse($response, $request = null)
     {
-        return new static($response);
+        return new static($response, $request);
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -38,11 +38,11 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * The original request for the response.
+     * The original request.
      *
      * @var \Illuminate\Http\Request|null
      */
-    public readonly ?Request $baseRequest;
+    public $baseRequest;
 
     /**
      * The response to delegate to.

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -55,8 +55,13 @@ class FallbackRouteTest extends TestCase
         })->where('any', '.*');
 
         $this->assertStringContainsString('one', $this->get('/one')->getContent());
-        $this->assertStringContainsString('wildcard', $this->get('/non-existing')->getContent());
-        $this->assertEquals(200, $this->get('/non-existing')->getStatusCode());
+
+        tap($this->get('/non-existing'), function ($response) {
+            $this->assertStringContainsString('wildcard', $response->getContent());
+            $this->assertEquals(200, $response->getStatusCode());
+
+            $this->assertSame('non-existing', $response->baseRequest->route('any'));
+        });
     }
 
     public function testNoRoutes()

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -107,6 +107,8 @@ PHP);
             'id' => $user->id,
             'name' => $user->name,
         ]);
+
+        $this->assertTrue($user->is($response->baseRequest->route('user')));
     }
 
     public function testSoftDeletedModelsAreNotRetrieved()
@@ -144,6 +146,8 @@ PHP);
             'id' => $user->id,
             'name' => $user->name,
         ]);
+
+        $this->assertTrue($user->is($response->baseRequest->route('user')));
     }
 
     public function testEnforceScopingImplicitRouteBindings()

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -27,8 +27,17 @@ class RouteViewTest extends TestCase
         $this->assertStringContainsString('Test bar', $this->get('/route/value1/value2')->getContent());
         $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
 
-        $this->assertEquals('value1', $this->get('/route/value1/value2')->viewData('param'));
-        $this->assertEquals('value2', $this->get('/route/value1/value2')->viewData('param2'));
+        tap($this->get('/route/value1/value2'), function ($response) {
+            $this->assertEquals('value1', $response->viewData('param'));
+            $this->assertEquals('value1', $response->baseRequest->route('param'));
+            $this->assertEquals('value2', $response->baseRequest->route('param2'));
+        });
+
+        tap($this->get('/route/value1/value2'), function ($response) {
+            $this->assertEquals('value2', $response->viewData('param2'));
+            $this->assertEquals('value1', $response->baseRequest->route('param'));
+            $this->assertEquals('value2', $response->baseRequest->route('param2'));
+        });
     }
 
     public function testRouteViewWithStatus()

--- a/tests/Integration/Routing/SimpleRouteTest.php
+++ b/tests/Integration/Routing/SimpleRouteTest.php
@@ -16,5 +16,11 @@ class SimpleRouteTest extends TestCase
         $response = $this->get('/');
 
         $this->assertSame('Hello World', $response->content());
+
+        $response = $this->get('/?foo=bar');
+
+        $this->assertSame('Hello World', $response->content());
+
+        $this->assertSame('bar', $response->baseRequest->query('foo'));
     }
 }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -33,7 +33,12 @@ class UrlSigningTest extends TestCase
         })->name('foo');
 
         $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]));
-        $this->assertSame('valid', $this->get($url)->original);
+
+        tap($this->get($url), function ($response) {
+            $this->assertSame('valid', $response->original);
+
+            $this->assertIsString($response->baseRequest->query('signature'));
+        });
     }
 
     public function testSigningUrlWithCustomRouteSlug()
@@ -46,8 +51,14 @@ class UrlSigningTest extends TestCase
         $model->routable = 'routable-slug';
 
         $this->assertIsString($url = URL::signedRoute('foo', ['post' => $model]));
-        $this->assertSame('valid', $this->get($url)->original['valid']);
-        $this->assertSame('routable-slug', $this->get($url)->original['slug']);
+
+
+        tap($this->get($url), function ($response) {
+            $this->assertSame('valid', $response->original['valid']);
+            $this->assertSame('routable-slug', $response->original['slug']);
+
+            $this->assertSame('routable-slug', $response->baseRequest->route('post'));
+        });
     }
 
     public function testTemporarySignedUrls()

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -52,7 +52,6 @@ class UrlSigningTest extends TestCase
 
         $this->assertIsString($url = URL::signedRoute('foo', ['post' => $model]));
 
-
         tap($this->get($url), function ($response) {
             $this->assertSame('valid', $response->original['valid']);
             $this->assertSame('routable-slug', $response->original['slug']);


### PR DESCRIPTION
This allows us to make assertions on the request from `TestResponse`

Some benefits include:

```php
Route::get('/users/{user}', function (User $user) {
    return $user->toArray();
});

$response = $this->get('/users/5');

$response->assertOk();

tap($response->baseRequest, function ($request) {
    $this->assertInstanceOf(User::class, $request->route('user'));
    $this->assertSame(5, $request->route('user')->getKey());
});
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
