### PR TITLE
[10.x] Fix parallel testing without any database connection

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -141,6 +141,10 @@ trait TestDatabases
      */
     protected function whenNotUsingInMemoryDatabase($callback)
     {
+        if (ParallelTesting::option('without_databases')) {
+            return;
+        }
+
         $database = DB::getConfig('database');
 
         if ($database !== ':memory:') {

--- a/tests/Integration/Testing/TestWithoutDatabaseParallelTest.php
+++ b/tests/Integration/Testing/TestWithoutDatabaseParallelTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Illuminate\Tests\Integration\Testing;
 
@@ -8,7 +8,8 @@ use Orchestra\Testbench\TestCase;
 
 class TestWithoutDatabaseParallelTest extends TestCase
 {
-    protected function getPackageProviders($app) {
+    protected function getPackageProviders($app)
+    {
         return [ParallelTestingServiceProvider::class];
     }
 
@@ -25,5 +26,4 @@ class TestWithoutDatabaseParallelTest extends TestCase
         // We should not create a database connection to check if it's SQLite or not.
         ParallelTesting::callSetUpProcessCallbacks();
     }
-
 }

--- a/tests/Integration/Testing/TestWithoutDatabaseParallelTest.php
+++ b/tests/Integration/Testing/TestWithoutDatabaseParallelTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Testing;
+
+use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Testing\ParallelTestingServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class TestWithoutDatabaseParallelTest extends TestCase
+{
+    protected function getPackageProviders($app) {
+        return [ParallelTestingServiceProvider::class];
+    }
+
+    public function testRunningParallelTestWithoutDatabaseShouldNotCrashOnDefaultConnection()
+    {
+        // Given an application that does not use database connections at all
+        $this->app['config']->set('database.default', null);
+
+        // When we run parallel testing with `without-databases` option
+        $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
+        $_SERVER['LARAVEL_PARALLEL_TESTING_WITHOUT_DATABASES'] = 1;
+        $_SERVER['TEST_TOKEN'] = '1';
+
+        // We should not create a database connection to check if it's SQLite or not.
+        ParallelTesting::callSetUpProcessCallbacks();
+    }
+
+}


### PR DESCRIPTION
When running Parallel Testing, one of the checks that happens within the framework is whether we're using SQLite or not. However, this check is done via `DB::getConfig()`. What truly happens here is:

- DB Facade is invoked
- DatabaseManager class is resolved
- DatabaseManager::__call() is invoked
- DatabaseManager::connection() is invoked
- The default Database configuration is loaded from `database.default`.
- A new connection is established on this database.
- A verification of whether `getConfig()` returns `:memory:` is performed.

As we can see, even if we specify `without-databases`, the ParallelTesting class is still establishing a database connection.

The added test goes to show that if we create a Laravel Application and delete the `database.default` configuration in our project skeleton, then `php artisan test --parallel --without-databases` will still crash because it cannot establish a database connection to check if it's SQLite or not.

The code change partially mitigates the problem. I think a deeper issue is the fact that a complete database connection is being established just to check whether the developer is using SQLite or not. However, for the sake of simplicity and brevity, we can at least use the `without-databases` flag to decide to not even try connecting to any database.