### PR TITLE
[10.x] clone input command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -172,10 +172,10 @@ class Command extends SymfonyCommand
         );
 
         $this->components = $this->laravel->make(Factory::class, ['output' => $this->output]);
-
+        $this->input = clone $input;
         try {
             return parent::run(
-                $this->input = $input, $this->output
+               $input , $this->output
             );
         } finally {
             $this->untrap();


### PR DESCRIPTION
When we capture the event to rewrite options and arguments, the option and argument are reset. cloning allows us to keep the transmitted data in memory. 
https://github.com/symfony/console/blob/8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7/Input/Input.php#L49-L56


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
