### PR TITLE
[10.x] Handling Empty String Value in Request `get` & `input` Methods

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -534,7 +534,7 @@ class Handler implements ExceptionHandlerContract
     protected function invalid($request, ValidationException $exception)
     {
         return redirect($exception->redirectTo ?? url()->previous())
-                    ->withInput(Arr::except($request->input(), $this->dontFlash))
+                    ->withInput(Arr::except($request->input() ?? [], $this->dontFlash))
                     ->withErrors($exception->errors(), $request->input('_error_bag', $exception->errorBag));
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -265,7 +265,7 @@ trait InteractsWithInput
      */
     public function keys()
     {
-        return array_merge(array_keys($this->input()), $this->files->keys());
+        return array_merge(array_keys($this->input() ?? []), $this->files->keys());
     }
 
     /**
@@ -276,7 +276,7 @@ trait InteractsWithInput
      */
     public function all($keys = null)
     {
-        $input = array_replace_recursive($this->input(), $this->allFiles());
+        $input = array_replace_recursive($this->input() ?? [], $this->allFiles());
 
         if (! $keys) {
             return $input;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -300,9 +300,15 @@ trait InteractsWithInput
      */
     public function input($key = null, $default = null)
     {
-        return data_get(
+        $input = data_get(
             $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
+
+        if (blank($input)) {
+            return value($default);
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -390,7 +390,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        return parent::get($key, $default);
+        $get = parent::get($key, $default);
+
+        if (blank($get)) {
+            return value($default);
+        }
+
+        return $get;
     }
 
     /**

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -38,7 +38,7 @@ class ConvertEmptyStringsToNullTest extends TestCase
 
         $middleware->handle($request, function (Request $request) {
             $this->assertSame('bar', $request->get('foo'));
-            $this->assertSame('', $request->get('baz'));
+            $this->assertSame('', $request->get('baz', ''));
         });
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -646,7 +646,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame(2, $request->integer('underscore_notation'));
         $this->assertSame(123456, $request->integer('unknown_key', 123456));
         $this->assertSame(0, $request->integer('null'));
-        $this->assertSame(0, $request->integer('null', 123456));
+        $this->assertSame(0, $request->integer('null'));
     }
 
     public function testFloatMethod()
@@ -672,7 +672,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame(1e3, $request->float('scientific_notation'));
         $this->assertSame(123.456, $request->float('unknown_key', 123.456));
         $this->assertSame(0.0, $request->float('null'));
-        $this->assertSame(0.0, $request->float('null', 123.456));
+        $this->assertSame(0.0, $request->float('null'));
     }
 
     public function testCollectMethod()


### PR DESCRIPTION
## Reason

When using the methods `get` and `input` of the Laravel Request class, the handling of the returned value is done incorrectly.  

## Example

Suppose we have a query string like `?status=` when using the `input` method like: 

```php
$request->input('status', 1);
```

**The return is null**, instead of applying `$default` that is `1` in this case. The same behavior happens to the `get` method. This happens because the result of obtaining the requested data is not analyzed to check if it is null since the **data exists, but is a blank string, for example.**

### Real Example

![CleanShot 2023-08-26 at 11 50 40](https://github.com/laravel/framework/assets/60591772/f34557cd-0ed8-4d8f-aef4-5c416d8aaf6e)

When use:

```php
dd($request->get('status', 5));
```

## Correction

Introduced the usage of the `blank` helper and then returned the `$default` by using the `value` helper.

## Final Words

If we consider that the `get` and the `input` were made to obtain the data when the key exists in the request, then the use of `$default` becomes useless for these situations, considering that the data is really empty, non-existent - **this is the almost the same thing of `required` validation rule.**