### PR TITLE
[10.x] Allow failed job providers to be countable

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -133,10 +133,8 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface, PrunableF
 
     /**
      * Count the failed jobs.
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->getTable()->count();
     }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Queue\Failed;
 
+use Countable;
 use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider
+class DatabaseFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider, Countable
 {
     /**
      * The connection resolver implementation.
@@ -128,6 +129,16 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface, PrunableF
         } while ($deleted !== 0);
 
         return $totalDeleted;
+    }
+
+    /**
+     * Count the failed jobs.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->getTable()->count();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider, Countable
+class DatabaseFailedJobProvider implements Countable, FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -146,10 +146,8 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, Pruna
 
     /**
      * Count the failed jobs.
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->getTable()->count();
     }

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider, Countable
+class DatabaseUuidFailedJobProvider implements Countable, FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -2,11 +2,12 @@
 
 namespace Illuminate\Queue\Failed;
 
+use Countable;
 use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider
+class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider, Countable
 {
     /**
      * The connection resolver implementation.
@@ -141,6 +142,16 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, Pruna
         } while ($deleted !== 0);
 
         return $totalDeleted;
+    }
+
+    /**
+     * Count the failed jobs.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->getTable()->count();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -151,10 +151,8 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
 
     /**
      * Count the failed jobs.
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->read());
     }

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -7,7 +7,7 @@ use Countable;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 
-class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider, Countable
+class FileFailedJobProvider implements Countable, FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The file path where the failed job file should be stored.
@@ -150,14 +150,6 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
     }
 
     /**
-     * Count the failed jobs.
-     */
-    public function count(): int
-    {
-        return count($this->read());
-    }
-
-    /**
      * Execute the given callback while holding a lock.
      *
      * @param  \Closure  $callback
@@ -210,5 +202,13 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
             $this->path,
             json_encode($jobs, JSON_PRETTY_PRINT)
         );
+    }
+
+    /**
+     * Count the failed jobs.
+     */
+    public function count(): int
+    {
+        return count($this->read());
     }
 }

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Queue\Failed;
 
 use Closure;
+use Countable;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 
-class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider
+class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider, Countable
 {
     /**
      * The file path where the failed job file should be stored.
@@ -146,6 +147,16 @@ class FileFailedJobProvider implements FailedJobProviderInterface, PrunableFaile
 
             return count($jobs) - count($prunedJobs);
         });
+    }
+
+    /**
+     * Count the failed jobs.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->read());
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Queue\Failed;
 
-class NullFailedJobProvider implements FailedJobProviderInterface
+use Countable;
+
+class NullFailedJobProvider implements FailedJobProviderInterface, Countable
 {
     /**
      * Log a failed job into storage.
@@ -59,5 +61,15 @@ class NullFailedJobProvider implements FailedJobProviderInterface
     public function flush($hours = null)
     {
         //
+    }
+
+    /**
+     * Count the failed jobs.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return 0;
     }
 }

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -65,10 +65,8 @@ class NullFailedJobProvider implements FailedJobProviderInterface, Countable
 
     /**
      * Count the failed jobs.
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return 0;
     }

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Failed;
 
 use Countable;
 
-class NullFailedJobProvider implements FailedJobProviderInterface, Countable
+class NullFailedJobProvider implements Countable, FailedJobProviderInterface
 {
     /**
      * Log a failed job into storage.

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -9,6 +9,7 @@ use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabaseFailedJobProviderTest extends TestCase
 {
@@ -70,5 +71,32 @@ class DatabaseFailedJobProviderTest extends TestCase
 
         $this->assertSame(1, $db->getConnection()->table('failed_jobs')->count());
         $this->assertSame($exception, $db->getConnection()->table('failed_jobs')->first()->exception);
+    }
+
+    public function testCountFailedJobs()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $this->assertCount(0, $provider);
+
+        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertCount(1, $provider);
+
+        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertCount(3, $provider);
     }
 }

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -73,7 +73,7 @@ class DatabaseFailedJobProviderTest extends TestCase
         $this->assertSame($exception, $db->getConnection()->table('failed_jobs')->first()->exception);
     }
 
-    public function testCountFailedJobs()
+    public function testJobsCanBeCounted()
     {
         $db = new DB;
         $db->addConnection([

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Exception;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Exception;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DatabaseUuidFailedJobProviderTest extends TestCase
+{
+    public function testCountFailedJobs()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->uuid();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $this->assertCount(0, $provider);
+
+        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertCount(1, $provider);
+
+        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertCount(3, $provider);
+    }
+}
+
+
+

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -14,7 +14,7 @@ use RuntimeException;
 
 class DatabaseUuidFailedJobProviderTest extends TestCase
 {
-    public function testCountFailedJobs()
+    public function testJobsCanBeCounted()
     {
         $db = new DB;
         $db->addConnection([
@@ -41,6 +41,3 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertCount(3, $provider);
     }
 }
-
-
-

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -140,6 +140,18 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertEmpty($failedJobs);
     }
 
+    public function testCountFailedJobs()
+    {
+        $this->assertCount(0, $this->provider);
+
+        $this->logFailedJob();
+        $this->assertCount(1, $this->provider);
+
+        $this->logFailedJob();
+        $this->logFailedJob();
+        $this->assertCount(3, $this->provider);
+    }
+
     public function logFailedJob()
     {
         $uuid = Str::uuid();

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -140,7 +140,7 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertEmpty($failedJobs);
     }
 
-    public function testCountFailedJobs()
+    public function testJobsCanBeCounted()
     {
         $this->assertCount(0, $this->provider);
 


### PR DESCRIPTION
When trying to count the number of failed jobs, you have to retrieve _all_ records into memory and do an in-memory count, e.g.,

```php
$jobs = app(FailedJobProviderInterface::class)->all();

$totalFailedJobs = count($jobs);
```

For applications with thousands or millions of failed jobs...this is not ideal.

Making the 1st party drivers `Countable` without introducing a new method on the interface.

I've created a dedicated PR for the Dynamo DB driver, as I don't have a means to test it and am hoping someone from the community can help out: https://github.com/laravel/framework/pull/48178

---
Side note: kinda liking leaning on the `Countable` interface here. Not sure if genius or illegal 🚔.