### PR TITLE
[10.x] Method in VerifyCsrfToken to add exemptions to CSRF check

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -56,7 +56,7 @@ class VerifyCsrfToken
     {
         $this->app = $app;
         $this->encrypter = $encrypter;
-        $this->except = array_merge($this->except, $this->addExceptUrls());
+        $this->except = array_merge($this->except, $this->addExcept());
     }
 
     /**
@@ -221,7 +221,7 @@ class VerifyCsrfToken
      *
      * @return array
      */
-    protected function addExceptUrls(): array
+    protected function addExcept(): array
     {
         return [];
     }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -56,6 +56,7 @@ class VerifyCsrfToken
     {
         $this->app = $app;
         $this->encrypter = $encrypter;
+        $this->except = array_merge($this->except, $this->addExceptUrls());
     }
 
     /**
@@ -213,6 +214,16 @@ class VerifyCsrfToken
             false,
             $config['same_site'] ?? null
         );
+    }
+
+    /**
+     * Add set of URIs to exclude from CSRF protection.
+     *
+     * @return array
+     */
+    protected function addExceptUrls(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -56,7 +56,7 @@ class VerifyCsrfToken
     {
         $this->app = $app;
         $this->encrypter = $encrypter;
-        $this->except = array_merge($this->except, $this->addExcept());
+        $this->except = array_merge($this->except, array_values(array_unique($this->addExcept())));
     }
 
     /**

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
@@ -17,4 +17,9 @@ class VerifyCsrfTokenExceptStub extends VerifyCsrfToken
 
         return $this;
     }
+
+    protected function addExcept(): array
+    {
+        return ['/foo/baz'];
+    }
 }

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptStub.php
@@ -20,6 +20,9 @@ class VerifyCsrfTokenExceptStub extends VerifyCsrfToken
 
     protected function addExcept(): array
     {
-        return ['/foo/baz'];
+        return [
+            '/foo/baz',
+            'http://example.com/foo/baz',
+        ];
     }
 }

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -32,6 +32,10 @@ class VerifyCsrfTokenExceptTest extends TestCase
         $this->assertMatchingExcept(['/foo/baz']);
         $this->assertMatchingExcept(['foo/baz']);
         $this->assertNonMatchingExcept(['/baz/foo']);
+
+        $this->assertMatchingExcept(['http://example.com/foo/baz']);
+        $this->assertMatchingExcept(['http://example.com/foo/baz/']);
+        $this->assertNonMatchingExcept(['http://example.co/foo/baz/']);
     }
 
     public function testItCanExceptWildcardPaths()

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -26,6 +26,14 @@ class VerifyCsrfTokenExceptTest extends TestCase
         $this->assertNonMatchingExcept(['/bar/foo']);
     }
 
+    public function testItCanExceptAddedPaths()
+    {
+        $this->request = Request::create('http://example.com/foo/baz', 'POST');
+        $this->assertMatchingExcept(['/foo/baz']);
+        $this->assertMatchingExcept(['foo/baz']);
+        $this->assertNonMatchingExcept(['/baz/foo']);
+    }
+
     public function testItCanExceptWildcardPaths()
     {
         $this->assertMatchingExcept(['/foo/*']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Why?
As a developer who frequently uses named routes for Laravel projects, I find it weird that I have to use hardcoded routes when adding them in the  `$except` property of `app/Http/Middleware/VerifyCsrfToken.php`. If I insist and use a named route inside the said property, PHP will throw a fatal error (`expression is not allowed as field default value`) and crashing the application ✈️ 🔥 

## What is being solved?
Currently, in order to accomplish this task, we must override the `__construct()` of `Illuminate\Foundation\Http\Middleware\VerifyCsrfToken` and add the URIs there:

```php
// app/Http/Middleware/VerifyCsrfToken.php
namespace App\Http\Middleware;

use Illuminate\Contracts\Encryption\Encrypter;
use Illuminate\Contracts\Foundation\Application;
use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;

class VerifyCsrfToken extends Middleware
{   
    public function __construct(Application $app, Encrypter $encrypter)
    {
        parent::__construct($app, $encrypter);
        $this->except[] = route('stripe.webhook');
        $this->except[] = route('the.next.route');
        // and so on...
    }
}
```
In my opinion, while overriding the constructor may work, it should be considered a last resort. There is room for improvement in terms of both developer experience and code aesthetics.

## What is the solution?
This PR aims to have an alternative way of adding CSRF-exempted URIs, where expressions (like `route('stripe')` or `config('stripe.callback')`) will be allowed **without overriding the construct method**, and also provide developers to have conditions and logic around which route(s) to exclude in CSRF check. 

Example use will be as follows:
```php
<?php
// app/Http/Middleware/VerifyCsrfToken.php
namespace App\Http\Middleware;

use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;

class VerifyCsrfToken extends Middleware
{

    protected $except = [
        //
    ];

    protected function addExcept(): array
    {
        // add code flexibility by allowing conditions or logic to be added here, 
        // which is impossible to do inside a property

        return [
            route('stripe.webhook'),
            // other expressions
        ];
    }
}
```

If `addExceptUrls()` is not present in `app/Http/Middleware/VerifyCsrfToken.php`, only the `$except` property will be considered. But, if you provide a list of routes by returning them from `addExcept()`, those routes will be added to the existing ones in `$except`.


## Benefits
### Cleaner code
Overriding the constructor can potentially break the **Liskov Substitution Principle** (LSP). Subclasses should be substitutable for their base class without altering the correctness of the program. If a subclass's constructor has different requirements or behavior, it might violate this principle.

Having a dedicated method to do a specific job, i.e. adding routes to the `$except` property, is the best way to accomplish this, while also adhering to the **Single Responsibility Principle**.

### Better expectations
Hearing about exempting URLs from CSRF-check immediately makes people think about the `VerifyCsrfToken.php` file. Having both the `except` property and the `addExcept()` method inside the same file makes the best sense.

### Backward and forward compatibility
This feature will not break anything for the 10.x, and as of this writing, these changes are also compatible and can work hand-in-hand with the future updates for [VerifyCsrfToken.php](https://github.com/laravel/framework/pull/47309/files#diff-f144212c54668b3942147079c0cd571035548d29ce57c4d18ab1e5b3fd754241).