### PR TITLE
[10.x] Add a new method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1474,7 +1474,21 @@ trait HasAttributes
             $this->getUpdatedAtColumn(),
         ] : [];
     }
+    
+    /**
+     * Get all attributes that should be converted to dates including timestamps and user-defined.
+     *
+     * @return array
+     */
+    public function getDateCastableAttributes(): array
+    {
+        $dateAttributes = array_filter(
+            array_keys($this->getCasts()), fn(string $key): bool => $this->isDateCastable($key)
+        );
 
+        return array_unique([...$dateAttributes, ...$this->getDates()]);
+    }
+    
     /**
      * Get the format for database stored dates.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1474,7 +1474,7 @@ trait HasAttributes
             $this->getUpdatedAtColumn(),
         ] : [];
     }
-    
+
     /**
      * Get all attributes that should be converted to dates including timestamps and user-defined.
      *
@@ -1483,12 +1483,12 @@ trait HasAttributes
     public function getDateCastableAttributes(): array
     {
         $dateAttributes = array_filter(
-            array_keys($this->getCasts()), fn(string $key): bool => $this->isDateCastable($key)
+            array_keys($this->getCasts()), fn (string $key): bool => $this->isDateCastable($key)
         );
 
         return array_unique([...$dateAttributes, ...$this->getDates()]);
     }
-    
+
     /**
      * Get the format for database stored dates.
      *


### PR DESCRIPTION
As [my PR](https://github.com/laravel/framework/pull/47951) has been marked as a breaking change, I would suggest introducing a new method that gives us the same result as `getDates()` from Laravel 9.

This method would be helpful to determine "what model's attributes are date-castable", including timestamps (`created_at`, `updated_at`, `deleted_at`) and defined by a programmer in `$casts`.

If this PR is accepted, then I would send a PR to the laravelcollective library (and [forks](https://github.com/LaravelLux/html/blob/e25e743cadb2685a8a6ab4bdab5e270f3cf8d443/src/Eloquent/FormAccessible.php#L31))

I sent PR to the upgrade guide as well -> https://github.com/laravel/docs/pull/8940

