### PR TITLE
[10.x] Allow Mail Facade alwaysTo method to accept arrays of email addresses and names

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -143,12 +143,17 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Set the global to address and name.
      *
-     * @param  string  $address
+     * @param  string|array  $address
      * @param  string|null  $name
      * @return void
      */
     public function alwaysTo($address, $name = null)
     {
+        if (is_array($address) && Arr::isAssoc($address)) {
+            $name = array_values($address);
+            $address = array_keys($address);
+        }
+
         $this->to = compact('address', 'name');
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Mailables\Address;
+use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -93,16 +93,24 @@ class Message
      * Add a recipient to the message.
      *
      * @param  string|array  $address
-     * @param  string|null  $name
+     * @param  string|array|null  $name
      * @param  bool  $override
      * @return $this
      */
     public function to($address, $name = null, $override = false)
     {
         if ($override) {
-            is_array($address)
-                ? $this->message->to(...$address)
-                : $this->message->to(new Address($address, (string) $name));
+            if (is_array($address) && is_array($name)) {
+                $addresses = array_map(function ($address, $name) {
+                    return new Address($address, (string) $name);
+                }, $address, $name);
+
+                $this->message->to(...$addresses);
+            } else {
+                is_array($address)
+                    ? $this->message->to(...$address)
+                    : $this->message->to(new Address($address, (string) $name));
+            }
 
             return $this;
         }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -304,7 +304,6 @@ class MailMailerTest extends TestCase
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $mailer = new Mailer('array', $view, new ArrayTransport);
         $mailer->alwaysTo(['taylor@laravel.com' => 'Taylor Otwell', 'jess@laravel.com' => 'Jess Archer']);
-        //        $mailer->alwaysTo(['taylor@laravel.com', 'jess@laravel.com']);
 
         $sentMessage = $mailer->send('foo', ['data'], function (Message $message) {
             $message->from('hello@laravel.com');


### PR DESCRIPTION
Follow-up of #47625.

This Pull Request allows the `alwaysTo` method on the `Mail` facade to accept an array of email addresses and, optionally, names.

For example, the following can be supplied to the `alwaysTo` method:
Existing Functionality - 1 email address and 1 name:
`Mail::alwaysTo('taylor@laravel.com', 'Taylor Otwell')`

New Functionality - an array of email addresses:
`Mail::alwaysTo(['taylor@laravel.com', 'nuno@laravel.com'])`

New Functionality - an associative array of 'email-address' => 'name' pairs:
`Mail::alwaysTo(['taylor@laravel.com' => 'Taylor Otwell', 'nuno@laravel.com' => 'Nuno Maduro'])`