### PR TITLE
[10.x] Fix Storage::cloud() return type

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -86,7 +86,7 @@ class FilesystemManager implements FactoryContract
     /**
      * Get a default cloud filesystem instance.
      *
-     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     * @return \Illuminate\Contracts\Filesystem\Cloud
      */
     public function cloud()
     {


### PR DESCRIPTION
The current type `\Illuminate\Contracts\Filesystem\Filesystem` does not contains the `url` method 

the good type should be `\Illuminate\Contracts\Filesystem\Cloud` that also extends `\Illuminate\Contracts\Filesystem\Filesystem`.

```php
Storage::cloud()->url($path); // Actually show Undefined method 'url'. 
```
