### PR TITLE
[10.x] createMany & createManyQuietly make argument optional

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -238,7 +238,7 @@ abstract class Factory
      * @param  int|null|iterable<int, array<string, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
      */
-    public function createMany(int|null|iterable $records = null)
+    public function createMany(int|iterable|null $records = null)
     {
         if (is_null($records)) {
             $records = $this->count ?? 1;
@@ -261,7 +261,7 @@ abstract class Factory
      * @param  int|null|iterable<int, array<string, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
      */
-    public function createManyQuietly(int|null|iterable $records = null)
+    public function createManyQuietly(int|iterable|null $records = null)
     {
         return Model::withoutEvents(function () use ($records) {
             return $this->createMany($records);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -235,11 +235,15 @@ abstract class Factory
     /**
      * Create a collection of models and persist them to the database.
      *
-     * @param  int|iterable<int, array<string, mixed>>  $records
+     * @param  int|null|iterable<int, array<string, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
      */
-    public function createMany(int|iterable $records)
+    public function createMany(int|null|iterable $records = null)
     {
+        if (is_null($records)) {
+            $records = $this->count ?? 1;
+        }
+
         if (is_numeric($records)) {
             $records = array_fill(0, $records, []);
         }
@@ -254,10 +258,10 @@ abstract class Factory
     /**
      * Create a collection of models and persist them to the database without dispatching any model events.
      *
-     * @param  int|iterable<int, array<string, mixed>>  $records
+     * @param  int|null|iterable<int, array<string, mixed>>  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>
      */
-    public function createManyQuietly(int|iterable $records)
+    public function createManyQuietly(int|null|iterable $records = null)
     {
         return Model::withoutEvents(function () use ($records) {
             return $this->createMany($records);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -130,6 +130,14 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertCount(2, $users);
 
+        $users = FactoryTestUserFactory::times(2)->createMany();
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(2, $users);
+
+        $users = FactoryTestUserFactory::new()->createMany();
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(1, $users);
+
         $users = FactoryTestUserFactory::times(10)->create();
         $this->assertCount(10, $users);
     }

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -76,12 +76,14 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
     [['string' => 'string']]
 ));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany(3));
+assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createMany());
 
 // assertType('Illuminate\Database\Eloquent\Collection<int, User>', $factory->createManyQuietly([['string' => 'string']]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly(
     [['string' => 'string']]
 ));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly(3));
+assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>', $factory->createManyQuietly());
 
 // assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create());
 // assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->create([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This builds on the changes from #48048. This allows `createMany()` to be called on a factory with _no_ argument and still _always return a collection of the model._

If the number of models has been specified with `count($x)` or `times($x)`, that will be used to create `$x` many models.

If the number of models has _not_ been specified, it will simply return a collection with a single model.

```php
// Collection of 3 Users
User::factory()->count(3)->createMany();

// Collection of 1 User
User::factory()->createMany();
```

`createMany` is useful for static typing because it always returns an Eloquent Collection, similar to how the `createOne` method always returns a single model. `create` always requires a type check.
