### PR TITLE
[10.x] Can set custom Response for denial within `Gate@inspect()`

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -73,7 +73,7 @@ class Gate implements GateContract
      *
      * @var Illuminate\Auth\Access\Response|null
      */
-    protected $defaultDenialResponse = null;
+    protected $defaultDenialResponse;
 
     /**
      * The callback to be used to guess policy names.

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -83,14 +83,14 @@ class Gate implements GateContract
     /**
      * Create a new gate instance.
      *
-     * @param  Container  $container
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  callable  $userResolver
      * @param  array  $abilities
      * @param  array  $policies
      * @param  array  $beforeCallbacks
      * @param  array  $afterCallbacks
      * @param  callable|null  $guessPolicyNamesUsingCallback
-     * @param  Response|null  $denialResponse
+     * @param  \Illuminate\Auth\Access\Response|null  $denialResponse
      */
     public function __construct(Container $container, callable $userResolver, array $abilities = [],
                                 array $policies = [], array $beforeCallbacks = [], array $afterCallbacks = [],

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1114,7 +1114,9 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = new Gate(container: new Container, userResolver: function () {
             //
-        }, denialResponse: Response::denyWithStatus(999, 'my_message', 'abc'));
+        });
+
+        $gate->defaultDenialResponse(Response::denyWithStatus(999, 'my_message', 'abc'));
 
         $gate->define('foo', function() { return false; });
 
@@ -1134,7 +1136,7 @@ class AuthAccessGateTest extends TestCase
         });
 
         $gate->define('foo', function() { return false; });
-        $gate->setDenialResponse(Response::denyWithStatus(404, 'not_found', 'xyz'));
+        $gate->defaultDenialResponse(Response::denyWithStatus(404, 'not_found', 'xyz'));
 
         $response = $gate->inspect('foo', new AccessGateTestDummy);
         $this->assertTrue($response->denied());

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1109,6 +1109,40 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertFalse($gate->check('absent_invokable'));
     }
+
+    public function testCanSetDenialResponseInConstructor()
+    {
+        $gate = new Gate(container: new Container, userResolver: function () {
+            //
+        }, denialResponse: Response::denyWithStatus(999, 'my_message', 'abc'));
+
+        $gate->define('foo', function() { return false; });
+
+        $response = $gate->inspect('foo', new AccessGateTestDummy);
+
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertSame('my_message', $response->message());
+        $this->assertSame('abc', $response->code());
+        $this->assertSame(999, $response->status());
+    }
+
+    public function testCanSetDenialResponse()
+    {
+        $gate = new Gate(container: new Container, userResolver: function () {
+            //
+        });
+
+        $gate->define('foo', function() { return false; });
+        $gate->setDenialResponse(Response::denyWithStatus(404, 'not_found', 'xyz'));
+
+        $response = $gate->inspect('foo', new AccessGateTestDummy);
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertSame('not_found', $response->message());
+        $this->assertSame('xyz', $response->code());
+        $this->assertSame(404, $response->status());
+    }
 }
 
 class AccessGateTestClassForGuest


### PR DESCRIPTION
Allow setting the Response returned when a Gate's `inspect()` method fails. This is particularly helpful when using the `can` middleware.

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Gate::setDenialResponse(Response::denyAsNotFound());
    }
}
```

While it's possible to return a response from a Policy's method (or throw an Exception), this can lead to a lot of duplicated code.  I personally think it makes more sense to return a bool in most cases.

Being able to deny as not found is beneficial for security, as it doesn't expose whether a resource is matched or if the user is just unauthorized.