### PR TITLE
Makes Str::password have a minimal complexity

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -804,12 +804,11 @@ class Str
      * Generate a random, secure password.
      *
      * @param  int  $length
-     * @param  int|null  $lowerCase Include a minimal of N lower-case letters, or null to not use them.
-     * @param  int|null  $upperCase Include a minimal of N upper-case letters, or null to not use them.
-     * @param  int|null  $numbers Include a minimal of N numbers, or null to not use them.
-     * @param  int|null  $symbols Include a minimal of N symbols, or null to not use them.
-     * @param  int|null  $spaces Include a minimal of N spaces, or null to not use them.
-     *
+     * @param  int|null  $lowerCase  Include a minimal of N lower-case letters, or null to not use them.
+     * @param  int|null  $upperCase  Include a minimal of N upper-case letters, or null to not use them.
+     * @param  int|null  $numbers  Include a minimal of N numbers, or null to not use them.
+     * @param  int|null  $symbols  Include a minimal of N symbols, or null to not use them.
+     * @param  int|null  $spaces  Include a minimal of N spaces, or null to not use them.
      * @return string
      */
     public static function password($length = 32, $lowerCase = 1, $upperCase = 1, $numbers = 1, $symbols = 1, $spaces = null)
@@ -820,7 +819,7 @@ class Str
             + ($symbols ?? 0)
             + ($spaces ?? 0);
 
-        if($length < $totalMinimalCharacters) {
+        if ($length < $totalMinimalCharacters) {
             throw new InvalidArgumentException(
                 "You requested {$length} password characters, but the minimal characters are requiring a length of at least {$totalMinimalCharacters}."
             );
@@ -829,9 +828,9 @@ class Str
         $requiredCharacters = collect();
         $addToRequiredCharacters = function ($characters, $length) use (&$requiredCharacters) {
             if ($length > 0) {
-                $requiredCharacters->push(...$characters->pipe(fn($c) => Collection::times(
+                $requiredCharacters->push(...$characters->pipe(fn ($c) => Collection::times(
                     $length,
-                    fn() => $characters[random_int(0, $characters->count() - 1)]
+                    fn () => $characters[random_int(0, $characters->count() - 1)]
                 )));
             }
         };
@@ -881,9 +880,9 @@ class Str
 
                 return $c->merge($characters);
             })
-            ->pipe(fn($c) => Collection::times(
+            ->pipe(fn ($c) => Collection::times(
                 $length - $requiredCharacters->count(),
-                fn() => $c[random_int(0, $c->count() - 1)]
+                fn () => $c[random_int(0, $c->count() - 1)]
             ))
             ->merge($requiredCharacters)
             ->shuffle()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1124,6 +1124,17 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(strlen(Str::password()) === 32);
     }
+
+    public function testPasswordComplexity()
+    {
+        $password = Str::password(5, 1, 1, 1, 1, 1);
+
+        $this->assertEquals(1, preg_match('/[a-z]/', $password));
+        $this->assertEquals(1, preg_match('/[A-Z]/', $password));
+        $this->assertEquals(1, preg_match('/[0-9]/', $password));
+        $this->assertEquals(1, preg_match('/[^a-zA-Z0-9 ]/', $password));
+        $this->assertEquals(1, preg_match('/ /', $password));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
Currently, Str::password generates a random password, however if you (or third party) upholds a minimum complexity, the current way does not enure all required characters are in the password.

This updated function allows for a minimum complexity: if you need a minimum of 1 uppercase letter, 1 number and 1 symbol, this function makes sure it's there.

Also: the previous function didn't have a seperation between lower and upper case letters - if your minimum complexity requires both, than this is needed.

To master, it's a breaking change. Upgrading as follows:

 - Search for all your uses of Str::password.
 - The first (length) argument stays the same
 - Change all `true` arguments to `0` (or a higher number if you need a minimal complexity)
 - Change all `false` arguments to `null`