### PR TITLE
[10.x] Introduce Custom Validation Rules for Model and Model Fields with OnCreateRules and OnUpdateRules Attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -348,11 +348,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static function booted()
     {
        static::updating(function (self $model){
-           $model->useUpdateRules();
+           $model->getModelRules();
+           $model->getPropertyRules();
            $model->validate();
        });
         static::creating(function (self $model){
-            $model->useUpdateRules();
+            $model->getModelRules(useOnCreateRules: false);
+            $model->getPropertyRules(useOnCreateRules: false);
             $model->validate();
         });
 

--- a/src/Illuminate/Database/Eloquent/Validations/FieldsValidationException.php
+++ b/src/Illuminate/Database/Eloquent/Validations/FieldsValidationException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Validations;
+
+use Attribute;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+use Throwable;
+
+class FieldsValidationException extends \Exception
+{
+    readonly public array $errors;
+
+    public function __construct(array  $errors, int $code = 0, ?Throwable $previous = null)
+    {
+        $this->errors = $errors;
+        parent::__construct("Field validation errors", $code, $previous);
+    }
+
+    public function messages(): array
+    {
+        return $this->errors;
+    }
+
+}

--- a/src/Illuminate/Database/Eloquent/Validations/OnCreateRules.php
+++ b/src/Illuminate/Database/Eloquent/Validations/OnCreateRules.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Validations;
+
+use Attribute;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class OnCreateRules
+{
+    public array|string $rules;
+
+    /**
+     * Create a new OnUpdateRules instance.
+     *
+     * @param array|string $rules The rules to apply.
+     */
+    public function __construct(array|string $rules)
+    {
+        if (is_array($rules) && Arr::isAssoc($rules)) {
+            foreach ($rules as $field => $rule) {
+                $this->validateFieldAndRules($field, $rule);
+                $this->rules = $rules;
+            }
+        } elseif (is_string($rules)) {
+            $this->rules = $rules;
+        } else {
+            throw new InvalidArgumentException('Validation rules must be a string or an array.');
+        }
+    }
+
+    /**
+     * Validate the field and its associated rules.
+     *
+     * @param string $field The field name.
+     * @param mixed  $rules The validation rules.
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    private function validateFieldAndRules(string $field, mixed $rules): void
+    {
+        if (empty($field)) {
+            throw new InvalidArgumentException('Field name must be a non-empty string.');
+        }
+
+        if (!is_string($rules) && !is_array($rules)) {
+            throw new InvalidArgumentException('Validation rules must be a string or an array.');
+        }
+
+        if (is_array($rules)) {
+            foreach ($rules as $rule) {
+                if (!is_string($rule)) {
+                    throw new InvalidArgumentException('Each rule must be a string.');
+                }
+            }
+        } elseif (!is_string($rules)) {
+            throw new InvalidArgumentException('Each rule must be a string.');
+        }
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Validations/OnUpdateRules.php
+++ b/src/Illuminate/Database/Eloquent/Validations/OnUpdateRules.php
@@ -7,12 +7,12 @@ use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
-class Rules
+class OnUpdateRules
 {
     public array|string $rules;
 
     /**
-     * Create a new Rules instance.
+     * Create a new OnUpdateRules instance.
      *
      * @param array|string $rules The rules to apply.
      */
@@ -23,8 +23,7 @@ class Rules
                 $this->validateFieldAndRules($field, $rule);
                 $this->rules = $rules;
             }
-        } elseif (is_string($rules) || is_array($rules)) {
-
+        } elseif (is_string($rules)) {
             $this->rules = $rules;
         } else {
             throw new InvalidArgumentException('Validation rules must be a string or an array.');

--- a/src/Illuminate/Database/Eloquent/Validations/Rules.php
+++ b/src/Illuminate/Database/Eloquent/Validations/Rules.php
@@ -21,8 +21,10 @@ class Rules
         if (is_array($rules) && Arr::isAssoc($rules)) {
             foreach ($rules as $field => $rule) {
                 $this->validateFieldAndRules($field, $rule);
+                $this->rules = $rules;
             }
         } elseif (is_string($rules) || is_array($rules)) {
+
             $this->rules = $rules;
         } else {
             throw new InvalidArgumentException('Validation rules must be a string or an array.');

--- a/src/Illuminate/Database/Eloquent/Validations/Rules.php
+++ b/src/Illuminate/Database/Eloquent/Validations/Rules.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Validations;
+
+use Attribute;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class Rules
+{
+    public array|string $rules;
+
+    /**
+     * Create a new Rules instance.
+     *
+     * @param array|string $rules The rules to apply.
+     */
+    public function __construct(array|string $rules)
+    {
+        if (is_array($rules) && Arr::isAssoc($rules)) {
+            foreach ($rules as $field => $rule) {
+                $this->validateFieldAndRules($field, $rule);
+            }
+        } elseif (is_string($rules) || is_array($rules)) {
+            $this->rules = $rules;
+        } else {
+            throw new InvalidArgumentException('Validation rules must be a string or an array.');
+        }
+    }
+
+    /**
+     * Validate the field and its associated rules.
+     *
+     * @param string $field The field name.
+     * @param mixed  $rules The validation rules.
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    private function validateFieldAndRules(string $field, mixed $rules): void
+    {
+        if (empty($field)) {
+            throw new InvalidArgumentException('Field name must be a non-empty string.');
+        }
+
+        if (!is_string($rules) && !is_array($rules)) {
+            throw new InvalidArgumentException('Validation rules must be a string or an array.');
+        }
+
+        if (is_array($rules)) {
+            foreach ($rules as $rule) {
+                if (!is_string($rule)) {
+                    throw new InvalidArgumentException('Each rule must be a string.');
+                }
+            }
+        } elseif (!is_string($rules)) {
+            throw new InvalidArgumentException('Each rule must be a string.');
+        }
+    }
+}

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -64,7 +64,7 @@ class QueueSqsJobTest extends TestCase
             'MD5OfBody' => md5($this->mockedPayload),
             'ReceiptHandle' => $this->mockedReceiptHandle,
             'MessageId' => $this->mockedMessageId,
-            'Attributes' => ['ApproximateReceiveCount' => 1],
+            'Validations' => ['ApproximateReceiveCount' => 1],
         ];
     }
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -60,7 +60,7 @@ class QueueSqsQueueTest extends TestCase
             'MD5OfBody' => md5($this->mockedPayload),
             'ReceiptHandle' => $this->mockedReceiptHandle,
             'MessageId' => $this->mockedMessageId,
-            'Attributes' => ['ApproximateReceiveCount' => 1],
+            'Validations' => ['ApproximateReceiveCount' => 1],
         ]);
 
         $this->mockedReceiveMessageResponseModel = new Result([
@@ -79,7 +79,7 @@ class QueueSqsQueueTest extends TestCase
         ]);
 
         $this->mockedQueueAttributesResponseModel = new Result([
-            'Attributes' => [
+            'Validations' => [
                 'ApproximateNumberOfMessages' => 1,
             ],
         ]);


### PR DESCRIPTION
**Added:**
- Introduced a new validation enhancement for Eloquent models.
- Added the ability to define validation rules using custom attributes: `OnCreateRules` and `OnUpdateRules`.
- Modified the `validateUsing` method in the `Model` class to support custom validation rules.
- Added property  `protected array $rules;`

**Changed:**
- Updated the `booted` method in the `Model` class to automatically validate on creation and updating.
- Added a new static call for method `validateUsing` inside `__callStatic` method to call the method dynamically and statically 

**Context:**
This enhancement improves data validation for Eloquent models by allowing developers to define specific validation rules using custom attributes. The new attributes, `OnCreateRules` and `OnUpdateRules`, enable you to tailor validation rules for model creation and updates, respectively.

By utilizing these attributes, developers can fine-tune validation for individual models, properties, or attributes, giving more control over data integrity. This enhancement helps streamline validation logic and promote better code organization.

**Examples:**

1. **Validation on Creation:**
   ```php
   use Illuminate\Database\Eloquent\Validations\OnCreateRules;

   #[OnCreateRules(['name' => 'required', 'email' => 'required|email'])]
   class User extends Model {
       // ...
   }
   ```


2. **Validation on Update:**
   ```php
   use Illuminate\Database\Eloquent\Validations\OnUpdateRules;

   #[OnUpdateRules(['email' => 'required|email'])]
   class User extends Model {
       // ...
   }
   ```

3. **Applying both attributes to the Model:**
   ```php
   use Illuminate\Database\Eloquent\Validations\OnUpdateRules;

   #[OnUpdateRules(['email' => 'required|email'])]
   #[OnCreateRules(['name' => 'required', 'email' => 'required|email'])]
   class User extends Model {
       // ...
   }
   ```

4. **Using on model fields:**
   ```php
   use Illuminate\Database\Eloquent\Validations\OnUpdateRules;

   #[OnUpdateRules(['email' => 'required|email'])]
   #[OnCreateRules(['name' => 'required', 'email' => 'required|email'])]
   class User extends Model {
      #[OnUpdateRules([ 'required'])] --> this is also valid
       public string $name;
       
       #[OnUpdateRules(['email' => 'required|email'])]  --> this is valid as long as the key matches the property
       #[OnCreateRules('required|email')] --> this is also valid
       public string $email;
   }
   ```
5. **Custom Rules with Validation:**

   ```php
   $product = Product::validateUsing(function ($rules) {
       $rules['price'] = 'numeric|min:0';
       return $rules;
   })->create($data);
   ```

6. **Automatic Validation on Creation and Updating:**
   ```php
   protected static function booted()
   {
       static::creating(function (self $model) {
           $model->getModelRules(useOnCreateRules: false);
           $model->getPropertyRules(useOnCreateRules: false);
           $model->validate();
       });
       static::updating(function (self $model) {
           $model->getModelRules();
           $model->getPropertyRules();
           $model->validate();
       });
   }
   ```

**Note:**
This pull request is a work in progress and is being submitted for initial review and feedback. Further improvements and adjustments will be made based on the feedback received.

Please also note that this does not enforce any developer to use this, this only start working once the attributes are applied to the model/properties
```