### PR TITLE
[10.x] Add dynamic return types to rescue helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -727,10 +727,13 @@ if (! function_exists('rescue')) {
     /**
      * Catch a potential exception and return a default value.
      *
-     * @param  callable  $callback
-     * @param  mixed  $rescue
+     * @template TRescueValue
+     * @template TRescueFallback
+     *
+     * @param  callable(): TRescueValue  $callback
+     * @param  (callable(\Throwable): TRescueFallback)|TRescueFallback  $rescue
      * @param  bool|callable  $report
-     * @return mixed
+     * @return TRescueValue|TRescueFallback
      */
     function rescue(callable $callback, $rescue = null, $report = true)
     {

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -53,3 +53,7 @@ assertType('int', transform(new User(), fn () => 1));
 assertType('null', transform(null, fn () => 1));
 assertType('null', transform('', fn () => 1));
 assertType('null', transform([], fn () => 1));
+
+assertType('int|null', rescue(fn () => 123));
+assertType('int', rescue(fn () => 123, 345));
+assertType('int', rescue(fn () => 123, fn () => 345));


### PR DESCRIPTION
This allows editors and tools like PHPStan to understand the return type of the `rescue()` helper