### PR TITLE
[10.x] Add Contract/Interface for Redirector class

### DIFF
--- a/src/Illuminate/Contracts/Routing/Redirector.php
+++ b/src/Illuminate/Contracts/Routing/Redirector.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Routing;
+
+interface Redirector
+{
+    /**
+     * Create a new redirect response to the previous location.
+     *
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  mixed  $fallback
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function back($status = 302, $headers = [], $fallback = false);
+
+    /**
+     * Create a new redirect response to the current URI.
+     *
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function refresh($status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response, while putting the current URL in the session.
+     *
+     * @param  string  $path
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function guest($path, $status = 302, $headers = [], $secure = null);
+
+    /**
+     * Create a new redirect response to the previously intended location.
+     *
+     * @param  mixed  $default
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function intended($default = '/', $status = 302, $headers = [], $secure = null);
+
+    /**
+     * Create a new redirect response to the given path.
+     *
+     * @param  string  $path
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function to($path, $status = 302, $headers = [], $secure = null);
+
+    /**
+     * Create a new redirect response to an external URL (no validation).
+     *
+     * @param  string  $path
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function away($path, $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to the given HTTPS path.
+     *
+     * @param  string  $path
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function secure($path, $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to a named route.
+     *
+     * @param  string  $route
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function route($route, $parameters = [], $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to a signed named route.
+     *
+     * @param  string  $route
+     * @param  mixed  $parameters
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function signedRoute($route, $parameters = [], $expiration = null, $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to a signed named route.
+     *
+     * @param  string  $route
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function temporarySignedRoute($route, $expiration, $parameters = [], $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to a controller action.
+     *
+     * @param  string|array  $action
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function action($action, $parameters = [], $status = 302, $headers = []);
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1438,7 +1438,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             'queue' => [\Illuminate\Queue\QueueManager::class, \Illuminate\Contracts\Queue\Factory::class, \Illuminate\Contracts\Queue\Monitor::class],
             'queue.connection' => [\Illuminate\Contracts\Queue\Queue::class],
             'queue.failer' => [\Illuminate\Queue\Failed\FailedJobProviderInterface::class],
-            'redirect' => [\Illuminate\Routing\Redirector::class],
+            'redirect' => [\Illuminate\Routing\Redirector::class, \Illuminate\Contracts\Routing\Redirector::class],
             'redis' => [\Illuminate\Redis\RedisManager::class, \Illuminate\Contracts\Redis\Factory::class],
             'redis.connection' => [\Illuminate\Redis\Connections\Connection::class, \Illuminate\Contracts\Redis\Connection::class],
             'request' => [\Illuminate\Http\Request::class, \Symfony\Component\HttpFoundation\Request::class],

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Contracts\Routing\Redirector as RedirectorContract;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Traits\Macroable;
 
-class Redirector
+class Redirector implements RedirectorContract
 {
     use Macroable;
 


### PR DESCRIPTION
Almost all Laravel class implementations adhere to some interface or contract. That is not the case for the redirector, making it difficult to add a custom implementation. This PR adds a Contract/Interface for the Redirector allowing extensibility.

The signature for "setRedirector" on the FormRequest class and the FormRequestServiceProvider were not changed as those are backwards incompatible changes that should be released in a major version. I can open a PR for that on the 11.x branch?