### PR TITLE
[10.x] Allow default values when merging values into a resource

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -140,11 +140,16 @@ trait ConditionallyLoadsAttributes
      *
      * @param  bool  $condition
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MergeValue|mixed
      */
-    protected function mergeWhen($condition, $value)
+    protected function mergeWhen($condition, $value, $default = null)
     {
-        return $condition ? new MergeValue(value($value)) : new MissingValue;
+        if ($condition) {
+            return new MergeValue(value($value));
+        }
+
+        return func_num_args() === 3 ? new MergeValue(value($default)) : new MissingValue();
     }
 
     /**
@@ -152,11 +157,14 @@ trait ConditionallyLoadsAttributes
      *
      * @param  bool  $condition
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MergeValue|mixed
      */
-    protected function mergeUnless($condition, $value)
+    protected function mergeUnless($condition, $value, $default = null)
     {
-        return ! $condition ? new MergeValue(value($value)) : new MissingValue;
+        $arguments = func_num_args() === 2 ? [$value] : [$value, $default];
+
+        return $this->mergeWhen(! $condition, ...$arguments);
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1598,6 +1598,29 @@ class ResourceTest extends TestCase
         ], $results);
     }
 
+    public function testMergeValuesMayFallbackToDefaults()
+    {
+        $filter = new class
+        {
+            use ConditionallyLoadsAttributes;
+
+            public function work()
+            {
+                return $this->filter([
+                    $this->mergeUnless(false, ['Taylor', 'Mohamed'], ['First', 'Second']),
+                    $this->mergeWhen(false, ['Adam', 'Matt'], ['Abigail', 'Lydia']),
+                    'Jeffrey',
+                ]);
+            }
+        };
+
+        $results = $filter->work();
+
+        $this->assertEquals([
+            'Taylor', 'Mohamed', 'Abigail', 'Lydia', 'Jeffrey',
+        ], $results);
+    }
+
     public function testNestedMerges()
     {
         $filter = new class


### PR DESCRIPTION
This PR adds the option to enter a default when merging data into a resource. If the condition is not met and no default value is given a `MissingValue` instance will be returned, just like before.

Before:

```php
class MyResource extends JsonResource
{
    public function toArray($request): array
    {
        return [
            /* other properties */
            $this->mergeWhen($this->hasSpecificData(), $this->specificData()),
            $this->mergeUnless($this->hasSpecificData(), static::genericData()),
        ];
    }
}
```

After:

```php
class MyResource extends JsonResource
{
    public function toArray($request): array
    {
        return [
            /* other properties */
            $this->mergeWhen($this->hasSpecificData(), $this->specificData(), static::genericData()),
        ];
    }
}
```