### PR TITLE
[10.x] Allow password reset callback to modify the result

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -63,13 +63,13 @@ class PasswordBroker implements PasswordBrokerContract
         $token = $this->tokens->create($user);
 
         if ($callback) {
-            $callback($user, $token);
-        } else {
-            // Once we have the reset token, we are ready to send the message out to this
-            // user with a link to reset their password. We will then redirect back to
-            // the current URI having nothing set in the session to indicate errors.
-            $user->sendPasswordResetNotification($token);
+            return $callback($user, $token) ?? static::RESET_LINK_SENT;
         }
+
+        // Once we have the reset token, we are ready to send the message out to this
+        // user with a link to reset their password. We will then redirect back to
+        // the current URI having nothing set in the session to indicate errors.
+        $user->sendPasswordResetNotification($token);
 
         return static::RESET_LINK_SENT;
     }


### PR DESCRIPTION
The use case here is not allowing some users to reset their passwords. Allowing the callback to return a result enables this without having to do a bunch of jank. Example callback someone might use:

```php
function (User $user, string $token): string {
    if ($user->isUsingSingleSignOn()) {
        return PasswordBroker::INVALID_USER;
    }

    $user->sendPasswordResetNotification($token);

    return PasswordBroker::RESET_LINK_SENT;
}
```

---

EDIT: failing tests are not related to this PR.