### PR TITLE
[10.x] Allow Mail Facade alwaysTo method to accept arrays of email addresses and names

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -149,9 +149,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function alwaysTo($address, $name = null)
     {
-        if (is_string($address)) {
-            $address = [$address];
-        }
+        $address = Arr::wrap($address);
 
         if (is_string($name)) {
             $name = [$name];

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -151,9 +151,7 @@ class Mailer implements MailerContract, MailQueueContract
     {
         $address = Arr::wrap($address);
 
-        if (is_string($name)) {
-            $name = [$name];
-        }
+        $name = Arr::wrap($name);
 
         $this->to = compact('address', 'name');
     }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -144,13 +144,17 @@ class Mailer implements MailerContract, MailQueueContract
      * Set the global to address and name.
      *
      * @param  string|array  $address
-     * @param  string|null  $name
+     * @param  string|array|null  $name
      * @return void
      */
     public function alwaysTo($address, $name = null)
     {
         if (is_string($address)) {
             $address = [$address];
+        }
+
+        if (is_string($name)) {
+            $name = [$name];
         }
 
         $this->to = compact('address', 'name');

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -143,12 +143,16 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Set the global to address and name.
      *
-     * @param  string  $address
+     * @param  string|array  $address
      * @param  string|null  $name
      * @return void
      */
     public function alwaysTo($address, $name = null)
     {
+        if (is_string($address)) {
+            $address = [$address];
+        }
+
         $this->to = compact('address', 'name');
     }
 

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static void alwaysFrom(string $address, string|null $name = null)
  * @method static void alwaysReplyTo(string $address, string|null $name = null)
  * @method static void alwaysReturnPath(string $address)
- * @method static void alwaysTo(string $address, string|null $name = null)
+ * @method static void alwaysTo(string|array $address, string|array|null $name = null)
  * @method static \Illuminate\Mail\PendingMail to(mixed $users, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail cc(mixed $users, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail bcc(mixed $users, string|null $name = null)

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -242,7 +242,7 @@ class MailMailerTest extends TestCase
         $view->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $mailer = new Mailer('array', $view, new ArrayTransport);
-        $mailer->alwaysTo('taylor@laravel.com', 'Taylor Otwell');
+        $mailer->alwaysTo(['taylor@laravel.com', 'jess@laravel.com'], ['Taylor Otwell', 'Jess Archer']);
 
         $sentMessage = $mailer->send('foo', ['data'], function (Message $message) {
             $message->from('hello@laravel.com');
@@ -256,6 +256,7 @@ class MailMailerTest extends TestCase
         });
 
         $this->assertSame('taylor@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
+        $this->assertSame('jess@laravel.com', $sentMessage->getEnvelope()->getRecipients()[1]->getAddress());
         $this->assertDoesNotMatchRegularExpression('/^To: nuno@laravel.com/m', $sentMessage->toString());
         $this->assertDoesNotMatchRegularExpression('/^Cc: dries@laravel.com/m', $sentMessage->toString());
         $this->assertMatchesRegularExpression('/^X-To: nuno@laravel.com/m', $sentMessage->toString());


### PR DESCRIPTION
This Pull Request allows the `alwaysTo` method on the `Mail` facade to accept an array of email addresses and an array of names. Currently, the method only supports a single email address and name. However, there are times (for example in a staging/test environment with multiple collaborating users) where it would be useful to provide an array of email addresses and names, rather than a single instance of each.