### PR TITLE
[10.x] Adds inline attachments support for "notifications" markdown mailables

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -97,16 +97,51 @@ class MailChannel
             return $message->view;
         }
 
-        $configRepository = Container::getInstance()->get(ConfigRepository::class);
-
         return [
-            'html' => fn ($messageData = []) => $this->markdown->theme(
-                $message->theme ?: $configRepository->get('mail.markdown.theme', 'default')
-            )->render($message->markdown, array_merge($message->data(), $messageData)),
-            'text' => fn ($messageData = []) => $this->markdown->theme(
-                $message->theme ?: $configRepository->get('mail.markdown.theme', 'default')
-            )->renderText($message->markdown, array_merge($message->data(), $messageData)),
+            'html' => $this->buildMarkdownHtml($message),
+            'text' => $this->buildMarkdownText($message),
         ];
+    }
+
+    /**
+     * Build the HTML view for a Markdown message.
+     *
+     * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @return \Closure
+     */
+    protected function buildMarkdownHtml($message)
+    {
+        return fn ($data) => $this->markdownRenderer($message)->render(
+            $message->markdown, array_merge($message->data(), $data)
+        );
+    }
+
+    /**
+     * Build the text view for a Markdown message.
+     *
+     * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @return \Closure
+     */
+    protected function buildMarkdownText($message)
+    {
+        return fn ($data) => $this->markdownRenderer($message)->renderText(
+            $message->markdown, array_merge($message->data(), $data)
+        );
+    }
+
+    /**
+     * Gets the markdown instance
+     *
+     * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @return \Illuminate\Mail\Markdown
+     */
+    protected function markdownRenderer($message)
+    {
+        $config = Container::getInstance()->get(ConfigRepository::class);
+
+        $theme = $message->theme ?: $config->get('mail.markdown.theme', 'default');
+
+        return $this->markdown->theme($theme);
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -100,8 +100,8 @@ class MailChannel
         }
 
         return [
-            'html' => fn ($messageArray = []) => $this->markdown->render($message->markdown, $messageArray),
-            'text' => fn ($messageArray = []) => $this->markdown->renderText($message->markdown, $messageArray),
+            'html' => fn ($messageData = []) => $this->markdown->render($message->markdown, $messageData),
+            'text' => fn ($messageData = []) => $this->markdown->renderText($message->markdown, $messageData),
         ];
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -100,8 +100,8 @@ class MailChannel
         }
 
         return [
-            'html' => fn($messageArray) => $this->markdown->render($message->markdown, $messageArray),
-            'text' => fn($messageArray) => $this->markdown->renderText($message->markdown, $messageArray),
+            'html' => fn ($messageArray = []) => $this->markdown->render($message->markdown, $messageArray),
+            'text' => fn ($messageArray = []) => $this->markdown->renderText($message->markdown, $messageArray),
         ];
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -100,8 +100,8 @@ class MailChannel
         }
 
         return [
-            'html' => $this->markdown->render($message->markdown, $message->data()),
-            'text' => $this->markdown->renderText($message->markdown, $message->data()),
+            'html' => fn($messageArray) => $this->markdown->render($message->markdown, $messageArray),
+            'text' => fn($messageArray) => $this->markdown->renderText($message->markdown, $messageArray),
         ];
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -130,7 +130,7 @@ class MailChannel
     }
 
     /**
-     * Gets the markdown instance
+     * Gets the markdown instance.
      *
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return \Illuminate\Mail\Markdown

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -130,7 +130,7 @@ class MailChannel
     }
 
     /**
-     * Gets the markdown instance.
+     * Get the Markdown implementation.
      *
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return \Illuminate\Mail\Markdown

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications\Channels;
 
+use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable;
@@ -12,7 +13,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
-use Illuminate\Config\Repository as ConfigRepository;
 
 class MailChannel
 {

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -139,7 +139,7 @@ class MailChannel
     {
         $config = Container::getInstance()->get(ConfigRepository::class);
 
-        $theme = $message->theme ?: $config->get('mail.markdown.theme', 'default');
+        $theme = $message->theme ?? $config->get('mail.markdown.theme', 'default');
 
         return $this->markdown->theme($theme);
     }

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -112,7 +112,7 @@ class MailChannel
     protected function buildMarkdownHtml($message)
     {
         return fn ($data) => $this->markdownRenderer($message)->render(
-            $message->markdown, array_merge($message->data(), $data)
+            $message->markdown, array_merge($data, $message->data()),
         );
     }
 
@@ -125,7 +125,7 @@ class MailChannel
     protected function buildMarkdownText($message)
     {
         return fn ($data) => $this->markdownRenderer($message)->renderText(
-            $message->markdown, array_merge($message->data(), $data)
+            $message->markdown, array_merge($data, $message->data()),
         );
     }
 

--- a/tests/Integration/Notifications/Fixtures/mail/color-test.blade.php
+++ b/tests/Integration/Notifications/Fixtures/mail/color-test.blade.php
@@ -1,0 +1,1 @@
+body{color: test;}

--- a/tests/Integration/Notifications/Fixtures/markdown.blade.php
+++ b/tests/Integration/Notifications/Fixtures/markdown.blade.php
@@ -1,0 +1,1 @@
+<img src="{{ $message->embed('image.jpg') }}">

--- a/tests/Integration/Notifications/Fixtures/markdown.blade.php
+++ b/tests/Integration/Notifications/Fixtures/markdown.blade.php
@@ -1,1 +1,1 @@
-<img src="{{ $message->embed('image.jpg') }}">
+Embed content: {{ $message->embed(__FILE__) }}

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -22,9 +22,9 @@ use Orchestra\Testbench\TestCase;
 
 class SendingMailNotificationsTest extends TestCase
 {
-    public MailFactory&MockInterface $mailFactory;
-    public Mailer&MockInterface $mailer;
-    public Markdown&MockInterface $markdown;
+    public $mailFactory;
+    public $mailer;
+    public $markdown;
 
     protected function tearDown(): void
     {
@@ -111,11 +111,11 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->withArgs(function (...$args) use ($notification, $user, $callbackExpectationClosure) {
             $viewArray = $args[0];
 
-            if (! m::on(fn ($closure) => $closure() === 'htmlContent')->match($viewArray['html'])) {
+            if (! m::on(fn ($closure) => $closure([]) === 'htmlContent')->match($viewArray['html'])) {
                 return false;
             }
 
-            if (! m::on(fn ($closure) => $closure() === 'textContent')->match($viewArray['text'])) {
+            if (! m::on(fn ($closure) => $closure([]) === 'textContent')->match($viewArray['text'])) {
                 return false;
             }
 

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -75,6 +75,7 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->markdown->shouldReceive('theme')->twice()->with('default')->andReturn($this->markdown);
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
@@ -148,6 +149,7 @@ class SendingMailNotificationsTest extends TestCase
             'name' => 'Taylor Otwell',
         ]);
 
+        $this->markdown->shouldReceive('theme')->twice()->with('default')->andReturn($this->markdown);
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
@@ -185,6 +187,7 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->markdown->shouldReceive('theme')->with('default')->twice()->andReturn($this->markdown);
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
@@ -212,6 +215,7 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->markdown->shouldReceive('theme')->with('default')->twice()->andReturn($this->markdown);
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -78,7 +78,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
-        $this->setMailerSendAssertions($notification, $user, function($closure) {
+        $this->setMailerSendAssertions($notification, $user, function ($closure) {
             $message = m::mock(Message::class);
 
             $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
@@ -100,7 +100,6 @@ class SendingMailNotificationsTest extends TestCase
             return true;
         });
 
-
         $user->notify($notification);
     }
 
@@ -109,14 +108,14 @@ class SendingMailNotificationsTest extends TestCase
         NotifiableUser $user,
         callable $callbackExpectationClosure
     ) {
-        $this->mailer->shouldReceive('send')->once()->withArgs(function(...$args) use ($notification, $user, $callbackExpectationClosure){
+        $this->mailer->shouldReceive('send')->once()->withArgs(function (...$args) use ($notification, $user, $callbackExpectationClosure) {
             $viewArray = $args[0];
 
-            if (!m::on(fn($closure) => $closure() === 'htmlContent')->match($viewArray['html'])) {
+            if (! m::on(fn ($closure) => $closure() === 'htmlContent')->match($viewArray['html'])) {
                 return false;
             }
 
-            if (!m::on(fn($closure) => $closure() === 'textContent')->match($viewArray['text'])) {
+            if (! m::on(fn ($closure) => $closure() === 'textContent')->match($viewArray['text'])) {
                 return false;
             }
 
@@ -152,7 +151,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
-        $this->setMailerSendAssertions($notification, $user, function($closure) {
+        $this->setMailerSendAssertions($notification, $user, function ($closure) {
             $message = m::mock(Message::class);
 
             $message->shouldReceive('to')->once()->with(['taylor@laravel.com' => 'Taylor Otwell', 'foo_taylor@laravel.com']);
@@ -189,7 +188,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
-        $this->setMailerSendAssertions($notification, $user, function($closure) {
+        $this->setMailerSendAssertions($notification, $user, function ($closure) {
             $message = m::mock(Message::class);
 
             $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
@@ -216,7 +215,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
-        $this->setMailerSendAssertions($notification, $user, function($closure) {
+        $this->setMailerSendAssertions($notification, $user, function ($closure) {
             $message = m::mock(Message::class);
 
             $message->shouldReceive('to')->once()->with(['foo_taylor@laravel.com', 'bar_taylor@laravel.com']);
@@ -227,7 +226,6 @@ class SendingMailNotificationsTest extends TestCase
 
             return true;
         });
-
 
         $user->notify($notification);
     }
@@ -338,8 +336,6 @@ class SendingMailNotificationsTest extends TestCase
 
         $user->notify($notification);
     }
-
-
 }
 
 class NotifiableUser extends Model

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use Mockery as m;
-use Mockery\MockInterface;
 use Orchestra\Testbench\TestCase;
 
 class SendingMailNotificationsTest extends TestCase

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Notifications;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\View;
+use Orchestra\Testbench\TestCase;
+
+class SendingMailableNotificationsTest extends TestCase
+{
+    public $mailer;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('mail.driver', 'array');
+
+        $app['config']->set('app.locale', 'en');
+
+        View::addLocation(__DIR__.'/Fixtures');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->string('name')->nullable();
+        });
+    }
+
+    public function testMarkdownNotification()
+    {
+        $user = MailableNotificationUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user->notify(new MarkdownNotification());
+    }
+}
+
+
+class MailableNotificationUser extends Model
+{
+    use Notifiable;
+
+    public $table = 'users';
+    public $timestamps = false;
+}
+
+
+class MarkdownNotification extends Notification
+{
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)->markdown('markdown');
+    }
+}

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -96,9 +96,8 @@ class MailableNotificationUser extends Model
 class MarkdownNotification extends Notification
 {
     public function __construct(
-        private readonly ?string $theme = null
-    ) {
-    }
+        protected $theme = null
+    ){}
 
     public function via($notifiable): array
     {

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -66,22 +66,15 @@ class SendingMailableNotificationsTest extends TestCase
 
         $user->notify(new MarkdownNotification('color-test'));
         $mailTransport = app('mailer')->getSymfonyTransport();
-        $email = $mailTransport->messages()[0]->getOriginalMessage()->toString();
 
-        $bodyStyleLine = str($email)->explode("\r\n")
-            ->filter(fn ($line) => str_contains($line, '<body style='))
-            ->first();
-
-        $this->assertStringContainsString('color: test', $bodyStyleLine);
+        $contents = $mailTransport->messages()[0]->getOriginalMessage()->toString();
+        $this->assertStringContainsString('<body style=3D"color: test;">', $contents);
 
         // confirm passing no theme resets to the app's default theme
         $user->notify(new MarkdownNotification());
 
-        $email = $mailTransport->messages()[1]->getOriginalMessage()->toString();
-
-        $this->assertNull(str($email)->explode("\r\n")
-            ->filter(fn ($line) => str_contains($line, '<body style='))
-            ->first());
+        $contents = $mailTransport->messages()[1]->getOriginalMessage()->toString();
+        $this->assertStringNotContainsString('<body style=3D"color: test;">', $contents);
     }
 }
 

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -68,7 +68,7 @@ class SendingMailableNotificationsTest extends TestCase
         $mailTransport = app('mailer')->getSymfonyTransport();
         $email = $mailTransport->messages()[0]->getOriginalMessage()->toString();
 
-        $bodyStyleLine =str($email)->explode("\r\n")
+        $bodyStyleLine = str($email)->explode("\r\n")
             ->filter(fn ($line) => str_contains($line, '<body style='))
             ->first();
 
@@ -85,7 +85,6 @@ class SendingMailableNotificationsTest extends TestCase
     }
 }
 
-
 class MailableNotificationUser extends Model
 {
     use Notifiable;
@@ -94,12 +93,13 @@ class MailableNotificationUser extends Model
     public $timestamps = false;
 }
 
-
 class MarkdownNotification extends Notification
 {
     public function __construct(
         private readonly ?string $theme = null
-    ){}
+    ) {
+    }
+
     public function via($notifiable): array
     {
         return ['mail'];

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -97,7 +97,8 @@ class MarkdownNotification extends Notification
 {
     public function __construct(
         protected $theme = null
-    ){}
+    ) {
+    }
 
     public function via($notifiable): array
     {


### PR DESCRIPTION
Based https://github.com/laravel/framework/pull/47603, with some minor adjustments, this pull request completes https://github.com/laravel/framework/pull/47140, by adding support for inline attachments support for "notifications" markdown mailables.

Note that, notifications use a different mail channel from regular mailables, therefore the code needed to be introduced here too.