### PR TITLE
Fix memory leak on flush method for TaggableStore

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -126,4 +126,14 @@ class RedisTaggedCache extends TaggedCache
 
         return true;
     }
+
+    protected function onKeyWritten(string $key): void
+    {
+        // No need to do anything as the Redis store manages the entry list internally.
+    }
+
+    protected function onKeyForgotten(string $key): void
+    {
+        // No need to do anything as the Redis store manages the entry list internally.
+    }
 }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -21,6 +21,7 @@ class TaggedCache extends Repository
 
     /**
      * List of keys within this namespace
+     *
      * @var array
      */
     protected $itemKeys = [];
@@ -121,7 +122,7 @@ class TaggedCache extends Repository
     protected function event($event)
     {
         $itemKey = $this->itemKey($event->key);
-        if ($event instanceof KeyWritten && !in_array($itemKey, $this->itemKeys)) {
+        if ($event instanceof KeyWritten && ! in_array($itemKey, $this->itemKeys)) {
             $this->itemKeys[] = $itemKey;
         } elseif ($event instanceof KeyForgotten && in_array($itemKey, $this->itemKeys)) {
             $this->itemKeys = array_values(array_filter($this->itemKeys, function ($k) use ($itemKey) {

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -20,7 +20,7 @@ class TaggedCache extends Repository
     protected $tags;
 
     /**
-     * List of keys within this namespace
+     * List of keys within this namespace.
      *
      * @var array
      */

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -161,6 +161,7 @@ class TaggedCache extends Repository
         if (! is_array($keys)) {
             $keys = [];
         }
+
         return $keys;
     }
 

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -126,7 +126,7 @@ class TaggedCache extends Repository
         $itemKey = $this->itemKey($event->key);
         if ($itemKey !== $this->getMetadataKey() && ($event instanceof KeyWritten || $event instanceof KeyForgotten)) {
             $itemKeys = $this->getItemKeys();
-            if ($event instanceof KeyWritten && !in_array($itemKey, $itemKeys)) {
+            if ($event instanceof KeyWritten && ! in_array($itemKey, $itemKeys)) {
                 $itemKeys[] = $itemKey;
             } elseif ($event instanceof KeyForgotten && in_array($itemKey, $this->itemKeys)) {
                 $itemKeys = array_values(

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -208,8 +208,11 @@ class CacheTaggedCacheTest extends TestCase
         $store = new ArrayStore;
         $tags = ['bop'];
         $before = memory_get_usage(true);
+        // Store a 5MB cache value then flush it 100 times, then verify the overall memory usage did not increase
         for ($i = 0; $i < 100; $i++) {
-            $store->tags($tags)->forever('foo', 'bar');
+            $key = str_replace('.', '', uniqid());
+            $value = bin2hex(random_bytes(1024 * 5));
+            $store->tags($tags)->forever($key, $value);
             $store->tags($tags)->flush();
         }
         $after = memory_get_usage(true);

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -203,6 +203,19 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame('bar', $store->tags($tags)->get('foo'));
     }
 
+    public function testFlushFunctionDoesntLeakMemory()
+    {
+        $store = new ArrayStore;
+        $tags = ['bop'];
+        $before = memory_get_usage(true);
+        for ($i = 0; $i < 100; $i++) {
+            $store->tags($tags)->forever('foo', 'bar');
+            $store->tags($tags)->flush();
+        }
+        $after = memory_get_usage(true);
+        $this->assertSame($before, $after);
+    }
+
     private function getTestCacheStoreWithTagValues(): ArrayStore
     {
         $store = new ArrayStore;


### PR DESCRIPTION
https://github.com/laravel/framework/issues/48100

Currently when calling `flush()` on a `TaggableStore`, all that happens is the namespace is reset, meaning the reference to any cached data is lost, and any further cache reads miss.

This however leads to the data staying in the store, and therefore gradually leaking memory - this is problematic in long running processes for example and can lead to unpredictable crashes.

The approach here is to keep an additional cache entry: `<namespace>:meta:entries` consisting of a list of keys within the tag, and on calling `flush()` looping through these keys and removing them from the store.

As it happens the RedisTaggedCache/RedisTagSet already has similar behaviour, so I have not applied this new logic there.