### PR TITLE
[10.x] Add support for passing eloquent collection to `Builder::whereKey()` and `whereKeyNot()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -232,6 +232,10 @@ class Builder implements BuilderContract
             $id = $id->getKey();
         }
 
+        if ($id instanceof Collection) {
+            $id = $id->modelKeys();
+        }
+
         if (is_array($id) || $id instanceof Arrayable) {
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
                 $this->query->whereIntegerInRaw($this->model->getQualifiedKeyName(), $id);
@@ -259,6 +263,10 @@ class Builder implements BuilderContract
     {
         if ($id instanceof Model) {
             $id = $id->getKey();
+        }
+
+        if ($id instanceof Collection) {
+            $id = $id->modelKeys();
         }
 
         if (is_array($id) || $id instanceof Arrayable) {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1844,7 +1844,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder()->setModel($model);
         $keyName = $model->getQualifiedKeyName();
 
-        $collection = new Collection([1, 2, 3]);
+        $collection = new BaseCollection([1, 2, 3]);
 
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with($keyName, $collection);
 
@@ -1921,14 +1921,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKeyNot($array);
     }
 
-    public function testWhereKeyNotMethodWithCollection()
+    public function testWhereKeyNotMethodWithBaseCollection()
     {
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder = $this->getBuilder()->setModel($model);
         $keyName = $model->getQualifiedKeyName();
 
-        $collection = new Collection([1, 2, 3]);
+        $collection = new BaseCollection([1, 2, 3]);
 
         $builder->getQuery()->shouldReceive('whereIntegerNotInRaw')->once()->with($keyName, $collection);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1851,6 +1851,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($collection);
     }
 
+    public function testWhereKeyMethodWithEloquentCollection()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->andReturn('int');
+        $model->shouldReceive('getKey')->andReturn(1);
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $collection = new Collection([$model]);
+
+        $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with($keyName, $collection->modelKeys());
+
+        $builder->whereKey($collection);
+    }
+
     public function testWhereKeyMethodWithModel()
     {
         $model = new EloquentBuilderTestStubStringPrimaryKey;
@@ -1931,6 +1946,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $collection = new BaseCollection([1, 2, 3]);
 
         $builder->getQuery()->shouldReceive('whereIntegerNotInRaw')->once()->with($keyName, $collection);
+
+        $builder->whereKeyNot($collection);
+    }
+
+    public function testWhereKeyNotMethodWithEloquentCollection()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->andReturn('int');
+        $model->shouldReceive('getKey')->andReturn(1);
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $collection = new Collection([$model]);
+
+        $builder->getQuery()->shouldReceive('whereIntegerNotInRaw')->once()->with($keyName, $collection->modelKeys());
 
         $builder->whereKeyNot($collection);
     }


### PR DESCRIPTION
This PR adds support for passing an eloquent collection to the `whereKey` and `whereKeyNot` methods of the Eloquent Builder.

Currently, we can pass an eloquent model to these methods like so;
```php
// We don't have to do this
$users = User::whereKeyNot($anotherUser->id)->get();

// We can simply do this;
$users = User::whereKeyNot($anotherUser)->get();
// This will currently grab the key off the User model and perform a whereNotIn(...)
```

Similarly, we can also pass an array of ids;
```php
$users = User::whereKeyNot($otherUsers->modelKeys())->get();
```

It will be a little more convenient to simply pass the eloquent collection we have to these methods, and the model keys will be plucked under the hood. That is exactly what this PR brings!
```php
$users = User::whereKeyNot($otherUsers)->get();
```