### PR TITLE
whereRelation eloqunt query now can accept array, string or closure 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -450,7 +450,6 @@ trait QueriesRelationships
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
         return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
-
             if ($column instanceof Closure) {
                 $column($query);
             } elseif (is_array($value)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -384,6 +384,8 @@ trait QueriesRelationships
         return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
+            } elseif (is_array($value)) {
+                $query->whereIn($column, $value);
             } else {
                 $query->where($column, $operator, $value);
             }
@@ -404,6 +406,8 @@ trait QueriesRelationships
         return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
                 $column($query);
+            } elseif (is_array($value)) {
+                $query->whereIn($column, $value);
             } else {
                 $query->where($column, $operator, $value);
             }
@@ -423,7 +427,19 @@ trait QueriesRelationships
     public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
         return $this->whereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
+            if ($column instanceof Closure) {
+
+                $column($query);
+
+            } elseif (is_array($value)) {
+
+                $query->whereIn($column, $value);
+
+            } else {
+
+                $query->where($column, $operator, $value);
+
+            }
         });
     }
 
@@ -440,7 +456,20 @@ trait QueriesRelationships
     public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
     {
         return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
+
+            if ($column instanceof Closure) {
+
+                $column($query);
+
+            } elseif (is_array($value)) {
+
+                $query->whereIn($column, $value);
+
+            } else {
+
+                $query->where($column, $operator, $value);
+
+            }
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -428,17 +428,11 @@ trait QueriesRelationships
     {
         return $this->whereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
             if ($column instanceof Closure) {
-
                 $column($query);
-
             } elseif (is_array($value)) {
-
                 $query->whereIn($column, $value);
-
             } else {
-
                 $query->where($column, $operator, $value);
-
             }
         });
     }
@@ -458,17 +452,11 @@ trait QueriesRelationships
         return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
 
             if ($column instanceof Closure) {
-
                 $column($query);
-
             } elseif (is_array($value)) {
-
                 $query->whereIn($column, $value);
-
             } else {
-
                 $query->where($column, $operator, $value);
-
             }
         });
     }

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -120,11 +120,19 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $users = User::whereRelation('posts', 'public', true)->get();
 
         $this->assertEquals([1], $users->pluck('id')->all());
+
+        $users=User::whereRelation('posts', 'public', [true])->get();
+
+        $this->assertEquals([1], $users->pluck('id')->all());
     }
 
     public function testOrWhereRelation()
     {
         $users = User::whereRelation('posts', 'public', true)->orWhereRelation('posts', 'public', false)->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+
+        $users = User::whereRelation('posts', 'public', [true])->orWhereRelation('posts', 'public', [false])->get();
 
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
@@ -134,6 +142,10 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $texts = User::whereRelation('posts.texts', 'content', 'test')->get();
 
         $this->assertEquals([1], $texts->pluck('id')->all());
+
+        $texts = User::whereRelation('posts.texts', 'content', ['test'])->get();
+
+        $this->assertEquals([1], $texts->pluck('id')->all());
     }
 
     public function testNestedOrWhereRelation()
@@ -141,11 +153,18 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $texts = User::whereRelation('posts.texts', 'content', 'test')->orWhereRelation('posts.texts', 'content', 'test2')->get();
 
         $this->assertEquals([1, 2], $texts->pluck('id')->all());
+        $texts = User::whereRelation('posts.texts', 'content', ['test'])->orWhereRelation('posts.texts', 'content', ['test2'])->get();
+
+        $this->assertEquals([1, 2], $texts->pluck('id')->all());
     }
 
     public function testWhereMorphRelation()
     {
         $comments = Comment::whereMorphRelation('commentable', '*', 'public', true)->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+
+        $comments = Comment::whereMorphRelation('commentable', '*', 'public', [true])->get();
 
         $this->assertEquals([1], $comments->pluck('id')->all());
     }
@@ -157,6 +176,13 @@ class EloquentWhereHasTest extends DatabaseTestCase
             ->get();
 
         $this->assertEquals([1, 2], $comments->pluck('id')->all());
+
+        $comments = Comment::whereMorphRelation('commentable', '*', 'public', [true])
+            ->orWhereMorphRelation('commentable', '*', 'public', [false])
+            ->get();
+
+        $this->assertEquals([1, 2], $comments->pluck('id')->all());
+
     }
 
     public function testWithCount()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -182,7 +182,6 @@ class EloquentWhereHasTest extends DatabaseTestCase
             ->get();
 
         $this->assertEquals([1, 2], $comments->pluck('id')->all());
-
     }
 
     public function testWithCount()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -121,7 +121,7 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
         $this->assertEquals([1], $users->pluck('id')->all());
 
-        $users=User::whereRelation('posts', 'public', [true])->get();
+        $users = User::whereRelation('posts', 'public', [true])->get();
 
         $this->assertEquals([1], $users->pluck('id')->all());
     }


### PR DESCRIPTION
If ```$column``` is an instance of Closure, a nested condition is added to the related model using the provided closure as the condition.
If ```$value``` is an array, a "whereIn" condition is applied to the related model's column using the whereIn method of the query builder.
If none of the above conditions are met, a regular "where" condition is added to the related model's column using the where method of the query builder.