### PR TITLE
[10.x] Return type of `listen` method in `Illuminate\Events\Dispatcher`

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -81,6 +81,7 @@ class Dispatcher implements DispatcherContract
                 ->each(function ($event) use ($events) {
                     $this->listen($event, $events);
                 });
+
             return;
         }
 
@@ -89,6 +90,7 @@ class Dispatcher implements DispatcherContract
                 ->each(function ($event) use ($events) {
                     $this->listen($event, $events->resolve());
                 });
+
             return;
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -77,12 +77,12 @@ class Dispatcher implements DispatcherContract
     public function listen($events, $listener = null)
     {
         if ($events instanceof Closure) {
-            return collect($this->firstClosureParameterTypes($events))
+            collect($this->firstClosureParameterTypes($events))
                 ->each(function ($event) use ($events) {
                     $this->listen($event, $events);
                 });
         } elseif ($events instanceof QueuedClosure) {
-            return collect($this->firstClosureParameterTypes($events->closure))
+            collect($this->firstClosureParameterTypes($events->closure))
                 ->each(function ($event) use ($events) {
                     $this->listen($event, $events->resolve());
                 });

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -81,12 +81,18 @@ class Dispatcher implements DispatcherContract
                 ->each(function ($event) use ($events) {
                     $this->listen($event, $events);
                 });
-        } elseif ($events instanceof QueuedClosure) {
+            return;
+        }
+
+        if ($events instanceof QueuedClosure) {
             collect($this->firstClosureParameterTypes($events->closure))
                 ->each(function ($event) use ($events) {
                     $this->listen($event, $events->resolve());
                 });
-        } elseif ($listener instanceof QueuedClosure) {
+            return;
+        }
+
+        if ($listener instanceof QueuedClosure) {
             $listener = $listener->resolve();
         }
 


### PR DESCRIPTION
In  `listen` method at `Illuminate\Events\Dispatcher`, ưe are using `collect(...)->each(...)` and it will return a `Illuminate\Support\Collection`. But this method should return void as declaring.
