### PR TITLE
[10.x] Fix forced use of write DB connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1080,7 +1080,7 @@ class Connection implements ConnectionInterface
      */
     protected function escapeString($value)
     {
-        return $this->getPdo()->quote($value);
+        return $this->getReadPdo()->quote($value);
     }
 
     /**


### PR DESCRIPTION
I am using [Read & Write Connection](https://laravel.com/docs/10.x/database#read-and-write-connections) (with a few tricks) and Laravel Octane.

My site is read-heavy, very few where I need to use write connection to work with DB. So most endpoints only require read DB connection.

Also, I started using a new feature from laravel 10.x, it's [`toRawSql`](https://github.com/laravel/framework/pull/47507), to simplify key creation for caching queries. As it turns out, queries that only require a read-only connection now also require a write connection to the database.

And at possible unavailability of write database, my site goes down, although it is quite enough only read-connection for processing current requests.