### PR TITLE
[10.x] Introducing `--pick` Option: Running Seeder with Prompts

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+
 use function Laravel\Prompts\multiselect;
 
 #[AsCommand(name: 'db:seed')]

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Console\Seeds;
 
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
@@ -123,10 +124,16 @@ class SeedCommand extends Command
      * Choose the seeder to run by interacting with the prompt.
      *
      * @return array
+     *
+     * @throws \Exception
      */
     protected function pickSeeder()
     {
-        $files = scandir(database_path('seeders'));
+        try {
+            $files = scandir(database_path('seeders'));
+        } catch (Exception) {
+            throw new Exception('Unable to scan seeders directory.');
+        }
 
         $seeders = [];
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -145,6 +145,10 @@ class SeedCommand extends Command
             $seeders[] = str_replace('.php', '', $file);
         }
 
+        if (empty($seeders)) {
+            throw new Exception('No seeders found.');
+        }
+
         return multiselect(
             label: 'Select seeders to run',
             options: $seeders,

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -88,7 +88,6 @@ class SeedCommand extends Command
      * Prepare the given seeder.
      *
      * @param  string  $class
-     *
      * @return \Illuminate\Database\Seeder
      */
     protected function prepareSeeder(string $class)
@@ -131,7 +130,7 @@ class SeedCommand extends Command
         $seeders = [];
 
         foreach ($files as $file) {
-            if (!str_contains($file, '.php')) {
+            if (! str_contains($file, '.php')) {
                 continue;
             }
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -61,11 +61,9 @@ class SeedCommand extends Command
             return 1;
         }
 
-        if ($this->input->getOption('pick')) {
-            $seeders = $this->pickSeeder();
-        } else {
-            $seeders = [$this->getSeeder()];
-        }
+        $seeders = $this->input->getOption('pick')
+            ? $this->pickSeeder()
+            : $this->getSeeder();
 
         $this->components->info('Seeding database.');
 
@@ -87,9 +85,9 @@ class SeedCommand extends Command
     }
 
     /**
-     * Get a seeder instance from the container.
+     * Prepare the given seeder.
      *
-     * @param  string|null  $seeder
+     * @param  string  $class
      *
      * @return \Illuminate\Database\Seeder
      */
@@ -105,9 +103,9 @@ class SeedCommand extends Command
     }
 
     /**
-     * Get a seeder instance from the container.
+     * Get the seeder to be run.
      *
-     * @return \Illuminate\Database\Seeder
+     * @return array
      */
     protected function getSeeder()
     {
@@ -118,11 +116,11 @@ class SeedCommand extends Command
             $class = 'DatabaseSeeder';
         }
 
-        return $class;
+        return [$class];
     }
 
     /**
-     * Pick the seeder to run by interacting with prompts.
+     * Choose the seeder to run by interacting with the prompt.
      *
      * @return array
      */

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -39,7 +39,7 @@ class SeedCommandTest extends TestCase
         $container->shouldReceive('call');
         $container->shouldReceive('environment')->once()->andReturn('testing');
         $container->shouldReceive('runningUnitTests')->andReturn('true');
-        $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
+        $container->shouldReceive('make')->with('Database\\Seeders\\DatabaseSeeder')->andReturn($seeder);
         $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
             $outputStyle
         );


### PR DESCRIPTION
With the introduction of the [Laravel Prompts](https://laravel.com/docs/prompts), we have the ability to utilize the power it offers to introduce new approaches to using existing Laravel commands.

With this PR, I add the `--pick` option which, when used makes all seeders of the application be listed to be selected using [Laravel Prompts](https://laravel.com/docs/prompts).

The main benefit with this is **being able to run more than one seeder at the same time** without the need of it exists as part of the `DatabaseSeeder` 😄

![CleanShot 2023-08-10 at 9 50 17](https://github.com/laravel/framework/assets/60591772/bbe3913f-48dd-4b14-9518-a00c165c813a)

## Notes:
- The seeder selection is mandatory when using `--pick`, but `DatabaseSeeder` is assigned by default.
- The choice of the option name was intended to provide an easy way to execute it, as something like `--select` in my opinion would have a bit more verbosity.