### PR TITLE
[10.x] Added a method for dropping index only if it exists in the given table

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -338,15 +338,13 @@ class Builder
         $indexes = $sm->listTableIndexes($table);
         $index = is_array($index) ? $index : [$index];
 
-        foreach($index as $key)
-        {
+        foreach ($index as $key) {
             if (array_key_exists($key, $indexes)) {
-                $this->table($table, function (Blueprint $blueprint) use($key) {
+                $this->table($table, function (Blueprint $blueprint) use ($key) {
                     $blueprint->dropForeign($key);
                     $blueprint->dropIndex($key);
                 });
             }
-
         }
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -329,23 +329,27 @@ class Builder
      * Drop index from a table schema only if exists.
      *
      * @param  string  $table
-     * @param  string  $index
+     * @param  string|array  $index
      * @return void
      */
     public function dropIndexIfExists($table, $index)
     {
         $sm = $this->getConnection()->getDoctrineSchemaManager();
         $indexes = $sm->listTableIndexes($table);
-        
-        if (array_key_exists($index, $indexes)) { 
-            $this->table($table, function (Blueprint $blueprint) use($index) {
-                $blueprint->dropForeign($index);
-                $blueprint->dropIndex($index);
-            });
+        $index = is_array($index) ? $index : [$index];
+
+        foreach($index as $key)
+        {
+            if (array_key_exists($key, $indexes)) {
+                $this->table($table, function (Blueprint $blueprint) use($key) {
+                    $blueprint->dropForeign($key);
+                    $blueprint->dropIndex($key);
+                });
+            }
+
         }
     }
 
-    
     /**
      * Drop all tables from the database.
      *

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -326,6 +326,27 @@ class Builder
     }
 
     /**
+     * Drop index from a table schema only if exists.
+     *
+     * @param  string  $table
+     * @param  string  $index
+     * @return void
+     */
+    public function dropIndexIfExists($table, $index)
+    {
+        $sm = $this->getConnection()->getDoctrineSchemaManager();
+        $indexes = $sm->listTableIndexes($table);
+        
+        if (array_key_exists($index, $indexes)) { 
+            $this->table($table, function (Blueprint $blueprint) use($index) {
+                $blueprint->dropForeign($index);
+                $blueprint->dropIndex($index);
+            });
+        }
+    }
+
+    
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -21,7 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static void create(string $table, \Closure $callback)
  * @method static void drop(string $table)
  * @method static void dropIfExists(string $table)
- * @method static void dropIndexIfExists(string $table,string $index)
+ * @method static void dropIndexIfExists(string $table, string|array $index)
  * @method static void dropColumns(string $table, string|array $columns)
  * @method static void dropAllTables()
  * @method static void dropAllViews()

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -21,6 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static void create(string $table, \Closure $callback)
  * @method static void drop(string $table)
  * @method static void dropIfExists(string $table)
+ * @method static void dropIndexIfExists(string $table,string $index)
  * @method static void dropColumns(string $table, string|array $columns)
  * @method static void dropAllTables()
  * @method static void dropAllViews()

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -65,7 +65,7 @@ class DatabaseSchemaBuilderTest extends TestCase
 
         $sm->shouldReceive('listTableIndexes')->once()->with('users')->andReturn(['user_foreign' => []]);
 
-        $this->assertNull($builder->dropIndexIfExists('users','user_foreign'));
+        $this->assertNull($builder->dropIndexIfExists('users', 'user_foreign'));
     }
 
     public function testHasTableCorrectlyCallsGrammar()

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -66,7 +66,6 @@ class DatabaseSchemaBuilderTest extends TestCase
         $sm->shouldReceive('listTableIndexes')->once()->with('users')->andReturn(['user_foreign' => []]);
 
         $this->assertNull($builder->dropIndexIfExists('users','user_foreign'));
-
     }
 
     public function testHasTableCorrectlyCallsGrammar()


### PR DESCRIPTION

The provided pull request is a method named **dropIndexIfExists** that allows for dropping an index from a database table if it exists. It takes two parameters: $table, which represents the table name, and $index, which represents the index to be dropped.
This method can be used within **Laravel** migrations or other database-related tasks where you need to drop an index if it exists before making changes to the table structure.
example usage:
`Schema::dropIndexIfExists('editor_invoices','foreign_invoice_id')`
