### PR TITLE
[10.x] make stack push/prepend honour stack context

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -38,9 +38,11 @@ trait CompilesStacks
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        [$stack, $id] = [$parts[0], $parts[1] ?? ''];
+        [$stack, $id] = [$parts[0], trim($parts[1] ?? '')];
 
-        $id = trim($id) ?: "'".(string) Str::uuid()."'";
+        $id = $id
+            ? "'".substr($stack, 1, -1).':'.substr($id, 1, -1)."'"
+            : "'".(string) Str::uuid()."'";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPush('.$stack.'); ?>';
@@ -87,9 +89,11 @@ $__env->startPush('.$stack.'); ?>';
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        [$stack, $id] = [$parts[0], $parts[1] ?? ''];
+        [$stack, $id] = [$parts[0], trim($parts[1] ?? '')];
 
-        $id = trim($id) ?: "'".(string) Str::uuid()."'";
+        $id = $id
+            ? "'".substr($stack, 1, -1).':'.substr($id, 1, -1)."'"
+            : "'".(string) Str::uuid()."'";
 
         return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
 $__env->startPrepend('.$stack.'); ?>';

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -24,7 +24,7 @@ bar
 test
 @endPrependOnce';
 
-        $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'foo:bar\')): $__env->markAsRenderedOnce(\'foo:bar\');
 $__env->startPrepend(\'foo\'); ?>
 test
 <?php $__env->stopPrepend(); endif; ?>';

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -34,7 +34,7 @@ test
 test
 @endPushOnce';
 
-        $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'foo:bar\')): $__env->markAsRenderedOnce(\'foo:bar\');
 $__env->startPush(\'foo\'); ?>
 test
 <?php $__env->stopPush(); endif; ?>';


### PR DESCRIPTION
The `@pushOnce` and `@prependOnce` Blade directives currently do a check on the second parameter, if provided, to make sure the content of the block is only inserted once to the stack.

The problem is that it doesn’t matter which stack it is, meaning that the following scenario does not work, even though I’d expect it to:

```blade
@stack('first')
@stack('second')
```

```blade
@pushOnce('first', 'something')
  …
@endPushOnce

@pushOnce('second', 'something')
  …
@endPushOnce
```

Here, the contents of `something` will only get pushed to the `first` stack, and not the `second`, as `hasRenderedOnce` is not aware of the difference. This disregards the fact that the `something` targetting the `second` stack could be completely different, and I shouldn’t need to create a more unique name, like `second:something`, to get it to work.

This PR attempts to resolve this “bug” (in air quotes because it’s not _really_ a bug per-se, but it does produce undesired behaviour), by providing that more unique name in the background. That unique name is the name of the stack itself – should be unique enough, right?

As a side note, I did consider adding “scope” support to the once-checkers on the view factory, but felt that might be overkill for the requirement.

If this should rather target 11.x, please let me know.