### PR TITLE
[10.x] Add getRawQueryLog() method

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1556,8 +1556,10 @@ class Connection implements ConnectionInterface
     public function getRawQueryLog()
     {
         return array_map(fn (array $log) => [
-            'raw_query' => $this->queryGrammar
-                ->substituteBindingsIntoRawSql($log['query'], $this->prepareBindings($log['bindings'])),
+            'raw_query' => $this->queryGrammar->substituteBindingsIntoRawSql(
+                $log['query'],
+                $this->prepareBindings($log['bindings'])
+            ),
             'time' => $log['time'],
         ], $this->getQueryLog());
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1556,7 +1556,8 @@ class Connection implements ConnectionInterface
     public function getRawQueryLog()
     {
         return array_map(fn (array $log) => [
-            'raw_query' => $this->queryGrammar->substituteBindingsIntoRawSql($log['query'], $log['bindings']),
+            'raw_query' => $this->queryGrammar
+                ->substituteBindingsIntoRawSql($log['query'], $this->prepareBindings($log['bindings'])),
             'time' => $log['time'],
         ], $this->getQueryLog());
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1556,7 +1556,7 @@ class Connection implements ConnectionInterface
     public function getRawQueryLog()
     {
         return array_map(fn (array $log) => [
-            'row_query' => $this->queryGrammar->substituteBindingsIntoRawSql($log['query'], $log['bindings']),
+            'raw_query' => $this->queryGrammar->substituteBindingsIntoRawSql($log['query'], $log['bindings']),
             'time' => $log['time'],
         ], $this->getQueryLog());
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1549,6 +1549,19 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Get the connection query log with embedded bindings.
+     *
+     * @return array
+     */
+    public function getRawQueryLog()
+    {
+        return array_map(fn (array $log) => [
+            'row_query' => $this->queryGrammar->substituteBindingsIntoRawSql($log['query'], $log['bindings']),
+            'time' => $log['time'],
+        ], $this->getQueryLog());
+    }
+
+    /**
      * Clear the query log.
      *
      * @return void

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -87,6 +87,7 @@ namespace Illuminate\Support\Facades;
  * @method static void unsetTransactionManager()
  * @method static bool pretending()
  * @method static array getQueryLog()
+ * @mothod static array getRowQueryLog()
  * @method static void flushQueryLog()
  * @method static void enableQueryLog()
  * @method static void disableQueryLog()

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -87,7 +87,7 @@ namespace Illuminate\Support\Facades;
  * @method static void unsetTransactionManager()
  * @method static bool pretending()
  * @method static array getQueryLog()
- * @mothod static array getRowQueryLog()
+ * @mothod static array getRawQueryLog()
  * @method static void flushQueryLog()
  * @method static void enableQueryLog()
  * @method static void disableQueryLog()

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -87,7 +87,7 @@ namespace Illuminate\Support\Facades;
  * @method static void unsetTransactionManager()
  * @method static bool pretending()
  * @method static array getQueryLog()
- * @mothod static array getRawQueryLog()
+ * @method static array getRawQueryLog()
  * @method static void flushQueryLog()
  * @method static void enableQueryLog()
  * @method static void disableQueryLog()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -502,6 +502,32 @@ class DatabaseConnectionTest extends TestCase
         $this->assertSame($connection, $schema->getConnection());
     }
 
+    public function testGetRawQueryLog()
+    {
+        $mock = $this->getMockConnection(['getQueryLog']);
+        $mock->expects($this->once())->method('getQueryLog')->willReturn([
+            [
+                'query' => 'select * from tbl where col = ?',
+                'bindings' => [
+                    0 => 'foo',
+                ],
+                'time' => 1.23,
+            ]
+        ]);
+
+        $queryGrammar = $this->createMock(Grammar::class);
+        $queryGrammar->expects($this->once())
+            ->method('substituteBindingsIntoRawSql')
+            ->with('select * from tbl where col = ?', ['foo'])
+            ->willReturn("select * from tbl where col = 'foo'");
+        $mock->setQueryGrammar($queryGrammar);
+
+        $log = $mock->getRawQueryLog();
+
+        $this->assertEquals("select * from tbl where col = 'foo'", $log[0]['row_query']);
+        $this->assertEquals(1.23, $log[0]['time']);
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -524,7 +524,7 @@ class DatabaseConnectionTest extends TestCase
 
         $log = $mock->getRawQueryLog();
 
-        $this->assertEquals("select * from tbl where col = 'foo'", $log[0]['row_query']);
+        $this->assertEquals("select * from tbl where col = 'foo'", $log[0]['raw_query']);
         $this->assertEquals(1.23, $log[0]['time']);
     }
 


### PR DESCRIPTION
> ⚠ NOTICE: A failed test is not about my changes

In #47507 , toRawSql() was implemented that can retrieve the complete query with values bound to the SQL output by toSql().

I thought it would be nice to have an extension method that could retrieve the complete query with bound values, similarly with DB:::getQueryLog()

I implemented it.

## Usage
Basically, the usage is the same as getQueryLog()

```php
DB::enableQueryLog();

// do something with querying

$logs = DB::getRawQueryLog();
```

In the case of getQueryLog(), we could get an associative array like this

```
[
  [
    "query" => "select * from "users" where "id" in (?, ?, ?)"
    "bindings" => [
      0 => 3
      1 => 6
      2 => 8
    ]
    "time" => 4.06
  ]
]
```

Now, we could get an associative array like this with getRawQueryLog()

```
[
  [
    "raw_query" => "select * from "users" where "id" in (3, 6, 8)"
    "time" => 4.06
  ]
]
```