### PR TITLE
[10.x] feat: Add a progressIndicator to the InteractsWithIO trait

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -289,7 +289,6 @@ trait InteractsWithIO
      * @param  array  $indicatorValues
      * @param  string  $startMsg
      * @param  string  $finishMsg
-     *
      * @return mixed|void
      */
     public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '], string $startMsg = '', string $finishMsg = '')

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -283,12 +283,12 @@ trait InteractsWithIO
     /**
      * Execute a given callback while advancing a progress indicator.
      *
-     * @param  iterable|mixed  $totalSteps The callback is called per step or for the given value.
-     * @param  \Closure  $callback The callback receives the current step or the given value and the indicator instance.
-     * @param  int  $indicatorChangeInterval The number of milliseconds after which the indicator should change.
-     * @param  array  $indicatorValues The values the indicator should cycle through.
-     * @param  string  $startMsg The message to display when starting the indicator.
-     * @param  string  $finishMsg The message to display when finishing the indicator.
+     * @param  iterable|mixed  $totalSteps  The callback is called per step or for the given value.
+     * @param  \Closure  $callback  The callback receives the current step or the given value and the indicator instance.
+     * @param  int  $indicatorChangeInterval  The number of milliseconds after which the indicator should change.
+     * @param  array  $indicatorValues  The values the indicator should cycle through.
+     * @param  string  $startMsg  The message to display when starting the indicator.
+     * @param  string  $finishMsg  The message to display when finishing the indicator.
      * @return mixed|void
      */
     public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '], string $startMsg = '', string $finishMsg = '')

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -283,16 +283,20 @@ trait InteractsWithIO
     /**
      * Execute a given callback while advancing a progress indicator.
      *
-     * @param iterable|null $totalSteps
-     * @param \Closure $callback
+     * @param  iterable|null  $totalSteps
+     * @param  \Closure  $callback
+     * @param  int  $indicatorChangeInterval
+     * @param  array  $indicatorValues
+     * @param  string  $startMsg
+     * @param  string  $finishMsg
      *
-     * @return mixed
+     * @return mixed|void
      */
-    public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '])
+    public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '], string $startMsg = '', string $finishMsg = '')
     {
         $indicator = new ProgressIndicator($this->output, indicatorChangeInterval: $indicatorChangeInterval, indicatorValues: $indicatorValues);
 
-        $indicator->start('');
+        $indicator->start($startMsg);
 
         if (is_iterable($totalSteps)) {
             $result = [];
@@ -305,7 +309,7 @@ trait InteractsWithIO
             $result = $callback($indicator);
         }
 
-        $indicator->finish('');
+        $indicator->finish($finishMsg);
 
         return $result;
     }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -7,6 +7,7 @@ use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper\ProgressIndicator;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -277,6 +278,36 @@ trait InteractsWithIO
         if (is_iterable($totalSteps)) {
             return $totalSteps;
         }
+    }
+
+    /**
+     * Execute a given callback while advancing a progress indicator.
+     *
+     * @param iterable|null $totalSteps
+     * @param \Closure $callback
+     *
+     * @return mixed
+     */
+    public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '])
+    {
+        $indicator = new ProgressIndicator($this->output, indicatorChangeInterval: $indicatorChangeInterval, indicatorValues: $indicatorValues);
+
+        $indicator->start('');
+
+        if (is_iterable($totalSteps)) {
+            $result = [];
+            foreach ($totalSteps as $value) {
+                $result[] = $callback($value, $indicator);
+
+                $indicator->advance();
+            }
+        } else {
+            $result = $callback($indicator);
+        }
+
+        $indicator->finish('');
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -283,12 +283,12 @@ trait InteractsWithIO
     /**
      * Execute a given callback while advancing a progress indicator.
      *
-     * @param  iterable|null  $totalSteps
-     * @param  \Closure  $callback
-     * @param  int  $indicatorChangeInterval
-     * @param  array  $indicatorValues
-     * @param  string  $startMsg
-     * @param  string  $finishMsg
+     * @param  iterable|mixed  $totalSteps The callback is called per step or for the given value.
+     * @param  \Closure  $callback The callback receives the current step or the given value and the indicator instance.
+     * @param  int  $indicatorChangeInterval The number of milliseconds after which the indicator should change.
+     * @param  array  $indicatorValues The values the indicator should cycle through.
+     * @param  string  $startMsg The message to display when starting the indicator.
+     * @param  string  $finishMsg The message to display when finishing the indicator.
      * @return mixed|void
      */
     public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '], string $startMsg = '', string $finishMsg = '')

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -289,7 +289,7 @@ trait InteractsWithIO
      * @param  array  $indicatorValues  The values the indicator should cycle through.
      * @param  string  $startMsg  The message to display when starting the indicator.
      * @param  string  $finishMsg  The message to display when finishing the indicator.
-     * @return mixed|void
+     * @return mixed
      */
     public function withProgressIndicator($totalSteps, $callback, int $indicatorChangeInterval = 250, array $indicatorValues = ['◜ ', ' ◝', ' ◞', '◟ '], string $startMsg = '', string $finishMsg = '')
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Sometimes in a console context e.g. when you import legacy data you do not know exactly how much data-entries you handle (or it would be a performance issues to know it). In this context you can not use a progress bar to indicate that your script is still running.
But Symfony also offers the console helper ProgressIndicator which does the job, so why not add it to the trait as we have the `->withProgressBar`-Method?

**Example:**
```php
	/**
	 * Execute the console command.
	 *
	 * @return int
	 */
	public function handle(): int
	{
		$values = [];
		for ($i = 1; $i < 100000; ++$i) {
			$values[] = $i;
		}
		$valuesSquared = $this->withProgressIndicator($values, function (int $value, ProgressIndicator $spinner) {
			usleep(50);
			return $value^2;
		});

		return Command::SUCCESS;
	}
```

**Extended Example:**
```php
	/**
	 * Execute the console command.
	 *
	 * @return int
	 */
	public function handle(): int
	{
		$values = [];
		for ($i = 1; $i < 100000; ++$i) {
			$values[] = $i;
		}
		$valuesSquared = $this->withProgressIndicator($values, function (int $value, ProgressIndicator $spinner) {
			$spinner->setMessage('Processing value '.$value);
			usleep(50);
			return $value^2;
		}, 100, ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'], 'Processing values', 'Done processing values');

		return Command::SUCCESS;
	}
```