### PR TITLE
change id column to uuid(varchar 255 -> char 36)

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('{{table}}', function (Blueprint $table) {
-            $table->string('id')->primary();
+            $table->uuid('id')->primary();
             $table->string('name');
             $table->integer('total_jobs');
             $table->integer('pending_jobs');

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->id();
-            $table->string('uuid')->unique();
+            $table->uuid('uuid')->unique();
             $table->text('connection');
             $table->text('queue');
             $table->longText('payload');


### PR DESCRIPTION
First core PR. I've tried to review the documentation for this as best I know how. 

---

This change puts the id column to uuid type(char 36) for the job_batches table.

Currently, the id column is a varchar 255. By moving to char 36, it providers better indexing and 'smaller' database columns.

Since this column is not referenced anywhere as a foreign key(that I could find), this should not be a breaking change in any way and only bring slight improvement to the job_batches database performance.