### PR TITLE
[10.x] Add getter for components on IO interaction

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -442,16 +442,6 @@ trait InteractsWithIO
     }
 
     /**
-     * Get the components implementation.
-     *
-     * @return \Illuminate\Console\View\Components\Factory
-     */
-    public function getComponents()
-    {
-        return $this->components;
-    }
-
-    /**
      * Get the output implementation.
      *
      * @return \Illuminate\Console\OutputStyle
@@ -459,5 +449,15 @@ trait InteractsWithIO
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * Get the output component factory implementation.
+     *
+     * @return \Illuminate\Console\View\Components\Factory
+     */
+    public function outputComponents()
+    {
+        return $this->components;
     }
 }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -442,6 +442,16 @@ trait InteractsWithIO
     }
 
     /**
+     * Get the components implementation.
+     *
+     * @return \Illuminate\Console\View\Components\Factory
+     */
+    public function getComponents()
+    {
+        return $this->components;
+    }
+
+    /**
      * Get the output implementation.
      *
      * @return \Illuminate\Console\OutputStyle


### PR DESCRIPTION
This pull request allows for access to the components propery on Commands and other locations that use the InteractsWithIO trait. This allows components to be used outside of the context of those locations, such as when using https://github.com/wilderborn/partyline to access the console outside of the context of a command
