### PR TITLE
[slim-skeleton-11.x] Adds `Artisan::command(...)->...` schedule methods

### DIFF
--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -4,12 +4,19 @@ namespace Illuminate\Foundation\Console;
 
 use Closure;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schedule;
+use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionFunction;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @mixin \Illuminate\Console\Scheduling\Event
+ */
 class ClosureCommand extends Command
 {
+    use ForwardsCalls;
+
     /**
      * The command callback.
      *
@@ -78,5 +85,30 @@ class ClosureCommand extends Command
         $this->setDescription($description);
 
         return $this;
+    }
+
+    /**
+     * Creates a new scheduled event for the command.
+     *
+     * @param  array $parameters
+     * @return \Illuminate\Console\Scheduling\Event
+     */
+    public function schedule($parameters = [])
+    {
+        return Schedule::command($this->name, $parameters);
+    }
+
+    /**
+     * Dynamically handle calls into a new scheduled event.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->schedule(), $method, $parameters);
     }
 }

--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -88,7 +88,7 @@ class ClosureCommand extends Command
     }
 
     /**
-     * Creates a new scheduled event for the command.
+     * Create a new scheduled event for the command.
      *
      * @param  array  $parameters
      * @return \Illuminate\Console\Scheduling\Event
@@ -99,7 +99,7 @@ class ClosureCommand extends Command
     }
 
     /**
-     * Dynamically handle calls into a new scheduled event.
+     * Dynamically proxy calls to a new scheduled event.
      *
      * @param  string  $method
      * @param  array  $parameters

--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -90,7 +90,7 @@ class ClosureCommand extends Command
     /**
      * Creates a new scheduled event for the command.
      *
-     * @param  array $parameters
+     * @param  array  $parameters
      * @return \Illuminate\Console\Scheduling\Event
      */
     public function schedule($parameters = [])

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -132,7 +132,8 @@ class ScheduleListCommandTest extends TestCase
 
     public function testClosureCommandsMayBeScheduled()
     {
-        $closure = function () {};
+        $closure = function () {
+        };
 
         Artisan::command('one', $closure)->weekly()->everySecond();
         Artisan::command('two', $closure)->everyTwoSeconds();

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ProcessUtils;
 use Orchestra\Testbench\TestCase;
 
@@ -127,6 +128,29 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * * * * * 15s  php artisan inspire ........... Next Due: 15 seconds from now')
             ->expectsOutput('  * * * * * 20s  php artisan inspire ........... Next Due: 20 seconds from now')
             ->expectsOutput('  * * * * * 30s  php artisan inspire ........... Next Due: 30 seconds from now');
+    }
+
+    public function testClosureCommandsMayBeScheduled()
+    {
+        $closure = function () {};
+
+        Artisan::command('one', $closure)->weekly()->everySecond();
+        Artisan::command('two', $closure)->everyTwoSeconds();
+        Artisan::command('three', $closure)->everyFiveSeconds();
+        Artisan::command('four', $closure)->everyTenSeconds();
+        Artisan::command('five', $closure)->everyFifteenSeconds();
+        Artisan::command('six', $closure)->everyTwentySeconds()->hourly();
+        Artisan::command('six', $closure)->everyThreeHours()->everySecond();
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('  * 0   * * 0 1s   php artisan one ............... Next Due: 1 second from now')
+            ->expectsOutput('  * *   * * * 2s   php artisan two .............. Next Due: 2 seconds from now')
+            ->expectsOutput('  * *   * * * 5s   php artisan three ............ Next Due: 5 seconds from now')
+            ->expectsOutput('  * *   * * * 10s  php artisan four ............ Next Due: 10 seconds from now')
+            ->expectsOutput('  * *   * * * 15s  php artisan five ............ Next Due: 15 seconds from now')
+            ->expectsOutput('  0 *   * * * 20s  php artisan six ............. Next Due: 20 seconds from now')
+            ->expectsOutput('  * */3 * * * 1s   php artisan six ............... Next Due: 1 second from now');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This pull request continues the work on making the skeleton more "slim", by allowing to chain schedule methods directly on the `Artisan::command` call. Here is an example, on the `console.php`:

```php
Artisan::command('inspire', function () {
    $this->comment(Inspiring::quote());
})->purpose('Display an inspiring quote')->hourly();
```

Optionally, users may also pass "arguments" to the closure command, my prefixing the schedule call to the schedule methods command:

```php
Artisan::command('inspire {name}', function () {
    //
})->purpose('Display an inspiring quote')->schedule(['name' => 'taylor']->hourly();
```

If this pull request gets merged, here is the following pull request that adjusts this skeleton: https://github.com/laravel/laravel/pull/6230.