### PR TITLE
[10.x] Ensuring Primary Reference on Retry in `createOrFirst()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -582,7 +582,7 @@ class Builder implements BuilderContract
         try {
             return $this->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values)));
         } catch (UniqueConstraintViolationException $exception) {
-            return $this->where($attributes)->first();
+            return $this->useWritePdo()->where($attributes)->first();
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -653,7 +653,7 @@ class BelongsToMany extends Relation
                 $this->getQuery()->withSavepointIfNeeded(fn () => $this->attach($instance, $joining, $touch));
             });
         } catch (UniqueConstraintViolationException $exception) {
-            return (clone $this)->where($attributes)->first();
+            return (clone $this)->useWritePdo()->where($attributes)->first();
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -254,7 +254,7 @@ abstract class HasOneOrMany extends Relation
         try {
             return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values)));
         } catch (UniqueConstraintViolationException $exception) {
-            return $this->where($attributes)->first();
+            return $this->useWritePdo()->where($attributes)->first();
         }
     }
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -184,6 +184,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
             return $scope();
         });
+        $relation->getQuery()->shouldReceive('useWritePdo')->once()->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(stdClass::class));
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -230,6 +230,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
             return $scope();
         });
+        $relation->getQuery()->shouldReceive('useWritePdo')->once()->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
 
@@ -250,6 +251,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
             return $scope();
         });
+        $relation->getQuery()->shouldReceive('useWritePdo')->once()->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
 


### PR DESCRIPTION
# Summary

This PR refines the `createOrFirst()` method to guarantee referencing the primary database when re-attempting record retrieval after a `UniqueConstraintViolationException`.

# Details:

- #47973
  - #48144

The existing `createOrFirst()` method, when facing a unique constraint violation, retries by fetching the matching record. However, in environments with replication, there's no assurance that the newly created record is immediately available on replicas due to possible replication lags.

To address this:

```php
public function createOrFirst(array $attributes = [], array $values = [])
{
    try {
        return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values)));
    } catch (UniqueConstraintViolationException $exception) {
        return $this->useWritePdo()->where($attributes)->first();
    }
}
```

With this change, in case of a retry, the method explicitly references the primary database using `useWritePdo()`, ensuring immediate and accurate record retrieval without being affected by replication delays.
