### PR TITLE
[11.x] Extend the UrlGenerator contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -60,6 +60,42 @@ interface UrlGenerator
     public function route($name, $parameters = [], $absolute = true);
 
     /**
+     * Get the URL for a given route instance.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
+     * @return string
+     *
+     * @throws \Illuminate\Routing\Exceptions\UrlGenerationException
+     */
+    public function toRoute($route, $parameters, $absolute);
+
+    /**
+     * Create a signed route URL for a named route.
+     *
+     * @param  string  $name
+     * @param  mixed  $parameters
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  bool  $absolute
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true);
+
+    /**
+     * Create a temporary signed route URL for a named route.
+     *
+     * @param  string  $name
+     * @param  \DateTimeInterface|\DateInterval|int  $expiration
+     * @param  array  $parameters
+     * @param  bool  $absolute
+     * @return string
+     */
+    public function temporarySignedRoute($name, $expiration, $parameters = [], $absolute = true);
+
+    /**
      * Get the URL to a controller action.
      *
      * @param  string|array  $action

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -60,18 +60,6 @@ interface UrlGenerator
     public function route($name, $parameters = [], $absolute = true);
 
     /**
-     * Get the URL for a given route instance.
-     *
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  mixed  $parameters
-     * @param  bool  $absolute
-     * @return string
-     *
-     * @throws \Illuminate\Routing\Exceptions\UrlGenerationException
-     */
-    public function toRoute($route, $parameters, $absolute);
-
-    /**
      * Create a signed route URL for a named route.
      *
      * @param  string  $name


### PR DESCRIPTION
Hello 

This pull requests aims to expand the things you can do by using the `Illuminate\Contracts\Routing\UrlGenerator` contract.
Currently, there is quite a difference in functionality between using the Facade (and the actual default implementation of this contract) and using the interface, in that you cannot generate signed routes.

> **Note:** The way I differentiated between what public methods of the default UrlGenerator implementation I should add to the contract and which I should not was to only add the routes that actually _generate an url_. Other methods could be added as well to create a parity of functionalities between the Facade and the Contract.

This PR adds the following stubs to the `UrlGenerator` contract:
- `public function toRoute($route, $parameters, $absolute);`
- `public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true);`
- `public function temporarySignedRoute($name, $expiration, $parameters = [], $absolute = true);`

I am requesting for a pull in the `master` branch, as this is technically a breaking change. Although for the majority of users this will not break anything, any custom implementation of the url generator will need to add these new methods.
