### PR TITLE
Add more info to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before sending in bug reports."
+        "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before submitting bug reports."
         "If you notice improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem."
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -3,11 +3,13 @@ description: "Report something that's broken."
 body:
   - type: markdown
     attributes:
-      value: "Before submitting your report, [please ensure your Laravel version is still supported](https://laravel.com/docs/releases#support-policy)."
+      value: |
+        "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before sending in bug reports."
+        "If you notice improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem."
   - type: input
     attributes:
       label: Laravel Version
-      description: Provide the Laravel version that you are using.
+      description: Provide the Laravel version that you are using. [Please ensure it is still supported.](https://laravel.com/docs/releases#support-policy)
       placeholder: 10.4.1
     validations:
       required: true


### PR DESCRIPTION
People keep sending in bug reports about docblocks so I want to try to make this a little more clear by updating the issue header description.

I also moved the note about supported Laravel versions to the Laravel version input description.
