### PR TITLE
[10.x] Extend the collection `reject` method to accept `where`-alike conditions

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -788,11 +788,17 @@ trait EnumeratesValues
      * Create a collection of all elements that do not pass a given truth test.
      *
      * @param  (callable(TValue, TKey): bool)|bool|TValue  $callback
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return static
      */
-    public function reject($callback = true)
+    public function reject($callback = true, $operator = null, $value = null)
     {
         $useAsCallable = $this->useAsCallable($callback);
+
+        if (! $useAsCallable && func_num_args() !== 1) {
+            return $this->reject($this->operatorForWhere(...func_get_args()));
+        }
 
         return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
             return $useAsCallable

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -796,7 +796,7 @@ trait EnumeratesValues
     {
         $useAsCallable = $this->useAsCallable($callback);
 
-        if (! $useAsCallable && func_num_args() !== 1) {
+        if (! $useAsCallable && func_num_args() > 1) {
             return $this->reject($this->operatorForWhere(...func_get_args()));
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3899,6 +3899,20 @@ class SupportCollectionTest extends TestCase
         $c = new $collection(['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $c->reject('baz')->values()->all());
 
+        $c = new $collection([
+            ['name' => 'foo', 'score' => 15],
+            ['name' => 'bar', 'score' => 10],
+            ['name' => 'baz', 'score' => 4],
+        ]);
+        $this->assertEquals([
+            ['name' => 'foo', 'score' => 15],
+            ['name' => 'bar', 'score' => 10],
+        ], $c->reject('score', '<', 5)->values()->all());
+        $this->assertEquals([
+            ['name' => 'bar', 'score' => 10],
+            ['name' => 'baz', 'score' => 4],
+        ], $c->reject('name', 'foo')->values()->all());
+
         $c = new $collection(['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $c->reject(function ($v) {
             return $v === 'baz';


### PR DESCRIPTION
## Why

I was looking for a way to remove an object from the collection by id without having to write a callback function. 

I know we can use `->where('id', '!=', 5)`, but `->reject('id', 5)` felt more natural and speaks for itself when reading code.

## Usage examples
```php
$items->reject('name', 'Unknown')
```
```php
$items->reject('score', '<', 5)
```
```php
$items->reject('hasPermission', false)
```

## Alternative

Instead of having this functionality in `reject`, another method such as `whereNot` or `rejectWhere` can be introduced.
