### PR TITLE
[10.x] Add ability attribute to customize resource authorization

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Auth\Access;
 
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Foundation\Http\Controllers\AbilityMapper;
 use Illuminate\Support\Str;
 
 trait AuthorizesRequests
@@ -108,15 +109,7 @@ trait AuthorizesRequests
      */
     protected function resourceAbilityMap()
     {
-        return [
-            'index' => 'viewAny',
-            'show' => 'view',
-            'create' => 'create',
-            'store' => 'create',
-            'edit' => 'update',
-            'update' => 'update',
-            'destroy' => 'delete',
-        ];
+        return (new AbilityMapper())->mapAbilitiesForClass(static::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Attributes/Ability.php
+++ b/src/Illuminate/Foundation/Http/Attributes/Ability.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Ability
+{
+    /**
+     * Name of the ability.
+     *
+     * @var string|null
+     */
+    public readonly ?string $ability;
+
+    /**
+     * Create a new ability instance.
+     *
+     * @param  string|null  $ability
+     * @return void
+     */
+    public function __construct(?string $ability)
+    {
+        $this->ability = $ability;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Controllers/AbilityMapper.php
+++ b/src/Illuminate/Foundation/Http/Controllers/AbilityMapper.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Controllers;
+
+use Illuminate\Foundation\Http\Attributes\Ability;
+use Illuminate\Support\Arr;
+use ReflectionClass;
+use ReflectionMethod;
+
+class AbilityMapper
+{
+    /**
+     * Indicates whether reflection is used to discover ability attributes.
+     *
+     * @var bool
+     */
+    protected static bool $discoverAbilityAttributes = false;
+
+    /**
+     * Map abilities to authorize resources with.
+     *
+     * @param  class-string  $class
+     * @return array<string, string>
+     */
+    public function mapAbilitiesForClass(string $class): array
+    {
+        $abilities = static::defaultAbilityMap();
+
+        if (static::$discoverAbilityAttributes) {
+            $abilities = array_merge($abilities, static::mapAttributeAbilities($class));
+        }
+
+        return array_filter($abilities);
+    }
+
+    /**
+     * Discover ability attributes.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function discoverAbilityAttributes(bool $value = true): void
+    {
+        static::$discoverAbilityAttributes = $value;
+    }
+
+    /**
+     * Determine if ability attributes are discovered.
+     *
+     * @return bool
+     */
+    public static function discoversAbilityAttributes(): bool
+    {
+        return static::$discoverAbilityAttributes;
+    }
+
+    /**
+     * Map abilities from attributes.
+     *
+     * @param  class-string  $class
+     * @return array<string, string|null>
+     * @throws \ReflectionException
+     */
+    protected function mapAttributeAbilities(string $class): array
+    {
+        $class = new ReflectionClass($class);
+
+        return collect($class->getMethods(ReflectionMethod::IS_PUBLIC))
+            ->mapWithKeys(function (ReflectionMethod $method) {
+                if ($method->getName() === '__construct') {
+                    return [];
+                }
+
+                $attributes = $method->getAttributes(Ability::class);
+
+                $attribute = Arr::first($attributes);
+
+                if ($attribute === null) {
+                    return [];
+                }
+
+                return [$method->getName() => $attribute->newInstance()?->ability];
+            })
+            ->toArray();
+    }
+
+    /**
+     * Default ability map.
+     *
+     * @return array<string, string>
+     */
+    protected function defaultAbilityMap(): array
+    {
+        return [
+            'index' => 'viewAny',
+            'show' => 'view',
+            'create' => 'create',
+            'store' => 'create',
+            'edit' => 'update',
+            'update' => 'update',
+            'destroy' => 'delete',
+        ];
+    }
+}


### PR DESCRIPTION
More interested to see what people think than a final PR.

This PR allows you to override abilities to use when authorizing resources.

Example:
```php
    public function __construct()
    {
        $this->authorizeResource('App\User', 'user');
    }

    #[Ability('view_any_user')]
    public function index()
    {
        //
    }
```

This could be further extended by being able to override the parameter(s) used.