### PR TITLE
[10.x] Accept Mailables\Address as mail address

### DIFF
--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Mail;
 
 use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Mail\Attachment;
+use Illuminate\Mail\Mailables\Address as MailableAddress;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
@@ -53,7 +54,9 @@ class MailMessageTest extends TestCase
 
     public function testToMethodWithOverride()
     {
+        $this->message->to('bar@foo.baz', 'Bar');
         $this->assertInstanceOf(Message::class, $message = $this->message->to('foo@bar.baz', 'Foo', true));
+        $this->assertCount(1, $message->getSymfonyMessage()->getTo());
         $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getTo()[0]);
     }
 
@@ -235,5 +238,53 @@ class MailMessageTest extends TestCase
         $this->assertSame("Content-Disposition: inline; name={$name};\r\n filename={$name}", $headers[2]);
 
         unlink($path);
+    }
+
+    public function testItAcceptsToMailableAddressArrayAndConvertsToSwiftAddress()
+    {
+        $message = $this->message->to([new MailableAddress('foo@bar.baz', 'Foo')]);
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getTo()[0]);
+    }
+
+    public function testItAcceptsToMailableAddressArrayAndConvertsToSwiftAddressWithOverride()
+    {
+        $this->message->to('bar@foo.baz', 'Bar');
+        $message = $this->message->to([new MailableAddress('foo@bar.baz', 'Foo')], null, true);
+        $this->assertCount(1, $message->getSymfonyMessage()->getTo());
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getTo()[0]);
+    }
+
+    public function testItAcceptsBccMailableAddressArrayAndConvertsToSwiftAddress()
+    {
+        $message = $this->message->bcc([new MailableAddress('foo@bar.baz', 'Foo')]);
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getBcc()[0]);
+    }
+
+    public function testItAcceptsBccMailableAddressArrayAndConvertsToSwiftAddressWithOverride()
+    {
+        $this->message->bcc('bar@foo.baz', 'Bar');
+        $message = $this->message->bcc([new MailableAddress('foo@bar.baz', 'Foo')], null, true);
+        $this->assertCount(1, $message->getSymfonyMessage()->getBcc());
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getBcc()[0]);
+    }
+
+    public function testItAcceptsCcMailableAddressArrayAndConvertsToSwiftAddress()
+    {
+        $message = $this->message->cc([new MailableAddress('foo@bar.baz', 'Foo')]);
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getCc()[0]);
+    }
+
+    public function testItAcceptsCcMailableAddressArrayAndConvertsToSwiftAddressWithOverride()
+    {
+        $this->message->cc('bar@foo.baz', 'Bar');
+        $message = $this->message->cc([new MailableAddress('foo@bar.baz', 'Foo')], null, true);
+        $this->assertCount(1, $message->getSymfonyMessage()->getCc());
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getCc()[0]);
+    }
+
+    public function testItAcceptsReplyToMailableAddressArrayAndConvertsToSwiftAddress()
+    {
+        $message = $this->message->replyTo([new MailableAddress('foo@bar.baz', 'Foo')]);
+        $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getReplyTo()[0]);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently the `Illuminate\Mail\Mailables\Envelope` accepts `\Illuminate\Mail\Mailables\Address` as a "to" and "bcc":
```php
public function envelope(): Envelope
{
    return new Envelope(
        to: [new Address('foo@bar.baz', 'Foo')],
        bcc: [new Address('foo@bar.baz', 'Foo')],
    );
}
```

but doing the same with Mail Message
```php
Mail::send('', [], static function (Message $message) {
    $message->to([new Address('foo@bar.baz', 'Foo')]);
});
```
fails because it only accepts `\Symfony\Component\Mime\Address` as possible address.

This pull add the ability to pass `\Illuminate\Mail\Mailables\Address` to the message - "to", "bcc, "cc", and other methods that call `addAddresses` directly like replyTo.

This is useful as we have a helper method on User to generate an address with mail and name and pass it to Envelope, and sometimes in a queue'd job/cron to Mail directly, which the latter required us to create an extension of the message and pass it as:
```php
 $message->to([$user->getMailAddress()->toSymfonyAddress()])
 ```