### PR TITLE
[10.x] Enhancing `updateOrCreate()` to Use `firstOrCreate()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -595,8 +595,10 @@ class Builder implements BuilderContract
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
-            $instance->fill($values)->save();
+        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+            if (! $instance->wasRecentlyCreated) {
+                $instance->fill($values)->save();
+            }
         });
     }
 


### PR DESCRIPTION
# Summary

This PR proposes a modification to the `updateOrCreate()` method in line with recent changes brought by the introduction of the `createOrFirst()` method.

# Details

- #47973
  - #48144

In the previous PR by @tonysm, the `firstOrCreate()` method was enhanced to leverage `createOrFirst()`, making it more race-condition resistant, especially in highly concurrent environments. This was achieved by attempting to create a record first and, if encountering a unique constraint violation, falling back to find the matching record. This robust approach, however, was not mirrored in the `updateOrCreate()` method.

To address this and bring consistency:

```php
public function updateOrCreate(array $attributes, array $values = [])
{
    return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
        if (!$instance->wasRecentlyCreated) {
            $instance->fill($values)->save();
        }
    });
}
```

By doing this, the `updateOrCreate()` method will now utilize the enhanced `firstOrCreate()`, making it more resilient against potential race conditions and ensuring that both methods share a unified and robust approach in concurrent situations.



