### PR TITLE
[10.x] Use AuthenticateSession on Sanctum requests

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -127,4 +127,24 @@ trait GuardHelpers
     {
         $this->provider = $provider;
     }
+
+    /**
+     * This is checked in AuthenticateSession middleware, default to false.
+     *
+     * @return false
+     */
+    public function viaRemember()
+    {
+        return false;
+    }
+
+    /**
+     * Forget the current user.
+     *
+     * @return void
+     */
+    public function logoutCurrentDevice()
+    {
+        $this->forgetUser();
+    }
 }

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -49,11 +49,11 @@ class AuthenticateSession implements AuthenticatesSessions
             }
         }
 
-        if (! $request->session()->has('password_hash_'.$this->auth->getDefaultDriver())) {
+        if (! $request->session()->has('password_hash')) {
             $this->storePasswordHashInSession($request);
         }
 
-        if ($request->session()->get('password_hash_'.$this->auth->getDefaultDriver()) !== $request->user()->getAuthPassword()) {
+        if ($request->session()->get('password_hash') !== $request->user()->getAuthPassword()) {
             $this->logout($request);
         }
 
@@ -77,7 +77,7 @@ class AuthenticateSession implements AuthenticatesSessions
         }
 
         $request->session()->put([
-            'password_hash_'.$this->auth->getDefaultDriver() => $request->user()->getAuthPassword(),
+            'password_hash' => $request->user()->getAuthPassword(),
         ]);
     }
 


### PR DESCRIPTION
This PR allows `auth.session` to be used after `auth:sanctum` to logout other session on password change.

It is a better approach to my [existing sanctum PR](https://github.com/laravel/sanctum/pull/461) where I attempted to solve the issue by introducing a stripped-down version of `AuthenticateSession`. This PR has a better DX as it keeps the `auth.session` implementation that developers already know.

The `AuthenticateSession` middleware makes it possible to invalidate sessions on other devices https://laravel.com/docs/10.x/authentication#invalidating-sessions-on-other-devices

### The problem

If a user is logged in in two different browsers, and change their password in one, the web guard is invalidated in the other, but the sanctum guard is not and requests can still be sent to the API.

If a bad actor had access to a web session, they still have access to the sanctum guarded API after a password update.

Currently, using `auth.session` on Sanctum frontend requests will throw two fatal errors as `RequestGuard` doesn't have `viaRemember` or `logoutCurrentDevice` methods. These have been added to the `GuardHelpers` trait with sensible defaults for both framework and custom guards.

### Password Hash

This PR also reverts a change where the password hash was stored per guard. https://github.com/laravel/framework/pull/33876

I can't see an advantage of storing the password hash per guard as the same user is authenticated across guards even in multi guard auth. If a request changes the user's password the password hash should update for all guards in the session, not just the guard that changed it. Additionally, the author of that PR has been deleted from github. I'd be grateful if anyone can shed some light on this change and the issue it was addressing.

### Test Repo

As this is a difficult scenario to test I have created a [test repo](https://github.com/patrickomeara/sanctum-logout-issue).

The main branch of the test repo shows the issue, where the user can still make a sanctum request after a password change in another session. The web guard has been logged out here, but not the sanctum guard.

https://github.com/laravel/framework/assets/571773/de23c7dd-0512-4dd2-b83a-6cbd777be668

The [auth.session](https://github.com/patrickomeara/sanctum-logout-issue/tree/auth.session) branch of the test repo uses this PR branch of `laravel/framework` to show the request now returns a 401 and has logged the user out of both web and sanctum guards.

https://github.com/laravel/framework/assets/571773/1a479eb1-f3fb-48f0-8eb9-25aa5064ccb8

The difference between the branches can be viewed [here](https://github.com/patrickomeara/sanctum-logout-issue/compare/main...auth.session).

### Dusk/Jetstream

If this PR is accepted Dusk and Jetstream will need a small change to the logout mechanisms to remove the guard suffix.

https://github.com/laravel/dusk/blob/1040b15b78ed829ba1166ef10757385b0416ae8e/src/Http/Controllers/UserController.php#L63

https://github.com/search?q=org%3Alaravel+password_hash_+repo%3Alaravel%2Fjetstream&type=code

### Backward Compatibility

This is a breaking change if developers are interacting with `password_hash_<guard>` in the application layer. In this case, we could iterate over the guards and set `password_hash_<guard>` for each one, and leave the `password_hash` change to 11.x. The downfall with this approach is: unless we can collect all of the guards the app uses, not just the request, we end up in the same situation. 

The `AuthenticateSession` middleware adds `password_hash` if it is not currently present before the request proceeds. if the application layer does not interact with`password_hash_<guard>` this change will not break existing functionality.

Any existing sanctum guarded sessions will still be valid after the `auth.session` middleware is added as the first request will set it. However, all subsequent requests after a password change will be logged out. This will still be an issue if this change were to target 11.x.

It should be noted that Laravel 7.x used the key `password_hash` if a session is still in use from 7.x updating to this will log sessions out that have had a password change since the 7.x request was made. Changing the key to something new will alleviate this edge case ie `hashed_password`