### PR TITLE
[10.x] Add Collection::wrap to add method on BatchFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\UpdatedBatchJobCounts;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 
 class BatchFake extends Batch
 {
@@ -79,6 +80,8 @@ class BatchFake extends Batch
      */
     public function add($jobs)
     {
+        $jobs = Collection::wrap($jobs);
+
         foreach ($jobs as $job) {
             $this->added[] = $job;
         }


### PR DESCRIPTION
Hello,

I faced an issue (https://github.com/laravel/framework/issues/47588) with the add method on the BatchFake class. After searching through the original add Method on the Batch class I saw the line

```php
$jobs = Collection::wrap($jobs)-> [...]
```
This line is missing in the BatchFake class. This results in some weird behavior on single job adds to a batch in testing. For example my InitialJob has two Jobs to be added:

```php
    public function handle(): void
    {
        $this->batch()->add(new FirstJob());
        $this->batch()->add(new SecondJob());
    }
```

In my test i would expect that the count of the `$batch->added` will be 2. But it is something around 22 because in the BatchFake class the $jobs aren't wrapped before they are added to the array in a foreach loop.

BatchFake add method:
```php
    public function add($jobs)
    {
        foreach ($jobs as $job) {
            $this->added[] = $job;
        }

        return $this;
    }
```

If the parameter would be wrapped before the for each loop, it would provide the expected result.

I could not find test for the BatchFake class in the repository. Maybe i missed them?

If more information are needed I would love to provide them.