### PR TITLE
[10.x]  Add hasAny function to ComponentAttributeBag, Allow multiple keys in has function

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -59,7 +59,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     *  Determine if a given attribute exists in the attribute array.
+     * Determine if a given attribute exists in the attribute array.
      *
      * @param  TKey|array<array-key, TKey>  $key
      * @return bool

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -59,14 +59,45 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     * Determine if a given attribute exists in the attribute array.
+     *  Determine if a given attribute exists in the attribute array.
      *
-     * @param  string  $key
+     * @param  TKey|array<array-key, TKey>  $key
      * @return bool
      */
     public function has($key)
     {
-        return array_key_exists($key, $this->attributes);
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! array_key_exists($value, $this->attributes)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if any of the keys exist in the attribute array.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function hasAny($key)
+    {
+        if (! count($this->attributes)) {
+            return false;
+        }
+
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->has($value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -77,7 +108,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function missing($key)
     {
-        return ! $this->has($key, $this->attributes);
+        return ! $this->has($key);
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -61,7 +61,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Determine if a given attribute exists in the attribute array.
      *
-     * @param  TKey|array<array-key, TKey>  $key
+     * @param  array|string  $key
      * @return bool
      */
     public function has($key)
@@ -80,7 +80,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Determine if any of the keys exist in the attribute array.
      *
-     * @param  mixed  $key
+     * @param  array|string  $key
      * @return bool
      */
     public function hasAny($key)

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -118,8 +118,14 @@ class ViewComponentAttributeBagTest extends TestCase
         $bag = new ComponentAttributeBag(['name' => 'test']);
 
         $this->assertTrue((bool) $bag->has('name'));
+        $this->assertTrue((bool) $bag->has(['name']));
+        $this->assertTrue((bool) $bag->hasAny(['class', 'name']));
+        $this->assertTrue((bool) $bag->hasAny('class', 'name'));
         $this->assertFalse((bool) $bag->missing('name'));
         $this->assertFalse((bool) $bag->has('class'));
+        $this->assertFalse((bool) $bag->has(['class']));
+        $this->assertFalse((bool) $bag->has(['name', 'class']));
+        $this->assertFalse((bool) $bag->has('name', 'class'));
         $this->assertTrue((bool) $bag->missing('class'));
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The `has()` function for the ComponentAttributeBag has been pulled in line with that of a [collection](https://github.com/laravel/framework/blob/aef89589ea70e0081c139b06550220cc75f20ea6/src/Illuminate/Collections/Collection.php#L577), allowing the user to check existence for multiple keys' existence within the attribute bag more efficiently.
`hasAny()` did not exist at all before requiring creation of macros or methods such as
```php
$isAnchor = count(
        $attributes
            ->only('href', ':href', 'v-bind:href')
            ->filter(null)
            ->getAttributes(),
    ) > 0;
```
to determine wether a href has been set.
After this change it is possible to shorten this to
```php
$isAnchor = $attributes->filter(null)->hasAny('href', ':href', 'v-bind:href');
```

This was also functionality already available to collections, thus we have kept this functionality inline with it.

This is not a breaking change as the old function allowed only one argument to be passed, now it will allow one or more. And has the already expected behaviour of the has function.