### PR TITLE
[10.x] Add `Request::rawString()` method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -330,6 +330,18 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input from the request as a string.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return string
+     */
+    public function rawString($key, $default = null)
+    {
+        return (string) $this->input($key, $default);
+    }
+
+    /**
      * Retrieve input as a boolean value.
      *
      * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -613,6 +613,32 @@ class HttpRequestTest extends TestCase
         $this->assertSame('', $request->string('unknown_key')->value());
     }
 
+    public function testRawStringMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'int' => 123,
+            'int_str' => '456',
+            'float' => 123.456,
+            'float_str' => '123.456',
+            'float_zero' => 0.000,
+            'float_str_zero' => '0.000',
+            'str' => 'abc',
+            'empty_str' => '',
+            'null' => null,
+        ]);
+        $this->assertIsString($request->rawString('int'));
+        $this->assertIsSTring($request->rawString('unknown_key'));
+        $this->assertSame('123', $request->rawString('int'));
+        $this->assertSame('456', $request->rawString('int_str'));
+        $this->assertSame('123.456', $request->rawString('float'));
+        $this->assertSame('123.456', $request->rawString('float_str'));
+        $this->assertSame('0', $request->rawString('float_zero'));
+        $this->assertSame('0.000', $request->rawString('float_str_zero'));
+        $this->assertSame('', $request->rawString('empty_str'));
+        $this->assertSame('', $request->rawString('null'));
+        $this->assertSame('', $request->rawString('unknown_key'));
+    }
+
     public function testBooleanMethod()
     {
         $request = Request::create('/', 'GET', ['with_trashed' => 'false', 'download' => true, 'checked' => 1, 'unchecked' => '0', 'with_on' => 'on', 'with_yes' => 'yes']);


### PR DESCRIPTION
The `Illuminate\Http\Request` class currently has 2 methods `str()` and `string()` that return `Illuminate\Support\Stringable` objects. 

When working in a non-strict environment, these methods are fine since any functions or methods that expect `string` will auto-cast the object using PHP's `__toString()` method, however there are other times when using `strict_types=1` where you need to cast the value ahead of time which can get quite repetitive.

I think in an ideal world, the `string()` method would return a scalar string but that would be a breaking change. So I've added a new `rawString()` method that returns a scalar string instead.