### PR TITLE
Update DatabaseQueue.php

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -256,7 +256,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected function getLockForPopping()
     {
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $databaseVersion = $this->database->getConfig('options.version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -256,7 +256,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected function getLockForPopping()
     {
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $databaseVersion = $this->database->getConfig('options.version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $databaseVersion = $this->database->getConfig('version') ?? $this->database->getConfig('options.version') ?? ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -256,7 +256,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected function getLockForPopping()
     {
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $databaseVersion = $this->database->getConfig('version') ?? $this->database->getConfig('options.version') ?? ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $databaseVersion = $this->database->getConfig('version') ?? $this->database->getConfig('options.version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';


### PR DESCRIPTION
Fixes #47510 

When using the database driver for queues on an MSSQL connection, the PHP version on Mac specifically causes an error in DatabaseQueue.php when getting the database version.  This fix allows users to manually set the version in the database config options array.  