### PR TITLE
[10.x] Add `wordWrap` to `Str`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1346,6 +1346,19 @@ class Str
     }
 
     /**
+     * Wraps a string to a given number of characters
+     *
+     * @param  string  $string
+     * @param  int  $characters
+     * @param  string  $break
+     * @param  bool  $cut_long_words
+     * @return string
+     */
+    public static function wordWrap($string, $characters = 75, $break = PHP_EOL, $cut_long_words = false){
+        return wordwrap($string, $characters, $break, $cut_long_words);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1354,7 +1354,8 @@ class Str
      * @param  bool  $cut_long_words
      * @return string
      */
-    public static function wordWrap($string, $characters = 75, $break = "\n", $cut_long_words = false){
+    public static function wordWrap($string, $characters = 75, $break = "\n", $cut_long_words = false)
+    {
         return wordwrap($string, $characters, $break, $cut_long_words);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1354,7 +1354,7 @@ class Str
      * @param  bool  $cut_long_words
      * @return string
      */
-    public static function wordWrap($string, $characters = 75, $break = PHP_EOL, $cut_long_words = false){
+    public static function wordWrap($string, $characters = 75, $break = "\n", $cut_long_words = false){
         return wordwrap($string, $characters, $break, $cut_long_words);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1346,17 +1346,17 @@ class Str
     }
 
     /**
-     * Wraps a string to a given number of characters.
+     * Wrap a string to a given number of characters.
      *
      * @param  string  $string
      * @param  int  $characters
      * @param  string  $break
-     * @param  bool  $cut_long_words
+     * @param  bool  $cutLongWords
      * @return string
      */
-    public static function wordWrap($string, $characters = 75, $break = "\n", $cut_long_words = false)
+    public static function wordWrap($string, $characters = 75, $break = "\n", $cutLongWords = false)
     {
-        return wordwrap($string, $characters, $break, $cut_long_words);
+        return wordwrap($string, $characters, $break, $cutLongWords);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1346,7 +1346,7 @@ class Str
     }
 
     /**
-     * Wraps a string to a given number of characters
+     * Wraps a string to a given number of characters.
      *
      * @param  string  $string
      * @param  int  $characters

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1114,6 +1114,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Wraps a string to a given number of characters
+     *
+     * @param  int  $characters
+     * @param  string  $break
+     * @param  bool  $cut_long_words
+     * @return Stringable
+     */
+    public function wordWrap($characters = 75, $break = PHP_EOL, $cut_long_words = false){
+        return new static(Str::wordWrap($this->value, $characters, $break, $cut_long_words));
+    }
+
+    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $before

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1121,7 +1121,8 @@ class Stringable implements JsonSerializable, ArrayAccess
      * @param  bool  $cut_long_words
      * @return Stringable
      */
-    public function wordWrap($characters = 75, $break = "\n", $cut_long_words = false){
+    public function wordWrap($characters = 75, $break = "\n", $cut_long_words = false)
+    {
         return new static(Str::wordWrap($this->value, $characters, $break, $cut_long_words));
     }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1114,7 +1114,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Wraps a string to a given number of characters
+     * Wraps a string to a given number of characters.
      *
      * @param  int  $characters
      * @param  string  $break

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1121,7 +1121,7 @@ class Stringable implements JsonSerializable, ArrayAccess
      * @param  bool  $cut_long_words
      * @return Stringable
      */
-    public function wordWrap($characters = 75, $break = PHP_EOL, $cut_long_words = false){
+    public function wordWrap($characters = 75, $break = "\n", $cut_long_words = false){
         return new static(Str::wordWrap($this->value, $characters, $break, $cut_long_words));
     }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1114,16 +1114,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Wraps a string to a given number of characters.
+     * Wrap a string to a given number of characters.
      *
      * @param  int  $characters
      * @param  string  $break
-     * @param  bool  $cut_long_words
-     * @return Stringable
+     * @param  bool  $cutLongWords
+     * @return static
      */
-    public function wordWrap($characters = 75, $break = "\n", $cut_long_words = false)
+    public function wordWrap($characters = 75, $break = "\n", $cutLongWords = false)
     {
-        return new static(Str::wordWrap($this->value, $characters, $break, $cut_long_words));
+        return new static(Str::wordWrap($this->value, $characters, $break, $cutLongWords));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -901,6 +901,14 @@ class SupportStrTest extends TestCase
         $this->assertEquals(3, Str::wordCount('МАМА МЫЛА РАМУ', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
     }
 
+    public function testWordWrap()
+    {
+        $this->assertEquals('Hello<br />World', Str::wordWrap('Hello World', 3, '<br />'));
+        $this->assertEquals('Hel<br />lo<br />Wor<br />ld', Str::wordWrap('Hello World', 3, '<br />', true));
+
+        $this->assertEquals('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
+    }
+
     public static function validUuidList()
     {
         return [


### PR DESCRIPTION
This PR adds `wordWrap` the Stringable API. 

# What It Does
The method is a wrapper for the [`wordwrap`](https://www.php.net/manual/en/function.wordwrap.php) function which is used to split strings with a given string by character length.

Without this change we would need to do the following to achieve the word wrapping

`str(wordwrap($string, width: 20))`

# Use Cases
The PHP documentation for the function shows an example of adding `<br />` elements into a string, however, that seems like a problem you solve with styling.

My own personal use case was to split a string into chunks so they could be used in an svg template, rendered by Blade to be passed to an image generating service.

The string would be split into chunks of 25 characters then passed to the template as a Collection (shown below).

```php
public function using(string $title): self
{
    return tap($this, function() use ($title) {
        $this->title_parts = str($title)->wordWrap(characters: 25, break: PHP_EOL)->explode(PHP_EOL);
    });
}
```
