### PR TITLE
[10.x] Using complete insert for mysqldump when appending migration dump to schema file

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -53,7 +53,7 @@ class MySqlSchemaState extends SchemaState
     protected function appendMigrationData(string $path)
     {
         $process = $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand().' '.$this->migrationTable.' --no-create-info --skip-extended-insert --skip-routines --compact'
+            $this->baseDumpCommand().' '.$this->migrationTable.' --no-create-info --skip-extended-insert --skip-routines --compact --complete-insert'
         ), null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));


### PR DESCRIPTION
Because of a flickering issue in mysql dump what causes sometimes that the columns in an insert command were in a wrong order.  Fixing this issue can be done easily by adding the column names to the generated insert query.

See example 
```SQL
INSERT INTO `migrations` VALUES (1,1, '2023_08_09_120725_init_schema');
```
Which becomes the following after this change:
```SQL
INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (1,'2023_08_09_120725_init_schema',1);
```


