### PR TITLE
[10.x] Migrate JSON data to shared InputBag

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -404,7 +404,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function json($key = null, $default = null)
     {
         if (! isset($this->json)) {
-            $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
+            $this->json = new InputBag((array) json_decode($this->getContent(), true));
         }
 
         if (is_null($key)) {
@@ -488,7 +488,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $newRequest->content = $request->content;
 
         if ($newRequest->isJson()) {
-            $newRequest->request = new InputBag($newRequest->json()->all());
+            $newRequest->request = $newRequest->json();
         }
 
         return $newRequest;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1587,4 +1587,18 @@ class HttpRequestTest extends TestCase
 
         $this->assertSame('Taylor Otwell', $request->get('name'));
     }
+
+    public function testItCanHaveObjectsInJsonPayload()
+    {
+        if (! method_exists(SymfonyRequest::class, 'getPayload')) {
+            return;
+        }
+
+        $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"framework":{"name":"Laravel"}}');
+        $request = Request::createFromBase($base);
+
+        $value = $request->get('framework');
+
+        $this->assertSame(['name' => 'Laravel'], $request->get('framework'));
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1571,4 +1571,20 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf(InputBag::class, $request->getPayload());
         $this->assertSame('world', $request->getPayload()->get('hello'));
     }
+
+    public function testJsonRequestsCanMergeDataIntoJsonRequest()
+    {
+        if (! method_exists(SymfonyRequest::class, 'getPayload')) {
+            return;
+        }
+
+        $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"first":"Taylor","last":"Otwell"}');
+        $request = Request::createFromBase($base);
+
+        $request->merge([
+            'name' => $request->get('first').' '.$request->get('last'),
+        ]);
+
+        $this->assertSame('Taylor Otwell', $request->get('name'));
+    }
 }


### PR DESCRIPTION
fixes #47877

We recently made a change to how the JSON input was handled due to a change in Symfony.

With the change, we created a new `InputBag` instance for the `request` data and left the `json` data in the original `ParameterBag`.

This meant that when data was merged into the request, via `request()->merge()`, it was not shared with the `request` `InputBag`.

This PR migrates the `json` input to an `InputBag` as well and then uses that `InputBag` instance as the `request` data when creating a new Request instance.

Request merge now works as it previously did, but with the caveat that all data within the `json` payload must be a scalar type. Object in JSON are decoded as associative arrays.

This does bring consistency across all input types, so I feel this is probably the best approach anyway.