### PR TITLE
[10.x] add `toAssociative` method to `Arr` and `Collection`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -812,6 +812,30 @@ class Arr
     }
 
     /**
+     * Ensure the array is associative, using the value for missing keys.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @return array
+     */
+    public static function toAssociative($array, $callback = null)
+    {
+        $callback ??= fn ($value) => (string) $value;
+
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            if (is_string($key)) {
+                $result[$key] = $value;
+            } else {
+                $result[$value] = $callback($value, $key, $array);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Conditionally compile classes from an array into a CSS class list.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1695,6 +1695,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Ensure the items are associative, using the value for missing keys.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function toAssociative($callback = null)
+    {
+        $callback ??= fn ($value) => (string) $value;
+
+        return new static(Arr::toAssociative($this->items, fn ($value, $key, $original) => $callback($value, $key, $this)));
+    }
+
+    /**
      * Get a base Support collection instance from this collection.
      *
      * @return \Illuminate\Support\Collection<TKey, TValue>

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1196,4 +1196,46 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testToAssociative()
+    {
+        $original = [
+            'value-1',
+            'key-1' => 'value',
+            'value-2',
+            'key-2' => 'value',
+        ];
+
+        $result = Arr::toAssociative($original);
+
+        $this->assertEquals([
+            'value-1' => 'value-1',
+            'key-1' => 'value',
+            'value-2' => 'value-2',
+            'key-2' => 'value',
+        ], $result);
+    }
+
+    public function testToAssociativeWithCallback()
+    {
+        $original = [
+            'value-1',
+            'key-1' => 'value',
+            'value-2',
+            'key-2' => 'value',
+        ];
+
+        $result = Arr::toAssociative($original, function ($value, $key, $array) use ($original) {
+            $this->assertSame($original, $array);
+
+            return "{$value}:{$key}";
+        });
+
+        $this->assertEquals([
+            'key-1' => 'value',
+            'key-2' => 'value',
+            'value-1' => 'value-1:0',
+            'value-2' => 'value-2:1',
+        ], $result);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5564,6 +5564,48 @@ class SupportCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testToAssociative()
+    {
+        $original = collect([
+            'value-1',
+            'key-1' => 'value',
+            'value-2',
+            'key-2' => 'value',
+        ]);
+
+        $result = $original->toAssociative();
+
+        $this->assertEquals([
+            'value-1' => 'value-1',
+            'key-1' => 'value',
+            'value-2' => 'value-2',
+            'key-2' => 'value',
+        ], $result->all());
+    }
+
+    public function testToAssociativeWithCallback()
+    {
+        $original = collect([
+            'value-1',
+            'key-1' => 'value',
+            'value-2',
+            'key-2' => 'value',
+        ]);
+
+        $result = $original->toAssociative(function ($value, $key, $collection) use ($original) {
+            $this->assertSame($original, $collection);
+
+            return "{$value}:{$key}";
+        });
+
+        $this->assertEquals([
+            'key-1' => 'value',
+            'key-2' => 'value',
+            'value-1' => 'value-1:0',
+            'value-2' => 'value-2:1',
+        ], $result->all());
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
This PR introduces an array / collection method that is useful for configuration options.

Often it can be useful for configuration options to offer an API that has the following signature:

- Just unique values.
- A mix of string => value and int => value
- Just string => value.

A few examples to illustrate when this pattern comes in handy...

Take an API resource class that allows you to specify the attributes you want to include from a model, while also using a key => value pair to indicate that the attribute should be renamed in the API response:

```php
class UserResource extends BaseResource
{
    /**
     * The model attributes to include.
     *
     * @var  array<string|int, string>  $attributes
     */
    protected $attributes = [
        'name',
        'email',
        'username' => 'login',
        'business_name' => 'businessName',
    ];
}
```

This array will require some normalization...

```php
$items = collect($this->attributes)->mapWithKeys(function ($value, $key) {
    return is_string($key)
        ? [$key => $value]
        : [$value => $value];
});

//    [
//        'name' => 'name',
//        'email' => 'email',
//        'username' => 'login',
//        'business_name' => 'businessName',
//    ];
```


, which is what this new method does:

```php
$items = collect($this->attributes)->toAssociative();

//    [
//        'name' => 'name',
//        'email' => 'email',
//        'username' => 'login',
//        'business_name' => 'businessName',
//    ];
```

You may also see this pattern in configuration files, where a key may be provided to provide a "nice" name, otherwise the value is used.

```php
return [
    'monitor_api_usage' => [
        'user:5',
        'team:6',
        'user:88' => 'Tim'
    ],
];
```

This array will also need some normalisation to output the "nice" name when present...

| Name   | API Requests |
|--------|--------------|
| user:5 | 56 |
| team:6 | 23 |
| Tim | 9 | 

Lastly, the method accepts a callable. The result of the callback is used as the value.

> **Note** The callable is only executed when they item's key is an integer. In the following example the callable is only invoked twice.

```php
collect([
    'user:5',
    'team:6',
    'user:88' => 'Tim'
])->toAssociative(fn ($value) => "raw:{$value}");

//    [
//        'user:5' => 'raw:user:5',
//        'team:6' => 'raw:team:6',
//        'user:88' => 'Tim',
//    ];
```


| Name   | API Requests |
|--------|--------------|
| raw:user:5 | 56 |
| raw:team:6 | 23 |
| Tim | 9 | 

## Naming

I don't have a good name for this method. I've instead outsourced to Twitter: https://twitter.com/timacdonald87/status/1671732330648723458