### PR TITLE
[10.x] Http Client - Allow modifying base url during retry

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -872,7 +872,7 @@ class PendingRequest
     }
 
     /**
-     * Get the url
+     * Get the url.
      *
      * @param  string  $url
      * @return string


### PR DESCRIPTION
The `retry()` method on a pending request already allows you the modify the pending request, but it currently does not support modifying the base URL during the retry. This is caused by the fact that the url is constructed outside the retry- logic. This PR fixes that.

```php
Http::baseUrl('https://foo.com')
    ->retry(fn ($request) => $request->baseUrl('https://foo.com'))
    ->get('some/path');
```

This is useful in case you have to resend the request to another domain if a certain error response is initially returned. An example is when using Apple's [app store server api](https://developer.apple.com/documentation/appstoreserverapi#3820693): if requesting subscription status on the production environment returns a certain error, then you have to retry on the sandbox environment as you might have the id of subscription that was created in that sandbox environment. Without the changes of this PR, this scenario requires you to write a lot of extra code to make the 2 requests.