### PR TITLE
[10.x] Allows HTTP exceptions to be thrown for views

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -5,6 +5,7 @@ namespace Illuminate\View\Engines;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\ViewException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
 
 class CompilerEngine extends PhpEngine
@@ -100,6 +101,10 @@ class CompilerEngine extends PhpEngine
      */
     protected function handleViewException(Throwable $e, $obLevel)
     {
+        if ($e instanceof HttpException) {
+            parent::handleViewException($e, $obLevel);
+        }
+
         $e = new ViewException($this->getMessage($e), 0, 1, $e->getFile(), $e->getLine(), $e);
 
         parent::handleViewException($e, $obLevel);

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -11,6 +11,7 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\ViewException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ViewCompilerEngineTest extends TestCase
 {
@@ -41,6 +42,30 @@ class ViewCompilerEngineTest extends TestCase
 
         $this->assertSame('Hello World
 ', $results);
+    }
+
+    public function testRegularExceptionsAreReThrownAsViewExceptions()
+    {
+        $engine = $this->getEngine();
+        $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/regular-exception.php');
+        $engine->getCompiler()->shouldReceive('isExpired')->once()->andReturn(false);
+
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessage('regular exception message');
+
+        $engine->get(__DIR__.'/fixtures/foo.php');
+    }
+
+    public function testHttpExceptionsAreNotReThrownAsViewExceptions()
+    {
+        $engine = $this->getEngine();
+        $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/http-exception.php');
+        $engine->getCompiler()->shouldReceive('isExpired')->once()->andReturn(false);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('http exception message');
+
+        $engine->get(__DIR__.'/fixtures/foo.php');
     }
 
     public function testThatViewsAreNotAskTwiceIfTheyAreExpired()

--- a/tests/View/fixtures/http-exception.php
+++ b/tests/View/fixtures/http-exception.php
@@ -1,0 +1,5 @@
+<?php
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+throw new HttpException(403, 'http exception message');

--- a/tests/View/fixtures/regular-exception.php
+++ b/tests/View/fixtures/regular-exception.php
@@ -1,0 +1,3 @@
+<?php
+
+throw new Exception('regular exception message');


### PR DESCRIPTION
This pull request allows "http" exceptions to be thrown for views. Here is an example, when using blade's `@php` tags:

```php
@php
    if (! Gate::check('view-books')) {
        abort(403);
    }

    $books = auth()->user()->books;
@endphp

@foreach ($books as $book)
    <div>
        {{ $book->title }}
    </div>
@endforeach
```