### PR TITLE
[10.x] OOP principles: Ensure existence of Bootstrap method

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Bootstrap.php
+++ b/src/Illuminate/Contracts/Foundation/Bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation;
+
+interface Bootstrap
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function bootstrap(Application $app);
+}

--- a/src/Illuminate/Foundation/Bootstrap/BootProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/BootProviders.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 
-class BootProviders
+class BootProviders implements Bootstrap
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -6,13 +6,14 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 use Illuminate\Log\LogManager;
 use Monolog\Handler\NullHandler;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Throwable;
 
-class HandleExceptions
+class HandleExceptions implements Bootstrap
 {
     /**
      * Reserved memory so that errors can be displayed properly on memory exhaustion.

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -6,15 +6,16 @@ use Exception;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
-class LoadConfiguration
+class LoadConfiguration implements Bootstrap
 {
     /**
      * Bootstrap the given application.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
      * @return void
      */
     public function bootstrap(Application $app)
@@ -35,14 +36,14 @@ class LoadConfiguration
         // options available to the developer for use in various parts of this app.
         $app->instance('config', $config = new Repository($items));
 
-        if (! isset($loadedFromCache)) {
+        if (!isset($loadedFromCache)) {
             $this->loadConfigurationFiles($app, $config);
         }
 
         // Finally, we will set the application's environment based on the configuration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
-        $app->detectEnvironment(fn () => $config->get('app.env', 'production'));
+        $app->detectEnvironment(fn() => $config->get('app.env', 'production'));
 
         date_default_timezone_set($config->get('app.timezone', 'UTC'));
 
@@ -52,8 +53,8 @@ class LoadConfiguration
     /**
      * Load the configuration items from all of the files.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Contracts\Config\Repository  $repository
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Illuminate\Contracts\Config\Repository $repository
      * @return void
      *
      * @throws \Exception
@@ -62,7 +63,7 @@ class LoadConfiguration
     {
         $files = $this->getConfigurationFiles($app);
 
-        if (! isset($files['app'])) {
+        if (!isset($files['app'])) {
             throw new Exception('Unable to load the "app" configuration file.');
         }
 
@@ -74,7 +75,7 @@ class LoadConfiguration
     /**
      * Get all of the configuration files for the application.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
      * @return array
      */
     protected function getConfigurationFiles(Application $app)
@@ -86,7 +87,7 @@ class LoadConfiguration
         foreach (Finder::create()->files()->name('*.php')->in($configPath) as $file) {
             $directory = $this->getNestedDirectory($file, $configPath);
 
-            $files[$directory.basename($file->getRealPath(), '.php')] = $file->getRealPath();
+            $files[$directory . basename($file->getRealPath(), '.php')] = $file->getRealPath();
         }
 
         ksort($files, SORT_NATURAL);
@@ -97,8 +98,8 @@ class LoadConfiguration
     /**
      * Get the configuration file nesting path.
      *
-     * @param  \SplFileInfo  $file
-     * @param  string  $configPath
+     * @param \SplFileInfo $file
+     * @param string $configPath
      * @return string
      */
     protected function getNestedDirectory(SplFileInfo $file, $configPath)
@@ -106,7 +107,7 @@ class LoadConfiguration
         $directory = $file->getPath();
 
         if ($nested = trim(str_replace($configPath, '', $directory), DIRECTORY_SEPARATOR)) {
-            $nested = str_replace(DIRECTORY_SEPARATOR, '.', $nested).'.';
+            $nested = str_replace(DIRECTORY_SEPARATOR, '.', $nested) . '.';
         }
 
         return $nested;

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -15,7 +15,7 @@ class LoadConfiguration implements Bootstrap
     /**
      * Bootstrap the given application.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public function bootstrap(Application $app)
@@ -36,14 +36,14 @@ class LoadConfiguration implements Bootstrap
         // options available to the developer for use in various parts of this app.
         $app->instance('config', $config = new Repository($items));
 
-        if (!isset($loadedFromCache)) {
+        if (! isset($loadedFromCache)) {
             $this->loadConfigurationFiles($app, $config);
         }
 
         // Finally, we will set the application's environment based on the configuration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
-        $app->detectEnvironment(fn() => $config->get('app.env', 'production'));
+        $app->detectEnvironment(fn () => $config->get('app.env', 'production'));
 
         date_default_timezone_set($config->get('app.timezone', 'UTC'));
 
@@ -53,8 +53,8 @@ class LoadConfiguration implements Bootstrap
     /**
      * Load the configuration items from all of the files.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     * @param \Illuminate\Contracts\Config\Repository $repository
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Config\Repository  $repository
      * @return void
      *
      * @throws \Exception
@@ -63,7 +63,7 @@ class LoadConfiguration implements Bootstrap
     {
         $files = $this->getConfigurationFiles($app);
 
-        if (!isset($files['app'])) {
+        if (! isset($files['app'])) {
             throw new Exception('Unable to load the "app" configuration file.');
         }
 
@@ -75,7 +75,7 @@ class LoadConfiguration implements Bootstrap
     /**
      * Get all of the configuration files for the application.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return array
      */
     protected function getConfigurationFiles(Application $app)
@@ -87,7 +87,7 @@ class LoadConfiguration implements Bootstrap
         foreach (Finder::create()->files()->name('*.php')->in($configPath) as $file) {
             $directory = $this->getNestedDirectory($file, $configPath);
 
-            $files[$directory . basename($file->getRealPath(), '.php')] = $file->getRealPath();
+            $files[$directory.basename($file->getRealPath(), '.php')] = $file->getRealPath();
         }
 
         ksort($files, SORT_NATURAL);
@@ -98,8 +98,8 @@ class LoadConfiguration implements Bootstrap
     /**
      * Get the configuration file nesting path.
      *
-     * @param \SplFileInfo $file
-     * @param string $configPath
+     * @param  \SplFileInfo  $file
+     * @param  string  $configPath
      * @return string
      */
     protected function getNestedDirectory(SplFileInfo $file, $configPath)
@@ -107,7 +107,7 @@ class LoadConfiguration implements Bootstrap
         $directory = $file->getPath();
 
         if ($nested = trim(str_replace($configPath, '', $directory), DIRECTORY_SEPARATOR)) {
-            $nested = str_replace(DIRECTORY_SEPARATOR, '.', $nested) . '.';
+            $nested = str_replace(DIRECTORY_SEPARATOR, '.', $nested).'.';
         }
 
         return $nested;

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -5,11 +5,12 @@ namespace Illuminate\Foundation\Bootstrap;
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidFileException;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 use Illuminate\Support\Env;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
-class LoadEnvironmentVariables
+class LoadEnvironmentVariables implements Bootstrap
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Facades\Facade;
 
-class RegisterFacades
+class RegisterFacades implements Bootstrap
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 
-class RegisterProviders
+class RegisterProviders implements Bootstrap
 {
     /**
      * Bootstrap the given application.

--- a/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\Bootstrap;
 use Illuminate\Http\Request;
 
-class SetRequestForConsole
+class SetRequestForConsole implements Bootstrap
 {
     /**
      * Bootstrap the given application.


### PR DESCRIPTION
Hello!


This pull request creates the Bootstrap interface (in `Illuminate\Contracts\Foundation`) and implements it in the bootstrapper classes (`Illuminate\Foundation\Bootstrap`). This ensures the existence of the `bootstrap($app)` method.

```php
$this->make($bootstrapper)->bootstrap($this);
```

In the Application class, the bootstrap method is called on the bootstrapper list, which includes classes like BootstrapProviders, HandleExceptions, RegisterFacades, RegisterProviders, and so on.


```php
public function bootstrapWith(array $bootstrappers)
    {
        $this->hasBeenBootstrapped = true;

        foreach ($bootstrappers as $bootstrapper) {
            $this['events']->dispatch('bootstrapping: '.$bootstrapper, [$this]);

            $this->make($bootstrapper)->bootstrap($this);

            $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
        }
    }
```


The existence of this method should be guaranteed in both the current bootstrapper classes and any future classes that may be added. This action aligns with the principles of Object-Oriented Programming (OOP).


Thanks!
