### PR TITLE
[10.x] Added the ability to clear Factory afterMake and afterCreate callbacks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -708,6 +708,19 @@ abstract class Factory
     }
 
     /**
+     * Clear "after making" and "after creating" callbacks.
+     *
+     * @return static
+     */
+    public function withoutEvents()
+    {
+        return $this->newInstance([
+            'afterCreating' => collect(),
+            'afterMaking' => collect(),
+        ]);
+    }
+
+    /**
      * Specify how many models should be generated.
      *
      * @param  int|null  $count

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -228,6 +228,22 @@ class DatabaseEloquentFactoryTest extends TestCase
         unset($_SERVER['__test.user.making'], $_SERVER['__test.user.creating']);
     }
 
+    public function test_after_creating_and_making_callbacks_are_cleared()
+    {
+        FactoryTestUserFactory::new()
+            ->afterMaking(function ($user) {
+                $_SERVER['__test.user.making'] = $user;
+            })
+            ->afterCreating(function ($user) {
+                $_SERVER['__test.user.creating'] = $user;
+            })
+            ->withoutEvents()
+            ->create();
+
+        $this->assertArrayNotHasKey('__test.user.making', $_SERVER);
+        $this->assertArrayNotHasKey('__test.user.creating', $_SERVER);
+    }
+
     public function test_has_many_relationship()
     {
         $users = FactoryTestUserFactory::times(10)


### PR DESCRIPTION
Hello,

I was in need to call a Factory without afterCreate defined callback and i thought that this feature could be useful for more people eventually, so I implemented the method withoutEvents() that allows to call the factory without events I also did the test.

Greetings

/roger