### PR TITLE
[10.x] Add commonly reusable Composer related commands from 1st party packages

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -39,6 +39,97 @@ class Composer
     }
 
     /**
+     * Install the given Composer packages into the application.
+     *
+     * @param  array<int, string>  $packages
+     * @param  bool  $dev
+     * @param  \Closure|\Symfony\Component\Console\Output\OutputInterface|null  $output
+     * @return bool
+     */
+    protected function requirePackages(array $packages, bool $dev = false, Closure|OutputInterface $output = null)
+    {
+        $composer = $this->findComposer();
+
+        $command = explode(' ', $composer);
+
+        array_push($command, 'require');
+
+        $command = array_merge(
+            $command,
+            $packages,
+            $dev ? ['--dev'] : [],
+        );
+
+        return 0 === (new Process($command, cwd: $this->workingPath, env: ['COMPOSER_MEMORY_LIMIT' => '-1']))
+            ->setTimeout(null)
+            ->run(
+                $output instanceof OutputInterface
+                    ? function ($type, $line) use ($output) {
+                        $output->write('    '.$line);
+                    } : $output
+            );
+    }
+
+    /**
+     * Remove the given Composer packages from the application.
+     *
+     * @param  array<int, string>  $packages
+     * @param  bool  $dev
+     * @param  \Closure|\Symfony\Component\Console\Output\OutputInterface|null  $output
+     * @return bool
+     */
+    protected function removePackages(array $packages, bool $dev = false, Closure|OutputInterface $output = null)
+    {
+        $composer = $this->findComposer();
+
+        $command = explode(' ', $composer);
+
+        array_push($command, 'remove');
+
+        $command = array_merge(
+            $command,
+            $packages,
+            $dev ? ['--dev'] : [],
+        );
+
+        return 0 === (new Process($command, cwd: $this->workingPath, env: ['COMPOSER_MEMORY_LIMIT' => '-1']))
+            ->setTimeout(null)
+            ->run(
+                $output instanceof OutputInterface
+                    ? function ($type, $line) use ($output) {
+                        $output->write('    '.$line);
+                    } : $output
+            );
+    }
+
+    /**
+     * Modify the "composer.json" file contents using the given callback.
+     *
+     * @param  callable(array):array  $callback
+     * @return void
+     *
+     * @throw \RuntimeException
+     */
+    public function modify(callable $callback)
+    {
+        $composerFile = "{$this->workingPath}/composer.json";
+
+        if (! file_exists($composerFile)) {
+            throw new RuntimeException("Unable to locate `composer.json` file at [{$this->workingPath}].");
+        }
+
+        $composer = json_decode(file_get_contents($composerFile), true, 512, JSON_THROW_ON_ERROR);
+
+        file_put_contents(
+            $composerFile,
+            json_encode(
+                call_user_func($callback, $composer),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            )
+        );
+    }
+
+    /**
      * Regenerate the Composer autoloader files.
      *
      * @param  string|array  $extra
@@ -131,91 +222,5 @@ class Composer
         }
 
         return explode(' ', $output)[2] ?? null;
-    }
-
-    /**
-     * Installs the given Composer Packages into the application.
-     *
-     * @param  array<int, string>  $packages
-     * @param  bool  $asDev
-     * @param  \Closure|\Symfony\Component\Console\Output\OutputInterface|null  $output
-     * @return bool
-     */
-    protected function requirePackages(array $packages, bool $asDev = false, Closure|OutputInterface $output = null)
-    {
-        $composer = $this->findComposer();
-        $command = explode(' ', $composer);
-        array_push($command, 'require');
-
-        $command = array_merge(
-            $command,
-            $packages,
-            $asDev ? ['--dev'] : [],
-        );
-
-        return 0 === (new Process($command, cwd: $this->workingPath, env: ['COMPOSER_MEMORY_LIMIT' => '-1']))
-            ->setTimeout(null)
-            ->run(
-                $output instanceof OutputInterface
-                    ? function ($type, $line) use ($output) {
-                        $output->write('    '.$line);
-                    } : $output
-            );
-    }
-
-    /**
-     * Removes the given Composer Packages from the application.
-     *
-     * @param  array<int, string>  $packages
-     * @param  bool  $asDev
-     * @param  \Closure|\Symfony\Component\Console\Output\OutputInterface|null  $output
-     * @return bool
-     */
-    protected function removePackages(array $packages, bool $asDev = false, Closure|OutputInterface $output = null)
-    {
-        $composer = $this->findComposer();
-        $command = explode(' ', $composer);
-        array_push($command, 'remove');
-
-        $command = array_merge(
-            $command,
-            $packages,
-            $asDev ? ['--dev'] : [],
-        );
-
-        return 0 === (new Process($command, cwd: $this->workingPath, env: ['COMPOSER_MEMORY_LIMIT' => '-1']))
-            ->setTimeout(null)
-            ->run(
-                $output instanceof OutputInterface
-                    ? function ($type, $line) use ($output) {
-                        $output->write('    '.$line);
-                    } : $output
-            );
-    }
-
-    /**
-     * Modify composer content.
-     *
-     * @param  callable(array):array  $callback
-     * @return void
-     *
-     * @throw \RuntimeException
-     */
-    public function modify(callable $callback)
-    {
-        $composerFile = "{$this->workingPath}/composer.json";
-
-        if (! file_exists($composerFile)) {
-            throw new RuntimeException("Unable to locate `composer.json` from [{$this->workingPath}]");
-        }
-
-        $composer = json_decode(file_get_contents($composerFile), true, 512, JSON_THROW_ON_ERROR);
-
-        $composer = call_user_func($callback, $composer);
-
-        file_put_contents(
-            $composerFile,
-            json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-        );
     }
 }


### PR DESCRIPTION
* `requirePackages` and `removePackages` are commonly used in our starter kit packages
* `modify` should be useful to add `repositories` or `require` without running composer install. The current use-case would be for generating custom tools for Laravel Nova.
