### PR TITLE
[10.x] Remove return on void callback

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -211,7 +211,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
 
                 $app->forgetScopedInstances();
 
-                return Facade::clearResolvedInstances();
+                Facade::clearResolvedInstances();
             };
 
             return new Worker(


### PR DESCRIPTION
Just a minor fix: 

`Facade::clearResolvedInstances()` is a void function, so it does not make sense to returns it's value 😀. 

<img width="1029" alt="image" src="https://github.com/laravel/framework/assets/1103494/fababe3a-8f68-407a-bcb0-8420f0cd4d5f">

`Facade::clearResolvedInstances()`: 
<img width="654" alt="image" src="https://github.com/laravel/framework/assets/1103494/c96868c3-abaa-4ad7-b176-bee64eb2fb7c">


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
