### PR TITLE
[10.x] Fix RetryBatchCommand overlapping of failed jobs when run concurrently with the same Batch ID using isolatableId

### DIFF
--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -4,10 +4,11 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Isolatable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:retry-batch')]
-class RetryBatchCommand extends Command
+class RetryBatchCommand extends Command implements Isolatable
 {
     /**
      * The console command signature.
@@ -49,5 +50,15 @@ class RetryBatchCommand extends Command
         }
 
         $this->newLine();
+    }
+
+    /**
+     * Get the custom mutex name for an isolated command.
+     *
+     * @return string
+     */
+    public function isolatableId()
+    {
+        return $this->argument('id');
     }
 }


### PR DESCRIPTION
There is an issue in the job batching system that allows the same failed jobs to be added to the `jobs` table and executed multiple times (depending on the number of parallel processes of the `RetryBatchCommand` command for the same batch ID). This can result in a negative value for the number of pending jobs.

Steps to reproduce:

Create a batch with, for example, 1000 jobs.

Make the jobs fail (throw an exception)

Run the batch and verify that the value of `failed_jobs` in the `pending_jobs` table is 1000.

Make the jobs successful (remove the exception thrown)

Run several instances of the `php artisan queue:retry-batch {id}` command simultaneously or with a small time difference.

Check the `job_batches` table, and you will see that `pending_jobs` has a negative value. This indicates that some jobs have been executed multiple times by different processes.

Changes Made:

Updated the `RetryBatchCommand` class to implement the `Isolatable` interface.

Added the `isolatableId` method to the `RetryBatchCommand` class, which returns the value of the id argument as the custom mutex name.

By implementing the `Isolatable` interface and providing a custom mutex name using the `isolatableId` method, the RetryBatchCommand now benefits from isolated execution. This means that multiple instances of the `RetryBatchCommand` can be executed concurrently, as long as they have different id arguments. The custom mutex name ensures that only commands with the same id argument are mutually exclusive, allowing for more efficient and parallel processing of retry batches.