### PR TITLE
[9.x] visibility check

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -418,8 +418,12 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function getVisibility($path)
     {
-        if ($this->driver->visibility($path) == Visibility::PUBLIC) {
-            return FilesystemContract::VISIBILITY_PUBLIC;
+        try  {
+            if ($this->driver->visibility($path) == Visibility::PUBLIC) {
+                return FilesystemContract::VISIBILITY_PUBLIC;
+            }
+        }catch(UnableToRetrieveMetadata $e){
+            throw_if($this->throwsExceptions(), $e);
         }
 
         return FilesystemContract::VISIBILITY_PRIVATE;


### PR DESCRIPTION
When checking visibility in S3, it should use the filesystem config setting to decide if throwing an exception or not.

the visibility check can fail if s3 is setup without permissions to modify permissions.

