### PR TITLE
[10.x] Show config when the value is false or zero

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -32,16 +32,14 @@ class ConfigShowCommand extends Command
     {
         $config = $this->argument('config');
 
-        $data = config($config);
-
-        if (! $data) {
+        if (! config()->has($config)) {
             $this->components->error("Configuration file `{$config}` does not exist.");
 
             return Command::FAILURE;
         }
 
         $this->newLine();
-        $this->render($config, $data);
+        $this->render($config);
         $this->newLine();
 
         return Command::SUCCESS;
@@ -51,11 +49,12 @@ class ConfigShowCommand extends Command
      * Render the configuration values.
      *
      * @param  string  $name
-     * @param  mixed  $data
      * @return void
      */
-    public function render($name, $data)
+    public function render($name)
     {
+        $data = config($name);
+
         if (! is_array($data)) {
             $this->title($name, $this->formatValue($data));
 


### PR DESCRIPTION
`config:show`  command checks for the existence of the configuration with a value, so when the value is false or null, it returns the result `Configuration file `{$config}` does not exist.`.
This will be fixed after merge.