### PR TITLE
[10.x] Add assertDatabaseHasCount assertaion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
+use Illuminate\Testing\Constraints\HasCountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\NotSoftDeletedInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
@@ -80,6 +81,24 @@ trait InteractsWithDatabase
     {
         $this->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), 0)
+        );
+
+        return $this;
+    }
+
+     /**
+     * Assert the count of a given where condition exists in the database.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  array  $data
+     * @param  int  $count
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseHasCount($table, array $data, int $count, $connection = null)
+    {
+        $this->assertThat(
+            $this->getTable($table), new HasCountInDatabase($this->getConnection($connection, $table), $data, $count)
         );
 
         return $this;

--- a/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Testing\Constraints;
+
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Constraint\Constraint;
+use ReflectionClass;
+
+class HasCountInDatabase extends Constraint
+{
+    /**
+     * The database connection.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The expected table entries count that will be checked against the actual count.
+     *
+     * @var int
+     */
+    protected $expectedCount;
+
+    /**
+     * The actual table entries count that will be checked against the expected count.
+     *
+     * @var int
+     */
+    protected $actualCount;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  array  $data
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function __construct(Connection $database, array $data, int $expectedCount)
+    {
+        $this->expectedCount = $expectedCount;
+
+        $this->data = $data;
+
+        $this->database = $database;
+    }
+
+    /**
+     * Check if the expected and actual count are equal.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table): bool
+    {
+        $this->actualCount = $this->database->table($table)->where($this->data)->count();
+
+        return $this->actualCount === $this->expectedCount;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table): string
+    {
+        return sprintf(
+            "table [%s] matches expected entries count of %s. Entries found: %s.\n",
+            $table, $this->expectedCount, $this->actualCount
+        );
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toString($options = 0): string
+    {
+        return (new ReflectionClass($this))->name;
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -95,6 +95,32 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
+    public function testSeeInDatabaseCountFindsResults()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHasCount($this->table, $this->data, 1);
+    }
+
+    public function testAssertDatabaseHasCountSupportModels()
+    {
+        $this->mockCountBuilder(2);
+
+        $this->assertDatabaseHasCount(ProductStub::class, $this->data, 2);
+        $this->assertDatabaseHasCount(new ProductStub, $this->data, 2);
+    }
+
+    public function testAssertTableEntriesHasCountWrong()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount($this->table, 3);
+    }
+
     public function testDontSeeInDatabaseDoesNotFindResults()
     {
         $this->mockCountBuilder(0);


### PR DESCRIPTION
when testing a database we sometimes want to check how many times data may be in the database

ex: we want to know how much active users are in the user's table

We was using:

$this->assertCount(2, User::where('active', true)->get());

now we can syntax similar to assertDatabaseHas and assertDatabaseCount

$this->assertDatabaseHasCount(User::class, ['active' => true], 2);
