### PR TITLE
[10.x] Collection::except() with null returns all

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -362,6 +362,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function except($keys)
     {
+        if (is_null($keys)) {
+            return new static($this->items);
+        }
+
         if ($keys instanceof Enumerable) {
             $keys = $keys->all();
         } elseif (! is_array($keys)) {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -475,6 +475,10 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function except($keys)
     {
+        if (is_null($keys)) {
+            return new static($this->items);
+        }
+
         $dictionary = Arr::except($this->getDictionary(), array_map($this->getDictionaryKey(...), (array) $keys));
 
         return new static(array_values($dictionary));

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -435,13 +435,14 @@ class DatabaseEloquentCollectionTest extends TestCase
         $one->shouldReceive('getKey')->andReturn(1);
 
         $two = m::mock(Model::class);
-        $two->shouldReceive('getKey')->andReturn('2');
+        $two->shouldReceive('getKey')->andReturn(2);
 
         $three = m::mock(Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);
 
+        $this->assertEquals($c, $c->except(null));
         $this->assertEquals(new Collection([$one, $three]), $c->except(2));
         $this->assertEquals(new Collection([$one]), $c->except([2, 3]));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2264,12 +2264,14 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
+        $this->assertEquals($data->all(), $data->except(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->except(['last', 'email', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->except('last', 'email', 'missing')->all());
-
         $this->assertEquals(['first' => 'Taylor'], $data->except(collect(['last', 'email', 'missing']))->all());
+
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(['last'])->all());
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except('last')->all());
+        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except(collect(['last']))->all());
     }
 
     /**


### PR DESCRIPTION
Similar to Collection::only() which allows `null`

https://github.com/laravel/framework/blob/c59d540ab142d36ee0f62c3ddc749329a968466b/src/Illuminate/Collections/Collection.php#L901-L915



this change allows to get all records, only or excepts the ones you want. For example, you can write

```
    public function get($only = null, $except = null)
    {
        return $this->connection->table($this->table)
            ->get()
            ->only($only)
            ->except($except)
            ->all();
    }
```
instead of
```
    public function get($only = null, $except = null)
    {
        $collection = $this->connection->table($this->table)
            ->get()
            ->only($only);

        if (!is_null($except)) {
            $collection = $collection->except($except);
        }
        return $collection->all();
    }
```

So I can quickly get all records of the table `->get();`
only the records I want `->get([1,3,5]);` 
or all except some records `->get(null, [2,4]);`
