### PR TITLE
[10.x] Add more helpful helpers for cascades and restrictions

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -73,4 +73,24 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->onDelete('no action');
     }
+
+    /**
+     * Indicate that updates and deletes should cascade.
+     *
+     * @return $this
+     */
+    public function cascade()
+    {
+        return $this->onUpdate('cascade')->onDelete('cascade');
+    }
+
+    /**
+     * Indicate that updates and deletes should be restricted.
+     *
+     * @return $this
+     */
+    public function restrict()
+    {
+        return $this->onUpdate('restrict')->onDelete('restrict');
+    }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -437,6 +437,20 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on update cascade', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->cascade();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on delete cascade on update cascade', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->restrict();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on delete restrict on update restrict', $statements[0]);
     }
 
     public function testAddingIncrementingID()


### PR DESCRIPTION
By analyzing many open-source projects I realized that the most frequent type of foreign keys have cascades on both update and delete:

```php
...->onUpdate('cascade')->onDelete('cascade');
```

While #33522 provided helpful `cascadeOnUpdate()` and `cascadeOnDelete()` methods, the actual character count stays the same in case you need to cascade both actions. My PR provides a nicer way to achieve cascading.

Example of how the code will look like:

```php
// Before
$table->foreignIdFor(User::class)->constrained()->cascadeOnUpdate()->cascadeOnDelete();

// After
$table->foreignIdFor(User::class)->constrained()->cascade();
```

Same goes for `->restrict()` method. Tests are provided for both methods.