### PR TITLE
[10.x] Remove warnings in sorted middleware

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use ErrorException;
 use Illuminate\Support\Collection;
 
 class SortedMiddleware extends Collection
@@ -94,7 +95,15 @@ class SortedMiddleware extends Collection
 
         yield $stripped;
 
-        $interfaces = @class_implements($stripped);
+        $interfaces = false;
+
+        try {
+            $interfaces = class_implements($stripped);
+        } catch (ErrorException $exception) {
+            if ($exception->getMessage() !== "class_implements(): Class {$stripped} does not exist and could not be loaded") {
+                throw $exception;
+            }
+        }
 
         if ($interfaces !== false) {
             foreach ($interfaces as $interface) {
@@ -102,7 +111,15 @@ class SortedMiddleware extends Collection
             }
         }
 
-        $parents = @class_parents($stripped);
+        $parents = false;
+
+        try {
+            $parents = class_parents($stripped);
+        } catch (ErrorException $exception) {
+            if ($exception->getMessage() !== "class_parents(): Class {$stripped} does not exist and could not be loaded") {
+                throw $exception;
+            }
+        }
 
         if ($parents !== false) {
             foreach ($parents as $parent) {

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -99,6 +99,28 @@ class RoutingSortedMiddlewareTest extends TestCase
 
         $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
     }
+
+    public function testItIgnoresMissingClasses()
+    {
+        $priority = [
+            'First',
+            'Second',
+            'Third',
+        ];
+
+        $middleware = [
+            'Second',
+            'First',
+            'Missing',
+        ];
+
+        $expected = [
+            'First',
+            'Second',
+        ];
+
+        $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
+    }
 }
 
 interface FirstContractStub


### PR DESCRIPTION
The current implementation throws exceptions when working in a strict PHP environment which converts warnings to exceptions. This can be avoided.

I am currently facing a weird bootup error where nova does not exist but the middleware is trying to consult it.

I tracked down the problem to this function call, which uses the `@` trick to hide warnings. This alternate approach uses explicit exception handling which will silently ignore the missing class definition, which is (i believe) the intent of this code.

~Existing tests should cover the existing functionality without change. I'll add a unit test for this specific case where a class does not exist.~ added a test. 

There is the possibility that someone has relied on the warnings emitted by this code, could it break something if it works quieter now? idk...

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->