### PR TITLE
[10.x] Add havingCount method to Builder class

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2291,6 +2291,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "having count" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string|null  $operator
+     * @param  int|null  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function havingCount($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->havingRaw("COUNT({$this->grammar->wrap($column)}) $operator ?", [$value], $boolean);
+    }
+
+    /**
      * Add an "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column


### PR DESCRIPTION
## Summary

This merge request adds the `havingCount` method to the `Illuminate\Database\Eloquent\Builder` class in the Laravel framework. The `havingCount` method allows for adding a "having count" clause to Eloquent queries, making it easier to perform count-based filtering.

## Changes Made

- Added the `havingCount` method to the `Illuminate\Database\Eloquent\Builder` class.
- The `havingCount` method accepts a column name, optional operator, value, and boolean parameter.
- The method constructs a "having count" clause using the provided parameters and passes it to `havingRaw` for execution.

## Usage Example

```php
$users = User::query()
    ->groupBy('age')
    ->havingCount('age', '>', 3)
    ->get();
```
This example retrieves users who have more than three entries with the same age.