### PR TITLE
[10.x] Remove unwanted call to include stack traces

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -471,9 +471,7 @@ class LogManager implements LoggerInterface
      */
     protected function formatter()
     {
-        return tap(new LineFormatter(null, $this->dateFormat, true, true), function ($formatter) {
-            $formatter->includeStacktraces();
-        });
+        return new LineFormatter(null, $this->dateFormat, true, true, true);
     }
 
     /**


### PR DESCRIPTION
An additional call is not required to include stack traces as the 5th parameter of constructor of `Monolog\Formatter\LineFormatter`

The constructor call the method `includeStacktraces` itself with the value of 5th parameter of constructor.

https://github.com/Seldaek/monolog/blob/e2392369686d420ca32df3803de28b5d6f76867d/src/Monolog/Formatter/LineFormatter.php#L43-L50