### PR TITLE
[10.x] Support inline disk for scoped driver

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -284,7 +284,7 @@ class FilesystemManager implements FactoryContract
         }
 
         return $this->build(tap(
-            $this->getConfig($config['disk']),
+            is_string($config['disk']) ? $this->getConfig($config['disk']) : $config['disk'],
             fn (&$parent) => $parent['prefix'] = $config['prefix']
         ));
     }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -97,4 +97,27 @@ class FilesystemManagerTest extends TestCase
             rmdir(__DIR__.'/../../to-be-scoped');
         }
     }
+
+    public function testCanBuildInlineScopedDisks()
+    {
+        try {
+            $filesystem = new FilesystemManager(new Application);
+
+            $local = $filesystem->disk('local');
+            $scoped = $filesystem->build([
+                'driver' => 'scoped',
+                'disk' => [
+                    'driver' => 'local',
+                    'root' => 'to-be-scoped',
+                ],
+                'prefix' => 'path-prefix',
+            ]);
+
+            $scoped->put('dirname/filename.txt', 'file content');
+            $this->assertEquals('file content', $local->get('path-prefix/dirname/filename.txt'));
+            $local->deleteDirectory('path-prefix');
+        } finally {
+            rmdir(__DIR__.'/../../to-be-scoped');
+        }
+    }
 }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -103,7 +103,6 @@ class FilesystemManagerTest extends TestCase
         try {
             $filesystem = new FilesystemManager(new Application);
 
-            $local = $filesystem->disk('local');
             $scoped = $filesystem->build([
                 'driver' => 'scoped',
                 'disk' => [
@@ -114,9 +113,12 @@ class FilesystemManagerTest extends TestCase
             ]);
 
             $scoped->put('dirname/filename.txt', 'file content');
-            $this->assertEquals('file content', $local->get('path-prefix/dirname/filename.txt'));
-            $local->deleteDirectory('path-prefix');
+            $this->assertTrue(is_dir(__DIR__ . '/../../to-be-scoped/path-prefix'));
+            $this->assertEquals(file_get_contents(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt'), 'file content');
         } finally {
+            unlink(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt');
+            rmdir(__DIR__.'/../../to-be-scoped/path-prefix/dirname');
+            rmdir(__DIR__.'/../../to-be-scoped/path-prefix');
             rmdir(__DIR__.'/../../to-be-scoped');
         }
     }


### PR DESCRIPTION
Currently, if you want to use the `scoped` disk driver, there is a requirement to have a separate disk that is unscoped.

If you want to make all of your storage writes in a scoped manner (for example, to customer specific directories), then this requires you to have another `disk` that is configured, that you don't want to ever actually use directly.

There is potential for a developer to use the disk inadvertently, or for you to have to mark it as 'hidden' in some way, such as prefixing with an underscore, or similar.

This pull request allows you to _optionally_ declare your disk inline in the scoped driver, so that you don't need to have this additional storage disk, if you only ever want to interact with the scoped driver itself.
