### PR TITLE
[10.x] Add Collection::enforce() method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -322,7 +322,7 @@ trait EnumeratesValues
      *
      * @throws \UnexpectedValueException
      */
-    public function enforce($type)
+    public function ensure($type)
     {
         return $this->each(function ($item) use ($type) {
             $itemType = get_debug_type($item);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -324,7 +324,7 @@ trait EnumeratesValues
      */
     public function enforce($type)
     {
-        return $this->each(function($item) use ($type) {
+        return $this->each(function ($item) use ($type) {
             $itemType = get_debug_type($item);
 
             if ($itemType !== $type) {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -317,8 +317,7 @@ trait EnumeratesValues
      *
      * @template TEnforceIntoValue
      *
-     * @param  string|class-string<TEnforceIntoValue>  $type
-     *
+     * @param  class-string<TEnforceIntoValue>  $type
      * @return static<mixed, TEnforceIntoValue>
      *
      * @throws \UnexpectedValueException

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -313,6 +313,28 @@ trait EnumeratesValues
     }
 
     /**
+     * Ensure that every item in the collection is of the expected type.
+     *
+     * @template TEnforceIntoValue
+     *
+     * @param  string|class-string<TEnforceIntoValue>  $type
+     *
+     * @return static<mixed, TEnforceIntoValue>
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function enforce($type)
+    {
+        return $this->each(function($item) use ($type) {
+            $itemType = get_debug_type($item);
+
+            if ($itemType !== $type) {
+                throw new UnexpectedValueException("Collection should only include '{$type}' items, but '{$itemType}' found.");
+            }
+        });
+    }
+
+    /**
      * Determine if the collection is not empty.
      *
      * @return bool

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5598,17 +5598,17 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testEnforce($collection)
+    public function testEnsure($collection)
     {
         $data = $collection::make([1, 2, 3]);
 
-        $data->enforce('int');
+        $data->ensure('int');
 
         $data = $collection::make([1, 2, 3, 'foo']);
 
         $this->expectException(UnexpectedValueException::class);
 
-        $data->enforce('int');
+        $data->ensure('int');
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5580,6 +5580,22 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEnforce($collection)
+    {
+        $data = $collection::make([1, 2, 3]);
+
+        $data->enforce('int');
+
+        $data = $collection::make([1, 2, 3, 'foo']);
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $data->enforce('int');
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array


### PR DESCRIPTION
This adds a new `Collection::enforce()` method that enforces the type of all items in the collection (and also applies type annotations). This allows for the following code:

```php
// $user is guaranteed to be a User or null
$user = collect($users)
  ->enforce(User::class)
  ->first();
```

It also means that for developers who use an IDE that parses type annotations, calling `enforce` will also enable code intelligence:

<img width="657" alt="image" src="https://github.com/laravel/framework/assets/21592/a0916ecc-1975-49e3-85d5-fb2e5eda05fe">
