### PR TITLE
[10.x] Add `has_traits` helper method

### DIFF
--- a/bin/facades.php
+++ b/bin/facades.php
@@ -346,10 +346,10 @@ function handleUnknownIdentifierType($method, $typeNode)
 
     if (
         in_array($typeNode->name, [
-                'TWhenParameter',
-                'TWhenReturnType',
-                'TUnlessParameter',
-                'TUnlessReturnType',
+            'TWhenParameter',
+            'TWhenReturnType',
+            'TUnlessParameter',
+            'TUnlessReturnType',
         ], strict: true) &&
         has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
     ) {

--- a/bin/facades.php
+++ b/bin/facades.php
@@ -345,28 +345,12 @@ function handleUnknownIdentifierType($method, $typeNode)
     }
 
     if (
-        $typeNode->name === 'TWhenParameter' &&
-        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
-    ) {
-        return 'mixed';
-    }
-
-    if (
-        $typeNode->name === 'TWhenReturnType' &&
-        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
-    ) {
-        return 'mixed';
-    }
-
-    if (
-        $typeNode->name === 'TUnlessParameter' &&
-        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
-    ) {
-        return 'mixed';
-    }
-
-    if (
-        $typeNode->name === 'TUnlessReturnType' &&
+        in_array($typeNode->name, [
+                'TWhenParameter',
+                'TWhenReturnType',
+                'TUnlessParameter',
+                'TUnlessReturnType',
+        ], strict: true) &&
         has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
     ) {
         return 'mixed';

--- a/bin/facades.php
+++ b/bin/facades.php
@@ -346,28 +346,28 @@ function handleUnknownIdentifierType($method, $typeNode)
 
     if (
         $typeNode->name === 'TWhenParameter' &&
-        in_array(Conditionable::class, class_uses_recursive($method->getDeclaringClass()->getName()))
+        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
     ) {
         return 'mixed';
     }
 
     if (
         $typeNode->name === 'TWhenReturnType' &&
-        in_array(Conditionable::class, class_uses_recursive($method->getDeclaringClass()->getName()))
+        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
     ) {
         return 'mixed';
     }
 
     if (
         $typeNode->name === 'TUnlessParameter' &&
-        in_array(Conditionable::class, class_uses_recursive($method->getDeclaringClass()->getName()))
+        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
     ) {
         return 'mixed';
     }
 
     if (
         $typeNode->name === 'TUnlessReturnType' &&
-        in_array(Conditionable::class, class_uses_recursive($method->getDeclaringClass()->getName()))
+        has_traits($method->getDeclaringClass()->getName(), Conditionable::class)
     ) {
         return 'mixed';
     }

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -107,10 +107,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchNow($command, $handler = null)
     {
-        $uses = class_uses_recursive($command);
-
-        if (in_array(InteractsWithQueue::class, $uses) &&
-            in_array(Queueable::class, $uses) &&
+        if (has_traits($command, [InteractsWithQueue::class, Queueable::class]) &&
             ! $command->job) {
             $command->setJob(new SyncJob($this->container, json_encode([]), 'sync', 'sync'));
         }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -125,7 +125,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     {
         parent::__construct();
 
-        if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
+        if (has_traits($this, CreatesMatchingTest::class)) {
             $this->addTestOptions();
         }
 
@@ -181,7 +181,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         $info = $this->type;
 
-        if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
+        if (has_traits($this, CreatesMatchingTest::class)) {
             if ($this->handleTestCreation($path)) {
                 $info .= ' and test';
             }

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -157,9 +157,7 @@ class PruneCommand extends Command
      */
     protected function isPrunable($model)
     {
-        $uses = class_uses_recursive($model);
-
-        return in_array(Prunable::class, $uses) || in_array(MassPrunable::class, $uses);
+        return has_traits($model, [Prunable::class, MassPrunable::class], any: true);
     }
 
     /**
@@ -173,7 +171,7 @@ class PruneCommand extends Command
         $instance = new $model;
 
         $count = $instance->prunable()
-            ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($instance))), function ($query) {
+            ->when(has_traits($instance, SoftDeletes::class), function ($query) {
                 $query->withTrashed();
             })->count();
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -892,7 +892,7 @@ abstract class Factory
             return $this->macroCall($method, $parameters);
         }
 
-        if ($method === 'trashed' && in_array(SoftDeletes::class, class_uses_recursive($this->modelName()))) {
+        if ($method === 'trashed' && has_traits($this->modelName(), SoftDeletes::class)) {
             return $this->state([
                 $this->newModel()->getDeletedAtColumn() => $parameters[0] ?? Carbon::now()->subDay(),
             ]);

--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -24,9 +24,9 @@ trait MassPrunable
         $total = 0;
 
         do {
-            $total += $count = in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
-                        ? $query->forceDelete()
-                        : $query->delete();
+            $total += $count = has_traits($this, SoftDeletes::class)
+                ? $query->forceDelete()
+                : $query->delete();
 
             if ($count > 0) {
                 event(new ModelsPruned(static::class, $total));

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1703,7 +1703,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->load(collect($this->relations)->reject(function ($relation) {
             return $relation instanceof Pivot
-                || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true));
+                || (is_object($relation) && has_traits($relation, AsPivot::class));
         })->keys()->all());
 
         $this->syncOriginal();

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -18,7 +18,7 @@ trait Prunable
         $total = 0;
 
         $this->prunable()
-            ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($this))), function ($query) {
+            ->when(has_traits($this, SoftDeletes::class), function ($query) {
                 $query->withTrashed();
             })->chunkById($chunkSize, function ($models) use (&$total) {
                 $models->each->prune();
@@ -50,7 +50,7 @@ trait Prunable
     {
         $this->pruning();
 
-        return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+        return has_traits($this, SoftDeletes::class)
                 ? $this->forceDelete()
                 : $this->delete();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -174,7 +174,7 @@ class BelongsToMany extends Relation
             return $table;
         }
 
-        if (in_array(AsPivot::class, class_uses_recursive($model))) {
+        if (has_traits($model, AsPivot::class)) {
             $this->using($table);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -153,7 +153,7 @@ class HasManyThrough extends Relation
      */
     public function throughParentSoftDeletes()
     {
-        return in_array(SoftDeletes::class, class_uses_recursive($this->throughParent));
+        return has_traits($this->throughParent, SoftDeletes::class);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -945,9 +945,7 @@ class Blueprint
             return $this->foreignId($column);
         }
 
-        $modelTraits = class_uses_recursive($model);
-
-        if (in_array(HasUlids::class, $modelTraits, true)) {
+        if (has_traits($model, HasUlids::class)) {
             return $this->foreignUlid($column);
         }
 

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -184,9 +184,7 @@ abstract class Seeder
             ? $this->container->call([$this, 'run'], $parameters)
             : $this->run(...$parameters);
 
-        $uses = array_flip(class_uses_recursive(static::class));
-
-        if (isset($uses[WithoutModelEvents::class])) {
+        if (has_traits(static::class, WithoutModelEvents::class)) {
             $callback = $this->withoutModelEvents($callback);
         }
 

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -116,7 +116,7 @@ class CallQueuedListener implements ShouldQueue
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array(InteractsWithQueue::class, class_uses_recursive($instance))) {
+        if (has_traits($instance, InteractsWithQueue::class)) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -208,7 +208,7 @@ trait InteractsWithDatabase
     protected function isSoftDeletableModel($model)
     {
         return $model instanceof Model
-            && in_array(SoftDeletes::class, class_uses_recursive($model));
+            && has_traits($model, SoftDeletes::class);
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -181,7 +181,7 @@ class CallQueuedHandler
      */
     protected function ensureSuccessfulBatchJobIsRecorded($command)
     {
-        if (! has_traits($command, [Batchable::class, InteractsWithQueue::class], any: true)) {
+        if (! has_traits($command, [Batchable::class, InteractsWithQueue::class])) {
             return;
         }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -153,7 +153,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array(InteractsWithQueue::class, class_uses_recursive($instance))) {
+        if (has_traits($instance, InteractsWithQueue::class)) {
             $instance->setJob($job);
         }
 
@@ -181,10 +181,7 @@ class CallQueuedHandler
      */
     protected function ensureSuccessfulBatchJobIsRecorded($command)
     {
-        $uses = class_uses_recursive($command);
-
-        if (! in_array(Batchable::class, $uses) ||
-            ! in_array(InteractsWithQueue::class, $uses)) {
+        if (! has_traits($command, [Batchable::class, InteractsWithQueue::class], any: true)) {
             return;
         }
 
@@ -271,7 +268,7 @@ class CallQueuedHandler
      */
     protected function ensureFailedBatchJobIsRecorded(string $uuid, $command, $e)
     {
-        if (! in_array(Batchable::class, class_uses_recursive($command))) {
+        if (! has_traits($command, Batchable::class)) {
             return;
         }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -80,7 +80,7 @@ trait SerializesAndRestoresModelIdentifiers
         )->useWritePdo()->get();
 
         if (is_a($value->class, Pivot::class, true) ||
-            in_array(AsPivot::class, class_uses($value->class))) {
+            has_traits($value->class, AsPivot::class, recursive: false)) {
             return $collection;
         }
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -42,14 +42,14 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            $routeBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
+            $routeBindingMethod = $route->allowsTrashedBindings() && has_traits($instance, SoftDeletes::class)
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
             if ($parent instanceof UrlRoutable &&
                 ! $route->preventsScopedBindings() &&
                 ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
-                $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
+                $childRouteBindingMethod = $route->allowsTrashedBindings() && has_traits($instance, SoftDeletes::class)
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -152,6 +152,30 @@ if (! function_exists('filled')) {
     }
 }
 
+if (! function_exists('has_traits')) {
+    /**
+     * Checks if a trait or class uses trait(s) (as well as parent classes
+     * and their traits when recursive).
+     *
+     * @param  object|class-string  $class_or_trait
+     * @param  class-string|array<class-string>  $traits
+     * @param  bool  $recursive  Check parent classes/traits
+     * @param  bool  $any  Return true if class_or_trait has ANY of the trait(s)
+     */
+    function has_traits(
+        string|object $class_or_trait,
+        string|array $traits,
+        bool $recursive = true,
+        bool $any = false,
+    ): bool {
+        $uses = $recursive
+            ? class_uses_recursive($class_or_trait)
+            : class_uses($class_or_trait);
+
+        return $any ? Arr::hasAny($uses, $traits) : Arr::has($uses, $traits);
+    }
+}
+
 if (! function_exists('object_get')) {
     /**
      * Get an item from an object using "dot" notation.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -470,6 +470,51 @@ class SupportHelpersTest extends TestCase
         );
     }
 
+    public function testHasTraitsChecksRecursive()
+    {
+        $this->assertFalse(has_traits(
+            SupportTestClassTwo::class,
+            SupportTestTraitTwo::class,
+            recursive: false,
+        ));
+
+        $this->assertTrue(has_traits(
+            SupportTestClassTwo::class,
+            SupportTestTraitTwo::class,
+            recursive: true,
+        ));
+    }
+
+    public function testHasTraitsReturnsTrueIfClassHasAllTraits()
+    {
+        $this->assertTrue(has_traits(SupportTestClassTwo::class, [
+            SupportTestTraitOne::class,
+            SupportTestTraitTwo::class,
+        ]));
+    }
+
+    public function testHasTraitsReturnsTrueIfClassHasAnyTraits()
+    {
+        $this->assertTrue(has_traits(SupportTestClassOne::class, [
+            SupportTestTraitOne::class,
+            SupportTestTraitTwo::class,
+        ], recursive: false, any: true));
+    }
+
+    public function testHasTraitsAcceptsObject()
+    {
+        $this->assertTrue(
+            has_traits(new SupportTestClassOne, SupportTestTraitTwo::class),
+        );
+    }
+
+    public function testHasTraitsAcceptsTraits()
+    {
+        $this->assertTrue(
+            has_traits(SupportTestTraitTwo::class, SupportTestTraitOne::class),
+        );
+    }
+
     public function testTraitUsesRecursive()
     {
         $this->assertSame([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This PR adds a `has_traits` helper method similar to `is_subclass_of` but for traits. Yes I know you can use the following:
```php
in_array(Trait::class, class_uses_recursive(Class::class));
```
but the above is cumbersome and `has_traits` is much more expressive/shorter.

The helper method 1) works for traits and classes, 2) checks recursively by default, and 3) allows multiple traits to be checked at the same time (both AND and OR through the `$any` parameter). Examples:
```php
has_traits($object, Trait::class); // true if $object or parents have Trait
has_traits(Class::class, Trait::class, recursive: false); // true only if Class has Trait
has_traits(AnotherTrait::class, [Trait1::class, Trait2::class]); // true if AnotherTrait has Trait1 AND Trait2
has_traits(Class::class, [Trait1::class, Trait2::class], any: true); // true if Class has Trait1 AND/OR Trait2
```

I thought it best to stick with one helper method instead of creating several methods with similar bodies (e.g., `has_traits`, `has_traits_recursive`, `has_any_traits`, etc.), but I can break it up into different methods if you don't like the switches.

I also took the liberty of cleaning up the codebase to use the new method, but if this is not desired then please let me know.

I'll submit a PR to the docs repo if this is accepted.

Thanks!