### PR TITLE
[10.x] Allow `Macroable::mixin` to accept traits

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -118,13 +118,13 @@ trait Macroable
     }
 
     /**
-     * Register trait mixins.
+     * Register trait based mixin.
      *
      * @param  class-string  $mixin
      *
      * @throws \ReflectionException
      */
-    protected static function registerTraitMixin(string $mixin, bool $replace): void
+    private static function registerTraitMixin(string $mixin, bool $replace): void
     {
         $object = static::resolveTraitObject($mixin);
         $methods = static::getTraitMethods($object);
@@ -143,13 +143,13 @@ trait Macroable
     }
 
     /**
-     * Register class mixins.
+     * Register class based mixin.
      *
      * @param  class-string|object  $mixin
      *
      * @throws \ReflectionException
      */
-    public static function registerClassMixin(string|object $mixin, bool $replace): void
+    private static function registerClassMixin(string|object $mixin, bool $replace): void
     {
         $object = is_string($mixin) ? new $mixin : $mixin;
         $methods = static::getClassMethods($object);
@@ -166,13 +166,9 @@ trait Macroable
      *
      * @param  class-string  $mixin
      */
-    protected static function resolveTraitObject(string $mixin): object
+    private static function resolveTraitObject(string $mixin): object
     {
-        $anonymousClass = get_class(
-            eval('return new class() extends '.static::class." {use {$mixin};};"),
-        );
-
-        return new $anonymousClass;
+        return eval('return new class() extends '.static::class." {use {$mixin};};");
     }
 
     /**
@@ -182,7 +178,7 @@ trait Macroable
      *
      * @throws \ReflectionException
      */
-    protected static function getTraitMethods(object $mixin): array
+    private static function getTraitMethods(object $mixin): array
     {
         $class = get_class($mixin);
 
@@ -198,7 +194,7 @@ trait Macroable
      *
      * @throws \ReflectionException
      */
-    protected static function getClassMethods(object $mixin): array
+    private static function getClassMethods(object $mixin): array
     {
         return (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -10,6 +10,13 @@ use ReflectionMethod;
 trait Macroable
 {
     /**
+     * Stack of macro instances.
+     *
+     * @var array<static>
+     */
+    protected static array $macroInstanceStack = [];
+
+    /**
      * The registered string macros.
      *
      * @var array
@@ -84,11 +91,13 @@ trait Macroable
 
         $macro = static::$macros[$method];
 
-        if ($macro instanceof Closure) {
-            $macro = $macro->bindTo(null, static::class);
-        }
+        return static::bindMacroInstance(null, function () use (&$macro, &$parameters) {
+            if ($macro instanceof Closure) {
+                $macro = $macro->bindTo(null, static::class);
+            }
 
-        return $macro(...$parameters);
+            return $macro(...$parameters);
+        });
     }
 
     /**
@@ -110,11 +119,91 @@ trait Macroable
 
         $macro = static::$macros[$method];
 
-        if ($macro instanceof Closure) {
-            $macro = $macro->bindTo($this, static::class);
-        }
+        return static::bindMacroInstance($this, function () use (&$macro, &$parameters) {
+            if ($macro instanceof Closure) {
+                $macro = $macro->bindTo($this, static::class);
+            }
 
-        return $macro(...$parameters);
+            return $macro(...$parameters);
+        });
+    }
+
+    /**
+     * Stack a macro instance from inside calls of self::this() and execute closure.
+     *
+     * @param  static|null  $context
+     * @param  callable(): mixed  $callable
+     *
+     * @throws Throwable
+     */
+    protected static function bindMacroInstance($instance, callable $callable): mixed
+    {
+        static::$macroInstanceStack[] = $instance;
+
+        try {
+            return $callable();
+        } finally {
+            array_pop(static::$macroInstanceStack);
+        }
+    }
+
+    /**
+     * Return the current instance inside a macro or null/new static if static.
+     *
+     * @return static
+     */
+    protected static function this(bool $returnNullIfStatic = false)
+    {
+        return end(static::$macroInstanceStack) ?: ($returnNullIfStatic ? null : new static());
+    }
+
+    /**
+     * Get the methods from class.
+     *
+     * @return ReflectionMethod[]
+     *
+     * @throws \ReflectionException
+     */
+    private static function getClassMethods(object $mixin): array
+    {
+        return (new ReflectionClass($mixin))->getMethods(
+            ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
+        );
+    }
+
+    /**
+     * Get the methods from the trait anonymous class.
+     *
+     * @return ReflectionMethod[]
+     *
+     * @throws \ReflectionException
+     */
+    private static function getTraitMethods(object $mixin): array
+    {
+        $class = get_class($mixin);
+
+        return collect(static::getClassMethods($mixin))
+            ->filter(fn ($method) => $method->class === $class)
+            ->all();
+    }
+
+    /**
+     * Register class based mixin.
+     *
+     * @param  class-string|object  $mixin
+     *
+     * @throws \ReflectionException
+     */
+    private static function registerClassMixin(string|object $mixin, bool $replace): void
+    {
+        $object = is_string($mixin) ? new $mixin : $mixin;
+        $methods = static::getClassMethods($object);
+
+        foreach ($methods as $method) {
+            if ($replace || ! static::hasMacro($method->name)) {
+                static::macro($method->name, $method->invoke($object));
+            }
+        }
     }
 
     /**
@@ -143,25 +232,6 @@ trait Macroable
     }
 
     /**
-     * Register class based mixin.
-     *
-     * @param  class-string|object  $mixin
-     *
-     * @throws \ReflectionException
-     */
-    private static function registerClassMixin(string|object $mixin, bool $replace): void
-    {
-        $object = is_string($mixin) ? new $mixin : $mixin;
-        $methods = static::getClassMethods($object);
-
-        foreach ($methods as $method) {
-            if ($replace || ! static::hasMacro($method->name)) {
-                static::macro($method->name, $method->invoke($object));
-            }
-        }
-    }
-
-    /**
      * Resolves an anonymous class for a trait.
      *
      * @param  class-string  $mixin
@@ -169,35 +239,5 @@ trait Macroable
     private static function resolveTraitObject(string $mixin): object
     {
         return eval('return new class() extends '.static::class." {use {$mixin};};");
-    }
-
-    /**
-     * Get the methods from the trait anonymous class.
-     *
-     * @return ReflectionMethod[]
-     *
-     * @throws \ReflectionException
-     */
-    private static function getTraitMethods(object $mixin): array
-    {
-        $class = get_class($mixin);
-
-        return collect(static::getClassMethods($mixin))
-            ->filter(fn ($method) => $method->class === $class)
-            ->all();
-    }
-
-    /**
-     * Get the methods from class.
-     *
-     * @return ReflectionMethod[]
-     *
-     * @throws \ReflectionException
-     */
-    private static function getClassMethods(object $mixin): array
-    {
-        return (new ReflectionClass($mixin))->getMethods(
-            ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
-        );
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This PR allows `Macroable::mixin` to accept traits, inspiration is drawn from [Carbon's macro syntax](https://carbon.nesbot.com/docs/#api-macro).

Traits allow the mixin syntax to be cleaned up as the methods no longer need to return a closure, for example, given the following class mixin:

```php
class TestClassMixin
{
    public function methodOne()
    {
        return function ($value) {
            return $this->methodTwo($value);
        };
    }

    protected function methodTwo()
    {
        return function ($value) {
            return $this->protectedVariable.'-'.$value;
        };
    }
}
```

The trait equivalent would be:

```php
trait TestTraitMixin
{
    public function methodOne($value)
    {
        return self::this()->methodTwo($value);
    }

    protected function methodTwo($value)
    {
        return self::this()->protectedVariable.'-'.$value;
    }
}
```

which is then registered as follows (note that this PR also updates the API to allow the same class-string syntax with classes):

```php
// registering a trait
TestMacroable::mixin(TestTraitMixin::class);

// registering a class
TestMacroable::mixin(TestClassMixin::class);
TestMacroable::mixin(new TestClassMixin);
```

Note that the trait uses a static `self::this()` method as opposed to `$this` to access the instance the macro was called on---because an anonymous object is created with the trait applied, so `$this` no longer has the same dynamic properties. Carbon has the same syntax in their trait mixins.

Thanks!