### PR TITLE
[10.x] Fix paginator URL when page name contains brackets

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -174,10 +174,12 @@ abstract class AbstractPaginator implements Htmlable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = str_contains($this->pageName, '[')
+            ? Arr::undot([str_replace(['[', ']'], ['.', ''], $this->pageName) => $page])
+            : [$this->pageName => $page];
 
         if (count($this->query) > 0) {
-            $parameters = array_merge($this->query, $parameters);
+            $parameters = array_replace_recursive($this->query, $parameters);
         }
 
         return $this->path()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -45,7 +45,7 @@ class PaginatorTest extends TestCase
         $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
     }
 
-    public function testLengthPaginatorCorrectlyGenerateUrlsWithQueryAndPageNamesWithBrackets()
+    public function testPaginatorCorrectlyGenerateUrlsWithQueryAndPageNamesWithBrackets()
     {
         $p = new Paginator(['item1', 'item2', 'item3'], 2, 2, [
             'path' => 'http://website.com/test',

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -45,6 +45,23 @@ class PaginatorTest extends TestCase
         $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
     }
 
+    public function testLengthPaginatorCorrectlyGenerateUrlsWithQueryAndPageNamesWithBrackets()
+    {
+        $p = new Paginator(['item1', 'item2', 'item3'], 2, 2, [
+            'path' => 'http://website.com/test',
+            'pageName' => 'items[page]',
+            'query' => [
+                'status' => 'open',
+                'items' => ['page' => 1, 'per_page' => 15],
+            ],
+        ]);
+
+        $this->assertSame(
+            'http://website.com/test?status=open&items%5Bpage%5D=2&items%5Bper_page%5D=15',
+            $p->url($p->currentPage())
+        );
+    }
+
     public function testItRetrievesThePaginatorOptions()
     {
         $p = new Paginator(['item1', 'item2', 'item3'], 2, 2, ['path' => 'http://website.com/test']);


### PR DESCRIPTION
I faced with a situation, where I had to maintain multiple Paginator on the same page. I isolated all paginator options in the query string the following: `https://example.local?users[per_page]=10&users[page]=4&products[per_page]=50&products[page]=2`.

It's good, because I can easily access to each paginator related parameters as an array:

```php
$request->query('users'); // ['per_page' => 10, 'page' => 4]
```
A paginator instance looks like:

```php
$users = User::query()
->paginate($request->input('users.per_page'), ['*'], 'users[page]', $request->input('users.page', 1))
->withQueryString();
```

It works well, because I can access to the `users.page` / `users.per_page` query string parameters as well. Also, passing the `pageName` option as `users[page]` works as well, so it preserves the URL structure for the next pages.

-----

The issue is that, with this setup, the paginator duplicates the `users[page]` query string parameter:

`https://example.local?users[per_page]=10&users[page]=3&users[page]=4...`

The paginator works still as it should, but this can cause some issues when interacting with the URL using JS:

```js
// https://example.local?users[per_page]=10&users[page]=3&users[page]=4

let query = new URLSearchParams(window.location.search) ;

query.get('users[page]'); // it returns 3, while the paginator uses 4
```

This PR should fix this, by making sure only one parameter is present in the query string with the `$pageName`.

I belive this breaks nothing, so I targeted the `10.x` branch.