### PR TITLE
[10.x] Fix Http global middleware for queue, octane, and dependecy injection

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Http\HtmlDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Foundation\Precognition;
 use Illuminate\Foundation\Vite;
+use Illuminate\Http\Client\Factory as ClientFactory;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\AggregateServiceProvider;
@@ -42,6 +43,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public $singletons = [
         Vite::class => Vite::class,
+        ClientFactory::class => ClientFactory::class,
     ];
 
     /**

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -13,7 +13,7 @@ use Illuminate\Foundation\Http\HtmlDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Foundation\Precognition;
 use Illuminate\Foundation\Vite;
-use Illuminate\Http\Client\Factory as ClientFactory;
+use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\AggregateServiceProvider;
@@ -43,7 +43,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public $singletons = [
         Vite::class => Vite::class,
-        ClientFactory::class => ClientFactory::class,
+        HttpFactory::class => HttpFactory::class,
     ];
 
     /**

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -42,8 +42,8 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * @var array
      */
     public $singletons = [
-        Vite::class => Vite::class,
         HttpFactory::class => HttpFactory::class,
+        Vite::class => Vite::class,
     ];
 
     /**

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase;
+
+class HttpClientTest extends TestCase
+{
+    public function testGlobalMiddlewarePersistsAfterFacadeFlush(): void
+    {
+        Http::macro('getGlobalMiddleware', fn () => $this->globalMiddleware);
+        Http::globalRequestMiddleware(fn ($request) => $request->withHeader('User-Agent', 'Example Application/1.0'));
+        Http::globalRequestMiddleware(fn ($request) => $request->withHeader('User-Agent', 'Example Application/1.0'));
+
+        $this->assertCount(2, Http::getGlobalMiddleware());
+
+        Facade::clearResolvedInstances();
+
+        $this->assertCount(2, Http::getGlobalMiddleware());
+    }
+}


### PR DESCRIPTION
fixes #47738

We added the ability to add global middleware to the Http client.

```php
Http::globalRequestMiddleware(fn ($request) => $request->withHeader(
    'User-Agent', 'Example Application/1.0'
));
```

Because Facades are cached for the duration of a request, this works as expected for each Http request.

On the queue / in octane however, these middleware are not applied.

This is because the underlying `Factory` is not a singleton, so the `Factory` instance is refreshed on each job execution / octane request. The `Factory` instance is where the middleware is stored.

This PR binds the `Factory` as a singleton. Excluding testing infrastructure, the only state the `Factory` maintains is the global middleware and the event service provider. As the event service provider is also a singleton, we shouldn't need to refresh it manually for Octane.

In addition to the queue and Octane fixes, this fix also means that the requests made by the `NotPwnedVerifier` will now pass through the global middleware, which I believe is the expected behaviour.

This is because the `NotPwnedVerifier` injects the `Factory` via the constructor, rather than accessing the Facade.

This also applies to any user-land code that is injecting the `Factory` class, which I also believe is the expected behaviour.