### PR TITLE
[10.x] Add ability to customize class resolution in event discovery

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -13,6 +13,13 @@ use Symfony\Component\Finder\Finder;
 class DiscoverEvents
 {
     /**
+     * The callback to be used to guess class names.
+     *
+     * @var callable(SplFileInfo, string): string|null
+     */
+    public static $guessClassNamesUsingCallback;
+
+    /**
      * Get all of the events and listeners by searching the given listener directory.
      *
      * @param  string  $listenerPath
@@ -87,6 +94,10 @@ class DiscoverEvents
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
+        if (static::$guessClassNamesUsingCallback) {
+            return call_user_func(static::$guessClassNamesUsingCallback, $file, $basePath);
+        }
+
         $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
 
         return str_replace(
@@ -94,5 +105,16 @@ class DiscoverEvents
             ['\\', app()->getNamespace()],
             ucfirst(Str::replaceLast('.php', '', $class))
         );
+    }
+
+    /**
+     * Specify a callback to be used to guess class names.
+     *
+     * @param  callable(SplFileInfo, string): string  $callback
+     * @return void
+     */
+    public static function guessClassNamesUsing(callable $callback)
+    {
+        static::$guessClassNamesUsingCallback = $callback;
     }
 }


### PR DESCRIPTION
I recently re-read a tweet by Dries saying "Most objects can be placed wherever you like in the app directory." https://twitter.com/driesvints/status/1526835414098534400?s=20

I develop my projects using the DDD structure defined by Brent in his blog. The main point here is the way namespaces are defined (https://stitcher.io/blog/laravel-beyond-crud-01-domain-oriented-laravel#on-the-topic-of-namespaces) : 
```
{
    // …

    "autoload" : {
        "psr-4" : {
            "App\\" : "app/App/",
            "Domain\\" : "app/Domain/",
            "Support\\" : "app/Support/"
        }
    }
}
```

Everything goes well but event discovery does not work because file name to class name translation is not designed for this structure.

This PR adds the ability to customize the way the translation is done and unlocks event discovery in such DDD structures.