### PR TITLE
[10.x] Add force save option

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1126,7 +1126,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // that is already in this database using the current IDs in this "where"
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
-            $saved = $this->isDirty() ?
+            $saved = (($options['force'] ?? false) ?: $this->isDirty()) ?
                 $this->performUpdate($query) : true;
         }
 
@@ -1175,7 +1175,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $this->fireModelEvent('saved', false);
 
-        if ($this->isDirty() && ($options['touch'] ?? true)) {
+        if ((($options['force'] ?? false) ?: $this->isDirty()) && ($options['touch'] ?? true)) {
             $this->touchOwners();
         }
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -144,7 +144,7 @@ class EloquentUpdateTest extends DatabaseTestCase
     public function testSave($counter, $saveOptions, $queries, $updatedTimestamps)
     {
         $model = TestUpdateModel3::create([
-            'counter' => 0
+            'counter' => 0,
         ]);
 
         $updatedAt = $model->updated_at;


### PR DESCRIPTION
(inspired by https://github.com/laravel/framework/pull/47754)

When you set a property on a model which happens to be the same value as the currently known state, there is no query sent to the database since Eloquent sees no changes to the model and therefore skips sending a query to the database.

There are cases however where the current PHP state of the model might not coincide with the actual database value, so you want to be able to forcefully call a save anyway.

```php
$model = MyModel::create(['lights' => 'on']);
// Model is saved with `lights = 'on'`.

// ... imagine extra work here that takes a few seconds.
sleep(5);
// In the meantime, the database value could have actually become `lights = 'off'` by some other call.

// Set lights on again.
$model->lights = 'on';

// We must force the save now because in PHP the model is still known as `'on'` so the model is not dirty.
$model->save(['force' => true]);
```

Alternatively, one could call:
```php
$model->update(['lights' => 'on'], ['force' => true]);
```

This bypasses the `isDirty()` check and therefore executes the query.