### PR TITLE
fixed No matching scheduled command found issue

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -52,13 +52,18 @@ class ScheduleTestCommand extends Command
                 return trim(str_replace($commandBinary, '', $commandName)) === $name;
             });
 
-            if (count($matches) !== 1) {
+            if (count($matches) === 0) {
                 $this->components->info('No matching scheduled command found.');
 
                 return;
             }
 
             $index = key($matches);
+
+            if (count($matches) > 1) {
+                $index = $this->getSelectedCommandByIndex($matches);
+            }
+
         } else {
             $index = $this->getSelectedCommandByIndex($commandNames);
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -63,7 +63,6 @@ class ScheduleTestCommand extends Command
             if (count($matches) > 1) {
                 $index = $this->getSelectedCommandByIndex($matches);
             }
-
         } else {
             $index = $this->getSelectedCommandByIndex($commandNames);
         }


### PR DESCRIPTION
This pull request addresses two issues related to the `schedule:test` command when dealing with multiple closure-based scheduled commands.

Closes #47783 

**Issue:** Incorrect message when using the `--name` option with multiple matching commands
- Previously, when using the command `php artisan schedule:test --name <name>`, if multiple commands found then the returned message was `"No matching scheduled command found."` even if multiple commands with the same name existed. This was misleading.
- Solution:
  1. Updated the logic to display the `"No matching scheduled command found"` message only when no command with the given name exists.
  2. Implemented new logic to prompt the user to choose the desired command when multiple commands match the given description.

Apart from the above, another bug was also fixed which was reported in that issue in another PR, so this issue can be closed, description is given below

**Issue:** Incorrectly selecting scheduled closures by index number
- The `php artisan schedule:test` command allowed users to select a task by its index number, but the task selection logic was based on the task name generated by the `schedule:test` command, causing all closure-based tasks to have the same name.
- Solution: Modified the command to display options with their respective index numbers. Now, when the user selects an option, the correct task associated with that index is executed.
PR for Above issue is already merged - https://github.com/laravel/framework/pull/47862
