### PR TITLE
[10.x] Remove redundant variable in `MemcachedStore`

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -80,9 +80,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
         if ($this->onVersionThree) {
             $values = $this->memcached->getMulti($prefixedKeys, Memcached::GET_PRESERVE_ORDER);
         } else {
-            $null = null;
-
-            $values = $this->memcached->getMulti($prefixedKeys, $null, Memcached::GET_PRESERVE_ORDER);
+            $values = $this->memcached->getMulti($prefixedKeys, null, Memcached::GET_PRESERVE_ORDER);
         }
 
         if ($this->memcached->getResultCode() != 0) {


### PR DESCRIPTION
This PR removes redundant variable in `MemcachedStore`