### PR TITLE
[10.x] Fix docblocks for throw_if and throw_unless

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -317,7 +317,7 @@ if (! function_exists('throw_if')) {
      * @template TException of \Throwable
      *
      * @param  mixed  $condition
-     * @param  TException|class-string<TException>  $exception
+     * @param  TException|string|class-string<TException>  $exception
      * @param  mixed  ...$parameters
      * @return mixed
      *
@@ -344,7 +344,7 @@ if (! function_exists('throw_unless')) {
      * @template TException of \Throwable
      *
      * @param  mixed  $condition
-     * @param  TException|class-string<TException>  $exception
+     * @param  TException|string|class-string<TException>  $exception
      * @param  mixed  ...$parameters
      * @return mixed
      *

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -317,7 +317,7 @@ if (! function_exists('throw_if')) {
      * @template TException of \Throwable
      *
      * @param  mixed  $condition
-     * @param  TException|string|class-string<TException>  $exception
+     * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
      * @return mixed
      *
@@ -344,7 +344,7 @@ if (! function_exists('throw_unless')) {
      * @template TException of \Throwable
      *
      * @param  mixed  $condition
-     * @param  TException|string|class-string<TException>  $exception
+     * @param  TException|class-string<TException>|string  $exception
      * @param  mixed  ...$parameters
      * @return mixed
      *


### PR DESCRIPTION
The docblocks were updated in #47938 but do not support passing in a string message as the `$exception` parameter.

`throw_if(true, 'My exception message')` is now giving a PHPStan error because it's expecting only a `class-string`. This fixes the issue by allowing a string as a parameter which is supported by the functions. 
