### PR TITLE
[10.x] Support Inline Attachments within Markdown Mailable

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -100,8 +100,8 @@ class MailChannel
         }
 
         return [
-            'html' => fn ($messageArray = []) => $this->markdown->render($message->markdown, $messageArray),
-            'text' => fn ($messageArray = []) => $this->markdown->renderText($message->markdown, $messageArray),
+            'html' => fn ($messageData = []) => $this->markdown->render($message->markdown, $messageData),
+            'text' => fn ($messageData = []) => $this->markdown->renderText($message->markdown, $messageData),
         ];
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -100,8 +100,8 @@ class MailChannel
         }
 
         return [
-            'html' => fn($messageArray) => $this->markdown->render($message->markdown, $messageArray),
-            'text' => fn($messageArray) => $this->markdown->renderText($message->markdown, $messageArray),
+            'html' => fn ($messageArray = []) => $this->markdown->render($message->markdown, $messageArray),
+            'text' => fn ($messageArray = []) => $this->markdown->renderText($message->markdown, $messageArray),
         ];
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -100,8 +100,8 @@ class MailChannel
         }
 
         return [
-            'html' => $this->markdown->render($message->markdown, $message->data()),
-            'text' => $this->markdown->renderText($message->markdown, $message->data()),
+            'html' => fn($messageArray) => $this->markdown->render($message->markdown, $messageArray),
+            'text' => fn($messageArray) => $this->markdown->renderText($message->markdown, $messageArray),
         ];
     }
 

--- a/tests/Integration/Notifications/Fixtures/mail/color-test.blade.php
+++ b/tests/Integration/Notifications/Fixtures/mail/color-test.blade.php
@@ -1,0 +1,1 @@
+body{color: test;}

--- a/tests/Integration/Notifications/Fixtures/markdown.blade.php
+++ b/tests/Integration/Notifications/Fixtures/markdown.blade.php
@@ -1,0 +1,1 @@
+<img src="{{ $message->embed('image.jpg') }}">

--- a/tests/Integration/Notifications/Fixtures/markdown.blade.php
+++ b/tests/Integration/Notifications/Fixtures/markdown.blade.php
@@ -1,1 +1,1 @@
-<img src="{{ $message->embed('image.jpg') }}">
+Embed content: {{ $message->embed(__FILE__) }}

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Notifications;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\View;
+use Orchestra\Testbench\TestCase;
+
+class SendingMailableNotificationsTest extends TestCase
+{
+    public $mailer;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('mail.driver', 'array');
+
+        $app['config']->set('app.locale', 'en');
+
+        View::addLocation(__DIR__.'/Fixtures');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->string('name')->nullable();
+        });
+    }
+
+    public function testMarkdownNotification()
+    {
+        $user = MailableNotificationUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user->notify(new MarkdownNotification());
+    }
+}
+
+
+class MailableNotificationUser extends Model
+{
+    use Notifiable;
+
+    public $table = 'users';
+    public $timestamps = false;
+}
+
+
+class MarkdownNotification extends Notification
+{
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)->markdown('markdown');
+    }
+}


### PR DESCRIPTION
to close https://github.com/laravel/framework/issues/47592

If using a view for building a message, the actual rendering of the view into HTML doesn't happen until later in the process, where it has the Message object (which has the `embed()` method) for use within the View. When using markdown instead, the process *was* happening before calling Mailer@send().

By converting these two to closures, we allow for the markdown component to be built within Mailer@renderView() instead (which passes the message data as an array).

Note that there were some unrelated tests which needed updating. This was only to accommodate how those tests' expectations were set up.