### PR TITLE
Do not check for binary file

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -5,7 +5,6 @@ namespace Illuminate\Http\Middleware;
 use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class SetCacheHeaders
 {
@@ -41,7 +40,7 @@ class SetCacheHeaders
     {
         $response = $next($request);
 
-        if (! $request->isMethodCacheable() || (! $response->getContent() && ! $response instanceof BinaryFileResponse)) {
+        if (! $request->isMethodCacheable()) {
             return $response;
         }
 

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -54,7 +54,7 @@ class CacheTest extends TestCase
         }, 'max_age=120;s_maxage=60');
 
         $this->assertNotNull($response->getMaxAge());
-        $this->assertNotNull($response->getEtag());
+        $this->assertNull($response->getEtag());
     }
 
     public function testSetHeaderToFileEvenWithNoContent()

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -47,14 +47,14 @@ class CacheTest extends TestCase
         $this->assertNull($response->getMaxAge());
     }
 
-    public function testDoNotSetHeaderWhenNoContent()
+    public function testDoSetHeaderWhenNoContent()
     {
         $response = (new Cache)->handle(new Request, function () {
             return new Response;
         }, 'max_age=120;s_maxage=60');
 
-        $this->assertNull($response->getMaxAge());
-        $this->assertNull($response->getEtag());
+        $this->assertNotNull($response->getMaxAge());
+        $this->assertNotNull($response->getEtag());
     }
 
     public function testSetHeaderToFileEvenWithNoContent()


### PR DESCRIPTION
I'm using the `cache.headers` middleware to set caching headers for multiple controllers, including JSON responses and inline file (stream) responses.
This is really useful, as sometimes you create a response on-the-fly, instead of returning a file response.

However I've noticed the cache headers weren't parsed + set at all, as it does seem to expect a binary file + content.
I think it would be nice to always set the headers, even when the content is not a binary file, or the content does not exist. I was thinking about a 'heartbeat' that can be cached.

Let me know if I need to make adjustments or add more tests. :)

Note: I removed the `$response->getContent()` check, as this would be null/empty - maybe this is incorrect?

Thanks.