### PR TITLE
[10.x] Fix `eachById` on `HasManyThrough` relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -567,6 +567,24 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Execute a callback over each item while chunking by ID.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
+    {
+        $column = $column ?? $this->getRelated()->getQualifiedKeyName();
+
+        $alias = $alias ?? $this->getRelated()->getKeyName();
+
+        return $this->prepareQueryBuilder()->eachById($callback, $count, $column, $alias);
+    }
+
+    /**
      * Get a generator for the given query.
      *
      * @return \Illuminate\Support\LazyCollection

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -407,6 +407,26 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         });
     }
 
+    public function testEachByIdReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $country->posts()->eachById(function ($post) {
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'laravel_through_key',
+            ], array_keys($post->getAttributes()));
+        });
+    }
+
     public function testLazyReturnsCorrectModels()
     {
         $this->seedData();


### PR DESCRIPTION
This PR updates `eachById` on the HasManyThrough relation which suffered from the same issue described in https://github.com/laravel/framework/pull/24096 (basically the id on the models returned were the ones of the parent).

