### PR TITLE
[10.x] Fix $exceptTables to allow an array of table names

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -112,7 +112,7 @@ trait DatabaseTruncation
     {
         if (property_exists($this, 'exceptTables')) {
             return array_merge(
-                $this->exceptTables[$connectionName] ?? [],
+                $this->exceptTables[$connectionName] ?? $this->exceptTables ?: [],
                 [$this->app['config']->get('database.migrations')]
             );
         }

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -111,9 +111,18 @@ trait DatabaseTruncation
     protected function exceptTables(?string $connectionName): array
     {
         if (property_exists($this, 'exceptTables')) {
+            $migrationsTable = $this->app['config']->get('database.migrations');
+
+            if (array_is_list($this->exceptTables ?? [])) {
+                return array_merge(
+                    $this->exceptTables ?? [],
+                    [$migrationsTable],
+                );
+            }
+
             return array_merge(
-                $this->exceptTables[$connectionName] ?? $this->exceptTables ?: [],
-                [$this->app['config']->get('database.migrations')]
+                $this->exceptTables[$connectionName] ?? [],
+                [$migrationsTable],
             );
         }
 


### PR DESCRIPTION
The current implementation of [Database Truncation](https://laravel.com/docs/10.x/dusk#reset-truncation) in Laravel has a bug where it requires table names to be grouped by connection name, to ensure that specific tables are not truncated between tests. 

An example is shown below, and the current code is [here](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Testing/DatabaseTruncation.php#L76-L122).

```php
abstract class DuskTestCase extends BaseTestCase
{
    use CreatesApplication;
    use DatabaseTruncation;

    protected $connectionsToTruncate = ['mysql_testing'];
    protected $seeder = 'DatabaseSeeder';
    protected $exceptTables = [
        'mysql_testing' => [
            'table1',
            'table2'
        ]
    ];
}
```

According to the [documentation](https://laravel.com/docs/10.x/dusk#reset-truncation), it should be possible for this array to contain table names, as follows:

```php
abstract class DuskTestCase extends BaseTestCase
{
    use CreatesApplication;
    use DatabaseTruncation;

    protected $connectionsToTruncate = ['mysql_testing'];
    protected $seeder = 'DatabaseSeeder';
    protected $exceptTables = [
        'table1',
        'table2'
    ];
}
```

This PR changes the DatabaseTruncation trait to allow `$exceptTables` to be an array of table names.