### PR TITLE
[11.x] Alternative Eloquent model local scope definition syntax

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Scopes\Scope;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -1616,6 +1617,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function hasNamedScope($scope)
     {
+        if (method_exists($this, $scope)) {
+            $reflectedMethod = new \ReflectionMethod($this, $scope);
+            $returnType = $reflectedMethod->getReturnType();
+            return $returnType && $returnType->getName() === Scope::class;
+        }
         return method_exists($this, 'scope'.ucfirst($scope));
     }
 
@@ -1628,7 +1634,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function callNamedScope($scope, array $parameters = [])
     {
-        return $this->{'scope'.ucfirst($scope)}(...$parameters);
+        return method_exists($this, $scope)
+            ? $this->{$scope}(...$parameters)
+            : $this->{'scope'.ucfirst($scope)}(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Scopes/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scopes/Scope.php
@@ -6,9 +6,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 class Scope
 {
-
     /**
-     * The scope apply callback.
+     * Apply callback.
      *
      * @var callable
      */
@@ -41,6 +40,7 @@ class Scope
     public function __invoke(Builder $builder): static
     {
         $this->builder = $builder;
+
         return $this;
     }
 
@@ -55,9 +55,10 @@ class Scope
      */
     public function __call($method, $parameters)
     {
-        if (!$this->builder) {
+        if (! $this->builder) {
             $this->__invoke($this->apply->__invoke());
         }
+
         return $this->builder->$method(...$parameters);
     }
 
@@ -71,5 +72,4 @@ class Scope
     {
         return new static($apply);
     }
-
 }

--- a/src/Illuminate/Database/Eloquent/Scopes/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scopes/Scope.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class Scope
+{
+
+    /**
+     * The scope apply callback.
+     *
+     * @var callable
+     */
+    protected $apply;
+
+    /**
+     * The builder instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Builder
+     */
+    protected $builder;
+
+    /**
+     * Create a new local scope instance.
+     *
+     * @param  callable|null  $apply
+     * @return void
+     */
+    public function __construct(callable $apply = null)
+    {
+        $this->apply = $apply;
+    }
+
+    /**
+     * Invoke with builder for additional query constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return static
+     */
+    public function __invoke(Builder $builder): static
+    {
+        $this->builder = $builder;
+        return $this;
+    }
+
+    /**
+     * Handle when additional methods are called against the scope.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (!$this->builder) {
+            $this->__invoke($this->apply->__invoke());
+        }
+        return $this->builder->$method(...$parameters);
+    }
+
+    /**
+     * Create a new local scope instance.
+     *
+     * @param  callable|null  $apply
+     * @return static
+     */
+    public static function make(callable $apply = null): static
+    {
+        return new static($apply);
+    }
+
+}

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -116,7 +116,6 @@ class DatabaseEloquentLocalScopesTest extends TestCase
     }
 }
 
-
 class ExtendedScope extends Scope
 {
     // inherits all the methods from Scope

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -91,13 +91,6 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertEquals(['2020-01-01', true], $query->getBindings());
     }
 
-    public function testWorksWithStandardStaticSyntax()
-    {
-        $query = EloquentLocalScopesTestModel::active()->newerThan('2020-01-01');
-        $this->assertSame('select * from "table" where "active" = ? and "created_at" > ?', $query->toSql());
-        $this->assertEquals([true, '2020-01-01'], $query->getBindings());
-    }
-
     public function testAllowsClassExtension()
     {
         $model = new EloquentLocalScopesTestModel;
@@ -107,7 +100,22 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertEquals(['2020-01-01', true], $query->getBindings());
     }
 
+    public function testScopeCacheIsPopulated()
+    {
+
+        $model = new EloquentLocalScopesTestModel;
+
+        $model->hasNamedScope('newerThan');
+        $model->hasNamedScope('newerThan');
+
+        $scopeCache = $model->getScopeCache();
+        $scopeClassName = EloquentLocalScopesTestModel::class.':newerThan';
+
+        $this->assertArrayHasKey($scopeClassName, $scopeCache);
+        $this->assertTrue($scopeCache[$scopeClassName]);
+    }
 }
+
 
 class ExtendedScope extends Scope
 {

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scopes\Scope;
 
 class EloquentModelScopeTest extends DatabaseTestCase
 {
@@ -19,6 +20,20 @@ class EloquentModelScopeTest extends DatabaseTestCase
 
         $this->assertFalse($model->hasNamedScope('doesNotExist'));
     }
+
+    public function testModelHasNewScope()
+    {
+        $model = new TestScopeModel1;
+
+        $this->assertTrue($model->hasNamedScope('alsoExists'));
+    }
+
+    public function testModelDoesNotHaveNewScope()
+    {
+        $model = new TestScopeModel1;
+
+        $this->assertFalse($model->hasNamedScope('doesNotAlsoExist'));
+    }
 }
 
 class TestScopeModel1 extends Model
@@ -26,5 +41,10 @@ class TestScopeModel1 extends Model
     public function scopeExists()
     {
         return true;
+    }
+
+    public function alsoExists(): Scope
+    {
+        return Scope::make(fn () => true);
     }
 }


### PR DESCRIPTION
**Summary**

This PR introduces the ability define local scopes using methods without the `scope` prefix & that are typed as `Scope` in Eloquent models. This feature aligns with the recent change in how `Accessor/Mutators` are defined & allows for backwards compatibility (non-breaking).

The only difference in syntax between this new scope definition & the new `Accessor/Mutators` is that it requires the `return` inside of the `closure`. This allows us to invoke the closure as a `Builder` instance in the new `Scope` class which 
 facilitates chaining further Builder methods after a method that returns the type of `Scope`. There maybe alternatives requiring that the closure does not need the return that are not breaking which may come to light once a few other developers review it.

This feature would require that scoped defined in this manner are not called statically on the model.

**Example Usage:**
```
// inside eloquent model (named argument is optional)
public function type(Builder $query, $type): Scope
   {
        return Scope::make(
            apply: function () use ($query, $type) {
                return $query->where('type', $type);
            },
        );
   }

// querying the model
$query = $model->type('foo')->get();
```

I believe that providing a relatively unified syntax for model methods, and then differentiating them in logic by return type is a good step forward for the framework.

**Update/Edit**
This PR has been updated to include a check for children of the ` Scope` class in the `hasNamedClass` method on the `Model` class allowing for extension.

I benchmarked both reflection and static caching to determine the more performant approach. The results showed that caching the scopes was twice as fast on 1000 iterations (see screenshot). Consequently, I opted for the cache option, statically storing the scopes on the model once they've been checked.

<img width="343" alt="Benchmark of reflection" src="https://github.com/laravel/framework/assets/112100521/8a3e36c2-27ff-4e37-8f89-f9b22db6c9c6">

Tests have been added to confirm the cache population and to demonstrate that the Scope class can be extended. Additionally, a helper method has been added to the Model class to return the scope cache & the `hasNamedScope` method has been refactored to make it more readable abstracting a new private method `checkScope`
