### PR TITLE
[10.x] Make default ID column configurable in `Query\Builder::find` `forPageBeforeId` and `forPageAfterId`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2456,11 +2456,12 @@ class Builder implements BuilderContract
      *
      * @param  int  $perPage
      * @param  int|null  $lastId
-     * @param  string  $column
+     * @param  string|null  $column
      * @return $this
      */
-    public function forPageBeforeId($perPage = 15, $lastId = 0, $column = 'id')
+    public function forPageBeforeId($perPage = 15, $lastId = 0, $column = null)
     {
+        $column ??= $this->defaultKeyName();
         $this->orders = $this->removeExistingOrdersFor($column);
 
         if (! is_null($lastId)) {
@@ -2476,11 +2477,12 @@ class Builder implements BuilderContract
      *
      * @param  int  $perPage
      * @param  int|null  $lastId
-     * @param  string  $column
+     * @param  string|null  $column
      * @return $this
      */
-    public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
+    public function forPageAfterId($perPage = 15, $lastId = 0, $column = null)
     {
+        $column ??= $this->defaultKeyName();
         $this->orders = $this->removeExistingOrdersFor($column);
 
         if (! is_null($lastId)) {
@@ -2655,7 +2657,7 @@ class Builder implements BuilderContract
      */
     public function find($id, $columns = ['*'])
     {
-        return $this->where('id', '=', $id)->first($columns);
+        return $this->where($this->defaultKeyName(), '=', $id)->first($columns);
     }
 
     /**


### PR DESCRIPTION
The protected method `Illuminate\Database\Query\Builder::defaultKeyName()` is already used in `Illuminate\Database\Concerns\BuildsQueries::chunkById()` and `Illuminate\Database\Concerns\BuildsQueries::orderedLazyById()`. It was introduced by https://github.com/laravel/framework/pull/28065.

This is necessary to avoid overloading this methods only to change the default value of the `$column` argument.
~Example: MongoDB uses `_id` by default. [We have to redefine the methods](https://github.com/jenssegers/laravel-mongodb/blob/1303b5fb05d1c8f06d29c55b79e3e5468c946f45/src/Query/Builder.php#L658-L672).~