### PR TITLE
[10.x] Add --open option to php artisan make:migration command to open newly created migration file in the editor

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -48,6 +48,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 
     /**
      * The created migration file path.
+     * 
      * @var string
      */
     protected $file;

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -136,6 +136,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 
         if (empty($ide)) {
             $this->components->warn('Please set the LARAVEL_IDE environment variable');
+            
             return;
         }
 


### PR DESCRIPTION
This pull request adds a new option to the `php artisan make:migration` command called `--open`. This option will open the newly created migration file in the editor after it is created. 

> This makes it easier to start working on the migration file without having to manually open it in the editor.

The `--open` option uses the `LARAVEL_IDE` environment variable that must be set to the name of the IDE you want to use to open the migration file. For example, if you want to open the migration file in VS Code, you would set the LARAVEL_IDE variable to code like `export LARAVEL_IDE=code`

To use the `--open` option, simply pass it as a parameter to the `php artisan make:migration` command. For example, the following command will create a new migration file called `create_users_table` and open it in VS Code:

`php artisan make:migration create_users_table --open`