### PR TITLE
[10.x] Fix return type and convert function to arrow function

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -216,15 +216,13 @@ class View implements ArrayAccess, Htmlable, ViewContract
     /**
      * Get the sections of the rendered view.
      *
-     * @return array
+     * @return string
      *
      * @throws \Throwable
      */
     public function renderSections()
     {
-        return $this->render(function () {
-            return $this->factory->getSections();
-        });
+        return $this->render(fn () => $this->factory->getSections());
     }
 
     /**


### PR DESCRIPTION
This PR addresses two changes in the code. First, it fixes the return type of the `renderSections` method from array to string. Second, it converts the function from a regular function to an arrow function for a more concise syntax.