### PR TITLE
Fix docblock types for EventServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -25,7 +25,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The model observers to register.
      *
-     * @var array<class-string, string|object|array<int, string|object>>
+     * @var array<class-string, class-string|object|array<int, class-string|object>>
      */
     protected $observers = [];
 

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -11,21 +11,21 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The event handler mappings for the application.
      *
-     * @var array<string, array<int, string>>
+     * @var array<class-string, array<int, class-string>>
      */
     protected $listen = [];
 
     /**
      * The subscribers to register.
      *
-     * @var array
+     * @var array<class-string|object>
      */
     protected $subscribe = [];
 
     /**
      * The model observers to register.
      *
-     * @var array<string, string|object|array<int, string|object>>
+     * @var array<class-string, string|object|array<int, string|object>>
      */
     protected $observers = [];
 


### PR DESCRIPTION
The docblocks for `EventServiceProvider::$listen` in `laravel/framework` and `laravel/laravel` are not invariant. This PR updates the docblock to use the more specific type `class-string` that matches the extending class.

I have also updated the types for `EventServiceProvider::$subscribe` and `EventServiceProvider::$observers` to better represent what they actually contain.