### PR TITLE
[11.x] Return collection on Http::pool(...)

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -845,7 +845,7 @@ class PendingRequest
      * Send a pool of asynchronous requests concurrently.
      *
      * @param  callable  $callback
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function pool(callable $callback)
     {
@@ -857,7 +857,7 @@ class PendingRequest
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();
         }
 
-        return $results;
+        return new Collection($results);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -68,7 +68,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Response patch(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response put(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
- * @method static array pool(callable $callback)
+ * @method static \Illuminate\Support\Collection pool(callable $callback)
  * @method static \Illuminate\Http\Client\Response send(string $method, string $url, array $options = [])
  * @method static \GuzzleHttp\Client buildClient()
  * @method static \GuzzleHttp\Client createClient(\GuzzleHttp\HandlerStack $handlerStack)


### PR DESCRIPTION
This PR changes the return object of `Http::pool(...)` from regular array into a collection instance.