### PR TITLE
[10.x] Ensure duration is present

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -218,6 +218,10 @@ class Kernel implements KernelContract
     {
         $this->app->terminate();
 
+        if ($this->commandStartedAt === null) {
+            return;
+        }
+
         $this->commandStartedAt->setTimezone($this->app['config']->get('app.timezone') ?? 'UTC');
 
         foreach ($this->commandLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -214,6 +214,10 @@ class Kernel implements KernelContract
 
         $this->app->terminate();
 
+        if ($this->requestStartedAt === null) {
+            return;
+        }
+
         $this->requestStartedAt->setTimezone($this->app['config']->get('app.timezone') ?? 'UTC');
 
         foreach ($this->requestLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {

--- a/tests/Integration/Console/CommandDurationThresholdTest.php
+++ b/tests/Integration/Console/CommandDurationThresholdTest.php
@@ -198,4 +198,12 @@ class CommandDurationThresholdTest extends TestCase
 
         $this->assertSame('Australia/Melbourne', $startedAt->timezone->getName());
     }
+
+    public function testItHandlesCallingTerminateWithoutHandle()
+    {
+        $this->app[Kernel::class]->terminate(new StringInput('foo'), 21);
+
+        // this is a placeholder just to show that the above did not throw an exception.
+        $this->assertTrue(true);
+    }
 }

--- a/tests/Integration/Http/RequestDurationThresholdTest.php
+++ b/tests/Integration/Http/RequestDurationThresholdTest.php
@@ -186,4 +186,12 @@ class RequestDurationThresholdTest extends TestCase
         $kernel->terminate($request, $response);
         $this->assertNull($kernel->requestStartedAt());
     }
+
+    public function testItHandlesCallingTerminateWithoutHandle()
+    {
+        $this->app[Kernel::class]->terminate(Request::create('http://localhost/test-route'), new Response);
+
+        // this is a placeholder just to show that the above did not throw an exception.
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
fixes #47591 #47600

It seems that in some scenarios on Vapor that the request duration is not present. I'm not entirely sure how this state exists, but it seems to be related to handling static file, I think.

I've put a check in for request and command handlers.