### PR TITLE
[10.x] Fix mutators for fields with integers in name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -140,7 +140,7 @@ trait HasAttributes
     public static $snakeAttributes = true;
 
     /**
-     * List of attributes to force mutations
+     * List of attributes to force mutations.
      *
      * @var array
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -140,6 +140,13 @@ trait HasAttributes
     public static $snakeAttributes = true;
 
     /**
+     * List of attributes to force mutations
+     *
+     * @var array
+     */
+    public static $forceMutateAttributes = [];
+
+    /**
      * The cache of the mutated attributes for each class.
      *
      * @var array
@@ -2196,13 +2203,13 @@ trait HasAttributes
             collect($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance))
                     ->mapWithKeys(function ($match) {
                         return [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true];
-                    })->all();
+                    })->merge(static::$forceMutateAttributes)->all();
 
         static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))
                 ->merge($attributeMutatorMethods)
                 ->map(function ($match) {
                     return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
-                })->all();
+                })->merge(static::$forceMutateAttributes)->all();
     }
 
     /**


### PR DESCRIPTION
# Problem
Imagine, you have field in database like `image_404` and mutator `getImage404Attribute`. 

If you call field like `$model->image_404` - all fine, mutator works.

But if you try to call `$model->toArray()` - mutator will not work because reflection return wrong field name (`getImage404Attribute` -> `Image404` -> `Str::snake('Image404')` -> `image404`)

# Result
This solution is naive and look like a crutch, but i spent a few days and could not figure out how to solve this another way.

All other options require to get model fields, but this cannot be done in `static` context - that buries all optimization with `$mutatorCache`

I would be grateful for criticism and possible solutions. Thanks.

PS: field names like `image_404` - horrible, but legacy is legacy. 