### PR TITLE
Bump nesbot/carbon for PHP 8.3 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",
         "monolog/monolog": "^3.0",
-        "nesbot/carbon": "^2.62.1",
+        "nesbot/carbon": "^2.67",
         "nunomaduro/termwind": "^1.13",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,7 +23,7 @@
         "illuminate/conditionable": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
-        "nesbot/carbon": "^2.62.1",
+        "nesbot/carbon": "^2.67",
         "voku/portable-ascii": "^2.0"
     },
     "conflict": {


### PR DESCRIPTION
This should fix the failing tests on PHP 8.3 prefer-lowest are, which happened due to the new PHP 8.3 DateTime Exceptions like `DateMalformedStringException`.

See https://github.com/briannesbitt/Carbon/pull/2770 which was released in [`nesbot/carbon:2.67.0`](https://github.com/briannesbitt/Carbon/releases/tag/2.67.0) 