### PR TITLE
[10.x] fix issue #47727 with wrong return type

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -193,7 +193,7 @@ class Request implements ArrayAccess
     protected function json()
     {
         if (! $this->data) {
-            $this->data = json_decode($this->body(), true);
+            $this->data = json_decode($this->body(), true) ?? [];
         }
 
         return $this->data;


### PR DESCRIPTION
json_decode can indeed return null - so it should be converted to an empty array. 

See issue #47727