### PR TITLE
[10.x] Fix `assertRedirectToRoute` when route uri is empty

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -193,11 +193,7 @@ class TestResponse implements ArrayAccess
             $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
         );
 
-        $request = Request::create($this->headers->get('Location'));
-
-        PHPUnit::assertEquals(
-            app('url')->to($uri), $request->fullUrl()
-        );
+        $this->assertLocation($uri);
 
         return $this;
     }

--- a/tests/Testing/AssertRedirectToRouteTest.php
+++ b/tests/Testing/AssertRedirectToRouteTest.php
@@ -34,6 +34,10 @@ class AssertRedirectToRouteTest extends TestCase
             ->get('named-route-with-param/{param}')
             ->name('named-route-with-param');
 
+        $this->router
+            ->get('')
+            ->name('route-with-empty-url');
+
         $this->urlGenerator = $this->app->make(UrlGenerator::class);
     }
 
@@ -68,6 +72,16 @@ class AssertRedirectToRouteTest extends TestCase
                 'param' => 'foo',
                 'extra' => 'another',
             ]);
+    }
+
+    public function testAssertRedirectToRouteWithRouteNameAndParamsWhenRouteUrlIsEmpty()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->route('route-with-empty-url', ['foo' => 'bar']));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToRoute('route-with-empty-url', ['foo' => 'bar']);
     }
 
     protected function tearDown(): void

--- a/tests/Testing/AssertRedirectToRouteTest.php
+++ b/tests/Testing/AssertRedirectToRouteTest.php
@@ -36,7 +36,7 @@ class AssertRedirectToRouteTest extends TestCase
 
         $this->router
             ->get('')
-            ->name('route-with-empty-url');
+            ->name('route-with-empty-uri');
 
         $this->urlGenerator = $this->app->make(UrlGenerator::class);
     }
@@ -74,14 +74,14 @@ class AssertRedirectToRouteTest extends TestCase
             ]);
     }
 
-    public function testAssertRedirectToRouteWithRouteNameAndParamsWhenRouteUrlIsEmpty()
+    public function testAssertRedirectToRouteWithRouteNameAndParamsWhenRouteUriIsEmpty()
     {
         $this->router->get('test-route', function () {
-            return new RedirectResponse($this->urlGenerator->route('route-with-empty-url', ['foo' => 'bar']));
+            return new RedirectResponse($this->urlGenerator->route('route-with-empty-uri', ['foo' => 'bar']));
         });
 
         $this->get('test-route')
-            ->assertRedirectToRoute('route-with-empty-url', ['foo' => 'bar']);
+            ->assertRedirectToRoute('route-with-empty-uri', ['foo' => 'bar']);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Overview

There is a small issue with `assertRedirectToRoute` adding a trailing slash to the actual redirect url being tested, when the `Location` header has an empty path, and an existing query string.

## Example

Having a route that returns a redirect response, to a route with an empty uri (and at least one parameter):

```php
Route::get('sample-uri', function () {
  return new RedirectResponse(route('route-with-empty-uri', ['foo' => 'bar']));
})->name('perform-redirect');

Route::get('', fn () => 'ok')->name('route-with-empty-uri');
```
When we try to test the redirection:

```php
$this->get(route('perform-redirect'))
  ->assertRedirectToRoute('route-with-empty-uri', ['foo' => 'bar']);
```
The actual redirection would be `http://localhost?foo=bar`, and this is what we expect, but the actual url generated by `assertRedirectToRoute` is `http://localhost/?foo=bar` and the test fails.

## Problem

It happens due to the `$request->fullUrl()` adding the trailing slash when both `baseUrl` and `requestUri` are empty.

## Solution

I changed the:

```php
$request = Request::create($this->headers->get('Location'));

PHPUnit::assertEquals(
    app('url')->to($uri), $request->fullUrl()
);
```

to:

```php
$this->assertLocation($uri);
```

which seems to solve the issue and also matches the `assertRedirect` implementation.