### PR TITLE
[11.x] `assertSee` handle empty values

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -530,7 +530,7 @@ class TestResponse implements ArrayAccess
 
         foreach ($values as $value) {
             if (! $allowEmptyValues && (string) $value === '') {
-                PHPUnit::fail('An empty string was passed to `assertSee`.');
+                PHPUnit::fail('An empty value was passed to `assertSee`.');
             }
 
             PHPUnit::assertStringContainsString((string) $value, $this->getContent());

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -522,7 +522,7 @@ class TestResponse implements ArrayAccess
     {
         $value = Arr::wrap($value);
 
-        if (!$allowEmptyValues && empty($value)) {
+        if (! $allowEmptyValues && empty($value)) {
             PHPUnit::fail('An empty value was passed to `assertSee`.');
         }
 
@@ -530,7 +530,7 @@ class TestResponse implements ArrayAccess
 
         foreach ($values as $value) {
 
-            if (!$allowEmptyValues && (string) $value === '') {
+            if (! $allowEmptyValues && (string) $value === '') {
                 PHPUnit::fail('An empty string was passed to `assertSee`.');
             }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -518,13 +518,22 @@ class TestResponse implements ArrayAccess
      * @param  bool  $escape
      * @return $this
      */
-    public function assertSee($value, $escape = true)
+    public function assertSee($value, $escape = true, $allowEmptyValues = false)
     {
         $value = Arr::wrap($value);
+
+        if (!$allowEmptyValues && empty($value)) {
+            PHPUnit::fail('An empty value was passed to `assertSee`.');
+        }
 
         $values = $escape ? array_map('e', $value) : $value;
 
         foreach ($values as $value) {
+
+            if (!$allowEmptyValues && (string) $value === '') {
+                PHPUnit::fail('An empty string was passed to `assertSee`.');
+            }
+
             PHPUnit::assertStringContainsString((string) $value, $this->getContent());
         }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -529,7 +529,6 @@ class TestResponse implements ArrayAccess
         $values = $escape ? array_map('e', $value) : $value;
 
         foreach ($values as $value) {
-
             if (! $allowEmptyValues && (string) $value === '') {
                 PHPUnit::fail('An empty string was passed to `assertSee`.');
             }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -329,6 +329,62 @@ class TestResponseTest extends TestCase
         $response->assertSee(['bar & baz', 'baz & qux']);
     }
 
+    public function testAssertSeeCatchesNullValue()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee(null);
+    }
+
+    public function testAssertSeeCatchesEmptyArray()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee([]);
+    }
+
+    public function testAssertSeeCatchesEmptyString()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee('');
+    }
+
+    public function testAssertSeeCatchesEmptyStringInArray()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee(['foo', '', 'bar']);
+    }
+
+    public function testAssertSeeAllowsEmptyValues()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee(null, allowEmptyValues: true);
+        $response->assertSee([], allowEmptyValues: true);
+        $response->assertSee('', allowEmptyValues: true);
+        $response->assertSee(['foo', '', 'bar'], allowEmptyValues: true);
+    }
+
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
currently when passing an empty value to `assertSee` the test will pass.  these values include:

- `null`
- `[]`
- `''`
- `['foo', '', 'bar']`

rarely (IMO) is this the desired behavior, and may create false confidence in the test.

often times we ran into this issue when a user inadvertently accessed a non-existent property on a Model.

```php
public function test_can_edit_user(): void
{
    $user = (new UserFactory)->create();

    $this->get(route('admin.users.edit', [$user->id]))
         ->assertOk()
         ->assertSee('Edit User')
         ->assertSee($user->wrong_field);  <----
}
```

sometimes users would type a non-existent field name, other times they might copy/paste from another test and forget to update the field names.  if `$user->wrong_field` was empty, the test would still pass, and the user would be none the wiser.

this change will fail the test by default when passed empty values, but also allow users to override if appropriate.
