### PR TITLE
[10.x] Add WithoutRelations attribute for model serialization

### DIFF
--- a/src/Illuminate/Queue/Attributes/WithoutRelations.php
+++ b/src/Illuminate/Queue/Attributes/WithoutRelations.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class WithoutRelations
+{
+    //
+}

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -15,16 +15,16 @@ trait SerializesAndRestoresModelIdentifiers
      * Get the property value prepared for serialization.
      *
      * @param  mixed  $value
-     * @param  bool  $withoutRelations
+     * @param  bool  $withRelations
      * @return mixed
      */
-    protected function getSerializedPropertyValue($value, $withoutRelations = false)
+    protected function getSerializedPropertyValue($value, $withRelations = true)
     {
         if ($value instanceof QueueableCollection) {
             return (new ModelIdentifier(
                 $value->getQueueableClass(),
                 $value->getQueueableIds(),
-                !$withoutRelations ? $value->getQueueableRelations() : [],
+                $withRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
             ))->useCollectionClass(
                 ($collectionClass = get_class($value)) !== EloquentCollection::class
@@ -37,7 +37,7 @@ trait SerializesAndRestoresModelIdentifiers
             return new ModelIdentifier(
                 get_class($value),
                 $value->getQueueableId(),
-                !$withoutRelations ? $value->getQueueableRelations() : [],
+                $withRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
             );
         }

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -15,15 +15,16 @@ trait SerializesAndRestoresModelIdentifiers
      * Get the property value prepared for serialization.
      *
      * @param  mixed  $value
+     * @param  bool  $withoutRelations
      * @return mixed
      */
-    protected function getSerializedPropertyValue($value)
+    protected function getSerializedPropertyValue($value, $withoutRelations = false)
     {
         if ($value instanceof QueueableCollection) {
             return (new ModelIdentifier(
                 $value->getQueueableClass(),
                 $value->getQueueableIds(),
-                $value->getQueueableRelations(),
+                !$withoutRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
             ))->useCollectionClass(
                 ($collectionClass = get_class($value)) !== EloquentCollection::class
@@ -36,7 +37,7 @@ trait SerializesAndRestoresModelIdentifiers
             return new ModelIdentifier(
                 get_class($value),
                 $value->getQueueableId(),
-                $value->getQueueableRelations(),
+                !$withoutRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
             );
         }

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Queue\Attributes\WithoutRelations;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -45,7 +46,9 @@ trait SerializesModels
                 $name = "\0*\0{$name}";
             }
 
-            $values[$name] = $this->getSerializedPropertyValue($value);
+            $withoutRelations = $property->getAttributes(WithoutRelations::class) !== [];
+
+            $values[$name] = $this->getSerializedPropertyValue($value, $withoutRelations);
         }
 
         return $values;

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -46,9 +46,10 @@ trait SerializesModels
                 $name = "\0*\0{$name}";
             }
 
-            $withoutRelations = $property->getAttributes(WithoutRelations::class) !== [];
-
-            $values[$name] = $this->getSerializedPropertyValue($value, $withoutRelations);
+            $values[$name] = $this->getSerializedPropertyValue(
+                $value,
+                empty($property->getAttributes(WithoutRelations::class))
+            );
         }
 
         return $values;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\Attributes\WithoutRelations;
 use Illuminate\Queue\SerializesModels;
 use LogicException;
 use Orchestra\Testbench\TestCase;
@@ -318,6 +319,19 @@ class ModelSerializationTest extends TestCase
         );
     }
 
+    public function test_it_respects_without_relations_attribute()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+        ])->load(['roles']);
+
+        $serialized = serialize(new ModelSerializationWithoutRelations($user));
+
+        $this->assertSame(
+            'O:69:"Illuminate\Tests\Integration\Queue\ModelSerializationWithoutRelations":1:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:39:"Illuminate\Tests\Integration\Queue\User";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}}', $serialized
+        );
+    }
+
     public function test_serialization_types_empty_custom_eloquent_collection()
     {
         $class = new ModelSerializationTypedCustomCollectionTestClass(
@@ -497,6 +511,19 @@ class ModelSerializationAccessibleTestClass
 class ModelSerializationParentAccessibleTestClass extends ModelSerializationAccessibleTestClass
 {
     //
+}
+
+class ModelSerializationWithoutRelations
+{
+    use SerializesModels;
+
+    #[WithoutRelations]
+    public User $user;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
 }
 
 class ModelRelationSerializationTestClass


### PR DESCRIPTION
Hey all,

I normally serialize my models without their relations, I've had some issues with circular dependencies and often don't even need them after unserialization. I usually do this by calling `withoutRelations` on the model(s) in my constructor like this:
```php
<?php

use App\Models\User;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\SerializesModels;

class Queued implements ShouldQueue
{
    use SerializesModels;

    public User $user;

    public function __construct(User $user)
    {
        $this->user = $user->withoutRelations();
    }
}
```

There is however no way to do this with property-promotion. And apart from that I like to keep my job (etc.) constructors as slim as possible.

The following is possible with this PR:
```php
<?php

use App\Models\User;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\Attributes\WithoutRelations;
use Illuminate\Queue\SerializesModels;

class Queued implements ShouldQueue
{
    use SerializesModels;

    public function __construct(
        #[WithoutRelations]
        public User $user,
    ) {
        //
    }
}
```
I don't know if my approach is the best but it's the first that came to mind.

I'm curious to know what you think.