### PR TITLE
[10.x] CacheTTL helper

### DIFF
--- a/src/Illuminate/Cache/CacheTTL.php
+++ b/src/Illuminate/Cache/CacheTTL.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Cache;
+
+enum CacheTTL: int
+{
+    case SECOND = 1;
+    case MINUTE = 60;
+    case HOUR = 3600;
+    case DAY = 86400;
+
+    public static function second(): int
+    {
+        return self::SECOND->value;
+    }
+
+    public static function seconds(int $seconds): int
+    {
+        return $seconds * self::SECOND->value;
+    }
+
+    public static function minute(): int
+    {
+        return self::MINUTE->value;
+    }
+
+    public static function minutes(int $minutes): int
+    {
+        return $minutes * self::MINUTE->value;
+    }
+
+    public static function hour(): int
+    {
+        return self::HOUR->value;
+    }
+
+    public static function hours(int $hours): int
+    {
+        return $hours * self::HOUR->value;
+    }
+
+    public static function day(): int
+    {
+        return self::DAY->value;
+    }
+
+    public static function days(int $days): int
+    {
+        return $days * self::DAY->value;
+    }
+
+    public static function week(): int
+    {
+        return self::days(7);
+    }
+
+    public static function weeks(int $weeks): int
+    {
+        return $weeks * self::week();
+    }
+
+    public static function month(): int
+    {
+        return self::days(30);
+    }
+
+    public static function months(int $months): int
+    {
+        return $months * self::month();
+    }
+
+    public static function year(): int
+    {
+        return self::days(365);
+    }
+
+    public static function years(int $years): int
+    {
+        return $years * self::year();
+    }
+}
+

--- a/src/Illuminate/Cache/CacheTTL.php
+++ b/src/Illuminate/Cache/CacheTTL.php
@@ -79,4 +79,3 @@ enum CacheTTL: int
         return $years * self::year();
     }
 }
-

--- a/tests/Cache/CacheTTLTest.php
+++ b/tests/Cache/CacheTTLTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\CacheTTL;
+use PHPUnit\Framework\TestCase;
+
+class CacheTTLTest extends TestCase
+{
+    public function testReturnsTtlForSeconds()
+    {
+        $this->assertSame(CacheTTL::SECOND->value, CacheTTL::second());
+        $this->assertSame(CacheTTL::SECOND->value * 30, CacheTTL::seconds(30));
+    }
+
+    public function testReturnsTtlForMinutes()
+    {
+        $this->assertSame(CacheTTL::MINUTE->value, CacheTTL::minute());
+        $this->assertSame(CacheTTL::MINUTE->value * 5, CacheTTL::minutes(5));
+    }
+
+    public function testReturnsTtlForHours()
+    {
+        $this->assertSame(CacheTTL::HOUR->value, CacheTTL::hour());
+        $this->assertSame(CacheTTL::HOUR->value * 2, CacheTTL::hours(2));
+    }
+
+    public function testReturnsTtlForDays()
+    {
+        $this->assertSame(CacheTTL::DAY->value, CacheTTL::day());
+        $this->assertSame(CacheTTL::DAY->value * 3, CacheTTL::days(3));
+    }
+
+    public function testReturnsTtlForWeeks()
+    {
+        $this->assertSame(CacheTTL::DAY->value * 7, CacheTTL::week());
+        $this->assertSame(CacheTTL::DAY->value * 7 * 2, CacheTTL::weeks(2));
+    }
+
+    public function testReturnsTtlForMonths()
+    {
+        $this->assertSame(CacheTTL::DAY->value * 30, CacheTTL::month());
+        $this->assertSame(CacheTTL::DAY->value * 30 * 2, CacheTTL::months(2));
+    }
+
+    public function testReturnsTtlForYears()
+    {
+        $this->assertSame(CacheTTL::DAY->value * 365, CacheTTL::year());
+        $this->assertSame(CacheTTL::DAY->value * 365 * 2, CacheTTL::years(2));
+    }
+}


### PR DESCRIPTION
## Changes

This PR adds a Enum CacheTTL that provides some values for cache TTL as well as some helper methods for defining TTL for cache keys in a more friendly way for developers.

## Why

This will help developers to avoid using arbitrary "magic numbers" in the code like:

```php
Cache::store('redis')->put('bar', 'baz', 600); // 10 Minutes
```

To something more friendly and self-explanatory:

```php
Cache::store('redis')->put('bar', 'baz', CacheTTL::minutes(10));
```

The goal is to improve the DX for developers providing an easy and friendly way to set TTL for the cache.