### PR TITLE
[10.x] Collection Ordinal Numbers

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
+use NumberFormatter;
 use stdClass;
 use Traversable;
 
@@ -147,6 +148,20 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         return $sorted->filter(fn ($value) => $value == $highestValue)
             ->sort()->keys()->all();
+    }
+
+    /**
+     * Get the ordinal number of the given items.
+     *
+     * @param string|null $locale
+     * @return self
+    */
+    public function ordinal($locale = null)
+    {
+        return $this
+            ->filter(fn ($item) => ! is_null($item))
+            ->map(fn ($value) => (new NumberFormatter($locale ?? Carbon::getLocale(), NumberFormatter::ORDINAL))->format($value))
+            ->values();
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -188,6 +188,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the ordinal number of the given items.
+     *
+     * @param  string|null  $locale
+     * @return self
+     */
+    public function ordinal($locale = null)
+    {
+        return $this->collect()->ordinal($locale);
+    }
+
+    /**
      * Collapse the collection of items into a single array.
      *
      * @return static<int, mixed>

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -24,6 +24,7 @@ use ReflectionClass;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
+use TypeError;
 use UnexpectedValueException;
 
 if (PHP_VERSION_ID >= 80100) {
@@ -4606,6 +4607,35 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection;
         $this->assertNull($data->mode());
+    }
+
+    /**
+    * @dataProvider collectionClassProvider
+    */
+    public function testOrdinalNumberOnEmptyCollectionReturnsEmpty($collection)
+    {
+        $data = new $collection;
+        $this->assertSame([], $data->ordinal()->toArray());
+    }
+
+    /**
+    * @dataProvider collectionClassProvider
+    */
+    public function testOrdinalNumber($collection)
+    {
+        $data = new $collection([1,2,3]);
+        $this->assertEquals(['1st', '2nd', '3rd'], $data->ordinal()->toArray());
+    }
+
+    /**
+    * @dataProvider collectionClassProvider
+    */
+    public function testItThrowsExceptionWhenPasstheStringItems($collection)
+    {
+        $data = new $collection(['first', 'second', 'third']);
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('NumberFormatter::format(): Argument #1 ($num) must be of type int|float, string given');
+        $data->ordinal();
     }
 
     /**


### PR DESCRIPTION
- Laravel provides mode, median and avg of the numbers. I have an idea to make ordinal numbers of the given collection.

- Yes, I have macro already. But sometimes I've work around it the other developers also need it. I don't know it is okay or not!! So..

```php
collect([1,2])->ordinal(); // '1st', '2nd'

collect([11, 32])->ordinal('fr'); // "11e", "2e"

collect(['Taylor', 1])->ordinal(); // throws TypeError  NumberFormatter::format(): Argument #1 ($num) must be of type int|float, string given.

collect([2.05, 3.05])->ordinal(); // "2nd", "3rd"
```
