### PR TITLE
[10.x] Add an encoding check string utility and a validator that uses it

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -421,6 +421,26 @@ class Str
     }
 
     /**
+     * Determine if a given string is valid in a specified encoding.
+     *
+     * @param  string  $value
+     * @param  string  $encoding
+     * @return bool
+     */
+    public static function isEncoding(string $value, string $encoding = 'UTF-8'): bool
+    {
+        if ($value === '') {
+            return true;
+        }
+        if (! in_array($encoding, mb_list_encodings(), true)) {
+            //Non-existent encoding
+            return false;
+        }
+
+        return mb_check_encoding($value, $encoding);
+    }
+
+    /**
      * Determine if a given value is valid JSON.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -161,6 +161,21 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is valid in a specific encoding.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateEncoding($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'encoding');
+
+        return Str::isEncoding((string) $value, $parameters[0]);
+    }
+
+    /**
      * "Break" on first validation fail.
      *
      * Always returns true, just lets us put "bail" in rules.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -871,6 +871,31 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::slug(null));
     }
 
+    public function testIsEncoding()
+    {
+        $isoe = "\xE9"; //é in ISO-8859-1
+        $utf8e = "\xC3\xA9"; //é in UTF-8
+        $this->assertTrue(Str::isEncoding('e', 'ASCII'));
+        $this->assertFalse(Str::isEncoding('é', 'ASCII'));
+        $this->assertTrue(Str::isEncoding('é'));
+        $this->assertTrue(Str::isEncoding('é', 'UTF-8'));
+        $this->assertTrue(Str::isEncoding($isoe, 'ISO-8859-1'));
+        //This is unfortunately sad but true
+        $this->assertTrue(Str::isEncoding($utf8e, 'ISO-8859-1'));
+        $this->assertTrue(Str::isEncoding($isoe, 'Windows-1252'));
+        $this->assertFalse(Str::isEncoding($isoe, 'UTF-8'));
+        $this->assertFalse(Str::isEncoding($isoe));
+        $this->assertFalse(Str::isEncoding('e', 'invalid encoding'));
+        $this->assertFalse(Str::isEncoding('e', ''));
+        $this->assertFalse(Str::isEncoding('é', '7bit'));
+    }
+
+    public function testIsEncodingNull()
+    {
+        $this->expectException(\TypeError::class);
+        $this->assertFalse(Str::isEncoding(null));
+    }
+
     public function testPadBoth()
     {
         $this->assertSame('__Alien___', Str::padBoth('Alien', 10, '_'));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7850,6 +7850,23 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateWithValidEncoding()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'é'], ['foo' => 'encoding:UTF-8']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidateWithInvalidEncoding()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'é'], ['foo' => 'encoding:ASCII']);
+        $this->assertFalse($v->passes());
+        //"\xE9" is é in ISO-8859-1
+        $v = new Validator($trans, ['foo' => "\xE9"], ['foo' => 'encoding:UTF-8']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateWithValidUlid()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Laravel has an `ascii` validator that checks whether a value (string, or other type converted to string) is valid ASCII. However, there are no validators or support methods to check for any other character set (apart from some specific cases like `alpha_num`).

The mbstring extension provides the [`mb_check_encoding`](https://www.php.net/manual/en/function.mb-check-encoding.php) function that will check whether a string is valid in a given encoding. In the same approach to other methods in the `Str` support class, I have wrapped this function to work the same way as the `isAscii` method.

This method allows you to check whether a string is valid in a given encoding:

    $isValid = Str::isEncoding("\xE9", 'ISO-8859-1'); //é in ISO-8859-1

The selected encoding is checked before use using the [`mb_list_encodings`](https://www.php.net/manual/en/function.mb-list-encodings.php) function; a non-existent encoding will result in a `false` return value. An empty string will always return `true` (same behaviour as the `isAscii` method).

I've added a validator that uses this new method as a validator using the `encoding` name, so you can define a validator rule like:

    'foo' => 'encoding:UTF-8',

I wrote this because I needed to validate UTF-8 input where it was quite likely to receive text incorrectly encoded as ISO-8859-1 or Windows-1252.

A key limitation of this validator (it's an inherent limitation of 8-bit charsets and UTF-8), is that it can't detect when a UTF-8 string has been presented as ISO-8859-\*. This is because all 8-bit values are valid in ISO-8859 charsets, and consequently all valid UTF-8 is also valid ISO-8859-\*, but the reverse is not true. It's possible to partially detect this through heuristics, but that's beyond the scope of this utility.

TL;DR: This PR adds a `Str::isEncoding` method and an `encoding` validator that uses it, along with tests for both uses.