### PR TITLE
[10.x] Retain `$request->request` `InputBag` type

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -487,7 +488,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $newRequest->content = $request->content;
 
         if ($newRequest->isJson()) {
-            $newRequest->request = $newRequest->json();
+            $newRequest->request = new InputBag($newRequest->json()->all());
         }
 
         return $newRequest;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -1555,5 +1556,18 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
         $request->flashExcept(['email']);
+    }
+
+    public function testGeneratingJsonRequestFromParentRequestUsesCorrectType()
+    {
+        if (! method_exists(SymfonyRequest::class, 'getPayload')) {
+            return;
+        }
+
+        $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"hello":"world"}');
+
+        $request = Request::createFromBase($base);
+
+        $this->assertInstanceOf(InputBag::class, $request->getPayload());
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1569,5 +1569,6 @@ class HttpRequestTest extends TestCase
         $request = Request::createFromBase($base);
 
         $this->assertInstanceOf(InputBag::class, $request->getPayload());
+        $this->assertSame('world', $request->getPayload()->get('hello'));
     }
 }


### PR DESCRIPTION
When we create the Illuminate request, we set the `$request->request` property to the value of the `$request->json` property.

Symfony is expecting `$request->request` to be an `InputBag` when invoking `$request->getPayload()`. See:

https://github.com/symfony/symfony/blob/42d9d7cd64c5b9897a2113c12d76c75a8d31ad9c/src/Symfony/Component/HttpFoundation/Request.php#L1514

The `$request->json` property is an instance of `ParameterBag`. This is the parent class of `InputBag`.

So we are setting `$request->request` to an instance of `ParameterBag` instead of `InputBag` which is then breaking due to the return type on `Request::getPayload()`

## Side note

It is possible that we should make `$request->json` an instance of `InputBag` to make things consistent, however this is a quick fix to fix the framework asap.

fixes #47834