### PR TITLE
[10.x] Guaranteed resolution via app()->makeAs()

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -737,7 +737,7 @@ class Container implements ArrayAccess, ContainerContract
      * @template TAbstract of object
      * @template TExpected of object
      *
-     * @param  $abstract
+     * @param  string|callable  $abstract
      * @param  array  $parameters
      * @param  class-string<TExpected>|null  $expected
      * @return ($abstract is class-string<TAbstract> ? ($expected is null ? TAbstract : TExpected) : TExpected)

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -732,6 +732,30 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Guarantee a resolved object is a given class.
+     *
+     * @template TAbstract of object
+     * @template TClass of object
+     *
+     * @param  $abstract
+     * @param  array  $parameters
+     * @param  class-string<TClass>|null  $class
+     * @return ($abstract is class-string<TAbstract> ? ($class is null ? TAbstract : TClass) : TClass)
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function makeAs($abstract, array $parameters = [], string $class = null)
+    {
+        $expected = class_exists($abstract) ? ($class ?? $abstract) : $class;
+
+        if (is_a($concrete = $this->make($abstract, $parameters), $expected)) {
+            return $concrete;
+        }
+
+        throw new BindingResolutionException("Target [$expected] is not instantiable.");
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return mixed

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -735,18 +735,18 @@ class Container implements ArrayAccess, ContainerContract
      * Guarantee a resolved object is a given class.
      *
      * @template TAbstract of object
-     * @template TClass of object
+     * @template TExpected of object
      *
      * @param  $abstract
      * @param  array  $parameters
-     * @param  class-string<TClass>|null  $class
-     * @return ($abstract is class-string<TAbstract> ? ($class is null ? TAbstract : TClass) : TClass)
+     * @param  class-string<TExpected>|null  $expected
+     * @return ($abstract is class-string<TAbstract> ? ($expected is null ? TAbstract : TExpected) : TExpected)
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function makeAs($abstract, array $parameters = [], string $class = null)
+    public function makeAs($abstract, array $parameters = [], string $expected = null)
     {
-        $expected = class_exists($abstract) ? ($class ?? $abstract) : $class;
+        $expected ??= $abstract;
 
         if (is_a($concrete = $this->make($abstract, $parameters), $expected)) {
             return $concrete;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -689,6 +689,7 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs(ContainerConcreteStub::class));
     }
+
     public function testContainerCanMakeAsFromMagicString()
     {
         $container = new Container;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -719,7 +719,7 @@ class ContainerTest extends TestCase
         });
 
         $this->expectException(BindingResolutionException::class);
-        $container->makeAs(ContainerConcreteStub::class, [],ContainerImplementationStubTwo::class);
+        $container->makeAs(ContainerConcreteStub::class, [], ContainerImplementationStubTwo::class);
     }
 
     // public function testContainerCanCatchCircularDependency()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -697,7 +697,7 @@ class ContainerTest extends TestCase
             return new ContainerConcreteStub;
         });
 
-        $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs('makeAs', [],ContainerConcreteStub::class ));
+        $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs('makeAs', [], ContainerConcreteStub::class));
     }
 
     public function testMakeAsThrowsContainerExceptionWhenMisused()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -680,6 +680,34 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationStub::class, $result);
     }
 
+    /**
+     * @test
+     * @group current
+     */
+    public function testContainerCanMakeAsFromAbstract()
+    {
+        $container = new Container;
+        $container->bind(ContainerConcreteStub::class, function () {
+            return new ContainerConcreteStub;
+        });
+
+        $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs(ContainerConcreteStub::class));
+    }
+
+    /**
+     * @test
+     * @group current
+     */
+    public function testContainerCanMakeAsFromMagicString()
+    {
+        $container = new Container;
+        $container->bind('makeAs', function () {
+            return new ContainerConcreteStub;
+        });
+
+        $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs('makeAs', [],ContainerConcreteStub::class ));
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -680,10 +680,6 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationStub::class, $result);
     }
 
-    /**
-     * @test
-     * @group current
-     */
     public function testContainerCanMakeAsFromAbstract()
     {
         $container = new Container;
@@ -693,11 +689,6 @@ class ContainerTest extends TestCase
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs(ContainerConcreteStub::class));
     }
-
-    /**
-     * @test
-     * @group current
-     */
     public function testContainerCanMakeAsFromMagicString()
     {
         $container = new Container;
@@ -706,6 +697,28 @@ class ContainerTest extends TestCase
         });
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $container->makeAs('makeAs', [],ContainerConcreteStub::class ));
+    }
+
+    public function testMakeAsThrowsContainerExceptionWhenMisused()
+    {
+        $container = new Container;
+        $container->bind(ContainerConcreteStub::class, function () {
+            return 'Taylor';
+        });
+
+        $this->expectException(BindingResolutionException::class);
+        $container->makeAs(ContainerConcreteStub::class);
+    }
+
+    public function testMakeAsThrowsContainerExceptionWhenExpectationIsNotMet()
+    {
+        $container = new Container;
+        $container->bind(ContainerConcreteStub::class, function () {
+            return new ContainerConcreteStub;
+        });
+
+        $this->expectException(BindingResolutionException::class);
+        $container->makeAs(ContainerConcreteStub::class, [],ContainerImplementationStubTwo::class);
     }
 
     // public function testContainerCanCatchCircularDependency()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
# Reason
How often do you `app()->make('magic-string')` and then immediately test to make sure the expected object was resolved? I do it frequently. I also use [phpstan](https://phpstan.org/) and am always fighting the `mixed` signature of `app()->make()`.

# Feature

Added `makeAs()` to `Illuminate\Container` to support the following cases:

When bound with the class name:
```
$resolved = app()->makeAs(MyBoundClass::class);
```

When bound with a different magic string:
```
$resolved = app()->makeAs('magic-string', [], MyBoundClass::class);
```

In both cases, `$resolved` guaranteed to be the passed class and is typed for `phpstan`.