### PR TITLE
[10.x] Enhancement of Interface Cloud: Addition of `fileExists` method

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Cloud.php
+++ b/src/Illuminate/Contracts/Filesystem/Cloud.php
@@ -11,4 +11,11 @@ interface Cloud extends Filesystem
      * @return string
      */
     public function url($path);
+
+    /**
+     * Determine if a file exists.
+     * @param  string  $path
+     * @return bool
+     */
+    public function fileExists(string $path);
 }


### PR DESCRIPTION
**Description**:
This pull request addresses a recurring PHPStan error that point out an undefined method, fileExists(), being called on the Illuminate\Contracts\Filesystem\Cloud interface.

This has been corrected by introducing a fileExists() method in the Cloud interface, which clarifies the contract for all classes that implement this interface. Consequently, it serves two essential tasks:

Fixes PHPStan error: Call to an undefined method Illuminate\Contracts\Filesystem\Cloud::fileExists(). when I using the `Storage::cloud()->fileExists($s3_relative_path)` to ensure the determine if a file exists.
Makes the interface's responsibilities more explicit and precise.
Modified Files:
Illuminate\Contracts\Filesystem\Cloud
Tasks:
 Add fileExists() method to the Cloud interface
 Update all the classes that implement Cloud interface and provide an implementation for fileExists()
Testing:
After the correction:

 All existing tests should pass without any error
 No PHPStan errors should be thrown for Call to an undefined method Illuminate\Contracts\Filesystem\Cloud::fileExists(). ✏️ app/Console/Commands/File/Retrieve.php
Note: This PR doesn't include implementations for fileExists(). The classes that implement Cloud should provide their own.