### PR TITLE
[10.x] Add broadcastAs function at BroadcastNotificationCreated

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -130,6 +130,6 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return method_exists($this->notification, 'broadcastAs')
         ? $this->notification->broadcastAs()
-        : get_class($this->notification);;
+        : get_class($this->notification);
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -120,4 +120,16 @@ class BroadcastNotificationCreated implements ShouldBroadcast
                     ? $this->notification->broadcastType()
                     : get_class($this->notification);
     }
+
+    /**
+     * Get the event name of the notification being broadcast.
+     *
+     * @return string
+     */
+    public function broadcastAs()
+    {
+        return method_exists($this->notification, 'broadcastAs')
+        ? $this->notification->broadcastAs()
+        : get_class($this->notification);;
+    }
 }


### PR DESCRIPTION
I add this function so it will get the broadcast event name as the same way it does for other events.

I needed this, because I wanted to specify the event name , and without this function, it will get only the class name.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
