### PR TITLE
[10.x] Add support `toHtmlAttributes` to `Arr`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -858,6 +858,33 @@ class Arr
     }
 
     /**
+     * Convert an array of attributes to a string.
+     *
+     * @param  array  $array
+     * @return HtmlString
+     */
+    public static function toHtmlAttributes($array)
+    {
+        $htmlAttributes = static::wrap($array);
+
+        $attributes = [];
+
+        foreach ($htmlAttributes as $attribute => $constraint) {
+            if ($constraint === true) {
+                $attributes[] = $attribute;
+            } elseif (is_array($constraint)) {
+                foreach ($constraint as $key => $value) {
+                    $attributes[] = sprintf('%s-%s="%s"', $attribute, $key, htmlentities($value));
+                }
+            } elseif ($constraint) {
+                $attributes[] = sprintf('%s="%s"', $attribute, htmlentities($constraint));
+            }
+        }
+
+        return new HtmlString(implode(' ', $attributes));
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -956,7 +956,7 @@ class Str
      * @param  string|iterable<string>  $replace
      * @param  string|iterable<string>  $subject
      * @param  bool  $caseSensitive
-     * @return string
+     * @return array|string|string[]
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -956,7 +956,7 @@ class Str
      * @param  string|iterable<string>  $replace
      * @param  string|iterable<string>  $subject
      * @param  bool  $caseSensitive
-     * @return array|string|string[]
+     * @return string|string[]
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1004,6 +1004,45 @@ class SupportArrTest extends TestCase
         $this->assertSame('font-weight: bold; margin-top: 4px; margin-left: 2px;', $styles);
     }
 
+    public function testToHtmlAttributes()
+    {
+        $attributes = Arr::toHtmlAttributes([])->toHtml();
+
+        $this->assertSame('', $attributes);
+
+        $attributes = Arr::toHtmlAttributes([
+            'class' => 'font-bold',
+            'id' => 'foo',
+            'style' => 'margin-top: 4px;',
+        ])->toHtml();
+
+        $this->assertSame('class="font-bold" id="foo" style="margin-top: 4px;"', $attributes);
+
+        $attributes = Arr::toHtmlAttributes([
+            'class' => 'font-bold',
+            'id' => 'foo',
+            'style' => 'margin-top: 4px;',
+            'disabled' => true,
+            'required' => false,
+        ])->toHtml();
+
+        $this->assertSame('class="font-bold" id="foo" style="margin-top: 4px;" disabled', $attributes);
+
+        $attributes = Arr::toHtmlAttributes([
+            'class' => 'font-bold',
+            'id' => 'foo',
+            'style' => 'margin-top: 4px;',
+            'disabled' => true,
+            'required' => false,
+            'data' => [
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ],
+        ])->toHtml();
+
+        $this->assertSame('class="font-bold" id="foo" style="margin-top: 4px;" disabled data-foo="bar" data-baz="qux"', $attributes);
+    }
+
     public function testWhere()
     {
         $array = [100, '200', 300, '400', 500];


### PR DESCRIPTION
This PR is add support `toHtmlAttributes` in `Arr`.

```blade
@php
    $attributes = [
         'id' => 'button',
         'disabled' => true,
         'data' => [
             'url' => 'http://laravel.test',
         ],
    ];
@endphp

<div {{ Arr::toHtmlAttributes($attributes) }}></div>

<!-- This will convert to -->

<div id="button" disabled data-url="http://laravel.test"></div>

```