### PR TITLE
[10.x] Fix sql server paging problems

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -48,7 +48,7 @@ class SqlServerGrammar extends Grammar
     public function compileSelect(Builder $query)
     {
         // An order by clause is required for SQL Server offset to function...
-        if ($query->offset && empty($query->orders)) {
+        if (($query->offset || $query->limit) && empty($query->orders)) {
             $query->orders[] = ['sql' => '(SELECT 0)'];
         }
 
@@ -264,38 +264,6 @@ class SqlServerGrammar extends Grammar
         $parameter = $this->parameter($having['value']);
 
         return '('.$column.' '.$having['operator'].' '.$parameter.') != 0';
-    }
-
-    /**
-     * Move the order bindings to be after the "select" statement to account for an order by subquery.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return array
-     */
-    protected function sortBindingsForSubqueryOrderBy($query)
-    {
-        return Arr::sort($query->bindings, function ($bindings, $key) {
-            return array_search($key, ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder']);
-        });
-    }
-
-    /**
-     * Compile the limit / offset row constraint for a query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return string
-     */
-    protected function compileRowConstraint($query)
-    {
-        $start = (int) $query->offset + 1;
-
-        if ($query->limit > 0) {
-            $finish = (int) $query->offset + (int) $query->limit;
-
-            return "between {$start} and {$finish}";
-        }
-
-        return ">= {$start}";
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2690,7 +2690,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerExists()
     {
         $builder = $this->getSqlServerBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select top 1 1 [exists] from [users]', [], true)->andReturn([['exists' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select top 1 1 [exists] from [users] order by (SELECT 0)', [], true)->andReturn([['exists' => 1]]);
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);
     }
@@ -3856,7 +3856,7 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take(10);
-        $this->assertSame('select top 10 * from [users]', $builder->toSql());
+        $this->assertSame('select top 10 * from [users] order by (SELECT 0)', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->orderBy('email', 'desc');
@@ -3875,7 +3875,7 @@ SQL;
             return $query->select('created_at')->from('logins')->where('users.name', 'nameBinding')->whereColumn('user_id', 'users.id')->limit(1);
         };
         $builder->select('*')->from('users')->where('email', 'emailBinding')->orderBy($subQuery)->skip(10)->take(10);
-        $this->assertSame('select * from [users] where [email] = ? order by (select top 1 [created_at] from [logins] where [users].[name] = ? and [user_id] = [users].[id]) asc offset 10 rows fetch next 10 rows only', $builder->toSql());
+        $this->assertSame('select * from [users] where [email] = ? order by (select top 1 [created_at] from [logins] where [users].[name] = ? and [user_id] = [users].[id] order by (SELECT 0)) asc offset 10 rows fetch next 10 rows only', $builder->toSql());
         $this->assertEquals(['emailBinding', 'nameBinding'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
I fixed it long ago in this PR: https://github.com/laravel/framework/pull/39863

But now the problem is back since this PR: https://github.com/laravel/framework/pull/44937#issuecomment-1638132702

### Problem
* Page 1 has no offset and there is no explicit filtering
* page 2: has offset and thus has explicit filtering

if column 0 is not identical to the SQL server fragmentation/page order (which is not identical to the primary key order). It can be that items on page 1 are also shown on later pages and visa versa, items are missing that should be on page 1.

### Solution

To also page when there is a limit set, OR an offset set, this way we guarentuee items are not mistakenly sorted wrongly.


### alternative solutions

Always add select 0 to make sure order is always followed, even when there is no limit and offset. Although this is less of na issue.


### Breaking changes

I removed 2 protected methods that were no longer used since #44937.
Since the subset using sql server drivers is very small there is a very, very small change any developer had these methods overwritten or used. even if someone had overwritten them it wouldn't change a thing. and if someone used them, they were probably not valid anymore anyways.