### PR TITLE
[11.x] Add base paginator class

### DIFF
--- a/src/Illuminate/Pagination/AbstractBasePaginator.php
+++ b/src/Illuminate/Pagination/AbstractBasePaginator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+abstract class AbstractBasePaginator
+{
+    //
+}

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -20,7 +20,7 @@ use Traversable;
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractCursorPaginator implements Htmlable, Stringable
+abstract class AbstractCursorPaginator extends AbstractBasePaginator implements Htmlable, Stringable
 {
     use ForwardsCalls, Tappable;
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -14,7 +14,7 @@ use Traversable;
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractPaginator implements Htmlable, Stringable
+abstract class AbstractPaginator extends AbstractBasePaginator implements Htmlable, Stringable
 {
     use ForwardsCalls, Tappable;
 


### PR DESCRIPTION
This is a retry of an old PRs of mine (#42003), but now, the motivation behind is quite different.

When using typehints, it would be nice to have a base paginator class that we could refer to instead of using union typehints all the time (if a value could be both classic and cursor paginator class as well).

```diff
- use Illuminate\Pagination\CursorPaginator;
- use Illuminate\Pagination\LengthAwarePaginator;
- use Illuminate\Pagination\Paginator;
-
- public function resolvePaginator($request): LengthAwarePaginator|Paginator|CursorPaginator

+ use Illuminate\Pagination\AbstractBasePaginator as Paginator;
+
+ public function resolvePaginator($request): Paginator
```

Also, this would be helpful when having a custom paginator implementation and still would not break.

I think this is not a BC, but I find better sending on the master branch.