### PR TITLE
[10.x] Adds testing helpers for Precognition

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -314,7 +314,7 @@ trait MakesHttpRequests
      *
      * @return $this
      */
-    public function usingPrecognition()
+    public function withPrecognition()
     {
         return $this->withHeader('Precognition', 'true');
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -310,7 +310,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the precognition header.
+     * Set the Laravel Precognition header to "true".
      *
      * @return $this
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -310,7 +310,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the Laravel Precognition header to "true".
+     * Set the Precognition header to "true".
      *
      * @return $this
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -310,7 +310,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the precognition header
+     * Set the precognition header.
      *
      * @return $this
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -310,6 +310,16 @@ trait MakesHttpRequests
     }
 
     /**
+     * Set the precognition header
+     *
+     * @return $this
+     */
+    public function usingPrecognition()
+    {
+        return $this->withHeader('Precognition', 'true');
+    }
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1418,7 +1418,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the Precognition request was successful
+     * Assert that the Precognition request was successful.
      *
      * @return $this
      */

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1418,6 +1418,25 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the Precognition request was successful
+     *
+     * @return $this
+     */
+    public function assertPrecognitionSuccess()
+    {
+        PHPUnit::assertTrue(
+            $this->headers->has('Precognition-Success'), 'Precognition-Success Header not present on response.'
+        );
+
+        PHPUnit::assertSame(
+            'True', $this->headers->get('Precognition-Success'),
+            'Precognition-Success Header was found, but the value is not `True`.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Get the current session store.
      *
      * @return \Illuminate\Session\Store

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -96,6 +96,29 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the Precognition request was successful.
+     *
+     * @return $this
+     */
+    public function assertSuccessfulPrecognition()
+    {
+        $this->assertNoContent();
+
+        PHPUnit::assertTrue(
+            $this->headers->has('Precognition-Success'),
+            'Header [Precognition-Success] not present on response.'
+        );
+
+        PHPUnit::assertSame(
+            'true',
+            $this->headers->get('Precognition-Success'),
+            'The Precognition-Success header was found, but the value is not `true`.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response is a server error.
      *
      * @return $this
@@ -1413,27 +1436,6 @@ class TestResponse implements ArrayAccess
                 "Session has unexpected key [{$key}]."
             );
         }
-
-        return $this;
-    }
-
-    /**
-     * Assert that the Precognition request was successful.
-     *
-     * @return $this
-     */
-    public function assertPrecognitionSuccess()
-    {
-        $this->assertNoContent();
-
-        PHPUnit::assertTrue(
-            $this->headers->has('Precognition-Success'), 'Precognition-Success Header not present on response.'
-        );
-
-        PHPUnit::assertSame(
-            'true', $this->headers->get('Precognition-Success'),
-            'Precognition-Success Header was found, but the value is not `true`.'
-        );
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1424,6 +1424,8 @@ class TestResponse implements ArrayAccess
      */
     public function assertPrecognitionSuccess()
     {
+        $this->assertNoContent();
+        
         PHPUnit::assertTrue(
             $this->headers->has('Precognition-Success'), 'Precognition-Success Header not present on response.'
         );

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1429,8 +1429,8 @@ class TestResponse implements ArrayAccess
         );
 
         PHPUnit::assertSame(
-            'True', $this->headers->get('Precognition-Success'),
-            'Precognition-Success Header was found, but the value is not `True`.'
+            'true', $this->headers->get('Precognition-Success'),
+            'Precognition-Success Header was found, but the value is not `true`.'
         );
 
         return $this;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1425,7 +1425,7 @@ class TestResponse implements ArrayAccess
     public function assertPrecognitionSuccess()
     {
         $this->assertNoContent();
-        
+
         PHPUnit::assertTrue(
             $this->headers->has('Precognition-Success'), 'Precognition-Success Header not present on response.'
         );

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Http\RedirectResponse;
 use Orchestra\Testbench\TestCase;
 
@@ -190,8 +191,14 @@ class MakesHttpRequestsTest extends TestCase
     public function testWithPrecognition()
     {
         $this->withPrecognition();
-
         $this->assertSame('true', $this->defaultHeaders['Precognition']);
+
+        $this->app->make(Registrar::class)
+            ->get('test-route', fn () => 'ok')->middleware(HandlePrecognitiveRequests::class);
+        $this->get('test-route')
+            ->assertStatus(204)
+            ->assertHeader('Precognition', 'true')
+            ->assertHeader('Precognition-Success', 'true');
     }
 }
 

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -186,6 +186,13 @@ class MakesHttpRequestsTest extends TestCase
 
         $this->assertEquals(['from', 'to'], $callOrder);
     }
+
+    public function testUsingPrecognition()
+    {
+        $this->usingPrecognition();
+
+        $this->assertSame('true', $this->defaultHeaders['Precognition']);
+    }
 }
 
 class MyMiddleware

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -187,9 +187,9 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertEquals(['from', 'to'], $callOrder);
     }
 
-    public function testUsingPrecognition()
+    public function testWithPrecognition()
     {
-        $this->usingPrecognition();
+        $this->withPrecognition();
 
         $this->assertSame('true', $this->defaultHeaders['Precognition']);
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1040,7 +1040,7 @@ class TestResponseTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Precognition-Success Header not present on response.');
 
-        $baseResponse = new Response();
+        $baseResponse = new Response('', 204);
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
@@ -1052,7 +1052,7 @@ class TestResponseTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Precognition-Success Header was found, but the value is not `true`.');
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response('', 204), function ($response) {
             $response->header('Precognition-Success', '');
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1050,7 +1050,7 @@ class TestResponseTest extends TestCase
     public function testAssertPrecognitionSuccessfulWithIncorrectValue()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Precognition-Success Header was found, but the value is not `True`.');
+        $this->expectExceptionMessage('Precognition-Success Header was found, but the value is not `true`.');
 
         $baseResponse = tap(new Response, function ($response) {
             $response->header('Precognition-Success', '');

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1038,19 +1038,19 @@ class TestResponseTest extends TestCase
     public function testAssertPrecognitionSuccessfulWithMissingHeader()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Precognition-Success Header not present on response.');
+        $this->expectExceptionMessage('Header [Precognition-Success] not present on response.');
 
         $baseResponse = new Response('', 204);
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
-        $response->assertPrecognitionSuccess();
+        $response->assertSuccessfulPrecognition();
     }
 
     public function testAssertPrecognitionSuccessfulWithIncorrectValue()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Precognition-Success Header was found, but the value is not `true`.');
+        $this->expectExceptionMessage('The Precognition-Success header was found, but the value is not `true`.');
 
         $baseResponse = tap(new Response('', 204), function ($response) {
             $response->header('Precognition-Success', '');
@@ -1058,7 +1058,7 @@ class TestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse($baseResponse);
 
-        $response->assertPrecognitionSuccess();
+        $response->assertSuccessfulPrecognition();
     }
 
     public function testAssertJsonWithArray()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1035,6 +1035,32 @@ class TestResponseTest extends TestCase
         $response->assertHeaderMissing('Location');
     }
 
+    public function testAssertPrecognitionSuccessfulWithMissingHeader()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Precognition-Success Header not present on response.');
+
+        $baseResponse = new Response();
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertPrecognitionSuccess();
+    }
+
+    public function testAssertPrecognitionSuccessfulWithIncorrectValue()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Precognition-Success Header was found, but the value is not `True`.');
+
+        $baseResponse = tap(new Response, function ($response) {
+            $response->header('Precognition-Success', '');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertPrecognitionSuccess();
+    }
+
     public function testAssertJsonWithArray()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
This should help anyone wanting to write a test for an endpoint using Precognition.

```php
$this->usingPrecognition()
    ->get('/')
    ->assertPrecognitionSuccess();
```
