### PR TITLE
[10.x] Add `config:show` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -34,6 +34,7 @@ class ConfigShowCommand extends Command
 
         if (! $data) {
             $this->components->error("Config `{$config}` does not exist.");
+
             return Command::FAILURE;
         }
 
@@ -55,6 +56,7 @@ class ConfigShowCommand extends Command
     {
         if (! is_array($data)) {
             $this->title($config, $this->formatValue($data));
+
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'config:show')]
 class ConfigShowCommand extends Command
@@ -20,7 +21,7 @@ class ConfigShowCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Lists all the config values';
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -14,14 +14,14 @@ class ConfigShowCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'config:show {config : The config to show}';
+    protected $signature = 'config:show {config : The configuration file to show}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Lists all the config values';
+    protected $description = 'Display all of the values for a given configuration file';
 
     /**
      * Execute the console command.
@@ -31,37 +31,38 @@ class ConfigShowCommand extends Command
     public function handle()
     {
         $config = $this->argument('config');
+
         $data = config($config);
 
         if (! $data) {
-            $this->components->error("Config `{$config}` does not exist.");
+            $this->components->error("Configuration file `{$config}` does not exist.");
 
             return Command::FAILURE;
         }
 
         $this->newLine();
-        $this->display($config, $data);
+        $this->render($config, $data);
         $this->newLine();
 
         return Command::SUCCESS;
     }
 
     /**
-     * Render the config information.
+     * Render the configuration values.
      *
-     * @param  string  $config
+     * @param  string  $name
      * @param  mixed  $data
      * @return void
      */
-    public function display($config, $data)
+    public function render($name, $data)
     {
         if (! is_array($data)) {
-            $this->title($config, $this->formatValue($data));
+            $this->title($name, $this->formatValue($data));
 
             return;
         }
 
-        $this->title($config);
+        $this->title($name);
 
         foreach (Arr::dot($data) as $key => $value) {
             $this->components->twoColumnDetail(
@@ -72,7 +73,7 @@ class ConfigShowCommand extends Command
     }
 
     /**
-     * Renders the title.
+     * Render the title.
      *
      * @param  string  $title
      * @param  string|null  $subtitle
@@ -87,7 +88,7 @@ class ConfigShowCommand extends Command
     }
 
     /**
-     * Formats the config key.
+     * Format the given configuration key.
      *
      * @param  string  $key
      * @return string
@@ -104,9 +105,9 @@ class ConfigShowCommand extends Command
     }
 
     /**
-     * Formats the config value.
+     * Format the given configuration value.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return string
      */
     protected function formatValue($value)

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+
+#[AsCommand(name: 'config:show')]
+class ConfigShowCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'config:show {config : The config to show}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $config = $this->argument('config');
+        $data = config($config);
+
+        if (! $data) {
+            $this->components->error("Config `{$config}` does not exist.");
+            return Command::FAILURE;
+        }
+
+        $this->newLine();
+        $this->display($config, $data);
+        $this->newLine();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Render the config information.
+     *
+     * @param  string  $config
+     * @param  mixed  $data
+     * @return void
+     */
+    public function display($config, $data)
+    {
+        if (! is_array($data)) {
+            $this->title($config, $this->formatValue($data));
+            return;
+        }
+
+        $this->title($config);
+
+        foreach (Arr::dot($data) as $key => $value) {
+            $this->components->twoColumnDetail(
+                $this->formatKey($key),
+                $this->formatValue($value)
+            );
+        }
+    }
+
+    /**
+     * Renders the title.
+     *
+     * @param  string  $title
+     * @param  string|null  $subtitle
+     * @return void
+     */
+    public function title($title, $subtitle = null)
+    {
+        $this->components->twoColumnDetail(
+            "<fg=green;options=bold>{$title}</>",
+            $subtitle,
+        );
+    }
+
+    /**
+     * Formats the config key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function formatKey($key)
+    {
+         return preg_replace_callback(
+            '/(.*)\.(.*)$/', fn ($matches) => sprintf(
+                '<fg=gray>%s ⇁</> %s',
+                str_replace('.', ' ⇁ ', $matches[1]),
+                $matches[2]
+            ), $key
+        );
+    }
+
+    /**
+     * Formats the config value
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function formatValue($value)
+    {
+        return match (true) {
+            is_bool($value) => sprintf('<fg=#ef8414;options=bold>%s</>', $value ? 'true' : 'false'),
+            is_null($value) => '<fg=#ef8414;options=bold>null</>',
+            is_numeric($value) => "<fg=#ef8414;options=bold>{$value}</>",
+            is_array($value) => '[]',
+            is_object($value) => get_class($value),
+            is_string($value) => $value,
+            default => print_r($value, true),
+        };
+    }
+}

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -91,7 +91,7 @@ class ConfigShowCommand extends Command
      */
     protected function formatKey($key)
     {
-         return preg_replace_callback(
+        return preg_replace_callback(
             '/(.*)\.(.*)$/', fn ($matches) => sprintf(
                 '<fg=gray>%s ⇁</> %s',
                 str_replace('.', ' ⇁ ', $matches[1]),
@@ -101,7 +101,7 @@ class ConfigShowCommand extends Command
     }
 
     /**
-     * Formats the config value
+     * Formats the config value.
      *
      * @param  string  $value
      * @return string

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -35,6 +35,7 @@ use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ComponentMakeCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
+use Illuminate\Foundation\Console\ConfigShowCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
@@ -111,6 +112,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ClearResets' => ClearResetsCommand::class,
         'ConfigCache' => ConfigCacheCommand::class,
         'ConfigClear' => ConfigClearCommand::class,
+        'ConfigShow' => ConfigShowCommand::class,
         'Db' => DbCommand::class,
         'DbMonitor' => DatabaseMonitorCommand::class,
         'DbPrune' => PruneCommand::class,

--- a/tests/Config/Console/ConfigShowCommandTest.php
+++ b/tests/Config/Console/ConfigShowCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Config\Console;
+
+use Illuminate\Foundation\Console\ConfigShowCommand;
+use Orchestra\Testbench\TestCase;
+
+class ConfigShowCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('COLUMNS=64');
+    }
+
+    public function testDisplayConfig()
+    {
+        config()->set('test', [
+            'string' => 'Test',
+            'int' => 1,
+            'float' => 1.2,
+            'boolean' => true,
+            'null' => null,
+            'array' => [
+                ConfigShowCommand::class,
+            ],
+            'empty_array' => [],
+            'assoc_array' => ['foo' => 'bar'],
+            'class' => new \stdClass,
+        ]);
+
+        $this->artisan(ConfigShowCommand::class, ['config' => 'test'])
+            ->assertSuccessful()
+            ->expectsOutput('  test .......................................................  ')
+            ->expectsOutput('  string ................................................ Test  ')
+            ->expectsOutput('  int ...................................................... 1  ')
+            ->expectsOutput('  float .................................................. 1.2  ')
+            ->expectsOutput('  boolean ............................................... true  ')
+            ->expectsOutput('  null .................................................. null  ')
+            ->expectsOutput('  array ⇁ 0 .. Illuminate\Foundation\Console\ConfigShowCommand  ')
+            ->expectsOutput('  empty_array ............................................. []  ')
+            ->expectsOutput('  assoc_array ⇁ foo ...................................... bar  ')
+            ->expectsOutput('  class ............................................. stdClass  ');
+    }
+
+    public function testDisplayNestedConfigItems()
+    {
+        config()->set('test', [
+            'nested' => [
+                'foo' => 'bar',
+            ],
+        ]);
+
+        $this->artisan(ConfigShowCommand::class, ['config' => 'test.nested'])
+            ->assertSuccessful()
+            ->expectsOutput('  test.nested ................................................  ')
+            ->expectsOutput('  foo .................................................... bar  ');
+    }
+
+    public function testDisplaySingleValue()
+    {
+        config()->set('foo', 'bar');
+
+        $this->artisan(ConfigShowCommand::class, ['config' => 'foo'])
+            ->assertSuccessful()
+            ->expectsOutput('  foo .................................................... bar  ');
+    }
+
+    public function testDisplayErrorIfConfigDoesNotExist()
+    {
+        $this->artisan(ConfigShowCommand::class, ['config' => 'invalid'])
+            ->assertFailed();
+    }
+}

--- a/tests/Testing/Console/ConfigShowCommandTest.php
+++ b/tests/Testing/Console/ConfigShowCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Config\Console;
+namespace Illuminate\Tests\Testing\Console;
 
 use Illuminate\Foundation\Console\ConfigShowCommand;
 use Orchestra\Testbench\TestCase;


### PR DESCRIPTION
This PR adds the capability to see the `config` values directly from your `cli`.

## Output

<img width="1160" alt="image" src="https://github.com/laravel/framework/assets/823088/60a2076e-9de0-4ce4-9919-a9dcf4f9791b">

### It can also work with nested config values like this:

```sh
php artisan config:view auth.guards
```

#### Output

<img width="1125" alt="image" src="https://github.com/laravel/framework/assets/823088/cbe802a7-0e09-4641-8680-665357783037">

### or, even single values

```sh
php artisan config:view auth.guards.web.driver
```

<img width="1121" alt="image" src="https://github.com/laravel/framework/assets/823088/51fa3e01-31df-4734-9c4b-7204417e2a94">

Cheers.