### PR TITLE
[11.x] Improved Performance for Testing with In-Memory Databases

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -18,9 +18,11 @@ trait RefreshDatabase
     {
         $this->beforeRefreshingDatabase();
 
-        $this->usingInMemoryDatabase()
-                        ? $this->refreshInMemoryDatabase()
-                        : $this->refreshTestDatabase();
+        if ($this->usingInMemoryDatabase()) {
+            $this->restoreInMemoryDatabase();
+        }
+
+        $this->refreshTestDatabase();
 
         $this->afterRefreshingDatabase();
     }
@@ -38,28 +40,19 @@ trait RefreshDatabase
     }
 
     /**
-     * Refresh the in-memory database.
+     * Restore the in-memory database between tests.
      *
      * @return void
      */
-    protected function refreshInMemoryDatabase()
+    protected function restoreInMemoryDatabase()
     {
-        $this->artisan('migrate', $this->migrateUsing());
+        $database = $this->app->make('db');
 
-        $this->app[Kernel::class]->setArtisan(null);
-    }
-
-    /**
-     * The parameters that should be used when running "migrate".
-     *
-     * @return array
-     */
-    protected function migrateUsing()
-    {
-        return [
-            '--seed' => $this->shouldSeed(),
-            '--seeder' => $this->seeder(),
-        ];
+        foreach ($this->connectionsToTransact() as $name) {
+            if (isset(RefreshDatabaseState::$inMemoryConnections[$name])) {
+                $database->connection($name)->setPdo(RefreshDatabaseState::$inMemoryConnections[$name]);
+            }
+        }
     }
 
     /**
@@ -91,6 +84,11 @@ trait RefreshDatabase
 
         foreach ($this->connectionsToTransact() as $name) {
             $connection = $database->connection($name);
+
+            if ($this->usingInMemoryDatabase()) {
+                RefreshDatabaseState::$inMemoryConnections[$name] ??= $connection->getPdo();
+            }
+
             $dispatcher = $connection->getEventDispatcher();
 
             $connection->unsetEventDispatcher();

--- a/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
@@ -5,6 +5,13 @@ namespace Illuminate\Foundation\Testing;
 class RefreshDatabaseState
 {
     /**
+     * The current SQLite in-memory database connections.
+     *
+     * @var array<string, \PDO>
+     */
+    public static $inMemoryConnections = [];
+
+    /**
      * Indicates if the test database has been migrated.
      *
      * @var bool
@@ -17,11 +24,4 @@ class RefreshDatabaseState
      * @var bool
      */
     public static $lazilyRefreshed = false;
-
-    /**
-     * The list of in-memory database connections.
-     *
-     * @var array<string, \PDO>
-     */
-    public static $inMemoryConnections = [];
 }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
@@ -17,4 +17,11 @@ class RefreshDatabaseState
      * @var bool
      */
     public static $lazilyRefreshed = false;
+
+    /**
+     * The list of in-memory database connections.
+     *
+     * @var array<string, \PDO>
+     */
+    public static $inMemoryConnections = [];
 }


### PR DESCRIPTION
This pull request aims to enhance the performance and developer experience when running tests with an in-memory database in Laravel. By keeping a reference to the PDO object and restoring it for connections, we enable transaction-based database refresh, resulting in a significant performance boost. Test suites that used to take minutes to run are now completed in just seconds, providing a much smoother testing process.

![image](https://github.com/laravel/framework/assets/204594/38fd8f7f-c5e0-49d2-97fa-237c01fb5a31)

I believe this change is non-breaking as it replicates the same database operations that would occur with a persisted database configuration. However, if there are any concerns, please let me know, and I can rebase and retarget the pull request on the master branch.

Please feel free to provide any feedback or preferences regarding the implementation or coding style. Your input is greatly appreciated.

Thank you.