### PR TITLE
[10.x] Add array type for `call` method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -638,7 +638,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Call the given Closure / class@method and inject its dependencies.
      *
-     * @param  callable|string  $callback
+     * @param  callable|array|string  $callback
      * @param  array<string, mixed>  $parameters
      * @param  string|null  $defaultMethod
      * @return mixed


### PR DESCRIPTION
I'm teaching Service Container, and I'm teaching `Method Injection` but the first parameters must be array because in docs see like this:
https://laravel.com/docs/10.x/container#method-invocation-and-injection