### PR TITLE
[10.x] Introducing replicate method for Laravel Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -426,6 +426,26 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Replicates the items in the collection and returns the new collection.
+     *
+     * @param int $times
+     * @return static<TValue, TKey>
+     */
+    public function replicate(int $times): static
+    {
+        $result = [];
+        for ($i = 0; $i < $times; $i++)
+        {
+            foreach ($this->items as $item)
+            {
+                $result[] = $item;
+            }
+        }
+
+        return new static($result);
+    }
+
+    /**
      * Remove an item from the collection by key.
      *
      * \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TKey>|TKey  $keys

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -426,7 +426,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Replicates the items in the collection and returns the new collection.
+     * Replicate the items in the collection and returns the new collection.
      *
      * @param int $times
      * @return static<TValue, TKey>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -511,6 +511,25 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Replicates the items in the collection and returns the new collection.
+     *
+     * @param int $times
+     * @return static<TValue, TKey>
+     */
+    public function replicate(int $times): static
+    {
+        return new static(function () use ($times) {
+            for ($i = 0; $i < $times; $i++)
+            {
+                foreach ($this as $item)
+                {
+                    yield $item;
+                }
+            }
+        });
+    }
+
+    /**
      * Get an item by key.
      *
      * @template TGetDefault

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -511,7 +511,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Replicates the items in the collection and returns the new collection.
+     * Replicate the items in the collection and returns the new collection.
      *
      * @param int $times
      * @return static<TValue, TKey>

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2138,8 +2138,8 @@ class SupportCollectionTest extends TestCase
     public function testReplicate($collection)
     {
         $data = new $collection([1, 2, 3]);
-        $copiedData = $data->replicate(3);
-        $this->assertEquals([1, 2, 3, 1, 2, 3, 1, 2, 3], $copiedData->toArray());
+        $replicatedData = $data->replicate(3);
+        $this->assertEquals([1, 2, 3, 1, 2, 3, 1, 2, 3], $replicatedData->toArray());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2135,6 +2135,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testReplicate($collection)
+    {
+        $data = new $collection([1, 2, 3]);
+        $copiedData = $data->replicate(3);
+        $this->assertEquals([1, 2, 3, 1, 2, 3, 1, 2, 3], $copiedData->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testChunk($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);


### PR DESCRIPTION
**Description**
Inspired by Python's list replication capabilities I implemented the `replicate` method on the Laravel Collection class, which allows users to replicate the elements of a collection of a specified number of times.

**Usage**
```php
$collection = collect([1, 2, 3]);
$replication = $collection->replicate(3);
// [1, 2, 3, 1, 2, 3, 1, 3, 4]
```

**Benefits**
Effortless creation of collections with repeated elements, which can be used in for example tests. Also people used to Python are familiar with the functionality. It does not break any existing code as its just an extra method on the Collection class.