### PR TITLE
[10.x] Standardization creation of Helpers outside of those supplied by the framework

### DIFF
--- a/src/Illuminate/Support/BaseHelpers.php
+++ b/src/Illuminate/Support/BaseHelpers.php
@@ -22,7 +22,8 @@ abstract class BaseHelpers
     /**
      * @return New Instance Class.
      */
-    public static function instance() {
+    public static function instance()
+    {
         return new static();
     }
     

--- a/src/Illuminate/Support/BaseHelpers.php
+++ b/src/Illuminate/Support/BaseHelpers.php
@@ -27,5 +27,4 @@ abstract class BaseHelpers
     {
         return new static();
     }
-
 }

--- a/src/Illuminate/Support/BaseHelpers.php
+++ b/src/Illuminate/Support/BaseHelpers.php
@@ -6,6 +6,7 @@ abstract class BaseHelpers
 {
     /**
      * Handle calls to missing methods on the helper.
+     *
      * @param  string  $method
      * @param  array  $parameters
      * @return mixed
@@ -26,7 +27,5 @@ abstract class BaseHelpers
     {
         return new static();
     }
-    
-}
 
-?>
+}

--- a/src/Illuminate/Support/BaseHelpers.php
+++ b/src/Illuminate/Support/BaseHelpers.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Support;
+
+abstract class BaseHelpers
+{
+    /**
+     * Handle calls to missing methods on the helper.
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        throw new BadMethodCallException(sprintf(
+            'Method %s::%s does not exist.', static::class, $method
+        ));
+    }
+
+    /**
+     * @return New Instance Class.
+     */
+    public static function instance() {
+        return new static();
+    }
+    
+}
+
+?>

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -24,7 +24,8 @@
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
         "nesbot/carbon": "^2.62.1",
-        "voku/portable-ascii": "^2.0"
+        "voku/portable-ascii": "^2.0",
+        "rmunate/laravel_helpers": "^1.2"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -24,8 +24,8 @@
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
         "nesbot/carbon": "^2.62.1",
-        "voku/portable-ascii": "^2.0",
-        "rmunate/laravel_helpers": "^1.2"
+        "rmunate/laravel_helpers": "^1.2",
+        "voku/portable-ascii": "^2.0"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
**Why accept this contribution?**
I have worked with Laravel for many years, and I have seen that in almost all projects the Helpers of each system are created in different ways, in different paths and in different folders, I have seen people who start using the Framework who when they see the syntax of a Helper similar to that of a PHP own function attempt to use the function on another system. After seeing this, I wanted to standardize the process of creating helpers, I would like to provide the function and that a standard for creating helpers for developing systems, easy to use and implement, can be included in the official documentation.

**Originally created library code repository.**
https://github.com/rmunate/LaravelHelpers

If my contribution turns out to be useful, I promise to update the documentation in the helpers section of the framework.