### PR TITLE
[10.x] Add support for `BackedEnum` in Collection `groupBy` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -504,8 +504,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             foreach ($groupKeys as $groupKey) {
                 $groupKey = match (true) {
                     is_bool($groupKey) => (int) $groupKey,
-                    $groupKey instanceof \Stringable => (string) $groupKey,
                     $groupKey instanceof \BackedEnum => $groupKey->value,
+                    $groupKey instanceof \Stringable => (string) $groupKey,
                     default => $groupKey,
                 };
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -505,6 +505,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 $groupKey = match (true) {
                     is_bool($groupKey) => (int) $groupKey,
                     $groupKey instanceof \Stringable => (string) $groupKey,
+                    $groupKey instanceof \BackedEnum => $groupKey->value,
                     default => $groupKey,
                 };
 

--- a/tests/Support/Enums.php
+++ b/tests/Support/Enums.php
@@ -10,4 +10,5 @@ enum TestEnum
 enum TestBackedEnum: int
 {
     case A = 1;
+    case B = 2;
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3347,6 +3347,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testGroupByAttributeWithBackedEnumKey($collection)
+    {
+        $data = new $collection([
+            ['rating' => TestBackedEnum::A, 'url' => '1'],
+            ['rating' => TestBackedEnum::B, 'url' => '1'],
+        ]);
+
+        $result = $data->groupBy('rating');
+        $this->assertEquals([TestBackedEnum::A->value => [['rating' => TestBackedEnum::A, 'url' => '1']], TestBackedEnum::B->value => [['rating' => TestBackedEnum::B, 'url' => '1']]], $result->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testGroupByAttributePreservingKeys($collection)
     {
         $data = new $collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);


### PR DESCRIPTION
I tried to group the Eloquent model collection by the Enum-casted key and got this error:

```
TypeError
array_key_exists(): Argument #1 ($key) must be a valid array offset type
```

This PR aims to fix that by adding support for `BackedEnum` in `groupBy` method.

### Code example
```php
$attributesByCategory = Attribute::whereIn('category', [
      AttributeCategory::LOREM,
      AttributeCategory::IPSUM,
  ])
  ->get()
  ->groupBy('category');

enum AttributeCategory: string
{
    case LOREM  = 'lorem';
    case IPSUM   = 'ipsum';
}

class Attribute extends Model
{
    protected $casts = [
        'category' => AttributeCategory::class,
    ];
}
```