### PR TITLE
[10.x] Add `UncompromisedVerifier::class` to `provides()` in `ValidationServiceProvider`

### DIFF
--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -74,7 +74,9 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     public function provides()
     {
         return [
-            'validator', 'validation.presence', UncompromisedVerifier::class,
+            'validator',
+            'validation.presence',
+            UncompromisedVerifier::class,
         ];
     }
 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -73,10 +73,6 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     public function provides()
     {
-        return [
-            'validator',
-            'validation.presence',
-            UncompromisedVerifier::class,
-        ];
+        return ['validator', 'validation.presence', UncompromisedVerifier::class,];
     }
 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -74,7 +74,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     public function provides()
     {
         return [
-            'validator', 'validation.presence',
+            'validator', 'validation.presence', UncompromisedVerifier::class
         ];
     }
 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -74,7 +74,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     public function provides()
     {
         return [
-            'validator', 'validation.presence', UncompromisedVerifier::class
+            'validator', 'validation.presence', UncompromisedVerifier::class,
         ];
     }
 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -73,6 +73,6 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     public function provides()
     {
-        return ['validator', 'validation.presence', UncompromisedVerifier::class,];
+        return ['validator', 'validation.presence', UncompromisedVerifier::class];
     }
 }


### PR DESCRIPTION
This PR updates the `provides()` method in the ``ValidationServiceProvider`` class to include the `UncompromisedVerifier::class` in the list of provided services.
