### PR TITLE
[10.x] Allow object caching to be disabled for custom class casters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -814,11 +814,9 @@ trait HasAttributes
                 ? $value
                 : $caster->get($this, $key, $value, $this->attributes);
 
-            if (
-                $caster instanceof CastsInboundAttributes ||
+            if ($caster instanceof CastsInboundAttributes ||
                 ! is_object($value) ||
-                $objectCachingDisabled
-            ) {
+                $objectCachingDisabled) {
                 unset($this->classCastCache[$key]);
             } else {
                 $this->classCastCache[$key] = $value;
@@ -1140,11 +1138,9 @@ trait HasAttributes
             ))
         );
 
-        if (
-            $caster instanceof CastsInboundAttributes ||
+        if ($caster instanceof CastsInboundAttributes ||
             ! is_object($value) ||
-            ($caster->withoutObjectCaching ?? false)
-        ) {
+            ($caster->withoutObjectCaching ?? false)) {
             unset($this->classCastCache[$key]);
         } else {
             $this->classCastCache[$key] = $value;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This is in a similar vein as #40519, but for custom class casters. I need to disable object caching but there's currently no way to do this with custom casters. This PR allows a boolean `withoutObjectCaching` property to be defined on the class casters which `HasAttributes` then checks for before caching.

Thanks!