### PR TITLE
[10.x] Fix empty table displayed when using the --pending option but there are no pending migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,7 +76,9 @@ class StatusCommand extends BaseCommand
                     );
 
                 $this->newLine();
-            } else {
+            } else if($this->option('pending')) {
+                $this->components->info('No pending migrations found');
+            } else{
                 $this->components->info('No migrations found');
             }
         });

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,9 +76,9 @@ class StatusCommand extends BaseCommand
                     );
 
                 $this->newLine();
-            } else if($this->option('pending')) {
+            } elseif ($this->option('pending')) {
                 $this->components->info('No pending migrations found');
-            } else{
+            } else {
                 $this->components->info('No migrations found');
             }
         });

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -77,7 +77,7 @@ class StatusCommand extends BaseCommand
 
                 $this->newLine();
             } elseif ($this->option('pending')) {
-                $this->components->info('No pending migrations found');
+                $this->components->info('No pending migrations');
             } else {
                 $this->components->info('No migrations found');
             }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -60,15 +60,17 @@ class StatusCommand extends BaseCommand
 
             $batches = $this->migrator->getRepository()->getMigrationBatches();
 
-            if (count($migrations = $this->getStatusFor($ran, $batches)) > 0) {
+            $migrations = $this->getStatusFor($ran, $batches)
+                ->when($this->option('pending'), fn ($collection) => $collection->filter(function ($migration) {
+                    return str($migration[1])->contains('Pending');
+                }));
+
+            if (count($migrations) > 0) {
                 $this->newLine();
 
                 $this->components->twoColumnDetail('<fg=gray>Migration name</>', '<fg=gray>Batch / Status</>');
 
                 $migrations
-                    ->when($this->option('pending'), fn ($collection) => $collection->filter(function ($migration) {
-                        return str($migration[1])->contains('Pending');
-                    }))
                     ->each(
                         fn ($migration) => $this->components->twoColumnDetail($migration[0], $migration[1])
                     );


### PR DESCRIPTION
If you run artisan migrate:status --pending but there are no pending migrations only an empty table is displayed.

I changed it so "No pending migrations found" is displayed"  
As stated in #48017 just "No migrations found" could be a bit confusing, so please let me know if this is better.