### PR TITLE
[10.x] Add PendingRequest `withHeader()` method

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -392,7 +392,7 @@ class PendingRequest
             ]);
         });
     }
-	
+
     /**
      * Add the given header to the request.
      *
@@ -402,7 +402,7 @@ class PendingRequest
      */
     public function withHeader(string $name, mixed $value)
     {
-		return $this->withHeaders([$name => $value]);
+        return $this->withHeaders([$name => $value]);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -400,7 +400,7 @@ class PendingRequest
      * @param  mixed  $value
      * @return $this
      */
-    public function withHeader(string $name, mixed $value)
+    public function withHeader($name, $value)
     {
         return $this->withHeaders([$name => $value]);
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -392,6 +392,7 @@ class PendingRequest
             ]);
         });
     }
+	
     /**
      * Add the given header to the request.
      *

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -392,6 +392,17 @@ class PendingRequest
             ]);
         });
     }
+    /**
+     * Add the given header to the request.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function withHeader(string $name, mixed $value)
+    {
+		return $this->withHeaders([$name => $value]);
+    }
 
     /**
      * Replace the given headers on the request.

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -914,12 +914,12 @@ class HttpClientTest extends TestCase
 	{
 		$this->factory->fake();
 		
-		$this->factory->withHeader('X-Test-ArrayHeader', ['bar', 'baz'])->post('http://foo.com/json');
+		$this->factory->withHeader('X-Test-Header', 'foo')->post('http://foo.com/json');
 		
 		$this->factory->assertSent(function (Request $request) {
 			return $request->url() === 'http://foo.com/json' &&
 				$request->hasHeaders([
-					'X-Test-ArrayHeader' => ['bar', 'baz'],
+					'X-Test-Header' => 'foo',
 				]);
 		});
 	}
@@ -928,12 +928,12 @@ class HttpClientTest extends TestCase
 	{
 		$this->factory->fake();
 		
-		$this->factory->withHeader('X-Test-Header', 'foo')->post('http://foo.com/json');
+		$this->factory->withHeader('X-Test-ArrayHeader', ['bar', 'baz'])->post('http://foo.com/json');
 		
 		$this->factory->assertSent(function (Request $request) {
 			return $request->url() === 'http://foo.com/json' &&
 				$request->hasHeaders([
-					'X-Test-Header' => 'foo',
+					'X-Test-ArrayHeader' => ['bar', 'baz'],
 				]);
 		});
 	}

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -908,6 +908,35 @@ class HttpClientTest extends TestCase
                    $request->hasHeaders(['X-Test-Header' => ['baz']]);
         });
     }
+	
+	
+	public function testCanConfirmSingleStringHeader()
+	{
+		$this->factory->fake();
+		
+		$this->factory->withHeader('X-Test-ArrayHeader', ['bar', 'baz'])->post('http://foo.com/json');
+		
+		$this->factory->assertSent(function (Request $request) {
+			return $request->url() === 'http://foo.com/json' &&
+				$request->hasHeaders([
+					'X-Test-ArrayHeader' => ['bar', 'baz'],
+				]);
+		});
+	}
+	
+	public function testCanConfirmSingleArrayHeader()
+	{
+		$this->factory->fake();
+		
+		$this->factory->withHeader('X-Test-Header', 'foo')->post('http://foo.com/json');
+		
+		$this->factory->assertSent(function (Request $request) {
+			return $request->url() === 'http://foo.com/json' &&
+				$request->hasHeaders([
+					'X-Test-Header' => 'foo',
+				]);
+		});
+	}
 
     public function testExceptionAccessorOnSuccess()
     {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -908,35 +908,34 @@ class HttpClientTest extends TestCase
                    $request->hasHeaders(['X-Test-Header' => ['baz']]);
         });
     }
-	
-	
-	public function testCanConfirmSingleStringHeader()
-	{
-		$this->factory->fake();
-		
-		$this->factory->withHeader('X-Test-Header', 'foo')->post('http://foo.com/json');
-		
-		$this->factory->assertSent(function (Request $request) {
-			return $request->url() === 'http://foo.com/json' &&
-				$request->hasHeaders([
-					'X-Test-Header' => 'foo',
-				]);
-		});
-	}
-	
-	public function testCanConfirmSingleArrayHeader()
-	{
-		$this->factory->fake();
-		
-		$this->factory->withHeader('X-Test-ArrayHeader', ['bar', 'baz'])->post('http://foo.com/json');
-		
-		$this->factory->assertSent(function (Request $request) {
-			return $request->url() === 'http://foo.com/json' &&
-				$request->hasHeaders([
-					'X-Test-ArrayHeader' => ['bar', 'baz'],
-				]);
-		});
-	}
+
+    public function testCanConfirmSingleStringHeader()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeader('X-Test-Header', 'foo')->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                $request->hasHeaders([
+                    'X-Test-Header' => 'foo',
+                ]);
+        });
+    }
+
+    public function testCanConfirmSingleArrayHeader()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeader('X-Test-ArrayHeader', ['bar', 'baz'])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                $request->hasHeaders([
+                    'X-Test-ArrayHeader' => ['bar', 'baz'],
+                ]);
+        });
+    }
 
     public function testExceptionAccessorOnSuccess()
     {


### PR DESCRIPTION
This PR adds a convenience `withHeader()` method on the Http client PendingRequest class. I think that the majority of the time people only add a single header when using the `withHeaders()` method, so we could as well have a convenient method that saves 2 lines.

Before:

```php
Http::baseUrl(config('services.active-campaign.endpoint') . '/api/3')
    ->withHeaders([
        'Api-Token' => config('services.active-campaign.token')
    ])
    ->acceptJson();
```

After:

```php
Http::baseUrl(config('services.active-campaign.endpoint') . '/api/3')
    ->withHeader('Api-Token', config('services.active-campaign.token'))
    ->acceptJson();
```

Thanks!