### PR TITLE
[10.x] Fix return type of `prefixedResource` & `prefixedResource`

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -179,7 +179,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return void
+     * @return Router
      */
     protected function prefixedResource($name, $controller, array $options)
     {
@@ -201,7 +201,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return void
+     * @return Router
      */
     protected function prefixedSingleton($name, $controller, array $options)
     {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -179,7 +179,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return Router
+     * @return \Illuminate\Routing\Router
      */
     protected function prefixedResource($name, $controller, array $options)
     {
@@ -201,7 +201,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return Router
+     * @return \Illuminate\Routing\Router
      */
     protected function prefixedSingleton($name, $controller, array $options)
     {


### PR DESCRIPTION
Both functions return `Router` but in phpdoc, it returns void!