### PR TITLE
[10.x] update [JsonResponse]: using match expression instead of if-elseif-else

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -16,7 +16,7 @@ class JsonResponse extends BaseJsonResponse
     }
 
     /**
-     * Constructor.
+     * Create a new JSON response instance.
      *
      * @param  mixed  $data
      * @param  int  $status

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -77,15 +77,12 @@ class JsonResponse extends BaseJsonResponse
         // Ensure json_last_error() is cleared...
         json_decode('[]');
 
-        if ($data instanceof Jsonable) {
-            $this->data = $data->toJson($this->encodingOptions);
-        } elseif ($data instanceof JsonSerializable) {
-            $this->data = json_encode($data->jsonSerialize(), $this->encodingOptions);
-        } elseif ($data instanceof Arrayable) {
-            $this->data = json_encode($data->toArray(), $this->encodingOptions);
-        } else {
-            $this->data = json_encode($data, $this->encodingOptions);
-        }
+        $this->data = match (true) {
+            $data instanceof Jsonable => $data->toJson($this->encodingOptions),
+            $data instanceof JsonSerializable => json_encode($data->jsonSerialize(), $this->encodingOptions),
+            $data instanceof Arrayable => json_encode($data->toArray(), $this->encodingOptions),
+            default => json_encode($data, $this->encodingOptions),
+        };
 
         if (! $this->hasValidJson(json_last_error())) {
             throw new InvalidArgumentException(json_last_error_msg());


### PR DESCRIPTION
Hello!

In this PR, a match expression has been used instead of if-elseif-else statements in the `setData` method of the `JsonResponse` class with the goal of improving readability.

Thanks!