### PR TITLE
Unnecessary '$request' argument of Request Instance removed from Collection and Json resources 'toArray' method.

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
@@ -2,7 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
 class {{ class }} extends ResourceCollection
@@ -12,8 +11,8 @@ class {{ class }} extends ResourceCollection
      *
      * @return array<int|string, mixed>
      */
-    public function toArray(Request $request): array
+    public function toArray(): array
     {
-        return parent::toArray($request);
+        return parent::toArray();
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/resource.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource.stub
@@ -2,7 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class {{ class }} extends JsonResource
@@ -12,8 +11,8 @@ class {{ class }} extends JsonResource
      *
      * @return array<string, mixed>
      */
-    public function toArray(Request $request): array
+    public function toArray(): array
     {
-        return parent::toArray($request);
+        return parent::toArray();
     }
 }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -99,14 +99,11 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Resolve the resource to an array.
      *
-     * @param  \Illuminate\Http\Request|null  $request
      * @return array
      */
     public function resolve($request = null)
     {
-        $data = $this->toArray(
-            $request = $request ?: Container::getInstance()->make('request')
-        );
+        $data = $this->toArray();
 
         if ($data instanceof Arrayable) {
             $data = $data->toArray();
@@ -120,10 +117,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
      */
-    public function toArray(Request $request)
+    public function toArray()
     {
         if (is_null($this->resource)) {
             return [];

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -94,12 +94,11 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     /**
      * Transform the resource into a JSON array.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
      */
-    public function toArray(Request $request)
+    public function toArray()
     {
-        return $this->collection->map->toArray($request)->all();
+        return $this->collection->map->toArray()->all();
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/AnonymousResourceCollectionWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/AnonymousResourceCollectionWithPaginationInformation.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class AnonymousResourceCollectionWithPaginationInformation extends AnonymousResourceCollection
 {
-    public function paginationInformation($request)
+    public function paginationInformation()
     {
         $paginated = $this->resource->toArray();
 

--- a/tests/Integration/Http/Fixtures/AuthorResource.php
+++ b/tests/Integration/Http/Fixtures/AuthorResource.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class AuthorResource extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return ['name' => $this->name];
     }

--- a/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 class AuthorResourceWithOptionalRelationship extends PostResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'name' => $this->name,

--- a/tests/Integration/Http/Fixtures/ObjectResource.php
+++ b/tests/Integration/Http/Fixtures/ObjectResource.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class ObjectResource extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'name' => $this->first_name,

--- a/tests/Integration/Http/Fixtures/PostCollectionResource.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResource.php
@@ -8,7 +8,7 @@ class PostCollectionResource extends ResourceCollection
 {
     public $collects = PostResource::class;
 
-    public function toArray($request)
+    public function toArray()
     {
         return ['data' => $this->collection];
     }

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithPaginationInformation.php
@@ -8,7 +8,7 @@ class PostCollectionResourceWithPaginationInformation extends ResourceCollection
 {
     public $collects = PostResource::class;
 
-    public function toArray($request)
+    public function toArray()
     {
         return ['data' => $this->collection];
     }

--- a/tests/Integration/Http/Fixtures/PostModelCollectionResource.php
+++ b/tests/Integration/Http/Fixtures/PostModelCollectionResource.php
@@ -8,7 +8,7 @@ class PostModelCollectionResource extends ResourceCollection
 {
     public $collects = Post::class;
 
-    public function toArray($request)
+    public function toArray()
     {
         return ['data' => $this->collection];
     }

--- a/tests/Integration/Http/Fixtures/PostResource.php
+++ b/tests/Integration/Http/Fixtures/PostResource.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResource extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return ['id' => $this->id, 'title' => $this->title, 'custom' => true];
     }

--- a/tests/Integration/Http/Fixtures/PostResourceWithAnonymousResourceCollectionWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithAnonymousResourceCollectionWithPaginationInformation.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithAnonymousResourceCollectionWithPaginationInformation extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return ['id' => $this->id, 'title' => $this->title, 'custom' => true];
     }

--- a/tests/Integration/Http/Fixtures/PostResourceWithJsonOptions.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithJsonOptions.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithJsonOptions extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithJsonOptionsAndTypeHints.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithJsonOptionsAndTypeHints.php
@@ -11,7 +11,7 @@ class PostResourceWithJsonOptionsAndTypeHints extends JsonResource
         parent::__construct($resource);
     }
 
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalAppendedAttributes.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalAppendedAttributes.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithOptionalAppendedAttributes extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalAttributes.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalAttributes.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithOptionalAttributes extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->whenNotNull($this->id),

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithOptionalData extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalHasAttributes.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalHasAttributes.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithOptionalHasAttributes extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalMerging.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalMerging.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithOptionalMerging extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalPivotRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalPivotRelationship.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 class PostResourceWithOptionalPivotRelationship extends PostResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 class PostResourceWithOptionalRelationship extends PostResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipAggregates.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipAggregates.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 class PostResourceWithOptionalRelationshipAggregates extends PostResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipCounts.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipCounts.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 class PostResourceWithOptionalRelationshipCounts extends PostResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/PostResourceWithUnlessOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithUnlessOptionalData.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PostResourceWithUnlessOptionalData extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return [
             'id' => $this->id,

--- a/tests/Integration/Http/Fixtures/ResourceWithPreservedKeys.php
+++ b/tests/Integration/Http/Fixtures/ResourceWithPreservedKeys.php
@@ -6,7 +6,7 @@ class ResourceWithPreservedKeys extends PostResource
 {
     protected $preserveKeys = true;
 
-    public function toArray($request)
+    public function toArray()
     {
         return $this->resource;
     }

--- a/tests/Integration/Http/Fixtures/SerializablePostResource.php
+++ b/tests/Integration/Http/Fixtures/SerializablePostResource.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class SerializablePostResource extends JsonResource
 {
-    public function toArray($request)
+    public function toArray()
     {
         return new JsonSerializableResource($this);
     }


### PR DESCRIPTION
The $request argument in Resource files seems unnecessary. That is why I removed it from the JsonResouce and ResourceCollection. 