### PR TITLE
[10.x] Allow class string to be passed to `Macroable::mixin`

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -31,7 +31,7 @@ trait Macroable
     /**
      * Mix another object into the class.
      *
-     * @param  object  $mixin
+     * @param  class-string|object  $mixin
      * @param  bool  $replace
      * @return void
      *
@@ -39,6 +39,8 @@ trait Macroable
      */
     public static function mixin($mixin, $replace = true)
     {
+        $mixin = is_string($mixin) ? new $mixin() : $mixin;
+
         $methods = (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
         );

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -39,7 +39,7 @@ trait Macroable
      */
     public static function mixin($mixin, $replace = true)
     {
-        $mixin = is_string($mixin) ? new $mixin() : $mixin;
+        $mixin = is_string($mixin) ? resolve($mixin) : $mixin;
 
         $methods = (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -72,6 +72,13 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
     }
 
+    public function testClassBasedMacrosPassedAsString()
+    {
+        TestMacroable::mixin(TestMixin::class);
+        $instance = new TestMacroable;
+        $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
+    }
+
     public function testClassBasedMacrosNoReplace()
     {
         TestMacroable::macro('methodThree', function () {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR allows class strings (in addition to objects) to be passed to `Macroable::mixin`:

```php
// equivalent
Collection::mixin(CollectionMixins::class)
Collection::mixin(new CollectionMixins)
```