### PR TITLE
[10.x] Add new SQL error message "No connection could be made because the target machine actively refused it"

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -65,6 +65,7 @@ trait DetectsLostConnections
             'SSL: Handshake timed out',
             'SQLSTATE[08006] [7] SSL error: sslv3 alert unexpected message',
             'SQLSTATE[08006] [7] unrecognized SSL error code:',
+            'SQLSTATE[HY000] [2002] No connection could be made because the target machine actively refused it',
         ]);
     }
 }


### PR DESCRIPTION
Add new connection error message for mysql PDO

This message is coming when using Artisan CLI with SQL command ```SHOW DATABASES```.

My error handling is checking against the trait ```Illuminate\Database\DetectsLostConnections::causedByLostConnection($exception)```
