### PR TITLE
Logger: format Throwable

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -10,6 +10,7 @@ use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Traits\Conditionable;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Throwable;
 
 class Logger implements LoggerInterface
 {
@@ -181,10 +182,16 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context): void
     {
-        $this->logger->{$level}(
-            $message = $this->formatMessage($message),
-            $context = array_merge($this->context, $context)
-        );
+        if ($message instanceof Throwable) {
+            $context['exception'] = $message;
+            $message = $message->getMessage();
+        } else {
+            $message = $this->formatMessage($message);
+        }
+
+        $context = array_merge($this->context, $context);
+
+        $this->logger->{$level}($message, $context);
 
         $this->fireLogEvent($level, $message, $context);
     }


### PR DESCRIPTION
## Idea
Add support to correct formatting `Throwable` while using logger

```php
$e = new RuntimeException('test');
$this->logger->error($e);
```

Log `Throwable` follow PSR because `Throwable` implements the `Stringable` interface.
```php
interface Psr\Log\LoggerInterface {
    public function log($level, string|\Stringable $message, array $context = []): void;
}
```

## For what?
Before it log message as `(string) $e`, now we use next format:
```php
$message = $e->getMessage();
$context['exception'] = `$e`; 
// which can be formatted later (by default to string, or by custom drivers (as sentry) to related format)
```
In this case, we can have the following pros:
2. support logging from exceptions from libraries that use `Psr\Log\LoggerInterface`
3. support logging exceptions with correct stack trace for Sentry (in this case there is no duplication of errors compared to  `report()`)
4. support to replace usage `report()` with logger in your code

## If you say "NO"
Please look at https://github.com/laravel/framework/pull/47654 