### PR TITLE
Revert "[11.x] `assertSee` handle empty values"

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -518,21 +518,13 @@ class TestResponse implements ArrayAccess
      * @param  bool  $escape
      * @return $this
      */
-    public function assertSee($value, $escape = true, $allowEmptyValues = false)
+    public function assertSee($value, $escape = true)
     {
         $value = Arr::wrap($value);
-
-        if (! $allowEmptyValues && empty($value)) {
-            PHPUnit::fail('An empty value was passed to `assertSee`.');
-        }
 
         $values = $escape ? array_map('e', $value) : $value;
 
         foreach ($values as $value) {
-            if (! $allowEmptyValues && (string) $value === '') {
-                PHPUnit::fail('An empty value was passed to `assertSee`.');
-            }
-
             PHPUnit::assertStringContainsString((string) $value, $this->getContent());
         }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -329,62 +329,6 @@ class TestResponseTest extends TestCase
         $response->assertSee(['bar & baz', 'baz & qux']);
     }
 
-    public function testAssertSeeCatchesNullValue()
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $response = $this->makeMockResponse([
-            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
-        ]);
-
-        $response->assertSee(null);
-    }
-
-    public function testAssertSeeCatchesEmptyArray()
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $response = $this->makeMockResponse([
-            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
-        ]);
-
-        $response->assertSee([]);
-    }
-
-    public function testAssertSeeCatchesEmptyString()
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $response = $this->makeMockResponse([
-            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
-        ]);
-
-        $response->assertSee('');
-    }
-
-    public function testAssertSeeCatchesEmptyStringInArray()
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $response = $this->makeMockResponse([
-            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
-        ]);
-
-        $response->assertSee(['foo', '', 'bar']);
-    }
-
-    public function testAssertSeeAllowsEmptyValues()
-    {
-        $response = $this->makeMockResponse([
-            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
-        ]);
-
-        $response->assertSee(null, allowEmptyValues: true);
-        $response->assertSee([], allowEmptyValues: true);
-        $response->assertSee('', allowEmptyValues: true);
-        $response->assertSee(['foo', '', 'bar'], allowEmptyValues: true);
-    }
-
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
Reverts laravel/framework#47597