### PR TITLE
[10.x] Move class from file logic in Console Kernel to dedicated method

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -341,7 +341,7 @@ class Kernel implements KernelContract
         $namespace = $this->app->getNamespace();
 
         foreach ((new Finder)->in($paths)->files() as $file) {
-            $command = $this->classFromFile($file, $namespace);
+            $command = $this->commandClassFromFile($file, $namespace);
 
             if (is_subclass_of($command, Command::class) &&
                 ! (new ReflectionClass($command))->isAbstract()) {
@@ -350,6 +350,22 @@ class Kernel implements KernelContract
                 });
             }
         }
+    }
+
+    /**
+     * Extract the command class name from the given file path.
+     *
+     * @param  \SplFileInfo  $file
+     * @param  string  $namespace
+     * @return string
+     */
+    protected function commandClassFromFile(SplFileInfo $file, string $namespace): string
+    {
+        return $namespace.str_replace(
+            ['/', '.php'],
+            ['\\', ''],
+            Str::after($file->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
+        );
     }
 
     /**
@@ -516,17 +532,5 @@ class Kernel implements KernelContract
     protected function renderException($output, Throwable $e)
     {
         $this->app[ExceptionHandler::class]->renderForConsole($output, $e);
-    }
-
-    /**
-     * Extract the class name from the given file path.
-     */
-    protected function classFromFile(SplFileInfo $file, string $namespace): string
-    {
-        return $namespace.str_replace(
-            ['/', '.php'],
-            ['\\', ''],
-            Str::after($file->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
-        );
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

I still am unable to auto-register my commands (see #47312), moving the Console Kernel "class from file" logic to its own method will allow me (and others) to override the specific logic without having to duplicate most of the `load` method.


Thanks!

