### PR TITLE
[10.x] Give access to job UUID in the job queued event

### DIFF
--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -40,6 +40,7 @@ class JobQueued
      * @param  string  $connectionName
      * @param  string|int|null  $id
      * @param  \Closure|string|object  $job
+     * @param  string|null  $payload
      * @return void
      */
     public function __construct($connectionName, $id, $job, $payload = null)

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -52,7 +52,7 @@ class JobQueued
     }
 
     /**
-     * The decoded payload.
+     * Get the decoded job payload.
      *
      * @return array
      */

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use RuntimeException;
+
 class JobQueued
 {
     /**
@@ -26,6 +28,13 @@ class JobQueued
     public $job;
 
     /**
+     * The job payload.
+     *
+     * @var ?string
+     */
+    public $payload;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
@@ -33,10 +42,25 @@ class JobQueued
      * @param  \Closure|string|object  $job
      * @return void
      */
-    public function __construct($connectionName, $id, $job)
+    public function __construct($connectionName, $id, $job, $payload = null)
     {
         $this->connectionName = $connectionName;
         $this->id = $id;
         $this->job = $job;
+        $this->payload = $payload;
+    }
+
+    /**
+     * The decoded payload.
+     *
+     * @return array
+     */
+    public function payload()
+    {
+        if ($this->payload === null) {
+            throw new RuntimeException('The job payload was not provided when the event was dispatched.');
+        }
+
+        return json_decode($this->payload, true, flags: JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -30,7 +30,7 @@ class JobQueued
     /**
      * The job payload.
      *
-     * @var ?string
+     * @var string|null
      */
     public $payload;
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -305,15 +305,15 @@ abstract class Queue
             $this->container->bound('db.transactions')) {
             return $this->container->make('db.transactions')->addCallback(
                 function () use ($payload, $queue, $delay, $callback, $job) {
-                    return tap($callback($payload, $queue, $delay), function ($jobId) use ($job) {
-                        $this->raiseJobQueuedEvent($jobId, $job);
+                    return tap($callback($payload, $queue, $delay), function ($jobId) use ($job, $payload) {
+                        $this->raiseJobQueuedEvent($jobId, $job, $payload);
                     });
                 }
             );
         }
 
-        return tap($callback($payload, $queue, $delay), function ($jobId) use ($job) {
-            $this->raiseJobQueuedEvent($jobId, $job);
+        return tap($callback($payload, $queue, $delay), function ($jobId) use ($job, $payload) {
+            $this->raiseJobQueuedEvent($jobId, $job, $payload);
         });
     }
 
@@ -341,12 +341,13 @@ abstract class Queue
      *
      * @param  string|int|null  $jobId
      * @param  \Closure|string|object  $job
+     * @param  string  $payload
      * @return void
      */
-    protected function raiseJobQueuedEvent($jobId, $job)
+    protected function raiseJobQueuedEvent($jobId, $job, $payload)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->dispatch(new JobQueued($this->connectionName, $jobId, $job));
+            $this->container['events']->dispatch(new JobQueued($this->connectionName, $jobId, $job, $payload));
         }
     }
 

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -6,8 +6,11 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\DatabaseQueue;
+use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
 class QueueDatabaseQueueIntegrationTest extends TestCase
@@ -44,7 +47,9 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
 
         $this->queue = new DatabaseQueue($this->connection(), $this->table);
 
-        $this->container = $this->createMock(Container::class);
+        $this->container = new Container;
+
+        $this->container->instance('events', new Dispatcher($this->container));
 
         $this->queue->setContainer($this->container);
 
@@ -240,5 +245,23 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         $popped_job = $this->queue->pop($mock_queue_name);
 
         $this->assertNull($popped_job);
+    }
+
+    public function testJobPayloadIsAvailableOnEvent()
+    {
+        $event = null;
+        Str::createUuidsUsingSequence([
+            'expected-job-uuid',
+        ]);
+        $this->container['events']->listen(function (JobQueued $e) use (&$event) {
+            $event = $e;
+        });
+
+        $this->queue->push('MyJob', [
+            'laravel' => 'Framework'
+        ]);
+
+        $this->assertIsArray($event->payload());
+        $this->assertSame('expected-job-uuid', $event->payload()['uuid']);
     }
 }

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -258,7 +258,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
         });
 
         $this->queue->push('MyJob', [
-            'laravel' => 'Framework'
+            'laravel' => 'Framework',
         ]);
 
         $this->assertIsArray($event->payload());


### PR DESCRIPTION
The `JobQueued` event is dispatched whenever a job has been pushed to the queue (although, not for "bulk" jobs).

The `JobQueued` event does expose the database's record ID, however this ID changes if a job fails and is retried.

Currently the jobs "sticky" ID - which is held in the payload - is not available.

The job's payload ID is sticky because it does not change when a job fails and is retried - however the database ID does change.

This change makes tracking the job from queued through all it's lifecycle hooks much easier. Without it...it's pretty much impossible.