### PR TITLE
[10.x] Added a method for getting a lazy collection with relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -854,7 +854,7 @@ class Builder implements BuilderContract
     public function cursorWithRelations()
     {
         return $this->cursor()->map(function ($model) {
-            return array_first($this->eagerLoadRelations([$model]));
+            return $this->eagerLoadRelations([$model])[0];
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -847,6 +847,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a lazy collection for this query with relationships.
+     *
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function cursorWithRelations()
+    {
+        return $this->cursor()->map(function($model) {
+            return array_first($builder->eagerLoadRelations([$model]));
+        });
+    }
+
+    /**
      * Add a generic "order by" clause if the query doesn't already have one.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -854,7 +854,7 @@ class Builder implements BuilderContract
     public function cursorWithRelations()
     {
         return $this->cursor()->map(function ($model) {
-            return array_first($builder->eagerLoadRelations([$model]));
+            return array_first($this->eagerLoadRelations([$model]));
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -853,7 +853,7 @@ class Builder implements BuilderContract
      */
     public function cursorWithRelations()
     {
-        return $this->cursor()->map(function($model) {
+        return $this->cursor()->map(function ($model) {
             return array_first($builder->eagerLoadRelations([$model]));
         });
     }


### PR DESCRIPTION
This improvement will help to get a lazy collection with relationships. As it turned out, a lazy collection does not load relationships. It's confusing. I immediately asked the question how to make a lazy collection load relationships.

I hope this change will help to better understand the framework.
A separate method has been added so as not to cause errors with code support.

```php
// Model user
class User extends Model {
   // relationship
   public function post() {
      return $this->hasOne(Post::class);
   }
}

// Model post
class Post extends Model {}
```

Problem
```php
User::with('post')->cursor()->first();
/*
[
   'id' => 1,
   'name' => 'Admin'
]
*/

User::with('post')->cursorWithRelations()->first();
/*
[
   'id' => 1,
   'name' => 'Admin',
   'post' => [
      'id' => 1
      ....
   ]
]
*/
```

I didn't write a unit test because I use the laravel api. I can create a unit test based on your request. Just write a comment "We need a test".