### PR TITLE
[10.x] Allow descending indexes in migrations 

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1679,7 +1679,13 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
+        $columnized = implode('_', array_map(
+            static fn ($key, $value) => is_string($key) ? $key : $value,
+            array_keys($columns),
+            $columns,
+        ));
+
+        $index = strtolower($this->prefix.$this->table.'_'.$columnized.'_'.$type);
 
         return str_replace(['-', '.'], '_', $index);
     }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -298,6 +298,11 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Convert an array into a delimited string.
+     * Given array can be one of the following.
+     * - List of column names
+     * - Assoc array with column names as key and sort direction as value
+     *
      * @param  array $columns
      * @return string
      */

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -301,16 +301,16 @@ abstract class Grammar extends BaseGrammar
      * Convert an array into a delimited string.
      * Given array can be one of the following.
      * - List of column names
-     * - Assoc array with column names as key and sort direction as value
+     * - Assoc array with column names as key and sort direction as value.
      *
-     * @param  array $columns
+     * @param  array  $columns
      * @return string
      */
     protected function columnizeIndexKeys(array $columns): string
     {
         foreach ($columns as $column => $order) {
             $expressions[] = is_string($column)
-                ? $this->wrap($column) . ' ' . $order
+                ? $this->wrap($column).' '.$order
                 : $this->wrap($order);
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -298,6 +298,21 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * @param  array $columns
+     * @return string
+     */
+    protected function columnizeIndexKeys(array $columns): string
+    {
+        foreach ($columns as $column => $order) {
+            $expressions[] = is_string($column)
+                ? $this->wrap($column) . ' ' . $order
+                : $this->wrap($order);
+        }
+
+        return implode(', ', $expressions);
+    }
+
+    /**
      * Format a value so that it can be used in "default" clauses.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use RuntimeException;
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use RuntimeException;
 
@@ -338,7 +339,7 @@ class MySqlGrammar extends Grammar
             $type,
             $this->wrap($command->index),
             $command->algorithm ? ' using '.$command->algorithm : '',
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -220,7 +220,7 @@ class PostgresGrammar extends Grammar
         $sql = sprintf('alter table %s add constraint %s unique (%s)',
             $this->wrapTable($blueprint),
             $this->wrap($command->index),
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
 
         if (! is_null($command->deferrable)) {

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -247,7 +247,7 @@ class PostgresGrammar extends Grammar
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -176,7 +176,7 @@ class SQLiteGrammar extends Grammar
         return sprintf('create unique index %s on %s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
     }
 
@@ -192,7 +192,7 @@ class SQLiteGrammar extends Grammar
         return sprintf('create index %s on %s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -199,7 +199,7 @@ class SqlServerGrammar extends Grammar
         return sprintf('create unique index %s on %s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
     }
 
@@ -215,7 +215,7 @@ class SqlServerGrammar extends Grammar
         return sprintf('create index %s on %s (%s)',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnizeIndexKeys($command->columns)
         );
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -258,6 +258,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyWithDirection()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->unique(['foo' => 'desc'], 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add constraint "bar" unique ("foo" desc)', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint('users');
@@ -276,6 +286,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexWithDirection()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar' => 'desc'], 'baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar" desc)', $statements[0]);
     }
 
     public function testAddingFulltextIndex()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -213,6 +213,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyWithDirection()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->unique(['foo' => 'desc'], 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "bar" on "users" ("foo" desc)', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint('users');
@@ -221,6 +231,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexWithDirection()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar' => 'desc'], 'baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar" desc)', $statements[0]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -35,7 +35,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
     public function testIndexDefaultNames()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->unique(['foo', 'bar']);
+        $blueprint->unique(['foo', 'bar' => 'desc']);
         $commands = $blueprint->getCommands();
         $this->assertSame('users_foo_bar_unique', $commands[0]->index);
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -258,6 +258,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyWithDirection()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->unique(['foo' => 'desc'], 'bar');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "bar" on "users" ("foo" desc)', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint('users');
@@ -266,6 +276,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexWithDirection()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar' => 'desc'], 'baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar" desc)', $statements[0]);
     }
 
     public function testAddingSpatialIndex()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is an attempt to implement https://github.com/laravel/ideas/issues/2314.

Descending indexes are useful for speeding up queries on multi-column indexes (please checkout @tpetry's [article](https://sqlfordevs.com/descending-index) for more information).

Descending index is supported on all databases Laravel supports by default, but there was no way to specify it using migrations.

This is an attempt to make it possible to specify descending indexes through migrations (without using `DB::raw(...)`).

# Before

```php
$table->index(['category', DB::raw('created_at desc')], 'my_index');
```

# After

```php
$table->index(['category', 'created_at' => 'desc']);
```

# Breaking changes

If people were passing associative arrays to `$table->index(...)` in the current implementation, that would break. I figured no one writes that way so this is targeted at 10.x but if this is a concern, I will switch the target to 11.x.

# Limitations

MySQL started supporting descending indexes since 8.0.
Versions before it simply ignores the ordering clause.
