### PR TITLE
[10.x] Add `assertJsonPathFragment` to test a fragment within a response path

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -152,6 +152,41 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
+     * Assert that the response contains the given JSON fragment at the given path in the response.
+     *
+     * @param  string  $path
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertPathFragment(string $path, array $data)
+    {
+        $decodedPath = $this->json($path);
+
+        if (is_null($decodedPath) || $decodedPath === false) {
+            PHPUnit::fail("A null value was returned from the path '$path'.");
+        }
+
+        $actual = json_encode(
+            Arr::sortRecursive($decodedPath),
+            JSON_UNESCAPED_UNICODE
+        );
+
+        foreach (Arr::sortRecursive($data) as $key => $value) {
+            $expected = $this->jsonSearchStrings($key, $value);
+
+            PHPUnit::assertTrue(
+                Str::contains($actual, $expected),
+                'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
+                '['.json_encode([$key => $value], JSON_UNESCAPED_UNICODE).']'.PHP_EOL.PHP_EOL.
+                'within'.PHP_EOL.PHP_EOL.
+                "[{$actual}]."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response does not contain the given JSON fragment.
      *
      * @param  array  $data

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -706,6 +706,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response contains the given JSON fragment at the given path in the response.
+     *
+     * @param  string  $path
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertJsonPathFragment(string $path, array $data)
+    {
+        $this->decodeResponseJson()->assertPathFragment($path, $data);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response does not contain the given JSON fragment.
      *
      * @param  array  $data

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1261,6 +1261,43 @@ class TestResponseTest extends TestCase
         $response->assertJsonFragment(['id' => 1]);
     }
 
+    public function testAssertJsonPathFragment()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonPathFragment('0', ['bar' => 'bar 0']);
+
+        $response->assertJsonPathFragment('0', ['bar' => 'bar 0', 'foobar' => 'foobar 0', 'foo' => 'foo 0']);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonPathFragment('foobar', ['foobar_foo' => 'foo']);
+
+        $response->assertJsonPathFragment('foobar', ['foobar_bar' => 'bar', 'foobar_foo' => 'foo']);
+
+        $response->assertJsonPathFragment('baz', ['bar' => 'foo 0', 'foo' => 'bar 0']);
+
+        $response->assertJsonPathFragment('barfoo.2.bar', ['foo' => 'bar 0', 'rab' => 'rab 0', 'bar' => 'foo 0']);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPathFragment('*', ['foo' => 'bar', 'id' => 10]);
+
+        $response->assertJsonPathFragment('0', ['id' => 10]);
+        $response->assertJsonPathFragment('1', ['id' => 20]);
+        $response->assertJsonPathFragment('2', ['id' => 30]);
+    }
+
+    public function testAssertJsonPathFragmentCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPathFragment('0', ['id' => 20]);
+        $response->assertJsonPathFragment('*', ['id' => 1]);
+    }
+
     public function testAssertJsonStructure()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
Hi

Sometimes, my colleagues and I use model factories in feature tests to generate test data. In such cases, we need to validate a particular section of the response using the data produced by the factory. 

However, due to the `id` attribute being appended after other attributes in the model instance (the `id` key appearing at the end in the `toArray` returned value), we cannot utilize `assertJsonPath`. Consequently, we have to depend on `assertJsonFragment`. After applying `assertJsonFragment`, it is necessary to construct a dirty nested array with specific data.

Having the `assertJsonPathFragment` method would greatly enhance the readability and maintainability of our test code.