### PR TITLE
[10.x] Add forget recursive to Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -297,6 +297,35 @@ class Arr
         }
     }
 
+
+    /**
+     * Remove one or many array items from a given array recursively without specifying a path to the key
+     *
+     * @param  array  $array
+     * @param  array|string|int  $keys
+     * @return void
+     */
+    public static function forgetRecursive(&$array, $keys)
+    {
+        $keys = (array) $keys;
+
+        if (count($keys) === 0) {
+            return;
+        }
+
+        foreach ($array as $key => &$value) {
+            if (in_array($key, $keys)) {
+                unset($array[$key]);
+
+                continue;
+            }
+
+            if (static::accessible($value)) {
+                self::forgetRecursive($value, $keys);
+            }
+        }
+    }
+
     /**
      * Get an item from an array using "dot" notation.
      *

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1083,6 +1083,55 @@ class SupportArrTest extends TestCase
         $this->assertEquals([2 => [1 => 'products']], $array);
     }
 
+    public function testForgetRecursive()
+    {
+        $array = ['user' => ['email' => 'joe@example.com', 'password' => 'foo']];
+        Arr::forgetRecursive($array, null);
+        $this->assertEquals(['user' => ['email' => 'joe@example.com', 'password' => 'foo']], $array);
+
+        $array = ['user' => ['email' => 'joe@example.com', 'password' => 'foo']];
+        Arr::forgetRecursive($array, 'password');
+        $this->assertEquals(['user' => ['email' => 'joe@example.com']], $array);
+
+        $array = ['user' => ['email' => 'joe@example.com', 'password' => 'foo'], 'password' => 'bar'];
+        Arr::forgetRecursive($array, 'password');
+        $this->assertEquals(['user' => ['email' => 'joe@example.com']], $array);
+
+        $array = ['payment' => ['amount' => 500, 'account' => ['cvc' => 123, 'credit_card' => '4111 1111 1111 1111']]];
+        Arr::forgetRecursive($array, ['cvc', 'credit_card']);
+        $this->assertEquals(['payment' => ['amount' => 500, 'account' => []]], $array);
+
+        $array = ['name' => 'hAz', '1' => 'test', 2 => 'bAz', ['1' => ['bar', 'bazz']]];
+        Arr::forgetRecursive($array, 1);
+        $this->assertEquals(['name' => 'hAz', 2 => 'bAz', 3 => []], $array);
+
+        $array = [
+            'name' => 'John',
+            'password' => 'pass',
+            'second_level' => [
+                'name' => 'Jane',
+                'password' => 'pass',
+                'third_level' => [
+                    'name' => 'Dave',
+                    'password' => 'pass'
+                ]
+            ]
+        ];
+
+        $expected = [
+            'name' => 'John',
+            'second_level' => [
+                'name' => 'Jane',
+                'third_level' => [
+                    'name' => 'Dave'
+                ]
+            ]
+        ];
+
+        Arr::forgetRecursive($array, 'password');
+        $this->assertEquals($expected, $array);
+    }
+
     public function testWrap()
     {
         $string = 'a';


### PR DESCRIPTION
This PR adds a new method `forgetRecursive()` to the Arr class, which allows you to remove multiple keys from a multi-dimensional array. Sometimes you don't know what is the path to the key that you want to remove, or you don't want to specify the path to all keys with the same name.

So instead of this

```php
$array = ['name' => 'John', 'password' => 'pass', 'second_level' => ['name' => 'Jane', 'password' => 'pass']];

Arr::forget($array, ['password', 'second_level.password']);
```

You can use this

```php
$array = ['name' => 'John', 'password' => 'pass', 'second_level' => ['name' => 'Jane', 'password' => 'pass']];

Arr::forgetRecursive($array, 'password');
```
