### PR TITLE
[10.x] Fix groupBy failing for Enum cast model attributes

### DIFF
--- a/tests/Support/Enums.php
+++ b/tests/Support/Enums.php
@@ -10,4 +10,5 @@ enum TestEnum
 enum TestBackedEnum: int
 {
     case A = 1;
+    case B = 2;
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2426,6 +2426,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylor', $data->get('name'));
         $this->assertSame('foo', $data->get('email'));
         $this->assertSame('male', $data->get('gender'));
+
+        $data = new Collection(['name' => 'taylor', TestBackedEnum::A->value => 'foo']);
+
+        $this->assertSame('foo', $data->getOrPut(TestBackedEnum::A, null));
+        $this->assertSame('foo', $data->get(TestBackedEnum::A));
+        $this->assertSame('bar', $data->getOrPut(TestBackedEnum::B, 'bar'));
+        $this->assertSame('bar', $data->get(TestBackedEnum::B));
     }
 
     public function testPut()
@@ -3300,6 +3307,24 @@ class SupportCollectionTest extends TestCase
 
         $result = $data->groupBy('name');
         $this->assertEquals(['Laravel' => [$payload[0], $payload[1]], 'Framework' => [$payload[2]]], $result->toArray());
+
+        $result = $data->groupBy('url');
+        $this->assertEquals(['1' => [$payload[0], $payload[1]], '2' => [$payload[2]]], $result->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByAttributeWithEnumKey($collection)
+    {
+        $data = new $collection($payload = [
+            ['name' => TestBackedEnum::A, 'url' => '1'],
+            ['name' => TestBackedEnum::A, 'url' => '1'],
+            ['name' => 'foobar', 'url' => '2'],
+        ]);
+
+        $result = $data->groupBy('name');
+        $this->assertEquals([1 => [$payload[0], $payload[1]], 'foobar' => [$payload[2]]], $result->toArray());
 
         $result = $data->groupBy('url');
         $this->assertEquals(['1' => [$payload[0], $payload[1]], '2' => [$payload[2]]], $result->toArray());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This PR fixes the collection `groupBy` method failing when trying to group by a model attribute that has an Enum cast.

The other changes were to be able to easily use Enums on the resultant collection to get the sub arrays:


E.g.,
```php
$collection = User::all()->groupBy('enum'); // where 'enum' is casted to an Enum class

$collection->get(Enum::Case);
```

Thanks!