### PR TITLE
Fixed Type Declaration for `toArray` Method in Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -902,7 +902,7 @@ trait EnumeratesValues
     /**
      * Get the collection of items as a plain array.
      *
-     * @return array<TKey, mixed>
+     * @return array<TKey, TValue>
      */
     public function toArray()
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -179,3 +179,8 @@ assertType('Illuminate\Support\Collection<int, string|User>', $collection->pad(2
 assertType('array<int, mixed>', $collection->getQueueableIds());
 
 assertType('array<int, string>', $collection->getQueueableRelations());
+
+assertType('array<int, User>', $collection->toArray());
+assertType('array<int, string>', $collection->map(function ($item){
+    return 'string';
+})->toArray());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1046,9 +1046,9 @@ assertType('User', $collection[0] = new User);
 $collection->offsetUnset(0);
 unset($collection[0]);
 
-assertType('array<int, mixed>', $collection->toArray());
-assertType('array<string, mixed>', collect(['string' => 'string'])->toArray());
-assertType('array<int, mixed>', collect([1, 2])->toArray());
+assertType('array<int, User>', $collection->toArray());
+assertType('array<string, string>', collect(['string' => 'string'])->toArray());
+assertType('array<int, int>', collect([1, 2])->toArray());
 
 assertType('ArrayIterator<int, User>', $collection->getIterator());
 foreach ($collection as $int => $user) {

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -846,9 +846,9 @@ class CustomLazyCollection extends LazyCollection
 
 // assertType('CustomLazyCollection<int, User>', CustomLazyCollection::make([new User]));
 
-assertType('array<int, mixed>', $collection->toArray());
-assertType('array<string, mixed>', LazyCollection::make(['string' => 'string'])->toArray());
-assertType('array<int, mixed>', LazyCollection::make([1, 2])->toArray());
+assertType('array<int, User>', $collection->toArray());
+assertType('array<string, string>', LazyCollection::make(['string' => 'string'])->toArray());
+assertType('array<int, int>', LazyCollection::make([1, 2])->toArray());
 
 assertType('Traversable<int, User>', $collection->getIterator());
 foreach ($collection as $int => $user) {


### PR DESCRIPTION
Pull Request Description: Fixed Type Declaration for toArray Method

Overview:
This pull request addresses an issue with the type declaration in the toArray method within the Laravel framework. The current type declaration always returns mixed type whatever the data in collection.