### PR TITLE
Add 'true', 'false' to validating boolean

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -470,7 +470,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'true', 'false'];
 
         return in_array($value, $acceptable, true);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2633,7 +2633,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -2670,7 +2670,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2630,7 +2630,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
         $this->assertFalse($v->passes());
@@ -2667,7 +2667,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
If you are using f.e. API with query param for some boolean, when you set: ?foo=true, it will throw an validation exception since it's a string.