### PR TITLE
Add afterMorphs in Blueprint to add columns morph after some column

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -431,7 +431,7 @@ class Blueprint
     public function dropForeignIdFor($model, $column = null)
     {
         if (is_string($model)) {
-            $model = new $model();
+            $model = new $model;
         }
 
         return $this->dropForeign([$column ?: $model->getForeignKey()]);
@@ -447,7 +447,7 @@ class Blueprint
     public function dropConstrainedForeignIdFor($model, $column = null)
     {
         if (is_string($model)) {
-            $model = new $model();
+            $model = new $model;
         }
 
         return $this->dropConstrainedForeignId($column ?: $model->getForeignKey());
@@ -936,7 +936,7 @@ class Blueprint
     public function foreignIdFor($model, $column = null)
     {
         if (is_string($model)) {
-            $model = new $model();
+            $model = new $model;
         }
 
         $column = $column ?: $model->getForeignKey();
@@ -1714,8 +1714,7 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type,
-            compact('index', 'columns', 'algorithm')
+            $type, compact('index', 'columns', 'algorithm')
         );
     }
 


### PR DESCRIPTION
Hi,
After starting to use morphs, I felt the need to use after(), however, it doesn't work on morphs, so I decided to make this feature through this need, I believe it will help many users.

I made the code used based on nullableMorphs, as they are similar needs.
Example of use:
```
        Schema::table('test_table', function (Blueprint $table) {
            $table->afterMorphs('my_morph', 'after_column');
        });
```