### PR TITLE
[10.x] Refactor `uniqueIds` validation in `resolveRouteBindingQuery`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -49,11 +49,7 @@ trait HasUlids
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
+        if (in_array($field ?? $this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
             throw (new ModelNotFoundException)->setModel(get_class($this), $value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -49,11 +49,7 @@ trait HasUuids
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
-
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUuid($value)) {
+        if (in_array($field ?? $this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUuid($value)) {
             throw (new ModelNotFoundException)->setModel(get_class($this), $value);
         }
 


### PR DESCRIPTION
This PR combines repeated conditions with duplicated logic into a single IF statement.

Before:

```php
if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUlid($value)) {
    throw (new ModelNotFoundException)->setModel(get_class($this), $value);
}

if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
    throw (new ModelNotFoundException)->setModel(get_class($this), $value);
}
```

After:

```php
if (in_array($field ?? $this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
    throw (new ModelNotFoundException)->setModel(get_class($this), $value);
}
```