### PR TITLE
Bringing back the "getDates()" previous functionality 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1467,12 +1467,18 @@ trait HasAttributes
      *
      * @return array
      */
-    public function getDates()
+    public function getDates(): array
     {
-        return $this->usesTimestamps() ? [
+        $dateAttributes = array_filter(
+            array_keys($this->getCasts()), fn(string $key): bool => $this->isDateCastable($key)
+        );
+
+        $timestamps = $this->usesTimestamps() ? [
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
         ] : [];
+
+        return array_unique([...$dateAttributes, ...$timestamps]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1470,7 +1470,7 @@ trait HasAttributes
     public function getDates(): array
     {
         $dateAttributes = array_filter(
-            array_keys($this->getCasts()), fn(string $key): bool => $this->isDateCastable($key)
+            array_keys($this->getCasts()), fn (string $key): bool => $this->isDateCastable($key)
         );
 
         $timestamps = $this->usesTimestamps() ? [


### PR DESCRIPTION
Before Laravel 10 this method gave us a list of all date-type attributes including both - explicitly set up in the model and timestamps. Since version 10 it returns only those 2 timestamps or empty array and it breaks some functionalities.

Example:
https://github.com/LaravelCollective/html/blob/64ddfdcaeeb8d332bd98bef442bef81e39c3910b/src/Eloquent/FormAccessible.php#L31
https://github.com/laravel/framework/pull/42587#issuecomment-1462502416

My proposal is just to bring back the previous functionality. There is no more the $dates attribute, but according to the [L10 upgrade guide](https://laravel.com/docs/10.x/upgrade#model-dates-property), it was just kind of an alias.

If not, then maybe a separate method?