### PR TITLE
Allowing bind of IPv6 addresses in development server

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -201,6 +201,13 @@ class ServeCommand extends Command
      */
     protected function getHostAndPort()
     {
+        if (preg_match('/(\[.*\]):?([0-9]+)?/', $this->input->getOption('host'), $matches) !== false) {
+            return [
+                $matches[1] ?? $this->input->getOption('host'),
+                $matches[2] ?? null,
+            ];
+        }
+
         $hostParts = explode(':', $this->input->getOption('host'));
 
         return [


### PR DESCRIPTION
Resolving the issue [Cannot bind IPv6 to local development server "artisan serve"](https://github.com/laravel/framework/issues/47803):

Adding detect pattern of IPv6 address to artisan serve command:

![image](https://github.com/laravel/framework/assets/60560085/9e5b5b46-70e6-4a60-816a-92a72fecf790)

> Note: i have tested with my public IPv6 address and have been success too.
> Note: no tests were found testing the "serve" command, does anyone know how we can create them?