### PR TITLE
[10.x] Feature: Create non-primary autoincrements in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -793,7 +793,7 @@ class Blueprint
      * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function integer($column, $autoIncrement = false, $unsigned = false)
+    public function integer($column, bool|string $autoIncrement = false, $unsigned = false)
     {
         return $this->addColumn('integer', $column, compact('autoIncrement', 'unsigned'));
     }
@@ -802,7 +802,7 @@ class Blueprint
      * Create a new tiny integer (1-byte) column on the table.
      *
      * @param  string  $column
-     * @param  bool  $autoIncrement
+     * @param  bool|string  $autoIncrement
      * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
@@ -815,7 +815,7 @@ class Blueprint
      * Create a new small integer (2-byte) column on the table.
      *
      * @param  string  $column
-     * @param  bool  $autoIncrement
+     * @param  bool|string  $autoIncrement
      * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
@@ -857,7 +857,7 @@ class Blueprint
      * @param  bool  $autoIncrement
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function unsignedInteger($column, $autoIncrement = false)
+    public function unsignedInteger($column, bool|string $autoIncrement = false)
     {
         return $this->integer($column, $autoIncrement, true);
     }

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this after(string $column) Place the column "after" another column (MySQL)
  * @method $this always(bool $value = true) Used as a modifier for generatedAs() (PostgreSQL)
- * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
+ * @method $this autoIncrement(string $indexType = 'PRIMARY') Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this after(string $column) Place the column "after" another column (MySQL)
  * @method $this always(bool $value = true) Used as a modifier for generatedAs() (PostgreSQL)
- * @method $this autoIncrement(string $indexType = 'primary') Set INTEGER columns as auto-increment (primary key)
+ * @method $this autoIncrement(bool|string $indexType = true) Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this after(string $column) Place the column "after" another column (MySQL)
  * @method $this always(bool $value = true) Used as a modifier for generatedAs() (PostgreSQL)
- * @method $this autoIncrement(string $indexType = 'PRIMARY') Set INTEGER columns as auto-increment (primary key)
+ * @method $this autoIncrement(string $indexType = 'primary') Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1201,11 +1201,12 @@ class MySqlGrammar extends Grammar
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             $key = is_string($column->autoIncrement) ? $column->autoIncrement : $this->getDefaultSerialKeyType();
 
-            if (!in_array($key, $this->serialsKeys)) {
+            if (! in_array($key, $this->serialsKeys)) {
                 throw new \RuntimeException(
                     "Unsupported auto_increment key type [{$key}]."
                 );
             }
+
             return " auto_increment {$key} key";
         }
     }
@@ -1296,7 +1297,7 @@ class MySqlGrammar extends Grammar
 
     /**
      * Get the default key type for the serials.
-     * 
+     *
      * @return string
      */
     protected function getDefaultSerialKeyType(): string

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1132,8 +1132,14 @@ class PostgresGrammar extends Grammar
     {
         if (! $column->change
             && (in_array($column->type, $this->serials) || ($column->generatedAs !== null))
-            && $column->autoIncrement) {
-            return ' primary key';
+            && $column->autoIncrement
+        ) {
+            if (!in_array($column->autoIncrement, $this->supportedAutoIncrementKeyTypes(), true)) {
+                throw new \RuntimeException(
+                    "Invalid serial key type [{$column->autoIncrement}]."
+                )
+            }
+            return " {$column->autoIncrement} key";
         }
     }
 
@@ -1215,5 +1221,15 @@ class PostgresGrammar extends Grammar
         }
 
         return $sql;
+    }
+
+    /**
+     * Get the supported serial key types.
+     *
+     * @return string[]
+     */
+    protected function supportedAutoIncrementKeyTypes(): array
+    {
+        return ['primary', 'unique'];
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1137,7 +1137,7 @@ class PostgresGrammar extends Grammar
             if (!in_array($column->autoIncrement, $this->supportedAutoIncrementKeyTypes(), true)) {
                 throw new \RuntimeException(
                     "Invalid serial key type [{$column->autoIncrement}]."
-                )
+                );
             }
             return " {$column->autoIncrement} key";
         }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -987,10 +987,17 @@ class SQLiteGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
+     * 
+     * @throws \RuntimeException
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+            if (!in_array($column->autoIncrement, $this->supportedSerialKeyTypes(), true)) {
+                throw new \InvalidArgumentException(
+                    "Unsupported autoincrement key type [{$column->autoIncrement}]."
+                );
+            }
             return ' primary key autoincrement';
         }
     }
@@ -1006,5 +1013,10 @@ class SQLiteGrammar extends Grammar
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_extract('.$field.$path.')';
+    }
+
+    public function supportedSerialKeyTypes(): array
+    {
+        return ['primary'];
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -992,6 +992,11 @@ class SqlServerGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (! $column->change && in_array($column->type, $this->serials) && $column->autoIncrement) {
+            if (!in_array($column->autoIncrement, $this->supportedSerialKeyTypes(), true)) {
+                throw new \InvalidArgumentException(
+                    "Unsupported indentity key type [{$column->autoIncrement}]."
+                );
+            }
             return ' identity primary key';
         }
     }
@@ -1046,5 +1051,15 @@ class SqlServerGrammar extends Grammar
         }
 
         return "N'$value'";
+    }
+
+    /**
+     * Get the supported serial key types.
+     *
+     * @return string[]
+     */
+    public function supportedSerialKeyTypes(): array
+    {
+        return ['primary', 'unique'];
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -66,6 +66,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` auto_increment = 1000', $statements[1]);
     }
 
+
     public function testAddColumnsWithMultipleAutoIncrementStartingValue()
     {
         $blueprint = new Blueprint('users');
@@ -77,6 +78,29 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
             'alter table `users` add `id` bigint unsigned not null auto_increment primary key, add `name` varchar(255) not null',
             'alter table `users` auto_increment = 100',
         ], $statements);
+    }
+
+    public function testAddNonPrimaryAutoIncrementColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'unique');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter table `users` add `customer_number` int not null auto_increment unique key',
+            $statements[0]
+        );
+    }
+
+    public function testInvalidKeyForIncrementColumnThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported auto_increment key type [index].');
+
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'index');
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testEngineCreateTable()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -92,6 +92,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
             $statements[0]
         );
     }
+    public function testAddNonPrimaryAutoIncrementColumnAsModifier()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number')->autoIncrement('unique');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter table `users` add `customer_number` int not null auto_increment unique key',
+            $statements[0]
+        );
+    }
 
     public function testInvalidKeyForIncrementColumnThrowsException()
     {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -67,6 +67,29 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddNonPrimaryAutoIncrementColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'unique');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter table "users" add column "customer_number" serial not null unique key',
+            $statements[0]
+        );
+    }
+
+    public function testInvalidKeyForIncrementColumnThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported serial key type [index].');
+
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'index');
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
     public function testCreateTableAndCommentColumn()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -300,6 +300,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
+    public function testAddingNonPrimaryAutoIncrementColumnThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported autoincrement key type [unique].');
+
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'unique');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
     public function testAddingForeignID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -345,6 +345,30 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add "foo" bigint not null identity primary key', $statements[0]);
     }
 
+    public function testAddNonPrimaryAutoIncrementColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'unique');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals(
+            'alter table "users" add "customer_number" int not null identity unique key',
+            $statements[0]
+        );
+    }
+
+    public function testInvalidKeyForIncrementColumnThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported indentity key type [index]');
+
+        $blueprint = new Blueprint('users');
+        $blueprint->integer('customer_number', 'index');
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
+
     public function testAddingForeignID()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
# The Problem
There is currently no easy and reliable way to add auto-increments into a migration without it being a primary key.

There is debate as to wether this should be desirable, however, I believe it should, at least, be possible. A valid usecase is wanting non-incrementing ids to avoid record number 4563 implicating the existance of 4562, 4561, etc., allowing for easy scraping of data in URLs. Instead, you may wish for your increments to be in a separate column to that which you use to primarily identify the record.

Currently, the only way to achieve this is with something as horrible as:

```php
Schema::table('users', function (Blueprint $table) {
    $table->unsignedBigInteger('customer_number')->unique()->nullable()->after('id');
});

\Illuminate\Support\Facades\DB::statement('ALTER TABLE users MODIFY customer_number INT AUTO_INCREMENT');
```

This is ugly for two reasons: firstly, you have to do the `ALTER TABLE` outside of the migration function to ensure it runs in the correct order. Secondly, this will cause significant issues if you change the underlying database; the above code will only work for MySQL databases, and would throw errors for any other type. This breaks the purpose of having abstraction layers in the first place.

# The Solution

This pull requests allows for backwards compatibility, still accepting the same behaviour for passing any of the integer-based columns a `true` or `false` value for `$autoIncrements`. However, it additionally adds the ability to pass in a string to indicate the key type. For the databases that support it (all grammars except sqlite), you can pass `unique` instead.

Eg.

```php
Schema::table('users', function (Blueprint $table) {
     $table->uuid('id')->primary();
     $table->string('name');
     $table->integer('customer_number', 'unique');
});

// or

Schema::table('users', function (Blueprint $table) {
     $table->uuid('id')->primary();
     $table->string('name');
     $table->integer('customer_number')->autoIncrements('unique');
});
```

# The Constraints
The primary constraint for this change is keeping it backwards compatible; this is not a big enough change to break BWC, and so this is the most eloquent way I could come up with to allow this functionality.

I considered adding an additional property, however this didn't make sense for when you didn't want a column to be auto incrementing. Instead, I have expanded the meaning of the increment parameter to include the key type.

If anyone has any suggestion of how to achieve this better, then I am open to changing the approach.

It is also worth noting that this raises another issue: sqlite. Sqlite is the only supported grammar that does _not_ support non-primary auto-increments (at least, from what I can see from the documentation).