### PR TITLE
[10.x] Allow Listeners to dynamically specify delay using `withDelay`

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -579,16 +579,20 @@ class Dispatcher implements DispatcherContract
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
         $connection = $this->resolveQueue()->connection(method_exists($listener, 'viaConnection')
-                    ? (isset($arguments[0]) ? $listener->viaConnection($arguments[0]) : $listener->viaConnection())
-                    : $listener->connection ?? null);
+            ? (isset($arguments[0]) ? $listener->viaConnection($arguments[0]) : $listener->viaConnection())
+            : $listener->connection ?? null);
 
         $queue = method_exists($listener, 'viaQueue')
-                    ? (isset($arguments[0]) ? $listener->viaQueue($arguments[0]) : $listener->viaQueue())
-                    : $listener->queue ?? null;
+            ? (isset($arguments[0]) ? $listener->viaQueue($arguments[0]) : $listener->viaQueue())
+            : $listener->queue ?? null;
 
-        isset($listener->delay)
-                    ? $connection->laterOn($queue, $listener->delay, $job)
-                    : $connection->pushOn($queue, $job);
+        $delay = method_exists($listener, 'withDelay')
+            ? (isset($arguments[0]) ? $listener->withDelay($arguments[0]) : $listener->withDelay())
+            : $listener->delay ?? null;
+
+        is_null($delay)
+            ? $connection->pushOn($queue, $job)
+            : $connection->laterOn($queue, $delay, $job);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

There's currently not a way to specify the queued listener delay at runtime like there is with the queue and connection (`viaQueue` and `viaConnection`, respectively). This PR allows a listener to define a `withDelay` method (`NotificationSender` uses same method name) that can accept the event to adjust the delay based on the event properties.


##### Example
```php
class Listener implements ShouldQueue
{
    public function __invoke(Event $event): void
    {
        // ...
    }

    public function withDelay(Event $event): int
    {
        return $event->fooBar
            ? <short_delay>
            : <long_delay>;
    }
}
```

If this PR is accepted then I'll submit a PR to the docs repo.

Thanks!
