### PR TITLE
[10.x] update HasAttributes trait by using match instead of if-elseif-else 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -862,7 +862,7 @@ trait HasAttributes
             return static::$castTypeCache[$castType];
         }
 
-        $convertedCastType = match ($castType) {
+        $convertedCastType = match (true) {
             $this->isCustomDateTimeCast($castType) => 'custom_datetime',
             $this->isImmutableCustomDateTimeCast($castType) => 'immutable_custom_datetime',
             $this->isDecimalCast($castType) => 'decimal',
@@ -1155,7 +1155,7 @@ trait HasAttributes
         $enumClass = $this->getCasts()[$key];
 
         $this->attributes[$key] = match (true) {
-            !isset($value) => null,
+            ! isset($value) => null,
             is_object($value) => $this->getStorableEnumValue($value),
             default => $this->getStorableEnumValue(
                 $this->getEnumCaseFromValue($enumClass, $value)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -862,17 +862,13 @@ trait HasAttributes
             return static::$castTypeCache[$castType];
         }
 
-        if ($this->isCustomDateTimeCast($castType)) {
-            $convertedCastType = 'custom_datetime';
-        } elseif ($this->isImmutableCustomDateTimeCast($castType)) {
-            $convertedCastType = 'immutable_custom_datetime';
-        } elseif ($this->isDecimalCast($castType)) {
-            $convertedCastType = 'decimal';
-        } elseif (class_exists($castType)) {
-            $convertedCastType = $castType;
-        } else {
-            $convertedCastType = trim(strtolower($castType));
-        }
+        $convertedCastType = match ($castType) {
+            $this->isCustomDateTimeCast($castType) => 'custom_datetime',
+            $this->isImmutableCustomDateTimeCast($castType) => 'immutable_custom_datetime',
+            $this->isDecimalCast($castType) => 'decimal',
+            class_exists($castType) => $castType,
+            default => trim(strtolower($castType)),
+        };
 
         return static::$castTypeCache[$castType] = $convertedCastType;
     }
@@ -1158,15 +1154,13 @@ trait HasAttributes
     {
         $enumClass = $this->getCasts()[$key];
 
-        if (! isset($value)) {
-            $this->attributes[$key] = null;
-        } elseif (is_object($value)) {
-            $this->attributes[$key] = $this->getStorableEnumValue($value);
-        } else {
-            $this->attributes[$key] = $this->getStorableEnumValue(
+        $this->attributes[$key] = match (true) {
+            !isset($value) => null,
+            is_object($value) => $this->getStorableEnumValue($value),
+            default => $this->getStorableEnumValue(
                 $this->getEnumCaseFromValue($enumClass, $value)
-            );
-        }
+            )
+        };
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2046,28 +2046,41 @@ trait HasAttributes
 
         if ($attribute === $original) {
             return true;
-        } elseif (is_null($attribute)) {
+        }
+
+        if (is_null($attribute)) {
             return false;
-        } elseif ($this->isDateAttribute($key) || $this->isDateCastableWithCustomFormat($key)) {
-            return $this->fromDateTime($attribute) ===
-                $this->fromDateTime($original);
-        } elseif ($this->hasCast($key, ['object', 'collection'])) {
-            return $this->fromJson($attribute) ===
-                $this->fromJson($original);
-        } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
+        }
+
+        if ($this->isDateAttribute($key) || $this->isDateCastableWithCustomFormat($key)) {
+            return $this->fromDateTime($attribute) === $this->fromDateTime($original);
+        }
+
+        if ($this->hasCast($key, ['object', 'collection'])) {
+            return $this->fromJson($attribute) === $this->fromJson($original);
+        }
+
+        if ($this->hasCast($key, ['real', 'float', 'double'])) {
             if ($original === null) {
                 return false;
             }
 
             return abs($this->castAttribute($key, $attribute) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
-        } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
-            return $this->castAttribute($key, $attribute) ===
-                $this->castAttribute($key, $original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
+        }
+
+        if ($this->hasCast($key, static::$primitiveCastTypes)) {
+            return $this->castAttribute($key, $attribute) === $this->castAttribute($key, $original);
+        }
+
+        if ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
+        }
+
+        if ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && $original !== null && Str::startsWith($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
+        }
+
+        if ($this->isClassCastable($key) && $original !== null && Str::startsWith($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
             return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
         }
 


### PR DESCRIPTION
Hello!

This PR,the if-elseif-else statements in the `getCastType` and `setEnumCastableAttribute` methods have been converted to match expressions in PHP 8.0.

Whenever an if statement ultimately ends with a return, the elseif structure can be converted to an if statement. This change improves code readability. Additionally, in the `originalIsEquivalent` method, the if-elseif statements have been converted to if blocks.

Thanks!