### PR TITLE
[10.x] Update the `data_forget` helper function

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -168,12 +168,12 @@ if (! function_exists('data_forget')) {
                 }
             }
         } elseif (Arr::accessible($target)) {
-            if ($segments) {
-                data_forget($target, $segments);
-            }
-
             if (Arr::exists($target, $segment)) {
                 Arr::forget($target, $segment);
+            }
+
+            if ($segments) {
+                data_forget($target, $segments);
             }
         } elseif (is_object($target)) {
             if ($segments && isset($target->{$segment})) {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -154,7 +154,7 @@ if (! function_exists('data_forget')) {
      * Remove / unset an item from an array or object using "dot" notation.
      *
      * @param  mixed  $target
-     * @param  string|array|int|null  $key
+     * @param  string|array  $key
      * @return mixed
      */
     function data_forget(&$target, $key)

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -168,9 +168,11 @@ if (! function_exists('data_forget')) {
                 }
             }
         } elseif (Arr::accessible($target)) {
-            if ($segments && Arr::exists($target, $segment)) {
-                data_forget($target[$segment], $segments);
-            } else {
+            if ($segments) {
+                data_forget($target, $segments);
+            }
+
+            if (Arr::exists($target, $segment)) {
                 Arr::forget($target, $segment);
             }
         } elseif (is_object($target)) {


### PR DESCRIPTION
Hi there!

- The first commit of this PR only just updates the function docblocks, because the `$key` must not be **int** or **null**
- The second one fixes the function issue of passing an array of two items, let's demonstrate it with the next example

```PHP
$verySimpleData = [
    'name' => 'Mahmoud Ramadan',
    'title' => 'Back-end Developer',
    'comments' => [
        ['comment' => 'foo', 'rank' => 'First'],
        ['comment' => 'bar', 'rank' => 'Second'],
    ]
];

return data_forget($verySimpleData, ['name', 'comments']);
```

when I run the previous code before this PR will be merged, I found that nothing changed. so, I debugged the code and I found that **$segment** in this line `$segment = array_shift($segments)` will be assigned with **name**, and the **$segments** will be updated to be **['comments']** and the next code that will be executed according to the condition

```PHP
if ($segments && Arr::exists($target, $segment)) {
    // This line will be executed with these values
    // data_forget('Mahmoud Ramadan', ['comments']);
    data_forget($target[$segment], $segments);
} else {
    Arr::forget($target, $segment);
}
```

the previous code will be executed with comment values and the function will call itself, and there will be no condition that will correspond to these values. so, I update the code as exists in this PR to fix this issue.