### PR TITLE
[10.x] Add option to adjust database default lock timeout

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -215,7 +215,7 @@ class CacheManager implements FactoryContract
             $this->getPrefix($config),
             $config['lock_table'] ?? 'cache_locks',
             $config['lock_lottery'] ?? [2, 100],
-            $config['lock_default_timeout_in_seconds'] ?? 86400,
+            $config['lock_timeout'] ?? 86400,
         );
 
         return $this->repository($store->setLockConnection(

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -214,7 +214,8 @@ class CacheManager implements FactoryContract
             $config['table'],
             $this->getPrefix($config),
             $config['lock_table'] ?? 'cache_locks',
-            $config['lock_lottery'] ?? [2, 100]
+            $config['lock_lottery'] ?? [2, 100],
+            $config['lock_default_timeout_in_seconds'] ?? 86400,
         );
 
         return $this->repository($store->setLockConnection(

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -29,9 +29,11 @@ class DatabaseLock extends Lock
     protected $lottery;
 
     /**
-     * @var int expire time used set when no lock time is provided.
+     * The default number of seconds that a lock should be held.
+     *
+     * @var int
      */
-    protected int $defaultTimeoutInSeconds;
+    protected $defaultTimeoutInSeconds;
 
     /**
      * Create a new lock instance.

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -4,7 +4,6 @@ namespace Illuminate\Cache;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\QueryException;
-use Illuminate\Support\Carbon;
 
 class DatabaseLock extends Lock
 {

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -30,6 +30,11 @@ class DatabaseLock extends Lock
     protected $lottery;
 
     /**
+     * @var int expire time used set when no lock time is provided.
+     */
+    protected int $defaultTimeoutInSeconds;
+
+    /**
      * Create a new lock instance.
      *
      * @param  \Illuminate\Database\Connection  $connection
@@ -40,13 +45,14 @@ class DatabaseLock extends Lock
      * @param  array  $lottery
      * @return void
      */
-    public function __construct(Connection $connection, $table, $name, $seconds, $owner = null, $lottery = [2, 100])
+    public function __construct(Connection $connection, $table, $name, $seconds, $owner = null, $lottery = [2, 100], $defaultTimeoutInSeconds = 86400)
     {
         parent::__construct($name, $seconds, $owner);
 
         $this->connection = $connection;
         $this->table = $table;
         $this->lottery = $lottery;
+        $this->defaultTimeoutInSeconds = $defaultTimeoutInSeconds;
     }
 
     /**
@@ -91,7 +97,9 @@ class DatabaseLock extends Lock
      */
     protected function expiresAt()
     {
-        return $this->seconds > 0 ? time() + $this->seconds : Carbon::now()->addDays(1)->getTimestamp();
+        $lockTimeout = $this->seconds > 0 ? $this->seconds : $this->defaultTimeoutInSeconds;
+
+        return time() + $lockTimeout;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -59,9 +59,11 @@ class DatabaseStore implements LockProvider, Store
     protected $lockLottery;
 
     /**
-     * @var int expire time used set when no lock time is provided.
+     * The default number of seconds that a lock should be held.
+     *
+     * @var int
      */
-    protected int $lockDefaultTimeoutInSeconds;
+    protected $defaultLockTimeoutInSeconds;
 
     /**
      * Create a new database store.
@@ -78,14 +80,14 @@ class DatabaseStore implements LockProvider, Store
                                                     $prefix = '',
                                                     $lockTable = 'cache_locks',
                                                     $lockLottery = [2, 100],
-                                                    $lockDefaultTimeoutInSeconds = 86400)
+                                                    $defaultLockTimeoutInSeconds = 86400)
     {
         $this->table = $table;
         $this->prefix = $prefix;
         $this->connection = $connection;
         $this->lockTable = $lockTable;
         $this->lockLottery = $lockLottery;
-        $this->lockDefaultTimeoutInSeconds = $lockDefaultTimeoutInSeconds;
+        $this->defaultLockTimeoutInSeconds = $defaultLockTimeoutInSeconds;
     }
 
     /**
@@ -285,7 +287,7 @@ class DatabaseStore implements LockProvider, Store
             $seconds,
             $owner,
             $this->lockLottery,
-            $this->lockDefaultTimeoutInSeconds
+            $this->defaultLockTimeoutInSeconds
         );
     }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -59,6 +59,11 @@ class DatabaseStore implements LockProvider, Store
     protected $lockLottery;
 
     /**
+     * @var int expire time used set when no lock time is provided.
+     */
+    protected int $lockDefaultTimeoutInSeconds;
+
+    /**
      * Create a new database store.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -69,16 +74,18 @@ class DatabaseStore implements LockProvider, Store
      * @return void
      */
     public function __construct(ConnectionInterface $connection,
-                                $table,
-                                $prefix = '',
-                                $lockTable = 'cache_locks',
-                                $lockLottery = [2, 100])
+                                                    $table,
+                                                    $prefix = '',
+                                                    $lockTable = 'cache_locks',
+                                                    $lockLottery = [2, 100],
+                                                    $lockDefaultTimeoutInSeconds = 86400)
     {
         $this->table = $table;
         $this->prefix = $prefix;
         $this->connection = $connection;
         $this->lockTable = $lockTable;
         $this->lockLottery = $lockLottery;
+        $this->lockDefaultTimeoutInSeconds = $lockDefaultTimeoutInSeconds;
     }
 
     /**
@@ -277,7 +284,8 @@ class DatabaseStore implements LockProvider, Store
             $this->prefix.$name,
             $seconds,
             $owner,
-            $this->lockLottery
+            $this->lockLottery,
+            $this->lockDefaultTimeoutInSeconds
         );
     }
 


### PR DESCRIPTION
We use jobs to make unique notifications, delaying the job till end of the week to provide a weekly notification based on a certain event happening in the system.

Currently we are using database locks and noticed default the lock date is 1 day.

This PR makes this configurable, as most other cache lock systems there is no default timeout on the locks, i thought making it configurable, for us putting it to 1 week or 1 year would suffice.


### Origin of 1 day expire

seems to have been there since the start of database locking: https://github.com/laravel/framework/commit/b78880ad600cceb90cadbac1bef4aa60a3141106

hypotheses: Probably an afterthought that has never been cleaned up properly.