### PR TITLE
[10.x] SQS Queue Prefix

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -220,13 +220,19 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function suffixQueue($queue, $suffix = '')
     {
-        if (str_ends_with($queue, '.fifo')) {
-            $queue = Str::beforeLast($queue, '.fifo');
+        preg_match('/(.*\d+\/)(.*)/', $this->prefix, $matches);
 
-            return rtrim($this->prefix, '/').'/'.Str::finish($queue, $suffix).'.fifo';
+        [, $url, $queuePrefix] = $matches;
+
+        $url = rtrim($url, '/');
+
+        $queue = Str::of($queue)->prepend($queuePrefix);
+
+        if (str_ends_with($queue, '.fifo')) {
+            return $url.'/'.$queue->beforeLast('.fifo')->finish($suffix).'.fifo';
         }
 
-        return rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix);
+        return $url.'/'.$queue->finish($this->suffix);
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -174,6 +174,7 @@ class QueueSqsQueueTest extends TestCase
     public function testGetQueueProperlyResolvesUrlWithPrefixAndQueuePrefix()
     {
         $this->prefix .= 'example-prefix-';
+        $this->queueUrl = $this->prefix.$this->queueName;
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/example-prefix-test';

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -171,6 +171,26 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
     }
 
+    public function testGetQueueProperlyResolvesUrlWithPrefixAndQueuePrefix()
+    {
+        $this->prefix .= 'example-prefix-';
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/example-prefix-test';
+        $this->assertEquals($queueUrl, $queue->getQueue('test'));
+    }
+
+    public function testGetQueueProperlyResolvesFifoUrlWithPrefixAndQueuePrefix()
+    {
+        $this->prefix .= 'example-prefix-';
+        $this->queueName = 'emails.fifo';
+        $this->queueUrl = $this->prefix.$this->queueName;
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/example-prefix-test.fifo';
+        $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
+    }
+
     public function testGetQueueProperlyResolvesUrlWithoutPrefix()
     {
         $queue = new SqsQueue($this->sqs, $this->queueUrl);


### PR DESCRIPTION
This PR introduces the ability to prefix **all** SQS queues.

So if you have multiple environments, you can prefix them like so:
- `production-default`
- `production-emails`
- `staging-default`
- `staging-emails`

Obviously this is completely opt-in. 😄 

Related Issue: https://github.com/laravel/framework/issues/40743