### PR TITLE
[10.x] Fix visibility for `Model::incrementQuietly()` and `Model::decrementQuietly()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1034,7 +1034,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function incrementQuietly($column, $amount = 1, array $extra = [])
+    public function incrementQuietly($column, $amount = 1, array $extra = [])
     {
         return static::withoutEvents(function () use ($column, $amount, $extra) {
             return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
@@ -1049,7 +1049,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function decrementQuietly($column, $amount = 1, array $extra = [])
+    public function decrementQuietly($column, $amount = 1, array $extra = [])
     {
         return static::withoutEvents(function () use ($column, $amount, $extra) {
             return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');


### PR DESCRIPTION
A small bug fix where `incrementQuietly()` and `decrementQuietly()` can't be used outside the model since they are defined as `protected`.

The following code is currently failing;
```php
$post = Post::first();

$post->incrementQuietly('views'); // Call to undefined method App\Models\Post::incrementQuietly().
```