### PR TITLE
[10.x] Add TrustHosts::onlyApplicationUrl() method

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -60,6 +60,18 @@ abstract class TrustHosts
     }
 
     /**
+     * Get a regular expression matching the application URL.
+     *
+     * @return string|null
+     */
+    protected function onlyApplicationUrl()
+    {
+        if ($host = parse_url($this->app['config']->get('app.url'), PHP_URL_HOST)) {
+            return '^'.preg_quote($host).'$';
+        }
+    }
+
+    /**
      * Get a regular expression matching the application URL and all of its subdomains.
      *
      * @return string|null


### PR DESCRIPTION
Most of our apps should only be accessible from the application URL. To my surprise the TrustHosts middleware only has a helper for all subdomains, but not one for only the application URL. So this introduces just that exact method.