### PR TITLE
[10.x] Fix parsing error in console when parameter description contains `--`

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -16,7 +16,7 @@ class Parser
      *
      * @throws \InvalidArgumentException
      */
-    public static function parse($expression)
+    public static function parse(string $expression)
     {
         $name = static::name($expression);
 
@@ -35,7 +35,7 @@ class Parser
      *
      * @throws \InvalidArgumentException
      */
-    protected static function name($expression)
+    protected static function name(string $expression)
     {
         if (! preg_match('/[^\s]+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
@@ -45,7 +45,7 @@ class Parser
     }
 
     /**
-     * Extract all of the parameters from the tokens.
+     * Extract all parameters from the tokens.
      *
      * @param  array  $tokens
      * @return array
@@ -57,7 +57,7 @@ class Parser
         $options = [];
 
         foreach ($tokens as $token) {
-            if (preg_match('/-{2,}(.*)/', $token, $matches)) {
+            if (preg_match('/^-{2,}(.*)/', $token, $matches)) {
                 $options[] = static::parseOption($matches[1]);
             } else {
                 $arguments[] = static::parseArgument($token);
@@ -73,7 +73,7 @@ class Parser
      * @param  string  $token
      * @return \Symfony\Component\Console\Input\InputArgument
      */
-    protected static function parseArgument($token)
+    protected static function parseArgument(string $token)
     {
         [$token, $description] = static::extractDescription($token);
 
@@ -99,7 +99,7 @@ class Parser
      * @param  string  $token
      * @return \Symfony\Component\Console\Input\InputOption
      */
-    protected static function parseOption($token)
+    protected static function parseOption(string $token)
     {
         [$token, $description] = static::extractDescription($token);
 
@@ -132,7 +132,7 @@ class Parser
      * @param  string  $token
      * @return array
      */
-    protected static function extractDescription($token)
+    protected static function extractDescription(string $token)
     {
         $parts = preg_split('/\s+:\s+/', trim($token), 2);
 


### PR DESCRIPTION
## Overview

This PR addresses an issue in the Laravel Console's signature parser where it would produce incorrect results if a parameter description contained `--`.

## Problem

When defining a command's signature in Laravel Console, if a parameter description included `--`, it would lead to incorrect parsing of the command. This could cause unexpected behavior or even application errors depending on how the command was defined.

### Example

When I generate a new command with signature:

```php
protected $signature = 'check:api-routing {route_file : The file containing the main api routes generated by `php artisan route:list --json`}';
```

This is will produce following result:
```bash
Description:
  Check the differences between the api routing and the api routing file

Usage:
  check:api-routing [options]

Options:
      --json`
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --env[=ENV]       The environment the command should run under
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

## Solution

I've made a targeted change to the regular expression used in the `parameters` method, specifically by adding a `^` to ensure that `--` within a description does not interfere with the parsing process.

Here's a brief summary of the change:
- Updated the regular expression in the `parameters` method to include `^`, ensuring proper handling of `--` within parameter descriptions.

## Impact

This minor yet crucial fix ensures that developers can include `--` in parameter descriptions without any parsing issues. It improves the robustness of Laravel Console's command definition and parsing capabilities.

Please review and let me know if you have any questions or need further changes.