### PR TITLE
[10.x] Fix prompt rendering after `callSilent`

### DIFF
--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -64,9 +64,13 @@ trait CallsCommands
     {
         $arguments['command'] = $command;
 
-        return $this->resolveCommand($command)->run(
+        $result = $this->resolveCommand($command)->run(
             $this->createInputFromArguments($arguments), $output
         );
+
+        $this->restorePrompts();
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -119,4 +119,14 @@ trait ConfiguresPrompts
             return $result;
         }
     }
+
+    /**
+     * Restore the prompts output.
+     *
+     * @return void
+     */
+    protected function restorePrompts()
+    {
+        Prompt::setOutput($this->output);
+    }
 }


### PR DESCRIPTION
This PR solves https://github.com/laravel/prompts/issues/22, where prompts are not displayed in the parent command after the `callSilent` method has been used to call a child command.

This is caused by the child command replacing the `OutputInterface` used by Prompts with an instance of `NullOutput`, which is not reset afterwards.

Note that if the _child_ command uses Symfony _or_ Laravel prompts, the prompts will not output anything to the console, but they will still wait for user input. In these cases you would likely want to pass `--no-interaction` to the child command, however, there is an outstanding issue when using Laravel Prompts where prompts in the parent command will then lose interactivity as well. I will PR a fix for that separately.