### PR TITLE
[10.x] Add: `dispatch_if` && `dispatch_unless` helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -389,6 +389,42 @@ if (! function_exists('dispatch')) {
     }
 }
 
+if (! function_exists('dispatch_if')) {
+    /**
+     * Dispatch a job to its appropriate handler if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed  $job
+     * @return void|\Illuminate\Foundation\Bus\PendingDispatch
+     */
+    function dispatch_if($boolean, $job)
+    {
+        if ($boolean) {
+            return $job instanceof Closure
+                ? new PendingClosureDispatch(CallQueuedClosure::create($job))
+                : new PendingDispatch($job);
+        }
+    }
+}
+
+if (! function_exists('dispatch_unless')) {
+    /**
+     * Dispatch a job to its appropriate handler unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed  $job
+     * @return void|\Illuminate\Foundation\Bus\PendingDispatch
+     */
+    function dispatch_unless($boolean, $job)
+    {
+        if (! $boolean) {
+            return $job instanceof Closure
+                ? new PendingClosureDispatch(CallQueuedClosure::create($job))
+                : new PendingDispatch($job);
+        }
+    }
+}
+
 if (! function_exists('dispatch_sync')) {
     /**
      * Dispatch a command to its appropriate handler in the current process.


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hey, folks!

This PR aims to introduce two new helpers to allow us to conditionally work with queues. Currently we have `dispatch` and `dispatch_sync` to dispatch jobs or [queueing closures](https://laravel.com/docs/10.x/queues#queueing-closures), but we don't have options to conditionally do this. This PR adds:

1. `dispatch_if`:

```
dispatch_if(true, function () {
    // ...
});
```

2. `dispatch_unless`:

```
dispatch_unless(false, function () {
    // ...
});
```
### Docs

- I created a [PR](https://github.com/laravel/docs/pull/8905) inserting this in the documentation.

Hope this helps,

Thanks.