### PR TITLE
[10.x] Allows to define a Gate class

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -217,6 +217,32 @@ class Gate implements GateContract
     }
 
     /**
+     * Defines multiple abilities based on a class public methods and name.
+     *
+     * @param  string|class-string  $class
+     * @param  string|null  $as
+     * @return $this
+     */
+    public function defineWithClass($class, $as = null)
+    {
+        if (empty($as)) {
+            $as = Str::kebab(class_basename($class));
+        }
+
+        foreach ((new ReflectionClass($class))->getMethods() as $method) {
+            if ($method->isPublic()
+                && !$method->isStatic()
+                && !$method->isInternal()
+                && $method->getName() !== 'before'
+                && !Str::startsWith($method->getName(), '__')) {
+                $this->define(Str::kebab($method->getName()).'-'.$as, [$class, $method->getName()]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Define abilities for a resource.
      *
      * @param  string  $name

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static \Illuminate\Auth\Access\Response allowIf(\Illuminate\Auth\Access\Response|\Closure|bool $condition, string|null $message = null, string|null $code = null)
  * @method static \Illuminate\Auth\Access\Response denyIf(\Illuminate\Auth\Access\Response|\Closure|bool $condition, string|null $message = null, string|null $code = null)
  * @method static \Illuminate\Auth\Access\Gate define(string $ability, callable|array|string $callback)
+ * @method static \Illuminate\Auth\Access\Gate defineWithClass(string $class, string $as = null)
  * @method static \Illuminate\Auth\Access\Gate resource(string $name, string $class, array|null $abilities = null)
  * @method static \Illuminate\Auth\Access\Gate policy(string $class, string $policy)
  * @method static \Illuminate\Auth\Access\Gate before(callable $callback)

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -28,6 +28,40 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function testHallClassIsDefinedWithoutHallLastName()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->defineWithClass(CustomGates::class);
+
+        $this->assertTrue($gate->check('allow-custom-gates'));
+        $this->assertFalse($gate->check('deny-custom-gates'));
+        $this->assertFalse($gate->check('internal-custom-gates'));
+        $this->assertFalse($gate->check('construct-custom-gates'));
+        $this->assertTrue($gate->check('something-very-complex-custom-gates'));
+    }
+
+    public function testHallClassDefinedWithCustomName()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->defineWithClass(CustomGates::class, 'dashboard');
+
+        $this->assertTrue($gate->check('allow-dashboard'));
+        $this->assertFalse($gate->check('deny-dashboard'));
+        $this->assertTrue($gate->check('something-very-complex-dashboard'));
+    }
+
+    public function testHallClassUsesBefore()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->defineWithClass(CustomGatesWithBefore::class);
+
+        $this->assertFalse($gate->check('before-custom-gates-with-before'));
+        $this->assertTrue($gate->check('deny-custom-gates-with-before'));
+    }
+
     public function testBeforeCanTakeAnArrayCallbackAsObject()
     {
         $gate = new Gate(new Container, function () {
@@ -1434,5 +1468,46 @@ class AccessGateTestPolicyThrowingAuthorizationException
     public function create()
     {
         throw new AuthorizationException('Not allowed.', 'some_code');
+    }
+}
+
+class CustomGates
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function allow()
+    {
+        return true;
+    }
+
+    public function deny()
+    {
+        return false;
+    }
+
+    public function somethingVeryComplex()
+    {
+        return true;
+    }
+
+    public function __internal()
+    {
+        return true;
+    }
+}
+
+class CustomGatesWithBefore
+{
+    public function before()
+    {
+        return true;
+    }
+
+    public function deny()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
# What?

Allows to define multiple gates using a class name and methods for automatic naming.

For example, a class called "Metrics" with methods "see" and "override" will register the gates "see-metrics" and "override-metrics".

```php
namespace App\Gate;

use App\Models\User;

class Metrics
{
    public function see(User $user): bool
    {
        return $user->is_moderator;
    }
    
    public function override(User $user): bool
    {
        return $user->is_admin;
    }
}
```

Then, we can use the `defineWithClass` method.

```php
use Illuminate\Support\Facades\Gate;
use App\Gate\Metrics;

Gate::defineWithClass(Metrics::class);

if (Gate::allows('see-metrics')->allowed()) {
    return view('user.metrics')
}

return 'You can not see the metrics!';
```

It also supports alternative naming:

```php
use Illuminate\Support\Facades\Gate;
use App\Gate\Metrics;

Gate::defineWithClass(Metrics::class, 'data');

if (Gate::allows('see-data')->allowed()) {
    // ...
}
```

## How it works?

It basically gets the declared public methods (non-static) and appends the class base name as the gate definition name. It skips any internal method, and methods starting with `__` like `__unset`.

It's compatible with using `before()` to run a authorization callback before the gate.