### PR TITLE
[10.x] Adds Model@saveOrTouch()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1166,6 +1166,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Save the model or touch if there are no changes.
+     *
+     * @param  array  $options
+     * @return bool
+     */
+    public function saveOrTouch(array $options = [])
+    {
+        if (! $this->exists || $this->isDirty()) {
+            return $this->save($options);
+        }
+
+        return $this->touch();
+    }
+
+    /**
      * Perform any actions that are necessary after the model is saved.
      *
      * @param  array  $options


### PR DESCRIPTION
Taking a look at [this issue](https://github.com/spatie/laravel-medialibrary/issues/3282) on spatie's media-library package, I realize that if I call `Model@save()`, I have no way of knowing if an actual DB write is happening based on the return value of `Model@save()`.

```php
$user = User::create(['name' => 'Luke']);
$user->name = 'Luke';
assert(true === $user->save()); // no DB write is actually happening, updated_at timestamp does not change
```

The way around this is to write a check like:
```php
if ($user->exists && (! $user->isDirty())) {
    $user->touch();
}
else {
    $user->save();
}
```

For ease, this PR adds `saveOrTouch()`

```php
$user = User::create(['name' => 'Dries']);
$user->name = 'Dries';
assert(true === $user->saveOrTouch()); // DB write happens, so updated_at is changed
```