### PR TITLE
[10.x] Add Num helper

### DIFF
--- a/src/Illuminate/Support/Num.php
+++ b/src/Illuminate/Support/Num.php
@@ -20,7 +20,7 @@ class Num
     public static function float(string $value, ?string $decimalSeparator = null): float
     {
         $decimalSeparator = $decimalSeparator ?? self::guessDecimalSeparator($value);
-        $cleanedValue = preg_replace('/[^0-9' . preg_quote($decimalSeparator) . ']/', '', $value);
+        $cleanedValue = preg_replace('/[^0-9'.preg_quote($decimalSeparator).']/', '', $value);
 
         if ($decimalSeparator === self::COMMA) {
             $floatValue = (float) str_replace($decimalSeparator, self::POINT, $cleanedValue);

--- a/src/Illuminate/Support/Num.php
+++ b/src/Illuminate/Support/Num.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Num
+{
+    /**
+     * Decimal separator constants.
+     */
+    const POINT = '.';
+    const COMMA = ',';
+
+    /**
+     * Convert a string to a float.
+     *
+     * @param  string  $value
+     * @param  string|null  $decimalSeparator
+     * @return float
+     */
+    public static function float(string $value, ?string $decimalSeparator = null): float
+    {
+        $decimalSeparator = $decimalSeparator ?? self::guessDecimalSeparator($value);
+        $cleanedValue = preg_replace('/[^0-9' . preg_quote($decimalSeparator) . ']/', '', $value);
+
+        if ($decimalSeparator === self::COMMA) {
+            $floatValue = (float) str_replace($decimalSeparator, self::POINT, $cleanedValue);
+        } else {
+            $floatValue = (float) $cleanedValue;
+        }
+
+        return $floatValue;
+    }
+
+    /**
+     * Convert a string to an integer.
+     *
+     * @param  string  $value
+     * @param  string|null  $decimalSeparator
+     * @return int
+     */
+    public static function int(string $value, ?string $decimalSeparator = null): int
+    {
+        return (int) self::float($value, $decimalSeparator);
+    }
+
+    /**
+     * Guess the decimal separator from a string representing a number.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function guessDecimalSeparator(string $value): string
+    {
+        $pointCount = substr_count($value, self::POINT);
+        $commaCount = substr_count($value, self::COMMA);
+
+        if ($pointCount == 0 && $commaCount == 0) {
+            return self::POINT;
+        }
+
+        if ($pointCount > 0 && $commaCount == 0) {
+            return ($pointCount > 1) ? self::COMMA : self::POINT;
+        }
+
+        if ($pointCount == 0 && $commaCount > 0) {
+            return ($commaCount > 1) ? self::POINT : self::COMMA;
+        }
+
+        if ($pointCount < $commaCount) {
+            return self::POINT;
+        } elseif ($commaCount < $pointCount) {
+            return self::COMMA;
+        } else {
+            $lastPointPosition = strrpos($value, self::POINT);
+            $lastCommaPosition = strrpos($value, self::COMMA);
+
+            if ($lastPointPosition !== false && $lastCommaPosition !== false) {
+                return ($lastPointPosition > $lastCommaPosition) ? self::POINT : self::COMMA;
+            } elseif ($lastPointPosition !== false) {
+                return self::POINT;
+            } elseif ($lastCommaPosition !== false) {
+                return self::COMMA;
+            }
+        }
+
+        return self::POINT;
+    }
+}

--- a/tests/Support/SupportNumTest.php
+++ b/tests/Support/SupportNumTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Num;
+use PHPUnit\Framework\TestCase;
+
+class SupportNumTest extends TestCase
+{
+    public function testConversionOfNumberWithPointDecimalSeparatorToFloat()
+    {
+        $this->assertSame(123.0, Num::float('123', Num::POINT));
+        $this->assertSame(1234567.89, Num::float('1,234,567.89', Num::POINT));
+        $this->assertSame(1234567.0, Num::float('1,234,567', Num::POINT));
+        $this->assertSame(1234567.89, Num::float('1 234 567.89', Num::POINT));
+        $this->assertSame(1234567.89, Num::float('123,4567.89', Num::POINT));
+        $this->assertSame(1234567.89, Num::float('1\'234\'567.89', Num::POINT));
+        $this->assertSame(12345.0, Num::float('12,345', Num::POINT));
+        $this->assertSame(123456.0, Num::float('12,3456', Num::POINT));
+        $this->assertSame(3.14159265359, Num::float('3.14159265359', Num::POINT));
+        $this->assertSame(12.30, Num::float('$12.30', Num::POINT));
+        $this->assertSame(0.0, Num::float('text', Num::POINT));
+    }
+
+    public function testConversionOfNumberWithPointDecimalSeparatorToInteger()
+    {
+        $this->assertSame(123, Num::int('123', Num::POINT));
+        $this->assertSame(1234567, Num::int('1,234,567.89', Num::POINT));
+        $this->assertSame(1234567, Num::int('1,234,567', Num::POINT));
+        $this->assertSame(1234567, Num::int('1 234 567.89', Num::POINT));
+        $this->assertSame(1234567, Num::int('123,4567.89', Num::POINT));
+        $this->assertSame(1234567, Num::int('1\'234\'567.89', Num::POINT));
+        $this->assertSame(12345, Num::int('12,345', Num::POINT));
+        $this->assertSame(123456, Num::int('12,3456', Num::POINT));
+        $this->assertSame(12, Num::int('$12.30', Num::POINT));
+        $this->assertSame(0, Num::int('text', Num::POINT));
+    }
+
+    public function testConversionOfNumberWithCommaDecimalSeparatorToFloat()
+    {
+        $this->assertSame(123.0, Num::float('123', Num::COMMA));
+        $this->assertSame(1234567.89, Num::float('1 234 567,89'), Num::COMMA);
+        $this->assertSame(1234567.89, Num::float('1.234.567,89'), Num::COMMA);
+        $this->assertSame(1234567.89, Num::float('1\'234\'567,89'), Num::COMMA);
+        $this->assertSame(12.345, Num::float('12,345', Num::COMMA));
+        $this->assertSame(3.14159265359, Num::float('3,14159265359', Num::COMMA));
+        $this->assertSame(0.0, Num::float('text', Num::COMMA));
+    }
+
+    public function testConversionOfNumberWithCommaDecimalSeparatorToInteger()
+    {
+        $this->assertSame(123, Num::int('123', Num::COMMA));
+        $this->assertSame(1234567, Num::int('1 234 567,89'), Num::COMMA);
+        $this->assertSame(1234567, Num::int('1.234.567,89'), Num::COMMA);
+        $this->assertSame(1234567, Num::int('1\'234\'567,89'), Num::COMMA);
+        $this->assertSame(12, Num::int('12,345', Num::COMMA));
+        $this->assertSame(0, Num::int('text', Num::COMMA));
+    }
+
+    public function testGuessingDecimalSeparatorFromNumberString()
+    {
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('1,234,567.89'));
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('1,234,567'));
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('1 234 567.89'));
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('123,4567.89'));
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('1\'234\'567.89'));
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('123'));
+        $this->assertSame(Num::POINT, Num::guessDecimalSeparator('text'));
+        $this->assertSame(Num::COMMA, Num::guessDecimalSeparator('1.234.567,89'));
+        $this->assertSame(Num::COMMA, Num::guessDecimalSeparator('1\'234\'567,89'));
+        $this->assertSame(Num::COMMA, Num::guessDecimalSeparator('12,345'));
+        $this->assertSame(Num::COMMA, Num::guessDecimalSeparator('12,3456'));
+    }
+}


### PR DESCRIPTION
The default PHP functions `floatval()` and `intval()` not very helpful when dealing with different ways numbers are passed as strings.

For example:
```php
floatval("1 234 567.89") // float(1)
intval("1,234.56") // int(1)
```

This pull request adds a `Num` helper class with static methods: `float()`, `int()` and `guessDecimalSeparator()`.

You can provide a decimal separator to both methods if you know it.

The `guessDecimalSeparator()` helper can automatically identify the decimal separator if it's not explicitly specified.

Here's an example:
```php
Num::float('1 234 567.89'); // float(1234567.89)
Num::float('$12.30', Num::POINT); // float(12.30)
Num::int('12,345', Num::COMMA); // int(12)
Num::int('12,345', Num::POINT); // int(12345)
```
