### PR TITLE
[11.x] Add attempts to transaction on `saveOrFail`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -997,17 +997,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  array  $attributes
      * @param  array  $options
+     * @param int $attempts
      * @return bool
      *
      * @throws \Throwable
      */
-    public function updateOrFail(array $attributes = [], array $options = [])
+    public function updateOrFail(array $attributes = [], array $options = [], int $attempts = 1)
     {
         if (! $this->exists) {
             return false;
         }
 
-        return $this->fill($attributes)->saveOrFail($options);
+        return $this->fill($attributes)->saveOrFail($options, $attempts);
     }
 
     /**
@@ -1158,13 +1159,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Save the model to the database within a transaction.
      *
      * @param  array  $options
+     * @param int $attempts
      * @return bool
      *
      * @throws \Throwable
      */
-    public function saveOrFail(array $options = [])
+    public function saveOrFail(array $options = [], int $attempts = 1)
     {
-        return $this->getConnection()->transaction(fn () => $this->save($options));
+        return $this->getConnection()->transaction(
+            fn () => $this->save($options),
+            $attempts
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -997,7 +997,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  array  $attributes
      * @param  array  $options
-     * @param int $attempts
+     * @param  int $attempts
      * @return bool
      *
      * @throws \Throwable
@@ -1159,7 +1159,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Save the model to the database within a transaction.
      *
      * @param  array  $options
-     * @param int $attempts
+     * @param  int $attempts
      * @return bool
      *
      * @throws \Throwable

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -997,7 +997,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  array  $attributes
      * @param  array  $options
-     * @param  int $attempts
+     * @param  int  $attempts
      * @return bool
      *
      * @throws \Throwable
@@ -1159,7 +1159,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Save the model to the database within a transaction.
      *
      * @param  array  $options
-     * @param  int $attempts
+     * @param  int  $attempts
      * @return bool
      *
      * @throws \Throwable


### PR DESCRIPTION
This change enables passing down an attempt to database transaction on `saveOrFail`. 
Targeting master because it could be a potential breaking change since it changes signatures.
