### PR TITLE
Add `newValues` parameter in updateOrCreate method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -576,11 +576,12 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  $newValues
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, array $values = [], array $newValues = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
+        return tap($this->firstOrNew($attributes, $newValues), function ($instance) use ($values) {
             $instance->fill($values)->save();
         });
     }


### PR DESCRIPTION
Let's say I have a conversation table with roughly the structure `id, conversation, creator, last_msg_id, last_contacted_at`

where `creator` is the user who spoke for the first time in this session, it is only updated in the first session (subsequent updates are not needed), so I can't put it in the original $values ​​parameter of updateOrCreate (this will be updated every time overlay for the most recently spoken user)

adjusted

```php
ImConversation::query()->updateOrCreate(
    [
        'conversation' => 'user1,user2'
    ],
    [
        'last_msg_id' => $message->msg_id,
        'last_contacted_at' => time(),
        // update everytime
    ],
    // This will only set to the model `firstOrNew ` on first insert
    [
        'creator' => $message->from_uid
    ]
);
```