### PR TITLE
[10.x] Use atomic locks for command mutex

### DIFF
--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -14,6 +14,9 @@ interface CommandMutex
 
     /**
      * Determine if a command mutex exists for the given command.
+     * warning: Relying on this method can cause race conditions.
+     *
+     * @deprecated Will be removed in a future version.
      *
      * @param  \Illuminate\Console\Command  $command
      * @return bool

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -14,9 +14,6 @@ interface CommandMutex
 
     /**
      * Determine if a command mutex exists for the given command.
-     * warning: Relying on this method can cause race conditions.
-     *
-     * @deprecated Will be removed in a future version.
      *
      * @param  \Illuminate\Console\Command  $command
      * @return bool

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -44,6 +44,12 @@ class CacheCommandMutexTest extends TestCase
         };
     }
 
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
     public function testCanCreateMutex()
     {
         $this->mockUsingCacheStore();
@@ -117,7 +123,7 @@ class CacheCommandMutexTest extends TestCase
     {
         $lock = m::mock(LockProvider::class);
         $this->cacheFactory->expects('store')->once()->with('test')->andReturn($this->cacheRepository);
-        $this->cacheRepository->expects('getStore')->andReturn($lock);
+        $this->cacheRepository->expects('getStore')->twice()->andReturn($lock);
 
         $this->acquireLockExpectations($lock, true);
         $this->mutex->useStore('test');
@@ -138,7 +144,7 @@ class CacheCommandMutexTest extends TestCase
     {
         $lock = m::mock(LockProvider::class);
         $this->cacheFactory->expects('store')->once()->andReturn($this->cacheRepository);
-        $this->cacheRepository->expects('getStore')->andReturn($lock);
+        $this->cacheRepository->expects('getStore')->twice()->andReturn($lock);
 
         return $lock;
     }

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Console;
 
-use Carbon\CarbonInterval;
 use Illuminate\Console\CacheCommandMutex;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Factory;


### PR DESCRIPTION
Issue:

The commands that implement the [Isolatable](https://laravel.com/docs/10.x/artisan#isolatable-commands) feature depend on the caching functionality. When the command is running and we execute `php artisan cache:clear` or call `\Cache::flush();`, this puts any pending isolated commands into an invalid state.

This PR replaces the direct usage of Cache, with atomic locks, whenever the Cache driver supports it.

