### PR TITLE
[10.x] Add Method to Report only logged exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -247,6 +247,17 @@ class Handler implements ExceptionHandlerContract
             return;
         }
 
+        $this->reportError($e);
+    }
+
+    /**
+     * Reports error based on report method on exception or to logger.
+     *
+     * @param Throwable $e
+     * @return void
+     * @throws Throwable
+     */
+    protected function reportError(Throwable $e): void {
         if (Reflector::isCallable($reportCallable = [$e, 'report']) &&
             $this->container->call($reportCallable) !== false) {
             return;

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -253,11 +253,12 @@ class Handler implements ExceptionHandlerContract
     /**
      * Reports error based on report method on exception or to logger.
      *
-     * @param Throwable $e
+     * @param  Throwable  $e
      * @return void
+     *
      * @throws Throwable
      */
-    protected function reportError(Throwable $e): void 
+    protected function reportError(Throwable $e): void
     {
         if (Reflector::isCallable($reportCallable = [$e, 'report']) &&
             $this->container->call($reportCallable) !== false) {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -257,7 +257,8 @@ class Handler implements ExceptionHandlerContract
      * @return void
      * @throws Throwable
      */
-    protected function reportError(Throwable $e): void {
+    protected function reportError(Throwable $e): void 
+    {
         if (Reflector::isCallable($reportCallable = [$e, 'report']) &&
             $this->container->call($reportCallable) !== false) {
             return;

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -247,18 +247,18 @@ class Handler implements ExceptionHandlerContract
             return;
         }
 
-        $this->reportError($e);
+        $this->reportThrowable($e);
     }
 
     /**
      * Reports error based on report method on exception or to logger.
      *
-     * @param  Throwable  $e
+     * @param  \Throwable  $e
      * @return void
      *
-     * @throws Throwable
+     * @throws \Throwable
      */
-    protected function reportError(Throwable $e): void
+    protected function reportThrowable(Throwable $e): void
     {
         if (Reflector::isCallable($reportCallable = [$e, 'report']) &&
             $this->container->call($reportCallable) !== false) {


### PR DESCRIPTION
Added a method that is easier to overwrite in the Exception Handler class or to listen to with APM packages.

For example the Datadog APM tracer would otherwise trace for all exceptions, even those that don't even get logged.


Datadog APM error tracker:

```php
\DDTrace\hook_method(
            Handler::class,
            'reportError',
            function ($This, $scope, $args) {
                $span = \DDTrace\root_span();
                if (null === $span) {
                    return;
                }
                // from: https://github.com/DataDog/dd-trace-php/blob/master/src/Integrations/Integrations/Integration.php
                /** @var \Throwable $exception */
                $exception = $args[0];
                $span->meta[\DDTrace\Tag::ERROR_MSG] = $exception->getMessage();
                $span->meta[\DDTrace\Tag::ERROR_TYPE] = get_class($exception);
                $span->meta[\DDTrace\Tag::ERROR_STACK] = $exception->getTraceAsString();
            }
        );
```