### PR TITLE
Fix ofMany null column or only aggregate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -66,7 +66,7 @@ trait CanBeOneOfMany
      *
      * @throws \InvalidArgumentException
      */
-    public function ofMany($column = 'id', $aggregate = 'MAX', $relation = null)
+    public function ofMany($column = null, $aggregate = null, $relation = null)
     {
         $this->isOneOfMany = true;
 
@@ -75,6 +75,8 @@ trait CanBeOneOfMany
         );
 
         $keyName = $this->query->getModel()->getKeyName();
+
+        $column = is_null($column) ? [] : $column;
 
         $columns = is_string($columns = $column) ? [
             $column => $aggregate,

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -66,7 +66,7 @@ trait CanBeOneOfMany
      *
      * @throws \InvalidArgumentException
      */
-    public function ofMany($column = null, $aggregate = null, $relation = null)
+    public function ofMany($column = 'id', $aggregate = 'MAX', $relation = null)
     {
         $this->isOneOfMany = true;
 
@@ -77,6 +77,12 @@ trait CanBeOneOfMany
         $keyName = $this->query->getModel()->getKeyName();
 
         $column = is_null($column) ? [] : $column;
+        $aggregate ??= 'MAX';
+
+        if ($aggregate instanceof Closure) {
+            $closure = $aggregate;
+            $aggregate = 'MAX';
+        }
 
         $columns = is_string($columns = $column) ? [
             $column => $aggregate,
@@ -85,10 +91,6 @@ trait CanBeOneOfMany
 
         if (! array_key_exists($keyName, $columns)) {
             $columns[$keyName] = 'MAX';
-        }
-
-        if ($aggregate instanceof Closure) {
-            $closure = $aggregate;
         }
 
         foreach ($columns as $column => $aggregate) {


### PR DESCRIPTION
The DocComment of the function `ofMany` in trait `CanBeOneOfMany` states that `columns` and/or `aggregate` can be null, however if any of those are null the function breaks either in function `array_key_exists` or in `strtolower`.

Also if only the `aggregate` parameter is passed as a Closure the function will also break in `strtolower`.

This PR will prevent those cases, the function will always fallback to `column` 'id' if null given with the MAX aggregate. This will make the api cleaner when the user only wants to use an aggregate closure.

fixes issue #47836