### PR TITLE
[10.x] Fix event helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -423,9 +423,7 @@ if (! function_exists('event')) {
     /**
      * Dispatch an event and call the listeners.
      *
-     * @param  string|object  $event
-     * @param  mixed  $payload
-     * @param  bool  $halt
+     * @param  mixed ...$args
      * @return array|null
      */
     function event(...$args)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -423,7 +423,7 @@ if (! function_exists('event')) {
     /**
      * Dispatch an event and call the listeners.
      *
-     * @param  mixed ...$args
+     * @param  mixed  ...$args
      * @return array|null
      */
     function event(...$args)


### PR DESCRIPTION
You don't have to include the `$event` and other parameters in the `event` helper!