### PR TITLE
[10.x] Allow `%` symbol in component attribute names

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -128,7 +128,7 @@ class ComponentTagCompiler
                             )
                             |
                             (?:
-                                [\w\-:.@]+
+                                [\w\-:.@%]+
                                 (
                                     =
                                     (?:
@@ -193,7 +193,7 @@ class ComponentTagCompiler
                             )
                             |
                             (?:
-                                [\w\-:.@]+
+                                [\w\-:.@%]+
                                 (
                                     =
                                     (?:
@@ -588,7 +588,7 @@ class ComponentTagCompiler
         $attributeString = $this->parseBindAttributes($attributeString);
 
         $pattern = '/
-            (?<attribute>[\w\-:.@]+)
+            (?<attribute>[\w\-:.@%]+)
             (
                 =
                 (?<value>

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -100,13 +100,13 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $this->mockViewFactory();
 
-        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
+        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required x-intersect.margin.-50%.0px="visibleSection = \'profile\'" /><x-alert /></div>');
 
         $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestAlertComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
+<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true,'x-intersect.margin.-50%.0px' => 'visibleSection = \'profile\'']); ?>\n".
 "@endComponentClass##END-COMPONENT-CLASS####BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestAlertComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>


### PR DESCRIPTION
Resubmission of #47509 targeting the `10.x` branch

------------

I was recently dealing with a `component` where we wanted to use the `Alpine` [`intersect`](https://alpinejs.dev/plugins/intersect) plugin, but soon realised you couldn't do something like this...

```html
<x-component class="font-bold" x-intersect.margin.-50%.0px="visibleSection = 'profile'" />
```

It seems the Blade component compiler doesn't allow `%` symbols in attribute names.

Im not sure if there is a reason for this, or if it is an oversight, but I had a go at fixing it, so here it is.