### PR TITLE
[10.x] Adding Minutes Option in Some Frequencies

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -244,20 +244,18 @@ trait ManagesFrequencies
      */
     public function hourly()
     {
-        return $this->spliceIntoPosition(1, 0);
+        return $this->repeatHour(0, '*');
     }
 
     /**
      * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  array|int  $offset
+     * @param  array|string|int  $minutes
      * @return $this
      */
-    public function hourlyAt($offset)
+    public function hourlyAt($minutes)
     {
-        $offset = is_array($offset) ? implode(',', $offset) : $offset;
-
-        return $this->spliceIntoPosition(1, $offset);
+        return $this->repeatHour($minutes, '*');
     }
 
     /**
@@ -265,9 +263,9 @@ trait ManagesFrequencies
      *
      * @return $this
      */
-    public function everyOddHour()
+    public function everyOddHour($minutes)
     {
-        return $this->spliceIntoPosition(1, 0)->spliceIntoPosition(2, '1-23/2');
+        return $this->repeatHour($minutes, '1-23/2');
     }
 
     /**
@@ -275,10 +273,9 @@ trait ManagesFrequencies
      *
      * @return $this
      */
-    public function everyTwoHours()
+    public function everyTwoHours($minutes)
     {
-        return $this->spliceIntoPosition(1, 0)
-                    ->spliceIntoPosition(2, '*/2');
+        return $this->repeatHour($minutes, '*/2');
     }
 
     /**
@@ -286,10 +283,9 @@ trait ManagesFrequencies
      *
      * @return $this
      */
-    public function everyThreeHours()
+    public function everyThreeHours($minutes)
     {
-        return $this->spliceIntoPosition(1, 0)
-                    ->spliceIntoPosition(2, '*/3');
+        return $this->repeatHour($minutes, '*/3');
     }
 
     /**
@@ -297,10 +293,9 @@ trait ManagesFrequencies
      *
      * @return $this
      */
-    public function everyFourHours()
+    public function everyFourHours($minutes)
     {
-        return $this->spliceIntoPosition(1, 0)
-                    ->spliceIntoPosition(2, '*/4');
+        return $this->repeatHour($minutes, '*/4');
     }
 
     /**
@@ -308,10 +303,9 @@ trait ManagesFrequencies
      *
      * @return $this
      */
-    public function everySixHours()
+    public function everySixHours($minutes)
     {
-        return $this->spliceIntoPosition(1, 0)
-                    ->spliceIntoPosition(2, '*/6');
+        return $this->repeatHour($minutes, '*/6');
     }
 
     /**
@@ -321,8 +315,7 @@ trait ManagesFrequencies
      */
     public function daily()
     {
-        return $this->spliceIntoPosition(1, 0)
-                    ->spliceIntoPosition(2, 0);
+        return $this->repeatHour(0, 0);
     }
 
     /**
@@ -346,8 +339,7 @@ trait ManagesFrequencies
     {
         $segments = explode(':', $time);
 
-        return $this->spliceIntoPosition(2, (int) $segments[0])
-                    ->spliceIntoPosition(1, count($segments) === 2 ? (int) $segments[1] : '0');
+        return $this->repeatHour((int) data_get($segments, '1', '0'), (int) $segments[0]);
     }
 
     /**
@@ -374,7 +366,22 @@ trait ManagesFrequencies
     {
         $hours = $first.','.$second;
 
-        return $this->spliceIntoPosition(1, $offset)
+        return $this->repeatHour($offset, $hours);
+    }
+
+    /**
+     * Schedule the event to run multiple times per hour or multiples hours.
+     *
+     * @param  array|string|int  $minutes
+     * @param  array|string|int  $hours
+     * @return $this
+     */
+    protected function repeatHour($minutes, $hours)
+    {
+        $hours = is_array($hours) ? implode(',', $hours) : $hours;
+        $minutes = is_array($minutes) ? implode(',', $minutes) : $minutes;
+
+        return $this->spliceIntoPosition(1, $minutes)
                     ->spliceIntoPosition(2, $hours);
     }
 

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -261,6 +261,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every odd hour.
      *
+     * @param  array|string|int  $minutes
      * @return $this
      */
     public function everyOddHour($minutes)
@@ -271,6 +272,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every two hours.
      *
+     * @param  array|string|int  $minutes
      * @return $this
      */
     public function everyTwoHours($minutes)
@@ -281,6 +283,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every three hours.
      *
+     * @param  array|string|int  $minutes
      * @return $this
      */
     public function everyThreeHours($minutes)
@@ -291,6 +294,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every four hours.
      *
+     * @param  array|string|int  $minutes
      * @return $this
      */
     public function everyFourHours($minutes)
@@ -301,6 +305,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every six hours.
      *
+     * @param  array|string|int  $minutes
      * @return $this
      */
     public function everySixHours($minutes)

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -264,7 +264,7 @@ trait ManagesFrequencies
      * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyOddHour($offset)
+    public function everyOddHour($offset = 0)
     {
         return $this->hourBasedSchedule($offset, '1-23/2');
     }
@@ -275,7 +275,7 @@ trait ManagesFrequencies
      * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyTwoHours($offset)
+    public function everyTwoHours($offset = 0)
     {
         return $this->hourBasedSchedule($offset, '*/2');
     }
@@ -286,7 +286,7 @@ trait ManagesFrequencies
      * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyThreeHours($offset)
+    public function everyThreeHours($offset = 0)
     {
         return $this->hourBasedSchedule($offset, '*/3');
     }
@@ -297,7 +297,7 @@ trait ManagesFrequencies
      * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyFourHours($offset)
+    public function everyFourHours($offset = 0)
     {
         return $this->hourBasedSchedule($offset, '*/4');
     }
@@ -308,7 +308,7 @@ trait ManagesFrequencies
      * @param  array|string|int  $offset
      * @return $this
      */
-    public function everySixHours($offset)
+    public function everySixHours($offset = 0)
     {
         return $this->hourBasedSchedule($offset, '*/6');
     }

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -244,7 +244,7 @@ trait ManagesFrequencies
      */
     public function hourly()
     {
-        return $this->hourBasedSchedule(0, '*');
+        return $this->spliceIntoPosition(1, 0);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -244,73 +244,73 @@ trait ManagesFrequencies
      */
     public function hourly()
     {
-        return $this->repeatHour(0, '*');
+        return $this->hourBasedSchedule(0, '*');
     }
 
     /**
      * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  array|string|int  $minutes
+     * @param  array|string|int  $offset
      * @return $this
      */
-    public function hourlyAt($minutes)
+    public function hourlyAt($offset)
     {
-        return $this->repeatHour($minutes, '*');
+        return $this->hourBasedSchedule($offset, '*');
     }
 
     /**
      * Schedule the event to run every odd hour.
      *
-     * @param  array|string|int  $minutes
+     * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyOddHour($minutes)
+    public function everyOddHour($offset)
     {
-        return $this->repeatHour($minutes, '1-23/2');
+        return $this->hourBasedSchedule($offset, '1-23/2');
     }
 
     /**
      * Schedule the event to run every two hours.
      *
-     * @param  array|string|int  $minutes
+     * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyTwoHours($minutes)
+    public function everyTwoHours($offset)
     {
-        return $this->repeatHour($minutes, '*/2');
+        return $this->hourBasedSchedule($offset, '*/2');
     }
 
     /**
      * Schedule the event to run every three hours.
      *
-     * @param  array|string|int  $minutes
+     * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyThreeHours($minutes)
+    public function everyThreeHours($offset)
     {
-        return $this->repeatHour($minutes, '*/3');
+        return $this->hourBasedSchedule($offset, '*/3');
     }
 
     /**
      * Schedule the event to run every four hours.
      *
-     * @param  array|string|int  $minutes
+     * @param  array|string|int  $offset
      * @return $this
      */
-    public function everyFourHours($minutes)
+    public function everyFourHours($offset)
     {
-        return $this->repeatHour($minutes, '*/4');
+        return $this->hourBasedSchedule($offset, '*/4');
     }
 
     /**
      * Schedule the event to run every six hours.
      *
-     * @param  array|string|int  $minutes
+     * @param  array|string|int  $offset
      * @return $this
      */
-    public function everySixHours($minutes)
+    public function everySixHours($offset)
     {
-        return $this->repeatHour($minutes, '*/6');
+        return $this->hourBasedSchedule($offset, '*/6');
     }
 
     /**
@@ -320,7 +320,7 @@ trait ManagesFrequencies
      */
     public function daily()
     {
-        return $this->repeatHour(0, 0);
+        return $this->hourBasedSchedule(0, 0);
     }
 
     /**
@@ -344,7 +344,10 @@ trait ManagesFrequencies
     {
         $segments = explode(':', $time);
 
-        return $this->repeatHour((int) data_get($segments, '1', '0'), (int) $segments[0]);
+        return $this->hourBasedSchedule(
+            count($segments) === 2 ? (int) $segments[1] : '0',
+            (int) $segments[0]
+        );
     }
 
     /**
@@ -371,20 +374,21 @@ trait ManagesFrequencies
     {
         $hours = $first.','.$second;
 
-        return $this->repeatHour($offset, $hours);
+        return $this->hourBasedSchedule($offset, $hours);
     }
 
     /**
-     * Schedule the event to run multiple times per hour or multiples hours.
+     * Schedule the event to run at the given minutes and hours.
      *
      * @param  array|string|int  $minutes
      * @param  array|string|int  $hours
      * @return $this
      */
-    protected function repeatHour($minutes, $hours)
+    protected function hourBasedSchedule($minutes, $hours)
     {
-        $hours = is_array($hours) ? implode(',', $hours) : $hours;
         $minutes = is_array($minutes) ? implode(',', $minutes) : $minutes;
+
+        $hours = is_array($hours) ? implode(',', $hours) : $hours;
 
         return $this->spliceIntoPosition(1, $minutes)
                     ->spliceIntoPosition(2, $hours);

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -74,6 +74,7 @@ class FrequencyTest extends TestCase
     {
         $this->assertSame('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
         $this->assertSame('37 * * * *', $this->event->hourlyAt(37)->getExpression());
+        $this->assertSame('*/10 * * * *', $this->event->hourlyAt('*/10')->getExpression());
         $this->assertSame('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
@@ -90,6 +91,12 @@ class FrequencyTest extends TestCase
         $this->assertSame('37 */3 * * *', $this->event->everyThreeHours(37)->getExpression());
         $this->assertSame('37 */4 * * *', $this->event->everyFourHours(37)->getExpression());
         $this->assertSame('37 */6 * * *', $this->event->everySixHours(37)->getExpression());
+
+        $this->assertSame('*/10 1-23/2 * * *', $this->event->everyOddHour('*/10')->getExpression());
+        $this->assertSame('*/10 */2 * * *', $this->event->everyTwoHours('*/10')->getExpression());
+        $this->assertSame('*/10 */3 * * *', $this->event->everyThreeHours('*/10')->getExpression());
+        $this->assertSame('*/10 */4 * * *', $this->event->everyFourHours('*/10')->getExpression());
+        $this->assertSame('*/10 */6 * * *', $this->event->everySixHours('*/10')->getExpression());
 
         $this->assertSame('15,30,45 1-23/2 * * *', $this->event->everyOddHour([15, 30, 45])->getExpression());
         $this->assertSame('15,30,45 */2 * * *', $this->event->everyTwoHours([15, 30, 45])->getExpression());

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -84,6 +84,18 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 */3 * * *', $this->event->everyThreeHours()->getExpression());
         $this->assertSame('0 */4 * * *', $this->event->everyFourHours()->getExpression());
         $this->assertSame('0 */6 * * *', $this->event->everySixHours()->getExpression());
+
+        $this->assertSame('37 1-23/2 * * *', $this->event->everyOddHour(37)->getExpression());
+        $this->assertSame('37 */2 * * *', $this->event->everyTwoHours(37)->getExpression());
+        $this->assertSame('37 */3 * * *', $this->event->everyThreeHours(37)->getExpression());
+        $this->assertSame('37 */4 * * *', $this->event->everyFourHours(37)->getExpression());
+        $this->assertSame('37 */6 * * *', $this->event->everySixHours(37)->getExpression());
+
+        $this->assertSame('15,30,45 1-23/2 * * *', $this->event->everyOddHour([15, 30, 45])->getExpression());
+        $this->assertSame('15,30,45 */2 * * *', $this->event->everyTwoHours([15, 30, 45])->getExpression());
+        $this->assertSame('15,30,45 */3 * * *', $this->event->everyThreeHours([15, 30, 45])->getExpression());
+        $this->assertSame('15,30,45 */4 * * *', $this->event->everyFourHours([15, 30, 45])->getExpression());
+        $this->assertSame('15,30,45 */6 * * *', $this->event->everySixHours([15, 30, 45])->getExpression());
     }
 
     public function testMonthly()


### PR DESCRIPTION
Adding the minutes option in some frequencies, example:

```
$schedule->command('xxxxxx')->everyOddHour(17);
$schedule->command('xxxxxx')->everyOddHour('*/10');
$schedule->command('xxxxxx')->everyOddHour([15, 30, 45]);

$schedule->command('xxxxxx')->everyTwoHours(17);
$schedule->command('xxxxxx')->everyTwoHours('*/10');
$schedule->command('xxxxxx')->everyTwoHours([15, 30, 45]);

$schedule->command('xxxxxx')->everyThreeHours(17);
$schedule->command('xxxxxx')->everyThreeHours('*/10');
$schedule->command('xxxxxx')->everyThreeHours([15, 30, 45]);

$schedule->command('xxxxxx')->everyFourHours(17);
$schedule->command('xxxxxx')->everyFourHours('*/10');
$schedule->command('xxxxxx')->everyFourHours([15, 30, 45]);

$schedule->command('xxxxxx')->everySixHours(17);
$schedule->command('xxxxxx')->everySixHours('*/10');
$schedule->command('xxxxxx')->everySixHours([15, 30, 45]);
```