### PR TITLE
[10.x] fix: route collection should not override routes with same uri but different wheres

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -136,9 +136,9 @@ class RouteListCommand extends Command
     protected function getRouteInformation(Route $route)
     {
         return $this->filterRoute([
-            'domain' => $route->domain(),
+            'domain' => $route->getDomainWithWheres(),
             'method' => implode('|', $route->methods()),
-            'uri' => $route->uri(),
+            'uri' => $route->getUriWithWheres(),
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -856,6 +856,41 @@ class Route
         })->uri;
     }
 
+    public function getDomainWithWheres(): ?string
+    {
+        return $this->replaceWheres($this->domain());
+    }
+
+    public function getUriWithWheres(): ?string
+    {
+        return $this->replaceWheres($this->uri());
+    }
+
+    public function getQualifiedUriWithWheres(): ?string
+    {
+        return $this->replaceWheres($this->getDomain().$this->uri());
+    }
+
+    /**
+     * Inserts the where regex of each parameter in the url.
+     */
+    protected function replaceWheres(?string $uri): ?string
+    {
+        if (empty($uri)) {
+            return $uri;
+        }
+        $search = [];
+        $replace = [];
+        foreach ($this->wheres as $where => $regex) {
+            $search[] = '{'.$where.'}';
+            $replace[] = '{'.$where.':'.$regex.'}';
+            $search[] = '{'.$where.'?}';
+            $replace[] = '{'.$where.'?:'.$regex.'}';
+        }
+
+        return str_replace($search, $replace, $uri);
+    }
+
     /**
      * Get the name of the route instance.
      *

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -59,7 +59,7 @@ class RouteCollection extends AbstractRouteCollection
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->getDomain().$route->uri();
+        $domainAndUri = $route->getQualifiedUriWithWheres();
 
         foreach ($route->methods() as $method) {
             $this->routes[$method][$domainAndUri] = $route;

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -56,6 +56,23 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($routeIndex, $this->routeCollection->getByName('route_name'));
     }
 
+    public function testRouteCollectionAddRouteWithSameParamsButDifferentWheres()
+    {
+        $this->routeCollection->add((new Route('GET', 'foo/{bar}', [
+            'uses' => 'FooController@index',
+            'as' => 'foo_index',
+        ]))->where('bar', 'baz'));
+        $this->routeCollection->add((new Route('GET', 'foo/{bar}', [
+            'uses' => 'FooController@index',
+            'as' => 'foo_index',
+        ]))->where('bar', 'foo'));
+        $this->routeCollection->add((new Route('GET', 'foo/{bar}', [
+            'uses' => 'FooController@index',
+            'as' => 'foo_index',
+        ]))->where('bar', 'baz'));
+        $this->assertCount(2, $this->routeCollection);
+    }
+
     public function testRouteCollectionCanRetrieveByAction()
     {
         $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', $action = [


### PR DESCRIPTION
Consider the following route definition

```php
Route::get('{tenant}', 'BobaFettController@get')->where(['tenant' => 'boba|fett']');
Route::get('{tenant}', 'JackieChanController@get')->where(['tenant' => 'jackie|chan']');
```

While you would expect both those routes to be valid and not overlap each other, currently routes are only stored keyed by their url and doesn't account for the where parameters passed in, this results in the second route overriding the first one

This is even more problematic when the parameters would need to have a fixed name, for model route binding for instance, as working around this involves a lot of hacks 

This PR fixes this issue and also now shows the where condition directly into the parameters of the `route:list` command