### PR TITLE
[10.x] Allow console used without laravel application

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Concerns;
 
+use Illuminate\Contracts\Foundation\Application;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
 use Laravel\Prompts\PasswordPrompt;
@@ -24,7 +25,7 @@ trait ConfiguresPrompts
     {
         Prompt::setOutput($this->output);
 
-        Prompt::fallbackWhen(! $input->isInteractive() || windows_os() || $this->laravel->runningUnitTests());
+        Prompt::fallbackWhen(! $input->isInteractive() || windows_os() || ($this->laravel instanceof Application ? $this->laravel->runningUnitTests() : false));
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',


### PR DESCRIPTION
Hi,

Although the `$laravel` in `Illuminate\Console\Command` is still an `Illuminate\Contracts\Foundation\Application`, I have found that `setLaravel($laravel)` can only be used to set the type of `Illuminate\Contracts\Container\Container`.
And currently, except for the newly added `$this ->laravel ->runningUnitTests()`, which uses the function of `Application`, other places can be completely switched to `Container`.

Therefore, I change this for use `illuminate/console` in other app without laravel.