### PR TITLE
Pass data to DataAwareRules without dot placeholders

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -821,7 +821,7 @@ class Validator implements ValidatorContract
         }
 
         if ($rule instanceof DataAwareRule) {
-            $rule->setData($this->data);
+            $rule->setData($this->getDataWithoutPlaceholders());
         }
 
         if (! $rule->passes($attribute, $value)) {
@@ -1116,6 +1116,15 @@ class Validator implements ValidatorContract
         return $this->rules;
     }
 
+    protected function removePlaceholders(array $data): array
+    {
+        return collect($data)
+            ->mapWithKeys(fn ($value, $key) => [
+                str_replace($this->dotPlaceholder, '\\.', $key) => $value,
+            ])
+            ->all();
+    }
+
     /**
      * Get the validation rules with key placeholders removed.
      *
@@ -1123,11 +1132,17 @@ class Validator implements ValidatorContract
      */
     public function getRulesWithoutPlaceholders()
     {
-        return collect($this->rules)
-            ->mapWithKeys(fn ($value, $key) => [
-                str_replace($this->dotPlaceholder, '\\.', $key) => $value,
-            ])
-            ->all();
+        return $this->removePlaceholders($this->rules);
+    }
+
+    /**
+     * Get the data under validation with key placeholders removed.
+     *
+     * @return array
+     */
+    public function getDataWithoutPlaceholders()
+    {
+        return $this->removePlaceholders($this->data);
     }
 
     /**


### PR DESCRIPTION
Array passed to DataAwareRule via setData() does not "unescape" keys. If data passed to DataAwareRule during validation previously contained escaped dot '\.', it would result in unusable array keys with random $dotPlaceholder string in place of the dot:
```
[
"escapedHysossGbkoOsAHeTitem" => "value", // \. is replaced with HysossGbkoOsAHe and the rule has no way of knowing it
]
```

Proposed change replaces the placeholder string with '.' before passing the array to the rule.