### PR TITLE
[10.x] Add Migration Section to ShowModelCommand

### DIFF
--- a/prlyvV.diff
+++ b/prlyvV.diff
@@ -1,0 +1,13 @@
+diff --git a/src/Illuminate/Database/Console/ShowModelCommand.php b/src/Illuminate/Database/Console/ShowModelCommand.php
+index ad1be5d20338e530aa5bfd042af99b7ae7c37d39..ff58ca86c2cafc37635ffa6076aab0d4e0b174ab 100644
+--- a/src/Illuminate/Database/Console/ShowModelCommand.php
++++ b/src/Illuminate/Database/Console/ShowModelCommand.php
+@@ -414,7 +414,7 @@ protected function displayCli($class, $database, $table, $policy, $attributes, $
+      */
+     protected function getMigrations($model)
+     {
+-        $tableName = $model->getConnection()->getTablePrefix() . $model->getTable();
++        $tableName = $model->getConnection()->getTablePrefix().$model->getTable();
+ 
+         // Get the list of all migrations
+         $allMigrations = $this->laravel['migration.repository']->getMigrations(-1);

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -414,7 +414,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
      */
     protected function getMigrations($model)
     {
-        $tableName = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $tableName = $model->getConnection()->getTablePrefix().$model->getTable();
 
         // Get the list of all migrations
         $allMigrations = $this->laravel['migration.repository']->getMigrations(-1);


### PR DESCRIPTION
## Description

This pull request adds a new section to the `ShowModelCommand` that displays information about the migration files that affected the specified table.

## Changes Made

- Added new method `getMigrationsForTable` to retrieve migration files related to the table
- Displayed the list of migration files in the `model:show` command output

## Before

The `model:show` command only displayed information about the model, its attributes, relations, and observers. There was no information about the migration files associated with the table.

![Before](https://github.com/laravel/framework/assets/42186508/1d92d208-9efa-4012-acf9-e75c21279088)

## After

After this update, the `model:show` command includes a new "Migrations" section that shows the migration files responsible for modifying the specified table.

![After](https://github.com/laravel/framework/assets/42186508/4bf31c6b-9570-4aca-80f7-f30c2ce6e429)