### PR TITLE
[10.x] Add @slots directive for optional component slots

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -142,6 +142,25 @@ trait CompilesComponents
     }
 
     /**
+     * Compile the slots statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSlots($expression)
+    {
+        return "<?php foreach ({$expression} as \$__key => \$__value) {
+    \$__key = is_numeric(\$__key) ? \$__value : \$__key;
+    \$__value = !is_array(\$__value) && !\$__value instanceof \ArrayAccess ? [] : \$__value;
+    if (!isset(\$\$__key) || is_string(\$\$__key)) {
+        \$\$__key = new \Illuminate\View\ComponentSlot(\$\$__key ?? \$__value['contents'] ?? '', \$__value['attributes'] ?? []);
+    }
+} ?>
+<?php \$attributes ??= new \\Illuminate\\View\\ComponentAttributeBag; ?>
+<?php \$attributes = \$attributes->exceptProps{$expression}; ?>";
+    }
+
+    /**
      * Compile the prop statement into valid PHP.
      *
      * @param  string  $expression

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -122,6 +122,32 @@ class BladeTest extends TestCase
 <div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
+    public function test_optional_slots() {
+        $view = View::make('uses-optional-slots', ['noOptionals' => true, 'optionalAsAttribute' => false])->render();
+
+        $this->assertSame('<div >
+    Slot content
+    <div ></div>
+    <div class="bg-red-500">dummy text</div>
+</div>', trim($view));
+
+        $view = View::make('uses-optional-slots', ['noOptionals' => false, 'optionalAsAttribute' => true])->render();
+
+        $this->assertSame('<div >
+    Slot content
+    <div >Optional content</div>
+    <div class="bg-red-500">Another slot content</div>
+</div>', trim($view));
+
+        $view = View::make('uses-optional-slots', ['noOptionals' => false, 'optionalAsAttribute' => false])->render();
+
+        $this->assertSame('<div >
+    Slot content
+    <div >Optional content</div>
+    <div >Another slot content</div>
+</div>', trim($view));
+    }
+
     public function test_name_attribute_can_be_used_if_using_short_slot_names()
     {
         $content = Blade::render('<x-input-with-slot>

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -122,7 +122,8 @@ class BladeTest extends TestCase
 <div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
-    public function test_optional_slots() {
+    public function test_optional_slots()
+    {
         $view = View::make('uses-optional-slots', ['noOptionals' => true, 'optionalAsAttribute' => false])->render();
 
         $this->assertSame('<div >

--- a/tests/Integration/View/templates/components/optional-slot.blade.php
+++ b/tests/Integration/View/templates/components/optional-slot.blade.php
@@ -1,7 +1,7 @@
-@slots(['optional_slot', 'another_slot' => ['contents' => 'dummy text', 'attributes' => ['class' => 'bg-red-500']]])
+@slots(['optionalSlot', 'anotherSlot' => ['contents' => 'dummy text', 'attributes' => ['class' => 'bg-red-500']]])
 
 <div {{ $attributes }}>
     {{ $slot }}
-    <div {{ $optional_slot->attributes }}>{{ $optional_slot }}</div>
-    <div {{ $another_slot->attributes }}>{{ $another_slot }}</div>
+    <div {{ $optionalSlot->attributes }}>{{ $optionalSlot }}</div>
+    <div {{ $anotherSlot->attributes }}>{{ $anotherSlot }}</div>
 </div>

--- a/tests/Integration/View/templates/components/optional-slot.blade.php
+++ b/tests/Integration/View/templates/components/optional-slot.blade.php
@@ -1,0 +1,7 @@
+@slots(['optional_slot', 'another_slot' => ['contents' => 'dummy text', 'attributes' => ['class' => 'bg-red-500']]])
+
+<div {{ $attributes }}>
+    {{ $slot }}
+    <div {{ $optional_slot->attributes }}>{{ $optional_slot }}</div>
+    <div {{ $another_slot->attributes }}>{{ $another_slot }}</div>
+</div>

--- a/tests/Integration/View/templates/uses-optional-slots.blade.php
+++ b/tests/Integration/View/templates/uses-optional-slots.blade.php
@@ -3,17 +3,17 @@
     Slot content
 </x-optional-slot>
 @elseif($optionalAsAttribute)
-<x-optional-slot optional_slot="Optional content" another_slot="Another slot content">
+<x-optional-slot optionalSlot="Optional content" anotherSlot="Another slot content">
     Slot content
 </x-optional-slot>
 @else
 <x-optional-slot>
     Slot content
-    <x-slot:optional_slot>
+    <x-slot:optionalSlot>
         Optional content
-    </x-slot:optional_slot>
-    <x-slot:another_slot>
+    </x-slot:optionalSlot>
+    <x-slot:anotherSlot>
         Another slot content
-    </x-slot:another_slot>
+    </x-slot:anotherSlot>
 </x-optional-slot>
 @endif

--- a/tests/Integration/View/templates/uses-optional-slots.blade.php
+++ b/tests/Integration/View/templates/uses-optional-slots.blade.php
@@ -1,0 +1,19 @@
+@if($noOptionals)
+<x-optional-slot>
+    Slot content
+</x-optional-slot>
+@elseif($optionalAsAttribute)
+<x-optional-slot optional_slot="Optional content" another_slot="Another slot content">
+    Slot content
+</x-optional-slot>
+@else
+<x-optional-slot>
+    Slot content
+    <x-slot:optional_slot>
+        Optional content
+    </x-slot:optional_slot>
+    <x-slot:another_slot>
+        Another slot content
+    </x-slot:another_slot>
+</x-optional-slot>
+@endif

--- a/tests/View/Blade/BladeSlotsTest.php
+++ b/tests/View/Blade/BladeSlotsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeSlotsTest extends AbstractBladeTestCase
+{
+    public function testSlotssAreCompiled()
+    {
+        $this->assertSame('<?php foreach (([\'optional_slot\', \'another_slot\' => [\'contents\' => \'string\']]) as $__key => $__value) {
+    $__key = is_numeric($__key) ? $__value : $__key;
+    $__value = !is_array($__value) && !$__value instanceof \ArrayAccess ? [] : $__value;
+    if (!isset($$__key) || is_string($$__key)) {
+        $$__key = new \Illuminate\View\ComponentSlot($$__key ?? $__value[\'contents\'] ?? \'\', $__value[\'attributes\'] ?? []);
+    }
+} ?>
+<?php $attributes ??= new \\Illuminate\\View\\ComponentAttributeBag; ?>
+<?php $attributes = $attributes->exceptProps([\'optional_slot\', \'another_slot\' => [\'contents\' => \'string\']]); ?>', $this->compiler->compileString('@slots([\'optional_slot\', \'another_slot\' => [\'contents\' => \'string\']])'));
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR will add a `@slots` blade directive mainly for use in anonymous components.
It adds a mechanism to declare optional slots at the top of your components which will automatically be transformed into ComponentSlots when they are a string or do not exist.

The issue this solves is, say you're building a dialog component with text and a button which you can optionally change the styling and contents of. You might have your template look like this.
```blade
<dialog {{ $attributes->class('absolute inset') }}>
	{{ $slot }}
	<div>
		<button {{ $button->attributes->class('bg-green-200 ml-0 mr-auto') }}>{{ $button ?? 'close' }}</button>
	</div>
</dialog>
```
However this will never work as button is `null` and `$button->attributes` will throw an error let alone merging classes.
The options you have are adding php at the top or coalescing the `$button->attributes->class` and copy-pasting your classes.

The solution this offers is the following template
```blade
@slots(['button' => ['contents' => 'close']])
<dialog {{ $attributes->class('absolute inset') }}>
	{{ $slot }}
	<div>
		<button {{ $button->attributes->class('bg-green-200 ml-0 mr-auto') }}>{{ $button }}</button>
	</div>
</dialog>
```

Which will define all optional slots used in the code clearly at the top, and allow us to set default data to be overwritten if the named slot is used.

This is not breaking as it is a new feature which affects nothing if it is not used.