### PR TITLE
[10.x] Resolve multiple closure-based scheduled commands in schedule:test

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -32,55 +32,77 @@ class ScheduleTestCommand extends Command
     public function handle(Schedule $schedule)
     {
         $phpBinary = Application::phpBinary();
-
         $commands = $schedule->events();
-
         $commandNames = [];
 
         foreach ($commands as $command) {
-            $commandNames[] = $command->command ?? $command->getSummaryForDisplay();
+            $commandName = $command->command ?? $command->getSummaryForDisplay();
+
+            $suffix = '';
+
+            if (in_array($commandName, $commandNames)) {
+                $suffix = ' (' . count(array_filter($commandNames, fn($command) => $command === $commandName)) . ')';
+            }
+
+            $commandNames[] = $commandName . $suffix;
         }
 
         if (empty($commandNames)) {
             return $this->components->info('No scheduled commands have been defined.');
         }
 
-        if (! empty($name = $this->option('name'))) {
+        if (!empty($name = $this->option('name'))) {
             $commandBinary = $phpBinary.' '.Application::artisanBinary();
-
-            $matches = array_filter($commandNames, function ($commandName) use ($commandBinary, $name) {
-                return trim(str_replace($commandBinary, '', $commandName)) === $name;
+            $matches = array_filter($commands, function ($command) use ($commandBinary, $name) {
+                return trim(str_replace($commandBinary, '', $command->getSummaryForDisplay())) === $name;
             });
 
-            if (count($matches) !== 1) {
-                $this->components->info('No matching scheduled command found.');
+            if (count($matches) > 0) {
+                foreach ($matches as $match) {
+                    $this->runSingleTask($match, $commandBinary);
+                }
 
                 return;
+            } else {
+                $this->components->info('No matching scheduled command found.');
+                return;
             }
-
-            $index = key($matches);
         } else {
             $index = array_search($this->components->choice('Which command would you like to run?', $commandNames), $commandNames);
+            $this->runSingleTask($commands[$index], $phpBinary);
         }
 
-        $event = $commands[$index];
+        $this->newLine();
+    }
 
-        $summary = $event->getSummaryForDisplay();
+    /**
+     * Runs a single task.
+     *
+     * This function is responsible for the execution of a single task.
+     * It prepares the description of the task, executes it and displays a summary.
+     *
+     * @param \Illuminate\Console\Scheduling\Event $task
+     * @param string $phpBinary
+     * @return void
+     */
+    protected function runSingleTask(\Illuminate\Console\Scheduling\Event $task, string $phpBinary)
+    {
+        $summary = $task->getSummaryForDisplay();
 
-        $command = $event instanceof CallbackEvent
+        $command = $task instanceof CallbackEvent
             ? $summary
-            : trim(str_replace($phpBinary, '', $event->command));
+            : trim(str_replace($phpBinary, '', $task->command));
 
         $description = sprintf(
             'Running [%s]%s',
             $command,
-            $event->runInBackground ? ' in background' : '',
+            $task->runInBackground ? ' in background' : '',
         );
 
-        $this->components->task($description, fn () => $event->run($this->laravel));
+        $this->components->task($description, fn () => $task->run($this->laravel));
 
-        if (! $event instanceof CallbackEvent) {
-            $this->components->bulletList([$event->getSummaryForDisplay()]);
+        if (!$task instanceof CallbackEvent) {
+            $this->components->bulletList([$task->getSummaryForDisplay()]);
         }
 
         $this->newLine();

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -101,7 +101,7 @@ class ScheduleTestCommand extends Command
 
         $this->components->task($description, fn () => $task->run($this->laravel));
 
-        if (!$task instanceof CallbackEvent) {
+        if (! $task instanceof CallbackEvent) {
             $this->components->bulletList([$task->getSummaryForDisplay()]);
         }
 


### PR DESCRIPTION
### Problem
The existing implementation of the schedule:test command only allows for the execution of the first closure-based scheduled command when there are multiple closure-based scheduled tasks. This is due to the array_search method always returning the first matched index. Furthermore, when the --name option is used and there are multiple commands with the same name, the current behavior is to print "No matching scheduled command found." because the count($matches) is not exactly 1. As it mentioned in #47783.

**Solution**
This pull request aims to fix the issue with the schedule:test command. The command now allows the execution of all closure-based scheduled commands when multiple such commands exist. In addition, when using the --name option with multiple commands with the same name, all of the matching commands are now executed instead of none. The handle method was refactored to create a new method runSingleTask which runs a single task, thus making the code cleaner and more maintainable.

**Changes**

- Refactored the handle method to separate the responsibility of running a single task to a new method runSingleTask.
- Updated the handle method to iterate over all matches and run each one, for both named commands and numbered commands.

This solution ensures that the schedule:test command behaves as expected when working with closure-based scheduled commands. It's an essential fix to improve the developer experience when testing scheduled tasks in Laravel.
