### PR TITLE
LogManager: add support of custom "Logger" class

### DIFF
--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -709,6 +709,19 @@ class LogManagerTest extends TestCase
             '[%datetime%] %channel%.%level_name%: %message% %context% %extra%',
             rtrim($format->getValue($formatter)));
     }
+
+    public function testCustomLogger()
+    {
+        LogManager::setLoggerClass(CustomizeLogger::class);
+        $manager = new LogManager($this->app);
+
+        $logger1 = $manager->channel('single')->getLogger();
+        $logger2 = $manager->channel('single')->getLogger();
+
+        $this->assertSame($logger1, $logger2);
+
+        $this->assertSame(true, CustomizeLogger::$called);
+    }
 }
 
 class CustomizeFormatter
@@ -720,5 +733,17 @@ class CustomizeFormatter
                 '[%datetime%] %channel%.%level_name%: %message% %context% %extra%'
             ));
         }
+    }
+}
+
+class CustomizeLogger extends Logger
+{
+    public static bool $called = false;
+
+    public function getLogger()
+    {
+        self::$called = true;
+
+        return $this->logger;
     }
 }


### PR DESCRIPTION
Add support to set a custom `Logger` class in LogManager to have the possibility to override default logic.

Now it is called by creating a new instance directly by `new Logger();` and you can't override Logger.

By adding a static function setLoggerClass() and creating an instance by `(new self::$loggerClass()` add this possibility.

### Note
I have tried to make Logger by the container as `$app->make()` but caught an infinite loop.