### PR TITLE
DurationLimiter flexible limits setup

### DIFF
--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -160,11 +160,16 @@ if redis.call('EXISTS', KEYS[1]) == 0 then
     return {reset(), ARGV[2] + ARGV[3], ARGV[4] - 1}
 end
 
+local currentCount = tonumber(redis.call('HGET', KEYS[1], 'count'))
 if ARGV[1] >= redis.call('HGET', KEYS[1], 'start') and ARGV[1] <= redis.call('HGET', KEYS[1], 'end') then
+    if currentCount <= tonumber(ARGV[4]) then
+        redis.call('HINCRBY', KEYS[1], 'count', 1)
+        currentCount = currentCount + 1
+    end
     return {
-        tonumber(redis.call('HINCRBY', KEYS[1], 'count', 1)) <= tonumber(ARGV[4]),
+        currentCount <= tonumber(ARGV[4]),
         redis.call('HGET', KEYS[1], 'end'),
-        ARGV[4] - redis.call('HGET', KEYS[1], 'count')
+        ARGV[4] - currentCount
     }
 end
 


### PR DESCRIPTION
This one allows to set limiter rules more flexible.
The old logic was increase the counter of calls every time code executes, meaning counter increasing even if it's throttled, this approach does not allow to set different limits for the same key across the application.
The following changes would be fully backward compatible as it will refuse all the calls higher than the `maxLocks` rate.

For the example I want to show the real business case for this:
We have the 3rd party with limitation of 10 calls/sec. 
We operate with this 3rd party from queue jobs which has 2 types: low-priority jobs (high rate) and high-priority (low rate) 

Even though the rate is high, we don't want to let this kind of jobs take all of the rate-limit. 
What we want to do there is set the following rate limits:  low-priority jobs 2 calls/sec, high-priority jobs 6 calls/sec.

What's happening now:
We are setting the limits like this
```
->allow(2)
->every(1)
```
and
```
->allow(6)
->every(1)
```

Even with this, we have a high-rate low-priority jobs which just blocking high-priority jobs from executing
 