### PR TITLE
Added getter for Http Kernel middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -510,6 +510,16 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Get the application's middleware.
+     *
+     * @return array
+     */
+    public function getMiddleware()
+    {
+        return $this->middleware;
+    }
+
+    /**
      * Get the application's route middleware groups.
      *
      * @return array

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -10,6 +10,13 @@ use PHPUnit\Framework\TestCase;
 
 class KernelTest extends TestCase
 {
+    public function testGetMiddleware()
+    {
+        $kernel = new Kernel($this->getApplication(), $this->getRouter());
+
+        $this->assertEquals([], $kernel->getMiddleware());
+    }
+
     public function testGetMiddlewareGroups()
     {
         $kernel = new Kernel($this->getApplication(), $this->getRouter());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi.

We have run into a barrier, where we have a desire to get the global middlewares of the Http Kernel, yet it seems it is protected, and there is no method to extract it. This PR adds a simple getter. 

I did notice there are already getters for the middlewareGroups property, so I figured it is safe to add the same API for the middleware property?

Since this adds a simple getter method, it is unlikely to have any breaking changes. The only breaking change I can imagine is if a project has extended the Http Kernel, and have a getMiddleware method with another signature.

I am however worried if the naming `getMiddleware` can result in confusion, as it only returns the middleware registered on the Http Kernel, and not middleware groups or route middlewares.
