### PR TITLE
[10.x] Fixes unable to use `tran()->has()` on JSON language files.

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -101,7 +101,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function has($key, $locale = null, $fallback = true)
     {
-        return $this->get($key, [], $locale, $fallback) !== $key;
+        $locale = $locale ?: $this->locale;
+
+        $line = $this->get($key, [], $locale, $fallback);
+
+        if (! is_null($this->loaded['*']['*'][$locale][$key] ?? null)) {
+            return true;
+        }
+
+        return $line !== $key;
     }
 
     /**

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Translation;
+
+use Orchestra\Testbench\TestCase;
+
+class TranslatorTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function defineEnvironment($app)
+    {
+        $app['translator']->addJsonPath(__DIR__.'/lang');
+
+        parent::defineEnvironment($app);
+    }
+
+    public function testItCanGetFromLocaleForJson()
+    {
+        $this->assertSame('30 Days', __('30 Days'));
+
+        $this->app->setLocale('fr');
+
+        $this->assertSame('30 jours', __('30 Days'));
+    }
+
+    public function testItCanCheckLanguageExistsHasFromLocaleForJson()
+    {
+        $this->assertTrue(trans()->has('1 Day'));
+        $this->assertTrue(trans()->hasForLocale('1 Day'));
+        $this->assertTrue(trans()->hasForLocale('30 Days'));
+
+        $this->app->setLocale('fr');
+
+        $this->assertFalse(trans()->has('1 Day'));
+        $this->assertFalse(trans()->hasForLocale('1 Day'));
+        $this->assertTrue(trans()->hasForLocale('30 Days'));
+    }
+}

--- a/tests/Integration/Translation/lang/en.json
+++ b/tests/Integration/Translation/lang/en.json
@@ -1,0 +1,7 @@
+{
+    "1 Day": "1 Day",
+    "30 Days": "30 Days",
+    "365 Days": "365 Days",
+    "60 Days": "60 Days",
+    "90 Days": "90 Days"
+}

--- a/tests/Integration/Translation/lang/fr.json
+++ b/tests/Integration/Translation/lang/fr.json
@@ -1,0 +1,6 @@
+{
+    "30 Days": "30 jours",
+    "365 Days": "365 jours",
+    "60 Days": "60 jours",
+    "90 Days": "90 jours"
+}


### PR DESCRIPTION
Using `trans()->has()` on JSON file is not 100% reliable when the `$key` and `$replacement` is the same value.

e.g:

```json
{
    "30 Days": "30 Days"
}
```

```php
// Before
trans()->has('30 Days') // return false

// After
trans()->has('30 Days') // return true