### PR TITLE
[10.x] Adds Eloquent User Provider queryCallback setter from model

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -163,10 +163,9 @@ class EloquentUserProvider implements UserProvider
      */
     protected function newModelQuery($model = null)
     {
-        $query = is_null($model)
-                ? $this->createModel()->newQuery()
-                : $model->newQuery();
-        if(method_exists($model, 'authQueryCallback')){
+        $model = $model ?? $this->createModel();
+        $query = $model->newQuery();
+        if (method_exists($model, 'authQueryCallback')) {
             $this->withQuery([$model, 'authQueryCallback']);
         }
         with($query, $this->queryCallback);

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -166,7 +166,9 @@ class EloquentUserProvider implements UserProvider
         $query = is_null($model)
                 ? $this->createModel()->newQuery()
                 : $model->newQuery();
-
+        if(method_exists($model, 'authQueryCallback')){
+            $this->withQuery([$model, 'authQueryCallback']);
+        }
         with($query, $this->queryCallback);
 
         return $query;


### PR DESCRIPTION
In the current project, I need a comprehensive user check before authorizing it.

In the EloquentUserProvider, I found the necessary functionality - `$queryCallback` - however, there is no convenient functionality for to use it.

The best place for the `$queryCallback` logic , in my opinion, in the `Model`.