### PR TITLE
[10.x] Refactor the `__destruct` method in `PendingDispatch` class

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -185,12 +185,14 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        if (! $this->shouldDispatch()) {
-            return;
-        } elseif ($this->afterResponse) {
-            app(Dispatcher::class)->dispatchAfterResponse($this->job);
-        } else {
-            app(Dispatcher::class)->dispatch($this->job);
+        if ($this->shouldDispatch()) {
+            $dispatcher = app(Dispatcher::class);
+
+            if ($this->afterResponse) {
+                $dispatcher->dispatchAfterResponse($this->job);
+            } else {
+                $dispatcher->dispatch($this->job);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR refactors the __destruct method in the PendingDispatch class to improve code readability and maintainability.

The changes made in this PR include:

- Removal of the unnecessary condition if (! $this->shouldDispatch()) as the subsequent code is executed only when dispatching is required.
- Storing the Dispatcher instance in the $dispatcher variable to eliminate redundant calls to app(Dispatcher::class).
- Simplification of the conditional logic by directly checking $this->afterResponse and calling the appropriate dispatch method on the $dispatcher instance.

These modifications enhance the clarity of the code while preserving its existing functionality. The refactored __destruct method contributes to cleaner and more maintainable codebase.

Please review and merge this PR at your convenience. 🕵️