### PR TITLE
[10.x] Allows overriding the stub path at migration create time

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -19,6 +19,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+        {--stubpath : The location where the stub file should be loaded}
         {--fullpath : Output the full path of the migration (Deprecated)}';
 
     /**
@@ -103,13 +104,19 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      * @param  string  $name
      * @param  string  $table
      * @param  bool  $create
+     *
      * @return void
      */
     protected function writeMigration($name, $table, $create)
     {
-        $file = $this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
-        );
+        $file = $this->creator
+            ->withStubPath($this->input->getOption('stubpath') ?? null)
+            ->create(
+                $name,
+                $this->getMigrationPath(),
+                $table,
+                $create
+            );
 
         $this->components->info(sprintf('Migration [%s] created successfully.', $file));
     }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -228,4 +228,18 @@ class MigrationCreator
     {
         return $this->files;
     }
+
+    /**
+     * Allow overriding the custom stub path at execution time
+     *
+     * @return self
+     */
+    public function withStubPath(?string $path)
+    {
+        if ($path !== null) {
+            $this->customStubPath = $path;
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
There are times when it may be useful for creating migrations that are based on a path to the migration.stub *not* being either of the two defaults. This functionality allows a developer to specify a path to a stub of their choosing.
