### PR TITLE
[10.x] Fix flakey `HttpClientTest` test

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use JsonSerializable;
 use Mockery as m;
@@ -1715,7 +1716,7 @@ class HttpClientTest extends TestCase
 
     public function testRequestsWillBeWaitingSleepMillisecondsReceivedBeforeRetry()
     {
-        $startTime = microtime(true);
+        Sleep::fake();
 
         $this->factory->fake([
             '*' => $this->factory->sequence()
@@ -1734,8 +1735,13 @@ class HttpClientTest extends TestCase
 
         $this->factory->assertSentCount(3);
 
-        // Make sure was waited 300ms for the first two attempts
-        $this->assertEqualsWithDelta(0.3, microtime(true) - $startTime, 0.03);
+        // Make sure we waited 300ms for the first two attempts
+        Sleep::assertSleptTimes(2);
+
+        Sleep::assertSequence([
+            Sleep::usleep(100_000),
+            Sleep::usleep(200_000),
+        ]);
     }
 
     public function testMiddlewareRunsWhenFaked()


### PR DESCRIPTION
Similar to #48156. This PR replaces the use of `$startTime = microtime(true);` with `Sleep::fake()`.

The updated test in `HttpClientTest` was failing with the following:

```
Failed asserting that 0.33161306381225586 matches expected 0.3.

Expected: 0.3
Actual: 0.33161306381226
```