### PR TITLE
[10.x] Update the collection's where method filter to support array input

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -567,7 +567,6 @@ trait EnumeratesValues
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
-            
             return new static($filteredCollection);
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -567,6 +567,7 @@ trait EnumeratesValues
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
+
             return new static($filteredCollection);
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -567,7 +567,6 @@ trait EnumeratesValues
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
-            
             return $filteredCollection;     
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -562,12 +562,13 @@ trait EnumeratesValues
      */
     public function where($key, $operator = null, $value = null)
     {
-        if(is_iterable($key)) {
+        if (is_iterable($key)) {
             $filteredCollection = $this;
-            foreach($key as $searchKey => $searchValue) {
+            foreach ($key as $searchKey => $searchValue) {
 
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null , $searchValue));
             }
+            
             return $filteredCollection;     
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -565,10 +565,8 @@ trait EnumeratesValues
         if (is_iterable($key)) {
             $filteredCollection = $this;
             foreach ($key as $searchKey => $searchValue) {
-
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null , $searchValue));
             }
-            
             return $filteredCollection;     
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -570,7 +570,6 @@ trait EnumeratesValues
 
             return new static($filteredCollection);
         }
-        
         return $this->filter($this->operatorForWhere(...func_get_args()));
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -569,9 +569,9 @@ trait EnumeratesValues
             }
 
             return new static($filteredCollection);
-        } else {
-            return $this->filter($this->operatorForWhere(...func_get_args()));
         }
+        
+        return $this->filter($this->operatorForWhere(...func_get_args()));
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -567,6 +567,7 @@ trait EnumeratesValues
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
+            
             return $filteredCollection;     
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -566,7 +566,7 @@ trait EnumeratesValues
             $filteredCollection = $this;
             
             foreach ($key as $searchKey => $searchValue) {
-                $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null , $searchValue));
+                $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
             
             return $filteredCollection;     

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -564,11 +564,9 @@ trait EnumeratesValues
     {
         if (is_iterable($key)) {
             $filteredCollection = $this;
-            
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
-            
             return $filteredCollection;     
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -564,9 +564,11 @@ trait EnumeratesValues
     {
         if (is_iterable($key)) {
             $filteredCollection = $this;
+            
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null , $searchValue));
             }
+            
             return $filteredCollection;     
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -570,6 +570,7 @@ trait EnumeratesValues
 
             return new static($filteredCollection);
         }
+
         return $this->filter($this->operatorForWhere(...func_get_args()));
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -555,14 +555,23 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair.
      *
-     * @param  callable|string  $key
+     * @param  callable|string|array  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return static
      */
     public function where($key, $operator = null, $value = null)
     {
-        return $this->filter($this->operatorForWhere(...func_get_args()));
+        if(is_iterable($key)) {
+            $filteredCollection = $this;
+            foreach($key as $searchKey => $searchValue) {
+
+                $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null , $searchValue));
+            }
+            return $filteredCollection;     
+        } else {
+            return $this->filter($this->operatorForWhere(...func_get_args()));
+        }
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -567,7 +567,8 @@ trait EnumeratesValues
             foreach ($key as $searchKey => $searchValue) {
                 $filteredCollection = $filteredCollection->filter($filteredCollection->operatorForWhere($searchKey, null, $searchValue));
             }
-            return $filteredCollection;     
+            
+            return new static($filteredCollection);
         } else {
             return $this->filter($this->operatorForWhere(...func_get_args()));
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1114,10 +1114,11 @@ class SupportCollectionTest extends TestCase
             ['v' => 2, 'g' => 3],
             ['v' => 2, 'g' => null],
         ]);
-        $this->assertEquals([['v' => 2, 'g' => 3]], $c->where('v', 2)->where('g', 3)->values()->all());
+        
         $this->assertEquals([['v' => 2, 'g' => 3]], $c->where('v', 2)->where('g', '>', 2)->values()->all());
-        $this->assertEquals([], $c->where('v', 2)->where('g', 4)->values()->all());
-        $this->assertEquals([['v' => 2, 'g' => null]], $c->where('v', 2)->whereNull('g')->values()->all());
+        $this->assertEquals([['v' => 2, 'g' => 3]], $c->where(['v' => 2, 'g' => 3])->values()->all());
+        $this->assertEquals([], $c->where(['v' => 2, 'g' => 4])->values()->all());
+        $this->assertEquals([['v' => 2, 'g' => null]], $c->where(['v' => 2, 'g' => null])->values()->all());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1114,7 +1114,6 @@ class SupportCollectionTest extends TestCase
             ['v' => 2, 'g' => 3],
             ['v' => 2, 'g' => null],
         ]);
-        
         $this->assertEquals([['v' => 2, 'g' => 3]], $c->where('v', 2)->where('g', '>', 2)->values()->all());
         $this->assertEquals([['v' => 2, 'g' => 3]], $c->where(['v' => 2, 'g' => 3])->values()->all());
         $this->assertEquals([], $c->where(['v' => 2, 'g' => 4])->values()->all());


### PR DESCRIPTION
Previously we had to use multiple `where()` if we needed to use multiple conditions.

```
$collection = collect([
            ['product' => 'Desk', 'color' => 'orange', 'price' => 200],
            ['product' => 'Bookcase', 'color' => 'dark', 'price' => 150],
            ['product' => 'Door', 'color' => 'red', 'price' => 100],
            ['product' => 'Chair', 'color' => 'blue', 'price' => 100],
            ['product' => 'Chair', 'color' => 'blue', 'price' => 120],
            ['product' => 'Chair', 'color' => 'red', 'price' => 130],
        ]);
```

Previously we had to do following for multiple conditions:

`$filtered = $collection->where('color', 'blue')->where('product', 'Chair');`

This is great but when there is three or more than that, things looks dirty and less manageable. With this PR we can do this like following in a more cleaner way.

```
$filtered = $collection->where([
            'product' => 'Chair',
            'color' => 'blue'
        ]);
```

This comes more handy when there are more than two or three conditional data need to be checked.

**We can still use comparison operators other than equal to**

```
$filtered = $collection->where([
            'product' => 'Chair',
            'color' => 'blue'
        ])->where('price', '>', 100);
```