### PR TITLE
[10.x] Change the return type of getPublicToken function

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -206,7 +206,7 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Get the public token value from the Ably key.
      *
-     * @return mixed
+     * @return string
      */
     protected function getPublicToken()
     {


### PR DESCRIPTION
The `getPublicToken` function in `AblyBroadcaster`  class returns string not mixed.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
