### PR TITLE
[10.x] createMany & createManyQuietly add count argument

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -235,11 +235,15 @@ abstract class Factory
     /**
      * Create a collection of models and persist them to the database.
      *
-     * @param  iterable<int, array<string, mixed>>  $records
+     * @param  int|iterable<int, array<string, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
      */
-    public function createMany(iterable $records)
+    public function createMany(int|iterable $records)
     {
+        if (is_numeric($records)) {
+            $records = array_fill(0, $records, []);
+        }
+
         return new EloquentCollection(
             collect($records)->map(function ($record) {
                 return $this->state($record)->create();
@@ -250,10 +254,10 @@ abstract class Factory
     /**
      * Create a collection of models and persist them to the database without dispatching any model events.
      *
-     * @param  iterable<int, array<string, mixed>>  $records
+     * @param  int|iterable<int, array<string, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
      */
-    public function createManyQuietly(iterable $records)
+    public function createManyQuietly(int|iterable $records)
     {
         return Model::withoutEvents(function () use ($records) {
             return $this->createMany($records);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -126,6 +126,10 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertCount(2, $users);
 
+        $users = FactoryTestUserFactory::new()->createMany(2);
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(2, $users);
+
         $users = FactoryTestUserFactory::times(10)->create();
         $this->assertCount(10, $users);
     }

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -75,11 +75,13 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(func
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany(
     [['string' => 'string']]
 ));
+assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany(3));
 
 // assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createManyQuietly([['string' => 'string']]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly(
     [['string' => 'string']]
 ));
+assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly(3));
 
 // assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create());
 // assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adds the ability to pass an `int` to the `createMany` and `createManyQuietly` functions on Model Factories to create that number of models..

```php
// Before: $users = User::factory()->createMany([[], [], []]);
$users = User::factory()->createMany(3);

$this->assertCount(3, $users);
$this->assertInstanceOf(Eloquent\Collection::class, $users);
```

`createMany` is useful for static typing because it always returns an Eloquent Collection, similar to how the `createOne` method always returns a single model. However currently you _must_ pass an array of argument arrays. This change allows you to pass a count of the total records you want generated instead.

I could look at doing this with the normal create mechanism and confirming the type, but this seemed the most straight forward approach.
