### PR TITLE
[10.x] Allow custom mutex names for isolated commands

### DIFF
--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -101,6 +101,8 @@ class CacheCommandMutex implements CommandMutex
     }
 
     /**
+     * Get the isolatable command mutex name.
+     *
      * @param  \Illuminate\Console\Command  $command
      * @return string
      */
@@ -108,11 +110,9 @@ class CacheCommandMutex implements CommandMutex
     {
         $baseName = 'framework'.DIRECTORY_SEPARATOR.'command-'.$command->getName();
 
-        if (method_exists($command, 'getIsolatedMutexName')) {
-            return $baseName.'-'.$command->getIsolatedMutexName();
-        }
-
-        return $baseName;
+        return method_exists($command, 'isolatableId')
+            ? $baseName.'-'.$command->isolatableId()
+            : $baseName;
     }
 
     /**

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -106,7 +106,13 @@ class CacheCommandMutex implements CommandMutex
      */
     protected function commandMutexName($command)
     {
-        return 'framework'.DIRECTORY_SEPARATOR.'command-'.$command->getName();
+        $baseName = 'framework'.DIRECTORY_SEPARATOR.'command-'.$command->getName();
+
+        if (method_exists($command, 'getIsolatedMutexName')) {
+            return $baseName.'-'.$command->getIsolatedMutexName();
+        }
+
+        return $baseName;
     }
 
     /**

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -160,4 +160,54 @@ class CacheCommandMutexTest extends TestCase
             ->once()
             ->andReturns($acquiresSuccessfully);
     }
+
+    public function testCommandMutexNameWithoutIsolatedMutexNameMethod()
+    {
+        $this->mockUsingCacheStore();
+
+        $this->cacheRepository->shouldReceive('getStore')
+            ->with('test')
+            ->andReturn($this->cacheRepository);
+
+        $this->cacheRepository->shouldReceive('add')
+            ->once()
+            ->withArgs(function($key) {
+                $this->assertEquals('framework/command-command-name', $key);
+
+                return true;
+            })
+            ->andReturn(true);
+
+        $this->mutex->create($this->command);
+    }
+
+    public function testCommandMutexNameWithIsolatedMutexNameMethod()
+    {
+        $command = new class extends Command
+        {
+            protected $name = 'command-name';
+
+            public function getIsolatedMutexName()
+            {
+                return 'isolated';
+            }
+        };
+
+        $this->mockUsingCacheStore();
+
+        $this->cacheRepository->shouldReceive('getStore')
+            ->with('test')
+            ->andReturn($this->cacheRepository);
+
+        $this->cacheRepository->shouldReceive('add')
+            ->once()
+            ->withArgs(function($key) {
+                $this->assertEquals('framework/command-command-name-isolated', $key);
+
+                return true;
+            })
+            ->andReturn(true);
+
+        $this->mutex->create($command);
+    }
 }

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -172,7 +172,7 @@ class CacheCommandMutexTest extends TestCase
         $this->cacheRepository->shouldReceive('add')
             ->once()
             ->withArgs(function ($key) {
-                $this->assertEquals('framework/command-command-name', $key);
+                $this->assertEquals('framework'.DIRECTORY_SEPARATOR.'command-command-name', $key);
 
                 return true;
             })
@@ -202,7 +202,7 @@ class CacheCommandMutexTest extends TestCase
         $this->cacheRepository->shouldReceive('add')
             ->once()
             ->withArgs(function ($key) {
-                $this->assertEquals('framework/command-command-name-isolated', $key);
+                $this->assertEquals('framework'.DIRECTORY_SEPARATOR.'command-command-name-isolated', $key);
 
                 return true;
             })

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -171,7 +171,7 @@ class CacheCommandMutexTest extends TestCase
 
         $this->cacheRepository->shouldReceive('add')
             ->once()
-            ->withArgs(function($key) {
+            ->withArgs(function ($key) {
                 $this->assertEquals('framework/command-command-name', $key);
 
                 return true;
@@ -201,7 +201,7 @@ class CacheCommandMutexTest extends TestCase
 
         $this->cacheRepository->shouldReceive('add')
             ->once()
-            ->withArgs(function($key) {
+            ->withArgs(function ($key) {
                 $this->assertEquals('framework/command-command-name-isolated', $key);
 
                 return true;

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -187,7 +187,7 @@ class CacheCommandMutexTest extends TestCase
         {
             protected $name = 'command-name';
 
-            public function getIsolatedMutexName()
+            public function isolatableId()
             {
                 return 'isolated';
             }


### PR DESCRIPTION
Title: Allowing custom mutex names for isolated commands

Description:
This pull request introduces a modification to the `commandMutexName` function in order to support custom mutex names for isolated commands in Laravel's framework. Previously, all commands with the same name were being blocked simultaneously, regardless of their parameters. With this update, isolated commands can define their own identifier using the `getIsolatedMutexName` method.

Changes Made:

- Updated the `commandMutexName` function in the framework directory to include the command's isolated mutex name, if provided.

- Added a conditional check using `method_exists` to determine if the `getIsolatedMutexName` method is available for the command.

- If the `getIsolatedMutexName` method exists, the isolated mutex name is appended to the base name of the command's mutex.

- If the `getIsolatedMutexName` method is not present, the base name of the command's mutex is returned as before.

This modification enables more granular control over command execution, allowing isolated commands to have unique mutex names even if they share the same command name. This is especially useful when we want to block the simultaneous execution of a command with the same parameters, but not to block the execution of this command with other parameters.