### PR TITLE
Allow Syncing BelongsToMany With Different Pivot Values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -151,7 +151,6 @@ trait InteractsWithPivotTable
      */
     public function syncWithManyPivotValues($ids, array $values, bool $detaching = true)
     {
-
         if ($ids instanceof \illuminate\Support\Collection) {
             $ids = $ids->toArray();
         }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -141,7 +141,7 @@ trait InteractsWithPivotTable
         }), $detaching);
     }
 
-     /**
+    /**
      * Sync the intermediate tables with a list of IDs or collection of models with different pivot values.
      *
      * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
@@ -152,10 +152,9 @@ trait InteractsWithPivotTable
     public function syncWithManyPivotValues($ids, array $values, bool $detaching = true)
     {
 
-        if($ids instanceof \illuminate\Support\Collection){
+        if ($ids instanceof \illuminate\Support\Collection) {
             $ids = $ids->toArray();
         }
-        
         //$ids are paired with $values in the same position in their array eg. $ids[0] => $values[0]
         //If $ids length is less than that of the $values the remaining $ids with no value pair are
         //ignored while syncing to pivot table, meaning all $ids must have a pair to be synced
@@ -164,7 +163,7 @@ trait InteractsWithPivotTable
 
         return $this->sync(collect($this->parseIds($ids))->mapWithKeys(function ($value, $key) use ($values) {
             return [
-                $value => $values[$key]
+                $value => $values[$key],
             ];
         }), $detaching);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -141,6 +141,34 @@ trait InteractsWithPivotTable
         }), $detaching);
     }
 
+     /**
+     * Sync the intermediate tables with a list of IDs or collection of models with different pivot values.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  array  $values
+     * @param  bool  $detaching
+     * @return array
+     */
+    public function syncWithManyPivotValues($ids, array $values, bool $detaching = true)
+    {
+
+        if($ids instanceof \illuminate\Support\Collection){
+            $ids = $ids->toArray();
+        }
+        
+        //$ids are paired with $values in the same position in their array eg. $ids[0] => $values[0]
+        //If $ids length is less than that of the $values the remaining $ids with no value pair are
+        //ignored while syncing to pivot table, meaning all $ids must have a pair to be synced
+
+        array_splice($ids, count($values));
+
+        return $this->sync(collect($this->parseIds($ids))->mapWithKeys(function ($value, $key) use ($values) {
+            return [
+                $value => $values[$key]
+            ];
+        }), $detaching);
+    }
+
     /**
      * Format the sync / toggle record list so that it is keyed by ID.
      *

--- a/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
+++ b/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseConcernsInteractsWithPivotTableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new Manager;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->schema()->create('roles', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->schema()->create('role_user', function ($table) {
+            $table->integer('role_id')->unsigned();
+            $table->foreign('role_id')->references('id')->on('roles');
+            $table->integer('user_id')->unsigned();
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->string('office')->nullable();
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+
+    protected function connection(): mixed
+    {
+        return Model::getConnectionResolver()->connection();
+    }
+
+    public function seed()
+    {
+        $user = PivotInteractionUser::create(['id' => 1, 'name' => 'Chibuike']);
+        PivotInteractionRoles::insert([
+            ['id' => 1, 'name' => 'Eater'],
+            ['id' => 2, 'name' => 'Sleeper'],
+            ['id' => 3, 'name' => 'Skier'],
+        ]);
+
+        $user->roles()->attach(PivotInteractionRoles::first());
+    }
+
+    public function test_can_sync_many_pivot_values()
+    {
+        $this->seed();
+        $user = PivotInteractionUser::first();
+        $roles = PivotInteractionRoles::all();
+
+        //the roles variable holds the list of roles to be synced
+        //  [
+        //     0 => [
+        //       "id" => 1
+        //       "name" => "Eater"
+        //     ]
+        //     1 => [
+        //       "id" => 2
+        //       "name" => "Sleeper"
+        //     ]
+        //     2 => [
+        //       "id" => 3
+        //       "name" => "Skier"
+        //     ]
+        //   ]
+
+        //caveat is you'll have to know the order of the roles to sync with pivot values accordingly
+
+        //now we want to sync with pivot values to achieve the following arrangement
+        // Eater => Dinning
+        // Sleeper => Bedroom
+        // Skier => Innsbruck
+
+        $user->roles()->syncWithManyPivotValues($roles->pluck('id'), [
+            ['office' => 'Dinning'],
+            ['office' => 'Bedroom'],
+            ['office' => 'Innsbruck'],
+        ]);
+
+        $this->assertEquals(3, $user->roles()->count());
+        $this->assertEquals('Dinning', $user->roles()->where('name', 'Eater')->first()->pivot->office);
+        $this->assertEquals('Bedroom', $user->roles()->where('name', 'Sleeper')->first()->pivot->office);
+        $this->assertEquals('Innsbruck', $user->roles()->where('name', 'Skier')->first()->pivot->office);
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('roles');
+        $this->schema()->drop('role_user');
+    }
+}
+
+/**
+ * User model
+ */
+class PivotInteractionUser extends Model
+{
+    protected $fillable = ['name'];
+    protected $table = 'users';
+    public $timestamps = false;
+    public function roles()
+    {
+        return $this->belongsToMany(PivotInteractionRoles::class, 'role_user', 'user_id', 'role_id')->withPivot('office');
+    }
+}
+
+/**
+ * Role model
+ */
+
+class PivotInteractionRoles extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['name'];
+    protected $table = 'roles';
+
+    public function users()
+    {
+        return $this->belongsToMany(PivotInteractionUser::class, 'role_user', 'role_id', 'user_id');
+    }
+}

--- a/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
+++ b/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
@@ -136,7 +136,7 @@ class PivotInteractionUser extends Model
     protected $fillable = ['name'];
     protected $table = 'users';
     public $timestamps = false;
-    
+
     public function roles()
     {
         return $this->belongsToMany(PivotInteractionRoles::class, 'role_user', 'user_id', 'role_id')->withPivot('office');
@@ -146,7 +146,6 @@ class PivotInteractionUser extends Model
 /**
  * Role model.
  */
-
 class PivotInteractionRoles extends Model
 {
     public $timestamps = false;

--- a/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
+++ b/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
@@ -136,6 +136,7 @@ class PivotInteractionUser extends Model
     protected $fillable = ['name'];
     protected $table = 'users';
     public $timestamps = false;
+    
     public function roles()
     {
         return $this->belongsToMany(PivotInteractionRoles::class, 'role_user', 'user_id', 'role_id')->withPivot('office');

--- a/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
+++ b/tests/Database/DatabaseConcernsInteractsWithPivotTableTest.php
@@ -57,7 +57,6 @@ class DatabaseConcernsInteractsWithPivotTableTest extends TestCase
         return $this->connection()->getSchemaBuilder();
     }
 
-
     protected function connection(): mixed
     {
         return Model::getConnectionResolver()->connection();
@@ -130,7 +129,7 @@ class DatabaseConcernsInteractsWithPivotTableTest extends TestCase
 }
 
 /**
- * User model
+ * User model.
  */
 class PivotInteractionUser extends Model
 {
@@ -144,7 +143,7 @@ class PivotInteractionUser extends Model
 }
 
 /**
- * Role model
+ * Role model.
  */
 
 class PivotInteractionRoles extends Model


### PR DESCRIPTION
consider a payload with a list of subjects with their respective teacher_id to be synced in a many-to-many relationship with a class

The relationship looks like this

```php
  // App/Models/ClassModel.php

  public function subjects()
  {
    return $this->belongsToMany(Subject::class, 'class_subject', 'class_id')->withPivot('teacher_id');
  }
```
The payload looks like this
```json
{
    "class_subjects":[
         {
            "teacher_id": 1,
            "subject_id": 16
          },{
            "teacher_id": 7,
            "subject_id": 4
          }
      ]
}
```
With the *syncWithPivotValues()* we can't achieve this because it syncs all ids with one particular pivot value.
now with method *syncWithManyPivotValues()* we can sync all subject_ids with their respective pivot value (teacher_id)

### How to?
The subject id will have to be extracted from the payload to a separate array leaving the payload with only the teacher_id still with key-value pairs
these key-value pairs will be synced together with the subject id in the same position, meaning subject_id 16 will sync with pivot value of teacher_id 1.

All you have to do is transform the initial payload and call the **syncWithManyPivotValues()** method.

the final form of the payload will be like this

```php

$subject_ids = [16,4];
$payload = [
    ['teacher_id' => 1],
    ['teacher_id' => 7],

];

//syncing values

$class->subjects()->syncWithManyPivotValues($subject_ids, $payload);
```

