### PR TITLE
[10.x] `naturalLanguageList` string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1493,7 +1493,7 @@ class Str
     public static function naturalLanguateList(array $list, $and = 'and', $separator = ', ')
     {
         if (count($list) > 1) {
-            return implode($separator, array_slice($list, 0, -1)) . ' ' . $and . ' ' . array_pop($list);
+            return implode($separator, array_slice($list, 0, -1)).' '.$and.' '.array_pop($list);
         }
 
         return (string) array_pop($list);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1481,4 +1481,21 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Generate a comma separated list where the last two items are joined with 'and', forming natural language.
+     *
+     * @param  array  $list
+     * @param  string  $and
+     * @param  string  $separator
+     * @return string
+     */
+    public static function naturalLanguateList(array $list, $and = 'and', $separator = ', ')
+    {
+        if (count($list) > 1) {
+            return implode($separator, array_slice($list, 0, -1)) . ' ' . $and . ' ' . array_pop($list);
+        }
+
+        return (string) array_pop($list);
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1490,7 +1490,7 @@ class Str
      * @param  string  $separator
      * @return string
      */
-    public static function naturalLanguateList(array $list, $and = 'and', $separator = ', ')
+    public static function naturalLanguageList(array $list, $and = 'and', $separator = ', ')
     {
         if (count($list) > 1) {
             return implode($separator, array_slice($list, 0, -1)).' '.$and.' '.array_pop($list);

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1126,6 +1126,19 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Generate a comma separated list where the last two items are joined with 'and', forming natural language.
+     *
+     * @param  array  $list
+     * @param  string  $and
+     * @param  string  $separator
+     * @return static
+     */
+    public function naturalLanguateList(array $list, $and = 'and', $separator = ', ')
+    {
+        return new static(Str::naturalLanguateList($list, $and, $separator));
+    }
+
+    /**
      * Convert the string into a `HtmlString` instance.
      *
      * @return \Illuminate\Support\HtmlString

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1133,9 +1133,9 @@ class Stringable implements JsonSerializable, ArrayAccess
      * @param  string  $separator
      * @return static
      */
-    public function naturalLanguateList(array $list, $and = 'and', $separator = ', ')
+    public function naturalLanguageList(array $list, $and = 'and', $separator = ', ')
     {
-        return new static(Str::naturalLanguateList($list, $and, $separator));
+        return new static(Str::naturalLanguageList($list, $and, $separator));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1124,6 +1124,13 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(strlen(Str::password()) === 32);
     }
+
+    public function testNaturalLanguateList()
+    {
+        $this->assertSame('one, two and three', Str::naturalLanguateList(['one', 'two', 'three']));
+        $this->assertSame('one, two or three', Str::naturalLanguateList(['one', 'two', 'three'], 'or'));
+        $this->assertSame('one; two and three', Str::naturalLanguateList(['one', 'two', 'three'], separator: '; '));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1125,11 +1125,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(strlen(Str::password()) === 32);
     }
 
-    public function testNaturalLanguateList()
+    public function testNaturalLanguageList()
     {
-        $this->assertSame('one, two and three', Str::naturalLanguateList(['one', 'two', 'three']));
-        $this->assertSame('one, two or three', Str::naturalLanguateList(['one', 'two', 'three'], 'or'));
-        $this->assertSame('one; two and three', Str::naturalLanguateList(['one', 'two', 'three'], separator: '; '));
+        $this->assertSame('one, two and three', Str::naturalLanguageList(['one', 'two', 'three']));
+        $this->assertSame('one, two or three', Str::naturalLanguageList(['one', 'two', 'three'], 'or'));
+        $this->assertSame('one; two and three', Str::naturalLanguageList(['one', 'two', 'three'], separator: '; '));
     }
 }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1121,6 +1121,13 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('"value"', $this->stringable('value')->wrap('"'));
     }
 
+    public function testNaturalLanguateList()
+    {
+        $this->assertEquals('one, two and three', $this->stringable()->naturalLanguateList(['one', 'two', 'three']));
+        $this->assertEquals('one, two or three', $this->stringable()->naturalLanguateList(['one', 'two', 'three'], 'or'));
+        $this->assertEquals('one; two and three', $this->stringable()->naturalLanguateList(['one', 'two', 'three'], separator: '; '));
+    }
+
     public function testToHtmlString()
     {
         $this->assertEquals(

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1121,11 +1121,11 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('"value"', $this->stringable('value')->wrap('"'));
     }
 
-    public function testNaturalLanguateList()
+    public function testNaturalLanguageList()
     {
-        $this->assertEquals('one, two and three', $this->stringable()->naturalLanguateList(['one', 'two', 'three']));
-        $this->assertEquals('one, two or three', $this->stringable()->naturalLanguateList(['one', 'two', 'three'], 'or'));
-        $this->assertEquals('one; two and three', $this->stringable()->naturalLanguateList(['one', 'two', 'three'], separator: '; '));
+        $this->assertEquals('one, two and three', $this->stringable()->naturalLanguageList(['one', 'two', 'three']));
+        $this->assertEquals('one, two or three', $this->stringable()->naturalLanguageList(['one', 'two', 'three'], 'or'));
+        $this->assertEquals('one; two and three', $this->stringable()->naturalLanguageList(['one', 'two', 'three'], separator: '; '));
     }
 
     public function testToHtmlString()


### PR DESCRIPTION
This PR ships `naturalLanguateList` string helper.

Example:
```php
['one', 'two', 'three'] => 'one, two and three'
```
