### PR TITLE
[10.x] Add ability to measure a single callable and get result

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -38,9 +38,9 @@ class Benchmark
      * @template TReturn of mixed
      *
      * @param  (callable(): TReturn)  $callback
-     * @return array{0: float, 1: TReturn}
+     * @return array{0: TReturn, 1: float}
      */
-    public static function once(callable $callback): array
+    public static function value(callable $callback): array
     {
         gc_collect_cycles();
 
@@ -48,7 +48,7 @@ class Benchmark
 
         $result = $callback();
 
-        return [(hrtime(true) - $start) / 1000000, $result];
+        return [$result, (hrtime(true) - $start) / 1000000];
     }
 
     /**

--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -33,6 +33,25 @@ class Benchmark
     }
 
     /**
+     * Measure a callable once and return the duration and result.
+     *
+     * @template TReturn of mixed
+     *
+     * @param  (callable(): TReturn)  $callback
+     * @return array{0: float, 1: TReturn}
+     */
+    public static function once(callable $callback): array
+    {
+        gc_collect_cycles();
+
+        $start = hrtime(true);
+
+        $result = $callback();
+
+        return [(hrtime(true) - $start) / 1000000, $result];
+    }
+
+    /**
      * Measure a callable or array of callables over the given number of iterations, then dump and die.
      *
      * @param  \Closure|array  $benchmarkables


### PR DESCRIPTION
Gives the ability to measure a given callable inline and allow receive the resulting value, e.g.

```php
[$result, $duration] = Benchmark::once(function () {
    sleep(1);

    return 'foo';
});
```

Useful for providing metrics around different execution paths of your application.