### PR TITLE
[10.x] Add `content` method to Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -656,6 +656,24 @@ class Vite implements Htmlable
     }
 
     /**
+     * Get the content for an asset.
+     *
+     * @param  string  $asset
+     * @param  string|null  $buildDirectory
+     * @return string
+     */
+    public function content($asset, $buildDirectory = null)
+    {
+        $buildDirectory ??= $this->buildDirectory;
+
+        $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
+
+        $path = public_path($buildDirectory.'/'.$chunk['file']);
+
+        return file_get_contents($path);
+    }
+
+    /**
      * Generate an asset path for the application.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -656,7 +656,7 @@ class Vite implements Htmlable
     }
 
     /**
-     * Get the content for an asset.
+     * Get the content of a given asset.
      *
      * @param  string  $asset
      * @param  string|null  $buildDirectory

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -661,6 +661,8 @@ class Vite implements Htmlable
      * @param  string  $asset
      * @param  string|null  $buildDirectory
      * @return string
+     *
+     * @throws \Exception
      */
     public function content($asset, $buildDirectory = null)
     {
@@ -671,7 +673,7 @@ class Vite implements Htmlable
         $path = public_path($buildDirectory.'/'.$chunk['file']);
 
         if (! is_file($path) || ! file_exists($path)) {
-            return '';
+            throw new Exception("Unable to locate file at path: {$path}.");
         }
 
         return file_get_contents($path);

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -670,6 +670,10 @@ class Vite implements Htmlable
 
         $path = public_path($buildDirectory.'/'.$chunk['file']);
 
+        if (! is_file($path) || ! file_exists($path)) {
+            return '';
+        }
+
         return file_get_contents($path);
     }
 

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -673,7 +673,7 @@ class Vite implements Htmlable
         $path = public_path($buildDirectory.'/'.$chunk['file']);
 
         if (! is_file($path) || ! file_exists($path)) {
-            throw new Exception("Unable to locate file at path: {$path}.");
+            throw new Exception("Unable to locate file from Vite manifest: {$path}.");
         }
 
         return file_get_contents($path);

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -17,6 +17,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Foundation\Vite usePreloadTagAttributes(callable|array|false $attributes)
  * @method static \Illuminate\Support\HtmlString|void reactRefresh()
  * @method static string asset(string $asset, string|null $buildDirectory = null)
+ * @method static string content(string $asset, string|null $buildDirectory = null)
  * @method static string|null manifestHash(string|null $buildDirectory = null)
  * @method static bool isRunningHot()
  * @method static string toHtml()

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1184,6 +1184,21 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest($buildDir);
     }
 
+    public function testItRetrievesAssetContent()
+    {
+        $this->makeViteManifest();
+
+        $this->makeAsset('/app.versioned.js', 'some content');
+
+        $content = ViteFacade::content('resources/js/app.js');
+
+        $this->assertSame('some content', $content);
+
+        $this->cleanAsset('/app.versioned.js');
+
+        $this->cleanViteManifest();
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->usePublicPath(__DIR__);
@@ -1243,6 +1258,26 @@ class FoundationViteTest extends TestCase
         if (file_exists(public_path($path))) {
             rmdir(public_path($path));
         }
+    }
+
+    protected function makeAsset($asset, $content)
+    {
+        $path = public_path('build/assets');
+
+        if (! file_exists($path)) {
+            mkdir($path, recursive: true);
+        }
+
+        file_put_contents($path.'/'.$asset, $content);
+    }
+
+    protected function cleanAsset($asset)
+    {
+        $path = public_path('build/assets');
+
+        unlink($path . $asset);
+
+        rmdir($path);
     }
 
     protected function makeViteHotFile($path = null)

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1206,11 +1206,7 @@ class FoundationViteTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Unable to locate file at path: '.public_path('build/assets/app.versioned.js'));
 
-        $content = ViteFacade::content('resources/js/app.js');
-
-        $this->assertSame('some content', $content);
-
-        $this->cleanViteManifest();
+        ViteFacade::content('resources/js/app.js');
     }
 
     protected function makeViteManifest($contents = null, $path = 'build')

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1199,6 +1199,20 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest();
     }
 
+    public function testItThrowsWhenUnableToFindFileToRetrieveContent()
+    {
+        $this->makeViteManifest();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unable to locate file at path: '.public_path('build/assets/app.versioned.js'));
+
+        $content = ViteFacade::content('resources/js/app.js');
+
+        $this->assertSame('some content', $content);
+
+        $this->cleanViteManifest();
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->usePublicPath(__DIR__);

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1204,7 +1204,7 @@ class FoundationViteTest extends TestCase
         $this->makeViteManifest();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Unable to locate file at path: '.public_path('build/assets/app.versioned.js'));
+        $this->expectExceptionMessage('Unable to locate file from Vite manifest: '.public_path('build/assets/app.versioned.js'));
 
         ViteFacade::content('resources/js/app.js');
     }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1275,7 +1275,7 @@ class FoundationViteTest extends TestCase
     {
         $path = public_path('build/assets');
 
-        unlink($path . $asset);
+        unlink($path.$asset);
 
         rmdir($path);
     }


### PR DESCRIPTION
## About
This PR adds a method to retrieve compiled content for the given file available in the Vite manifest. It allows us to pack our Vite assets inline when needed.

## Example use case
You want to create an HTML page that needs to be open or sent as a single document (for example, as a mail attachment), and to work offline (without access to the internet) so the asset should be injected into the document for the browser to work on the local file without firing the HTTP requests.

## Usage example
```php
<style>{!! Vite::content('resources/scss/file.scss') !!}</style>
```