### PR TITLE
[10.x] remove `function_exists` from Illuminate\Events\functions.php

### DIFF
--- a/src/Illuminate/Events/functions.php
+++ b/src/Illuminate/Events/functions.php
@@ -4,15 +4,13 @@ namespace Illuminate\Events;
 
 use Closure;
 
-if (! function_exists('Illuminate\Events\queueable')) {
-    /**
-     * Create a new queued Closure event listener.
-     *
-     * @param  \Closure  $closure
-     * @return \Illuminate\Events\QueuedClosure
-     */
-    function queueable(Closure $closure)
-    {
-        return new QueuedClosure($closure);
-    }
+/**
+ * Create a new queued Closure event listener.
+ *
+ * @param  \Closure  $closure
+ * @return \Illuminate\Events\QueuedClosure
+ */
+function queueable(Closure $closure)
+{
+    return new QueuedClosure($closure);
 }


### PR DESCRIPTION
`function_exists` check is not necessary for a namespaced function. Since the `queueable` function is defined within the Illuminate\Events namespace, it will not conflict with any other functions outside of that namespace.