### PR TITLE
[10.x] Fix return type of `buildException` method

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -215,7 +215,7 @@ class ThrottleRequests
      * @param  string  $key
      * @param  int  $maxAttempts
      * @param  callable|null  $responseCallback
-     * @return \Illuminate\Http\Exceptions\ThrottleRequestsException
+     * @return \Illuminate\Http\Exceptions\ThrottleRequestsException|\Illuminate\Http\Exceptions\HttpResponseException
      */
     protected function buildException($request, $key, $maxAttempts, $responseCallback = null)
     {


### PR DESCRIPTION
When `buildException` is callable returned `HttpResponseException`.
But in phpdoc just added `ThrottleRequestsException`!