### PR TITLE
[11.x] Format Task runtime to be more human-readable

### DIFF
--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\View\Components;
 
+use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -9,6 +10,8 @@ use function Termwind\terminal;
 
 class Task extends Component
 {
+    use InteractsWithTime;
+
     /**
      * Renders the component using the given arguments.
      *
@@ -39,7 +42,7 @@ class Task extends Component
             throw $e;
         } finally {
             $runTime = $task
-                ? (' '.number_format((microtime(true) - $startTime) * 1000).'ms')
+                ? (' '.$this->formatRunTime($startTime))
                 : '';
 
             $runTimeWidth = mb_strlen($runTime);

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -42,7 +42,7 @@ class Task extends Component
             throw $e;
         } finally {
             $runTime = $task
-                ? (' '.$this->formatRunTime($startTime))
+                ? (' '.$this->runTimeForHumans($startTime))
                 : '';
 
             $runTimeWidth = mb_strlen($runTime);

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Terminal;
 
@@ -21,6 +22,8 @@ use function Termwind\terminal;
 #[AsCommand(name: 'queue:work')]
 class WorkCommand extends Command
 {
+    use InteractsWithTime;
+
     /**
      * The console command name.
      *
@@ -248,21 +251,6 @@ class WorkCommand extends Command
         }
 
         return Carbon::now();
-    }
-
-    /**
-     * Given a start time, format the total run time for human readability.
-     *
-     * @param  float  $startTime
-     * @return string
-     */
-    protected function formatRunTime($startTime)
-    {
-        $runTime = (microtime(true) - $startTime) * 1000;
-
-        return $runTime > 1000
-            ? CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true)
-            : number_format($runTime, 2).'ms';
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -220,7 +220,7 @@ class WorkCommand extends Command
             return $this->output->writeln(' <fg=yellow;options=bold>RUNNING</>');
         }
 
-        $runTime = $this->formatRunTime($this->latestStartedAt);
+        $runTime = $this->runTimeForHumans($this->latestStartedAt);
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
             $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0

--- a/src/Illuminate/Support/InteractsWithTime.php
+++ b/src/Illuminate/Support/InteractsWithTime.php
@@ -67,11 +67,14 @@ trait InteractsWithTime
      * Given a start time, format the total run time for human readability.
      *
      * @param  float  $startTime
+     * @param  float  $endTime
      * @return string
      */
-    protected function formatRunTime($startTime)
+    protected function runTimeForHumans($startTime, $endTime = null)
     {
-        $runTime = (microtime(true) - $startTime) * 1000;
+        $endTime ??= microtime(true);
+
+        $runTime = ($endTime - $startTime) * 1000;
 
         return $runTime > 1000
             ? CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true)

--- a/src/Illuminate/Support/InteractsWithTime.php
+++ b/src/Illuminate/Support/InteractsWithTime.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Carbon\CarbonInterval;
 use DateInterval;
 use DateTimeInterface;
 
@@ -60,5 +61,20 @@ trait InteractsWithTime
     protected function currentTime()
     {
         return Carbon::now()->getTimestamp();
+    }
+
+    /**
+     * Given a start time, format the total run time for human readability.
+     *
+     * @param  float  $startTime
+     * @return string
+     */
+    protected function formatRunTime($startTime)
+    {
+        $runTime = (microtime(true) - $startTime) * 1000;
+
+        return $runTime > 1000
+            ? CarbonInterval::milliseconds($runTime)->cascade()->forHumans(short: true)
+            : number_format($runTime, 2).'ms';
     }
 }


### PR DESCRIPTION
As a companion to https://github.com/laravel/framework/pull/47227 Not sure if it's better for this to target master or 10.x, so I went with master 🤷 

inspired by @JayBizzle's suggestion on Twitter: https://twitter.com/JayBird1979/status/1666878098774671360 