### PR TITLE
[10.x] ShouldBeUnique jobs works incorrect on failed DB transactions

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -59,6 +59,21 @@ class UniqueLock
     }
 
     /**
+     * Check if the lock for the given job is not set.
+     *
+     * @param  mixed  $job
+     * @return bool
+     */
+    public function unlocked($job)
+    {
+        $cache = method_exists($job, 'uniqueVia')
+            ? $job->uniqueVia()
+            : $this->cache;
+
+        return $cache->lock($this->getKey($job))->get(fn() => true);
+    }
+
+    /**
      * Generate the lock key for the given job.
      *
      * @param  mixed  $job

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -70,7 +70,7 @@ class UniqueLock
             ? $job->uniqueVia()
             : $this->cache;
 
-        return $cache->lock($this->getKey($job))->get(fn() => true);
+        return $cache->lock($this->getKey($job))->get(fn () => true);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PendingDispatch
 {
@@ -162,9 +163,19 @@ class PendingDispatch
 
         $uniqueLock = new UniqueLock(Container::getInstance()->make(Cache::class));
 
-        return $this->afterResponse
-            ? $uniqueLock->acquire($this->job)
-            : $uniqueLock->unlocked($this->job);
+        return $this->shouldBeQueued() && ! $this->afterResponse
+            ? $uniqueLock->unlocked($this->job)
+            : $uniqueLock->acquire($this->job);
+    }
+
+    /**
+     * Determine if the job should be queued.
+     *
+     * @return bool
+     */
+    protected function shouldBeQueued()
+    {
+        return $this->job instanceof ShouldQueue;
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -160,8 +160,11 @@ class PendingDispatch
             return true;
         }
 
-        return (new UniqueLock(Container::getInstance()->make(Cache::class)))
-                    ->unlocked($this->job);
+        $uniqueLock = new UniqueLock(Container::getInstance()->make(Cache::class));
+
+        return $this->afterResponse
+            ? $uniqueLock->acquire($this->job)
+            : $uniqueLock->unlocked($this->job);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -161,7 +161,7 @@ class PendingDispatch
         }
 
         return (new UniqueLock(Container::getInstance()->make(Cache::class)))
-                    ->acquire($this->job);
+                    ->unlocked($this->job);
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -357,7 +357,7 @@ abstract class Queue
     }
 
     /**
-     * Determine if the job should be dispatched and job uniqueness conditions met
+     * Determine if the job should be dispatched and job uniqueness conditions met.
      *
      * @param  \Closure|string|object  $job
      * @return bool


### PR DESCRIPTION
If queue afterCommit flag is true and database transaction failed (will be rolled back), then all jobs dispatched with ShouldBeUniqueUntilProcessing interface will get a persistent lock, and you can't dispatch them again at all (because there are no any instruments to clear the locks from redis).

Opened issue: https://github.com/laravel/framework/issues/47761