### PR TITLE
Allow encryption/decryption with custom key (passphrase)

### DIFF
--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -9,22 +9,24 @@ interface Encrypter
      *
      * @param  mixed  $value
      * @param  bool  $serialize
+     * @param  string|null  $key
      * @return string
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
-    public function encrypt($value, $serialize = true);
+    public function encrypt($value, $serialize = true, $key = null);
 
     /**
      * Decrypt the given value.
      *
      * @param  string  $payload
      * @param  bool  $unserialize
+     * @param  string|null  $key
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
-    public function decrypt($payload, $unserialize = true);
+    public function decrypt($payload, $unserialize = true, $key = null);
 
     /**
      * Get the encryption key that the encrypter is currently using.

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -95,15 +95,14 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
-    public function encrypt($value, $serialize = true)
+    public function encrypt($value, $serialize = true, $key = null)
     {
         $iv = random_bytes(openssl_cipher_iv_length(strtolower($this->cipher)));
 
         $value = \openssl_encrypt(
             $serialize ? serialize($value) : $value,
-            strtolower($this->cipher), $this->key, 0, $iv, $tag
+            strtolower($this->cipher), $key ?: $this->key, 0, $iv, $tag
         );
-
         if ($value === false) {
             throw new EncryptException('Could not encrypt the data.');
         }
@@ -146,7 +145,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
-    public function decrypt($payload, $unserialize = true)
+    public function decrypt($payload, $unserialize = true, $key = null)
     {
         $payload = $this->getJsonPayload($payload);
 
@@ -160,7 +159,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
         $decrypted = \openssl_decrypt(
-            $payload['value'], strtolower($this->cipher), $this->key, 0, $iv, $tag ?? ''
+            $payload['value'], strtolower($this->cipher), $key ?: $this->key, 0, $iv, $tag ?? ''
         );
 
         if ($decrypted === false) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -368,9 +368,9 @@ if (! function_exists('decrypt')) {
      * @param  bool  $unserialize
      * @return mixed
      */
-    function decrypt($value, $unserialize = true)
+    function decrypt($value, $unserialize = true, $key = null)
     {
-        return app('encrypter')->decrypt($value, $unserialize);
+        return app('encrypter')->decrypt($value, $unserialize, $key);
     }
 }
 
@@ -413,9 +413,9 @@ if (! function_exists('encrypt')) {
      * @param  bool  $serialize
      * @return string
      */
-    function encrypt($value, $serialize = true)
+    function encrypt($value, $serialize = true, $key = null)
     {
-        return app('encrypter')->encrypt($value, $serialize);
+        return app('encrypter')->encrypt($value, $serialize, $key);
     }
 }
 

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -5,9 +5,9 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static bool supported(string $key, string $cipher)
  * @method static string generateKey(string $cipher)
- * @method static string encrypt(mixed $value, bool $serialize = true)
+ * @method static string encrypt(mixed $value, bool $serialize = true, string $key = null)
  * @method static string encryptString(string $value)
- * @method static mixed decrypt(string $payload, bool $unserialize = true)
+ * @method static mixed decrypt(string $payload, bool $unserialize = true, string $key = null)
  * @method static string decryptString(string $payload)
  * @method static string getKey()
  *

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -117,6 +117,24 @@ class EncrypterTest extends TestCase
         $this->assertNotEmpty($data->mac);
     }
 
+    public function testAllowCustomKey()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('foo',true,'bar');
+
+        $this->assertSame('foo', $e->decrypt($encrypted,true,'bar'));
+
+    }
+
+    public function testThrowExceptionWithDifferentDecryptionKey()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Could not decrypt the data.');
+
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('foo',true,'bar');
+        $e->decrypt($encrypted);
+    }
     public function testDoNoAllowLongerKey()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -126,7 +126,7 @@ class EncrypterTest extends TestCase
 
     }
 
-    public function testThrowExceptionWithDifferentDecryptionKey()
+    public function testThrowExceptionWithDifferentDecryptionKeys()
     {
         $this->expectException(DecryptException::class);
         $this->expectExceptionMessage('Could not decrypt the data.');


### PR DESCRIPTION
### What is the proposal?
 - allowing the encryption/decryption functions with a custom key as a passphrase instead of the default `APP_ENV` key
 
 ### How is this proposal beneficial?
 - sometimes, you may want to encrypt and decrypt some data with a custom key (passphrase), this pr allows you to achieve so, while keeping on the default behavior.
 - for more info, please read this [discussion](https://github.com/laravel/framework/discussions/47686) 
 
 ### Usage
- in addition to the default way, you can now pass custom key (passphrase) to the encrypter functions 
```php
     $e = new Encrypter(str_repeat('a', 16));
     $encrypted = $e->encrypt(value: 'foo', key: 'bar');
     $decrypted = $e->decrypt('foo', 'true', 'bar');
```
- you can also use the helpers
```php
    $encrypted = encrypt(value: 'foo', key: 'bar');
    $decrypted = decrypt(value: 'foo', key: 'bar');
```

- or you can use the Crypt facade
```php
$encrypted = Crypt::encrypt(value: 'foo', key: 'bar');
$decrypted = Crypt::decrypt(payload: 'foo', key: 'bar');
```



