### PR TITLE
Add visibility Support for Scoped Disk Configurations

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -285,7 +285,13 @@ class FilesystemManager implements FactoryContract
 
         return $this->build(tap(
             is_string($config['disk']) ? $this->getConfig($config['disk']) : $config['disk'],
-            fn (&$parent) => $parent['prefix'] = $config['prefix']
+            function (&$parent) use ($config) {
+                $parent['prefix'] = $config['prefix'];
+
+                if (isset($config['visibility'])) {
+                    $parent['visibility'] = $config['visibility'];
+                }
+            }
         ));
     }
 


### PR DESCRIPTION
Scoped disks offer a streamlined approach to reduce configuration keys. However, the current implementation doesn't support setting the visibility attribute for a scoped disk. 

This PR introduces that capability, allowing for enhanced flexibility in disk configurations.