### PR TITLE
[10.x] Fix `Dispatcher::until` return type

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -34,7 +34,7 @@ interface Dispatcher
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return array|null
+     * @return mixed
      */
     public function until($event, $payload = []);
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -215,7 +215,7 @@ class Dispatcher implements DispatcherContract
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return array|null
+     * @return mixed
      */
     public function until($event, $payload = [])
     {

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -57,7 +57,7 @@ class NullDispatcher implements DispatcherContract
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return array|null
+     * @return mixed
      */
     public function until($event, $payload = [])
     {

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -377,7 +377,7 @@ class EventFake implements Dispatcher, Fake
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return array|null
+     * @return mixed
      */
     public function until($event, $payload = [])
     {


### PR DESCRIPTION
It appears the until method always returns whatever gets returned from a listener or null if nothing is returned from any listener.

As you can see the until method returns the result of the dispatch method with parameter `$halt` = `true`:
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Events/Dispatcher.php#L222

And the behaviour of dispatch with `$halt` = `true` is as follows:
- If a listener returns something other than `null`, that value will be early returned. https://github.com/laravel/framework/blob/10.x/src/Illuminate/Events/Dispatcher.php#L254
- If no listener returned anything, it will return `null` https://github.com/laravel/framework/blob/10.x/src/Illuminate/Events/Dispatcher.php#L268

I was considering adding a conditional return type to the dispatch method based on the `halt` boolean. I however thought they weren't used anywhere else in the framework and decided to omit this. Please let me know if this is wanted.