### PR TITLE
Pass queue from Mailable to SendQueuedMailable job

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -60,8 +60,8 @@ class SendQueuedMailable
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
         $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
-        $this->queue = property_exists($mailable, 'connection') ? $mailable->connection : null;
-        $this->connection = property_exists($mailable, 'queue') ? $mailable->queue : null;
+        $this->queue = property_exists($mailable, 'queue') ? $mailable->queue : null;
+        $this->connection = property_exists($mailable, 'connection') ? $mailable->connection : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
     }
 

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -60,7 +60,8 @@ class SendQueuedMailable
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
         $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
-        $this->queue = property_exists($mailable, 'queue') ? $mailable->queue : null;
+        $this->queue = property_exists($mailable, 'connection') ? $mailable->connection : null;
+        $this->connection = property_exists($mailable, 'queue') ? $mailable->queue : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
     }
 

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -60,6 +60,7 @@ class SendQueuedMailable
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
         $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
+        $this->queue = property_exists($mailable, 'queue') ? $mailable->queue : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
     }
 

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -56,13 +56,14 @@ class SendQueuedMailable
     public function __construct(MailableContract $mailable)
     {
         $this->mailable = $mailable;
-        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
-        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
-        $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
+
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
-        $this->queue = property_exists($mailable, 'queue') ? $mailable->queue : null;
         $this->connection = property_exists($mailable, 'connection') ? $mailable->connection : null;
+        $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
+        $this->queue = property_exists($mailable, 'queue') ? $mailable->queue : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
+        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
+        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
     }
 
     /**


### PR DESCRIPTION
Fixes issue where the unserialized job has the wrong queue. This occurs especially when dealing with Cloud Tasks, where we  need the correct queue after unserializing the job to fetch or update the status of the task from the server.

Currently, after unserializing, the queue of the job is incorrect, but the $mailable inside the job has the correct queue set to it.

In the screenshot provided below, I have illustrated how the serialized job has a mailable with the correct queue inside it. But when we do getQueue() on the job itself, it will always fall back to the default queue instead of the one for the mailable.

Interestingly enough, when the task is sent to the queue driver, it ends up in the correct queue. The issue arises when the queue driver receives the task and tries to gets it queue using ->getQueue().

![image](https://github.com/laravel/framework/assets/2018660/9590488f-5944-42fd-a858-34d62c7d355a)