### PR TITLE
[10.x] Fixing Double Job Delete to Optimize AWS SQS Calls

### DIFF
--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -65,11 +65,13 @@ class SqsJob extends Job implements JobContract
      */
     public function delete()
     {
-        parent::delete();
+        if(!$this->isDeleted()) {
+            $this->sqs->deleteMessage([
+                'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
+            ]);
+        }
 
-        $this->sqs->deleteMessage([
-            'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
-        ]);
+        parent::delete();
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -65,7 +65,7 @@ class SqsJob extends Job implements JobContract
      */
     public function delete()
     {
-        if(!$this->isDeleted()) {
+        if (! $this->isDeleted()) {
             $this->sqs->deleteMessage([
                 'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
             ]);


### PR DESCRIPTION
This pull request addresses a critical issue in the current implementation, where a double job delete occurs, leading to unnecessary and duplicated AWS calls to SQS (Simple Queue Service). The fix significantly improves the efficiency and resource utilization of the job deletion process, resulting in a more streamlined and cost-effective operation.

Benefits to End Users:

Enhanced Performance: Users will experience improved system performance due to the reduction in redundant AWS calls, leading to faster job processing and a more responsive application.

Cost Savings: By eliminating the extra SQS calls, this fix contributes to cost savings for users who rely on AWS resources for their application's job queue management.

Reliability: The removal of duplicated job deletions ensures the reliability and consistency of the job processing system, reducing the chances of errors and data inconsistencies.