### PR TITLE
[10.x] Allow utilising `withTrashed()`, `withoutTrashed()` and `onlyTrashed()` on `MorphTo` relationship even without `SoftDeletes` Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -146,6 +146,10 @@ class MorphTo extends BelongsTo
                                 (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
                             );
 
+        if ($callback = ($this->morphableConstraints['*'] ?? null)) {
+            $callback($query);
+        }
+
         if ($callback = ($this->morphableConstraints[get_class($instance)] ?? null)) {
             $callback($query);
         }
@@ -363,6 +367,48 @@ class MorphTo extends BelongsTo
         }
 
         return $query;
+    }
+
+    /**
+     * Add the with-trashed to the query when available.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    public function withTrashed()
+    {
+        $callback = fn ($query) => $query->hasMacro('withTrashed') ? $query->withTrashed() : $query;
+
+        return $this->when(true, $callback)
+            ->constrain(['*' => $callback]);
+    }
+
+    /**
+     * Add the without-trashed to the query when available.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    public function withoutTrashed()
+    {
+        $callback = fn ($query) => $query->hasMacro('withoutTrashed') ? $query->withoutTrashed() : $query;
+
+        return $this->when(true, $callback)
+            ->constrain(['*' => $callback]);
+    }
+
+    /**
+     * Add the only-trashed to the query when available.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    public function onlyTrashed()
+    {
+        $callback = fn ($query) => $query->hasMacro('onlyTrashed') ? $query->onlyTrashed() : $query;
+
+        return $this->when(true, $callback)
+            ->constrain(['*' => $callback]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -372,43 +372,52 @@ class MorphTo extends BelongsTo
     /**
      * Add the with-trashed to the query when available.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return void
+     * @return $this
      */
     public function withTrashed()
     {
         $callback = fn ($query) => $query->hasMacro('withTrashed') ? $query->withTrashed() : $query;
 
-        return $this->when(true, $callback)
-            ->constrain(['*' => $callback]);
+        $this->macroBuffer[] = [
+            'method' => 'when',
+            'parameters' => [true, $callback],
+        ];
+
+        return $this->when(true, $callback);
     }
 
     /**
      * Add the without-trashed to the query when available.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return void
+     * @return $this
      */
     public function withoutTrashed()
     {
         $callback = fn ($query) => $query->hasMacro('withoutTrashed') ? $query->withoutTrashed() : $query;
 
-        return $this->when(true, $callback)
-            ->constrain(['*' => $callback]);
+        $this->macroBuffer[] = [
+            'method' => 'when',
+            'parameters' => [true, $callback],
+        ];
+
+        return $this->when(true, $callback);
     }
 
     /**
      * Add the only-trashed to the query when available.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return void
+     * @return $this
      */
     public function onlyTrashed()
     {
         $callback = fn ($query) => $query->hasMacro('onlyTrashed') ? $query->onlyTrashed() : $query;
 
-        return $this->when(true, $callback)
-            ->constrain(['*' => $callback]);
+        $this->macroBuffer[] = [
+            'method' => 'when',
+            'parameters' => [true, $callback],
+        ];
+
+        return $this->when(true, $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -146,10 +146,6 @@ class MorphTo extends BelongsTo
                                 (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
                             );
 
-        if ($callback = ($this->morphableConstraints['*'] ?? null)) {
-            $callback($query);
-        }
-
         if ($callback = ($this->morphableConstraints[get_class($instance)] ?? null)) {
             $callback($query);
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -351,22 +351,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Replay stored macro calls on the actual related instance.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    protected function replayMacros(Builder $query)
-    {
-        foreach ($this->macroBuffer as $macro) {
-            $query->{$macro['method']}(...$macro['parameters']);
-        }
-
-        return $query;
-    }
-
-    /**
-     * Add the with-trashed to the query when available.
+     * Indicate that soft deleted models should be included in the results.
      *
      * @return $this
      */
@@ -383,7 +368,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Add the without-trashed to the query when available.
+     * Indicate that soft deleted models should not be included in the results.
      *
      * @return $this
      */
@@ -400,7 +385,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Add the only-trashed to the query when available.
+     * Indicate that only soft deleted models should be included in the results.
      *
      * @return $this
      */
@@ -414,6 +399,21 @@ class MorphTo extends BelongsTo
         ];
 
         return $this->when(true, $callback);
+    }
+
+    /**
+     * Replay stored macro calls on the actual related instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function replayMacros(Builder $query)
+    {
+        foreach ($this->macroBuffer as $macro) {
+            $query->{$macro['method']}(...$macro['parameters']);
+        }
+
+        return $query;
     }
 
     /**

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -99,7 +99,6 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     }
 }
 
-
 class Action extends Model
 {
     public $timestamps = false;

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -39,7 +39,6 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
 
         (new Comment)->commentable()->associate($post)->save();
         (new Comment)->commentable()->associate($video)->save();
-        (new Comment)->commentable()->associate($user)->save();
     }
 
     public function testWithMorphLoading()
@@ -53,7 +52,6 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
         $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
         $this->assertTrue($comments[1]->relationLoaded('commentable'));
-        $this->assertTrue($comments[2]->relationLoaded('commentable'));
     }
 
     public function testWithMorphLoadingWithSingleRelation()
@@ -77,7 +75,6 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertTrue($comments[0]->relationLoaded('commentable_with_trashed'));
         $this->assertNull($comments[0]->getRelation('commentable_with_trashed'));
         $this->assertTrue($comments[1]->relationLoaded('commentable_with_trashed'));
-        $this->assertTrue($comments[2]->relationLoaded('commentable_with_trashed'));
     }
 }
 

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -37,8 +37,6 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');
-            $table->string('target_type')->nullable();
-            $table->integer('target_id')->nullable();
         });
 
         $user = User::create();

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -39,6 +39,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
 
         (new Comment)->commentable()->associate($post)->save();
         (new Comment)->commentable()->associate($video)->save();
+        (new Comment)->commentable()->associate($user)->save();
     }
 
     public function testWithMorphLoading()
@@ -52,6 +53,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
         $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
         $this->assertTrue($comments[1]->relationLoaded('commentable'));
+        $this->assertTrue($comments[2]->relationLoaded('commentable'));
     }
 
     public function testWithMorphLoadingWithSingleRelation()
@@ -65,6 +67,18 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
         $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
     }
+
+    public function testMorphLoadingMixedWithTrashedRelations()
+    {
+        $comments = Comment::query()
+            ->with('commentable_with_trashed')
+            ->get();
+
+        $this->assertTrue($comments[0]->relationLoaded('commentable_with_trashed'));
+        $this->assertNull($comments[0]->getRelation('commentable_with_trashed'));
+        $this->assertTrue($comments[1]->relationLoaded('commentable_with_trashed'));
+        $this->assertTrue($comments[2]->relationLoaded('commentable_with_trashed'));
+    }
 }
 
 class Comment extends Model
@@ -74,6 +88,11 @@ class Comment extends Model
     public function commentable()
     {
         return $this->morphTo();
+    }
+
+    public function commentable_with_trashed()
+    {
+        return $this->commentable()->withTrashed();
     }
 }
 


### PR DESCRIPTION
This would be useful in some 3rd party packages as this has become an issue where it's not possible to define the relationship such as `$this->morphTo()->withTrashed()` unless all relationship uses `SoftDeletes` trait:

* laravel/nova-issues#5754
* spatie/laravel-activitylog#456

Test without and with code changes

![image](https://github.com/laravel/framework/assets/172966/5b62416d-9fa7-42e3-9213-53ff22bbd692)
