### PR TITLE
[9.x] Normalise predis command argument where it maybe an object.  

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -125,6 +125,17 @@ abstract class Connection
     }
 
     /**
+     * Parse command parameters for event dispatching.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function parseParametersForEvent(array $parameters)
+    {
+        return $parameters;
+    }
+
+    /**
      * Fire the given event if possible.
      *
      * @param  mixed  $event

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -127,7 +127,7 @@ abstract class Connection
     }
 
     /**
-     * Parse command parameters for event dispatching.
+     * Parse the command's parameters for event dispatching.
      *
      * @param  array  $parameters
      * @return array

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -118,7 +118,9 @@ abstract class Connection
         $time = round((microtime(true) - $start) * 1000, 2);
 
         if (isset($this->events)) {
-            $this->event(new CommandExecuted($method, $parameters, $time, $this));
+            $this->event(new CommandExecuted(
+                $method, $this->parseParametersForEvent($parameters), $time, $this
+            ));
         }
 
         return $result;

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -30,22 +30,6 @@ class PredisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Parse command parameters for event dispatching.
-     *
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function parseParametersForEvent(array $parameters)
-    {
-        return collect($parameters)
-            ->transform(function ($parameter) {
-                return $parameter instanceof ArrayableArgument
-                    ? $parameter->toArray()
-                    : $parameter;
-            })->all();
-    }
-
-    /**
      * Subscribe to a set of given channels for messages.
      *
      * @param  array|string  $channels
@@ -66,5 +50,21 @@ class PredisConnection extends Connection implements ConnectionContract
         }
 
         unset($loop);
+    }
+
+    /**
+     * Parse the command's parameters for event dispatching.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function parseParametersForEvent(array $parameters)
+    {
+        return collect($parameters)
+            ->transform(function ($parameter) {
+                return $parameter instanceof ArrayableArgument
+                    ? $parameter->toArray()
+                    : $parameter;
+            })->all();
     }
 }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -4,7 +4,6 @@ namespace Illuminate\Redis\Connections;
 
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
-use Illuminate\Redis\Events\CommandExecuted;
 use Predis\Command\Argument\ArrayableArgument;
 
 /**
@@ -31,32 +30,19 @@ class PredisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Run a command against the Redis database.
+     * Parse command parameters for event dispatching.
      *
-     * @param  string  $method
      * @param  array  $parameters
-     * @return mixed
+     * @return array
      */
-    public function command($method, array $parameters = [])
+    protected function parseParametersForEvent(array $parameters)
     {
-        $start = microtime(true);
-
-        $result = $this->client->{$method}(...$parameters);
-
-        $time = round((microtime(true) - $start) * 1000, 2);
-
-        if (isset($this->events)) {
-            $parameters = collect($parameters)
-                ->transform(function ($parameter) {
-                    return $parameter instanceof ArrayableArgument
-                        ? $parameter->toArray()
-                        : $parameter;
-                })->all();
-
-            $this->event(new CommandExecuted($method, $parameters, $time, $this));
-        }
-
-        return $result;
+        return collect($parameters)
+            ->transform(function ($parameter) {
+                return $parameter instanceof ArrayableArgument
+                    ? $parameter->toArray()
+                    : $parameter;
+            })->all();
     }
 
     /**

--- a/tests/Integration/Redis/PredisConnectionTest.php
+++ b/tests/Integration/Redis/PredisConnectionTest.php
@@ -20,7 +20,7 @@ class PredisConnectionTest extends TestCase
     public function testPredisCanEmitEventWithArrayableArgumentObject()
     {
         if (! class_exists(SearchArguments::class)) {
-            $this->markTestSkipped('Skipped tests on predis/predis dependency without '.SearchArguments::class);
+            return $this->markTestSkipped('Skipped tests on predis/predis dependency without '.SearchArguments::class);
         }
 
         $event = Event::fake();

--- a/tests/Integration/Redis/PredisConnectionTest.php
+++ b/tests/Integration/Redis/PredisConnectionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Redis;
+
+use Illuminate\Redis\Connections\PredisConnection;
+use Illuminate\Redis\Events\CommandExecuted;
+use Illuminate\Support\Facades\Event;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+use Predis\Client;
+use Predis\Command\Argument\Search\SearchArguments;
+
+class PredisConnectionTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app->get('config')->set('database.redis.client', 'predis');
+    }
+
+    public function testPredisCanEmitEventWithArrayableArgumentObject()
+    {
+        $event = Event::fake();
+
+        $command = 'ftSearch';
+        $parameters = ['test', "*", (new SearchArguments())->dialect('3')->withScores()];
+
+        $predis = new PredisConnection($client = m::mock(Client::class));
+        $predis->setEventDispatcher($event);
+
+        $client->shouldReceive($command)->with(...$parameters)->andReturnTrue();
+
+        $this->assertTrue($predis->command($command, $parameters));
+
+        $event->assertDispatched(function (CommandExecuted $event) use ($command, $parameters) {
+            return $event->connection instanceof PredisConnection
+                && $event->command === $command
+                && $event->parameters === ['test', '*', ['DIALECT', '3', 'WITHSCORES']];
+        });
+    }
+}

--- a/tests/Integration/Redis/PredisConnectionTest.php
+++ b/tests/Integration/Redis/PredisConnectionTest.php
@@ -19,6 +19,10 @@ class PredisConnectionTest extends TestCase
 
     public function testPredisCanEmitEventWithArrayableArgumentObject()
     {
+        if (! class_exists(SearchArguments::class)) {
+            $this->markTestSkipped('Skipped tests on predis/predis dependency without '.SearchArguments::class);
+        }
+
         $event = Event::fake();
 
         $command = 'ftSearch';

--- a/tests/Integration/Redis/PredisConnectionTest.php
+++ b/tests/Integration/Redis/PredisConnectionTest.php
@@ -22,7 +22,7 @@ class PredisConnectionTest extends TestCase
         $event = Event::fake();
 
         $command = 'ftSearch';
-        $parameters = ['test', "*", (new SearchArguments())->dialect('3')->withScores()];
+        $parameters = ['test', '*', (new SearchArguments())->dialect('3')->withScores()];
 
         $predis = new PredisConnection($client = m::mock(Client::class));
         $predis->setEventDispatcher($event);
@@ -31,7 +31,7 @@ class PredisConnectionTest extends TestCase
 
         $this->assertTrue($predis->command($command, $parameters));
 
-        $event->assertDispatched(function (CommandExecuted $event) use ($command, $parameters) {
+        $event->assertDispatched(function (CommandExecuted $event) use ($command) {
             return $event->connection instanceof PredisConnection
                 && $event->command === $command
                 && $event->parameters === ['test', '*', ['DIALECT', '3', 'WITHSCORES']];


### PR DESCRIPTION
Starting from predis 2.1.0 it is possible to apply an implementation of `Predis\Command\Argument\ArrayableArgument` 

fixes laravel/telescope#1366
