### PR TITLE
[10.x] Fix return type of `until` method in NullDispatcher

### DIFF
--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -57,7 +57,7 @@ class NullDispatcher implements DispatcherContract
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return mixed
+     * @return void
      */
     public function until($event, $payload = [])
     {


### PR DESCRIPTION
A failed test is not about my changes