### PR TITLE
[11.x] Increment/decrement with cast value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -967,6 +967,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
+        if ($this->isClassDeviable($column)) {
+            $amount = (clone $this)->setAttribute($column, $amount)->getAttributeFromArray($column);
+        }
+
         return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
             $this->syncChanges();
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -424,12 +424,12 @@ class DecimalCaster implements CastsAttributes, DeviatesCastableAttributes, Seri
 
     public function increment($model, $key, $value, $attributes)
     {
-        return new Decimal($attributes[$key] + $value);
+        return new Decimal($attributes[$key] + ($value instanceof Decimal ? $value->getValue() : $value));
     }
 
     public function decrement($model, $key, $value, $attributes)
     {
-        return new Decimal($attributes[$key] - $value);
+        return new Decimal($attributes[$key] - ($value instanceof Decimal ? $value->getValue() : $value));
     }
 
     public function serialize($model, $key, $value, $attributes)

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -158,6 +158,14 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $model->decrement('price', '333.333');
 
         $this->assertSame((new Decimal('320.988'))->getValue(), $model->price->getValue());
+
+        $model->increment('price', new Decimal('100.001'));
+
+        $this->assertSame((new Decimal('420.989'))->getValue(), $model->price->getValue());
+
+        $model->decrement('price', new Decimal('200.002'));
+
+        $this->assertSame((new Decimal('220.987'))->getValue(), $model->price->getValue());
     }
 
     public function testSerializableCasts()

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -424,12 +424,12 @@ class DecimalCaster implements CastsAttributes, DeviatesCastableAttributes, Seri
 
     public function increment($model, $key, $value, $attributes)
     {
-        return new Decimal($attributes[$key] + ($value instanceof Decimal ? $value->getValue() : $value));
+        return new Decimal($attributes[$key] + ($value instanceof Decimal ? (string) $value : $value));
     }
 
     public function decrement($model, $key, $value, $attributes)
     {
-        return new Decimal($attributes[$key] - ($value instanceof Decimal ? $value->getValue() : $value));
+        return new Decimal($attributes[$key] - ($value instanceof Decimal ? (string) $value : $value));
     }
 
     public function serialize($model, $key, $value, $attributes)

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -181,7 +181,7 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertInstanceOf(Euro::class, $model->amount);
         $this->assertEquals('2', $model->amount->value);
 
-        $model->incrementAmount(new Euro('1'));
+        $model->increment('amount', new Euro('1'));
         $this->assertEquals('3.00', $model->amount->value);
     }
 
@@ -394,7 +394,7 @@ class EuroCaster implements CastsAttributes
 
     public function set($model, $key, $value, $attributes)
     {
-        return $value->value;
+        return $value instanceof Euro ? $value->value : $value;
     }
 
     public function increment($model, $key, string $value, $attributes)
@@ -418,9 +418,4 @@ class Member extends Model
     protected $casts = [
         'amount' => Euro::class,
     ];
-
-    public function incrementAmount(Euro $amount)
-    {
-        $this->increment('amount', $amount->value);
-    }
 }

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -399,14 +399,14 @@ class EuroCaster implements CastsAttributes
 
     public function increment($model, $key, $value, $attributes)
     {
-        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->plus($value)->toScale(2));
+        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->plus($value->value)->toScale(2));
 
         return $model->$key;
     }
 
     public function decrement($model, $key, $value, $attributes)
     {
-        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->subtract($value)->toScale(2));
+        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->subtract($value->value)->toScale(2));
 
         return $model->$key;
     }

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -397,14 +397,14 @@ class EuroCaster implements CastsAttributes
         return $value instanceof Euro ? $value->value : $value;
     }
 
-    public function increment($model, $key, string $value, $attributes)
+    public function increment($model, $key, $value, $attributes)
     {
         $model->$key = new Euro((string) BigNumber::of($model->$key->value)->plus($value)->toScale(2));
 
         return $model->$key;
     }
 
-    public function decrement($model, $key, string $value, $attributes)
+    public function decrement($model, $key, $value, $attributes)
     {
         $model->$key = new Euro((string) BigNumber::of($model->$key->value)->subtract($value)->toScale(2));
 


### PR DESCRIPTION
The increment/decrement methods on an Eloquent model can be used in combination with a cast. To get that working, the cast needs to implement the `DeviatesCastableAttributes` interface.

But the current implementation has a limitation: you have to provide a raw database value to the increment/decrement method, instead of the casted value.

```php
// Only this currently works:
$model->increment('price', \Brick\Money\Money::of(123, 'EUR')->getMinorAmount()->toInt());

// This PR makes the following possible:
$model->increment('price', \Brick\Money\Money::of(123, 'EUR'));
```
<details>
  <summary>Cast used in example</summary>

  ```php
  use Brick\Money\Money;
  use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
  use Illuminate\Contracts\Database\Eloquent\DeviatesCastableAttributes;

  class AsMoney implements CastsAttributes, DeviatesCastableAttributes
  {
      public function __construct(
          protected string $currency
      ) {
      }
  
      public function get($model, string $key, $value, array $attributes) : ?Money
      {
          return $value !== null ? Money::ofMinor($value, $this->currency) : null;
      }
  
      public function set($model, string $key, $value, array $attributes) : ?int
      {
          return $value instanceof Money ? $value->getMinorAmount()->toInt() : $value;
      }
  
      public function increment($model, string $key, $value, array $attributes) : Money
      {
          return $this->get($model, $key, $attributes[$key], $attributes)->plus($value);
      }
  
      public function decrement($model, string $key, $value, array $attributes) : Money
      {
          return $this->get($model, $key, $attributes[$key], $attributes)->minus($value);
      }
  }
 ```
</details>

<br/>

This PR fixes that.
I targeted the master branch for this, because I think some cast classes may not have a ‘set’ method that can accept both a database value and a casted value.