### PR TITLE
Enable subdirectory support for migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -109,6 +109,10 @@ class Migrator
      */
     public function run($paths = [], array $options = [])
     {
+        // Retrieve all subdirectories for the given path(s) and
+        // merge them with the original path(s)
+        $paths = $this->retrieveSubdirectories($paths);
+
         // Once we grab all of the migration files for the path, we will compare them
         // against the migrations that have already been run for this package then
         // run each of the outstanding migrations against a database connection.
@@ -124,6 +128,28 @@ class Migrator
         $this->runPending($migrations, $options);
 
         return $migrations;
+    }
+
+    /**
+     * Recursively returns subdirectories within the given directory path(s),
+     * including child subdirectories.
+     */
+    private function retrieveSubdirectories(array|string $paths): array
+    {
+        $paths = is_string($paths) ? [$paths] : $paths;
+
+        $subdirs = [];
+
+        foreach ($paths as $path) {
+            $subdirs += glob($path . '/*', GLOB_ONLYDIR) ?? [];
+        }
+
+        if (!empty($subdirs)) {
+            $subdirs = $this->retrieveSubdirectories($subdirs);
+            return array_merge($paths, $subdirs);
+        }
+
+        return $paths;
     }
 
     /**


### PR DESCRIPTION
This commit implements the functionality to support subdirectories in Laravel migrations. The `retrieveSubdirectories` function is added, allowing the recursive retrieval of all subdirectories within the specified directory path(s), including child subdirectories. 

This enhancement enables a more organized structure for migration files by enabling the creation of subdirectories within the migrations directory. The code handles both single path and array of paths, offering flexibility in defining the target directories.

The migration ordering continues to be based on the existing timestamp ordering, as you can see in the initial example.
See the [discussion](https://github.com/laravel/framework/discussions/47521) .

Initial example:

- database
- - migrations
- - - 2023_06_22_000000_create_users_table.php
- - - 2023_06_22_000001_create_user_xs_table.php
- - - 2023_06_22_000002_create_user_ys_table.php
- - - 2023_06_22_000003_create_companies_table.php
- - - 2023_06_22_000004_create_company_zs_table.php
- - - 2023_06_22_000005_create_company_ts_table.php


Now, it can be converted to:

- database
- - migrations
- - - company_migrations
- - - - 2023_06_22_000003_create_companies_table.php
- - - - 2023_06_22_000004_create_company_zs_table.php
- - - - 2023_06_22_000005_create_company_ts_table.php
- - - user_migrations
- - - - 2023_06_22_000000_create_users_table.php
- - - - 2023_06_22_000001_create_user_xs_table.php
- - - - 2023_06_22_000002_create_user_ys_table.php