### PR TITLE
[10.x] Add `touching` and `touched` model events.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -99,6 +99,7 @@ trait HasEvents
                 'retrieved', 'creating', 'created', 'updating', 'updated',
                 'saving', 'saved', 'restoring', 'restored', 'replicating',
                 'deleting', 'deleted', 'forceDeleting', 'forceDeleted',
+                'touching', 'touched',
             ],
             $this->observables
         );
@@ -335,6 +336,28 @@ trait HasEvents
     public static function deleted($callback)
     {
         static::registerModelEvent('deleted', $callback);
+    }
+
+    /**
+     * Register a touching model event with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @return void
+     */
+    public static function touching($callback)
+    {
+        static::registerModelEvent('touching', $callback);
+    }
+
+    /**
+     * Register a touched model event with the dispatcher.
+     *
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @return void
+     */
+    public static function touched($callback)
+    {
+        static::registerModelEvent('touched', $callback);
     }
 
     /**


### PR DESCRIPTION
This PR adds `touching` and `touched` model events that are dispatched in the model method `touch()`. 

Like the other `*ing` events, if false is returned from the touching event the operation is cancelled.

My use case for this is sending a progress email on an order when any child relationships are added. The status of the order is calculated from the child relationships so I can't watch the status, but I can hook into these events.

I'll put in a docs PR if this is accepted.

