### PR TITLE
[10.x] Make the `firstOrCreate` methods in relations use `createOrFirst` behind the scenes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -624,7 +624,13 @@ class BelongsToMany extends Relation
             if (is_null($instance = $this->related->where($attributes)->first())) {
                 $instance = $this->createOrFirst($attributes, $values, $joining, $touch);
             } else {
-                $this->attach($instance, $joining, $touch);
+                try {
+                    $this->getQuery()->withSavepointIfNeeded(fn () => (
+                        $this->attach($instance, $joining, $touch)
+                    ));
+                } catch (UniqueConstraintViolationException $exception) {
+                    // Nothing to do, the model was already attached.
+                }
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -622,7 +622,7 @@ class BelongsToMany extends Relation
     {
         if (is_null($instance = (clone $this)->where($attributes)->first())) {
             if (is_null($instance = $this->related->where($attributes)->first())) {
-                $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
+                $instance = $this->createOrFirst($attributes, $values, $joining, $touch);
             } else {
                 $this->attach($instance, $joining, $touch);
             }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -627,7 +627,7 @@ class BelongsToMany extends Relation
                 try {
                     $this->getQuery()->withSavepointIfNeeded(fn () => $this->attach($instance, $joining, $touch));
                 } catch (UniqueConstraintViolationException $exception) {
-                    // Nothing to do, the model was already attached.
+                    // Nothing to do, the model was already attached...
                 }
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -625,9 +625,7 @@ class BelongsToMany extends Relation
                 $instance = $this->createOrFirst($attributes, $values, $joining, $touch);
             } else {
                 try {
-                    $this->getQuery()->withSavepointIfNeeded(fn () => (
-                        $this->attach($instance, $joining, $touch)
-                    ));
+                    $this->getQuery()->withSavepointIfNeeded(fn () => $this->attach($instance, $joining, $touch));
                 } catch (UniqueConstraintViolationException $exception) {
                     // Nothing to do, the model was already attached.
                 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -236,7 +236,7 @@ abstract class HasOneOrMany extends Relation
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->create(array_merge($attributes, $values));
+            $instance = $this->createOrFirst($attributes, $values);
         }
 
         return $instance;

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -155,6 +155,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+        $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $model = $this->expectCreatedModel($relation, ['foo']);
 
         $this->assertEquals($model, $relation->firstOrCreate(['foo']));
@@ -165,6 +166,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+        $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $model = $this->expectCreatedModel($relation, ['foo' => 'bar', 'baz' => 'qux']);
 
         $this->assertEquals($model, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -195,6 +195,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+        $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
@@ -208,6 +209,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+        $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -61,6 +61,32 @@ class EloquentHasManyTest extends DatabaseTestCase
         $this->assertEquals($latestLogin->id, $user->latestLogin->id);
     }
 
+    public function testFirstOrCreate()
+    {
+        $user = EloquentHasManyTestUser::create();
+
+        $post1 = $user->posts()->create(['title' => Str::random()]);
+        $post2 = $user->posts()->firstOrCreate(['title' => $post1->title]);
+
+        $this->assertTrue($post1->is($post2));
+        $this->assertCount(1, $user->posts()->get());
+    }
+
+    public function testFirstOrCreateWithinTransaction()
+    {
+        $user = EloquentHasManyTestUser::create();
+
+        $post1 = $user->posts()->create(['title' => Str::random()]);
+
+        DB::transaction(function () use ($user, $post1) {
+            $post2 = $user->posts()->firstOrCreate(['title' => $post1->title]);
+
+            $this->assertTrue($post1->is($post2));
+        });
+
+        $this->assertCount(1, $user->posts()->get());
+    }
+
     public function testCreateOrFirst()
     {
         $user = EloquentHasManyTestUser::create();


### PR DESCRIPTION
### Changed

- In https://github.com/laravel/framework/pull/47973, I only switched the `Builder::firstOrCreate` to also use the `createOrFirst` behind to scenes and missed the `BelongsToMany::firstOrCreate` and `HasOneOrMany::firstOrCreate`. This PR also changes the missed methods to use `firstOrCreate` instead of simply trying to `create` related records after not finding them, also solving the race condition issue in the relations.
- Wraps the "attach" method call on the `BelongsToMany::firstOrCreate` in a SAVEPOINT if needed and a `try/catch` to handle the unique violation there as well, making it more robust

---

Hat tip to @mpyw for pointing out that I missed those methods in the original implementation.