### PR TITLE
[10.x] Infer route action from URI when not declared

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -548,6 +548,7 @@ class Router implements BindingRegistrar, RegistrarContract
         // an acceptable array format before registering it and creating this route
         // instance itself. We need to build the Closure that will call this out.
         if ($this->actionReferencesController($action)) {
+            $action ??= Str::of($uri)->afterLast('/')->camel()->value();
             $action = $this->convertToControllerAction($action);
         }
 
@@ -575,6 +576,10 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function actionReferencesController($action)
     {
+        if ($action === null && (end($this->groupStack)['controller'] ?? false)) {
+            return true;
+        }
+
         if (! $action instanceof Closure) {
             return is_string($action) || (isset($action['uses']) && is_string($action['uses']));
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -465,6 +465,72 @@ class RouteRegistrarTest extends TestCase
         );
     }
 
+    public function testCanInferActionFromUri()
+    {
+        $this->router->controller(UserController::class)->group(function ($router) {
+            $router->get('me');
+        });
+
+        $this->assertSame(
+            UserController::class.'@me',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
+    public function testCanInferActionFromNestedPath()
+    {
+        $this->router->controller(UserController::class)->group(function ($router) {
+            $router->post('users/invite');
+        });
+
+        $this->assertSame(
+            UserController::class.'@invite',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
+    public function testCanTurnInferredActionsIntoCamelCase()
+    {
+        $this->router->controller(UserController::class)->group(function ($router) {
+            $router->post('reset-password');
+        });
+
+        $this->assertSame(
+            UserController::class.'@resetPassword',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
+    public function testCanInferActionFromTheLatestGroupController()
+    {
+        $this->router->controller(RouteRegistrarControllerStub::class)->group(function ($router) {
+            $router->controller(UserController::class)->group(function ($router) {
+                $router->get('me');
+            });
+        });
+
+        $this->assertSame(
+            UserController::class.'@me',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
+    public function testCanInferActionFromTheLastGroupWithController()
+    {
+        $this->router->controller(UserController::class)->group(function ($router) {
+            $router->middleware('auth')->group(function ($router) {
+                $router->prefix('users')->group(function ($router) {
+                    $router->get('me');
+                });
+            });
+        });
+
+        $this->assertSame(
+            UserController::class.'@me',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
     public function testRouteGroupingWithoutPrefix()
     {
         $this->router->group([], function ($router) {


### PR DESCRIPTION
This PR allows Laravel to automatically infer a route action based on its URI when the action is not explicitly defined.

This change allows developers to avoid repeating themselves when the URI reflects the controller action:
```php
// before
Route::controller(UserController::class)->group(function () {
    Route::get('me', 'me');
    Route::post('invite', 'invite');
    Route::post('reset-password', 'resetPassword');
});

// after
Route::controller(UserController::class)->group(function () {
    Route::get('me');
    Route::post('invite');
    Route::post('reset-password');
});
```

Here are more details about how it works:
- if the action is explicitly defined, Laravel routing will work as per usual
- if a controller is **not** defined, Laravel routing will work as per usual
- if the action is **not** explicitly defined, it infers the action from the URI
- if the URI has nested paths (e.g. `users/invite`), it infers the action from the last segment (`invite`)
- if the URI has dashes or underscores (e.g. `reset-password`), it infers the action by using camel case (`resetPassword`)
- if different controllers are defined in nested groups, it infers the action from the latest group
- if the latest nested group does **not** define a controller, it infers the action from the latest defined controller in the group stack