### PR TITLE
[11.x] Add UUID foreign key constraints with more sensible defaults

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1300,11 +1300,11 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
-     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     * @return \Illuminate\Database\Schema\ForeignUuidColumnDefinition
      */
     public function foreignUuid($column)
     {
-        return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
+        return $this->addColumnDefinition(new ForeignUuidColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
         ]));

--- a/src/Illuminate/Database/Schema/ForeignUuidColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignUuidColumnDefinition.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+use Illuminate\Support\Str;
+
+class ForeignUuidColumnDefinition extends ColumnDefinition
+{
+    /**
+     * The schema builder blueprint instance.
+     *
+     * @var \Illuminate\Database\Schema\Blueprint
+     */
+    protected $blueprint;
+
+    /**
+     * Create a new foreign UUID column definition.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(Blueprint $blueprint, $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->blueprint = $blueprint;
+    }
+
+    /**
+     * Create a foreign key constraint on this column referencing the "uuid" column of the conventionally related table.
+     *
+     * @param  string|null  $table
+     * @param  string|null  $column
+     * @param  string|null  $indexName
+     * @return \Illuminate\Database\Schema\ForeignKeyDefinition
+     */
+    public function constrained($table = null, $column = 'uuid', $indexName = null)
+    {
+        return $this->references($column, $indexName)->on($table ?? Str::of($this->name)->beforeLast('_'.$column)->plural());
+    }
+
+    /**
+     * Specify which column this foreign UUID references on another table.
+     *
+     * @param  string  $column
+     * @param  string  $indexName
+     * @return \Illuminate\Database\Schema\ForeignKeyDefinition
+     */
+    public function references($column, $indexName = null)
+    {
+        return $this->blueprint->foreign($this->name, $indexName)->references($column);
+    }
+}

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
+use Illuminate\Database\Schema\ForeignUuidColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -1085,20 +1086,20 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignUuid = $blueprint->foreignUuid('foo');
-        $blueprint->foreignUuid('company_id')->constrained();
-        $blueprint->foreignUuid('laravel_idea_id')->constrained();
+        $blueprint->foreignUuid('company_uuid')->constrained();
+        $blueprint->foreignUuid('laravel_idea_uuid')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
-        $blueprint->foreignUuid('team_column_id')->constrained('teams');
+        $blueprint->foreignUuid('team_column_uuid')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
+        $this->assertInstanceOf(ForeignUuidColumnDefinition::class, $foreignUuid);
         $this->assertSame([
-            'alter table `users` add `foo` char(36) not null, add `company_id` char(36) not null, add `laravel_idea_id` char(36) not null, add `team_id` char(36) not null, add `team_column_id` char(36) not null',
-            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
-            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add `foo` char(36) not null, add `company_uuid` char(36) not null, add `laravel_idea_uuid` char(36) not null, add `team_id` char(36) not null, add `team_column_uuid` char(36) not null',
+            'alter table `users` add constraint `users_company_uuid_foreign` foreign key (`company_uuid`) references `companies` (`uuid`)',
+            'alter table `users` add constraint `users_laravel_idea_uuid_foreign` foreign key (`laravel_idea_uuid`) references `laravel_ideas` (`uuid`)',
             'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
-            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_uuid_foreign` foreign key (`team_column_uuid`) references `teams` (`uuid`)',
         ], $statements);
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
+use Illuminate\Database\Schema\ForeignUuidColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -905,20 +906,20 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignUuid = $blueprint->foreignUuid('foo');
-        $blueprint->foreignUuid('company_id')->constrained();
-        $blueprint->foreignUuid('laravel_idea_id')->constrained();
+        $blueprint->foreignUuid('company_uuid')->constrained();
+        $blueprint->foreignUuid('laravel_idea_uuid')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
-        $blueprint->foreignUuid('team_column_id')->constrained('teams');
+        $blueprint->foreignUuid('team_column_uuid')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
+        $this->assertInstanceOf(ForeignUuidColumnDefinition::class, $foreignUuid);
         $this->assertSame([
-            'alter table "users" add column "foo" uuid not null, add column "company_id" uuid not null, add column "laravel_idea_id" uuid not null, add column "team_id" uuid not null, add column "team_column_id" uuid not null',
-            'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
-            'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
+            'alter table "users" add column "foo" uuid not null, add column "company_uuid" uuid not null, add column "laravel_idea_uuid" uuid not null, add column "team_id" uuid not null, add column "team_column_uuid" uuid not null',
+            'alter table "users" add constraint "users_company_uuid_foreign" foreign key ("company_uuid") references "companies" ("uuid")',
+            'alter table "users" add constraint "users_laravel_idea_uuid_foreign" foreign key ("laravel_idea_uuid") references "laravel_ideas" ("uuid")',
             'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
-            'alter table "users" add constraint "users_team_column_id_foreign" foreign key ("team_column_id") references "teams" ("id")',
+            'alter table "users" add constraint "users_team_column_uuid_foreign" foreign key ("team_column_uuid") references "teams" ("uuid")',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
+use Illuminate\Database\Schema\ForeignUuidColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -725,20 +726,20 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignUuid = $blueprint->foreignUuid('foo');
-        $blueprint->foreignUuid('company_id')->constrained();
-        $blueprint->foreignUuid('laravel_idea_id')->constrained();
+        $blueprint->foreignUuid('company_uuid')->constrained();
+        $blueprint->foreignUuid('laravel_idea_uuid')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
-        $blueprint->foreignUuid('team_column_id')->constrained('teams');
+        $blueprint->foreignUuid('team_column_uuid')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
+        $this->assertInstanceOf(ForeignUuidColumnDefinition::class, $foreignUuid);
         $this->assertSame([
             'alter table "users" add column "foo" varchar not null',
-            'alter table "users" add column "company_id" varchar not null',
-            'alter table "users" add column "laravel_idea_id" varchar not null',
+            'alter table "users" add column "company_uuid" varchar not null',
+            'alter table "users" add column "laravel_idea_uuid" varchar not null',
             'alter table "users" add column "team_id" varchar not null',
-            'alter table "users" add column "team_column_id" varchar not null',
+            'alter table "users" add column "team_column_uuid" varchar not null',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
+use Illuminate\Database\Schema\ForeignUuidColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -765,20 +766,20 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignUuid('foo');
-        $blueprint->foreignUuid('company_id')->constrained();
-        $blueprint->foreignUuid('laravel_idea_id')->constrained();
+        $blueprint->foreignUuid('company_uuid')->constrained();
+        $blueprint->foreignUuid('laravel_idea_uuid')->constrained();
         $blueprint->foreignUuid('team_id')->references('id')->on('teams');
-        $blueprint->foreignUuid('team_column_id')->constrained('teams');
+        $blueprint->foreignUuid('team_column_uuid')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertInstanceOf(ForeignUuidColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table "users" add "foo" uniqueidentifier not null, "company_id" uniqueidentifier not null, "laravel_idea_id" uniqueidentifier not null, "team_id" uniqueidentifier not null, "team_column_id" uniqueidentifier not null',
-            'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
-            'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
+            'alter table "users" add "foo" uniqueidentifier not null, "company_uuid" uniqueidentifier not null, "laravel_idea_uuid" uniqueidentifier not null, "team_id" uniqueidentifier not null, "team_column_uuid" uniqueidentifier not null',
+            'alter table "users" add constraint "users_company_uuid_foreign" foreign key ("company_uuid") references "companies" ("uuid")',
+            'alter table "users" add constraint "users_laravel_idea_uuid_foreign" foreign key ("laravel_idea_uuid") references "laravel_ideas" ("uuid")',
             'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
-            'alter table "users" add constraint "users_team_column_id_foreign" foreign key ("team_column_id") references "teams" ("id")',
+            'alter table "users" add constraint "users_team_column_uuid_foreign" foreign key ("team_column_uuid") references "teams" ("uuid")',
         ], $statements);
     }
 


### PR DESCRIPTION
I believe @jasonmccreary created a PR that set the default name for a `uuid()` column to `uuid`.
Now when we are creating a `foreignUuid()` foreign key the class that is being used is `ForeignIdColumnDefinition` which has a default column name of `id`. I think it makes more sense to use `uuid` here as well.
So, here's what I've done in this PR:

- Created a class called `ForeignUuidColumnDefinition` which is a clone of `ForeignIdColumnDefinition` with `uuid` as the default column name.
- Used this class in `foreignUuid()`
- Updated the tests to reflect this change

Now you create a migration and in your table have `uuid()->primary()` which creates a `uuid` column with the name `uuid` and set it as primary key.
Then in your child table or pivot table you add `foreignUuid('parent_uuid')` and you can use `->constrained()` on it without getting errors.