### PR TITLE
[10.x] Add loose option to date format validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -559,8 +559,20 @@ trait ValidatesAttributes
                 $date = DateTime::createFromFormat("!{$format}", $value);
                 $errors = DateTime::getLastErrors();
 
-                // Validates only that the specified format can be parsed
-                if (! $date || isset($errors['errors']) || isset($errors['warnings'])) {
+                // Validates only that the specified format can be parsed.
+                //
+                // DateTime::getLastErrors() returns false when there are no errors or warnings in PHP 8.2 and later,
+                // and an array containing information about warnings or errors in PHP 8.1 and earlier.
+                // Therefore, to check if there is an error or warning,
+                // we need to first confirm that $errors is not false,
+                // and then make a judgement by looking at the contents of the array.
+                if (
+                    ! $date
+                    || (
+                        $errors !== false
+                        && ($errors['warning_count'] !== 0 || $errors['error_count'] !== 0)
+                    )
+                ) {
                     continue;
                 }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -560,15 +560,17 @@ trait ValidatesAttributes
                 $errors = DateTime::getLastErrors();
 
                 // Validates only that the specified format can be parsed
-                if (!$date || isset($errors['errors']) || isset($errors['warnings'])) {
+                if (! $date || isset($errors['errors']) || isset($errors['warnings'])) {
                     continue;
                 }
 
-                if (!$strict) {
+                if (! $strict) {
                     return true;
                 } else {
                     // Validates an exact match with the parsed and reformatted version in the specified format
-                    if ($date->format($format) === $value) return true;
+                    if ($date->format($format) === $value) {
+                        return true;
+                    }
                 }
             } catch (ValueError) {
                 return false;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -551,8 +551,8 @@ trait ValidatesAttributes
             return false;
         }
 
-        $formats = array_filter($parameters, fn (int|string $v) => $v !== 'strict');
-        $strict = $formats !== $parameters;
+        $formats = array_filter($parameters, fn (int|string $v) => $v !== 'loose');
+        $loose = $formats !== $parameters;
 
         foreach ($formats as $format) {
             try {
@@ -564,7 +564,7 @@ trait ValidatesAttributes
                     continue;
                 }
 
-                if (! $strict) {
+                if ($loose) {
                     return true;
                 } else {
                     // Validates an exact match with the parsed and reformatted version in the specified format

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -559,20 +559,14 @@ trait ValidatesAttributes
                 $date = DateTime::createFromFormat("!{$format}", $value);
                 $errors = DateTime::getLastErrors();
 
+                // DateTime::getLastErrors() behaves differently depending on the PHP version
+                // when there are no errors or warnings.
+                // ~ PHP8.1: array with the same structure as in the case of errors and warnings
+                // PHP8.2: returns false
+                $hasErrors = is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
+
                 // Validates only that the specified format can be parsed.
-                //
-                // DateTime::getLastErrors() returns false when there are no errors or warnings in PHP 8.2 and later,
-                // and an array containing information about warnings or errors in PHP 8.1 and earlier.
-                // Therefore, to check if there is an error or warning,
-                // we need to first confirm that $errors is not false,
-                // and then make a judgement by looking at the contents of the array.
-                if (
-                    ! $date
-                    || (
-                        $errors !== false
-                        && ($errors['warning_count'] !== 0 || $errors['error_count'] !== 0)
-                    )
-                ) {
+                if (! $date || $hasErrors) {
                     continue;
                 }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5332,37 +5332,37 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testDateAndFormatStrictOption()
+    public function testDateAndFormatLooseOption()
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
         $format = DateTimeInterface::RFC3339;
 
         // UTC expressed as +00:00
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:'.$format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:loose,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:loose,'.$format]);
         $this->assertTrue($v->passes());
 
         // UTC expressed as Z
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:'.$format]);
         $this->assertTrue($v->fails());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:loose,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:loose,'.$format]);
         $this->assertTrue($v->passes());
 
         // JST expressed as +09:00
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:'.$format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:loose,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:loose,'.$format]);
         $this->assertTrue($v->passes());
 
         // Replace P with p
         $format = str_replace('P', 'p', $format);
 
         // UTC expressed as +00:00
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:'.$format]);
         $this->assertTrue($v->fails());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:loose,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:loose,'.$format]);
         $this->assertTrue($v->passes());
 
         // UTC expressed as Z
@@ -5372,9 +5372,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         // JST expressed as +09:00
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:'.$format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:loose,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:loose,'.$format]);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Validation;
 use Countable;
 use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -5285,7 +5286,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '00-01-01'], ['x' => 'date_format:Y-m-d']);
-        $this->assertTrue($v->fails());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
@@ -5328,6 +5329,52 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '17:43'], ['x' => 'date_format:H:i']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testDateAndFormatStrictOption()
+    {
+        date_default_timezone_set('UTC');
+        $trans = $this->getIlluminateArrayTranslator();
+        $format = DateTimeInterface::RFC3339;
+
+        // UTC expressed as +00:00
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:' . $format]);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:strict,' . $format]);
+        $this->assertTrue($v->passes());
+
+        // UTC expressed as Z
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:' . $format]);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:strict,' . $format]);
+        $this->assertTrue($v->fails());
+
+        // JST expressed as +09:00
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:' . $format]);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:strict,' . $format]);
+        $this->assertTrue($v->passes());
+
+        // Replace P with p
+        $format = str_replace('P', 'p', $format);
+
+        // UTC expressed as +00:00
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:' . $format]);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:strict,' . $format]);
+        $this->assertTrue($v->fails());
+
+        // UTC expressed as Z
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:' . $format]);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:strict,' . $format]);
+        $this->assertTrue($v->passes());
+
+        // JST expressed as +09:00
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:' . $format]);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:strict,' . $format]);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5366,9 +5366,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         // UTC expressed as Z
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:'.$format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:loose,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:loose,'.$format]);
         $this->assertTrue($v->passes());
 
         // JST expressed as +09:00

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5286,7 +5286,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '00-01-01'], ['x' => 'date_format:Y-m-d']);
-        $this->assertTrue($v->passes());
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
@@ -5341,19 +5341,19 @@ class ValidationValidatorTest extends TestCase
         // UTC expressed as +00:00
         $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:' . $format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:strict,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:loose,' . $format]);
         $this->assertTrue($v->passes());
 
         // UTC expressed as Z
         $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:' . $format]);
-        $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:strict,' . $format]);
         $this->assertTrue($v->fails());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:loose,' . $format]);
+        $this->assertTrue($v->passes());
 
         // JST expressed as +09:00
         $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:' . $format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:strict,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:loose,' . $format]);
         $this->assertTrue($v->passes());
 
         // Replace P with p
@@ -5361,20 +5361,20 @@ class ValidationValidatorTest extends TestCase
 
         // UTC expressed as +00:00
         $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:' . $format]);
-        $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:strict,' . $format]);
         $this->assertTrue($v->fails());
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+00:00'], ['x' => 'date_format:loose,' . $format]);
+        $this->assertTrue($v->passes());
 
         // UTC expressed as Z
         $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:' . $format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:strict,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00Z'], ['x' => 'date_format:loose,' . $format]);
         $this->assertTrue($v->passes());
 
         // JST expressed as +09:00
         $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:' . $format]);
         $this->assertTrue($v->passes());
-        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:strict,' . $format]);
+        $v = new Validator($trans, ['x' => '2023-01-01T00:00:00+09:00'], ['x' => 'date_format:loose,' . $format]);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
# What is this?
I used the date_format validation rule specifying the RFC::3339 method, and there was a non-intuitive behavior. It was previously raised as a bug in a Lumen [Issue](https://github.com/laravel/lumen-framework/issues/611), but it seems it hasn't been fixed yet, so I addressed it.

# Details
## About RFC3339 formatting
Whether to make the date_format validation rule strict or not changes the result when, for example, the format is specified as RFC3339.
As a premise, RFC3339 is in the form of 'Y-m-d\TH:i:sP', but in this format, there are two patterns for expressing the date: one uses 'Z' to indicate Coordinated Universal Time (UTC), and the other uses a time offset of '+00:00'.

## The conventional implementation
The date_format validation rule checks whether it can parse with the specified format using DateTime::createFromFormat(). However, because there are two ways to represent UTC, there is a pattern where something that should succeed in the inspection fails.

In the conventional implementation of date_format, after parsing with DateTime::createFromFormat(), it verifies whether the reformatted string perfectly matches the input value.

```php
// Parse the input with the specified format.
$date = DateTime::createFromFormat('!'.$format, $value);

// Inspect to ensure it has been parsed correctly and that the reformatted parsing result matches the input.
if ($date && $date->format($format) == $value) {
	return true;
}
```

Now, let's parse and reformat the following two types of date strings with RFC::3339.

### 2023-01-01T00:00:00+00:00
```php
$date = DateTime::createFromFormat('!'.DateTime::RFC3339, '2023-01-01T00:00:00+00:00');
echo $date->format(DateTime::RFC3339) . "\n";

// The output is "2023-01-01T00:00:00+00:00"
```

### 2023-01-01T00:00:00Z
```php
$date = DateTime::createFromFormat('!'.DateTime::RFC3339, '2023-01-01T00:00:00Z');
echo $date->format(DateTime::RFC3339) . "\n";

// The output is "2023-01-01T00:00:00+00:00"
```

In this way, in PHP, dates written in +00:00 and those written in Z are both reformatted to +00:00 notation. Therefore, even values that should pass the inspection can fail in the old implementation because they are treated as not complying with the format.

Here, from PHP8.0, in addition to the "P" format, the "p" format has been added.
https://php.watch/versions/8.0/date-utc-p-format

Both of these represent the time difference from GMT, but if you use p, it will return Z instead of +00:00. Now, let's replace the P used in the previous validation with p and perform the same validation.

### 2023-01-01T00:00:00+00:00
```php
$format = str_replace('P', 'p', DateTime::RFC3339);
$date = DateTime::createFromFormat('!'.$format, '2023-01-01T00:00:00+00:00');
echo $date->format(DateTime::RFC3339) . "\n";

// The output is "2023-01-01T00:00:00Z"
```

### 2023-01-01T00:00:00Z
```php
$format = str_replace('P', 'p', DateTime::RFC3339);
$date = DateTime::createFromFormat('!'.$format, '2023-01-01T00:00:00Z');
echo $date->format(DateTime::RFC3339) . "\n";

// The output is "2023-01-01T00:00:00Z"
```

With this, if you enter in Z notation, it will be reformatted in Z notation. However, even those entered in +00:00 notation will return as Z when using the p format, so the date_format inspection will not succeed after all. I think it's not recommended to branch these processes within validateDateFormat.

# What I did this time.
Considering the above, I have divided the strictness of the date_format check into two levels:

- Default: Strict check
  - Like the original implementation, it checks whether the parsing is successful with the specified format, and furthermore, whether the reformatted value is equal to the input value.
- Option: Loose check
  - It simply checks whether the parsing is successful with the specified format.

By making the loose validation an option, it prevents breaking changes to the existing validation rules. At the same time, it allows developers to choose between a loose check, which simply ensures that the input can be parsed in the specified format, or a strict check, which ensures that the reformatted value after parsing matches the input.

# How to use it
In the past, you would specify the format types as options separated by commas, like "date_format:xxx,xxx,xxx". With this revision, you can now specify "loose" as an option.

```php
public function rules(): array
{
    return [
        'foo' => ['date_format:Y-m-d'], // The usual validation as before
        'bar' => ['date_format:Y-m-d,loose'], // Loose check that only verifies if the input can be parsed
    ];
}
```

# The reason why we have been checking whether the reformatted result matches the input.
DateTime::createFromFormat() often returns quite lax results. Normally, if it cannot parse, DateTime::createFromFormat() returns false, but for example, in the following case, it returns an instance of DateTime instead of false.

```php
$date = DateTime::createFromFormat('Y-m-d H:i:s', '2023-13-14 30:60:70');
var_dump($date);
```

```
object(DateTime)#1 (3) {
  ["date"]=>
  string(26) "2024-01-15 07:01:10.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(16) "Europe/Amsterdam"
}
```

Because of such cases, it was necessary to verify that the value reformatted from the parsed DateTime instance matches the input.

However, such unexpected successful parses can be handled using DateTime::getLastErrors().

```php
$date = DateTime::createFromFormat('Y-m-d H:i:s', '2023-13-14 30:60:70');
var_dump(DateTime::getLastErrors());
```

```
array(4) {
  ["warning_count"]=>
  int(2)
  ["warnings"]=>
  array(1) {
    [19]=>
    string(27) "The parsed date was invalid"
  }
  ["error_count"]=>
  int(0)
  ["errors"]=>
  array(0) {
  }
}
```

Even when DateTime::createFromFormat() does not return false, warnings and errors can be captured using DateTime::getLastErrors(). Therefore, in this pull request, I used this method to ensure a minimum level of inspection accuracy even in the case of loose checks.