### PR TITLE
[10 ]  "getMany(...$keys)" An array of keys or multiple arguments containing keys

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -57,14 +57,18 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
-     * Get many configuration values.
+     * Get configuration values for multiple keys.
      *
-     * @param  array  $keys
-     * @return array
+     * @param  array  ...$keys  An array of keys or multiple arguments containing keys.
+     * @return array  An associative array with the configuration values for the specified keys.
      */
-    public function getMany($keys)
+    public function getMany(...$keys)
     {
         $config = [];
+
+        if (isset($keys[0]) && is_array($keys[0])) {
+            $keys = $keys[0];
+        }
 
         foreach ($keys as $key => $default) {
             if (is_numeric($key)) {


### PR DESCRIPTION
The "getMany()" method is adjusted to receive an array as it is currently working or also receive several arguments separated by commas, this allows more flexibility of use.