### PR TITLE
[10.x] Fix flaky test using microtime

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -847,7 +847,7 @@ class SupportHelpersTest extends TestCase
 
         Sleep::assertSequence([
             Sleep::usleep(100_000),
-        ]) ;
+        ]);
     }
 
     public function testRetryWithFailingWhenCallback()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -8,6 +8,7 @@ use Countable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Stringable;
 use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
@@ -775,7 +776,7 @@ class SupportHelpersTest extends TestCase
 
     public function testRetry()
     {
-        $startTime = microtime(true);
+        Sleep::fake();
 
         $attempts = retry(2, function ($attempts) {
             if ($attempts > 1) {
@@ -789,12 +790,16 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
-        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.03);
+        Sleep::assertSleptTimes(1);
+
+        Sleep::assertSequence([
+            Sleep::usleep(100_000),
+        ]);
     }
 
     public function testRetryWithPassingSleepCallback()
     {
-        $startTime = microtime(true);
+        Sleep::fake();
 
         $attempts = retry(3, function ($attempts) {
             if ($attempts > 2) {
@@ -812,12 +817,17 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(3, $attempts);
 
         // Make sure we waited 300ms for the first two attempts
-        $this->assertEqualsWithDelta(0.3, microtime(true) - $startTime, 0.03);
+        Sleep::assertSleptTimes(2);
+
+        Sleep::assertSequence([
+            Sleep::usleep(100_000),
+            Sleep::usleep(200_000),
+        ]);
     }
 
     public function testRetryWithPassingWhenCallback()
     {
-        $startTime = microtime(true);
+        Sleep::fake();
 
         $attempts = retry(2, function ($attempts) {
             if ($attempts > 1) {
@@ -833,7 +843,11 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
-        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.03);
+        Sleep::assertSleptTimes(1);
+
+        Sleep::assertSequence([
+            Sleep::usleep(100_000),
+        ]) ;
     }
 
     public function testRetryWithFailingWhenCallback()
@@ -853,7 +867,8 @@ class SupportHelpersTest extends TestCase
 
     public function testRetryWithBackoff()
     {
-        $startTime = microtime(true);
+        Sleep::fake();
+
         $attempts = retry([50, 100, 200], function ($attempts) {
             if ($attempts > 3) {
                 return $attempts;
@@ -865,7 +880,13 @@ class SupportHelpersTest extends TestCase
         // Make sure we made four attempts
         $this->assertEquals(4, $attempts);
 
-        $this->assertEqualsWithDelta(0.05 + 0.1 + 0.2, microtime(true) - $startTime, 0.05);
+        Sleep::assertSleptTimes(3);
+
+        Sleep::assertSequence([
+            Sleep::usleep(50_000),
+            Sleep::usleep(100_000),
+            Sleep::usleep(200_000),
+        ]);
     }
 
     public function testTransform()


### PR DESCRIPTION
### Fixed

- [internal] While working on https://github.com/laravel/framework/pull/48144#issuecomment-1690259463, I noticed this test was flaky. By switching to using the `Sleep::fake()` feature, we avoid that flakiness