### PR TITLE
[10.x] Tweak return type for missing config

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -103,7 +103,7 @@ class PasswordBrokerManager implements FactoryContract
      * Get the password broker configuration.
      *
      * @param  string  $name
-     * @return array
+     * @return array|null
      */
     protected function getConfig($name)
     {


### PR DESCRIPTION
My subclass of PasswordBrokerManager fails with Larastan with the error:

```
 ------ ---------------------------------------------------------------------- 
  Line   Services/MyAppPasswordBrokerManager.php                              
 ------ ---------------------------------------------------------------------- 
  22     Call to function is_null() with array will always evaluate to false.  
 ------ ---------------------------------------------------------------------- 
```

Line 22 is the same as the framework version:

```
        if (is_null($config)) {
            throw new InvalidArgumentException("Password resetter [{$name}] is not defined.");
        }
```

I think it's correct that `$config` can be null and this docblock tweak fixes that for Larastan.
