### PR TITLE
[10.x] add getRedisConnection to ThrottleRequestsWithRedis

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -121,7 +121,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     }
 
     /**
-     * Get Redis Connection.
+     * Get the Redis connection that should be used for throttling.
      *
      * @return \Illuminate\Redis\Connections\Connection
      */

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -121,7 +121,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     }
 
     /**
-     * Get Redis Connection
+     * Get Redis Connection.
      *
      * @return \Illuminate\Redis\Connections\Connection
      */

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -86,7 +86,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
     {
         $limiter = new DurationLimiter(
-            $this->redis, $key, $maxAttempts, $decayMinutes * 60
+            $this->getRedisConnection(), $key, $maxAttempts, $decayMinutes * 60
         );
 
         return tap(! $limiter->acquire(), function () use ($key, $limiter) {
@@ -118,5 +118,15 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function getTimeUntilNextRetry($key)
     {
         return $this->decaysAt[$key] - $this->currentTime();
+    }
+
+    /**
+     * Get Redis Connection
+     *
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    protected function getRedisConnection()
+    {
+        return $this->redis->connection();
     }
 }


### PR DESCRIPTION
### Problem
`\Illuminate\Contracts\Redis\Factory` usually become `\Illuminate\Redis\RedisManager` by DI.
`DurationLimiter` constructor expects `\Illuminate\Redis\Connections\Connection`, not `\Illuminate\Contracts\Redis\Factory`.
It now works because `\Illuminate\Redis\RedisManager` can behave as `\Illuminate\Redis\Connections\Connection` by using default connection.

### Solution
Passing `\Illuminate\Redis\Connections\Connection` to `DurationLimiter` is more prefer.

### Users who get benefits from this
Who wants to use Redis non-default connection for throttle count can override `getRedisConnection` method.


