### PR TITLE
[10.x] Ensure captured time is in configured timezone

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -218,7 +218,7 @@ class Kernel implements KernelContract
     {
         $this->app->terminate();
 
-        $this->commandStartedAt->setTimezone($this->app['config']->get('app.timezone', 'UTC'));
+        $this->commandStartedAt->setTimezone($this->app['config']->get('app.timezone') ?? 'UTC');
 
         foreach ($this->commandLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {
             $end ??= Carbon::now();

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -218,6 +218,8 @@ class Kernel implements KernelContract
     {
         $this->app->terminate();
 
+        $this->commandStartedAt->setTimezone($this->app['config']->get('app.timezone', 'UTC'));
+
         foreach ($this->commandLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {
             $end ??= Carbon::now();
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -214,6 +214,8 @@ class Kernel implements KernelContract
 
         $this->app->terminate();
 
+        $this->requestStartedAt->setTimezone($this->app['config']->get('app.timezone') ?? 'UTC');
+
         foreach ($this->requestLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {
             $end ??= Carbon::now();
 

--- a/tests/Integration/Console/CommandDurationThresholdTest.php
+++ b/tests/Integration/Console/CommandDurationThresholdTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Console;
 use Carbon\CarbonInterval;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -176,5 +177,25 @@ class CommandDurationThresholdTest extends TestCase
 
         $kernel->terminate($input, 21);
         $this->assertNull($kernel->commandStartedAt());
+    }
+
+    public function testUsesTheConfiguredDateTimezone()
+    {
+        Config::set('app.timezone', 'UTC');
+        $startedAt = null;
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $kernel->whenCommandLifecycleIsLongerThan(0, function ($started) use (&$startedAt) {
+            $startedAt = $started;
+        });
+
+        Config::set('app.timezone', 'Australia/Melbourne');
+        Carbon::setTestNow(Carbon::now());
+        $kernel->handle($input = new StringInput('foo'), new ConsoleOutput);
+
+        Carbon::setTestNow(now()->addMinute());
+        $kernel->terminate($input, 21);
+
+        $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());
     }
 }

--- a/tests/Integration/Http/RequestDurationThresholdTest.php
+++ b/tests/Integration/Http/RequestDurationThresholdTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
@@ -70,6 +71,25 @@ class RequestDurationThresholdTest extends TestCase
         $kernel->terminate($request, $response);
 
         $this->assertSame('http://localhost/test-route', $url);
+    }
+
+    public function testUsesTheConfiguredDateTimezone()
+    {
+        Config::set('app.timezone', 'UTC');
+        Route::get('test-route', fn () => 'ok');
+        $kernel = $this->app[Kernel::class];
+        $startedAt = null;
+        $kernel->whenRequestLifecycleIsLongerThan(CarbonInterval::seconds(1), function ($started) use (&$startedAt) {
+            $startedAt = $started;
+        });
+
+        Config::set('app.timezone', 'Australia/Melbourne');
+        Carbon::setTestNow(now()->startOfDay());
+        $kernel->handle($request = Request::create('http://localhost/test-route'));
+        Carbon::setTestNow(now()->addMinute());
+        $kernel->terminate($request, new Response);
+
+        $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());
     }
 
     public function testItCanExceedThresholdWhenSpecifyingDurationAsMilliseconds()


### PR DESCRIPTION
This is a bugfix to ensure that the captured "startedAt" time for requests / commands is  converted to use the applications timezone before being passed to the `handleRequestLifecycleLongerThan` and `handleCommandLifecycleLongerThan` functions.