### PR TITLE
[11.x] When passed a Model, `collect()` returns a collection containing the model

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -15,6 +15,10 @@ if (! function_exists('collect')) {
      */
     function collect($value = [])
     {
+        if ($value instanceof \Illuminate\Database\Eloquent\Model) {
+            $value = [$value];
+        }
+
         return new Collection($value);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use ArrayIterator;
 use Countable;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Stringable;
@@ -929,6 +930,13 @@ class SupportHelpersTest extends TestCase
             $expectedOutput,
             preg_replace_array($pattern, $replacements, $subject)
         );
+    }
+
+    public function testCollectModelReturnsModelCollection()
+    {
+        $class = new class() extends Model{};
+
+        $this->assertSame($class, collect($class)->first());
     }
 }
 


### PR DESCRIPTION
Inspired by @rasmuscnielsen's [tweet](https://twitter.com/rasmuscnielsen/status/1666833765178523652).

Currently 
```php
$model = User::first();

collect($model)->all() === $model->toArray();
```

But with this PR:
```php
collect($model)->all() === [$model];
```

I don't think I have personally ever run into this problem, but I could see that it would be bizarre behavior to a newer dev.