### PR TITLE
[10.x] Add `CanNot` rule in validation

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -33,6 +33,7 @@ return [
     ],
     'boolean' => 'The :attribute field must be true or false.',
     'can' => 'The :attribute field contains an unauthorized value.',
+    'cannot' => 'The :attribute field contains an unauthorized value.',
     'confirmed' => 'The :attribute field confirmation does not match.',
     'current_password' => 'The password is incorrect.',
     'date' => 'The :attribute field must be a valid date.',

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\Can;
+use Illuminate\Validation\Rules\CanNot;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -31,6 +32,18 @@ class Rule
     public static function can($ability, ...$arguments)
     {
         return new Can($ability, $arguments);
+    }
+
+    /**
+     * Get a cannot constraint builder instance.
+     *
+     * @param  string  $ability
+     * @param  mixed  ...$arguments
+     * @return \Illuminate\Validation\Rules\CanNot
+     */
+    public static function cannot($ability, ...$arguments)
+    {
+        return new CanNot($ability, $arguments);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/CanNot.php
+++ b/src/Illuminate/Validation/Rules/CanNot.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Gate;
+
+class CanNot implements Rule
+{
+    /**
+     * The ability to check.
+     *
+     * @var string
+     */
+    protected $ability;
+
+    /**
+     * The arguments to pass to the authorization check.
+     *
+     * @var array
+     */
+    protected $arguments;
+
+    /**
+     * Constructor.
+     *
+     * @param  string  $ability
+     * @param  array  $arguments
+     */
+    public function __construct($ability, array $arguments = [])
+    {
+        $this->ability = $ability;
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $arguments = $this->arguments;
+
+        $model = array_shift($arguments);
+
+        return Gate::denies($this->ability, array_filter([$model, ...$arguments, $value]));
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        $message = trans('validation.cannot');
+
+        return $message === 'validation.cannot'
+            ? ['The :attribute field contains an unauthorized value.']
+            : $message;
+    }
+}

--- a/tests/Validation/ValidationRuleCanNotTest.php
+++ b/tests/Validation/ValidationRuleCanNotTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\CanNot;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ValidationRuleCanNotTest extends TestCase
+{
+    protected $container;
+    protected $user;
+    protected $router;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = new stdClass;
+
+        Container::setInstance($this->container = new Container);
+
+        $this->container->singleton(GateContract::class, function () {
+            return new Gate($this->container, function () {
+                return $this->user;
+            });
+        });
+
+        $this->container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($this->container);
+
+        (new ValidationServiceProvider($this->container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+
+    public function testValidationFails()
+    {
+        $this->gate()->define('update-company', function ($user, $value) {
+            $this->assertEquals('1', $value);
+
+            return false;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['company' => '1'],
+            ['company' => new CanNot('update-company')]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidationPasses()
+    {
+        $this->gate()->define('update-company', function ($user, $class, $model, $value) {
+            $this->assertEquals(\App\Models\Company::class, $class);
+            $this->assertInstanceOf(stdClass::class, $model);
+            $this->assertEquals('1', $value);
+
+            return true;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['company' => '1'],
+            ['company' => new CanNot('update-company', [\App\Models\Company::class, new stdClass])]
+        );
+
+        $this->assertTrue($v->fails());
+    }
+
+    /**
+     * Get the Gate instance from the container.
+     *
+     * @return \Illuminate\Auth\Access\Gate
+     */
+    protected function gate()
+    {
+        return $this->container->make(GateContract::class);
+    }
+}


### PR DESCRIPTION
This PR is opposite that PR: https://github.com/laravel/framework/pull/47371
May you need to validate that user has no ability to do, you can use `Rule::cannot()`.