### PR TITLE
[10.x] Use 'sendSync' as an equivalent to 'sendNow'

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -111,6 +111,20 @@ class NotificationSender
     }
 
     /**
+     * Send the given notification immediately.
+     *
+     * @param            $notifiables
+     * @param            $notification
+     * @param array|null $channels
+     *
+     * @return void
+     */
+    public function sendSync($notifiables, $notification, array $channels = null)
+    {
+        $this->sendNow($notifiables, $notification, $channels);
+    }
+
+    /**
      * Get the notifiable's preferred locale for the notification.
      *
      * @param  mixed  $notifiable

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -46,6 +46,19 @@ class NotificationRoutesNotificationsTest extends TestCase
         $notifiable->notifyNow($instance);
     }
 
+    public function testNotificationCanBeSentSync()
+    {
+        $container = new Container;
+        $factory = m::mock(Dispatcher::class);
+        $container->instance(Dispatcher::class, $factory);
+        $notifiable = new RoutesNotificationsTestInstance;
+        $instance = new stdClass;
+        $factory->shouldReceive('sendSync')->with($notifiable, $instance, null);
+        Container::setInstance($container);
+
+        $notifiable->notifyNow($instance);
+    }
+
     public function testNotificationOptionRouting()
     {
         $instance = new RoutesNotificationsTestInstance;


### PR DESCRIPTION
Since `dispatchSync` is used instead of `dispatchNow`, I think it's a good idea to use `sendSync` instead of `sendNow` in later Laravel versions.