### PR TITLE
[9.x] Circumvent PHP 8.2.9 date format bug that makes artisan serve crash

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -305,6 +305,8 @@ class ServeCommand extends Command
             ? '/^\[\d+]\s\[([a-zA-Z0-9: ]+)\]/'
             : '/^\[([^\]]+)\]/';
 
+        $line = str_replace('  ', ' ', $line);
+
         preg_match($regex, $line, $matches);
 
         return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);


### PR DESCRIPTION
Circumvent PHP 8.2.9 bug that has double whitespace in datetimes for artisan serve. See #47930 for details.