### PR TITLE
[10.x] Fix LazyCollection::only() to avoid closing nested generators

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -943,10 +943,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                         yield $key => $value;
 
                         unset($keys[$key]);
-
-                        if (empty($keys)) {
-                            break;
-                        }
                     }
                 }
             }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -782,7 +782,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
             $collection->only(5, 6, 7);
         });
 
-        $this->assertEnumerates(8, function ($collection) {
+        $this->assertEnumeratesOnce(function ($collection) {
             $collection->only(5, 6, 7)->all();
         });
     }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -787,6 +787,26 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testOnlyDoesNotCloseGenerators()
+    {
+        $generator = function () {
+            yield 'foo' => 1;
+            yield 'bar' => 2;
+            yield 'baz' => 3;
+        };
+
+        $actual = LazyCollection::times(2, fn () => new LazyCollection(fn () => yield from $generator()))
+            ->map(fn (LazyCollection $nestedCollection) => $nestedCollection->only('foo', 'bar'))
+            ->toArray();
+
+        $expected = [
+            ['foo' => 1, 'bar' => 2],
+            ['foo' => 1, 'bar' => 2],
+        ];
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function testPadIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
This PR contains a fix for the `LazyCollection::only()` method.

When using `break` within *generators of generators*, we may end up closing nested generators. When this happens, we provoke a fatal error:

```
Cannot rewind a generator that was already run
```

Using `break` is safe when we are checking whether a generator is valid. If it's no longer valid, it makes sense to call break e.g.:

```php
// good use of break:

if (! $generator->valid()) {
    break;
}
```

Generators' design does not allow them to be run again once they are exhausted, that means that if we `break` the loop of a nested generator, the outer generator cannot iterate through it anymore and this provokes the previously mentioned fatal error.

The solution in this case is to continue the iteration without breaking it. When all the wanted keys are yielded, the condition `array_key_exists($key, $keys)` will check the key against an empty array. This will let us have an efficient iteration without the need of breaking it.