### PR TITLE
[10.x] Improve typehint for Model::getConnectionResolver()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1821,7 +1821,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the connection resolver instance.
      *
-     * @return \Illuminate\Database\ConnectionResolverInterface
+     * @return \Illuminate\Database\ConnectionResolverInterface|null
      */
     public static function getConnectionResolver()
     {


### PR DESCRIPTION
`static::$resolver` can be null, either before `Model::setConnectionResolver()` is called or after `Model::unsetConnectionResolver()` is called.

Running into an issue with static analysis complaining about this: https://github.com/wintercms/storm/actions/runs/5558377553/jobs/10153396089#step:10:16

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
