### PR TITLE
Fix docblocks, imports and arrow function

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -99,9 +99,9 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     protected function getRouteForMethods($request, array $methods)
     {
         if ($request->isMethod('OPTIONS')) {
-            return (new Route('OPTIONS', $request->path(), function () use ($methods) {
-                return new Response('', 200, ['Allow' => implode(',', $methods)]);
-            }))->bind($request);
+            return (new Route('OPTIONS', $request->path(), fn() =>
+                new Response('', 200, ['Allow' => implode(',', $methods)])
+            ))->bind($request);
         }
 
         $this->requestMethodNotAllowed($request, $methods, $request->method());

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -14,6 +14,7 @@ class RedirectController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Routing\UrlGenerator  $url
      * @return \Illuminate\Http\RedirectResponse
+     * @throws \Illuminate\Routing\Exceptions\UrlGenerationException
      */
     public function __invoke(Request $request, UrlGenerator $url)
     {


### PR DESCRIPTION
This PR addresses two changes in the code. First, it fixes the throws type definition of the RedirectController class. Second, it converts the function from a regular function to an arrow function for a more concise syntax.
