### PR TITLE
[10.x] Add truncateJoin helper method to Support\Arr and Support\Collection classes

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -454,6 +454,31 @@ class Arr
     }
 
     /**
+     * Display limited items from the array then replace the remaining items with message
+     *
+     * @param array $array
+     * @param int $limit
+     * @param string $glue
+     * @param string $connector
+     * @param string $message
+     * @return string
+     */
+    public static function truncateJoin($array, $limit, $glue, $connector = '+', $message = 'more')
+    {
+        $count = count($array);
+
+        if ($count <= $limit) {
+            return static::join($array, $glue);
+        }
+
+        $firstFewItems = static::join(array_slice($array, 0, $limit, true), $glue);
+        $remainingCount = $count - $limit;
+
+        // trim so that when the message parameter is empty string, it doesn't have a trailing space
+        return trim("$firstFewItems, $connector $remainingCount $message");
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -729,6 +729,20 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Display limited items from the array then replace the remaining items with message
+     *
+     * @param int $limit
+     * @param string $glue
+     * @param string $connector
+     * @param string $message
+     * @return string
+     */
+    public function truncateJoin($limit, $glue, $connector = '+', $message = 'more')
+    {
+        return Arr::truncateJoin($this->items, $limit, $glue, $connector, $message);
+    }
+
+    /**
      * Get the keys of the collection items.
      *
      * @return static<int, TKey>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -710,6 +710,20 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Display limited items from the array then replace the remaining items with message
+     *
+     * @param int $limit
+     * @param string $glue
+     * @param string $connector
+     * @param string $message
+     * @return string
+     */
+    public function truncateJoin($limit, $glue, $connector = '+', $message = 'more')
+    {
+        return $this->collect()->truncateJoin(...func_get_args());
+    }
+
+    /**
      * Get the keys of the collection items.
      *
      * @return static<int, TKey>

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -225,6 +225,21 @@ class SupportArrTest extends TestCase
         $this->assertSame('', Arr::join([], ', ', ' and '));
     }
 
+    public function testTruncateJoin()
+    {
+        $array = ['Antartica', 'Africa', 'Asia', 'Europe', 'North America', 'South America', 'Australia'];
+
+        $this->assertSame('Antartica, Africa, + 5 more', Arr::truncateJoin($array, 2, ', '));
+
+        $this->assertSame('Antartica, Africa, and 5 more', Arr::truncateJoin($array, 2, ', ', 'and'));
+
+        $this->assertSame('Antartica, Africa, and 5 more continents', Arr::truncateJoin($array, 2, ', ', 'and', 'more continents'));
+
+        $this->assertSame('Antartica', Arr::truncateJoin(['Antartica'], 2, ', '));
+
+        $this->assertSame('', Arr::truncateJoin([], 2, ', '));
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1913,6 +1913,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testTruncateJoin($collection)
+    {
+        $array = ['Antartica', 'Africa', 'Asia', 'Europe', 'North America', 'South America', 'Australia'];
+        
+        $this->assertSame('Antartica, Africa, + 5 more', (new $collection($array))->truncateJoin(2, ', '));
+
+        $this->assertSame('Antartica, Africa, and 5 more', (new $collection($array))->truncateJoin(2, ', ', 'and'));
+
+        $this->assertSame('Antartica, Africa, and 5 more continents', (new $collection($array))->truncateJoin(2, ', ', 'and', 'more continents'));
+
+        $this->assertSame('Antartica', (new $collection(['Antartica']))->truncateJoin(2, ', '));
+
+        $this->assertSame('', (new $collection([]))->truncateJoin(2, ', ', 'and'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCrossJoin($collection)
     {
         // Cross join with an array


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hi all, 

This is my first time submitting a PR to Laravel so please let me know if I can improve this PR any better.
Also, I'm not sure if `truncateJoin` is the proper name for this helper so let me know.

**Problem:**
I often find myself doing this a lot of times on my projects where I only output the first 2 elements from an array and append a message like `+3 locations` that's why I created this helper method to easily do that.
I usually write the codes for it like this:
```
$array = [1,2,3];
$limit = 2;
$count = Arr::count($array);

$firstFew = implode($array, array_slice($array, 0, $limit, true), ', ');
return "$firstFew, +{$count - $limit} more items";
```

but now, we can just use the Arr or Collection method to do this.

```
$array = [1, 2, 3, 4];
$limit = 2;

Arr::truncateJoin($array, $limit, ', ');

// or for collection
collect($array)->truncateJoin($limit, ', ');
```

and it will output the string
```
1, 2, +2 more
```