### PR TITLE
[10.x] Allow DatabaseRefreshed event to include given `database` and `seed` options

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -61,7 +61,7 @@ class FreshCommand extends Command
 
         if ($this->laravel->bound(Dispatcher::class)) {
             $this->laravel[Dispatcher::class]->dispatch(
-                new DatabaseRefreshed
+                new DatabaseRefreshed($database, $this->needsSeeding())
             );
         }
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -67,7 +67,7 @@ class RefreshCommand extends Command
 
         if ($this->laravel->bound(Dispatcher::class)) {
             $this->laravel[Dispatcher::class]->dispatch(
-                new DatabaseRefreshed
+                new DatabaseRefreshed($database, $this->needsSeeding())
             );
         }
 

--- a/src/Illuminate/Database/Events/DatabaseRefreshed.php
+++ b/src/Illuminate/Database/Events/DatabaseRefreshed.php
@@ -10,12 +10,12 @@ class DatabaseRefreshed implements MigrationEventContract
      * Create a new event instance.
      *
      * @param  string|null  $database
-     * @param  bool  $needsSeeding
+     * @param  bool  seeding
      * @return void
      */
     public function __construct(
         public ?string $database = null,
-        public bool $needsSeeding = false
+        public bool $seeding = false
     ) {
         //
     }

--- a/src/Illuminate/Database/Events/DatabaseRefreshed.php
+++ b/src/Illuminate/Database/Events/DatabaseRefreshed.php
@@ -6,5 +6,17 @@ use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContrac
 
 class DatabaseRefreshed implements MigrationEventContract
 {
-    //
+    /**
+     * Create a new event instance.
+     *
+     * @param  string|null  $database
+     * @param  bool  $needsSeeding
+     * @return void
+     */
+    public function __construct(
+        public ?string $database = null,
+        public bool $needsSeeding = false
+    ) {
+        //
+    }
 }


### PR DESCRIPTION
This would be useful to know if `migrate:fresh` or `migrate:refresh` was executed with `--seed` or `--database` option.

----------------------

I don't believe this is breaking change but we can retarget this changes to Laravel 11.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
