### PR TITLE
[10.x] Add `assertJsonPathCanonicalizing` method

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -247,7 +247,7 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
-     * Assert that the given path in the response contains all the expected values without looking at the order.
+     * Assert that the given path in the response contains all of the expected values without looking at the order.
      *
      * @param  string  $path
      * @param  array  $expect

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -247,6 +247,20 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
+     * Assert that the given path in the response contains all the expected values without looking at the order.
+     *
+     * @param  string  $path
+     * @param  array  $expect
+     * @return $this
+     */
+    public function assertPathCanonicalizing($path, $expect)
+    {
+        PHPUnit::assertEqualsCanonicalizing($expect, $this->json($path));
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a given JSON structure.
      *
      * @param  array|null  $structure

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -663,7 +663,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the given path in the response contains all the expected values without looking at the order.
+     * Assert that the given path in the response contains all of the expected values without looking at the order.
      *
      * @param  string  $path
      * @param  array  $expect

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -663,6 +663,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given path in the response contains all the expected values without looking at the order.
+     *
+     * @param  string  $path
+     * @param  array  $expect
+     * @return $this
+     */
+    public function assertJsonPathCanonicalizing($path, array $expect)
+    {
+        $this->decodeResponseJson()->assertPathCanonicalizing($path, $expect);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1223,8 +1223,8 @@ class TestResponseTest extends TestCase
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
-        $response->assertJsonPathCanonicalizing('*.foo', ['foo 0' , 'foo 1', 'foo 2', 'foo 3']);
-        $response->assertJsonPathCanonicalizing('*.foo', ['foo 1' , 'foo 0', 'foo 3', 'foo 2']);
+        $response->assertJsonPathCanonicalizing('*.foo', ['foo 0', 'foo 1', 'foo 2', 'foo 3']);
+        $response->assertJsonPathCanonicalizing('*.foo', ['foo 1', 'foo 0', 'foo 3', 'foo 2']);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1219,6 +1219,29 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('data.foo', fn ($value) => $value === null);
     }
 
+    public function testAssertJsonPathCanonicalizing()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonPathCanonicalizing('*.foo', ['foo 0' , 'foo 1', 'foo 2', 'foo 3']);
+        $response->assertJsonPathCanonicalizing('*.foo', ['foo 1' , 'foo 0', 'foo 3', 'foo 2']);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPathCanonicalizing('*.id', [10, 20, 30]);
+        $response->assertJsonPathCanonicalizing('*.id', [30, 10, 20]);
+    }
+
+    public function testAssertJsonPathCanonicalizingCanFail()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
+
+        $response->assertJsonPathCanonicalizing('*.foo', ['foo 0', 'foo 2', 'foo 3']);
+    }
+
     public function testAssertJsonFragment()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
When testing API calls, I often have lots of tests that need to check if a json response contains all the expected ids without looking at the order of the ids in the response. For example, in a API call test that asserts if a querystring filter option works correctly, you will not (or not easily be able to) setup your expected models with fixed and known order in the response. That is currently not possible as `assertJsonPath` takes the order of the expected values into account.

To fix this, this PR adds a dedicated json assertion. I used the "canonicalizing" suffix because that is what PHPUnit calls this kind of assertion. (But maybe someone knows a better, more Laravel-like 😅, name for this method?)

```php
$users = User::factory()->count(2)->create();

$this->get('/api/users')->assertJsonPathCanonicalizing('data.*.id', $users->pluck('id')->all());
```


