### PR TITLE
[10.x] Markdown Mailables: Allow omitting Footer and Header when customising components

### DIFF
--- a/src/Illuminate/Mail/resources/views/text/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/text/layout.blade.php
@@ -1,4 +1,4 @@
-{!! strip_tags($header) !!}
+{!! strip_tags($header ?? '') !!}
 
 {!! strip_tags($slot) !!}
 @isset($subcopy)
@@ -6,4 +6,4 @@
 {!! strip_tags($subcopy) !!}
 @endisset
 
-{!! strip_tags($footer) !!}
+{!! strip_tags($footer ?? '') !!}


### PR DESCRIPTION
When the Markdown mail components are [exported](https://laravel.com/docs/10.x/mail#customizing-the-components), it is possible to customise the templates and eg. to remove the header and footer components of the email templates. While they may be commented out in the `mail/html/message.blade.php` file, doing the same in the `mail/text/message.blade.php` file would throw an error since the `mail/text/layout.blade.php` file is expecting a `$footer` and `$header` variable to be set.

This admittedly very tiny change applies the current behaviour from the `html` template to the `text` version — by falling back to an empty string if the header/footer variables are not set.