### PR TITLE
[10.x] Build `Model`'s `$table` only once if not set

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1858,7 +1858,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getTable()
     {
-        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
+        return $this->table ??= Str::snake(Str::pluralStudly(class_basename($this)));
     }
 
     /**


### PR DESCRIPTION
Minor optimization, but no sense in performing extra string manipulations each time `getTable()` is called since the class's name will not change on subsequent calls.