### PR TITLE
Fix for issues with closure-based scheduled commands in schedule:test

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -52,32 +52,33 @@ class ScheduleTestCommand extends Command
                 return trim(str_replace($commandBinary, '', $commandName)) === $name;
             });
 
-            if (count($matches) === 0) {
+            if (count($matches) !== 1) {
                 $this->components->info('No matching scheduled command found.');
+
                 return;
             }
 
             $index = key($matches);
 
             // Handle multiple matches
-            if (count($matches) >= 1) {
+            if (count($matches) > 1) {
                 $options = array_map(function ($index, $value) {
                     return "$value [$index]";
                 }, array_keys($matches), $matches);
                 $userInput = $this->components->choice('Multiple matching scheduled commands found. Select one:', $options);
                 preg_match('/\[(\d+)\]/', $userInput, $choice);
-                $index = (int)$choice[1];
+                $index = (int) $choice[1];
             }
         } else {
             // if there are multiple scheduled commands with the same description
-            if(count($commandNames) !== count(array_unique($commandNames))){
+            if (count($commandNames) !== count(array_unique($commandNames))) {
                 $options = array_map(function ($index, $value) {
                     return "$value [$index]";
                 }, array_keys($commandNames), $commandNames);
                 $userInput = $this->components->choice('Which command would you like to run?', $options);
                 preg_match('/\[(\d+)\]/', $userInput, $choice);
-                $index = (int)$choice[1];
-            }else{
+                $index = (int) $choice[1];
+            } else {
                 $index = array_search($this->components->choice('Which command would you like to run?', $commandNames), $commandNames);
             }
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -52,15 +52,34 @@ class ScheduleTestCommand extends Command
                 return trim(str_replace($commandBinary, '', $commandName)) === $name;
             });
 
-            if (count($matches) !== 1) {
+            if (count($matches) === 0) {
                 $this->components->info('No matching scheduled command found.');
-
                 return;
             }
 
             $index = key($matches);
+
+            // Handle multiple matches
+            if (count($matches) >= 1) {
+                $options = array_map(function ($index, $value) {
+                    return "$value [$index]";
+                }, array_keys($matches), $matches);
+                $userInput = $this->components->choice('Multiple matching scheduled commands found. Select one:', $options);
+                preg_match('/\[(\d+)\]/', $userInput, $choice);
+                $index = (int)$choice[1];
+            }
         } else {
-            $index = array_search($this->components->choice('Which command would you like to run?', $commandNames), $commandNames);
+            // if there are multiple scheduled commands with the same description
+            if(count($commandNames) !== count(array_unique($commandNames))){
+                $options = array_map(function ($index, $value) {
+                    return "$value [$index]";
+                }, array_keys($commandNames), $commandNames);
+                $userInput = $this->components->choice('Which command would you like to run?', $options);
+                preg_match('/\[(\d+)\]/', $userInput, $choice);
+                $index = (int)$choice[1];
+            }else{
+                $index = array_search($this->components->choice('Which command would you like to run?', $commandNames), $commandNames);
+            }
         }
 
         $event = $commands[$index];

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -52,7 +52,7 @@ class ScheduleTestCommand extends Command
                 return trim(str_replace($commandBinary, '', $commandName)) === $name;
             });
 
-            if (count($matches) !== 1) {
+            if (count($matches) === 0) {
                 $this->components->info('No matching scheduled command found.');
 
                 return;


### PR DESCRIPTION
This pull request addresses two issues related to the `schedule:test` command when dealing with multiple closure-based scheduled commands.

Issue 1: Incorrectly selecting scheduled closures by index number
- The `php artisan schedule:test` command allowed users to select a task by its index number, but the task selection logic was based on the task name generated by the `schedule:test` command, causing all closure-based tasks to have the same name.
- Solution: Modified the command to display options with their respective index numbers. Now, when the user selects an option, the correct task associated with that index is executed.

Issue 2: Incorrect message when using the `--name` option with multiple matching commands
- Previously, when using the command `php artisan schedule:test --name <name>`, the returned message was "No matching scheduled command found," even if multiple commands with the same name existed. This was misleading.
- Solution:
  1. Updated the logic to display the "No matching scheduled command found" message only when no command with the given name exists.
  2. Implemented new logic to prompt the user to choose the desired command when multiple commands match the given description.
  
These changes ensure that the `schedule:test` command works correctly with closure-based scheduled commands.

I have thoroughly tested these changes on the provided reproduction repository on the attached issue, and all scheduled closures are now correctly executed based on the user's input. Additionally, the `--name` option now works as intended, providing choices when multiple matching commands exist.