### PR TITLE
[10.x] Show source content on last line when CLI dump output is greater than display height

### DIFF
--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -94,7 +94,15 @@ class CliDumper extends BaseCliDumper
         $output = (string) $this->dump($data, true);
         $lines = explode("\n", $output);
 
-        $lines[0] .= $this->getDumpSourceContent();
+        $content = $this->getDumpSourceContent();
+        $lines[0] .= $content;
+
+        if (count($lines) > $this->getDisplayHeight()) {
+            // get index of last non-empty line
+            $index = array_key_last(array_filter($lines));
+
+            $lines[$index] .= $content;
+        }
 
         $this->output->write(implode("\n", $lines));
 
@@ -130,5 +138,15 @@ class CliDumper extends BaseCliDumper
     protected function supportsColors(): bool
     {
         return $this->output->isDecorated();
+    }
+
+    /**
+     * Gets the height of the display.
+     */
+    protected function getDisplayHeight(): int
+    {
+        $height = explode(' ', @exec('stty size 2>/dev/null'))[0];
+
+        return (int) ($height ?: 50);
     }
 }

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Foundation\Console\CliDumper;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
@@ -204,6 +205,40 @@ class CliDumperTest extends TestCase
         $output = $this->dump('hey from view');
 
         $expected = "\"hey from view\" // resources/views/welcome.blade.php\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testSourceContentOnLastLineWhenOutputGreaterThanDisplayHeight()
+    {
+        $output = new BufferedOutput();
+        $mock = m::mock(CliDumper::class.'[getDisplayHeight]', [
+            $output,
+            '/my-work-directory',
+            '/my-work-directory/storage/framework/views',
+        ])->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('getDisplayHeight')->andReturn(5)
+            ->getMock();
+
+        $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+
+        $mock->dumpWithSource($cloner->cloneVar(['string', 1, 1.1, ['string', 1, 1.1]]));
+
+        $output = $output->fetch();
+
+        $expected = <<<'EOF'
+        array:4 [ // app/routes/console.php:18
+          0 => "string"
+          1 => 1
+          2 => 1.1
+          3 => array:3 [
+            0 => "string"
+            1 => 1
+            2 => 1.1
+          ]
+        ] // app/routes/console.php:18
+
+        EOF;
 
         $this->assertSame($expected, $output);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR builds upon #44211 and also displays the source content at the end of the `dd` output when the output is larger than the display height.

I've had several instance in CLI mode where a dd outputs miles of text, and I have to scroll for a long time to to try and find the source. Also having the source at the bottom is super convenient:

![image](https://github.com/laravel/framework/assets/4176520/d16cd5bc-abc7-409c-a5f7-0321928ee4b2)