### PR TITLE
[10.x] Fix folder dot notation with generator command

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -198,6 +198,13 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function qualifyClass($name)
     {
+        $explodedName = collect(explode(".", $name));
+        $explodedName->transform(function($value) {
+            return Str::ucfirst(Str::camel($value));
+        });
+
+        $name = implode("/", $explodedName->toArray());
+
         $name = ltrim($name, '\\/');
 
         $name = str_replace('/', '\\', $name);

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -198,12 +198,12 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function qualifyClass($name)
     {
-        $explodedName = collect(explode(".", $name));
-        $explodedName->transform(function($value) {
+        $explodedName = collect(explode('.', $name));
+        $explodedName->transform(function ($value) {
             return Str::ucfirst(Str::camel($value));
         });
 
-        $name = implode("/", $explodedName->toArray());
+        $name = implode('/', $explodedName->toArray());
 
         $name = ltrim($name, '\\/');
 


### PR DESCRIPTION
See #47979 

If you create components with the `php artisan make:component` command and use this as a name: `components.my-blade-view` (this is the naming convention for blade views)  
This will create a class with that name: `components.my-blade-view`
But I want a class with this name: `MyBladeView` in the `Components` folder.

Since the root of the problem is in the `GeneratorCommand` class, I fixed it there.  
I am not sure if this should apply to all `make:` commands or just some.  
Please let me know so I can change it.

This makes things easier because you can use the blade view naming conventions when creating a component, which can be more convenient.  