### PR TITLE
[10.x] Fix BusFake::assertChained() for a single job

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -341,11 +341,6 @@ class BusFake implements Fake, QueueingDispatcher
             "The expected [{$command}] job was not dispatched."
         );
 
-        PHPUnit::assertTrue(
-            collect($expectedChain)->isNotEmpty(),
-            'The expected chain can not be empty.'
-        );
-
         $this->isChainOfObjects($expectedChain)
             ? $this->assertDispatchedWithChainOfObjects($command, $expectedChain, $callback)
             : $this->assertDispatchedWithChainOfClasses($command, $expectedChain, $callback);

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -468,6 +468,14 @@ class SupportTestingBusFakeTest extends TestCase
     {
         $this->fake->chain([
             new ChainedJobStub,
+        ])->dispatch();
+
+        $this->fake->assertChained([
+            ChainedJobStub::class,
+        ]);
+
+        $this->fake->chain([
+            new ChainedJobStub,
             new OtherBusJobStub,
         ])->dispatch();
 


### PR DESCRIPTION
There is a bug when using the `Bus::assertChained()` method with an array containing only a single job.

It always returns an assertion error: `The expected chain can not be empty.`

Providing two or more jobs works fine.

This PR resolves this issue by removing a check if the `$expectedChain` is empty, which is the case, if only one job is provided as the first one gets removed from the `$expectedChain` on [line 323](https://github.com/gehrisandro/laravel-framework/blob/c78d206f768ce41ee09e699c864c9fbb1970cd65/src/Illuminate/Support/Testing/Fakes/BusFake.php#L323).

Another solution would be to move the check upwards before the `array_slice()`. But because there was no failing test when removing the check, I decided to remove it entirely.

If you prefer to keep the check please let me know. I will adjust the PR and add the missing test for that.