### PR TITLE
[10.x] Support providing subquery as value to `where` builder method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -803,7 +803,7 @@ class Builder implements BuilderContract
         // If the value is a Closure, it means the developer is performing an entire
         // sub-select within the query and we will need to compile the sub-select
         // within the where clause to get the appropriate query record results.
-        if ($value instanceof Closure) {
+        if ($this->isQueryable($value)) {
             return $this->whereSub($column, $operator, $value, $boolean);
         }
 
@@ -1658,18 +1658,22 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $operator
-     * @param  \Closure  $callback
+     * @param  \Closure||\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
      * @param  string  $boolean
      * @return $this
      */
-    protected function whereSub($column, $operator, Closure $callback, $boolean)
+    protected function whereSub($column, $operator, $callback, $boolean)
     {
         $type = 'Sub';
 
-        // Once we have the query instance we can simply execute it so it can add all
-        // of the sub-select's conditions to itself, and then we can cache it off
-        // in the array of where clauses for the "main" parent query instance.
-        $callback($query = $this->forSubQuery());
+        if ($callback instanceof Closure) {
+            // Once we have the query instance we can simply execute it so it can add all
+            // of the sub-select's conditions to itself, and then we can cache it off
+            // in the array of where clauses for the "main" parent query instance.
+            $callback($query = $this->forSubQuery());
+        } else {
+            $query = $callback instanceof EloquentBuilder ? $callback->toBase() : $callback;
+        }
 
         $this->wheres[] = compact(
             'type', 'column', 'operator', 'query', 'boolean'

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -259,6 +259,10 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertTrue(DB::table('posts')->where($subQuery, 'Sub query value')->exists());
         $this->assertFalse(DB::table('posts')->where($subQuery, 'Does not match')->exists());
         $this->assertTrue(DB::table('posts')->where($subQuery, '!=', 'Does not match')->exists());
+
+        $this->assertTrue(DB::table('posts')->where(DB::raw('\'Sub query value\''), $subQuery)->exists());
+        $this->assertFalse(DB::table('posts')->where(DB::raw('\'Does not match\''), $subQuery)->exists());
+        $this->assertTrue(DB::table('posts')->where(DB::raw('\'Does not match\''), '!=', $subQuery)->exists());
     }
 
     public function testWhereNot()


### PR DESCRIPTION
Currently, it is impossible to provide a subquery as the $value in a `where` builder method. You can only achieve a `where` with a subquery by providing the subquery as the first parameter. When doing that, you must also wrap the column name in `DB::raw()` otherwise the Builder will think the column name is just a raw value. When you use an operator, you also have to reverse that operator, which makes the code less readable/logical in my opinion.

```php
User::where(
    Game::select('min_score')->whereColumn('games.id', 'users.game_id'),
    '<',
    DB::raw('score')
)
```

This PR fixes that, so you can just provide the column name first, and then provide the subquery as the “value” parameter. That makes the code cleaner and more readable.
```php
User::where(
    'score',
    '>',
    Game::select('min_score')->whereColumn('games.id', 'users.game_id'),
)
```

_I targeted the 10.x branch because I think changing the parameter signature of a protected method is not a breaking change, but I'm not sure. If that is regarded as a breaking change, I will create a new PR against the master branch._