### PR TITLE
[10.x] Add ability to remove items from an array recursively

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -301,11 +301,13 @@ class Arr
      * Remove one or many array items from a given array recursively.
      *
      * @param  array  $array
-     * @param  string  $key
+     * @param  array|string  $key
      * @return array
      */
     public static function forgetRecursive(&$array, $key)
     {
+        $key = static::wrap($key);
+
         static::forget($array, $key);
 
         foreach ($array as &$value) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -298,6 +298,26 @@ class Arr
     }
 
     /**
+     * Remove one or many array items from a given array recursively.
+     *
+     * @param  array  $array
+     * @param  string  $key
+     * @return array
+     */
+    public static function forgetRecursive(&$array, $key)
+    {
+        static::forget($array, $key);
+
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = static::forgetRecursive($value, $key);
+            }
+        }
+
+        return $array;
+    }
+
+    /**
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1083,6 +1083,42 @@ class SupportArrTest extends TestCase
         $this->assertEquals([2 => [1 => 'products']], $array);
     }
 
+    public function testForgetRecursive()
+    {
+        $array = [
+            'keep' => 'this',
+            'remove' => 'this',
+            'look' => [
+                'in' => 'here',
+                'remove' => 'this',
+                'and' => [
+                    'also' => 'in here',
+                    'remove' => 'this',
+                    'but' => [
+                        'wait' => 'there is more',
+                        'remove' => 'this',
+                    ],
+                ],
+            ],
+        ];
+
+        $expect = [
+            'keep' => 'this',
+            'look' => [
+                'in' => 'here',
+                'and' => [
+                    'also' => 'in here',
+                    'but' => [
+                        'wait' => 'there is more',
+                    ],
+                ],
+            ],
+        ];
+
+        Arr::forgetRecursive($array, 'remove');
+        $this->assertEquals($array, $expect);
+    }
+
     public function testWrap()
     {
         $string = 'a';

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1085,38 +1085,15 @@ class SupportArrTest extends TestCase
 
     public function testForgetRecursive()
     {
-        $array = [
-            'keep' => 'this',
-            'remove' => 'this',
-            'look' => [
-                'in' => 'here',
-                'remove' => 'this',
-                'and' => [
-                    'also' => 'in here',
-                    'remove' => 'this',
-                    'but' => [
-                        'wait' => 'there is more',
-                        'remove' => 'this',
-                    ],
-                ],
-            ],
-        ];
-
-        $expect = [
-            'keep' => 'this',
-            'look' => [
-                'in' => 'here',
-                'and' => [
-                    'also' => 'in here',
-                    'but' => [
-                        'wait' => 'there is more',
-                    ],
-                ],
-            ],
-        ];
+        $array = ['keep' => 'this', 'remove' => 'this', 'look' => ['in' => 'here', 'remove' => 'this', 'and' => ['also' => 'in here', 'remove' => 'this', 'but' => ['wait' => 'there is more', 'remove' => 'this']]]];
 
         Arr::forgetRecursive($array, 'remove');
-        $this->assertEquals($array, $expect);
+        $this->assertEquals(['keep' => 'this', 'look' => ['in' => 'here', 'and' => ['also' => 'in here', 'but' => ['wait' => 'there is more']]]], $array);
+
+        $array = ['keep' => 'this', 'remove' => 'this', 'look' => ['in' => 'here', 'remove' => 'this', 'and' => ['also' => 'in here', 'remove' => 'this', 'but' => ['wait' => 'there is more', 'remove' => 'this']]]];
+
+        Arr::forgetRecursive($array, ['remove', 'and']);
+        $this->assertEquals(['keep' => 'this', 'look' => ['in' => 'here']], $array);
     }
 
     public function testWrap()


### PR DESCRIPTION
Recently, I was carrying out some snapshot testing that had randomly generated ULIDs in the output.

In order to be able to effectively snapshot test the static parts of the output, I needed to be able to remove the unique values.

Whilst Laravel has a `forget` method on the `Arr` class, this meant I would have to define each nested set of keys to be removed in each scenario.

This PR introduces a new `forgetRecursive` method - named for the existing `sortRecursive` method - which takes an array reference and key to be removed.

```php
$array = [
    'keep' => 'this',
    'remove' => 'this',
    'also' => [
        'keep' => 'this, but',
        'remove' => 'this',
    ],
];

Arr::forgetRecursive($array, 'remove');

// Results in
[
    'keep' => 'this',
    'also' => [
        'keep' => 'this, but',
    ],
];
```
