### PR TITLE
[10.x] Add --test and --pest options to make:component

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Str;
@@ -11,6 +12,8 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'make:component')]
 class ComponentMakeCommand extends GeneratorCommand
 {
+    use CreatesMatchingTest;
+
     /**
      * The console command name.
      *


### PR DESCRIPTION
In #38997, Luke added the `--test` and `--pest` options to various make commands.

This PR extends it to the `make:component` command as well.
All we need to do is just import the `CreatesMatchingTest` trait.

## Example
```
php artisan make:component Foo --test

   INFO  Component and test [app/View/Components/Foo.php] created successfully.
```

In the above example, the test file is created at `tests/Feature/View/Components/FooTest.php`.


If we add the `--view` option which only creates an anonymous component, the test file will not be created. But I think that's fair enough.

## Example
```
php artisan make:component Bar --view --test

   INFO  Component created successfully.
```