### PR TITLE
[11.x] Prevent attributes cast to an enum from being set to another enum

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -39,6 +39,7 @@ use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ValueError;
 
 trait HasAttributes
 {
@@ -309,7 +310,7 @@ trait HasAttributes
             }
 
             if ($this->isEnumCastable($key) && (! ($attributes[$key] ?? null) instanceof Arrayable)) {
-                $attributes[$key] = isset($attributes[$key]) ? $this->getStorableEnumValue($attributes[$key]) : null;
+                $attributes[$key] = isset($attributes[$key]) ? $this->getStorableEnumValue($this->getCasts()[$key], $attributes[$key]) : null;
             }
 
             if ($attributes[$key] instanceof Arrayable) {
@@ -1155,10 +1156,10 @@ trait HasAttributes
         if (! isset($value)) {
             $this->attributes[$key] = null;
         } elseif (is_object($value)) {
-            $this->attributes[$key] = $this->getStorableEnumValue($value);
+            $this->attributes[$key] = $this->getStorableEnumValue($enumClass, $value);
         } else {
             $this->attributes[$key] = $this->getStorableEnumValue(
-                $this->getEnumCaseFromValue($enumClass, $value)
+                $enumClass, $this->getEnumCaseFromValue($enumClass, $value)
             );
         }
     }
@@ -1180,11 +1181,16 @@ trait HasAttributes
     /**
      * Get the storable value from the given enum.
      *
+     * @param  string  $expectedEnum
      * @param  \UnitEnum|\BackedEnum  $value
      * @return string|int
      */
-    protected function getStorableEnumValue($value)
+    protected function getStorableEnumValue($expectedEnum, $value)
     {
+        if (! $value instanceof $expectedEnum) {
+            throw new ValueError(sprintf('Value [%s] is not of the expected enum type [%s]', var_export($value, true), $expectedEnum));
+        }
+
         return $value instanceof BackedEnum
                 ? $value->value
                 : $value->name;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1188,7 +1188,7 @@ trait HasAttributes
     protected function getStorableEnumValue($expectedEnum, $value)
     {
         if (! $value instanceof $expectedEnum) {
-            throw new ValueError(sprintf('Value [%s] is not of the expected enum type [%s]', var_export($value, true), $expectedEnum));
+            throw new ValueError(sprintf('Value [%s] is not of the expected enum type [%s].', var_export($value, true), $expectedEnum));
         }
 
         return $value instanceof BackedEnum

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -272,7 +272,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $this->expectException(ValueError::class);
         $this->expectExceptionMessage(
-            sprintf('Value [%s] is not of the expected enum type [%s]', var_export(ArrayableStatus::pending, true), StringStatus::class)
+            sprintf('Value [%s] is not of the expected enum type [%s].', var_export(ArrayableStatus::pending, true), StringStatus::class)
         );
 
         $model->string_status = ArrayableStatus::pending;

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use ValueError;
 
 include 'Enums.php';
 
@@ -263,6 +264,39 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $this->assertEquals(StringStatus::pending, $model->string_status);
         $this->assertEquals(StringStatus::done, $model2->string_status);
+    }
+
+    public function testAttributeCastToAnEnumCanNotBeSetToAnotherEnum(): void
+    {
+        $model = new EloquentModelEnumCastingTestModel;
+
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage(
+            sprintf('Value [%s] is not of the expected enum type [%s]', var_export(ArrayableStatus::pending, true), StringStatus::class)
+        );
+
+        $model->string_status = ArrayableStatus::pending;
+    }
+
+    public function testAttributeCastToAnEnumCanNotBeSetToAValueNotDefinedOnTheEnum(): void
+    {
+        $model = new EloquentModelEnumCastingTestModel;
+
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage(
+            sprintf('"unexpected_value" is not a valid backing value for enum %s', StringStatus::class)
+        );
+
+        $model->string_status = 'unexpected_value';
+    }
+
+    public function testAnAttributeWithoutACastCanBeSetToAnEnum(): void
+    {
+        $model = new EloquentModelEnumCastingTestModel;
+
+        $model->non_enum_status = StringStatus::pending;
+
+        $this->assertEquals(StringStatus::pending, $model->non_enum_status);
     }
 }
 


### PR DESCRIPTION
Prevent an attribute that is cast to an enum from being set to another enum value or a value not defined as a case on a `BackedEnum`. This will throw a `ValueError` like the following when attempting to do so.

```
Value [\App\SomeEnum::CASE] is not of the expected enum type [\App\AnotherEnum]
``` 

**NOTE:** This is technically a _breaking change_ but I'd consider it more of a bug fix so handle that as you will.

Resolves #47454