### PR TITLE
[10.x] Add tomorrow() and yesterday() helper functions

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -902,7 +902,7 @@ if (! function_exists('today')) {
     }
 }
 
-if (!function_exists('yesterday')) {
+if (! function_exists('yesterday')) {
     /**
      * Create a new Carbon instance for yesterday.
      *
@@ -911,11 +911,11 @@ if (!function_exists('yesterday')) {
      */
     function yesterday($tz = null)
     {
-        return today($tz = null)->subDay();
+        return today($tz)->subDay();
     }
 }
 
-if (!function_exists('tomorrow')) {
+if (! function_exists('tomorrow')) {
     /**
      * Create a new Carbon instance for tomorrow.
      *
@@ -924,11 +924,11 @@ if (!function_exists('tomorrow')) {
      */
     function tomorrow($tz = null)
     {
-        return today($tz = null)->addDay();
+        return today($tz)->addDay();
     }
 }
 
-if (!function_exists('trans')) {
+if (! function_exists('trans')) {
     /**
      * Translate the given message.
      *

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -902,7 +902,33 @@ if (! function_exists('today')) {
     }
 }
 
-if (! function_exists('trans')) {
+if (!function_exists('yesterday')) {
+    /**
+     * Create a new Carbon instance for yesterday.
+     *
+     * @param  \DateTimeZone|string|null  $tz
+     * @return \Illuminate\Support\Carbon
+     */
+    function yesterday($tz = null)
+    {
+        return today($tz = null)->subDay();
+    }
+}
+
+if (!function_exists('tomorrow')) {
+    /**
+     * Create a new Carbon instance for tomorrow.
+     *
+     * @param  \DateTimeZone|string|null  $tz
+     * @return \Illuminate\Support\Carbon
+     */
+    function tomorrow($tz = null)
+    {
+        return today($tz = null)->addDay();
+    }
+}
+
+if (!function_exists('trans')) {
     /**
      * Translate the given message.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request enables the usage of `tomorrow()` and `yesterday()` as global helper functions, akin to `today()` in Laravel. This means developers can avoid invoking `Illuminate\Support\Facades\Date` for retrieving the dates for either **yesterday** or **tomorrow**.

### Before

```php
echo today();    // 2023-07-07 00:00:00
```

### Now

```php
echo yesterday();    // 2023-07-06 00:00:00
echo tomorrow();    // 2023-07-08 00:00:00
```
