### PR TITLE
[10.x] Add global middleware to `Http` client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -36,6 +36,13 @@ class Factory
     protected $beforeSendingCallbacks = [];
 
     /**
+     * The middleware to apply to every request.
+     *
+     * @var array
+     */
+    protected $globalMiddleware = [];
+
+    /**
      * The stub callables that will handle requests.
      *
      * @var \Illuminate\Support\Collection
@@ -92,6 +99,19 @@ class Factory
     public function beforeSendingAll($callback)
     {
         $this->beforeSendingCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Add middleware to apply to every request.
+     *
+     * @param  callable  $middleware
+     * @return $this
+     */
+    public function globalMiddleware($middleware)
+    {
+        $this->globalMiddleware[] = $middleware;
 
         return $this;
     }
@@ -373,7 +393,7 @@ class Factory
      */
     protected function newPendingRequest()
     {
-        return tap(new PendingRequest($this), function ($request) {
+        return tap(new PendingRequest($this, $this->globalMiddleware), function ($request) {
             foreach ($this->beforeSendingCallbacks as $callback) {
                 $request->beforeSending($callback);
             }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
@@ -92,6 +93,32 @@ class Factory
     public function globalMiddleware($middleware)
     {
         $this->globalMiddleware[] = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Add request middleware to apply to every request.
+     *
+     * @param  callable  $middleware
+     * @return $this
+     */
+    public function globalRequestMiddleware($middleware)
+    {
+        $this->globalMiddleware[] = Middleware::mapRequest($middleware);
+
+        return $this;
+    }
+
+    /**
+     * Add response middleware to apply to every request.
+     *
+     * @param  callable  $middleware
+     * @return $this
+     */
+    public function globalResponseMiddleware($middleware)
+    {
+        $this->globalMiddleware[] = Middleware::mapResponse($middleware);
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -89,7 +89,7 @@ class Factory
      * @param  callable  $callback
      * @return $this
      */
-    public function beforeSending($callback)
+    public function beforeSendingAll($callback)
     {
         $this->beforeSendingCallbacks[] = $callback;
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -29,13 +29,6 @@ class Factory
     protected $dispatcher;
 
     /**
-     * The callbacks that should execute before every request is sent.
-     *
-     * @var array
-     */
-    protected $beforeSendingCallbacks = [];
-
-    /**
      * The middleware to apply to every request.
      *
      * @var array
@@ -88,19 +81,6 @@ class Factory
         $this->dispatcher = $dispatcher;
 
         $this->stubCallbacks = collect();
-    }
-
-    /**
-     * Add a new "before sending" callback to every request.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function beforeSendingAll($callback)
-    {
-        $this->beforeSendingCallbacks[] = $callback;
-
-        return $this;
     }
 
     /**
@@ -393,11 +373,7 @@ class Factory
      */
     protected function newPendingRequest()
     {
-        return tap(new PendingRequest($this, $this->globalMiddleware), function ($request) {
-            foreach ($this->beforeSendingCallbacks as $callback) {
-                $request->beforeSending($callback);
-            }
-        });
+        return new PendingRequest($this, $this->globalMiddleware);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\UriTemplate\UriTemplate;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
@@ -623,6 +624,32 @@ class PendingRequest
     public function withMiddleware(callable $middleware)
     {
         $this->middleware->push($middleware);
+
+        return $this;
+    }
+
+    /**
+     * Add new request middleware the client handler stack.
+     *
+     * @param  callable  $middleware
+     * @return $this
+     */
+    public function withRequestMiddleware(callable $middleware)
+    {
+        $this->middleware->push(Middleware::mapRequest($middleware));
+
+        return $this;
+    }
+
+    /**
+     * Add new response middleware the client handler stack.
+     *
+     * @param  callable  $middleware
+     * @return $this
+     */
+    public function withResponseMiddleware(callable $middleware)
+    {
+        $this->middleware->push(Middleware::mapResponse($middleware));
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -216,12 +216,13 @@ class PendingRequest
      * Create a new HTTP Client instance.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
+     * @param  array  $middleware
      * @return void
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(Factory $factory = null, $middleware = [])
     {
         $this->factory = $factory;
-        $this->middleware = new Collection;
+        $this->middleware = new Collection($middleware);
 
         $this->asJson();
 

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -123,54 +123,6 @@ class Request implements ArrayAccess
     }
 
     /**
-     * Add the given headers to the request.
-     *
-     * @return $this
-     */
-    public function withHeaders($headers)
-    {
-        foreach ($headers as $key => $value) {
-            $this->request = $this->request->withAddedHeader($key, $value);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Add a given header to the request.
-     *
-     * @return $this
-     */
-    public function withHeader($key, $value)
-    {
-        return $this->withHeaders([$key => $value]);
-    }
-
-    /**
-     * Replace the given headers on the request.
-     *
-     * @return $this
-     */
-    public function replaceHeaders($headers)
-    {
-        foreach ($headers as $key => $value) {
-            $this->request = $this->request->withHeader($key, $value);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Replace a given header on the request.
-     *
-     * @return $this
-     */
-    public function replaceHeader($key, $value)
-    {
-        return $this->replaceHeaders([$key => $value]);
-    }
-
-    /**
      * Get the body of the request.
      *
      * @return string

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -123,6 +123,54 @@ class Request implements ArrayAccess
     }
 
     /**
+     * Add the given headers to the request.
+     *
+     * @return $this
+     */
+    public function withHeaders($headers)
+    {
+        foreach ($headers as $key => $value) {
+            $this->request = $this->request->withAddedHeader($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a given header to the request.
+     *
+     * @return $this
+     */
+    public function withHeader($key, $value)
+    {
+        return $this->withHeaders([$key => $value]);
+    }
+
+    /**
+     * Replace the given headers on the request.
+     *
+     * @return $this
+     */
+    public function replaceHeaders($headers)
+    {
+        foreach ($headers as $key => $value) {
+            $this->request = $this->request->withHeader($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Replace a given header on the request.
+     *
+     * @return $this
+     */
+    public function replaceHeader($key, $value)
+    {
+        return $this->replaceHeaders([$key => $value]);
+    }
+
+    /**
      * Get the body of the request.
      *
      * @return string

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2317,7 +2317,7 @@ class HttpClientTest extends TestCase
         $this->assertTrue($onStatsFunctionCalled);
     }
 
-    public function testItCanMakeGlobalChangesToNewPendingRequests()
+    public function testItCanAddGlobalBeforeSendingCallbacks()
     {
         $requests = [];
         $this->factory->fake(function ($r) use (&$requests) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2317,7 +2317,7 @@ class HttpClientTest extends TestCase
         $this->assertTrue($onStatsFunctionCalled);
     }
 
-    public function testItCanAddGlobalHeadersBeforeSending()
+    public function testItCanAddGlobalHeadersBeforeSendingAll()
     {
         $requests = [];
         $this->factory->fake(function ($r) use (&$requests) {
@@ -2326,7 +2326,7 @@ class HttpClientTest extends TestCase
             return $this->factory::response('expected content');
         });
 
-        $this->factory->beforeSending(function (Request $request, array $options, PendingRequest $pending) {
+        $this->factory->beforeSendingAll(function (Request $request, array $options, PendingRequest $pending) {
             return $request->replaceHeader('User-Agent', 'Laravel Framework/1.0')
                 ->withHeader('shared', 'global')
                 ->withHeader('list', ['item-1', 'item-2'])

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -29,7 +29,6 @@ use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;


### PR DESCRIPTION
💡 Updated!

This PR allows an application to add Guzzle middleware that is applied to every request made via the `Http` client. It also introduces some nicer named methods to add request / response only middleware.

Read more about [Guzzle middleware in their docs](https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html#middleware).

As an example, an application may globally set a `User-Agent` header, to be a good citizen of the Internet. To do this, you may add a global "request" middleware:

```php
// In a service provider...

use Illuminate\Support\Facades\Http;

Http::globalRequestMiddleware(
    fn ($request) => $request->withHeader('User-Agent', 'Laravel Framework/1.0')
);
```

This will mean that every outgoing request will now have the `User-Agent: Laravel Framework/1.0` header.

Here is another example, showing the addition of a global "response" middleware.

```php
// In a service provider...

use Illuminate\Support\Facades\Http;

Http::globalResponseMiddleware(
    fn ($response) => $response->withHeader('X-Finished-At', now()->toDateTimeString())
);
```

It is also possible, of course, to add a complete middleware that wraps both the request and response cycle. As an example, the following middleware will add a response header including the duration of the request in milliseconds. The value may also be logged or recorded elsewhere.

```php
// In a service provider...

use Illuminate\Support\Facades\Http;

Http::globalMiddleware(function ($handler) {
    return function ($request, $options) use ($handler) {
        $startedAt = now();

        return $handler($request, $options)
            ->then(fn ($response) => $response->withHeader(
                'X-Duration', $startedAt->diffInMilliseconds(now())
            ));
    };
});
```

Something like the above would also be possible via the [`on_stats` Guzzle option](https://docs.guzzlephp.org/en/stable/request-options.html#on-stats).

The global middleware is also useful for logging and inspection of outgoing requests or incoming responses, although this is also possible by listening to events, but now we have a unified way of doing this.

```php
// In a service provider...

use RuntimeException;
use Illuminate\Support\Facades\Http;
use Illuminate\Support\Facades\Log;

Http::globalRequestMiddleware(function ($request) {
    if ($request->getUri()->getScheme() !== 'https') {
        throw new RuntimeException('Outgoing HTTP connections must use HTTPS.');
    }

    Log::info('Sending a HTTP request', ['url' => (string) $request->getUri()]);

    return $request;
});
```

I've also introduced named middleware methods for the request / response middleware to the `PendingRequest` class. These make adding middleware feel more at home in Laravel, IMO, when compared to having to reference the `GuzzleHttp\Middleware` class directly.

Here is a before and after of using the new named methods for a "request" middleware:

```diff
- use GuzzleHttp\Middleware;
use Illuminate\Support\Facades\Http;
 
- $response = Http::withMiddleware(Middleware::mapRequest(function ($request) {
+ $response = Http::withRequestMiddleware(function ($request) {
    return $request->withHeader('X-Example', 'Value');
- }))->get('http://example.com');
+ })->get('http://example.com');
```

You can see the currently documented way in the screenshot below. I feel these named methods greatly streamline the user-facing API.

<img width="637" alt="Screen Shot 2023-06-25 at 1 21 31 pm" src="https://github.com/laravel/framework/assets/24803032/6726db30-b386-49ca-bc12-7d7b21f6e522">


Here is the full API for adding middleware to Http requests after this PR:

```php
// Global middleware...

Http::globalMiddleware(function ($handler) {
    // ...
});

// Global request middleware...

Http::globalRequestMiddleware(function ($request) {
    // ...
});

// Global response middleware...

Http::globalResponseMiddleware(function ($response) {
    // ...
});

// One-time middleware...

Http::withMiddleware(function ($handler) {
    // ...
})->get(/* ... */);

// One-time request middleware...

Http::withRequestMiddleware(function ($handler) {
    // ...
})->get(/* ... */);

// One-time response middleware...

Http::withResponseMiddleware(function ($handler) {
    // ...
})->get(/* ... */);

```

Similar PRs:

- https://github.com/laravel/framework/pull/46637
- https://github.com/laravel/framework/pull/40332