### PR TITLE
Add whereRelationIn and orWhereRelationIn

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -391,6 +391,25 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a basic where in clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  array  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereRelationIn($relation, $column, $value)
+    {
+        return $this->whereHas($relation, function ($query) use ($column, $value) {
+            if ($column instanceof Closure) {
+                $column($query);
+            } else {
+                $query->whereIn($column, $value);
+            }
+        });
+    }
+
+    /**
      * Add an "or where" clause to a relationship query.
      *
      * @param  string  $relation
@@ -406,6 +425,25 @@ trait QueriesRelationships
                 $column($query);
             } else {
                 $query->where($column, $operator, $value);
+            }
+        });
+    }
+
+    /**
+     * Add an "or where in" clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  array  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orWhereRelationIn($relation, $column, $value)
+    {
+        return $this->orWhereHas($relation, function ($query) use ($column, $value) {
+            if ($column instanceof Closure) {
+                $column($query);
+            } else {
+                $query->whereIn($column, $value);
             }
         });
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -395,10 +395,10 @@ trait QueriesRelationships
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
-     * @param  array  $value
+     * @param  array|null  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereRelationIn($relation, $column, $value)
+    public function whereRelationIn($relation, $column, $value = null)
     {
         return $this->whereHas($relation, function ($query) use ($column, $value) {
             if ($column instanceof Closure) {
@@ -434,10 +434,10 @@ trait QueriesRelationships
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
-     * @param  array  $value
+     * @param  array|null  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereRelationIn($relation, $column, $value)
+    public function orWhereRelationIn($relation, $column, $value = null)
     {
         return $this->orWhereHas($relation, function ($query) use ($column, $value) {
             if ($column instanceof Closure) {

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -122,9 +122,23 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1], $users->pluck('id')->all());
     }
 
+    public function testWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts', 'public', [true, false])->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
     public function testOrWhereRelation()
     {
         $users = User::whereRelation('posts', 'public', true)->orWhereRelation('posts', 'public', false)->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
+    public function testOrWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts', 'public', [true])->orWhereRelationIn('posts', 'public', [false])->get();
 
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
@@ -136,9 +150,23 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1], $texts->pluck('id')->all());
     }
 
+    public function testNestedWhereRelationIn()
+    {
+        $texts = User::whereRelationIn('posts.texts', 'content', ['test', 'test2'])->get();
+
+        $this->assertEquals([1, 2], $texts->pluck('id')->all());
+    }
+
     public function testNestedOrWhereRelation()
     {
         $texts = User::whereRelation('posts.texts', 'content', 'test')->orWhereRelation('posts.texts', 'content', 'test2')->get();
+
+        $this->assertEquals([1, 2], $texts->pluck('id')->all());
+    }
+
+    public function testNestedOrWhereRelationIn()
+    {
+        $texts = User::whereRelationIn('posts.texts', 'content', ['test'])->orWhereRelationIn('posts.texts', 'content', ['test2'])->get();
 
         $this->assertEquals([1, 2], $texts->pluck('id')->all());
     }


### PR DESCRIPTION
Following the colleague's line of thought in discussion [46224](https://github.com/laravel/framework/discussions/46224) I've often looked for the presence of the 'whereRelationIn' method within Laravel's code.

The solution is much cleaner than using a closure.