### PR TITLE
[10.x] Provide flexibility on when model objects should prevent lazy loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -408,7 +408,7 @@ class Builder implements BuilderContract
         return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
             $model = $instance->newFromBuilder($item);
 
-            return $model->setModelPreventsLazyLoading($items, $model);
+            return $model::setModelPreventsLazyLoading($items, $model);
         }, $items));
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -408,11 +408,7 @@ class Builder implements BuilderContract
         return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
             $model = $instance->newFromBuilder($item);
 
-            if (count($items) > 1) {
-                $model->preventsLazyLoading = Model::preventsLazyLoading();
-            }
-
-            return $model;
+            return Model::setModelPreventsLazyLoading($items, $model);
         }, $items));
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -408,7 +408,7 @@ class Builder implements BuilderContract
         return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
             $model = $instance->newFromBuilder($item);
 
-            return Model::setModelPreventsLazyLoading($items, $model);
+            return $model->setModelPreventsLazyLoading($items, $model);
         }, $items));
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2191,8 +2191,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function setModelPreventsLazyLoading($items, $model)
     {
-        if (count($items) >= self::$minimumCountOfItemsToBeConsideredLazyLoading) {
-            $model->preventsLazyLoading = Model::preventsLazyLoading();
+        if (count($items) >= static::$minimumCountOfItemsToBeConsideredLazyLoading) {
+            $model->preventsLazyLoading = static::preventsLazyLoading();
         }
 
         return $model;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2220,7 +2220,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         return $model;
     }
 
-
     /**
      * Determine if discarding guarded attribute fills is disabled.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2187,7 +2187,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Determine if model should have its prevent lazy-loading flag set.
+     * Determine if model should have its prevent lazy loading flag set.
      *
      * @param  \Countable|array  $items
      * @param  static  $model
@@ -2196,14 +2196,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function setModelPreventsLazyLoading($items, $model)
     {
         /**
-         * If no callback is specified, we default to only preventing lazy-loading when the model was fetched
+         * If no callback is specified, we default to only preventing lazy loading when the model was fetched
          * in a collection of more than one model. This means we will prevent egregious n+1 queries while
-         * still allowing the user to lazy-load relations for single models.
+         * still allowing the user to lazy load relations for single models.
          */
-        $userFunction = static::$modelPreventsLazyLoadingCallback
+        $preventsLazyLoadingQualifierFunction = static::$modelPreventsLazyLoadingCallback
             ?? fn ($items, $model) => count($items) > 1 ? $model::preventsLazyLoading() : false;
 
-        $model->preventsLazyLoading = (bool) call_user_func($userFunction, $items, $model);
+        $model->preventsLazyLoading = (bool) call_user_func($preventsLazyLoadingQualifierFunction, $items, $model);
 
         return $model;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -176,6 +176,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $lazyLoadingViolationCallback;
 
     /**
+     * @var int
+     */
+    protected static $minimumCountOfItemsToBeConsideredLazyLoading = 2;
+
+    /**
      * Indicates if an exception should be thrown instead of silently discarding non-fillable attributes.
      *
      * @var bool
@@ -416,11 +421,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Prevent model relationships from being lazy loaded.
      *
      * @param  bool  $value
+     * @param  int  $count
      * @return void
      */
-    public static function preventLazyLoading($value = true)
+    public static function preventLazyLoading($value = true, $count = 2)
     {
         static::$modelsShouldPreventLazyLoading = $value;
+        static::$minimumCountOfItemsToBeConsideredLazyLoading = $count;
     }
 
     /**
@@ -2172,6 +2179,23 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function preventsLazyLoading()
     {
         return static::$modelsShouldPreventLazyLoading;
+    }
+
+    /**
+     * Indicate the model should prevent lazy-loading if items exceeds
+     * the minimum count of items to be considered lazy loading.
+     *
+     * @param  \Countable|array  $items
+     * @param  static  $model
+     * @return static
+     */
+    public static function setModelPreventsLazyLoading($items, $model)
+    {
+        if (count($items) >= self::$minimumCountOfItemsToBeConsideredLazyLoading) {
+            $model->preventsLazyLoading = Model::preventsLazyLoading();
+        }
+
+        return $model;
     }
 
     /**

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -43,11 +43,6 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
             $table->increments('id');
             $table->foreignId('model_2_id');
         });
-
-        Schema::create('test_model4', function (Blueprint $table) {
-            $table->increments('id');
-            $table->foreignId('model_2_id');
-        });
     }
 
     public function testStrictModeThrowsAnExceptionOnLazyLoading()

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -177,7 +177,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     public function testStrictModeRespectsLazyLoadingCallback()
     {
         Model::preventLazyLoading(false);
-        Model::setModelPreventsLazyLoadingCallback(function($items, $model, $default) {
+        Model::setModelPreventsLazyLoadingCallback(function ($items, $model, $default) {
             if (count($items)) {
                 $model->preventsLazyLoading = $default;
             }

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -177,13 +177,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     public function testStrictModeRespectsLazyLoadingCallback()
     {
         Model::preventLazyLoading(false);
-        Model::setModelPreventsLazyLoadingCallback(function ($items, $model, $default) {
-            if (count($items)) {
-                $model->preventsLazyLoading = $default;
-            }
-
-            return $model;
-        });
+        Model::setModelPreventsLazyLoadingCallback(fn ($items, $model) => $model::preventsLazyLoading());
 
         EloquentStrictLoadingTestModel1::create();
         $models = EloquentStrictLoadingTestModel1::get();


### PR DESCRIPTION
## What?
This allows for specifying what enables the `preventLazyLoading` flag on a Model instance when hydrated. The work of qualifying if a hydrated model object should prevent lazy loading is moved from Eloquent Builder to the Model class itself. Projects always have their own Model child classes, but it's much more rare and cumbersome to override the Builder class. It provides a handy API for setting this globally, but could be overridden by classes individually.

This is a non-breaking change.

#### Existing Behavior
For this example, consider we have a User model that morphsMany tokens (like Sanctum).

```php
Model::preventLazyLoading();

User::create(['name' => 'Thomas Erdelyi'])->createToken('api');

$tommy = User::get()[0];
$tommy->tokens; // ✅ a collection of tokens is returned

// now let's add another user
User::create()->createToken('api');

$tommy = User::get()[0];
$tommy->tokens; // ❌ LazyLoadingViolationException is raised
```

This is fine for most applications. But what if you want to get REALLY strict rules that developers should be explicit about what relationships need to be loaded? You're not covered by the current implementation and you may not even realize it. The method name is a bit misleading (it's preventing N+1 style lazy loading, not all lazy loading).

#### New behavior
```php
/**
 * We specify that if you fetch ANY model from the database, regardless if it was fetched
 * singly or as part of a broader query, it requires the relation is explicitly loaded.
 */
Model::setModelPreventsLazyLoadingCallback(function ($items, $model) {
    return $model::preventsLazyLoading();
});
$tommy = User::find(1);
$tommy->tokens; // ❌ LazyLoadingViolationException is raised

$tommy->loadMissing('tokens')->tokens; // ✅ a collection of tokens is returned
```

## Background
Using `Model::preventLazyLoading()` allows us to avoid n+1 problems. This is great!  However, there's a strange behavior with how this works... Take a look at the example above in existing-behavior.

Why is the LazyLoadingViolationException raised the second time, but not the first? Because that flag is only set to true when [the model is fetched in a group of 2 or more](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Builder.php#L411-L413).

On our development team, this behavior was considered unintuitive. Not to mention that without digging into the internals of how `Model::preventLazyLoading()` works, you might not know to write your test suite in such a way that multiple models need created just to make sure there isn't any accidental lazy loading.

## Development
<details>
  <summary>Implementation Choices</summary>

  ### `Model@setModelPreventsLazyLoading($items, $model)`
  By allowing this to receive both the `$items` and `$model` as parameters (rather than just the count of items), we allow for userland to handle each case distinctly.

  ### `Model@setModelPreventsLazyLoadingCallback(?callable $callback)`
  `$callback` should have a signature like:
  ```php
  function (\Countable|array $items, Model $model): bool {}
  ```
  You can access the current state of `$model::preventsLazyLoading()` here. For the case I'm describing, where we want the stricter rules, it's sufficient to set
  ```php
  Model::setModelPreventsLazyLoadingCallback(fn($items, $model) => $model::preventsLazyLoading());
  ```

If we decide we want to allow lazy loading in production, but disable it in development/staging environments, we'll run into no issues with the docs suggestion of using `Model::preventLazyLoading(! $this->app->isProduction());`.
</details>

<details>
  <summary>Future development considerations</summary>
  
  ```php
  class Model // ...
  {
      public static function requireEagerLoading()
      {
          Model::setModelPreventsLazyLoadingCallback(fn($items, $model) => $model::preventsLazyLoading());
      }
  }
```

</details>

## See also
* https://github.com/laravel/framework/pull/37503 (this the PR that relaxed the restriction)
* https://github.com/laravel/framework/pull/44769
* https://github.com/laravel/framework/pull/44761/
* https://github.com/laravel/framework/discussions/41268
* https://github.com/laravel/framework/issues/42285
* https://github.com/laravel/docs/pull/8912
* https://github.com/laravel/docs/pull/8913