### PR TITLE
[10.x] New carbon() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -550,8 +550,8 @@ if (! function_exists('carbon')) {
     /**
      * Create a new Carbon instance.
      *
-     * @param DateTimeInterface|string|null $time
-     * @param DateTimeZone|string|null      $tz
+     * @param  DateTimeInterface|string|null  $time
+     * @param  DateTimeZone|string|null  $tz
      * @return \Illuminate\Support\Carbon
      * 
      * @throws InvalidFormatException

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -553,7 +553,7 @@ if (! function_exists('carbon')) {
      * @param  DateTimeInterface|string|null  $time
      * @param  DateTimeZone|string|null  $tz
      * @return \Illuminate\Support\Carbon
-     * 
+     *
      * @throws InvalidFormatException
      */
     function carbon($time = null, $tz = null)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -546,6 +546,22 @@ if (! function_exists('mix')) {
     }
 }
 
+if (! function_exists('carbon')) {
+    /**
+     * Create a new Carbon instance.
+     *
+     * @param DateTimeInterface|string|null $time
+     * @param DateTimeZone|string|null      $tz
+     * @return \Illuminate\Support\Carbon
+     * 
+     * @throws InvalidFormatException
+     */
+    function carbon($time = null, $tz = null)
+    {
+        return Date::parse($time, $tz);
+    }
+}
+
 if (! function_exists('now')) {
     /**
      * Create a new Carbon instance for the current time.


### PR DESCRIPTION

This helper is intended to be a shortcut for a `Carbon::parse( ... )` call.

Instead of doing
```
use Carbon\Carbon;

$date_string = "2012-12-21";
$date = Carbon::parse($date_string);
```

or

```
$date_string = "2012-12-21";
$date = now()->parse($date_string);
```

you could do 
```
$date_string = "2012-12-21";
$date = carbon($date_string);
```