### PR TITLE
[10.x] Make DynamoDB failed job provider countable

### DIFF
--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Queue\Failed;
 
 use Aws\DynamoDb\DynamoDbClient;
+use Countable;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 
-class DynamoDbFailedJobProvider implements FailedJobProviderInterface
+class DynamoDbFailedJobProvider implements FailedJobProviderInterface, Countable
 {
     /**
      * The DynamoDB client instance.
@@ -160,6 +161,16 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
         ]);
 
         return true;
+    }
+
+    /**
+     * Count the failed jobs.
+     */
+    public function count(): int
+    {
+        return $this->dynamo->describeTable([
+            'TableName' => $this->table,
+        ])['Table']['ItemCount'];
     }
 
     /**

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -175,4 +175,19 @@ class DynamoDbFailedJobProviderTest extends TestCase
 
         $provider->forget('id');
     }
+
+    public function testJobsCanBeCounted()
+    {
+        $dynamoDbClient = m::mock(DynamoDbClient::class);
+        $dynamoDbClient->shouldReceive('describeTable')->once()->with([
+            'TableName' => 'table',
+        ])->andReturn([
+            'Table' => [
+                'ItemCount' => 5,
+            ]
+        ]);
+        $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
+
+        $this->assertCount(5, $provider);
+    }
 }

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -184,7 +184,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
         ])->andReturn([
             'Table' => [
                 'ItemCount' => 5,
-            ]
+            ],
         ]);
         $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
 


### PR DESCRIPTION
See: https://github.com/laravel/framework/pull/48177

Dynamo DB documentation: https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.DynamoDb.DynamoDbClient.html#_describeTable

I've left this one as a draft as I would absolutely love if someone from the community could test this out for me.

Should note that this is the "performant" way of counting records.

> The number of items in the specified table. DynamoDB updates this value approximately every six hours. Recent changes might not be reflected in this value.

Maybe we need to not use this? I'm not sure what best practice is with Dynamo and if this kind of "eventually consistent" approach is just part of how it works.