### PR TITLE
Add min_html and max_html validation rules

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -95,6 +95,7 @@ return [
         'string' => 'The :attribute field must not be greater than :max characters.',
     ],
     'max_digits' => 'The :attribute field must not have more than :max digits.',
+    'max_html' => 'The :attribute field must be least :max characters.',
     'mimes' => 'The :attribute field must be a file of type: :values.',
     'mimetypes' => 'The :attribute field must be a file of type: :values.',
     'min' => [
@@ -104,6 +105,7 @@ return [
         'string' => 'The :attribute field must be at least :min characters.',
     ],
     'min_digits' => 'The :attribute field must have at least :min digits.',
+    'min_html' => 'The :attribute field must be least :min characters.',
     'missing' => 'The :attribute field must be missing.',
     'missing_if' => 'The :attribute field must be missing when :other is :value.',
     'missing_unless' => 'The :attribute field must be missing unless :other is :value.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1540,6 +1540,36 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute has a minimum length after stripping out all HTML elements.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMinHtml($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min_html');
+
+        return mb_strlen(trim(strip_tags(html_entity_decode($value)))) >= $parameters[0];
+    }
+
+    /**
+     * Validate that an attribute has a maximum length after stripping out all HTML elements.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMaxHtml($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max_html');
+
+        return mb_strlen(trim(strip_tags(html_entity_decode($value)))) <= $parameters[0];
+    }
+
+    /**
      * Validate that an attribute is missing.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3092,6 +3092,34 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateHtmlMin()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => '<p>12345678910</p>'], ['foo' => 'MinHtml:10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '<p>123456789</p>'], ['foo' => 'MinHtml:10']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '<p data-attribute style="color: red"><div>123</div></p>'], ['foo' => 'MinHtml:10']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateHtmlMax()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => '<p>1234567890</p>'], ['foo' => 'MaxHtml:10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '<p>12345678910</p>'], ['foo' => 'MaxHtml:10']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '<p data-attribute style="color: red"><div>123</div></p>'], ['foo' => 'MaxHtml:10']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateMax()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
I have found myself a few times validating a minimum length on `description` fields which are populated via WYSIWYG editors and commonly contain HTML tags such as `<p>` and even HTML attributes `style="color: red"`.

Validating the minimum or maximum length allowed in this kind of fields is hard and inaccurate with the current validation rules since is nearly impossible to know how many of these tags and attributes are being included in the string and we will likely want to only count the length of the "content" inside all those tags.

This PR will be adding support to add length validation rules to fields containing HTML tags but still requiring to have a min/max length.

Basically the method strips out all the HTML from the input and runs the validation against content without all the HTML

```php
// This won't pass validation
\Validator::make(
    ['description' => '<p>123456789</p>'],
    ['description' => 'min_html:10']
);

// This will pass validation
\Validator::make(
    ['description' => '<p>1234567890</p>'],
    [ 'description' => 'min_html:10']
);
```

Notes:
I wanted to include this into the `min` and `max` rules as they already do this length validation but seems quite hard to provide those methods a way to validate against strings and HTML without any breaking change so I ended up naming them `min_html` and `max_html` and make sure the user is aware that the validation field may contain HTML.