### PR TITLE
[10.x] Add `domain` validation rule and `isDomain` Str

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -491,7 +491,11 @@ class Str
             return false;
         }
 
-        $pattern = '^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+(?:[a-zA-Z]{2,}\.?|[a-zA-Z0-9\-]{2,}\.?)$';
+        $pattern = '
+            ~^
+            (?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+(?:[a-zA-Z]{2,}\.?|[a-zA-Z0-9\-]{2,}\.?)$
+            ~ixu
+        ';
 
         return preg_match($pattern, $value) > 0;
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -480,6 +480,30 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid DOMAIN.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isDomain($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $pattern = '
+            ~^
+            (?:[\pL\pN\pS\-_]+\.)+
+            [\pL\pN\-_]{2,63}+
+            \.?
+            (?:[\pL\pN\-_]{2,63}+)?+
+            $~ixu
+        ';
+
+        return preg_match($pattern, $value) > 0;
+    }
+
+    /**
      * Determine if a given value is a valid UUID.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -491,14 +491,7 @@ class Str
             return false;
         }
 
-        $pattern = '
-            ~^
-            (?:[\pL\pN\pS\-_]+\.)+
-            [\pL\pN\-_]{2,63}+
-            \.?
-            (?:[\pL\pN\-_]{2,63}+)?+
-            $~ixu
-        ';
+        $pattern = '^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+(?:[a-zA-Z]{2,}\.?|[a-zA-Z0-9\-]{2,}\.?)$';
 
         return preg_match($pattern, $value) > 0;
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2310,6 +2310,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid DOMAIN.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateDomain($attribute, $value)
+    {
+        return Str::isDomain($value);
+    }
+
+    /**
      * Validate that an attribute is a valid ULID.
      *
      * @param  string  $attribute


### PR DESCRIPTION
### Description:
This PR adds a new validation rule named 'domain' to Laravel's validation system. The 'domain' rule allows you to validate if a given input is a valid domain name.

### Motivation:
The motivation behind this PR is to provide a convenient way to validate domain names in Laravel applications. By introducing the 'domain' rule, developers can easily ensure that user-provided input conforms to the expected format of a domain name.

### Usage:
```php
Validator::make(['your_domain' => 'laravel.com'], ['your_domain' => ['required', 'domain']);
```
