### PR TITLE
[10.x] Call `renderForAssertions` in `assertHasSubject`

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1330,6 +1330,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasSubject($subject)
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasSubject($subject),
             "Did not see expected text [{$subject}] in email subject."


### PR DESCRIPTION
### Description

When testing the "subject" of a mailable with `assertHasSubject` that has multiple locale and has not been "prepared" returns the default/wrong subject.

### Steps To Reproduce

```php
class ExampleMail extends Mailable
{
    public function envelope(): Envelope
    {
        return new Envelope(subject: __('mail.example.subject'));
    }
}
```

```php
// won't work
(new ExampleMail())
    ->locale('sv')
    ->assertHasSubject('swedish subject');

// will work
(new ExampleMail())
    ->locale('sv')
    ->assertSeeInHtml('...') // calls `renderForAssertions`
    ->assertHasSubject('swedish subject');


```