### PR TITLE
[10.x] Add support for `Cache::push()`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -191,6 +191,22 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Push a value onto a cached array.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function push($key, $value)
+    {
+        $array = $this->get($key, []);
+
+        $array[] = $value;
+
+        $this->put($key, $array);
+    }
+
+    /**
      * Store an item in the cache.
      *
      * @param  array|string  $key

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -195,15 +195,16 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @return bool
      */
-    public function push($key, $value)
+    public function push($key, $value, $ttl = null)
     {
         $array = $this->get($key, []);
 
         $array[] = $value;
 
-        $this->put($key, $array);
+        return $this->put($key, $array, $ttl);
     }
 
     /**


### PR DESCRIPTION
This PR proposes to add a `push()` method to the cache `Repository`.

Similar to the session `Store`, we can push an additional value onto an array in the session like so;
```php
Session::push('key', 'another value');
```

I think it will be much more convenient to push a value onto a cached array like so;
```php
Cache::put('key', ['value', 'another value']);

Cache::push('key', 'yet another value');
```