### PR TITLE
[10.x] Can apply WithoutRelations to entire class

### DIFF
--- a/src/Illuminate/Queue/Attributes/WithoutRelations.php
+++ b/src/Illuminate/Queue/Attributes/WithoutRelations.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
 class WithoutRelations
 {
     //

--- a/src/Illuminate/Queue/Attributes/WithoutRelations.php
+++ b/src/Illuminate/Queue/Attributes/WithoutRelations.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PROPERTY|Attribute::TARGET_CLASS)]
 class WithoutRelations
 {
     //

--- a/src/Illuminate/Queue/Attributes/WithoutRelations.php
+++ b/src/Illuminate/Queue/Attributes/WithoutRelations.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY|Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
 class WithoutRelations
 {
     //

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -20,10 +20,12 @@ trait SerializesModels
         $values = [];
 
         $reflectionClass = new ReflectionClass($this);
-        $properties = $reflectionClass->getProperties();
-        $classExplicitlyBarsRelations = ! empty($reflectionClass->getAttributes(WithoutRelations::class));
 
-        $class = get_class($this);
+        [$class, $properties, $classLevelWithoutRelations] = [
+            get_class($this),
+            $reflectionClass->getProperties(),
+            ! empty($reflectionClass->getAttributes(WithoutRelations::class)),
+        ];
 
         foreach ($properties as $property) {
             if ($property->isStatic()) {
@@ -48,9 +50,11 @@ trait SerializesModels
                 $name = "\0*\0{$name}";
             }
 
-            $withoutRelations = $classExplicitlyBarsRelations || ! empty($property->getAttributes(WithoutRelations::class));
-
-            $values[$name] = $this->getSerializedPropertyValue($value, ! $withoutRelations);
+            $values[$name] = $this->getSerializedPropertyValue(
+                $value,
+                ! $classLevelWithoutRelations &&
+                    empty($property->getAttributes(WithoutRelations::class))
+            );
         }
 
         return $values;

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -19,7 +19,9 @@ trait SerializesModels
     {
         $values = [];
 
-        $properties = (new ReflectionClass($this))->getProperties();
+        $reflectionClass = new ReflectionClass($this);
+        $properties = $reflectionClass->getProperties();
+        $classExplicitlyBarsRelations = ! empty($reflectionClass->getAttributes(WithoutRelations::class));
 
         $class = get_class($this);
 
@@ -46,10 +48,9 @@ trait SerializesModels
                 $name = "\0*\0{$name}";
             }
 
-            $values[$name] = $this->getSerializedPropertyValue(
-                $value,
-                empty($property->getAttributes(WithoutRelations::class))
-            );
+            $withoutRelations = $classExplicitlyBarsRelations || ! empty($property->getAttributes(WithoutRelations::class));
+
+            $values[$name] = $this->getSerializedPropertyValue($value, ! $withoutRelations);
         }
 
         return $values;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -338,16 +338,18 @@ class ModelSerializationTest extends TestCase
             'email' => 'taylor@laravel.com',
         ])->load(['roles']);
 
-        $serialized = serialize(new ModelSerializationAttributeTargetsClassTestClass($user));
+        $serialized = serialize(new ModelSerializationAttributeTargetsClassTestClass($user, new DataValueObject('hello')));
 
         $this->assertSame(
-            'O:83:"Illuminate\Tests\Integration\Queue\ModelSerializationAttributeTargetsClassTestClass":1:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:39:"Illuminate\Tests\Integration\Queue\User";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}}', $serialized
+            'O:83:"Illuminate\Tests\Integration\Queue\ModelSerializationAttributeTargetsClassTestClass":2:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:39:"Illuminate\Tests\Integration\Queue\User";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}s:5:"value";O:50:"Illuminate\Tests\Integration\Queue\DataValueObject":1:{s:5:"value";s:5:"hello";}}',
+            $serialized
         );
 
         /** @var ModelSerializationAttributeTargetsClassTestClass $unserialized */
         $unserialized = unserialize($serialized);
 
         $this->assertFalse($unserialized->user->relationLoaded('roles'));
+        $this->assertEquals('hello', $unserialized->value->value);
     }
 
     public function test_serialization_types_empty_custom_eloquent_collection()
@@ -549,10 +551,8 @@ class ModelSerializationAttributeTargetsClassTestClass
 {
     use SerializesModels;
 
-    public User $user;
-
-    public function __construct(User $user) {
-        $this->user = $user;
+    public function __construct(public User $user, public DataValueObject $value)
+    {
     }
 }
 
@@ -577,5 +577,12 @@ class CollectionSerializationTestClass
     public function __construct($users)
     {
         $this->users = $users;
+    }
+}
+
+class DataValueObject
+{
+    public function __construct(public $value = 1)
+    {
     }
 }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -332,6 +332,24 @@ class ModelSerializationTest extends TestCase
         );
     }
 
+    public function test_it_respects_without_relations_attribute_applied_to_class()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+        ])->load(['roles']);
+
+        $serialized = serialize(new ModelSerializationAttributeTargetsClassTestClass($user));
+
+        $this->assertSame(
+            'O:83:"Illuminate\Tests\Integration\Queue\ModelSerializationAttributeTargetsClassTestClass":1:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:39:"Illuminate\Tests\Integration\Queue\User";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}}', $serialized
+        );
+
+        /** @var ModelSerializationAttributeTargetsClassTestClass $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $this->assertFalse($unserialized->user->relationLoaded('roles'));
+    }
+
     public function test_serialization_types_empty_custom_eloquent_collection()
     {
         $class = new ModelSerializationTypedCustomCollectionTestClass(
@@ -522,6 +540,18 @@ class ModelSerializationWithoutRelations
 
     public function __construct(User $user)
     {
+        $this->user = $user;
+    }
+}
+
+#[WithoutRelations]
+class ModelSerializationAttributeTargetsClassTestClass
+{
+    use SerializesModels;
+
+    public User $user;
+
+    public function __construct(User $user) {
         $this->user = $user;
     }
 }


### PR DESCRIPTION
Can target the entire class so that no model has relationships set. Will not interfere with other properties.

```php
use App\Models\Podcast;
use App\Models\User;
use App\Models\DistributionPlatform;
use App\DataObject;
use Illuminate\Queue\SerializesModels;
use Illuminate\Queue\Attributes\WithoutRelations;

#[WithoutRelations]
class ProcessPodcastJob
{
    use SerializesModels;
 
    public function __construct(
        public Podcast $podcast,
        public User $user,
        public DistributionPlatform $platform,
        public DataObject $dataObject
    ) {}
}
```

All of the models will be serialized without relationships (rather than having to repeatedly apply the attribute to each model), while non-models will be unaffected.