### PR TITLE
[10.x] Fix ErrorException array to string conversion

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -442,6 +442,10 @@ trait FormatsMessages
             return $this->customValues[$attribute][$value];
         }
 
+        if (is_array($value)) {
+            $value = 'array';
+        }
+        
         $key = "validation.values.{$attribute}.{$value}";
 
         if (($line = $this->translator->get($key)) !== $key) {

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -51,4 +51,17 @@ class ValidationRequiredIfTest extends TestCase
             return true;
         }));
     }
+
+    public function testThatNoArrayToStringErrorExceptionIsThrownWhenDealingWithDependantBooleanField()
+    {
+        $validator = \Illuminate\Support\Facades\Validator::make([
+            'boolean_input' => ['test'],
+            'dependant_input' => null,
+        ], [
+            'boolean_input' => 'required|boolean',
+            'dependant_input' => 'required_if:boolean_input,true',
+        ]);
+
+        $this->assertIsBool($validator->fails());
+    }
 }


### PR DESCRIPTION
This a minor change addressing the issue #48187 .

The change is checking that the dependant field's value is not an array before processing it as a basic data type.
