### PR TITLE
[10.x] Fix validation of attributes that depend on previous excluded attribute

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -430,7 +430,6 @@ class Validator implements ValidatorContract
                 $this->validateAttribute($attribute, $rule);
 
                 if ($this->shouldBeExcluded($attribute)) {
-
                     break;
                 }
 
@@ -441,7 +440,7 @@ class Validator implements ValidatorContract
         }
         // Only remove attributes after having looped through all the rules, so that
         // the order of the attributes with applied "exclude" rule doesn't matter.
-        foreach ( $this->rules as $attribute => $rules ) {
+        foreach ($this->rules as $attribute => $rules) {
             if ($this->shouldBeExcluded($attribute)) {
                 $this->removeAttribute($attribute);
             }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -430,8 +430,6 @@ class Validator implements ValidatorContract
                 $this->validateAttribute($attribute, $rule);
 
                 if ($this->shouldBeExcluded($attribute)) {
-                    $this->removeAttribute($attribute);
-
                     break;
                 }
 
@@ -440,6 +438,12 @@ class Validator implements ValidatorContract
                 }
             }
         }
+        // Only remove attributes after having looped through all the rules, so that
+        // the order of the attributes with applied "exclude" rule doesn't matter.
+        foreach ($this->excludeAttributes as $attribute) {
+            $this->removeAttribute($attribute);
+        }
+
 
         // Here we will spin through all of the "after" hooks on this validator and
         // fire them off. This gives the callbacks a chance to perform all kinds

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -438,8 +438,7 @@ class Validator implements ValidatorContract
                 }
             }
         }
-        // Only remove attributes after having looped through all the rules, so that
-        // the order of the attributes with applied "exclude" rule doesn't matter.
+
         foreach ($this->rules as $attribute => $rules) {
             if ($this->shouldBeExcluded($attribute)) {
                 $this->removeAttribute($attribute);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -430,6 +430,7 @@ class Validator implements ValidatorContract
                 $this->validateAttribute($attribute, $rule);
 
                 if ($this->shouldBeExcluded($attribute)) {
+
                     break;
                 }
 
@@ -440,8 +441,10 @@ class Validator implements ValidatorContract
         }
         // Only remove attributes after having looped through all the rules, so that
         // the order of the attributes with applied "exclude" rule doesn't matter.
-        foreach ($this->excludeAttributes as $attribute) {
-            $this->removeAttribute($attribute);
+        foreach ( $this->rules as $attribute => $rules ) {
+            if ($this->shouldBeExcluded($attribute)) {
+                $this->removeAttribute($attribute);
+            }
         }
 
         // Here we will spin through all of the "after" hooks on this validator and

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -444,7 +444,6 @@ class Validator implements ValidatorContract
             $this->removeAttribute($attribute);
         }
 
-
         // Here we will spin through all of the "after" hooks on this validator and
         // fire them off. This gives the callbacks a chance to perform all kinds
         // of other validation that needs to get wrapped up in this operation.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8199,7 +8199,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedValidatedData, $validator->validated());
     }
 
-    public function testExcludeBeforeRequiredIf( )
+    public function testExcludeBeforeRequiredIf()
     {
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8199,6 +8199,39 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedValidatedData, $validator->validated());
     }
 
+    public function testExcludeBeforeRequiredIf( )
+    {
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            [
+                'profile_id' => null,
+                'type'       => 'denied',
+            ],
+            [
+                'type'       => ['required', 'string', 'exclude'],
+                'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
+            ],
+        );
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['profile_id' => null], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            [
+                'profile_id' => null,
+                'type'       => 'profile',
+            ],
+            [
+                'type'       => ['required', 'string', 'exclude'],
+                'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
+            ],
+        );
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame(['profile_id' => ['validation.required_if']], $validator->getMessageBag()->getMessages());
+    }
+
     public function testExcludingArrays()
     {
         $validator = new Validator(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8199,7 +8199,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedValidatedData, $validator->validated());
     }
 
-    public function testExcludeBeforeRequiredIf()
+    public function testExcludeBeforeADependentRule()
     {
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),


### PR DESCRIPTION
Hi, I finished #47622 PR and fixed the problem. As @onlime said, there was a problem when we use a validation rule that depends on another attribute while the other attribute has `exclude` validation rule.
In that situation, the excluded attribute must be placed after the attribute with dependent validation rule.
This PR fixed this problem and there is no need to consider the ordering.

```php
// WORKING:
[
    'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
    'type'       => ['required', 'string', 'exclude'],
],

// NON-WORKING, as 'type' is excluded before 'required_if' is checked in 'profile_id':
[
    'type'       => ['required', 'string', 'exclude'],
    'profile_id' => ['nullable', 'required_if:type,profile', 'integer'],
],
```