### PR TITLE
[9.x] Fix TestResponse::assertContent() compatibility with Symfony's responses

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -492,7 +492,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertContent($value)
     {
-        PHPUnit::assertSame($value, $this->content());
+        PHPUnit::assertSame($value, $this->getContent());
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TestResponseTest extends TestCase
@@ -233,6 +234,10 @@ class TestResponseTest extends TestCase
         } catch (AssertionFailedError $e) {
             $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
         }
+
+        $response = TestResponse::fromBaseResponse(new SymfonyResponse('expected response data'));
+
+        $response->assertContent('expected response data');
     }
 
     public function testAssertStreamedContent()


### PR DESCRIPTION
Despite `TestResponse`'s PHPDoc, the encapsulated base response can be a Symfony response. Nothing prevents it and we even allow it (see `assertStreamedContent()` for example) and everything works well with it.

The only assert method that is broken is `assertContent()` because `$this->content()` is used instead of `$this->getContent()`. Let's fix that?!