### PR TITLE
[10.x] Allow `digits` rules to work with `decimal`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2485,7 +2485,7 @@ trait ValidatesAttributes
     /**
      * Determine if the value is in the shape of a decimal.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function isDecimal($value)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2906,6 +2906,126 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testDecimalDigits()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['num' => '55.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '-55.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '+55.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '.55'], ['num' => 'digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '+.55'], ['num' => 'digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '-.55'], ['num' => 'digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '.55'], ['num' => 'digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '5.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertSame(['validation.digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '+5.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertSame(['validation.digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '-5.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertSame(['validation.digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '555.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertSame(['validation.digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '+555.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertSame(['validation.digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '-555.55'], ['num' => 'digits:4|decimal:2']);
+        $this->assertSame(['validation.digits'], $v->errors()->all());
+    }
+
+    public function testDecimalMaxDigits()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['num' => '55.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '5.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '-55.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '+55.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '.55'], ['num' => 'max_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '+.55'], ['num' => 'max_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '-.55'], ['num' => 'max_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '555.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertSame(['validation.max_digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '+555.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertSame(['validation.max_digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '-555.55'], ['num' => 'max_digits:4|decimal:2']);
+        $this->assertSame(['validation.max_digits'], $v->errors()->all());
+    }
+
+    public function testDecimalMinDigits()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['num' => '55.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '5.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '-55.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '+55.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '+.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '-.55'], ['num' => 'min_digits:2|decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['num' => '5.55'], ['num' => 'min_digits:4|decimal:2']);
+        $this->assertSame(['validation.min_digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '+5.55'], ['num' => 'min_digits:4|decimal:2']);
+        $this->assertSame(['validation.min_digits'], $v->errors()->all());
+
+        $v = new Validator($trans, ['num' => '-5.55'], ['num' => 'min_digits:4|decimal:2']);
+        $this->assertSame(['validation.min_digits'], $v->errors()->all());
+    }
+
     public function testValidateInt()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
It is currently possible to limit the number of digits in an integer:

```php
'int_number' => ['required', 'integer', 'max_digits:5'],
```

It is also currently possible to limit the number of digits after the decimal place in an decimal:

```php
'dec_number' => ['required', 'decimal:0,5'],
```

However, it is not possible to limit the total number of digits of a decimal. It would be useful to be able to specify the total number of digits.


```php
Validator::validate([
    'number' => 123.456,
], [
    'number' => ['decimal:0,3', 'max_digits:6'], // passes

    'number' => ['decimal:0,3', 'max_digits:5'], // fails. 3 before dot and 3 after = 6 digits
])
```

Documented: https://github.com/laravel/docs/pull/8943