### PR TITLE
[10.x] Add Factory::getNamespace()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -104,7 +104,7 @@ abstract class Factory
      *
      * @var string
      */
-    protected static $namespace = 'Database\\Factories\\';
+    public static $namespace = 'Database\\Factories\\';
 
     /**
      * The default model name resolver.
@@ -795,16 +795,6 @@ abstract class Factory
     public static function guessModelNamesUsing(callable $callback)
     {
         static::$modelNameResolver = $callback;
-    }
-
-    /**
-     * Return the namespace that contains the application's model factories.
-     *
-     * @return string
-     */
-    public static function getNamespace()
-    {
-        return static::$namespace;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -798,6 +798,16 @@ abstract class Factory
     }
 
     /**
+     * Return the namespace that contains the application's model factories.
+     *
+     * @return string
+     */
+    public static function getNamespace()
+    {
+        return static::$namespace;
+    }
+
+    /**
      * Specify the default namespace that contains the application's model factories.
      *
      * @param  string  $namespace

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -791,6 +791,13 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestPost::count());
         $this->assertSame(2, FactoryTestUser::count());
     }
+    
+    public function test_get_namespace()
+    {
+        Factory::useNamespace('Foo\\Bar\\');
+        
+        $this->assertSame('Foo\\Bar\\', Factory::getNamespace());
+    }
 
     /**
      * Get a database connection instance.

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -791,11 +791,11 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestPost::count());
         $this->assertSame(2, FactoryTestUser::count());
     }
-    
+
     public function test_get_namespace()
     {
         Factory::useNamespace('Foo\\Bar\\');
-        
+
         $this->assertSame('Foo\\Bar\\', Factory::getNamespace());
     }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -792,13 +792,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestUser::count());
     }
 
-    public function test_get_namespace()
-    {
-        Factory::useNamespace('Foo\\Bar\\');
-
-        $this->assertSame('Foo\\Bar\\', Factory::getNamespace());
-    }
-
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
When overriding the Factory name guesser via `Factory::guessFactoryNamesUsing()`, I often need to know the current factory namespace. While I could certainly just hard-code `Database\\Factories\\`, that goes out the window if `Factory::useNamespace()` is used.

This PR just adds `Factory::getNamespace()` to return the `static::$namespace` property.
