### PR TITLE
[10.x] Fix Http client pool return type

### DIFF
--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -78,7 +78,7 @@ class Pool
      *
      * @param  string  $method
      * @param  array  $parameters
-     * @return \Illuminate\Http\Client\PendingRequest
+     * @return \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\Promise
      */
     public function __call($method, $parameters)
     {


### PR DESCRIPTION
The current docblock code presumes that any method by `PendingRequest` return itself, however, this is not the case, even for simple scenarios:

``` php
Http::pool(fn (Pool $pool) => [
    $pool->get('http://localhost/first'), // Returns Promise and not PendingRequest
    $pool->get('http://localhost/second'), // Returns Promise and not PendingRequest
    $pool->get('http://localhost/third'), // Returns Promise and not PendingRequest
]);
``` 

Any method that represents creating an async request will return a **Promise** class: `get`, `head`, `post`, `patch`, `put`, and `delete`. Only methods to configure the request will return the class itself, ex: `withOptions`, `retry`, `timeout`.

When using a static analysis tool and creating a function to mock a pool request is where the problem comes. Here is an example to demonstrate it:

```php
public function prepareMyPoolRequest(Pool $pool, string $endpoint): Promise // This is the correct return type, however when running Psalm, it will throw an error saying that the ->get() method returns a PendingRequest.
{
     $baseUrl = '...';
     
     return $pool->get($baseUrl.$endpoint);
}
```

This pull request adds `\GuzzleHttp\Promise\Promise` to the `__call` magic method from `Pool` class for async requests.  This will create a union, and any method called (according to the new docblock) may return any of the two classes. This may generate some uncertainty in some static analysis cases.

A better way to patch this, in the static analysis view, would be creating the methods `get`, `head`, `post`, `patch`, `put`, and `delete` on the **Pool** class, enforcing that they will return a **Promise** instance and all other methods will fallback to the `__call` magic method that says it returns a **PendingRequest** instance, which is now correct. But this will lead to some new lines of code instead of just adjusting a docblock value.