### PR TITLE
[10.x] Replace mapWithKeys with map in CanBeOneOfMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -141,9 +141,8 @@ trait CanBeOneOfMany
      */
     public function latestOfMany($column = 'id', $relation = null)
     {
-        return $this->ofMany(collect(Arr::wrap($column))->mapWithKeys(function ($column) {
-            return [$column => 'MAX'];
-        })->all(), 'MAX', $relation);
+        return $this->ofMany(collect(Arr::wrap($column))->map(fn ($column) => [$column => 'MAX'])->all(),
+            'MAX', $relation);
     }
 
     /**
@@ -155,9 +154,8 @@ trait CanBeOneOfMany
      */
     public function oldestOfMany($column = 'id', $relation = null)
     {
-        return $this->ofMany(collect(Arr::wrap($column))->mapWithKeys(function ($column) {
-            return [$column => 'MIN'];
-        })->all(), 'MIN', $relation);
+        return $this->ofMany(collect(Arr::wrap($column))->map(fn ($column) => [$column => 'MIN'])->all(),
+            'MIN', $relation);
     }
 
     /**


### PR DESCRIPTION
As the keys were never used, I replaced it with map and the anonymous function with a arrow function.
