### PR TITLE
[10.x] Timestamp validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -530,6 +530,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if (is_numeric($value)) {
+            return (bool) DateTime::createFromFormat('!U', $value);
+        }
+
         $date = date_parse($value);
 
         return checkdate($date['month'], $date['day'], $date['year']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5261,7 +5261,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '1325376000'], ['x' => 'date']);
-        $this->assertTrue($v->fails());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => 'Not a date'], ['x' => 'date']);
         $this->assertTrue($v->fails());
@@ -5328,6 +5328,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '17:43'], ['x' => 'date_format:H:i']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1325376002'], ['foo' => 'date_format:U']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
This PR enables timestamp validation in `date` rule.

Before:
```
1325376000 => false
```
After:
```
1325376000 => true
```
