### PR TITLE
[10.x] Logger: format Throwable

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -10,6 +10,7 @@ use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Traits\Conditionable;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Throwable;
 
 class Logger implements LoggerInterface
 {
@@ -181,10 +182,15 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context): void
     {
-        $this->logger->{$level}(
-            $message = $this->formatMessage($message),
-            $context = array_merge($this->context, $context)
-        );
+        if ($message instanceof Throwable) {
+            $message = $message->getMessage();
+            $context = array_merge(['exception' => $message], $this->context, $context);
+        } else {
+            $message = $this->formatMessage($message);
+            $context = array_merge($this->context, $context);
+        }
+
+        $this->logger->{$level}($message, $context);
 
         $this->fireLogEvent($level, $message, $context);
     }


### PR DESCRIPTION
Add support to correct format Throwable while using logger

```php
$e = new RuntimeException('test');
$this->logger->error($e);
```

Before it log message as `(string) $e`, now we use next format:
$message - `$e->getMessage()`
$context - full `$e` which can be formatted later (by default to string, or by custom drivers (as sentry) to related format)