### PR TITLE
[10.x] Allow closures to be used as view data

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Support\Arr;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -241,7 +242,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
         if ($key instanceof Closure) {
             $with = [];
             $values = $key();
-            $keys = array_keys($values);
+            $keys = array_keys(Arr::wrap($values));
 
             $func = new ReflectionFunction($key);
             $originalKeys = array_keys($func->getStaticVariables());

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -241,8 +241,8 @@ class View implements ArrayAccess, Htmlable, ViewContract
     {
         if ($key instanceof Closure) {
             $with = [];
-            $values = $key();
-            $keys = array_keys(Arr::wrap($values));
+            $values = Arr::wrap($key());
+            $keys = array_keys($values);
 
             $func = new ReflectionFunction($key);
             $originalKeys = array_keys($func->getStaticVariables());

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -240,24 +240,24 @@ class View implements ArrayAccess, Htmlable, ViewContract
     {
         if ($key instanceof Closure) {
             $with = [];
-            $values = $closure();
+            $values = $key();
             $keys = array_keys($values);
-            
-            $func = new ReflectionFunction($closure);
+
+            $func = new ReflectionFunction($key);
             $originalKeys = array_keys($func->getStaticVariables());
-            
+
             for ($i = 0; $value = current($values); $i++) {
                 $key = $keys[$i];
-                
+
                 if (is_int($key)) {
                     $key = $originalKeys[$i];
                 }
-                
+
                 $with[$key] = $value;
-                
+
                 next($values);
             }
-            
+
             $this->data = array_merge($this->data, $with);
         }
         if (is_array($key)) {

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use ArrayAccess;
 use BadMethodCallException;
+use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\MessageProvider;
@@ -14,6 +15,7 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
+use ReflectionFunction;
 use Throwable;
 
 class View implements ArrayAccess, Htmlable, ViewContract
@@ -236,6 +238,28 @@ class View implements ArrayAccess, Htmlable, ViewContract
      */
     public function with($key, $value = null)
     {
+        if ($key instanceof Closure) {
+            $with = [];
+            $values = $closure();
+            $keys = array_keys($values);
+            
+            $func = new ReflectionFunction($closure);
+            $originalKeys = array_keys($func->getStaticVariables());
+            
+            for ($i = 0; $value = current($values); $i++) {
+                $key = $keys[$i];
+                
+                if (is_int($key)) {
+                    $key = $originalKeys[$i];
+                }
+                
+                $with[$key] = $value;
+                
+                next($values);
+            }
+            
+            $this->data = array_merge($this->data, $with);
+        }
         if (is_array($key)) {
             $this->data = array_merge($this->data, $key);
         } else {

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -232,7 +232,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
     /**
      * Add a piece of data to the view.
      *
-     * @param  string|array  $key
+     * @param  string|array|Closure  $key
      * @param  mixed  $value
      * @return $this
      */
@@ -260,7 +260,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
 
             $this->data = array_merge($this->data, $with);
         }
-        if (is_array($key)) {
+        else if (is_array($key)) {
             $this->data = array_merge($this->data, $key);
         } else {
             $this->data[$key] = $value;

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -32,13 +32,13 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $view->withFoo('bar')->withBaz('boom');
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
-        
+
         $foo = 'bar';
         $baz = 'boom';
         $boo = 'ahh!';
         $view = $this->getView();
-        $view->with(fn() => $foo);
-        $view->with(fn() => [$baz, 'scream' => $boo]);
+        $view->with(fn () => $foo);
+        $view->with(fn () => [$baz, 'scream' => $boo]);
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom', 'scream' => 'ahh!'], $view->getData());
     }
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -32,6 +32,14 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $view->withFoo('bar')->withBaz('boom');
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
+        
+        $foo = 'bar';
+        $baz = 'boom';
+        $boo = 'ahh!';
+        $view = $this->getView();
+        $view->with(fn() => $foo);
+        $view->with(fn() => [$baz, 'scream' => $boo]);
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom', 'scream' => 'ahh!'], $view->getData());
     }
 
     public function testRenderProperlyRendersView()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
View data is probably most often passed in a controller like so:

```php
return view('index', [
    'foo' => $foo,
    'bar' => $bar,
])
```

This is flexible:

```diff
return view('index', [
-   'foo' => $foo,
+   'baz' => $foo,
    'bar' => $bar,
])
```

But it's also unnecessarily verbose, especially in cases where, for consistency and convention, the developer is using the same variable name in the controller _and_ the view (as shown in the first above).

A slightly less-verbose alternative to that is:

```php
return view('index', compact('foo', 'bar'))
```

But this is less flexible. Now I can't easily rename `$foo` to `$baz`.

I want the simplicity of `compact` but the flexibility of an explicit array.

This PR achieves that by using [PHP's arrow functions'](https://www.php.net/manual/en/functions.arrow.php) ability to automatically `use` contextual variables (plus a light dusting of reflection) to allow for the following:

```php
return view('index', fn () => [
    'baz' => $foo,
    $bar,
])
```

Which I think is the best of both worlds

## Known issues

### Multiple variable use in the same closure

Placing an unnamed `$foo` after a named `$foo` OR a previous unnamed `$foo` _in the same closure_ will cause unexpected behaviour:

```php
return view('index', fn () => [
    'baz' => $foo,
    $bar,
    $foo,
])
```

Or:

```php
return view('index', fn () => [
    $foo,
    $bar,
    $foo,
])
```
<details>
<summary>(This second example is contrived and actually kind of silly, because hopefully you'd spot the redundancy. Compare:)</summary>

```php
return view('index', [
    'foo' => $foo,
    'bar' => $bar,
    'foo' => $foo,
])
```
</details>

In both cases, this implementation will throw a warning due to attempting to find a non-existent key on an array. This is because the closure's internal structure of `use`'d variables doesn't match the data array you want to build, but this logic currently assumes that you're not doing something so fancy.

More logic will be needed to mitigate this if it were to become a serious concern in the wild.

For contrast, try:

```php
return view('index', fn () => [
    $foo,
    $bar,
    'baz' => $foo,
])
```

This will work just fine.