### PR TITLE
[10.x] Adds start and end string replacement helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -357,18 +357,6 @@ class Str
     }
 
     /**
-     * Prune the last occurrence of the given suffix if it exists at the end of the value.
-     *
-     * @param  string  $value
-     * @param  string  $suffix
-     * @return string
-     */
-    public static function pruneEnd($value, $suffix)
-    {
-        return static::replaceEnd($suffix, '', $value);
-    }
-
-    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $value
@@ -1132,18 +1120,6 @@ class Str
         $quoted = preg_quote($prefix, '/');
 
         return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
-    }
-
-    /**
-     * Prune the first occurrence of the given prefix if it exists at the start of the value.
-     *
-     * @param  string  $value
-     * @param  string  $prefix
-     * @return string
-     */
-    public static function pruneStart($value, $prefix)
-    {
-        return static::replaceStart($prefix, '', $value);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -357,6 +357,18 @@ class Str
     }
 
     /**
+     * Prune the last occurrence of the given suffix if it exists at the end of the value.
+     *
+     * @param  string  $value
+     * @param  string  $suffix
+     * @return string
+     */
+    public static function pruneEnd($value, $suffix)
+    {
+        return static::replaceEnd($suffix, '', $value);
+    }
+
+    /**
      * Wrap the string with the given strings.
      *
      * @param  string  $value
@@ -1008,6 +1020,29 @@ class Str
     }
 
     /**
+     * Replace the first occurrence of the given value if it appears at the start of the string.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceStart($search, $replace, $subject)
+    {
+        $search = (string) $search;
+
+        if ($search === '') {
+            return $subject;
+        }
+
+        if (static::startsWith($subject, $search)) {
+            return static::replaceFirst($search, $replace, $subject);
+        }
+
+        return $subject;
+    }
+
+    /**
      * Replace the last occurrence of a given value in the string.
      *
      * @param  string  $search
@@ -1017,6 +1052,8 @@ class Str
      */
     public static function replaceLast($search, $replace, $subject)
     {
+        $search = (string) $search;
+
         if ($search === '') {
             return $subject;
         }
@@ -1025,6 +1062,29 @@ class Str
 
         if ($position !== false) {
             return substr_replace($subject, $replace, $position, strlen($search));
+        }
+
+        return $subject;
+    }
+
+    /**
+     * Replace the last occurrence of a given value if it appears at the end of the string.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceEnd($search, $replace, $subject)
+    {
+        $search = (string) $search;
+
+        if ($search === '') {
+            return $subject;
+        }
+
+        if (static::endsWith($subject, $search)) {
+            return static::replaceLast($search, $replace, $subject);
         }
 
         return $subject;
@@ -1072,6 +1132,18 @@ class Str
         $quoted = preg_quote($prefix, '/');
 
         return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+    }
+
+    /**
+     * Prune the first occurrence of the given prefix if it exists at the start of the value.
+     *
+     * @param  string  $value
+     * @param  string  $prefix
+     * @return string
+     */
+    public static function pruneStart($value, $prefix)
+    {
+        return static::replaceStart($prefix, '', $value);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -292,6 +292,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Prune the last occurrence of the given suffix if it exists at the end of the string.
+     *
+     * @param  string  $suffix
+     * @return static
+     */
+    public function pruneEnd($suffix)
+    {
+        return new static(Str::pruneEnd($this->value, $suffix));
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern
@@ -657,6 +668,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Replace the first occurrence of the given value if it appears at the start of the string.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @return static
+     */
+    public function replaceStart($search, $replace)
+    {
+        return new static(Str::replaceStart($search, $replace, $this->value));
+    }
+
+    /**
      * Replace the last occurrence of a given value in the string.
      *
      * @param  string  $search
@@ -666,6 +689,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function replaceLast($search, $replace)
     {
         return new static(Str::replaceLast($search, $replace, $this->value));
+    }
+
+    /**
+     * Replace the last occurrence of a given value if it appears at the end of the string.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @return static
+     */
+    public function replaceEnd($search, $replace)
+    {
+        return new static(Str::replaceEnd($search, $replace, $this->value));
     }
 
     /**
@@ -715,6 +750,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function start($prefix)
     {
         return new static(Str::start($this->value, $prefix));
+    }
+
+    /**
+     * Prune the first occurrence of the given prefix if it exists at the start of the string.
+     *
+     * @param  string  $prefix
+     * @return static
+     */
+    public function pruneStart($prefix)
+    {
+        return new static(Str::pruneStart($this->value, $prefix));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -292,17 +292,6 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Prune the last occurrence of the given suffix if it exists at the end of the string.
-     *
-     * @param  string  $suffix
-     * @return static
-     */
-    public function pruneEnd($suffix)
-    {
-        return new static(Str::pruneEnd($this->value, $suffix));
-    }
-
-    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern
@@ -750,17 +739,6 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function start($prefix)
     {
         return new static(Str::start($this->value, $prefix));
-    }
-
-    /**
-     * Prune the first occurrence of the given prefix if it exists at the start of the string.
-     *
-     * @param  string  $prefix
-     * @return static
-     */
-    public function pruneStart($prefix)
-    {
-        return new static(Str::pruneStart($this->value, $prefix));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -336,13 +336,6 @@ class SupportStrTest extends TestCase
         $this->assertSame('/test/string', Str::start('//test/string', '/'));
     }
 
-    public function testPruneStart()
-    {
-        $this->assertSame('test/string', Str::pruneStart('/test/string', '/'));
-        $this->assertSame('/string', Str::pruneStart('/test/string', '/test'));
-        $this->assertSame('/test/string', Str::pruneStart('//test/string', '/'));
-    }
-
     public function testFlushCache()
     {
         $reflection = new ReflectionClass(Str::class);
@@ -363,13 +356,6 @@ class SupportStrTest extends TestCase
         $this->assertSame('abbc', Str::finish('ab', 'bc'));
         $this->assertSame('abbc', Str::finish('abbcbc', 'bc'));
         $this->assertSame('abcbbc', Str::finish('abcbbcbc', 'bc'));
-    }
-
-    public function testPruneEnd()
-    {
-        $this->assertSame('ab', Str::pruneEnd('abbc', 'bc'));
-        $this->assertSame('abbc', Str::pruneEnd('abbcbc', 'bc'));
-        $this->assertSame('abcbbc', Str::pruneEnd('abcbbcbc', 'bc'));
     }
 
     public function testWrap()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -336,6 +336,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('/test/string', Str::start('//test/string', '/'));
     }
 
+    public function testPruneStart()
+    {
+        $this->assertSame('test/string', Str::pruneStart('/test/string', '/'));
+        $this->assertSame('/string', Str::pruneStart('/test/string', '/test'));
+        $this->assertSame('/test/string', Str::pruneStart('//test/string', '/'));
+    }
+
     public function testFlushCache()
     {
         $reflection = new ReflectionClass(Str::class);
@@ -356,6 +363,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('abbc', Str::finish('ab', 'bc'));
         $this->assertSame('abbc', Str::finish('abbcbc', 'bc'));
         $this->assertSame('abcbbc', Str::finish('abcbbcbc', 'bc'));
+    }
+
+    public function testPruneEnd()
+    {
+        $this->assertSame('ab', Str::pruneEnd('abbc', 'bc'));
+        $this->assertSame('abbc', Str::pruneEnd('abbcbc', 'bc'));
+        $this->assertSame('abcbbc', Str::pruneEnd('abcbbcbc', 'bc'));
     }
 
     public function testWrap()
@@ -609,6 +623,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));
     }
 
+    public function testReplaceStart()
+    {
+        $this->assertSame('foobar foobar', Str::replaceStart('bar', 'qux', 'foobar foobar'));
+        $this->assertSame('foo/bar? foo/bar?', Str::replaceStart('bar?', 'qux?', 'foo/bar? foo/bar?'));
+        $this->assertSame('quxbar foobar', Str::replaceStart('foo', 'qux', 'foobar foobar'));
+        $this->assertSame('qux? foo/bar?', Str::replaceStart('foo/bar?', 'qux?', 'foo/bar? foo/bar?'));
+        $this->assertSame('bar foobar', Str::replaceStart('foo', '', 'foobar foobar'));
+        $this->assertSame('1', Str::replaceStart(0, '1', '0'));
+        // Test for multibyte string support
+        $this->assertSame('xxxnköping Malmö', Str::replaceStart('Jö', 'xxx', 'Jönköping Malmö'));
+        $this->assertSame('Jönköping Malmö', Str::replaceStart('', 'yyy', 'Jönköping Malmö'));
+    }
+
     public function testReplaceLast()
     {
         $this->assertSame('foobar fooqux', Str::replaceLast('bar', 'qux', 'foobar foobar'));
@@ -619,6 +646,20 @@ class SupportStrTest extends TestCase
         // Test for multibyte string support
         $this->assertSame('Malmö Jönkxxxping', Str::replaceLast('ö', 'xxx', 'Malmö Jönköping'));
         $this->assertSame('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
+    }
+
+    public function testReplaceEnd()
+    {
+        $this->assertSame('foobar fooqux', Str::replaceEnd('bar', 'qux', 'foobar foobar'));
+        $this->assertSame('foo/bar? foo/qux?', Str::replaceEnd('bar?', 'qux?', 'foo/bar? foo/bar?'));
+        $this->assertSame('foobar foo', Str::replaceEnd('bar', '', 'foobar foobar'));
+        $this->assertSame('foobar foobar', Str::replaceEnd('xxx', 'yyy', 'foobar foobar'));
+        $this->assertSame('foobar foobar', Str::replaceEnd('', 'yyy', 'foobar foobar'));
+        $this->assertSame('fooxxx foobar', Str::replaceEnd('xxx', 'yyy', 'fooxxx foobar'));
+
+        // // Test for multibyte string support
+        $this->assertSame('Malmö Jönköping', Str::replaceEnd('ö', 'xxx', 'Malmö Jönköping'));
+        $this->assertSame('Malmö Jönkyyy', Str::replaceEnd('öping', 'yyy', 'Malmö Jönköping'));
     }
 
     public function testRemove()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -744,25 +744,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('/test/string', (string) $this->stringable('//test/string')->start('/'));
     }
 
-    public function testPruneStart()
-    {
-        $this->assertSame('test/string', (string) $this->stringable('/test/string')->pruneStart('/'));
-        $this->assertSame('/string', (string) $this->stringable('/test/string')->pruneStart('/test'));
-        $this->assertSame('/test/string', (string) $this->stringable('//test/string')->pruneStart('/'));
-    }
-
     public function testFinish()
     {
         $this->assertSame('abbc', (string) $this->stringable('ab')->finish('bc'));
         $this->assertSame('abbc', (string) $this->stringable('abbcbc')->finish('bc'));
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
-    }
-
-    public function testPruneEnd()
-    {
-        $this->assertSame('ab', (string) $this->stringable('abbc')->pruneEnd('bc'));
-        $this->assertSame('abbc', (string) $this->stringable('abbcbc')->pruneEnd('bc'));
-        $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->pruneEnd('bc'));
     }
 
     public function testIs()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -744,11 +744,25 @@ class SupportStringableTest extends TestCase
         $this->assertSame('/test/string', (string) $this->stringable('//test/string')->start('/'));
     }
 
+    public function testPruneStart()
+    {
+        $this->assertSame('test/string', (string) $this->stringable('/test/string')->pruneStart('/'));
+        $this->assertSame('/string', (string) $this->stringable('/test/string')->pruneStart('/test'));
+        $this->assertSame('/test/string', (string) $this->stringable('//test/string')->pruneStart('/'));
+    }
+
     public function testFinish()
     {
         $this->assertSame('abbc', (string) $this->stringable('ab')->finish('bc'));
         $this->assertSame('abbc', (string) $this->stringable('abbcbc')->finish('bc'));
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
+    }
+
+    public function testPruneEnd()
+    {
+        $this->assertSame('ab', (string) $this->stringable('abbc')->pruneEnd('bc'));
+        $this->assertSame('abbc', (string) $this->stringable('abbcbc')->pruneEnd('bc'));
+        $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->pruneEnd('bc'));
     }
 
     public function testIs()
@@ -863,6 +877,19 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Jönköping Malmö', (string) $this->stringable('Jönköping Malmö')->replaceFirst('', 'yyy'));
     }
 
+    public function testReplaceStart()
+    {
+        $this->assertSame('foobar foobar', (string) $this->stringable('foobar foobar')->replaceStart('bar', 'qux'));
+        $this->assertSame('foo/bar? foo/bar?', (string) $this->stringable('foo/bar? foo/bar?')->replaceStart('bar?', 'qux?'));
+        $this->assertSame('quxbar foobar', (string) $this->stringable('foobar foobar')->replaceStart('foo', 'qux'));
+        $this->assertSame('qux? foo/bar?', (string) $this->stringable('foo/bar? foo/bar?')->replaceStart('foo/bar?', 'qux?'));
+        $this->assertSame('bar foobar', (string) $this->stringable('foobar foobar')->replaceStart('foo', ''));
+        $this->assertSame('1', (string) $this->stringable('0')->replaceStart(0, '1'));
+        // Test for multibyte string support
+        $this->assertSame('xxxnköping Malmö', (string) $this->stringable('Jönköping Malmö')->replaceStart('Jö', 'xxx'));
+        $this->assertSame('Jönköping Malmö', (string) $this->stringable('Jönköping Malmö')->replaceStart('', 'yyy'));
+    }
+
     public function testReplaceLast()
     {
         $this->assertSame('foobar fooqux', (string) $this->stringable('foobar foobar')->replaceLast('bar', 'qux'));
@@ -873,6 +900,20 @@ class SupportStringableTest extends TestCase
         // Test for multibyte string support
         $this->assertSame('Malmö Jönkxxxping', (string) $this->stringable('Malmö Jönköping')->replaceLast('ö', 'xxx'));
         $this->assertSame('Malmö Jönköping', (string) $this->stringable('Malmö Jönköping')->replaceLast('', 'yyy'));
+    }
+
+    public function testReplaceEnd()
+    {
+        $this->assertSame('foobar fooqux', (string) $this->stringable('foobar foobar')->replaceEnd('bar', 'qux'));
+        $this->assertSame('foo/bar? foo/qux?', (string) $this->stringable('foo/bar? foo/bar?')->replaceEnd('bar?', 'qux?'));
+        $this->assertSame('foobar foo', (string) $this->stringable('foobar foobar')->replaceEnd('bar', ''));
+        $this->assertSame('foobar foobar', (string) $this->stringable('foobar foobar')->replaceLast('xxx', 'yyy'));
+        $this->assertSame('foobar foobar', (string) $this->stringable('foobar foobar')->replaceEnd('', 'yyy'));
+        $this->assertSame('fooxxx foobar', (string) $this->stringable('fooxxx foobar')->replaceEnd('xxx', 'yyy'));
+
+        // // Test for multibyte string support
+        $this->assertSame('Malmö Jönköping', (string) $this->stringable('Malmö Jönköping')->replaceEnd('ö', 'xxx'));
+        $this->assertSame('Malmö Jönkyyy', (string) $this->stringable('Malmö Jönköping')->replaceEnd('öping', 'yyy'));
     }
 
     public function testRemove()


### PR DESCRIPTION
I've run into this issue a couple of times recently where I need to trim or replace a value from the start or end of a string.

For example, let’s assume our string is `/path/to/my/public/nested/public` and I want to remove `/public` from the end of the string. I can do:

```php
Str::replaceLast('/public', '', '/path/to/my/public/nested/public');

// /path/to/my/public/nested

```

This works fine until I pass a string which no longer has `/public` on the end and suddenly, the `/public` is removed from the middle of my string:

```php
Str::replaceLast('/public', '', '/path/to/my/public/nested');

// /path/to/my/nested
```

Of course, I can get around this, but it feels kinda cumbersome:

```php
if (Str::endsWith('/path/to/my/public/nested/public', '/public')) {
    Str::replaceLast('/public', '', '/path/to/my/public/nested');
}

// /path/to/my/public/nested
```

This PR combines this approach into four new string helpers

```php
Str::replaceEnd('/public', '/private', '/path/to/my/public/nested/public');
// /path/to/my/public/nested/private

Str::replaceStart('/public', '/private', '/public/path/to/my/public/nested/public');
// /private/path/to/my/public/nested/public

Str::pruneEnd('/path/to/my/public/nested/public', '/public');
// /path/to/my/public/nested

Str::pruneStart('/public/path/to/my/public/nested/public', '/public');
// /path/to/my/public/nested/public
```

In each `end` method, the replacement is only carried out if the given value exists at the end of the string. It only replaces the **last** occurrence.

In each `start` method, the replacement is only carried out if the given value exists at the start of the string. It only replaces the **first** occurrence.

In both cases, the `prune` method wraps the `replace` counterpart as sugar to prevent the need to pass the empty string.