### PR TITLE
[10.x] Improve decimal shape validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -599,7 +599,9 @@ trait ValidatesAttributes
 
         $matches = [];
 
-        preg_match('/^[+-]?\d*.(\d*)$/', $value, $matches);
+        if (preg_match('/^[+-]?\d*\.?(\d*)$/', $value, $matches) !== 1) {
+            return false;
+        }
 
         $decimals = strlen(end($matches));
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2880,6 +2880,30 @@ class ValidationValidatorTest extends TestCase
             'scientific' => 'Decimal:0,3',
         ]);
         $this->assertSame(['scientific'], $v->errors()->keys());
+
+        $v = new Validator($trans, ['foo' => '+'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->fails());
+        $v = new Validator($trans, ['foo' => '-'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->fails());
+        $v = new Validator($trans, ['foo' => '10@12'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '+123'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '-123'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '+123.'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '-123.'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '123.'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '123.'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '123.34'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '123.34'], ['foo' => 'Decimal:0,2']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateInt()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2860,6 +2860,26 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Max:1.88888888888888888888']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            // these are the same number
+            'decimal' => '0.555',
+            'scientific' => '5.55e-1',
+        ], [
+            'decimal' => 'Decimal:0,2',
+            'scientific' => 'Decimal:0,2',
+        ]);
+        $this->assertSame(['decimal', 'scientific'], $v->errors()->keys());
+
+        $v = new Validator($trans, [
+            // these are the same number
+            'decimal' => '0.555',
+            'scientific' => '5.55e-1',
+        ], [
+            'decimal' => 'Decimal:0,3',
+            'scientific' => 'Decimal:0,3',
+        ]);
+        $this->assertSame(['scientific'], $v->errors()->keys());
     }
 
     public function testValidateInt()


### PR DESCRIPTION
The decimal rules checks that a value is numeric and then checks the value against a regex.

The current decimal validation regex is expecting:

`[+-]?` an optional positive / negative symbol

`\d*` zero or more digits

`.` any character, except new lines

`\d*` zero of more digits

All of the following values would pass this regex:

```
+
-
123
+123
-123
123@
123.
+123@
-123@
+123.
-123.
123@456
123.456
+123@456
-123@456
+123.456
-123.456
```

However, we first check that the value is `numeric` in PHP's eyes, so that reduces the values that get checked against the regex to the following set:

```
123
+123
-123
123.
+123.
-123.
123.456
+123.456
-123.456
```

but scientific notation will also pass the `is_numeric` check. So we add the following to the possible values. You will note, however, that these do not match the regex:

```
1.2e3
7E-10
```

When the `preg_match` happens, it has `0` results in `$matches`, and the rule interprets this as the number having `0` decimal places.

I believe this is a bug and the decimal rule should in fact check that the string matches the expected pattern, i.e., the decimal rule fails for scientific notation.