### PR TITLE
[10.x] Fix PHPDoc throw type

### DIFF
--- a/src/Illuminate/Log/ParsesLogConfiguration.php
+++ b/src/Illuminate/Log/ParsesLogConfiguration.php
@@ -54,6 +54,8 @@ trait ParsesLogConfiguration
      *
      * @param  array  $config
      * @return int
+     *
+     * @throws \InvalidArgumentException
      */
     protected function actionLevel(array $config)
     {


### PR DESCRIPTION
The current method `actionLevel`, as defined under the `ParsesLogConfiguration` trait, should indicate that it throws an `InvalidArgumentException` **exception**.