### PR TITLE
Feature: ability to add non-primary auto-increment columns in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this after(string $column) Place the column "after" another column (MySQL)
  * @method $this always(bool $value = true) Used as a modifier for generatedAs() (PostgreSQL)
- * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
+ * @method $this autoIncrement(string $indexType = 'PRIMARY') Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this after(string $column) Place the column "after" another column (MySQL)
  * @method $this always(bool $value = true) Used as a modifier for generatedAs() (PostgreSQL)
- * @method $this autoIncrement(string $indexType = 'PRIMARY') Set INTEGER columns as auto-increment (primary key)
+ * @method $this autoIncrement(string $indexType = 'primary') Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1132,8 +1132,14 @@ class PostgresGrammar extends Grammar
     {
         if (! $column->change
             && (in_array($column->type, $this->serials) || ($column->generatedAs !== null))
-            && $column->autoIncrement) {
-            return ' primary key';
+            && $column->autoIncrement
+        ) {
+            if (!in_array($column->autoIncrement, $this->supportedAutoIncrementKeyTypes(), true)) {
+                throw new \RuntimeException(
+                    "Invalid serial key type [{$column->autoIncrement}]."
+                )
+            }
+            return " {$column->autoIncrement} key";
         }
     }
 
@@ -1215,5 +1221,15 @@ class PostgresGrammar extends Grammar
         }
 
         return $sql;
+    }
+
+    /**
+     * Get the supported serial key types.
+     *
+     * @return string[]
+     */
+    protected function supportedAutoIncrementKeyTypes(): array
+    {
+        return ['primary', 'unique'];
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1137,7 +1137,7 @@ class PostgresGrammar extends Grammar
             if (!in_array($column->autoIncrement, $this->supportedAutoIncrementKeyTypes(), true)) {
                 throw new \RuntimeException(
                     "Invalid serial key type [{$column->autoIncrement}]."
-                )
+                );
             }
             return " {$column->autoIncrement} key";
         }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -987,10 +987,17 @@ class SQLiteGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
+     * 
+     * @throws \RuntimeException
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+            if (!in_array($column->autoIncrement, $this->supportedSerialKeyTypes(), true)) {
+                throw new \InvalidArgumentException(
+                    "Unsupported autoincrement key type [{$column->autoIncrement}]."
+                );
+            }
             return ' primary key autoincrement';
         }
     }
@@ -1006,5 +1013,10 @@ class SQLiteGrammar extends Grammar
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_extract('.$field.$path.')';
+    }
+
+    public function supportedSerialKeyTypes(): array
+    {
+        return ['primary'];
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -992,6 +992,11 @@ class SqlServerGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (! $column->change && in_array($column->type, $this->serials) && $column->autoIncrement) {
+            if (!in_array($column->autoIncrement, $this->supportedSerialKeyTypes(), true)) {
+                throw new \InvalidArgumentException(
+                    "Unsupported indentity key type [{$column->autoIncrement}]."
+                );
+            }
             return ' identity primary key';
         }
     }
@@ -1046,5 +1051,15 @@ class SqlServerGrammar extends Grammar
         }
 
         return "N'$value'";
+    }
+
+    /**
+     * Get the supported serial key types.
+     *
+     * @return string[]
+     */
+    public function supportedSerialKeyTypes(): array
+    {
+        return ['primary', 'unique'];
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Added the ability to create non-primary auto-increment keys in migrations for supported grammars.
