### PR TITLE
[10.x] Improve typehint for Illuminate\Cache\Repository::remember()

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -378,7 +378,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue


### PR DESCRIPTION
Both methods used in `remember()` have `array|string` typehint, for some reason `remember()` doesn't:

![image](https://github.com/laravel/framework/assets/44755807/83137882-c242-4806-9865-26a65169533e)
![image](https://github.com/laravel/framework/assets/44755807/7e88fde8-6e48-42a0-b557-acf080dd318c)
