### PR TITLE
[10.x] Allow DI in handle method of queued listeners as everything passed through constructor is serialized

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -104,7 +104,7 @@ class CallQueuedListener implements ShouldQueue
             $this->job, $container->make($this->class)
         );
 
-        $handler->{$this->method}(...array_values($this->data));
+        $container->call([$handler, $this->method], array_combine(array_map('get_class', $this->data), $this->data));
     }
 
     /**


### PR DESCRIPTION
Queued listeners can currently only be DI'ed through the constructor, but all those arguments are serialized and unserialized. For very big objects (Like the ConfigRepository), that is not desired as those objects take up a lot of space and might not fit in the column or in the case of horizon will make redis run out of memory. To inject those parameters without the construct method, currently you have to call the 'resolve' helper within the handle method, but that makes the code untestable. Instead, this PR adds support for DI in the handle method.