### PR TITLE
[10.x] Optimize tag method for efficient tag assignment

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -521,9 +521,7 @@ class Container implements ArrayAccess, ContainerContract
                 $this->tags[$tag] = [];
             }
 
-            foreach ((array) $abstracts as $abstract) {
-                $this->tags[$tag][] = $abstract;
-            }
+            $this->tags[$tag] = array_merge($this->tags[$tag], (array) $abstracts);
         }
     }
 


### PR DESCRIPTION
This pull request introduces an optimization to the `tag` method in the `Illuminate\Container\Container` class. The primary difference between the original and updated methods lies in the way tags are assigned to the given binding.

In the original method, individual abstracts are added to the corresponding tag array using a `foreach` loop. As the number of tags or abstracts grows, this can result in additional array operations for each combination, leading to potential overhead and reduced performance.

To address this, the updated method utilizes the `array_merge` function to directly merge the abstracts into the existing tag array. This approach is more efficient, especially for a large number of tags and abstracts. The `array_merge` function is optimized for merging multiple arrays efficiently, resulting in improved performance compared to the `foreach` loop.

The performance difference between the two methods becomes more noticeable as the number of tags and abstracts increases. The updated method with `array_merge` is expected to deliver better performance, particularly in scenarios involving a substantial number of tags and abstracts.

All existing test coverage in `ContainerTaggingTest` is preserved and passes successfully.
