### PR TITLE
[10.x] Remove unnecessary return statement in defaults method

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -41,7 +41,7 @@ class Hub implements HubContract
      */
     public function defaults(Closure $callback)
     {
-        return $this->pipeline('default', $callback);
+        $this->pipeline('default', $callback);
     }
 
     /**


### PR DESCRIPTION
This commit removes an unnecessary return statement in the 'defaults' method of the code. Previously, the method had a return statement that returned the result of the 'pipeline' method. However, since the return type of the 'defaults' method is void, the return statement was redundant and did not serve any purpose. Therefore, it has been removed in this commit to simplify the code and improve its clarity.