### PR TITLE
[10.x] Add `mergeIfMissing` method  to `ValidatedInput` class

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -113,7 +113,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Merge the validated input with the given array of additional data if missing.
      *
-     * @param array $items
+     * @param  array  $items
      * @return static
      */
     public function mergeIfMissing(array $items)

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -111,6 +111,19 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Merge the validated input with the given array of additional data if missing.
+     *
+     * @param array $items
+     * @return static
+     */
+    public function mergeIfMissing(array $items)
+    {
+        return $this->merge(collect($items)
+            ->reject(fn ($value, $key) => Arr::has($this->input, $key))
+            ->all());
+    }
+
+    /**
      * Get the input as a collection.
      *
      * @return \Illuminate\Support\Collection

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -37,7 +37,7 @@ class ValidatedInputTest extends TestCase
 
         $input = $input->mergeIfMissing([
             'name' => 'Jack',
-            'foo' => 'Bar'
+            'foo' => 'Bar',
         ]);
 
         $this->assertEquals('Taylor', $input->name);

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -31,6 +31,22 @@ class ValidatedInputTest extends TestCase
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());
     }
 
+    public function test_merge_if_missing()
+    {
+        $input = new ValidatedInput(['name' => 'Taylor']);
+
+        $input = $input->mergeIfMissing([
+            'name' => 'Jack',
+            'foo' => 'Bar'
+        ]);
+
+        $this->assertEquals('Taylor', $input->name);
+        $this->assertEquals('Taylor', $input['name']);
+        $this->assertEquals('Bar', $input->foo);
+        $this->assertEquals(['name' => 'Taylor'], $input->only(['name']));
+        $this->assertEquals(['name' => 'Taylor', 'foo' => 'Bar'], $input->all());
+    }
+
     public function test_input_existence()
     {
         $inputA = new ValidatedInput(['name' => 'Taylor']);


### PR DESCRIPTION
This PR introduces the `mergeIfMissing` method. The `mergeIfMissing` method allows for merging additional data into the validated data, but only for keys that are not already present.

Example

``` php

dd($request->safe()->all());  // ["name" => "Taylor Otwell"]

$validated = $request->safe()->merge(['name' => 'James']);

dd($validated->all()) // ["name" => "James"]

$validated = $request->safe()->mergeIfMissing(['name' => 'James']);

dd($validated->all()) // ["name" => "Taylor Otwell"]


```