### PR TITLE
[10.x] Refactor morph map alias functions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -345,7 +345,7 @@ trait HasRelationships
      */
     public static function getActualClassNameForMorph($class)
     {
-        return Arr::get(Relation::morphMap() ?: [], $class, $class);
+        return Relation::getActualClassNameForMorph($class, $class);
     }
 
     /**
@@ -765,10 +765,8 @@ trait HasRelationships
      */
     public function getMorphClass()
     {
-        $morphMap = Relation::morphMap();
-
-        if (! empty($morphMap) && in_array(static::class, $morphMap)) {
-            return array_search(static::class, $morphMap, true);
+        if (! is_null($model = Relation::getMorphAliasFromClass(static::class))) {
+            return $model;
         }
 
         if (static::class === Pivot::class) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -462,11 +462,7 @@ trait QueriesRelationships
         }
 
         if (is_string($model)) {
-            $morphMap = Relation::morphMap();
-
-            if (! empty($morphMap) && in_array($model, $morphMap)) {
-                $model = array_search($model, $morphMap, true);
-            }
+            $model = Relation::getMorphAliasFromClass($model, $model);
 
             return $this->where($relation->getMorphType(), $model, null, $boolean);
         }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -486,6 +486,25 @@ abstract class Relation implements BuilderContract
         return Arr::get(Relation::morphMap() ?: [], $class, $default);
     }
 
+
+    /**
+     * Retrieve the morph map alias from the morph class.
+     *
+     * @param  string $class
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function getMorphAliasFromClass($class, $default = null)
+    {
+        $morphMap = static::morphMap();
+
+        if (empty($morphMap) || ! in_array($class, $morphMap)) {
+            return $default;
+        }
+
+        return array_search($class, $morphMap, true);
+    }
+
     /**
      * Builds a table-keyed array from model class names.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
@@ -471,6 +472,18 @@ abstract class Relation implements BuilderContract
         }
 
         return static::$morphMap;
+    }
+
+    /**
+     * Retrieve the actual class name for a given morph class.
+     *
+     * @param  string  $class
+     * @param  mixed  $default
+     * @return string
+     */
+    public static function getActualClassNameForMorph($class, $default = null)
+    {
+        return Arr::get(Relation::morphMap() ?: [], $class, $default);
     }
 
     /**


### PR DESCRIPTION
This PR cleans up a few things.

1. Getting a model's alias from the class was used in a few places. The method to retrieve it is now at `Relation@getMorphAliasFromClass()`
2. Model has a static method called `getActualClassNameForMorph()`. This was copied to `Relation@getActualClassNameForMorph` and Model's method of the same name references it.