### PR TITLE
[11.x] add the `\Stringable` interface to classes that have `__toString()` method

### DIFF
--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Auth\Access;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
 
-class Response implements Arrayable
+class Response implements Arrayable, Stringable
 {
     /**
      * Indicates whether the response was allowed.

--- a/src/Illuminate/Broadcasting/Channel.php
+++ b/src/Illuminate/Broadcasting/Channel.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Broadcasting;
 
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
+use Stringable;
 
-class Channel
+class Channel implements Stringable
 {
     /**
      * The channel's name.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,8 +22,9 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
+use Stringable;
 
-abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, UrlRoutable
 {
     use Concerns\HasAttributes,
         Concerns\HasEvents,

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -6,8 +6,9 @@ use ArrayAccess;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
+use Stringable;
 
-class Response implements ArrayAccess
+class Response implements ArrayAccess, Stringable
 {
     use Concerns\DeterminesStatusCode, Macroable {
         __call as macroCall;

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Mail\Transport;
 
 use Illuminate\Support\Collection;
+use Stringable;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\RawMessage;
 
-class ArrayTransport implements TransportInterface
+class ArrayTransport implements Stringable, TransportInterface
 {
     /**
      * The collection of Symfony Messages.

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Mail\Transport;
 
 use Psr\Log\LoggerInterface;
+use Stringable;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\RawMessage;
 
-class LogTransport implements TransportInterface
+class LogTransport implements Stringable, TransportInterface
 {
     /**
      * The Logger instance.

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -5,12 +5,13 @@ namespace Illuminate\Mail\Transport;
 use Aws\Exception\AwsException;
 use Aws\Ses\SesClient;
 use Exception;
+use Stringable;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Message;
 
-class SesTransport extends AbstractTransport
+class SesTransport extends AbstractTransport implements Stringable
 {
     /**
      * The Amazon SES instance.

--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -5,12 +5,13 @@ namespace Illuminate\Mail\Transport;
 use Aws\Exception\AwsException;
 use Aws\SesV2\SesV2Client;
 use Exception;
+use Stringable;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Message;
 
-class SesV2Transport extends AbstractTransport
+class SesV2Transport extends AbstractTransport implements Stringable
 {
     /**
      * The Amazon SES V2 instance.

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -14,12 +14,13 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Tappable;
+use Stringable;
 use Traversable;
 
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractCursorPaginator implements Htmlable
+abstract class AbstractCursorPaginator implements Htmlable, Stringable
 {
     use ForwardsCalls, Tappable;
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -8,12 +8,13 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Tappable;
+use Stringable;
 use Traversable;
 
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractPaginator implements Htmlable
+abstract class AbstractPaginator implements Htmlable, Stringable
 {
     use ForwardsCalls, Tappable;
 

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Support;
 
 use Illuminate\Contracts\Support\Htmlable;
+use Stringable;
 
-class HtmlString implements Htmlable
+class HtmlString implements Htmlable, Stringable
 {
     /**
      * The HTML string.

--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -7,8 +7,9 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
+use Stringable;
 
-class Js implements Htmlable
+class Js implements Htmlable, Stringable
 {
     /**
      * The JavaScript string.

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -7,8 +7,9 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
 use Illuminate\Contracts\Support\MessageProvider;
 use JsonSerializable;
+use Stringable;
 
-class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, MessageProvider
+class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, MessageProvider, Stringable
 {
     /**
      * All of the registered messages.

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -10,8 +10,9 @@ use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
+use Stringable as BaseStringable;
 
-class Stringable implements JsonSerializable, ArrayAccess
+class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
 {
     use Conditionable, Dumpable, Macroable, Tappable;
 

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -4,11 +4,12 @@ namespace Illuminate\Support;
 
 use Countable;
 use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
+use Stringable;
 
 /**
  * @mixin \Illuminate\Contracts\Support\MessageBag
  */
-class ViewErrorBag implements Countable
+class ViewErrorBag implements Countable, Stringable
 {
     /**
      * The array of the view error bags.

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -4,8 +4,9 @@ namespace Illuminate\Testing;
 
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
+use Stringable;
 
-class TestComponent
+class TestComponent implements Stringable
 {
     /**
      * The original component.

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -10,8 +10,9 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\View\View;
+use Stringable;
 
-class TestView
+class TestView implements Stringable
 {
     use Macroable;
 

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Support\Traits\Conditionable;
+use Stringable;
 
-class Dimensions
+class Dimensions implements Stringable
 {
     use Conditionable;
 

--- a/src/Illuminate/Validation/Rules/ExcludeIf.php
+++ b/src/Illuminate/Validation/Rules/ExcludeIf.php
@@ -4,8 +4,9 @@ namespace Illuminate\Validation\Rules;
 
 use Closure;
 use InvalidArgumentException;
+use Stringable;
 
-class ExcludeIf
+class ExcludeIf implements Stringable
 {
     /**
      * The condition that validates the attribute.

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Support\Traits\Conditionable;
+use Stringable;
 
-class Exists
+class Exists implements Stringable
 {
     use Conditionable, DatabaseRule;
 

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Validation\Rules;
 
-class In
+use Stringable;
+
+class In implements Stringable
 {
     /**
      * The name of the rule.

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Validation\Rules;
 
-class NotIn
+use Stringable;
+
+class NotIn implements Stringable
 {
     /**
      * The name of the rule.

--- a/src/Illuminate/Validation/Rules/ProhibitedIf.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedIf.php
@@ -4,8 +4,9 @@ namespace Illuminate\Validation\Rules;
 
 use Closure;
 use InvalidArgumentException;
+use Stringable;
 
-class ProhibitedIf
+class ProhibitedIf implements Stringable
 {
     /**
      * The condition that validates the attribute.

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Validation\Rules;
 
 use InvalidArgumentException;
+use Stringable;
 
-class RequiredIf
+class RequiredIf implements Stringable
 {
     /**
      * The condition that validates the attribute.

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -4,8 +4,9 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
+use Stringable;
 
-class Unique
+class Unique implements Stringable
 {
     use Conditionable, DatabaseRule;
 

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\View;
 
-class AppendableAttributeValue
+use Stringable;
+
+class AppendableAttributeValue implements Stringable
 {
     /**
      * The attribute value.

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -11,9 +11,10 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
+use Stringable;
 use Traversable;
 
-class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
+class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate, Stringable
 {
     use Conditionable, Macroable;
 

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -3,8 +3,9 @@
 namespace Illuminate\View;
 
 use Illuminate\Contracts\Support\Htmlable;
+use Stringable;
 
-class ComponentSlot implements Htmlable
+class ComponentSlot implements Htmlable, Stringable
 {
     /**
      * The slot attribute bag.

--- a/src/Illuminate/View/InvokableComponentVariable.php
+++ b/src/Illuminate/View/InvokableComponentVariable.php
@@ -7,9 +7,10 @@ use Closure;
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Support\Enumerable;
 use IteratorAggregate;
+use Stringable;
 use Traversable;
 
-class InvokableComponentVariable implements DeferringDisplayableValue, IteratorAggregate
+class InvokableComponentVariable implements DeferringDisplayableValue, IteratorAggregate, Stringable
 {
     /**
      * The callable instance to resolve the variable value.

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -14,9 +14,10 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
+use Stringable;
 use Throwable;
 
-class View implements ArrayAccess, Htmlable, ViewContract
+class View implements ArrayAccess, Htmlable, Stringable, ViewContract
 {
     use Macroable {
         __call as macroCall;


### PR DESCRIPTION
according to the [PHP docs](https://www.php.net/manual/en/class.stringable.php):

> Stringable is implicitly present on any class that has the magic __toString() method defined, although it can and should be declared explicitly.

The return types of the `__toString()` methods are inconsistent, but I skipped addressing that now, because I'm not exactly clear on how we're handling that in the framework.
