### PR TITLE
[10.x] Fix validation of attributes that depend on previous excluded attribute

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -430,8 +430,6 @@ class Validator implements ValidatorContract
                 $this->validateAttribute($attribute, $rule);
 
                 if ($this->shouldBeExcluded($attribute)) {
-                    $this->removeAttribute($attribute);
-
                     break;
                 }
 
@@ -440,6 +438,12 @@ class Validator implements ValidatorContract
                 }
             }
         }
+        // Only remove attributes after having looped through all the rules, so that
+        // the order of the attributes with applied "exclude" rule doesn't matter.
+        foreach ($this->excludeAttributes as $attribute) {
+            $this->removeAttribute($attribute);
+        }
+
 
         // Here we will spin through all of the "after" hooks on this validator and
         // fire them off. This gives the callbacks a chance to perform all kinds

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -444,7 +444,6 @@ class Validator implements ValidatorContract
             $this->removeAttribute($attribute);
         }
 
-
         // Here we will spin through all of the "after" hooks on this validator and
         // fire them off. This gives the callbacks a chance to perform all kinds
         // of other validation that needs to get wrapped up in this operation.


### PR DESCRIPTION
When using a validation rule that depends on another attribute, e.g. `required_if`, and that other attribute had applied `exclude` rule, then the order in `$rules` matters. If the excluded attribute comes first, it is already excluded during the `Validator::passes()` run, before the `require_if` rule can check that attributes value.

Of my understanding, the rule order should not matter, so the following rules should give us the same validation:

```php
// WORKING:
        [
            'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
            'type'       => ['required', 'string', 'exclude'],
        ],

// NON-WORKING, as 'type' is excluded before 'required_if' is checked in 'profile_id':
        [
            'type'       => ['required', 'string', 'exclude'],
            'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
        ],
```

I have tested this with the following PEST test:

```php
<?php

it('passes validation with exclude rule', function (array $rules, array $data, array|false $expectedValidatedData) {
    $validator = Validator::make($data, $rules);
    expect($validator->passes())->toBeTrue()
        ->and($validator->validated())->toBe($expectedValidatedData);
})->with([
    'no-profile' => [
        [
            'type'       => ['required', 'string', 'exclude'],
            'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
        ],
        [
            'type'       => 'denied',
            'profile_id' => null,
        ],
        [
            'profile_id' => null,
        ],
    ],
    'profile-with-id' => [
        [
            'type'       => ['required', 'string', 'exclude'],
            'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
        ],
        [
            'type'       => 'profile',
            'profile_id' => 1,
        ],
        [
            'profile_id' => 1,
        ],
    ],
    'profile-missing-id' => [
        // should not validate! but would need to move 'profile_id' rules before 'type'
        [
            'type'       => ['required', 'string', 'exclude'],
            'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
        ],
        [
            'type'       => 'profile',
            'profile_id' => null,
        ],
        [
            'profile_id' => null,
        ],
    ],
]);

it('fails validation with exclude rule', function (array $rules, array $data) {
    $validator = Validator::make($data, $rules);
    expect($validator->passes())->toBeFalse();
})->with([
    'profile-missing-id' => [
        [
            'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
            'type'       => ['required', 'string', 'exclude'],
        ],
        [
            'type'       => 'profile',
            'profile_id' => null,
        ],
    ],
]);
```

expected:

```
   FAIL  Tests\Feature\Rules\ExcludeTest
  ✓ it passes validation with exclude rule with dataset "no-profile"                                    0.10s  
  ✓ it passes validation with exclude rule with dataset "profile-with-id"                               0.04s  
  ⨯ it passes validation with exclude rule with dataset "profile-missing-id"                            0.04s  
  ✓ it fails validation with exclude rule with dataset "profile-missing-id"                             0.04s  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Feature\Rules\ExcludeTest > it passes validation with exclude rule with dataset "profile-m…   
  Failed asserting that false is true.
```

but the actual result is:

```
   PASS  Tests\Feature\Rules\ExcludeTest
  ✓ it passes validation with exclude rule with dataset "no-profile"                                    0.10s  
  ✓ it passes validation with exclude rule with dataset "profile-with-id"                               0.04s  
  ✓ it passes validation with exclude rule with dataset "profile-missing-id"                            0.04s  
  ✓ it fails validation with exclude rule with dataset "profile-missing-id"                             0.04s  

  Tests:    4 passed (7 assertions)
  Duration: 0.31s
```

Can this considered to be a bug or is there some logic behind it? with my fix in this PR, `phpunit tests/Validation/` framework tests on latest 10.x still run through nicely.