### PR TITLE
[10.x] Add http client `Response::only()`

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
+use stdClass;
 
 class Response implements ArrayAccess
 {
@@ -80,6 +82,31 @@ class Response implements ArrayAccess
         }
 
         return data_get($this->decoded, $key, $default);
+    }
+
+    /**
+     * Get a subset containing the provided keys with values from the decoded body.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function only($keys)
+    {
+        $results = [];
+
+        $input = $this->json();
+
+        $placeholder = new stdClass;
+
+        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
+            $value = data_get($input, $key, $placeholder);
+
+            if ($value !== $placeholder) {
+                Arr::set($results, $key, $value);
+            }
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -267,6 +267,26 @@ class HttpClientTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $response['result']);
     }
 
+    public function testResponseOnlyGetter()
+    {
+        $response = $this->factory
+            ->fake(['*' => ['name' => 'Taylor', 'age' => null]])
+            ->get('http://foo.com/api');
+
+        $this->assertEquals(['name' => 'Taylor', 'age' => null], $response->only('name', 'age', 'email'));
+    }
+
+    public function testResponseOnlyGetterWithObjectSubkey()
+    {
+        $response = $this->factory
+            ->fake(['*' => ['developer' => ['name' => 'Taylor', 'age' => null]]])
+            ->get('http://foo.com/api');
+
+        $this->assertEquals(['developer' => ['name' => 'Taylor']], $response->only('developer.name', 'developer.skills'));
+        $this->assertEquals(['developer' => ['age' => null]], $response->only('developer.age'));
+        $this->assertEquals([], $response->only('developer.skills'));
+    }
+
     public function testResponseObjectAsArray()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR adds `Response::only()` helper for http client, similar to http request `Request::only()`.

Reference:
https://github.com/laravel/framework/blob/38434a778d48b9f64dae67f7ca4cf116878fedfb/src/Illuminate/Http/Concerns/InteractsWithInput.php#L424-L447

Tests are simliar but adjusted.
