### PR TITLE
[10.x] Ensure Illuminate\Http\Client\Response::json() decode once only

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -71,8 +71,8 @@ class Response implements ArrayAccess
      */
     public function json($key = null, $default = null)
     {
-        if (! $this->decoded) {
-            $this->decoded = json_decode($this->body(), true);
+        if (! isset($this->decoded)) {
+            $this->decoded = (array) json_decode($this->body(), true);
         }
 
         if (is_null($key)) {


### PR DESCRIPTION
`Illuminate\Http\Client\Response::json()` method has possibility unexpected duplicate json decode.

The json_decode() return expected value depend on correct body string, 
But the function itself may return null or empty array.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
