### PR TITLE
safe flag added into migrate  command to show the list of pending migration

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -51,4 +51,39 @@ trait ConfirmableTrait
             return $this->getLaravel()->environment() === 'production';
         };
     }
+
+    /**
+     * Confirm before proceeding with the action.
+     *
+     * This method dispalys list of pending migrations and  asks for confirmation .
+     *
+     * @param  string  $warning
+     * @return bool
+     */
+    public function confirmToProceedSafe($migrations = [], $warning = 'The following migrations will be executed')
+    {
+        $this->components->alert($warning);
+
+        $this->newLine();
+
+        $this->line('Total '.count($migrations).' migrations need to be applied:');
+
+        $this->newLine();
+
+        foreach ($migrations as $migration) {
+            $this->components->warn($migration);
+        }
+
+        $confirmed = $this->components->confirm('Apply the above migrations?');
+
+        if (! $confirmed) {
+            $this->newLine();
+
+            $this->components->warn('Command canceled.');
+
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -29,7 +29,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}
                 {--seeder= : The class name of the root seeder}
-                {--step : Force the migrations to be run so they can be rolled back individually}';
+                {--step : Force the migrations to be run so they can be rolled back individually}
+                {--safe : Display list of migrations and prompt the user to confirm whether wants to proceed or not}';
 
     /**
      * The console command description.
@@ -80,6 +81,14 @@ class MigrateCommand extends BaseCommand implements Isolatable
 
         $this->migrator->usingConnection($this->option('database'), function () {
             $this->prepareDatabase();
+
+            // Check If user wants to run migration in safe mode. If yes dispaly list of pending
+            // migrations and prompt the user to confirm whether wants to proceed or not
+            if ($this->option('safe')) {
+                if (! $this->confirmToProceedSafe($this->migrator->pendingMigrationsToDisplay($this->getMigrationPaths()))) {
+                    return 1;
+                }
+            }
 
             // Next, we will check to see if a path option has been defined. If it has
             // we will use the path relative to the root of this installation folder

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -775,4 +775,19 @@ class Migrator
             $this->events->dispatch($event);
         }
     }
+
+    /**
+     * Get the migration files that have not yet run.
+     *
+     * @param  array|string  $paths
+     * @return array
+     */
+    public function pendingMigrationsToDisplay($paths = [])
+    {
+        $files = $this->getMigrationFiles($paths);
+
+        return $this->pendingMigrations(
+            $files, $this->repository->getRan()
+        );
+    }
 }


### PR DESCRIPTION
I added a new "safe" flag in the migrate command, which allows users to list pending migrations and decide whether they want to run them or not. This feature is extremely useful as it helps users prevent running unwanted migrations without careful consideration.