### PR TITLE
Validation rules in,notIn - support for BackedEnums

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -84,7 +84,7 @@ class Rule
     /**
      * Get an in constraint builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string|\BackedEnum  $values
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in($values)
@@ -99,7 +99,7 @@ class Rule
     /**
      * Get a not_in constraint builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string|\BackedEnum  $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn($values)

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
+
 class In
 {
     /**
@@ -39,6 +41,10 @@ class In
     public function __toString()
     {
         $values = array_map(function ($value) {
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            }
+
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
+
 class NotIn
 {
     /**
@@ -37,6 +39,10 @@ class NotIn
     public function __toString()
     {
         $values = array_map(function ($value) {
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            }
+
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -7,6 +7,8 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use PHPUnit\Framework\TestCase;
 
+include 'Enums.php';
+
 class ValidationInRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
@@ -38,5 +40,13 @@ class ValidationInRuleTest extends TestCase
         $rule = Rule::in('1', '2', '3', '4');
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::in(StringStatus::pending);
+
+        $this->assertSame('in:"'.StringStatus::pending->value.'"', (string) $rule);
+
+        $rule = Rule::in([StringStatus::pending, StringStatus::done]);
+
+        $this->assertSame('in:"'.StringStatus::pending->value.'","'.StringStatus::done->value.'"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -45,8 +45,12 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertSame('in:"'.StringStatus::pending->value.'"', (string) $rule);
 
-        $rule = Rule::in([StringStatus::pending, StringStatus::done]);
+        $rule = Rule::in(StringStatus::pending, 'Laravel');
 
-        $this->assertSame('in:"'.StringStatus::pending->value.'","'.StringStatus::done->value.'"', (string) $rule);
+        $this->assertSame('in:"'.StringStatus::pending->value.'","Laravel"', (string) $rule);
+
+        $rule = Rule::in([StringStatus::pending, StringStatus::done, 'Laravel']);
+
+        $this->assertSame('in:"'.StringStatus::pending->value.'","'.StringStatus::done->value.'","Laravel"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -7,7 +7,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use PHPUnit\Framework\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class ValidationInRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -28,12 +28,12 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::notIn(StringStatus::pending);
+        $rule = Rule::notIn(StringStatus::pending, 'Laravel');
 
-        $this->assertSame('not_in:"'.StringStatus::pending->value.'"', (string) $rule);
+        $this->assertSame('not_in:"'.StringStatus::pending->value.'","Laravel"', (string) $rule);
 
-        $rule = Rule::notIn([StringStatus::pending, StringStatus::done]);
+        $rule = Rule::notIn([StringStatus::pending, StringStatus::done, 'Laravel']);
 
-        $this->assertSame('not_in:"'.StringStatus::pending->value.'","'.StringStatus::done->value.'"', (string) $rule);
+        $this->assertSame('not_in:"'.StringStatus::pending->value.'","'.StringStatus::done->value.'","Laravel"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -6,6 +6,8 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\NotIn;
 use PHPUnit\Framework\TestCase;
 
+include 'Enums.php';
+
 class ValidationNotInRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
@@ -25,5 +27,13 @@ class ValidationNotInRuleTest extends TestCase
         $rule = Rule::notIn('1', '2', '3', '4');
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::notIn(StringStatus::pending);
+
+        $this->assertSame('not_in:"'.StringStatus::pending->value.'"', (string) $rule);
+
+        $rule = Rule::notIn([StringStatus::pending, StringStatus::done]);
+
+        $this->assertSame('not_in:"'.StringStatus::pending->value.'","'.StringStatus::done->value.'"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -6,7 +6,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\NotIn;
 use PHPUnit\Framework\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class ValidationNotInRuleTest extends TestCase
 {


### PR DESCRIPTION
In this PR I would like to add support for `BackedEnum` to `in` and `notIn` validation rules.

### Examples:

`Rule::in(StringStatus::pending);`
`Rule::in([StringStatus::pending, StringStatus::done]);`
`Rule::notIn(StringStatus::pending);`
`Rule::notIn([StringStatus::pending, StringStatus::done]);`