### PR TITLE
[10.x] Add Storage::markdown() method to read and convert markdown into HTML

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -6,6 +6,7 @@ use ErrorException;
 use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
@@ -72,6 +73,21 @@ class Filesystem
     public function json($path, $flags = 0, $lock = false)
     {
         return json_decode($this->get($path, $lock), true, 512, $flags);
+    }
+
+    /**
+     * Get converted contents of a GitHub flavored Markdown file in HTML.
+     *
+     * @param  string  $path
+     * @param  array  $options
+     * @param  bool  $lock
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function markdown($path, $options = [], $lock = false)
+    {
+        return Str::markdown($this->get($path, $lock), $options);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -277,6 +277,20 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Get converted contents of a GitHub flavored Markdown file in HTML.
+     *
+     * @param  string  $path
+     * @param  array  $options
+     * @return string|null
+     */
+    public function markdown($path, $options = [])
+    {
+        $content = $this->get($path);
+
+        return is_null($content) ? null : Str::markdown($content, $options);
+    }
+
+    /**
      * Create a streamed response for a given file.
      *
      * @param  string  $path

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -7,6 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool missing(string $path)
  * @method static string get(string $path, bool $lock = false)
  * @method static array json(string $path, int $flags = 0, bool $lock = false)
+ * @method static string markdown(string $path, array $options = [], bool $lock = false)
  * @method static string sharedGet(string $path)
  * @method static mixed getRequire(string $path, array $data = [])
  * @method static mixed requireOnce(string $path, array $data = [])

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -51,6 +51,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static bool directoryMissing(string $path)
  * @method static string path(string $path)
  * @method static array|null json(string $path, int $flags = 0)
+ * @method static string|null markdown(string $path, array $options = [])
  * @method static \Symfony\Component\HttpFoundation\StreamedResponse response(string $path, string|null $name = null, array $headers = [], string|null $disposition = 'inline')
  * @method static \Symfony\Component\HttpFoundation\StreamedResponse download(string $path, string|null $name = null, array $headers = [])
  * @method static string|false putFile(\Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|array|null $file = null, mixed $options = [])

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -198,6 +198,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertNull($filesystemAdapter->json('file.json'));
     }
 
+    public function testMarkdownReturnsParsedMarkdown()
+    {
+        $this->filesystem->write('file.md', '*Hello World*');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $this->assertSame("<p><em>Hello World</em></p>\n", $filesystemAdapter->markdown('file.md'));
+    }
+
     public function testMimeTypeNotDetected()
     {
         $this->filesystem->write('unknown.mime-type', '');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -360,6 +360,13 @@ class FilesystemTest extends TestCase
         $this->assertNull($files->json(self::$tempDir.'/file.json'));
     }
 
+    public function testMarkdownReturnsParsedMarkdown()
+    {
+        file_put_contents(self::$tempDir.'/file.md', '*Hello World*');
+        $files = new Filesystem;
+        $this->assertSame("<p><em>Hello World</em></p>\n", $files->markdown(self::$tempDir.'/file.md'));
+    }
+
     public function testAppendAddsDataToFile()
     {
         file_put_contents(self::$tempDir.'/file.txt', 'foo');


### PR DESCRIPTION
Some time ago a `Storage::json()` and `File::json()` feature was added that would quickly `json_decode` a file before returning the contents.

I find myself doing something similar when dealing with Markdown files.
```php
$markdown = Storage::get('some-file.md');
$html = Str::markdown($markdown);
```

This PR adds a new `markdown()` method to both `Storage` and `File`.