### PR TITLE
Auth type narrowing

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\UnauthorizedException;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -46,7 +47,12 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerUserResolver()
     {
-        $this->app->bind(AuthenticatableContract::class, fn ($app) => call_user_func($app['auth']->userResolver()));
+        $this->app->bind(AuthenticatableContract::class, function ($app) {
+            $user = call_user_func($app['auth']->userResolver());
+            throw_if(! $user, new UnauthorizedException);
+
+            return $user;
+        });
     }
 
     /**

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth;
 
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Validation\UnauthorizedException;
 
 /**
  * These methods are typically the same across all guards.
@@ -105,6 +106,19 @@ trait GuardHelpers
         $this->user = null;
 
         return $this;
+    }
+
+    /**
+     * Get the currently authenticated user or throws an exception.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function userOrFail()
+    {
+        $user = $this->user();
+        throw_if(! $user, new UnauthorizedException);
+
+        return $user;
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Support\Timebox;
+use Illuminate\Validation\UnauthorizedException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -282,6 +283,24 @@ class AuthGuardTest extends TestCase
         $guard->getSession()->shouldNotReceive('get');
 
         $this->assertFalse($guard->hasUser());
+    }
+
+    public function testUserOrFailThrowsWhenUserIsNull()
+    {
+        $this->expectException(UnauthorizedException::class);
+        $guard = $this->getGuard();
+        $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
+
+        $guard->userOrFail();
+    }
+
+    public function testUserOrFailReturnsUser()
+    {
+        $user = m::mock(Authenticatable::class);
+        $guard = $this->getGuard();
+        $guard->setUser($user);
+
+        $this->assertSame($user, $guard->userOrFail());
     }
 
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()


### PR DESCRIPTION
This PR adds two features to help the typing of interacting with logged in users in controllers (and elsewhere). The problem with the current flow is that you are forced to implement extraneous type narrowing conditions when working behind an auth middleware.

```php
Route::middleware(['auth'])->get('/private', function () {
    // The typing of $user is ?User because the guard's ->user() method
    // doesn't know we're inside an `auth` middleware.
    $user = auth()->user(); 

    // Because the typing doesn't know that User is a always defined here
    // thanks to the middleware we're forced to add an extra narrowing
    // condition anywhere we use auth()->user()
    throw_if(! $user, new UnauthorizedException)
    
    return $user;
})
```

This PR adds `->userOrFail()` mimicking Eloquent's `->firstOrFail()` logic. It removes the need for the extraneous `throw_if` in the above code.

```php
Route::middleware(['auth'])->get('/private', function () {
    // The typing of $user is now `User` because of the `orFail` suffix
    // and we no longer have to manually narrow this type in user land code
    $user = auth()->userOrFail(); 
    
    return $user;
})
```

The tests for all of the above are already implemented.

----

Extra functionality: I've implemented the above as a macro in the past and have used it with great success. I really like how it reduces the need for extra `/** @var` doc blocks or extra `throw_if` conditionals. However, I still find that a lot of my controllers start with the exact same line, `$user = auth()->userOrFail()`.

In a similar vein, Laravel provides really nice route model binding to reduce boilerplate and remove the need for `Post::find($id)` at the beginning of all our `PostController` methods so I figured why not do the same thing for logged in users.

The second change to this PR adds a `throw_if` on to the `Illuminate\Contracts\Auth\Authenticatable` contract. This way you can type a `Authenticatable $user` in to any IoC resolved method and get back the logged in user. E.g.,

```php
Route::middleware(['auth'])->get('/private', function (Authenticatable $user) {
    // The typing of $user is now `Authenticatable` and you no longer need the
    // boilerplate for reaching in to the guard to get the user, the IoC resolves
    // it for you.
    return $user;
})
```

This is necessary because without the `throw_if` in the binding the IoC would try to inject `null` in to the `Authenticatable $user` and you'd end up with a PHP `TypeError`, which is exactly what the first half of this PR is trying to avoid.

I do not have tests for this yet because I'm not sure how/if you're testing the `AuthServiceProvider` in the existing tests. I didn't see anything in there that touched the service provider.

I realize this second half is a bit more experimental than the first half so if you'd like me to separate these in to unique PRs I'm happy to do that or revise however you think is best.

Thanks for everything!