### PR TITLE
Assertions for counting outgoing mailables

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -101,56 +101,6 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
-     * Assert the total number of mailables were sent.
-     *
-     * @param  int  $count
-     * @return void
-     */
-    public function assertSentCount($count)
-    {
-        $total = collect($this->mailables)->count();
-
-        PHPUnit::assertSame(
-            $count, $total,
-            "The total number of mailables sent was {$total} instead of {$count}."
-        );
-    }
-
-    /**
-     * Assert the total number of mailables were queued.
-     *
-     * @param  int  $count
-     * @return void
-     */
-    public function assertQueuedCount($count)
-    {
-        $total = collect($this->queuedMailables)->count();
-
-        PHPUnit::assertSame(
-            $count, $total,
-            "The total number of mailables queued was {$total} instead of {$count}."
-        );
-    }
-
-    /**
-     * Assert the total number of mailables were sent or queued.
-     *
-     * @param  int  $count
-     * @return void
-     */
-    public function assertOutgoingCount($count)
-    {
-        $total = collect($this->mailables)
-            ->concat($this->queuedMailables)
-            ->count();
-
-        PHPUnit::assertSame(
-            $count, $total,
-            "The total number of outgoing mailables was {$total} instead of {$count}."
-        );
-    }
-
-    /**
      * Determine if a mailable was not sent or queued to be sent based on a truth-test callback.
      *
      * @param  string|\Closure  $mailable
@@ -272,6 +222,56 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
         )->join(', ');
 
         PHPUnit::assertEmpty($this->queuedMailables, 'The following mailables were queued unexpectedly: '.$mailableNames);
+    }
+
+    /**
+     * Assert the total number of mailables that were sent.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertSentCount($count)
+    {
+        $total = collect($this->mailables)->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of mailables sent was {$total} instead of {$count}."
+        );
+    }
+
+    /**
+     * Assert the total number of mailables that were queued.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertQueuedCount($count)
+    {
+        $total = collect($this->queuedMailables)->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of mailables queued was {$total} instead of {$count}."
+        );
+    }
+
+    /**
+     * Assert the total number of mailables that were sent or queued.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertOutgoingCount($count)
+    {
+        $total = collect($this->mailables)
+            ->concat($this->queuedMailables)
+            ->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of outgoing mailables was {$total} instead of {$count}."
+        );
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -101,6 +101,56 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     }
 
     /**
+     * Assert the total number of mailables were sent.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertSentCount($count)
+    {
+        $total = collect($this->mailables)->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of mailables sent was {$total} instead of {$count}."
+        );
+    }
+
+    /**
+     * Assert the total number of mailables were queued.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertQueuedCount($count)
+    {
+        $total = collect($this->queuedMailables)->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of mailables queued was {$total} instead of {$count}."
+        );
+    }
+
+    /**
+     * Assert the total number of mailables were sent or queued.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertOutgoingCount($count)
+    {
+        $total = collect($this->mailables)
+            ->concat($this->queuedMailables)
+            ->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of outgoing mailables was {$total} instead of {$count}."
+        );
+    }
+
+    /**
      * Determine if a mailable was not sent or queued to be sent based on a truth-test callback.
      *
      * @param  string|\Closure  $mailable

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -133,6 +133,21 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->assertSent(MailableStub::class, 2);
     }
 
+    public function testAssertSentCount()
+    {
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        try {
+            $this->fake->assertSentCount(1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The total number of mailables sent was 2 instead of 1.', $e->getMessage());
+        }
+
+        $this->fake->assertSentCount(2);
+    }
+
     public function testAssertQueued()
     {
         try {
@@ -160,6 +175,21 @@ class SupportTestingMailFakeTest extends TestCase
         }
 
         $this->fake->assertQueued(MailableStub::class, 2);
+    }
+
+    public function testAssertQueuedCount()
+    {
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        try {
+            $this->fake->assertQueuedCount(1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The total number of mailables queued was 2 instead of 1.', $e->getMessage());
+        }
+
+        $this->fake->assertQueuedCount(2);
     }
 
     public function testSendQueuesAMailableThatShouldBeQueued()
@@ -202,6 +232,24 @@ class SupportTestingMailFakeTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The following mailables were queued unexpectedly: Illuminate\Tests\Support\MailableStub', $e->getMessage());
         }
+    }
+
+    public function testAssertOutgoingCount()
+    {
+        $this->fake->assertNothingOutgoing();
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        try {
+            $this->fake->assertOutgoingCount(2);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The total number of outgoing mailables was 1 instead of 2.', $e->getMessage());
+        }
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertOutgoingCount(2);
     }
 
     public function testAssertQueuedWithClosure()


### PR DESCRIPTION
Currently you may only assert a certain type of mailable was sent a number of times, or none at all. There is no way to assert the total number of mailables sent, queued, or both. Having these allow you to easily assert no _stray_ mailables are outgoing.

This pull requests includes `assertSentCount`, `assertQueuedCount`, and `assertOutgoingCount`. These are complimentary to assertions like `assertNothingOutgoing`, and similar to `assertDatabaseCount`.