### PR TITLE
[10.x] Update `assertNeverSlept` method

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -388,7 +388,7 @@ class Sleep
      */
     public static function assertNeverSlept()
     {
-        return static::assertSleptTimes(0);
+        static::assertSleptTimes(0);
     }
 
     /**


### PR DESCRIPTION
Removed the return statement from the `assertNeverSlept` method, as it returns void.