### PR TITLE
[10.x] Introduce short-hand "false" syntax for Blade component props

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -128,6 +128,10 @@ class ComponentTagCompiler
                             )
                             |
                             (?:
+                                (![\w]+)
+                            )
+                            |
+                            (?:
                                 [\w\-:.@%]+
                                 (
                                     =
@@ -190,6 +194,10 @@ class ComponentTagCompiler
                             |
                             (?:
                                 (\:\\\$)(\w+)
+                            )
+                            |
+                            (?:
+                                (![\w]+)
                             )
                             |
                             (?:
@@ -582,6 +590,7 @@ class ComponentTagCompiler
     protected function getAttributesFromAttributeString(string $attributeString)
     {
         $attributeString = $this->parseShortAttributeSyntax($attributeString);
+        $attributeString = $this->parseShortFalseSyntax($attributeString);
         $attributeString = $this->parseAttributeBag($attributeString);
         $attributeString = $this->parseComponentTagClassStatements($attributeString);
         $attributeString = $this->parseComponentTagStyleStatements($attributeString);
@@ -647,6 +656,21 @@ class ComponentTagCompiler
 
         return preg_replace_callback($pattern, function (array $matches) {
             return " :{$matches[1]}=\"\${$matches[1]}\"";
+        }, $value);
+    }
+
+    /**
+     * Parses a short false syntax like !required into a fully-qualified syntax like :required="false".
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function parseShortFalseSyntax(string $value)
+    {
+        $pattern = "/\s!(\w+)/x";
+
+        return preg_replace_callback($pattern, function (array $matches) {
+            return " :{$matches[1]}=\"false\"";
         }, $value);
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -734,6 +734,31 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame($attributes->get('other'), 'ok');
     }
 
+    public function testFalseShortSyntax()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool !bool></x-bool>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => false])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestBoolComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
+    public function testSelfClosingComponentWithFalseShortSyntax()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool !bool />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => false])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestBoolComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>
+@endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
     protected function mockViewFactory($existsSucceeds = true)
     {
         $container = new Container;
@@ -795,5 +820,20 @@ class TestInputComponent extends Component
     public function render()
     {
         return 'input';
+    }
+}
+
+class TestBoolComponent extends Component
+{
+    public $bool;
+
+    public function __construct($bool)
+    {
+        $this->bool = $bool;
+    }
+
+    public function render()
+    {
+        return 'bool';
     }
 }


### PR DESCRIPTION
Currently, setting the value of a Blade component prop to `false` can only be done with the binding syntax.

```blade
<x-layout :margin="false">
```

This syntax is quite verbose for something so simple, so this pull request introduces a new short-hand syntax.

```blade
<x-layout !margin />
```

The syntax is similar to the "not" operation in regular PHP code and feels quite familiar.

> Not sure whether "short false" syntax is the best name for this, open to suggestions.