### PR TITLE
[10.x] Change return type of `getPrivateToken` in AblyBroadcaster

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -216,7 +216,7 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Get the private token value from the Ably key.
      *
-     * @return mixed
+     * @return string
      */
     protected function getPrivateToken()
     {


### PR DESCRIPTION
The `getPrivateToken` return string instead of mixed!
