### PR TITLE
[10.x] Update DatabaseRule to handle Enums for simple where clause

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
@@ -81,7 +82,7 @@ trait DatabaseRule
      * Set a "where" constraint on the query.
      *
      * @param  \Closure|string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|array|string|int|bool|null  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\Closure|array|string|int|bool|null  $value
      * @return $this
      */
     public function where($column, $value = null)
@@ -98,6 +99,10 @@ trait DatabaseRule
             return $this->whereNull($column);
         }
 
+        if ($value instanceof BackedEnum) {
+            $value = $value->value;
+        }
+
         $this->wheres[] = compact('column', 'value');
 
         return $this;
@@ -107,13 +112,17 @@ trait DatabaseRule
      * Set a "where not" constraint on the query.
      *
      * @param  string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|array|string  $value
      * @return $this
      */
     public function whereNot($column, $value)
     {
         if ($value instanceof Arrayable || is_array($value)) {
             return $this->whereNotIn($column, $value);
+        }
+
+        if ($value instanceof BackedEnum) {
+            $value = $value->value;
         }
 
         return $this->where($column, '!'.$value);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This PR updates the `DatabaseRule` trait (used by `Rule::unique` and others) to automatically cast Enums to their value like the Query class does. For example, this throws an exception:

```php
Rule::unique(<class>)->where('status', Enum::Case);
```

whereas this does work in a normal query:
```php
Model::query()->where('status', Enum::Case);
```


Thanks!

