### PR TITLE
[10.x] Add Collection::getOrFail() Method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -455,6 +455,25 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get an item from the collection by key but throw an exception if no matching items exist.
+     *
+     * @param  TKey  $key
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function getOrFail($key)
+    {
+        if (array_key_exists($key, $this->items)) {
+            return $this->items[$key];
+        }
+
+        if ($this->items[$key] === null) {
+            throw new ItemNotFoundException;
+        }
+    }
+
+    /**
      * Get an item from the collection by key or add it to collection if it does not exist.
      *
      * @template TGetOrPutValue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -515,6 +515,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function get($key, $default = null);
 
     /**
+     * Get an item from the collection by key but throw an exception if no matching items exist.
+     *
+     * @param  TKey  $key
+     * @return TValue
+     */
+    public function getOrFail($key);
+
+    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -535,6 +535,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get an item from the collection by key but throw an exception if no matching items exist.
+     *
+     * @param  TKey  $key
+     * @return TValue
+     */
+    public function getOrFail($key)
+    {
+        return $this->passthru('getOrFail', func_get_args());
+    }
+
+    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -535,17 +535,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get an item from the collection by key but throw an exception if no matching items exist.
-     *
-     * @param  TKey  $key
-     * @return TValue
-     */
-    public function getOrFail($key)
-    {
-        return $this->passthru('getOrFail', func_get_args());
-    }
-
-    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2402,7 +2402,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testGetOrFailReturnsItemInCollection($collection)
     {
-        $data = new collection([
+        $data = new $collection([
             ['name' => 'taylor'],
             ['email' => 'foo'],
         ]);
@@ -2417,7 +2417,7 @@ class SupportCollectionTest extends TestCase
     public function testGetOrFailThrowExceptionIfNoItemsExist($collection)
     {
         $this->expectException(ItemNotFoundException::class);
-        
+
         $collection = new collection([
             ['name' => 'foo'],
             ['name' => 'bar'],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2397,6 +2397,35 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetOrFailReturnsItemInCollection($collection)
+    {
+        $data = new $collection([
+            ['name' => 'taylor'],
+            ['email' => 'foo'],
+        ]);
+
+        $this->assertSame('taylor', $data->getOrFail('name'));
+        $this->assertSame('foo', $data->getOrFail('email'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetOrFailThrowExceptionIfNoItemsExist($collection)
+    {
+        $this->expectException(ItemNotFoundException::class);
+        
+        $collection = new $collection([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]);
+
+        $collection->where('name', 'INVALID')->getOrFail('name');
+    }
+
     public function testGetOrPut()
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2402,7 +2402,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testGetOrFailReturnsItemInCollection($collection)
     {
-        $data = new $collection([
+        $data = new collection([
             ['name' => 'taylor'],
             ['email' => 'foo'],
         ]);
@@ -2418,7 +2418,7 @@ class SupportCollectionTest extends TestCase
     {
         $this->expectException(ItemNotFoundException::class);
         
-        $collection = new $collection([
+        $collection = new collection([
             ['name' => 'foo'],
             ['name' => 'bar'],
         ]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -449,6 +449,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testGetOrFailIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->getOrFail(4);
+        });
+    
+        $this->assertEnumerates(100, function ($collection) {
+            try {
+                $collection->getOrFail(101);
+            } catch (ItemNotFoundException) {
+                //
+            }
+        });
+    }
+
     public function testGroupByIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -449,21 +449,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testGetOrFailIsLazy()
-    {
-        $this->assertEnumerates(5, function ($collection) {
-            $collection->getOrFail(4);
-        });
-    
-        $this->assertEnumerates(100, function ($collection) {
-            try {
-                $collection->getOrFail(101);
-            } catch (ItemNotFoundException) {
-                //
-            }
-        });
-    }
-
     public function testGroupByIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
The `get` method is included in the laravel collection.

In the latest version of `psalm/plugin-laravel (v2.8.0)`, the return value of the `get` method is specified as `mixed|null`.
So psalm warns when the `get` method in the middle of the collection method chain may contain `null`.

If you access directly without `get`, it will be parsed as `mixed`, so you can use that to avoid this problem.
But it is not very convenient when used in a method chain.

Example(Access directly): `$collection->masterReceived['id']`

## Solution

A good way to solve this is to provide a `getOrFail` method.
The basic idea of the `getOrFail` method is the same as the `firstOrFail` method.

The `getOrFail` method retrieves an item from the collection by key, but throws an exception if there is no matching item.

Below is an example of a Psalm warning.

```
ERROR: PossiblyNullPropertyFetch - app/Services/Queries/Ordering/OrderingQuery.php:54:19 - Cannot get property on possibly null variable $masterReceived of type mixed|null (see https://psalm.dev/082)
                ? $masterReceived->id
```

It is not a change that destroys existing functionality since it is an addition to the collection method.