### PR TITLE
[10.x] Fix `ListenerMakeCommand` deprecations

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -44,14 +44,14 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $event = $this->option('event');
+        $event = $this->option('event') ?? '';
 
-        if (! Str::startsWith($event ?? '', [
+        if (! Str::startsWith($event, [
             $this->laravel->getNamespace(),
             'Illuminate',
             '\\',
         ])) {
-            $event = $this->laravel->getNamespace().'Events\\'.str_replace('/', '\\', $event ?? '');
+            $event = $this->laravel->getNamespace().'Events\\'.str_replace('/', '\\', $event);
         }
 
         $stub = str_replace(

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -46,12 +46,12 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         $event = $this->option('event');
 
-        if (! Str::startsWith($event, [
+        if (! Str::startsWith($event ?? '', [
             $this->laravel->getNamespace(),
             'Illuminate',
             '\\',
         ])) {
-            $event = $this->laravel->getNamespace().'Events\\'.str_replace('/', '\\', $event);
+            $event = $this->laravel->getNamespace().'Events\\'.str_replace('/', '\\', $event ?? '');
         }
 
         $stub = str_replace(


### PR DESCRIPTION
Fix `str_replace` depreciation if the event option is null
