### PR TITLE
[10.x] Add `named` method to resource route

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -115,6 +115,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Set the route name for all resource routes.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function named($name)
+    {
+        $this->options['named'] = $name;
+
+        return $this;
+    }
+
+    /**
      * Override the route parameter names.
      *
      * @param  array|string  $parameters

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -651,7 +651,7 @@ class ResourceRegistrar
         // so the names may be specified on a more "granular" level using methods.
         if (isset($options['named'])) {
             $name = $options['named'];
-        } else if (isset($options['names'])) {
+        } elseif (isset($options['names'])) {
             if (is_string($options['names'])) {
                 $name = $options['names'];
             } elseif (isset($options['names'][$method])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -649,7 +649,9 @@ class ResourceRegistrar
         // If the names array has been provided to us we will check for an entry in the
         // array first. We will also check for the specific method within this array
         // so the names may be specified on a more "granular" level using methods.
-        if (isset($options['names'])) {
+        if (isset($options['named'])) {
+            $name = $options['started'];
+        } else if (isset($options['names'])) {
             if (is_string($options['names'])) {
                 $name = $options['names'];
             } elseif (isset($options['names'][$method])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -650,7 +650,7 @@ class ResourceRegistrar
         // array first. We will also check for the specific method within this array
         // so the names may be specified on a more "granular" level using methods.
         if (isset($options['named'])) {
-            $name = $options['started'];
+            $name = $options['named'];
         } else if (isset($options['names'])) {
             if (is_string($options['names'])) {
                 $name = $options['names'];

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1078,6 +1078,17 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
     }
 
+    public function testNamedForResourceRoute()
+    {
+        $router = $this->getRouter();
+        $router->resource('lessons.courses', RouteTestResourceControllerWithModelParameter::class)->only('show')->named('lessons');
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertSame('lessons.show', $routes[0]->getName());
+    }
+
     public function testModelBindingWithCompoundParameterName()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
## The Problem

I develop a project, I created a resource route like below:

```php
Route::resource('lessons.course', LessonController::class);
```

After, the resource route names are like these:

```
index => lessons.courses.index
create => lessons.courses.create
store => lessons.courses.store
show => lessons.courses.show
edit => lessons.courses.edit
update => lessons.courses.update
destroy => lessons.courses.destroy
```

But, I like to convert the route names like these:

```
index => lessons.index
create => lessons.create
...
```

---

Maybe you think to use the `names` method, But it's so hard to add the `names` method for each resource route.

```php
Route::resource('lessons.courses', LessonController::class)->names([
    'index' => 'lessons.index',
    'create' => 'lessons.create',
    'store' => 'lessons.store',
    'show' => 'lessons.show',
    ...
]);
```

## What Added
Added a new method to the resource route that should pass the original route name:

```php
Route::resource('lessons.courses', LessonController::class)->named('lessons');
```

It's like adding a new name for resource route names.

----

This method helps to write less code for route names 🔥
Also, added tests✅

I don't know about the method name! If you have any suggests 