### PR TITLE
[10.x] New `mapWith` Collection Method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -810,6 +810,23 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Run an associative map over each of the items with another set of items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @template TMapWithKey of array-key
+     * @template TMapWithValue
+     *
+     * @param  callable(TValue, TKey): array<TMapWithKey, TMapWithValue>  $callback
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TMapWithKey>|iterable<array-key, TMapWithKey>  ...$arrays
+     * @return static<TMapWithKey, TMapWithValue>
+     */
+    public function mapWith(callable $callback, ...$arrays)
+    {
+        return new static(array_map($callback, $this->items, ...$arrays));
+    }
+
+    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3147,6 +3147,34 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testMapWith()
+    {
+        $data = new Collection([
+            ['name' => 'Foo', 'age' => 30],
+            ['name' => 'Bar', 'age' => 40],
+        ]);
+
+        $data = $data->mapWith(function ($fake, $baz) {
+            $fake['age'] += $baz;
+
+            return $fake;
+        }, [10, 20]);
+
+        $this->assertEquals(
+            [
+                [
+                    'name' => 'Foo',
+                    'age' => 40,
+                ],
+                [
+                    'name' => 'Bar',
+                    'age' => 60,
+                ],
+            ],
+            $data->all()
+        );
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
## Reason

As we know, the `array_map` function [offers us the ability to send a third parameter](https://www.php.net/manual/en/function.array-map.php) to be manipulated by the array provided in the second parameter.

## Introduction

This PR introduces the `mapWith` method enabling us to make the map with the addition of a third parameter to interact with as the `array_map` allows us.

## Examples

```php
$data = new Collection([
    ['name' => 'Taylor', 'age' => 30],
]);

$data = $data->mapWith(function ($people, $additional) {
    $people['age'] += $additional;
    
    return $people;
}, [10]);

$data->all() // [['name' => 'Jhon', 'age' => 40]]
```

Using other collections:

```php
$data = new Collection([
    ['name' => 'Taylor', 'age' => 30],
    ['name' => 'Nuno', 'age' => 40],
]);

$additional = new Collection([10, 20]);

$data = $data->mapWith(function ($people, $additional) {
    $people['age'] += $additional;
    
    return $people;
}, [...$additional->all()]);

$data->all() // [['name' => 'Taylor', 'age' => 40], ['name' => 'Nuno', 'age' => 60]]
```

Hope this helps,

Thanks.