### PR TITLE
Introduces a new method called `merge` on config `Repository` for merging a given array with an existing array value of config.

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -126,6 +126,20 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Merges a given array with an existing array configuration value.
+     *
+     * @param  string  $key
+     * @param  array  $value
+     * @return void
+     */
+    public function merge($key, array $value)
+    {
+        $array = $this->get($key, []);
+
+        $this->set($key, array_merge($array, $value));
+    }
+
+    /**
      * Get all of the configuration items for the application.
      *
      * @return array

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -9,6 +9,7 @@ namespace Illuminate\Support\Facades;
  * @method static void set(array|string $key, mixed $value = null)
  * @method static void prepend(string $key, mixed $value)
  * @method static void push(string $key, mixed $value)
+ * @method static void merge(string $key, array $value)
  * @method static array all()
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)


### PR DESCRIPTION
### If we need to merge a config file (that located domain dir) with another config file or need to merge a array with existing array value of config ( dynamic /from db ) then there is no way. 
  


### This pull request introduces a new method called ```merge``` on config ```Repository``` for merging a given array with an existing array value of config.

 Example:
 
 ```php
Config::merge('services.social', [
           'api_key' => 'test'
       ]);
```

I can access like:

```php
config('services.social.api_key')
```

