### PR TITLE
[10.x] Fluent arguments for `AttributeBag`

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -122,7 +122,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         if (is_null($keys)) {
             $values = $this->attributes;
         } else {
-            $keys = Arr::wrap($keys);
+            $keys = is_array($keys) ? $keys : func_get_args();
 
             $values = Arr::only($this->attributes, $keys);
         }
@@ -141,7 +141,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         if (is_null($keys)) {
             $values = $this->attributes;
         } else {
-            $keys = Arr::wrap($keys);
+            $keys = is_array($keys) ? $keys : func_get_args();
 
             $values = Arr::except($this->attributes, $keys);
         }
@@ -168,6 +168,8 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function whereStartsWith($needles)
     {
+		$needles = is_array($needles) ? $needles : func_get_args();
+
         return $this->filter(function ($value, $key) use ($needles) {
             return Str::startsWith($key, $needles);
         });
@@ -194,7 +196,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function thatStartWith($needles)
     {
-        return $this->whereStartsWith($needles);
+        return $this->whereStartsWith(is_array($needles) ? $needles : func_get_args());
     }
 
     /**

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -12,7 +12,12 @@ class ViewComponentAttributeBagTest extends TestCase
         $bag = new ComponentAttributeBag(['class' => 'font-bold', 'name' => 'test']);
 
         $this->assertSame('class="font-bold"', (string) $bag->whereStartsWith('class'));
+        $this->assertSame('class="font-bold" name="test"', (string) $bag->whereStartsWith('class', 'name'));
+        $this->assertSame('class="font-bold"', (string) $bag->thatStartWith('class'));
+        $this->assertSame('class="font-bold" name="test"', (string) $bag->thatStartWith('class', 'name'));
         $this->assertSame('font-bold', (string) $bag->whereStartsWith('class')->first());
+		$this->assertSame('class="font-bold" name="test"', (string) $bag->only('class', 'name'));
+		$this->assertSame('style="margin: 0;"', (string) $bag->except('name', 'class')->merge(['style' => 'margin: 0;']));
         $this->assertSame('name="test"', (string) $bag->whereDoesntStartWith('class'));
         $this->assertSame('test', (string) $bag->whereDoesntStartWith('class')->first());
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4']));


### PR DESCRIPTION
I frequently find myself confused by the `$attributes->only()` syntax. In various contexts, we have the freedom to use either `->func('foo', 'bar', 'baz')` or `->func(['foo', 'bar', 'baz'])`, according to our preference. However, with `$attributes`, this flexibility is not available. This pull request introduces the same behavior for `only`, `except`, `whereStartsWith`, and `thatStartWith` functions.