### PR TITLE
[10.x] Allow applying defaults to all scheduled commands

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -86,9 +86,11 @@ class Schedule
     protected $eventDefaults = [];
 
     /**
+     * The properties which can be set on an event via defaults.
+     *
      * @var array<int, string>
      */
-    protected $allowedAttributes = [
+    protected $allowedEventProperties = [
         'onOneServer',
         'timezone',
         'user',
@@ -418,7 +420,7 @@ class Schedule
     public function withEventDefaults(array $defaults, $callback = null)
     {
         foreach ($defaults as $key => $value) {
-            if (! in_array($key, $this->allowedAttributes)) {
+            if (! in_array($key, $this->allowedEventProperties)) {
                 throw new InvalidArgumentException("Invalid attribute: {$key}");
             }
         }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -15,8 +15,8 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Traits\Macroable;
-use RuntimeException;
 use InvalidArgumentException;
+use RuntimeException;
 
 class Schedule
 {
@@ -77,7 +77,6 @@ class Schedule
      * @var array<string, bool>
      */
     protected $mutexCache = [];
-
 
     /**
      * Default configuration for events.
@@ -147,12 +146,12 @@ class Schedule
     /**
      * Add event defaults to the event.
      *
-     * @param \Illuminate\Console\Scheduling\Event $event
+     * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return \Illuminate\Console\Scheduling\Event
      */
     protected function addEventDefaults($event)
     {
-        foreach($this->eventDefaults as $key => $value) {
+        foreach ($this->eventDefaults as $key => $value) {
             $event->{$key} = $value;
         }
 
@@ -413,13 +412,13 @@ class Schedule
      * Set defaults to apply to all scheduled commands.
      *
      * @param  array<string, mixed>  $defaults
-     * @param callable(Schedule): void|null $callback
+     * @param  callable(Schedule): void|null  $callback
      * @return void
      */
     public function withEventDefaults(array $defaults, $callback = null)
     {
-        foreach($defaults as $key => $value) {
-            if (!in_array($key, $this->allowedAttributes)) {
+        foreach ($defaults as $key => $value) {
+            if (! in_array($key, $this->allowedAttributes)) {
                 throw new InvalidArgumentException("Invalid attribute: {$key}");
             }
         }
@@ -430,9 +429,9 @@ class Schedule
             return;
         }
 
-        $schedule = tap(new static($this->timezone), function(Schedule $schedule) use ($defaults, $callback) {
-           $schedule->withEventDefaults($defaults);
-           call_user_func($callback, $schedule);
+        $schedule = tap(new static($this->timezone), function (Schedule $schedule) use ($defaults, $callback) {
+            $schedule->withEventDefaults($defaults);
+            call_user_func($callback, $schedule);
         });
 
         $this->events = [...$this->events, ...$schedule->events()];

--- a/tests/Integration/Console/CommandWithDefaultsTest.php
+++ b/tests/Integration/Console/CommandWithDefaultsTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Console;
 
-use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Orchestra\Testbench\TestCase;
@@ -57,5 +56,4 @@ class CommandWithDefaultsTest extends TestCase
 
 class SomeJob implements ShouldQueue
 {
-
 }

--- a/tests/Integration/Console/CommandWithDefaultsTest.php
+++ b/tests/Integration/Console/CommandWithDefaultsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class CommandWithDefaultsTest extends TestCase
+{
+    #[DataProvider('allowedPropertiesProvider')]
+    public function testWithDefaultsWithoutCallbackAppliesCallbacksToAllScheduledCalls(string $property, $value)
+    {
+        $schedule = new Schedule();
+
+        $schedule->withEventDefaults([$property => $value]);
+
+        $schedule->call('/path/to/command');
+        $schedule->call(SomeJob::class);
+        $events = $schedule->events();
+        $this->assertSame($value, $events[0]->{$property});
+        $this->assertSame($value, $events[1]->{$property});
+    }
+
+    #[DataProvider('allowedPropertiesProvider')]
+    public function testWithDefaultsWithCallbackAppliesToCurrentClosureOnly(string $property, $value)
+    {
+        $schedule = new Schedule();
+
+        $schedule->call('/path/to/command')->{$property} = $value;
+        $schedule->withEventDefaults([$property => $value], function ($schedule) {
+            $schedule->call('/path/to/command');
+        });
+        $dummyEvent = $schedule->call('/path/to/command');
+
+        $events = $schedule->events();
+        $this->assertSame($value, $events[0]->{$property});
+        $this->assertSame($value, $events[1]->{$property});
+        $this->assertEquals($dummyEvent->{$property}, $events[2]->{$property});
+    }
+
+    public static function allowedPropertiesProvider(): array
+    {
+        return [
+            'onOneServer' => ['onOneServer', fake()->boolean()],
+            'timezone' => ['timezone', fake()->timezone()],
+            'user' => ['user', fake()->userName()],
+            'environments' => ['environments', fake()->randomElements(['local', 'production', 'testing', 'staging'], 2)],
+            'evenInMaintenanceMode' => ['evenInMaintenanceMode', fake()->boolean()],
+            'withoutOverlapping' => ['withoutOverlapping', fake()->boolean()],
+            'runInBackground' => ['runInBackground', fake()->boolean()],
+        ];
+    }
+}
+
+class SomeJob implements ShouldQueue
+{
+
+}


### PR DESCRIPTION
## New Feature
You can now specify defaults properties of the Event\CallbackEvent from within `Illuminate\Console\Scheduling\Schedule`.

```php
// app/Console/Kernel.php
protected function schedule(Schedule $schedule)
{
    $schedule->withEventDefaults([
        'onOneServer' => true,
        'runInBackground' => true,
    ]);

    $schedule->command('cache:prune-stale-tags')->hourly();
    // ...
}
```

Alternately, you can use it similar to a RouteRegistrar:

```php
$schedule->command('run-type-checking')->user('nuno');

$schedule->withEventDefaults([
    'user' => 'dries',
], function(Schedule $schedule) {
    $schedule->command('check-worker-pods')->everyHour();
    $schedule->command('review-issues')->everyFiveMinutes();
});
```

This makes it so that you don't have to repeatedly specify those defaults for each command your app registers.

## Background
In our console's Kernel class, the `schedule()` function has dozens of scheduled commands/jobs.

```php
protected function schedule(Schedule $schedule)
{
    $schedule->command('users:notify-new-messages')
        ->everyFiveMinutes()
        ->runInBackground()
        ->onOneServer();

    $schedule->command('horizon:snapshot')
        ->everyFiveMinutes()
        ->runInBackground()
        ->onOneServer();

    $schedule->command('analytics:compute')
        ->everyHour()
        ->runInBackground()
        ->onOneServer().
    // ...
    $schedule->command('cache:prune-stale-tags')->hourly();
    // ...
}
```

This week, it was reported that we were seeing major spikes in CPU usage of our redis cache. We determined it was caused by this [suggested tag pruning command](https://laravel.com/docs/10.x/cache#pruning-stale-cache-tags), so we removed it (and it turns out, we weren't using tags anyways!)

At @inflcr we are hitting our busy time of year, so we had 25-40 workers spun up during the CPU usage spikes, which is why we had only recently come across this. After some digging, we realized the issue was that we had not specified the pruning should only run on a single server, so we were getting all the workers hitting our Redis instance at the same time.

Which got me thinking... we don't have ANYTHING we want running on multiple servers at once. And we do a pretty good job of specifying this. But obviously, when things slip through the cracks, they cost time and money.  Since `Illuminate\Console\Scheduling\Event` (and its child class `CallbackEvent`) are not built from the container, there's no way to easily override the class itself.  I thought an elegant solution to this would be to be able to specify these defaults.

## Possible Follow Up
Allow setting a whole "route" of commands with a certain frequency via the `Illuminate\Console\Scheduling\ManagesFrequencies` methods.