### PR TITLE
[10.x] Refactor `getClassForCallable()` in Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -676,7 +676,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClassForCallable($callback)
     {
-        if (! is_callable($callback) 
+        if (! is_callable($callback)
             || ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
             return false;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -676,20 +676,12 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClassForCallable($callback)
     {
-        if (PHP_VERSION_ID >= 80200) {
-            if (is_callable($callback) &&
-                ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
-                return $reflector->getClosureScopeClass()->name ?? false;
-            }
-
+        if (! is_callable($callback) 
+            || ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
             return false;
         }
 
-        if (! is_array($callback)) {
-            return false;
-        }
-
-        return is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+        return $reflector->getClosureScopeClass()?->getName() ?? false;
     }
 
     /**

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -497,11 +497,9 @@ class ContextualBindingTest extends TestCase
         $valueResolvedUsingArraySyntax = $container->call([$object, 'method']);
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingArraySyntax);
 
-        if (PHP_VERSION_ID >= 80200) {
-            // first class callable syntax...
-            $valueResolvedUsingFirstClassSyntax = $container->call($object->method(...));
-            $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingFirstClassSyntax);
-        }
+        // first class callable syntax...
+        $valueResolvedUsingFirstClassSyntax = $container->call($object->method(...));
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingFirstClassSyntax);
     }
 }
 


### PR DESCRIPTION
This refactoring simplifies the `getClassForCallable()` method while preserving its functionality (since the minimum PHP version is now ^8.1).