### PR TITLE
Remove `alreadyExists()` overrides in descendants

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -31,18 +31,6 @@ class EventMakeCommand extends GeneratorCommand
     protected $type = 'Event';
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName) ||
-               $this->files->exists($this->getPath($this->qualifyClass($rawName)));
-    }
-
-    /**
      * Get the stub file for the generator.
      *
      * @return string

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -49,17 +49,6 @@ class ExceptionMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($this->rootNamespace().'Exceptions\\'.$rawName);
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -82,17 +82,6 @@ class ListenerMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName);
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace


### PR DESCRIPTION
Remove descendants' `alreadyExists()` overrides as they make no sense or even duplicate code available in `GeneratorCommand::alreadyExists()`.

I ran `make:listener` during the week, implemented it, accidentally ran the artisan command again and artisan still created a new listener - wiping my shiny code.

Looking for `alreadyExists` in `Illuminate\Foundation\Console`, most `GeneratorCommand` descendants seem to rely on `GeneratorCommand::alreadyExists()`, so I thought it best to make these three last ones also rely on the parent's definition.

I don't know how to write tests for these GeneratorCommands, as there currently are no example tests I could copy.