### PR TITLE
 Translate CSRF token mismatch exception 

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -82,7 +82,7 @@ class VerifyCsrfToken
             });
         }
 
-        throw new TokenMismatchException('CSRF token mismatch.');
+        throw new TokenMismatchException(__('CSRF token mismatch.'));
     }
 
     /**


### PR DESCRIPTION
Developing an entire error handler just to translate the error message is too complicated and not very logical. I suggest adding a direct translation which will make working with errors much easier.
