### PR TITLE
[10.x] Allow sending http requests quietly without raising any events

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -79,7 +79,7 @@ class Factory
      */
     public function __construct(Dispatcher $dispatcher = null)
     {
-        $this->dispatcher = $dispatcher;
+        $this->setDispatcher($dispatcher);
 
         $this->stubCallbacks = collect();
     }
@@ -411,6 +411,19 @@ class Factory
     public function getDispatcher()
     {
         return $this->dispatcher;
+    }
+
+    /**
+     * Set the current event dispatcher implementation.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
+     * @return $this
+     */
+    public function setDispatcher(Dispatcher $dispatcher = null)
+    {
+        $this->dispatcher = $dispatcher;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\UriTemplate\UriTemplate;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Events\NullDispatcher;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
@@ -1345,6 +1346,20 @@ class PendingRequest
     public function getPromise()
     {
         return $this->promise;
+    }
+
+    /**
+     * Send the request without raising any events.
+     *
+     * @return $this
+     */
+    public function quietly()
+    {
+        if ($dispatcher = $this->getDispatcher()) {
+            $this->factory->setDispatcher(new NullDispatcher($dispatcher));
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -50,7 +50,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int $seconds)
- * @method static \Illuminate\Http\Client\PendingRequest quietly(bool $quite = true)
+ * @method static \Illuminate\Http\Client\PendingRequest quietly()
  * @method static \Illuminate\Http\Client\PendingRequest connectTimeout(int $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, \Closure|int $sleepMilliseconds = 0, callable|null $when = null, bool $throw = true)
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -50,6 +50,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int $seconds)
+ * @method static \Illuminate\Http\Client\PendingRequest quietly(bool $quite = true)
  * @method static \Illuminate\Http\Client\PendingRequest connectTimeout(int $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, \Closure|int $sleepMilliseconds = 0, callable|null $when = null, bool $throw = true)
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
*Why?*
I have a use case where I listen on `ResponseReceived` event that is fired in `src/Illuminate/Http/Client/PendingRequest.php@dispatchResponseReceivedEvent` and based on the provided info I send another request to our logging DB, but with that scenario in mind it will trigger an infinite loop sending logs to the logging DB.

*How?*
I found that the simplest way would be setting the event dispatcher to null dispatcher, So the tests will pass without any issues

Example usage
```php
Http::quietly()->get('https://laravel.com/'); // will not dispatch ResponseReceived event
Http::get('https://laravel.com/'); // will dispatch ResponseReceived event
```

We can also get the same result with this approach
```php
$request = new PendingRequest();
$request->timeout(10)->post($url, $data)->throw();
```
But the introduced approach seems more laravel way to me