### PR TITLE
[10.x] Ignore second in HttpRequestTest date comparison

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -723,7 +723,7 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->date('doesnt_exists'));
 
         $this->assertEquals($current, $request->date('as_datetime'));
-        $this->assertEquals($current, $request->date('as_format', 'U'));
+        $this->assertEquals($current->format('Y-m-d H:i:s P'), $request->date('as_format', 'U')->format('Y-m-d H:i:s P'));
         $this->assertEquals($current, $request->date('as_timezone', null, 'America/Santiago'));
 
         $this->assertTrue($request->date('as_date')->isSameDay($current));


### PR DESCRIPTION
Microsecond was 0 because of a PHP bug:
https://bugs.php.net/bug.php?id=74332

And because Carbon aligned its behavior.

But it now longer make sense now that most PHP versions handle it properly, I plan to remove this hack https://github.com/briannesbitt/Carbon/pull/2823

In order to keep the Laravel tests compatible, the easiest way would be ignore microsecond in the date comparison assertion.