### PR TITLE
[10.x] Support human-friendly text for file size

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -132,7 +132,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be exactly a certain size in kilobytes.
      *
-     * @param  string  $size
+     * @param  string|int  $size
      * @return $this
      */
     public function size($size)
@@ -146,8 +146,8 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be between a minimum and maximum size in kilobytes.
      *
-     * @param  string  $minSize
-     * @param  string  $maxSize
+     * @param  string|int  $minSize
+     * @param  string|int  $maxSize
      * @return $this
      */
     public function between($minSize, $maxSize)
@@ -161,7 +161,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be no less than the given number of kilobytes.
      *
-     * @param  string  $size
+     * @param  string|int  $size
      * @return $this
      */
     public function min($size)
@@ -174,7 +174,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be no more than the given number of kilobytes.
      *
-     * @param  string  $size
+     * @param  string|int  $size
      * @return $this
      */
     public function max($size)

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -329,7 +329,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
 
     /**
      * Convert a human-friendly file size to kilobytes.
-     * 
+     *
      * @param  string  $humanReadable
      * @return number The number of kilobytes
      */

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -335,14 +335,19 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function stringToKb(string $humanReadable)
     {
-        if ($humanReadable === null) return null;
-        if (is_numeric($humanReadable)) return $humanReadable;
+        if ($humanReadable === null) {
+            return null;
+        }
+
+        if (is_numeric($humanReadable)) {
+            return $humanReadable;
+        }
 
         $suffixesToKb = [
             'kb' => 1,
             'mb' => 1000,
             'gb' => 1000000,
-            'tb' => 1000000000
+            'tb' => 1000000000,
         ];
 
         $amount = floatval($humanReadable);

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -131,13 +131,13 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be exactly a certain size in kilobytes.
      *
-     * @param  int  $kilobytes
+     * @param  string  $size
      * @return $this
      */
-    public function size($kilobytes)
+    public function size($size)
     {
-        $this->minimumFileSize = $kilobytes;
-        $this->maximumFileSize = $kilobytes;
+        $this->minimumFileSize = $this->stringToKb($size);
+        $this->maximumFileSize = $this->minimumFileSize;
 
         return $this;
     }
@@ -145,14 +145,14 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be between a minimum and maximum size in kilobytes.
      *
-     * @param  int  $minKilobytes
-     * @param  int  $maxKilobytes
+     * @param  string  $minSize
+     * @param  string  $maxSize
      * @return $this
      */
-    public function between($minKilobytes, $maxKilobytes)
+    public function between($minSize, $maxSize)
     {
-        $this->minimumFileSize = $minKilobytes;
-        $this->maximumFileSize = $maxKilobytes;
+        $this->minimumFileSize = $this->stringToKb($minSize);
+        $this->maximumFileSize = $this->stringToKb($maxSize);
 
         return $this;
     }
@@ -160,12 +160,12 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be no less than the given number of kilobytes.
      *
-     * @param  int  $kilobytes
+     * @param  string  $size
      * @return $this
      */
-    public function min($kilobytes)
+    public function min($size)
     {
-        $this->minimumFileSize = $kilobytes;
+        $this->minimumFileSize = $this->stringToKb($size);
 
         return $this;
     }
@@ -173,12 +173,12 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be no more than the given number of kilobytes.
      *
-     * @param  int  $kilobytes
+     * @param  string  $size
      * @return $this
      */
-    public function max($kilobytes)
+    public function max($size)
     {
-        $this->maximumFileSize = $kilobytes;
+        $this->maximumFileSize = $this->stringToKb($size);
 
         return $this;
     }
@@ -325,5 +325,29 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
         $this->data = $data;
 
         return $this;
+    }
+
+    /**
+     * Convert a human-friendly file size to kilobytes.
+     * 
+     * @param  string  $humanReadable
+     * @return number The number of kilobytes
+     */
+    public function stringToKb(string $humanReadable)
+    {
+        if ($humanReadable === null) return null;
+        if (is_numeric($humanReadable)) return $humanReadable;
+
+        $suffixesToKb = [
+            'kb' => 1,
+            'mb' => 1000,
+            'gb' => 1000000,
+            'tb' => 1000000000
+        ];
+
+        $amount = floatval($humanReadable);
+        $suffix = strtolower(substr(trim($humanReadable), -2));
+
+        return round($suffixesToKb[$suffix] * $amount);
     }
 }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -223,6 +223,15 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testHumanReadable()
+    {
+        $this->assertEquals(File::default()->stringToKb('1mb'), 1000);
+        $this->assertEquals(File::default()->stringToKb('1.5mb'), 1500);
+        $this->assertEquals(File::default()->stringToKb('1.5555mb'), 1556);
+        $this->assertEquals(File::default()->stringToKb('1MB'), 1000);
+        $this->assertEquals(File::default()->stringToKb('1000'), 1000);
+    }
+
     public function testMacro()
     {
         File::macro('toDocument', function () {

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -223,13 +223,40 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testHumanReadable()
+    public function testMaxWithHumanReadableSize()
     {
-        $this->assertEquals(File::default()->stringToKb('1mb'), 1000);
-        $this->assertEquals(File::default()->stringToKb('1.5mb'), 1500);
-        $this->assertEquals(File::default()->stringToKb('1.5555mb'), 1556);
-        $this->assertEquals(File::default()->stringToKb('1MB'), 1000);
-        $this->assertEquals(File::default()->stringToKb('1000'), 1000);
+        $this->fails(
+            File::default()->max('1024kb'),
+            UploadedFile::fake()->create('foo.txt', 1025),
+            ['validation.max.file']
+        );
+
+        $this->passes(
+            File::default()->max('1024kb'),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 512),
+            ]
+        );
+    }
+
+    public function testMaxWithHumanReadableSizeAndMultipleValue()
+    {
+        $this->fails(
+            File::default()->max('1mb'),
+            UploadedFile::fake()->create('foo.txt', 1025),
+            ['validation.max.file']
+        );
+
+        $this->passes(
+            File::default()->max('1mb'),
+            [
+                UploadedFile::fake()->create('foo.txt', 1000),
+                UploadedFile::fake()->create('foo.txt', 999),
+                UploadedFile::fake()->create('foo.txt', 512),
+            ]
+        );
     }
 
     public function testMacro()

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -205,6 +205,24 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testMinWithHumanReadableSize()
+    {
+        $this->fails(
+            File::default()->min('1024kb'),
+            UploadedFile::fake()->create('foo.txt', 1023),
+            ['validation.min.file']
+        );
+
+        $this->passes(
+            File::default()->min('1024kb'),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1025),
+                UploadedFile::fake()->create('foo.txt', 2048),
+            ]
+        );
+    }
+
     public function testMax()
     {
         $this->fails(


### PR DESCRIPTION
Allows declaring file size limits as `10mb` instead of `10000` when validating file sizes.

```php
$data = $request->validate([
    // ...
    'image' => 'required|image|max:10mb'
]);
```

I can never remember which unit file size limits are in, and since I'm often working in megabytes, the number of zeroes makes it hard to comprehend at a glance.

This converts numbers suffixed with `kb`, `mb`, `gb`, or `tb` (why not) into a number of kilobytes. Numbers without units work just as before.