### PR TITLE
[10.x] Annotate a more specific type to the return value of `RouteAction::parse`

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -182,7 +182,7 @@ class Route
      * Parse the route action into a standard array.
      *
      * @param  callable|array|null  $action
-     * @return array{uses: callable|string, controller?: string, ...}
+     * @return array{uses: callable|string, controller?: string}
      *
      * @throws \UnexpectedValueException
      */

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -182,7 +182,7 @@ class Route
      * Parse the route action into a standard array.
      *
      * @param  callable|array|null  $action
-     * @return array{uses: callable|string, controller?: string}
+     * @return array{uses: callable|string, controller?: string, ...}
      *
      * @throws \UnexpectedValueException
      */

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -182,7 +182,7 @@ class Route
      * Parse the route action into a standard array.
      *
      * @param  callable|array|null  $action
-     * @return array
+     * @return array{uses: callable|string, controller?: string}
      *
      * @throws \UnexpectedValueException
      */

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -15,7 +15,7 @@ class RouteAction
      *
      * @param  string  $uri
      * @param  mixed  $action
-     * @return array{uses: callable|string, controller?: string}
+     * @return array{uses: callable|string, controller?: string, ...}
      */
     public static function parse($uri, $action)
     {

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -15,7 +15,7 @@ class RouteAction
      *
      * @param  string  $uri
      * @param  mixed  $action
-     * @return array{uses: callable|string, controller?: string, ...}
+     * @return array{uses: callable|string, controller?: string}
      */
     public static function parse($uri, $action)
     {

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -15,7 +15,7 @@ class RouteAction
      *
      * @param  string  $uri
      * @param  mixed  $action
-     * @return array
+     * @return array{uses: callable|string, controller?: string}
      */
     public static function parse($uri, $action)
     {


### PR DESCRIPTION
This pull request gives a more specific type to the return value of `RouteAction::parse`.

`RouteAction::parse` returns an array with `uses`, `controller` and some other keywords as keys. This can be seen by carefully reading the source code, but it is more helpful to code readers if this is explicitly annotated as a type. In fact, I got a little confused the first time I read this part, so I would like to indicate the contents of the array so that later people will not be like me.