### PR TITLE
[10.x] Do not apply global scopes when incrementing/decrementing an existing model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -951,10 +951,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function incrementOrDecrement($column, $amount, $extra, $method)
     {
-        $query = $this->newQueryWithoutRelationships();
-
         if (! $this->exists) {
-            return $query->{$method}($column, $amount, $extra);
+            return $this->newQueryWithoutRelationships()->{$method}($column, $amount, $extra);
         }
 
         $this->{$column} = $this->isClassDeviable($column)
@@ -967,7 +965,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
-        return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
+        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($column, $amount, $extra), function () use ($column) {
             $this->syncChanges();
 
             $this->fireModelEvent('updated', false);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2017,16 +2017,17 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
-        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
         $model->exists = true;
         $model->id = 1;
         $model->syncOriginalAttribute('id');
         $model->foo = 2;
 
-        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 
+        // hmm
         $model->publicIncrement('foo', 1);
         $this->assertFalse($model->isDirty());
 
@@ -2038,13 +2039,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testIncrementQuietlyOnExistingModelCallsQueryAndSetsAttributeAndIsQuiet()
     {
-        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
         $model->exists = true;
         $model->id = 1;
         $model->syncOriginalAttribute('id');
         $model->foo = 2;
 
-        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 
@@ -2065,13 +2066,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDecrementQuietlyOnExistingModelCallsQueryAndSetsAttributeAndIsQuiet()
     {
-        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
         $model->exists = true;
         $model->id = 1;
         $model->syncOriginalAttribute('id');
         $model->foo = 4;
 
-        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('decrement');
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -118,6 +118,24 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertEquals(1, $models[0]->counter);
         $this->assertEquals(0, $models[1]->counter);
     }
+
+    public function testIncrementOrDecrementIgnoresGlobalScopes()
+    {
+        /** @var TestUpdateModel3 $deletedModel */
+        $deletedModel = tap(TestUpdateModel3::create([
+            'counter' => 0,
+        ]), fn ($model) => $model->delete());
+
+        $deletedModel->increment('counter');
+
+        $this->assertEquals(1, $deletedModel->counter);
+
+        $deletedModel->fresh();
+        $this->assertEquals(1, $deletedModel->counter);
+
+        $deletedModel->decrement('counter');
+        $this->assertEquals(0, $deletedModel->fresh()->counter);
+    }
 }
 
 class TestUpdateModel1 extends Model


### PR DESCRIPTION
To close https://github.com/laravel/framework/issues/47620 To reproduce, you can [follow the set up](https://github.com/levu42/increment-global-scope-bug/commit/7b514befc7462d09612a1ddf78406bab7114d455) that @levu42 provided in the original issue.

Previously, a new query was built from `Model@newQueryWithoutRelationships()`, which applies global scopes. If the client code already has the model, applying global scopes could potentially make the update query not _see_ the row in the DB. To remedy this, we apply `Builder@newQueryWithoutScopes()`.

Note: I'm unsure if `Model@newQueryWithoutRelationships()` is actually needed when calling increment/decrement when the model doesn't exist. That could possibly be changed to `newQueryWithoutScopes()` as well. 🤷 I can't really think of a use case where this would ever be called, so if someone can clue me in, would appreciate the knowledge.