### PR TITLE
[10.x] Remove serializer and compression for RedisQueue

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -60,7 +60,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var \Illuminate\Redis\Connections\Connection
      */
-    protected  $redisConnection;
+    protected $redisConnection;
 
     /**
      * Create a new Redis queue instance.
@@ -375,19 +375,19 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function getConnection()
     {
-        if(isset($this->redisConnection)){
+        if (isset($this->redisConnection)) {
             return $this->redisConnection;
         }
 
         $this->redisConnection = $this->redis->connection($this->connection);
 
-        if($this->redisConnection instanceof PhpRedisConnection){
+        if ($this->redisConnection instanceof PhpRedisConnection) {
             $this->redisConnection = $this->redis->resolve($this->connection);
 
-            if(defined('\Redis::OPT_COMPRESSION') && $this->redisConnection->client()->getOption(\Redis::OPT_COMPRESSION) !== \Redis::COMPRESSION_NONE) {
+            if (defined('\Redis::OPT_COMPRESSION') && $this->redisConnection->client()->getOption(\Redis::OPT_COMPRESSION) !== \Redis::COMPRESSION_NONE) {
                 $this->redisConnection->client()->setOption(\Redis::OPT_COMPRESSION, \Redis::COMPRESSION_NONE);
             }
-            if(defined('\Redis::OPT_SERIALIZER') && $this->redisConnection->client()->getOption(\Redis::OPT_SERIALIZER) !== \Redis::SERIALIZER_NONE) {
+            if (defined('\Redis::OPT_SERIALIZER') && $this->redisConnection->client()->getOption(\Redis::OPT_SERIALIZER) !== \Redis::SERIALIZER_NONE) {
                 $this->redisConnection->client()->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_NONE);
             }
         }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -516,6 +516,23 @@ class RedisQueueIntegrationTest extends TestCase
         ]);
     }
 
+    public function testUnsettingCompressionAndSerializer()
+    {
+        $this->redis['phpredis']->connection()->setOption(\Redis::OPT_SERIALIZER, 1);
+        $this->redis['phpredis']->connection()->setOption(\Redis::OPT_COMPRESSION, 1);
+
+        $queue = new RedisQueue($this->redis['phpredis']);
+
+        $cleanConnection = $queue->getConnection();
+
+        $this->assertEquals(0, $cleanConnection->getOption(\Redis::OPT_SERIALIZER));
+        $this->assertEquals(0, $cleanConnection->getOption(\Redis::OPT_COMPRESSION));
+
+        // don't change the original connection so cache can still use compression or serialization
+        $this->assertEquals(1, $this->redis['phpredis']->connection()->getOption(\Redis::OPT_SERIALIZER));
+        $this->assertEquals(1, $this->redis['phpredis']->connection()->getOption(\Redis::OPT_COMPRESSION));
+    }
+
     /**
      * @param  string  $driver
      * @param  string  $default


### PR DESCRIPTION
This PR should address #47356 and #47578. 

Alternatively, maybe reference in the documentation that you should use a separate database.redis connection like that:
```php

        'queue' => [
            'url' => env('REDIS_URL'),
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'username' => env('REDIS_USERNAME'),
            'password' => env('REDIS_PASSWORD'),
            'port' => env('REDIS_PORT', '6379'),
            'database' => env('REDIS_DB', 0),
            'options'=> [
                'serializer' => 0,
                'compression' => 0,
            ],
        ],

```  
and then you can use that in the queue.php config file.

(First PR here hope I didn't miss anything)