### PR TITLE
[10.x] Fix prompt and console component spacing when calling another command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -168,7 +168,7 @@ class Command extends SymfonyCommand
      */
     public function run(InputInterface $input, OutputInterface $output): int
     {
-        $this->output = $this->laravel->make(
+        $this->output = $output instanceof OutputStyle ? $output : $this->laravel->make(
             OutputStyle::class, ['input' => $input, 'output' => $output]
         );
 


### PR DESCRIPTION
When using the `call` method in a command to call another command, we pass the parent's `OutputStyle` instance to be re-used by the child command:

https://github.com/laravel/framework/blob/8e98688037b1329e1b61407d78f967404a99267e/src/Illuminate/Console/Concerns/CallsCommands.php#L26-L29

This results in the `OutputStyle` instance being wrapped instance inside another `OutputStyle` instance, and any trailing newline calculation performed in the outer wrapper is not available to the inner one used by the parent process:

https://github.com/laravel/framework/blob/8e98688037b1329e1b61407d78f967404a99267e/src/Illuminate/Console/Command.php#L169-L173

This PR solves this by only wrapping the output interface when it's not already an `OutputStyle` instance.

An alternative would be to check if the received output instance is the same instance that we already have, rather than just the same class, but I can't think of any scenario where we'd still want the double wrapping. When using `callSilent`, we pass an instance of `NullOutput` to be used in the child command, which still works as expected.