### PR TITLE
[10.x] Fix Container function default argument value

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1061,6 +1061,10 @@ class Container implements ArrayAccess, ContainerContract
     protected function resolveClass(ReflectionParameter $parameter)
     {
         try {
+            if ($parameter->isDefaultValueAvailable()) {
+                return $parameter->getDefaultValue();
+            }
+
             return $parameter->isVariadic()
                         ? $this->resolveVariadicClass($parameter)
                         : $this->make(Util::getParameterClassName($parameter));
@@ -1070,12 +1074,6 @@ class Container implements ArrayAccess, ContainerContract
         // is optional, and if it is we will return the optional parameter value as
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
-            if ($parameter->isDefaultValueAvailable()) {
-                array_pop($this->with);
-
-                return $parameter->getDefaultValue();
-            }
-
             if ($parameter->isVariadic()) {
                 array_pop($this->with);
 

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -225,6 +225,7 @@ class ContextualBindingTest extends TestCase
             $resolvedInstance->implOne
         );
         $this->assertNull($resolvedInstance->implOne->inner);
+        $this->assertNull($resolvedInstance->implOne->optional);
 
         $this->assertInstanceOf(
             ContainerTestContextInjectTwo::class,
@@ -580,10 +581,12 @@ class ContainerTestContextInjectTwoInstances
 class ContainerTestContextWithOptionalInnerDependency
 {
     public $inner;
+    public $optional;
 
-    public function __construct(ContainerTestContextInjectOne $inner = null)
+    public function __construct(ContainerTestContextInjectOne $inner = null, ContainerTestContextInjectVariadicExtended $optional = null)
     {
         $this->inner = $inner;
+        $this->optional = $optional;
     }
 }
 
@@ -605,6 +608,10 @@ class ContainerTestContextInjectVariadic
     {
         $this->stubs = $stubs;
     }
+}
+
+class ContainerTestContextInjectVariadicExtended extends ContainerTestContextInjectVariadic
+{
 }
 
 class ContainerTestContextInjectVariadicAfterNonVariadic


### PR DESCRIPTION
The problem is that the `ContainerTestContextWithOptionalInnerDependency` 2nd `__construct` parameter (`ContainerTestContextInjectVariadicExtended`) will be resolved and will **not be null**. Example of test code:

```php
class ContainerTestContextInjectVariadic
{
    public $stubs;

    public function __construct(IContainerContextContractStub ...$stubs)
    {
        $this->stubs = $stubs;
    }
}

class ContainerTestContextInjectVariadicExtended extends ContainerTestContextInjectVariadic
{
}

class ContainerTestContextWithOptionalInnerDependency
{
    public $inner;
    public $optional;

    public function __construct(
        ContainerTestContextInjectOne $inner = null,
        ContainerTestContextInjectVariadicExtended $optional = null
    ) {
        $this->inner = $inner;
        $this->optional = $optional;
    }
}
```
