### PR TITLE
[10.x] Add timestamps casting and mutation support to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1079,9 +1079,9 @@ class Builder implements BuilderContract
      */
     public function touch($column = null)
     {
-        $time = $this->model->freshTimestamp();
-
         if ($column) {
+            $time = $this->model->freshTimestampForAttribute($column);
+
             return $this->toBase()->update([$column => $time]);
         }
 
@@ -1090,6 +1090,8 @@ class Builder implements BuilderContract
         if (! $this->model->usesTimestamps() || is_null($column)) {
             return false;
         }
+
+        $time = $this->model->freshTimestampForAttribute($column);
 
         return $this->toBase()->update([$column => $time]);
     }
@@ -1140,7 +1142,7 @@ class Builder implements BuilderContract
         $column = $this->model->getUpdatedAtColumn();
 
         $values = array_merge(
-            [$column => $this->model->freshTimestampString()],
+            [$column => $this->model->freshTimestampForAttribute($column)],
             $values
         );
 
@@ -1190,16 +1192,19 @@ class Builder implements BuilderContract
             return $values;
         }
 
-        $timestamp = $this->model->freshTimestampString();
-
+        $timestamps = [];
         $columns = array_filter([
             $this->model->getCreatedAtColumn(),
             $this->model->getUpdatedAtColumn(),
         ]);
 
         foreach ($columns as $column) {
+            $timestamps[$column] = $this->model->freshTimestampForAttribute($column);
+        }
+
+        if (! empty($timestamps)) {
             foreach ($values as &$row) {
-                $row = array_merge([$column => $timestamp], $row);
+                $row = array_merge($timestamps, $row);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -125,6 +125,25 @@ trait HasTimestamps
     }
 
     /**
+     * Get a fresh timestamp for the model attribute considering casting or mutation.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function freshTimestampForAttribute(string $key): mixed
+    {
+        $value = $this->freshTimestamp();
+
+        if ($this->hasGetMutator($key) || $this->hasCast($key)) {
+            $value =
+                (clone $this)->forceFill([$key => $value])->getAttributes()[$key] ??
+                $value;
+        }
+
+        return $value;
+    }
+
+    /**
      * Determine if the model uses timestamps.
      *
      * @return bool


### PR DESCRIPTION
This PR fixes #47769.

This PR adds a new method (`freshTimestampForAttribute`) to the Eloquent which can be used for creating fresh timestamp for any attribute considering either its mutation or casting and It's a replacement for the `freshTimestampString` method. so it will not ignore the casting or mutation of the model's attribute for any purpose.
This method can be used for other parts like `SoftDeletes` and touching related models instead of `freshTimestampString`.
For now I just used it to fix issue #47769.

Got the idea from @timacdonald PR (#47942).