### PR TITLE
[10.x] Add exception handler render request param type

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Contracts\Debug;
 
+use Illuminate\Http\Request;
 use Throwable;
 
 interface ExceptionHandler
@@ -33,7 +34,7 @@ interface ExceptionHandler
      *
      * @throws \Throwable
      */
-    public function render($request, Throwable $e);
+    public function render(Request $request, Throwable $e);
 
     /**
      * Render an exception to the console.

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -18,6 +18,7 @@ use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Router;
@@ -384,7 +385,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @throws \Throwable
      */
-    public function render($request, Throwable $e)
+    public function render(Request $request, Throwable $e)
     {
         $e = $this->mapException($e);
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -51,7 +51,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $this->config = m::mock(Config::class);
 
-        $this->request = m::mock(stdClass::class);
+        $this->request = m::mock(Request::class);
 
         $this->container = Container::setInstance(new Container);
 


### PR DESCRIPTION
Hello 👋🏻 

I need to add type to `$request` on exception render function on my app to achieve 100% type coverage but it's not compatible with parent. That's what I am adding on this PR to fix it.