### PR TITLE
[10.x] Make Vite throw a new `ManifestNotFoundException`

### DIFF
--- a/src/Illuminate/Foundation/ManifestNotFoundException.php
+++ b/src/Illuminate/Foundation/ManifestNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Exception;
+
+class ManifestNotFoundException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -673,7 +673,7 @@ class Vite implements Htmlable
      * @param  string  $buildDirectory
      * @return array
      *
-     * @throws \Exception
+     * @throws \Illuminate\Foundation\ManifestNotFoundException
      */
     protected function manifest($buildDirectory)
     {
@@ -681,7 +681,7 @@ class Vite implements Htmlable
 
         if (! isset(static::$manifests[$path])) {
             if (! is_file($path)) {
-                throw new Exception("Vite manifest not found at: {$path}");
+                throw new ManifestNotFoundException("Vite manifest not found at: $path");
             }
 
             static::$manifests[$path] = json_decode(file_get_contents($path), true);

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -673,7 +673,7 @@ class Vite implements Htmlable
      * @param  string  $buildDirectory
      * @return array
      *
-     * @throws \Illuminate\Foundation\ManifestNotFoundException
+     * @throws \Illuminate\Foundation\ViteManifestNotFoundException
      */
     protected function manifest($buildDirectory)
     {
@@ -681,7 +681,7 @@ class Vite implements Htmlable
 
         if (! isset(static::$manifests[$path])) {
             if (! is_file($path)) {
-                throw new ManifestNotFoundException("Vite manifest not found at: $path");
+                throw new ViteManifestNotFoundException("Vite manifest not found at: $path");
             }
 
             static::$manifests[$path] = json_decode(file_get_contents($path), true);

--- a/src/Illuminate/Foundation/ViteManifestNotFoundException.php
+++ b/src/Illuminate/Foundation/ViteManifestNotFoundException.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation;
 
 use Exception;
 
-class ManifestNotFoundException extends Exception
+class ViteManifestNotFoundException extends Exception
 {
     //
 }


### PR DESCRIPTION
**What**

This pull request introduces a new `ManifestNotFoundException` that simply extends `\Exception`. 
It's used instead of the base `\Exception` that is thrown when the Vite manifest cannot be found.

**Why**

I have specific exception handling in all my projects using Inertia or Hybridly: I don't want to display my custom error page for this error, since it won't be able to be rendered due to Vite not being started.

I currently use the following:

```php
protected function shouldRenderInertiaResponse(Response $response, Request $request, \Throwable $e): bool
{
    if (str_contains($e->getMessage(), 'Vite manifest not found')) {
        return false;
    }

    if (app()->environment($this->skipHandlingInEnvironments())) {
        return false;
    }

    return \in_array($response->status(), $this->httpStatusesToHandle(), strict: true);
}
```

I believe having a specific exception would make this kind of logic more reliable. This is not specific to my projects' exception handling, it could also be used in [Ignition](https://github.com/spatie/laravel-ignition/blob/main/src/Solutions/SolutionProviders/MissingViteManifestSolutionProvider.php#L20) as well, for instance.