### PR TITLE
Fix CacheBasedMaintenanceMode return type issue

### DIFF
--- a/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
@@ -82,7 +82,7 @@ class CacheBasedMaintenanceMode implements MaintenanceMode
      */
     public function data(): array
     {
-        return $this->getStore()->get($this->key);
+        return $this->getStore()->get($this->key, []);
     }
 
     /**

--- a/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
+++ b/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
@@ -34,7 +34,7 @@ class FoundationCacheBasedMaintenanceModeTest extends TestCase
 
         $manager = new CacheBasedMaintenanceMode($cache, 'store-key', 'key');
 
-        $cache->shouldReceive('get')->once()->with('key')->andReturn(['payload']);
+        $cache->shouldReceive('get')->once()->with('key', [])->andReturn(['payload']);
         $this->assertSame(['payload'], $manager->data());
     }
 


### PR DESCRIPTION
The `CacheBasedMaintenanceMode::data()` return type is an `array`, however the `$default` parameter of the cache factory method `$this->getStore()->get($this->key)` it returns from is `null`. So if nothing matches the key, a `TypeError` gets thrown in the `PreventRequestsDuringMaintenance` middleware. 

I've fixed the issue by changing the `$default` parameter to `[]` when called, so the correct type is always returned.

```
{
  "exception": {
    "class": "TypeError",
    "message": "Illuminate\\Foundation\\CacheBasedMaintenanceMode::data(): Return value must be of type array, null returned",
    "code": 0,
    "file": "vendor/laravel/framework/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php:85",
    "trace": [
      "vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php:49",
      "vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
      "app/Http/Middleware/SecurityHeaders.php:11",
      "vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
      "vendor/laravel/framework/src/Illuminate/Http/Middleware/FrameGuard.php:18",
      "vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
      "vendor/laravel/framework/src/Illuminate/Http/Middleware/HandleCors.php:49",
      "vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
      "app/Http/Middleware/AssignRequestLogContext.php:18",
      "vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:180",
      "vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:116",
      "vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:175",
      "vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:144",
      "public/index.php:52"
    ]
  }
}
```