### PR TITLE
[10.x] Add `hash_algo` option for token auth driver

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -169,7 +169,8 @@ class AuthManager implements FactoryContract
             $this->app['request'],
             $config['input_key'] ?? 'api_token',
             $config['storage_key'] ?? 'api_token',
-            $config['hash'] ?? false
+            $config['hash'] ?? false,
+            $config['hash_algo'] ?? 'sha256'
         );
 
         $this->app->refresh('request', $guard, 'setRequest');

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -39,6 +39,13 @@ class TokenGuard implements Guard
     protected $hash = false;
 
     /**
+     * The algorithm to be used for API token hashing if enabled.
+     *
+     * @var string
+     */
+    protected $hashAlgorithm;
+
+    /**
      * Create a new authentication guard.
      *
      * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
@@ -46,6 +53,7 @@ class TokenGuard implements Guard
      * @param  string  $inputKey
      * @param  string  $storageKey
      * @param  bool  $hash
+     * @param  string  $hashAlgorithm
      * @return void
      */
     public function __construct(
@@ -53,9 +61,11 @@ class TokenGuard implements Guard
         Request $request,
         $inputKey = 'api_token',
         $storageKey = 'api_token',
-        $hash = false)
+        $hash = false,
+        $hashAlgorithm = 'sha256')
     {
         $this->hash = $hash;
+        $this->hashAlgorithm = $hashAlgorithm;
         $this->request = $request;
         $this->provider = $provider;
         $this->inputKey = $inputKey;
@@ -82,7 +92,7 @@ class TokenGuard implements Guard
 
         if (! empty($token)) {
             $user = $this->provider->retrieveByCredentials([
-                $this->storageKey => $this->hash ? hash('sha256', $token) : $token,
+                $this->storageKey => $this->hash ? hash($this->hashAlgorithm, $token) : $token,
             ]);
         }
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -51,6 +51,24 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $guard->id());
     }
 
+    public function testTokenCanBeHashedWithCustomAlgorithm()
+    {
+        $provider = m::mock(UserProvider::class);
+        $user = new AuthTokenGuardTestUser;
+        $user->id = 1;
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha512', 'foo')])->andReturn($user);
+        $request = Request::create('/', 'GET', ['api_token' => 'foo']);
+
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', $hash = true, 'sha512');
+
+        $user = $guard->user();
+
+        $this->assertSame(1, $user->id);
+        $this->assertTrue($guard->check());
+        $this->assertFalse($guard->guest());
+        $this->assertSame(1, $guard->id());
+    }
+
     public function testUserCanBeRetrievedByAuthHeaders()
     {
         $provider = m::mock(UserProvider::class);


### PR DESCRIPTION
I've added a `hash_algo` config option for the token auth driver. This would allow alternative hashing algorithms to be used. It still defaults to `sha256`, so it should be a non-breaking change.

```php
'api' => [
    'driver' => 'token',
    'provider' => 'tokens',
    'hash' => true,
    'hash_algo' => 'sha512',
]
```