### PR TITLE
[10.x] Add support to ask and validate input in console commands

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Concerns;
 use Closure;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
@@ -152,6 +153,25 @@ trait InteractsWithIO
     public function ask($question, $default = null)
     {
         return $this->output->ask($question, $default);
+    }
+
+    /**
+     * Prompt the user for input until validation passes.
+     *
+     * @param  string  $question
+     * @param  string|null $default
+     * @param  array  $rules
+     * @return mixed
+     */
+    public function askAndValidate($question, $default = null, $rules = [])
+    {
+        $value = $this->ask($question, $default);
+
+        while ( ! $this->validateInput($value, $rules)) {
+            $value = $this->ask($question, $default);
+        }
+
+        return $value;
     }
 
     /**
@@ -449,5 +469,14 @@ trait InteractsWithIO
     public function getOutput()
     {
         return $this->output;
+    }
+
+    public function validateInput($value, array $rules): bool
+    {
+        return Validator::make([
+            'input' => $value
+        ], [
+            'input' => $rules
+        ])->passes();
     }
 }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -169,7 +169,7 @@ trait InteractsWithIO
     {
         $value = $this->ask($question, $default);
 
-        while ( ! $this->validateInput($value, $rules, $messages)) {
+        while (! $this->validateInput($value, $rules, $messages)) {
             $value = $this->ask($question, $default);
         }
 
@@ -476,9 +476,9 @@ trait InteractsWithIO
     /**
      * Validate input based on given rules. Any errors will be output to the user.
      *
-     * @param $value
-     * @param array $rules
-     * @param array $messages
+     * @param  $value
+     * @param  array  $rules
+     * @param  array  $messages
      * @return bool
      */
     public function validateInput($value, array $rules, array $messages = []): bool

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -222,7 +222,7 @@ class CommandTest extends TestCase
     {
         $output = m::mock(OutputStyle::class);
 
-        $output->shouldReceive('ask')->twice()->with('Name ?', null)->andReturns(null, 'Tom');
+        $output->shouldReceive('ask')->twice()->with('Name ?', null)->andReturns(null, 'Foo');
 
         $output->shouldReceive('writeln')->once()->withArgs(function (...$args) {
             return $args[0] === '<error>Invalid input:</error>';
@@ -253,7 +253,7 @@ class CommandTest extends TestCase
         $validator2->shouldReceive('validate')
             ->once()
             ->andReturn([
-                'input' => 'Tom',
+                'input' => 'Foo',
             ]);
 
         Validator::shouldReceive('make')

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -244,25 +244,21 @@ class CommandTest extends TestCase
         $validationException
             ->shouldReceive('errors')
             ->once()
-            ->andReturn(array_values($validationMessages))
-        ;
+            ->andReturn(array_values($validationMessages));
 
         $validator1->shouldReceive('validate')
             ->once()
-            ->andThrow($validationException)
-        ;
+            ->andThrow($validationException);
 
         $validator2->shouldReceive('validate')
             ->once()
             ->andReturn([
                 'input' => 'Tom'
-            ])
-        ;
+            ]);
 
         Validator::shouldReceive('make')
             ->twice()
-            ->andReturns($validator1, $validator2)
-        ;
+            ->andReturns($validator1, $validator2);
 
         $command = new Command;
         $command->setOutput($output);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
+use Illuminate\Support\Facades\Validator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -213,5 +214,39 @@ class CommandTest extends TestCase
         $command->setOutput($output);
 
         $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
+    }
+
+    public function testAskWithValidate()
+    {
+        $output = m::mock(OutputStyle::class);
+
+        $output->shouldReceive('ask')
+            ->twice()
+            ->with('Name ?', null)
+            ->andReturns(null, 'Tom')
+        ;
+
+        $validator1 = m::mock(\Illuminate\Contracts\Validation\Validator::class);
+        $validator2 = m::mock(\Illuminate\Contracts\Validation\Validator::class);
+
+        $validator1->shouldReceive('passes')
+            ->once()
+            ->andReturn(false)
+        ;
+
+        $validator2->shouldReceive('passes')
+            ->once()
+            ->andReturn(true)
+        ;
+
+        Validator::shouldReceive('make')
+            ->twice()
+            ->andReturns($validator1, $validator2)
+        ;
+
+        $command = new Command;
+        $command->setOutput($output);
+
+        $command->askAndValidate('Name ?', null, ['required', 'string', 'max: 25']);
     }
 }

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -253,7 +253,7 @@ class CommandTest extends TestCase
         $validator2->shouldReceive('validate')
             ->once()
             ->andReturn([
-                'input' => 'Tom'
+                'input' => 'Tom',
             ]);
 
         Validator::shouldReceive('make')


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When running commands that require a lot of input from the user, if you get partway through and the input is incorrect in some way, you may have to run the command again (depending on how the command is written to handle bad input).

It would be nice to ask for input and validate in a loop until the value is correct. The resulting code makes commands easy to read by combining the input and checking logic.

Example code below:
```php
public function handle()
{
    $name = $this->askAndValidate(question: 'Name ?', rules: ['required', 'string', 'max:25']);

    $this->info('Hello ' . $name);

    return 0;
}
```

You can even override messages too:

```php
$name = $this->askAndValidate(question: 'Name ?', rules: ['required', 'string', 'max:25'], messages: ['input.required' => 'input is required']);
```

In the askAndValidate method the user will be prompted in a loop until the validation passes. The Validator facade is used to make and validate the input from the user.

**Caveats**

There is 1 caveat with the validation part, as thats when adding custom error messages, the field name can only be `input`. Not sure of an alternative to tackle this.

