### PR TITLE
[10.x] make cache:clear consistently restart queue worker

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -705,7 +705,7 @@ class Worker
 
         if ($this->cache) {
             $lastRestart = $this->cache->get('illuminate:queue:restart');
-            
+
             if ($lastRestart === null) {
                 $lastRestart = now();
                 $this->cache->forever('illuminate:queue:restart', $lastRestart);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -701,9 +701,18 @@ class Worker
      */
     protected function getTimestampOfLastQueueRestart()
     {
+        $lastRestart = null;
+
         if ($this->cache) {
-            return $this->cache->get('illuminate:queue:restart');
+            $lastRestart = $this->cache->get('illuminate:queue:restart');
+            
+            if ($lastRestart === null) {
+                $lastRestart = now();
+                $this->cache->forever('illuminate:queue:restart', $lastRestart);
+            }
         }
+
+        return $lastRestart;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -711,10 +711,10 @@ class Worker
             $attempts = 0;
             $lockAcquired = false;
 
-            while ($attempts < $maxAttempts && !$lockAcquired) {
+            while ($attempts < $maxAttempts && ! $lockAcquired) {
                 $lockAcquired = $this->cache->add($lockKey, true, 2);
 
-                if (!$lockAcquired) {
+                if (! $lockAcquired) {
                     sleep($retryDelaySeconds);
                     $attempts++;
                 }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -140,20 +140,6 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command);
     }
 
-    public function testClearWillStopQueueWorker()
-    {
-        $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
-        $this->cacheRepository->shouldReceive('flush')->once();
-
-        $this->files->shouldReceive('exists')->andReturn(true);
-        $this->files->shouldReceive('files')->andReturn([]);
-
-        $queueWorker = m::mock(QueueWorker::class);
-        $queueWorker->shouldReceive('stop')->once()->andReturn(0);
-
-        $this->runCommand($this->command);
-    }
-
     protected function runCommand($command, $input = [])
     {
         return $command->run(new ArrayInput($input), new NullOutput);

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -140,6 +140,20 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command);
     }
 
+    public function testClearWillStopQueueWorker()
+    {
+        $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('flush')->once();
+
+        $this->files->shouldReceive('exists')->andReturn(true);
+        $this->files->shouldReceive('files')->andReturn([]);
+
+        $queueWorker = m::mock(QueueWorker::class);
+        $queueWorker->shouldReceive('stop')->once()->andReturn(0);
+
+        $this->runCommand($this->command);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new ArrayInput($input), new NullOutput);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -3,20 +3,15 @@
 namespace Illuminate\Tests\Queue;
 
 use Exception;
-
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Console\ClearCommand;
-use Illuminate\Contracts\Cache\Repository;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Foundation\Application;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
-use Illuminate\Support\Facades\Queue;
-
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
@@ -30,6 +25,8 @@ use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class QueueWorkerTest extends TestCase
 {
@@ -137,7 +134,7 @@ class QueueWorkerTest extends TestCase
         $this->command->run(new ArrayInput([]), new NullOutput);
 
         $status = $worker->daemon('default', 'queue', $workerOptions);
-        
+
         $this->assertSame(0, $status);
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -119,8 +119,10 @@ class QueueWorkerTest extends TestCase
 
         $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
         $this->cacheRepository->shouldReceive('flush')->once();
-        $this->cacheRepository->shouldReceive('get');
-        $this->cacheRepository->shouldReceive('forever');
+        $this->cacheRepository->shouldReceive('get')->once()->andReturn(null);
+        $this->cacheRepository->shouldReceive('forever')->once()->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->once()->andReturn(true);
+        $this->cacheRepository->shouldReceive('forget')->once()->andReturn(true);
 
         $app = new Application;
         $app['path.storage'] = __DIR__;


### PR DESCRIPTION
make cache:clear consistently restart queue worker with lock to prevent race conditions stated earlier in https://github.com/laravel/framework/pull/47693#issuecomment-1627791941