### PR TITLE
[10.x] Add `pipe` Helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -19,6 +19,7 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Pipeline;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -556,6 +557,19 @@ if (! function_exists('now')) {
     function now($tz = null)
     {
         return Date::now($tz);
+    }
+}
+
+if (! function_exists('pipe')) {
+    /**
+     * Create a new instance of Pipeline.
+     *
+     * @param  mixed  $passable
+     * @return \Illuminate\Pipeline\Pipeline
+     */
+    function pipe($passable)
+    {
+        return Pipeline::send($passable);
     }
 }
 


### PR DESCRIPTION
As the Laravel [Pipeline](https://laravel.com/docs/10.x/helpers#pipeline) is something extremely useful at different times and widely used - including throughout Laravel, having an alternative to use it would make development even easier. This PR aims to introduce a simple helper called `pipe()` that builds the Pipeline instance when used.