### PR TITLE
[10.x] Show between hours in cron expression

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 trait ManagesFrequencies
@@ -29,7 +30,8 @@ trait ManagesFrequencies
      */
     public function between($startTime, $endTime)
     {
-        return $this->when($this->inTimeInterval($startTime, $endTime));
+        return $this->when($this->inTimeInterval($startTime, $endTime))
+            ->spliceIntoPosition(2, Str::before($startTime, ':').'-'.Str::before($endTime, ':'));
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -227,4 +227,9 @@ class FrequencyTest extends TestCase
 
         $this->assertSame('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
     }
+
+    public function testBetween()
+    {
+        $this->assertSame('*/2 06-23 * * *', $this->event->everyTwoMinutes()->between('06:00', '23:00')->getExpression());
+    }
 }


### PR DESCRIPTION
Hey!

I've discovered something missing from cron expressions when you run `schedule:list`. Let's say I have a command that I have set up on a schedule to run every 2 minutes, between the hours of 6am and 11pm:

```php
$schedule->command('example')
    ->everyTwoMinutes()
    ->between('06:00', '23:00');
```

If I run `schedule:list`, that item shows as:

```bash
*/2 * * * *  php artisan example ................... Next Due: 36 seconds from now
```

Whilst it shows me that it's setup to run every 2 minutes, the hours it runs are missing from the expression. This PR changes that so the hours now show, as they would in regular crontab:

```bash
*/2 06-23 * * *  php artisan example ............... Next Due: 11 seconds from now
```

I've also added a new test to support this change.