### PR TITLE
[10.x] Add data_remove helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -149,33 +149,33 @@ if (! function_exists('data_set')) {
     }
 }
 
-if (! function_exists('data_remove')) {
+if (! function_exists('data_forget')) {
     /**
-     * Remove an item from an array or object using "dot" notation.
+     * Remove / unset an item from an array or object using "dot" notation.
      *
      * @param  mixed  $target
      * @param  string|array|int|null  $key
      * @return mixed
      */
-    function data_remove(&$target, $key)
+    function data_forget(&$target, $key)
     {
         $segments = is_array($key) ? $key : explode('.', $key);
 
         if (($segment = array_shift($segments)) === '*' && Arr::accessible($target)) {
             if ($segments) {
                 foreach ($target as &$inner) {
-                    data_remove($inner, $segments);
+                    data_forget($inner, $segments);
                 }
             }
         } elseif (Arr::accessible($target)) {
             if ($segments && Arr::exists($target, $segment)) {
-                data_remove($target[$segment], $segments);
+                data_forget($target[$segment], $segments);
             } else {
                 Arr::forget($target, $segment);
             }
         } elseif (is_object($target)) {
             if ($segments && isset($target->{$segment})) {
-                data_remove($target->{$segment}, $segments);
+                data_forget($target->{$segment}, $segments);
             } elseif (isset($target->{$segment})) {
                 unset($target->{$segment});
             }

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -149,6 +149,42 @@ if (! function_exists('data_set')) {
     }
 }
 
+if (! function_exists('data_remove')) {
+    /**
+     * Remove an item from an array or object using "dot" notation.
+     *
+     * @param  mixed  $target
+     * @param  string|array|int|null  $key
+     * @return mixed
+     */
+    function data_remove(&$target, $key)
+    {
+        $segments = is_array($key) ? $key : explode('.', $key);
+
+        if (($segment = array_shift($segments)) === '*' && Arr::accessible($target)) {
+            if ($segments) {
+                foreach ($target as &$inner) {
+                    data_remove($inner, $segments);
+                }
+            }
+        } elseif (Arr::accessible($target)) {            
+            if ($segments && Arr::exists($target, $segment)) {
+                data_remove($target[$segment], $segments);
+            } else {
+                Arr::forget($target, $segment);
+            }
+        } elseif (is_object($target)) {
+            if ($segments && isset($target->{$segment})) {
+                data_remove($target->{$segment}, $segments);
+            } elseif (isset($target->{$segment})) {
+                unset($target->{$segment});
+            }
+        }
+
+        return $target;
+    }
+}
+
 if (! function_exists('head')) {
     /**
      * Get the first element of an array. Useful for method chaining.

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -167,7 +167,7 @@ if (! function_exists('data_remove')) {
                     data_remove($inner, $segments);
                 }
             }
-        } elseif (Arr::accessible($target)) {            
+        } elseif (Arr::accessible($target)) {
             if ($segments && Arr::exists($target, $segment)) {
                 data_remove($target[$segment], $segments);
             } else {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -430,21 +430,21 @@ class SupportHelpersTest extends TestCase
 
         $this->assertEquals(
             ['hello' => 'world'],
-            data_remove($data, 'foo')
+            data_forget($data, 'foo')
         );
 
         $data = ['foo' => 'bar', 'hello' => 'world'];
 
         $this->assertEquals(
             ['foo' => 'bar', 'hello' => 'world'],
-            data_remove($data, 'nothing')
+            data_forget($data, 'nothing')
         );
 
         $data = ['one' => ['two' => ['three' => 'hello', 'four' => ['five']]]];
 
         $this->assertEquals(
             ['one' => ['two' => ['four' => ['five']]]],
-            data_remove($data, 'one.two.three')
+            data_forget($data, 'one.two.three')
         );
     }
 
@@ -470,7 +470,7 @@ class SupportHelpersTest extends TestCase
                     ],
                 ],
             ],
-            data_remove($data, 'article.comments.*.name')
+            data_forget($data, 'article.comments.*.name')
         );
     }
 
@@ -493,7 +493,7 @@ class SupportHelpersTest extends TestCase
             ],
         ];
 
-        data_remove($data, 'posts.*.comments.*.name');
+        data_forget($data, 'posts.*.comments.*.name');
 
         $this->assertEquals([
             'posts' => [

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -424,6 +424,95 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
+    public function testDataRemove()
+    {
+        $data = ['foo' => 'bar', 'hello' => 'world'];
+
+        $this->assertEquals(
+            ['hello' => 'world'],
+            data_remove($data, 'foo')
+        );
+
+        $data = ['foo' => 'bar', 'hello' => 'world'];
+
+        $this->assertEquals(
+            ['foo' => 'bar', 'hello' => 'world'],
+            data_remove($data, 'nothing')
+        );
+
+        $data = ['one' => ['two' => ['three' => 'hello', 'four' => ['five']]]];
+
+        $this->assertEquals(
+            ['one' => ['two' => ['four' => ['five']]]],
+            data_remove($data, 'one.two.three')
+        );
+    }
+
+    public function testDataRemoveWithStar()
+    {
+        $data = [
+            'article' => [
+                'title' => 'Foo',
+                'comments' => [
+                    ['comment' => 'foo','name' => 'First'],
+                    ['comment' => 'bar','name' => 'Second'],
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            [
+                'article' => [
+                    'title' => 'Foo',
+                    'comments' => [
+                        ['comment' => 'foo'],
+                        ['comment' => 'bar'],
+                    ]
+                ]
+            ],
+            data_remove($data, 'article.comments.*.name')
+        );
+    }
+
+    public function testDataRemoveWithDoubleStar()
+    {
+        $data = [
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'First', 'comment' => 'foo'],
+                        (object) ['name' => 'Second', 'comment' => 'bar'],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'Third', 'comment' => 'hello'],
+                        (object) ['name' => 'Fourth', 'comment' => 'world'],
+                    ],
+                ],
+            ],
+        ];
+
+        data_remove($data, 'posts.*.comments.*.name');
+
+        $this->assertEquals([
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['comment' => 'foo'],
+                        (object) ['comment' => 'bar'],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['comment' => 'hello'],
+                        (object) ['comment' => 'world'],
+                    ],
+                ],
+            ],
+        ], $data);
+    }
+
     public function testHead()
     {
         $array = ['a', 'b', 'c'];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -454,10 +454,10 @@ class SupportHelpersTest extends TestCase
             'article' => [
                 'title' => 'Foo',
                 'comments' => [
-                    ['comment' => 'foo','name' => 'First'],
-                    ['comment' => 'bar','name' => 'Second'],
-                ]
-            ]
+                    ['comment' => 'foo', 'name' => 'First'],
+                    ['comment' => 'bar', 'name' => 'Second'],
+                ],
+            ],
         ];
 
         $this->assertEquals(
@@ -467,8 +467,8 @@ class SupportHelpersTest extends TestCase
                     'comments' => [
                         ['comment' => 'foo'],
                         ['comment' => 'bar'],
-                    ]
-                ]
+                    ],
+                ],
             ],
             data_remove($data, 'article.comments.*.name')
         );


### PR DESCRIPTION
This PR adds a new helper to the Collection helper. In addition to the existing `data_get`, `data_set`, and `data_fill`, this will add the `data_remove` helper to remove keys from objects or arrays easily. This is ideal if you want to remove keys from nested objects or arrays using the wildcard helper.

For example:

```php
$data = [
    'article' => [
        'title' => 'Foo',
        'comments' => [
            ['comment' => 'foo','name' => 'First'],
            ['comment' => 'bar','name' => 'Second'],
        ]
    ]
];

data_remove($data, 'article.comments.*.name');

// Result
$data = [
    'article' => [
        'title' => 'Foo',
        'comments' => [
            ['comment' => 'foo'],
            ['comment' => 'bar'],
        ]
    ]
];
```

I wasn't sure about naming the function `data_forget` instead of `data_remove` as both terms are used throughout the framework. Let me know if you want the name changed.

Have a great day! 🙌🏻