### PR TITLE
[10.x] Implement password generation constraints through rules

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -812,29 +812,67 @@ class Str
      * @param  bool  $numbers
      * @param  bool  $symbols
      * @param  bool  $spaces
+     * @param  array $rules
      * @return string
      */
-    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
+    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false, $rules = [])
     {
-        return (new Collection)
-                ->when($letters, fn ($c) => $c->merge([
-                    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-                    'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                    'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-                    'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
-                    'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-                ]))
-                ->when($numbers, fn ($c) => $c->merge([
-                    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-                ]))
-                ->when($symbols, fn ($c) => $c->merge([
-                    '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
-                    '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
-                    ']', '|', ':', ';',
-                ]))
-                ->when($spaces, fn ($c) => $c->merge([' ']))
+        $letters_collection = collect([
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+            'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+            'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
+            'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+            'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        ]);
+
+        $numbers_collection = collect([
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        ]);
+
+        $symbols_collection = collect([
+            '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
+            '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
+            ']', '|', ':', ';',
+        ]);
+
+        $all_collections = [
+            'letters' => $letters_collection,
+            'numbers' => $numbers_collection,
+            'symbols' => $symbols_collection,
+            'spaces' => [' '],
+        ];
+
+        $initial_values = [];
+        $initial_keys = [];
+
+        for ($i = 0; $i < count($rules); $i++){
+            $initial_keys[] = $i;
+        }
+
+        foreach ($all_collections as $rule => $collection) {
+            if (in_array($rule, $rules)) {
+                $random_value = $collection[random_int(0, count($collection) - 1)];
+                $key = random_int(0, count($initial_keys) - 1);
+                $initial_values[$initial_keys[$key]] = $random_value;
+
+                unset($initial_keys[$key]);
+                $initial_keys = array_values($initial_keys);
+            }
+        }
+
+        $length = $length - count($initial_values);
+
+        $password_chars = (new Collection)
+                ->when($letters, fn ($c) => $c->merge($letters_collection))
+                ->when($numbers, fn ($c) => $c->merge($numbers_collection))
+                ->when($symbols, fn($c) => $c->merge($symbols_collection))
+                ->when($spaces, fn($c) => $c->merge([' ']))
                 ->pipe(fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)]))
-                ->implode('');
+                ->merge($initial_values)
+                ->toArray();
+
+        usort($password_chars, fn() => random_int(-1, 1));
+        return collect($password_chars)->implode('');
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1131,6 +1131,23 @@ class SupportStrTest extends TestCase
     public function testPasswordCreation()
     {
         $this->assertTrue(strlen(Str::password()) === 32);
+
+        $rules = ['letters', 'numbers', 'symbols', 'spaces'];
+        $password = Str::password(16, true, true, true, true, $rules);
+
+        $this->assertTrue(strlen($password) === 16);
+
+        # contains letter
+        $this->assertTrue(preg_match('/[a-zA-Z]/', $password) === 1);
+
+        # contains number
+        $this->assertTrue(preg_match('/[0-9]/', $password) === 1);
+
+        # contains symbol
+        $this->assertTrue(preg_match('/[~!#\$%\^&\*\(\)\-_.,<>\?\/\\\{\}\[\]\|:;]/', $password) === 1);
+
+        # contains space
+        $this->assertTrue(strpos($password, ' ') > -1);
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1132,8 +1132,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(strlen(Str::password()) === 32);
 
-        $rules = ['letters', 'numbers', 'symbols', 'spaces'];
-        $password = Str::password(16, true, true, true, true, $rules);
+        $password = Str::password(16, true, true, true, true, true);
 
         $this->assertTrue(strlen($password) === 16);
 


### PR DESCRIPTION
### Minor update of [Str::password()](https://laravel.com/docs/10.x/helpers#method-str-password) method 

The aim is to empower end users with the capability to define password generation rules. These rules allow to specify whether the generated password should include letters, numbers, symbols, or spaces by passing an array of such rules.

Although users can already instruct the generator to include these elements, there's no guarantee that the generated password will adhere to the validation rules set for the web app. This update addresses this concern by enabling alignment between the generator and the web app's password validation rules.

Existing logic has been preserved, incorporating specific modifications to introduce rules-based restrictions.
Old usage remains unaffected by this update.
