### PR TITLE
[10.x] Resource groups: share resource attributes with grouped routes

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -241,6 +241,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Define a route group with shared options.
+     *
+     * @param  \Closure|array|string  $routes
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function group($routes)
+    {
+        $this->options['group'] = $routes;
+
+        return $this;
+    }
+
+    /**
      * Register the resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -213,6 +213,19 @@ class PendingSingletonResourceRegistration
     }
 
     /**
+     * Define a route group with shared options.
+     *
+     * @param  \Closure|array|string  $routes
+     * @return \Illuminate\Routing\PendingSingletonResourceRegistration
+     */
+    public function group($routes)
+    {
+        $this->options['group'] = $routes;
+
+        return $this;
+    }
+
+    /**
      * Register the singleton resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -83,6 +83,8 @@ class ResourceRegistrar
             $this->parameters = $options['parameters'];
         }
 
+        $this->registerGroup($name, $controller, $options);
+
         // If the resource name contains a slash, we will assume the developer wishes to
         // register these resource routes with a prefix so we will set that up out of
         // the box so they don't have to mess with it. Otherwise, we will continue.
@@ -136,6 +138,8 @@ class ResourceRegistrar
         if (isset($options['parameters']) && ! isset($this->parameters)) {
             $this->parameters = $options['parameters'];
         }
+
+        $this->registerGroup($name, $controller, $options);
 
         // If the resource name contains a slash, we will assume the developer wishes to
         // register these singleton routes with a prefix so we will set that up out of
@@ -663,6 +667,30 @@ class ResourceRegistrar
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');
+    }
+
+    /**
+     * Register the resource group by sharing common options.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array  $options
+     * @return void
+     */
+    protected function registerGroup($name, $controller, $options)
+    {
+        if (! isset($options['group'])) {
+            return;
+        }
+
+        $attributes = $this->getResourceAction($name, $controller, '', $options);
+
+        $attributes['as'] .= '.';
+        $attributes['prefix'] = $this->getResourceUri($name);
+        $attributes['controller'] = $controller;
+        unset($attributes['uses']);
+
+        $this->router->group($attributes, $options['group']);
     }
 
     /**


### PR DESCRIPTION
This PR allows Laravel developers to easily group routes from resources. The advantage is that all route attributes belonging to the resource are shared with the grouped routes:

```php
// before
Route::resource('users', UserController::class);

Route::controller(UserController::class)->prefix('users')->as('users.')->group(function () {
    Route::get('me', 'me')->name('me');
    Route::post('invite', 'invite')->name('invite');
});

// after
Route::resource('users', UserController::class)->group(function () {
    Route::get('me', 'me')->name('me');
    Route::post('invite', 'invite')->name('invite');
});
```

The additional benefits of this approach are:
- less code, same result
- inheritance of controller, name, prefix, middleware, missing and where clauses
- sync between the 2 sets of routes: when the resource changes, the grouped routes change accordingly
- streamlined organisation of routes
- additional actions in resource controllers can be simply routed by adding them in a group
- consistency across routes definition

Here is a more advanced example to better show the benefits of this PR:

```php
// before
Route::resource('users.posts', UserPostController::class)
    ->middleware('foo')
    ->withoutMiddleware('bar')
    ->missing(fn () => to_route('dashboard'))
    ->where(['user' => '\d+']);

Route::controller(UserPostController::class)
    ->prefix('users/{user}/posts')
    ->as('users.posts.')
    ->middleware('foo')
    ->withoutMiddleware('bar')
    ->missing(fn () => to_route('dashboard'))
    ->where(['user' => '\d+'])
    ->group(function () {
        Route::get('review', 'review')->name('review');
        Route::post('archive', 'archive')->name('archive');
    });

// after
Route::resource('users.posts', UserPostController::class)
    ->middleware('foo')
    ->withoutMiddleware('bar')
    ->missing(fn () => to_route('dashboard'))
    ->where(['user' => '\d+'])
    ->group(function () {
        Route::get('review', 'review')->name('review');
        Route::post('archive', 'archive')->name('archive');
    });
```

The resource groups work for all the resources available in Laravel:

```php
Route::resource(...)->group(...);
Route::apiResource(...)->group(...);
Route::singleton(...)->group(...);
Route::apiSingleton(...)->group(...);
```