### PR TITLE
[10.x] Use model cast when builder created updated at value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1147,7 +1147,9 @@ class Builder implements BuilderContract
                 || $this->model->hasAttributeSetMutator($column)
                 || $this->model->hasCast($column)
             ) {
-                $timestamp = $this->model->newInstance([$column => $timestamp])->getAttributes()[$column];
+                $timestamp = $this->model->newInstance()
+                    ->forceFill([$column => $timestamp])
+                    ->getAttributes()[$column];
             }
 
             $values = array_merge([$column => $timestamp], $values);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1142,7 +1142,11 @@ class Builder implements BuilderContract
         if (! array_key_exists($column, $values)) {
             $timestamp = $this->model->freshTimestampString();
 
-            if ($this->model->hasCast($column)) {
+            if (
+                $this->model->hasSetMutator($column)
+                || $this->model->hasAttributeSetMutator($column)
+                || $this->model->hasCast($column)
+            ) {
                 $timestamp = $this->model->newInstance([$column => $timestamp])->getAttributes()[$column];
             }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1139,10 +1139,15 @@ class Builder implements BuilderContract
 
         $column = $this->model->getUpdatedAtColumn();
 
-        $values = array_merge(
-            [$column => $this->model->freshTimestampString()],
-            $values
-        );
+        if (! array_key_exists($column, $values)) {
+            $timestamp = $this->model->freshTimestampString();
+
+            if ($this->model->hasCast($column)) {
+                $timestamp = $this->model->newInstance([$column => $timestamp])->getAttributes()[$column];
+            }
+
+            $values = array_merge([$column => $timestamp], $values);
+        }
 
         $segments = preg_split('/\s+as\s+/i', $this->query->from);
 

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -4,10 +4,8 @@ namespace Illuminate\Tests\Integration\Database\MySql;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
-use stdClass;
 
 class EloquentCastTest extends MySqlTestCase
 {

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use stdClass;
+
+class EloquentCastTest extends MySqlTestCase
+{
+    protected $driver = 'mysql';
+
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->integer('created_at');
+            $table->integer('updated_at');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('users');
+    }
+
+    public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasNotPassed()
+    {
+        Carbon::setTestNow(now());
+
+        $createdAt = now()->timestamp;
+
+        $user = UserWithIntTimestamps::create([
+            'email' => fake()->unique()->email,
+        ]);
+
+        $this->assertSame($createdAt, $user->created_at->timestamp);
+        $this->assertSame($createdAt, $user->updated_at->timestamp);
+
+        $user->update([
+            'email' => fake()->unique()->email,
+        ]);
+
+        $this->assertSame($createdAt, $user->created_at->timestamp);
+        $this->assertSame($createdAt, $user->updated_at->timestamp);
+        $this->assertSame($createdAt, $user->fresh()->updated_at->timestamp);
+    }
+
+    public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
+    {
+        Carbon::setTestNow(now());
+
+        $createdAt = now()->timestamp;
+
+        $user = UserWithIntTimestamps::create([
+            'email' => fake()->unique()->email,
+        ]);
+
+        $this->assertSame($createdAt, $user->created_at->timestamp);
+        $this->assertSame($createdAt, $user->updated_at->timestamp);
+
+        Carbon::setTestNow(now()->addSecond());
+
+        $updatedAt = now()->timestamp;
+
+        $user->update([
+            'email' => fake()->unique()->email,
+        ]);
+
+        $this->assertSame($createdAt, $user->created_at->timestamp);
+        $this->assertSame($updatedAt, $user->updated_at->timestamp);
+        $this->assertSame($updatedAt, $user->fresh()->updated_at->timestamp);
+    }
+}
+
+class UserWithIntTimestamps extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'created_at' => UnixTimeStampToCarbon::class,
+        'updated_at' => UnixTimeStampToCarbon::class,
+    ];
+}
+
+class UnixTimeStampToCarbon implements CastsAttributes
+{
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return now();
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return 500;
+    }
+}

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -121,7 +121,7 @@ class UserWithIntTimestampsViaCasts extends Model
 {
     protected $table = 'users';
 
-    protected $guarded = [];
+    protected $fillable = ['email'];
 
     protected $casts = [
         'created_at' => UnixTimeStampToCarbon::class,
@@ -146,7 +146,7 @@ class UserWithIntTimestampsViaAttribute extends Model
 {
     protected $table = 'users';
 
-    protected $guarded = [];
+    protected $fillable = ['email'];
 
     protected function updatedAt(): Attribute
     {
@@ -169,7 +169,7 @@ class UserWithIntTimestampsViaMutator extends Model
 {
     protected $table = 'users';
 
-    protected $guarded = [];
+    protected $fillable = ['email'];
 
     protected function getUpdatedAtAttribute($value)
     {

--- a/tests/Integration/Database/MySql/EloquentCastTest.php
+++ b/tests/Integration/Database/MySql/EloquentCastTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\MySql;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
@@ -29,53 +30,94 @@ class EloquentCastTest extends MySqlTestCase
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasNotPassed()
     {
         Carbon::setTestNow(now());
-
         $createdAt = now()->timestamp;
 
-        $user = UserWithIntTimestamps::create([
+        $castUser = UserWithIntTimestampsViaCasts::create([
+            'email' => fake()->unique()->email,
+        ]);
+        $attributeUser = UserWithIntTimestampsViaAttribute::create([
+            'email' => fake()->unique()->email,
+        ]);
+        $mutatorUser = UserWithIntTimestampsViaMutator::create([
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $user->created_at->timestamp);
-        $this->assertSame($createdAt, $user->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->timestamp);
+        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
 
-        $user->update([
+        $castUser->update([
+            'email' => fake()->unique()->email,
+        ]);
+        $attributeUser->update([
+            'email' => fake()->unique()->email,
+        ]);
+        $mutatorUser->update([
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $user->created_at->timestamp);
-        $this->assertSame($createdAt, $user->updated_at->timestamp);
-        $this->assertSame($createdAt, $user->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->timestamp);
+        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->fresh()->updated_at->timestamp);
     }
 
     public function testItCastTimestampsCreatedByTheBuilderWhenTimeHasPassed()
     {
         Carbon::setTestNow(now());
-
         $createdAt = now()->timestamp;
 
-        $user = UserWithIntTimestamps::create([
+        $castUser = UserWithIntTimestampsViaCasts::create([
+            'email' => fake()->unique()->email,
+        ]);
+        $attributeUser = UserWithIntTimestampsViaAttribute::create([
+            'email' => fake()->unique()->email,
+        ]);
+        $mutatorUser = UserWithIntTimestampsViaMutator::create([
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $user->created_at->timestamp);
-        $this->assertSame($createdAt, $user->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->timestamp);
+        $this->assertSame($createdAt, $castUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->updated_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->updated_at->timestamp);
 
         Carbon::setTestNow(now()->addSecond());
-
         $updatedAt = now()->timestamp;
 
-        $user->update([
+        $castUser->update([
+            'email' => fake()->unique()->email,
+        ]);
+        $attributeUser->update([
+            'email' => fake()->unique()->email,
+        ]);
+        $mutatorUser->update([
             'email' => fake()->unique()->email,
         ]);
 
-        $this->assertSame($createdAt, $user->created_at->timestamp);
-        $this->assertSame($updatedAt, $user->updated_at->timestamp);
-        $this->assertSame($updatedAt, $user->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $castUser->created_at->timestamp);
+        $this->assertSame($updatedAt, $castUser->updated_at->timestamp);
+        $this->assertSame($updatedAt, $castUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $attributeUser->created_at->timestamp);
+        $this->assertSame($updatedAt, $attributeUser->updated_at->timestamp);
+        $this->assertSame($updatedAt, $attributeUser->fresh()->updated_at->timestamp);
+        $this->assertSame($createdAt, $mutatorUser->created_at->timestamp);
+        $this->assertSame($updatedAt, $mutatorUser->updated_at->timestamp);
+        $this->assertSame($updatedAt, $mutatorUser->fresh()->updated_at->timestamp);
     }
 }
 
-class UserWithIntTimestamps extends Model
+class UserWithIntTimestampsViaCasts extends Model
 {
     protected $table = 'users';
 
@@ -91,11 +133,61 @@ class UnixTimeStampToCarbon implements CastsAttributes
 {
     public function get($model, string $key, $value, array $attributes)
     {
-        return now();
+        return Carbon::parse($value);
     }
 
     public function set($model, string $key, $value, array $attributes)
     {
-        return 500;
+        return Carbon::parse($value)->timestamp;
+    }
+}
+
+class UserWithIntTimestampsViaAttribute extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    protected function updatedAt(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => Carbon::parse($value),
+            set: fn ($value) => Carbon::parse($value)->timestamp,
+        );
+    }
+
+    protected function createdAt(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => Carbon::parse($value),
+            set: fn ($value) => Carbon::parse($value)->timestamp,
+        );
+    }
+}
+
+class UserWithIntTimestampsViaMutator extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    protected function getUpdatedAtAttribute($value)
+    {
+        return Carbon::parse($value);
+    }
+
+    protected function setUpdatedAtAttribute($value)
+    {
+        $this->attributes['updated_at'] = Carbon::parse($value)->timestamp;
+    }
+
+    protected function getCreatedAtAttribute($value)
+    {
+        return Carbon::parse($value);
+    }
+
+    protected function setCreatedAtAttribute($value)
+    {
+        $this->attributes['created_at'] = Carbon::parse($value)->timestamp;
     }
 }


### PR DESCRIPTION
fixes #47769

If a model is using a cast on the `updated_at` column, it is not respected when the **eloquent builder** creates the `updated_at` value.

```php
<?php

namespace App\Models;

use App\Casts\UnixTimeStampToCarbon;
use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Database\Eloquent\Model;

class Customer extends Model
{
    use HasFactory;

    protected $casts = [
        'created_at' => UnixTimeStampToCarbon::class,
        'updated_at' => UnixTimeStampToCarbon::class,
    ];
}
```


When updating a model, in most cases the `updated_at` value is created in the **eloquent model**, where the cast is respected as expected.

When the model creates the value the builder receives the `updated_at` value in the array it is asked to put into the database. When this happens, everything is good.

When the value of `updated_at` has not changed, i.e. the time is the same as last time it was updated - which you might find happens in a unit test - the `updated_at` is not marked as "dirty" and the model does not pass the `updated_at` column through to the builder.

In this case, the builder manually creates and adds the `updated_at` value to the array it is putting into the database.

When the builder creates the `updated_at` value it does not use any casts that are in place on the model for the `updated_at` column.

For timestamp only values, if you are storing the `updated_at` as an integer, as per #47769, and not other dates, the value attempted to be insert into the database will be `2020-01-01 00:00:00` formatted and MySQL will throw an exception as it is expecting an integer.

## Performance implications

I ran some benchmarks using 10,000 iterations.

## Updated at set by the builder, i.e. time has not progressed

If you do not have a cast in place for the `updated_at` column: there is no change ☑️

If you do have a cast in place for the `updated_at` column: `0.006ms` > `0.02ms` ⬇️

## Updated at set by the model, i.e. time has progressed

`0.006ms` > `0.0ms` (micro optimisation) ⬆️

So the implications are only for the cases where you have a cast in place and time has not progressed, which I would guess is 99.999999999999% of the time in a unit test and not going to impact an actual user.