### PR TITLE
[10.x] Change `SendQueuedMailable` and `SendQueuedNotifications` to Be `Batchable`

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Mail;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
@@ -10,7 +11,7 @@ use Illuminate\Queue\InteractsWithQueue;
 
 class SendQueuedMailable
 {
-    use Queueable, InteractsWithQueue;
+    use InteractsWithQueue, Queueable, Batchable;
 
     /**
      * The mailable message instance.
@@ -74,6 +75,10 @@ class SendQueuedMailable
      */
     public function handle(MailFactory $factory)
     {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
         $this->mailable->send($factory);
     }
 

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,7 +14,7 @@ use Illuminate\Support\Collection;
 
 class SendQueuedNotifications implements ShouldQueue
 {
-    use InteractsWithQueue, Queueable, SerializesModels;
+    use InteractsWithQueue, Queueable, Batchable, SerializesModels;
 
     /**
      * The notifiable entities that should receive the notification.
@@ -109,6 +110,10 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function handle(ChannelManager $manager)
     {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
         $manager->sendNow($this->notifiables, $this->notification, $this->channels);
     }
 


### PR DESCRIPTION
Mails and notifications can currently be queued using the `SendQueuedMailable` and the `SendQueuedNotifications` queueable classes. However, these do not support being batched.

In our case, we need to batch the mails (or notifications) in order to properly track them. We are sending a few thousand similar mails at once, which would be a mess without batching. I could write a separate queued and batched job to send the mail, however, that would defeat the purpose of mails being queueable.

Because I do not see a reason why `SendQueuedMailable` doesn't support batching, I added a `SendQueuedBatchableMailable` class that inherits from `SendQueuedMailable` and adds the `Batchable` trait. This PR eliminates the need for this class by adding `Batchable` to the `SendQueuedMailable` already.

Let me know if there is a specific reason why this has not been like that already. If you feel that this makes sense, I can try adding tests for it.

ToDo:

- [ ] Add Tests