### PR TITLE
[10.x] Fix `Str::replace` return type

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -956,7 +956,7 @@ class Str
      * @param  string|iterable<string>  $replace
      * @param  string|iterable<string>  $subject
      * @param  bool  $caseSensitive
-     * @return string
+     * @return array|string|string[]
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -956,7 +956,7 @@ class Str
      * @param  string|iterable<string>  $replace
      * @param  string|iterable<string>  $subject
      * @param  bool  $caseSensitive
-     * @return array|string|string[]
+     * @return string|string[]
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {


### PR DESCRIPTION
The `str_replace` or `str_ireplace` functions return `array|string|string[]`, but currently Laravel only string.