### PR TITLE
[10.x] Refactor(InteractsWithQueue Trait): modify fail method ( remove else statement and merge tow if statement)

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -53,13 +53,11 @@ trait InteractsWithQueue
             $exception = new ManuallyFailedException($exception);
         }
 
-        if ($exception instanceof Throwable || is_null($exception)) {
-            if ($this->job) {
-                return $this->job->fail($exception);
-            }
-        } else {
-            throw new InvalidArgumentException('The fail method requires a string or an instance of Throwable.');
+        if (($exception instanceof Throwable || is_null($exception)) && $this->job) {
+            return $this->job->fail($exception);
         }
+
+        throw new InvalidArgumentException('The fail method requires a string or an instance of Throwable.');
     }
 
     /**


### PR DESCRIPTION
Hello!

This PR, the `fail` method in `InteractsWithQueue` trait has been simplified and made more readable by removing the else statement and combining two if conditions.


Thanks