### PR TITLE
[10.x] Fixed `trans_choice` when number is ``0

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -305,7 +305,7 @@ class MessageSelector
             case 'ur_PK':
             case 'zu':
             case 'zu_ZA':
-                return ($number == 1) ? 0 : 1;
+                return ($number <= 1) ? 0 : 1;
             case 'am':
             case 'am_ET':
             case 'bh':


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**Description:**
I have discovered that when the count is `0`, the `trans_choice` function is returning the plural word instead of the singular.

**Reproduce:**
1) Create `titles.php` file in lang folder
2) Add `'update' => 'Update|Updates',` 
3) Now, call `trans_choice('titles.update', 0);` its returning plural word `"Updates",` it should return `"Update"`

**Proof:**

This is what implemented in `framework/src/Illuminate/Translation/MessageSelector.php` and due to `==` returning 1 instead of 0 when the value is 0

![image](https://github.com/laravel/framework/assets/34036151/fab34883-8f91-4bbf-ba0e-8d5cbf7d8656)



