### PR TITLE
Prevent altering current route when using `RouteCollectionInterface::match`

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -82,9 +82,11 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             return $route->isFallback;
         });
 
-        return $routes->merge($fallbacks)->first(
+        $route = $routes->merge($fallbacks)->first(
             fn (Route $route) => $route->matches($request, $includingMethod)
         );
+
+        return $route instanceof Route ? clone $route : null;
     }
 
     /**

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -252,6 +252,29 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($routeB, $this->routeCollection->getByAction('OverwrittenView@view'));
     }
 
+    public function testRouteCollectionWontReturnRouteByObjectReference()
+    {
+        $route = new Route('GET', 'foo', [
+            'uses' => 'FooController@index',
+            'as' => 'foo_index',
+        ]);
+        $this->routeCollection->add($route);
+
+        $request = Request::create('foo');
+
+        $request->setRouteResolver(
+            fn () => $route->bind($request)
+        );
+
+        $currentRoute = $request->route();
+        $routeFromRequest = $this->routeCollection->match($request);
+
+        // If the route objects have the same properties, but are not the same object (reference) loose comparison
+        // will be true while strict comparison will be false.
+        $this->assertTrue($currentRoute == $routeFromRequest);
+        $this->assertFalse($currentRoute === $routeFromRequest);
+    }
+
     public function testCannotCacheDuplicateRouteNames()
     {
         $this->routeCollection->add(


### PR DESCRIPTION
This PR solves #47795.

During development of a project I stumbled upon a frustrating bug where the model that should have been bound by route model binding was instead a fresh instance. I found that a middleware was calling `Route::getRoutes()->match(request()->create($uri));`. This `$uri` happened to resolve to the same route as the current route, and due to the nature of the `match` function (automatically binding the route) it overwrote the parameters of the current request's route, including any model binding. If the `$uri` was for the same route, but different parameters, the original parameters were also lost.

After a long debugging, I found that the `matchAgainstRoutes` method in the `AbstractRouteCollection` returned a literal reference to the route currently in the request. By binding that route, it was also altering the current request's route, causing for strange behaviour.

This PR makes a change to return a cloned instance of the route instead, so that the binding does not overwrite the current request's route parameters.

Note: this change makes `CompiledRouteCollectionTest::testMatchingFindsRouteWithDifferentMethodDynamically` fail. I do not know if it's the intended behaviour of that test to expect literal object matches, or if it's an oversight, nor do I know if my approach is the best one. Either way I hope this PR can provide a basis to fix this bug.