### PR TITLE
[10.x] Ordering Results When Using `find`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -444,7 +444,9 @@ class Builder implements BuilderContract
             $results = $this->findMany($id, $columns);
 
             if ($results instanceof Arrayable) {
-                return $results->sortBy(fn (Model $model) => array_search($model->getKey(), $id instanceof Arrayable ? $id->toArray() : $id));
+                return (new Collection(
+                    $results->sortBy(fn (Model $model) => array_search($model->getKey(), $id instanceof Arrayable ? $id->toArray() : $id))
+                ))->values();
             }
 
             return $results;
@@ -467,6 +469,8 @@ class Builder implements BuilderContract
         if (empty($ids)) {
             return $this->model->newCollection();
         }
+
+        #dd($ids, $columns);
 
         return $this->whereKey($ids)->get($columns);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -444,9 +444,8 @@ class Builder implements BuilderContract
             $results = $this->findMany($id, $columns);
 
             if ($results instanceof Arrayable) {
-                return (new Collection(
-                    $results->sortBy(fn (Model $model) => array_search($model->getKey(), $id instanceof Arrayable ? $id->toArray() : $id))
-                ))->values();
+                return $results->sortBy(fn (Model $model) => array_search($model->getKey(), $id instanceof Arrayable ? $id->toArray() : $id))
+                    ->values();
             }
 
             return $results;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -470,8 +470,6 @@ class Builder implements BuilderContract
             return $this->model->newCollection();
         }
 
-        #dd($ids, $columns);
-
         return $this->whereKey($ids)->get($columns);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -441,7 +441,13 @@ class Builder implements BuilderContract
     public function find($id, $columns = ['*'])
     {
         if (is_array($id) || $id instanceof Arrayable) {
-            return $this->findMany($id, $columns);
+            $results = $this->findMany($id, $columns);
+
+            if ($results instanceof Arrayable) {
+                return $results->sortBy(fn (Model $model) => array_search($model->getKey(), $id instanceof Arrayable ? $id->toArray() : $id));
+            }
+
+            return $results;
         }
 
         return $this->whereKey($id)->first($columns);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -52,11 +52,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
         $builder->setModel($model);
-        $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [10,5]);
-        $builder->shouldReceive('get')->with(['column'])->andReturn([10,5]);
+        $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [10, 5]);
+        $builder->shouldReceive('get')->with(['column'])->andReturn([10, 5]);
 
-        $result = $builder->find([10,5], ['column']);
-        $this->assertEquals([10,5], $result);
+        $result = $builder->find([10, 5], ['column']);
+        $this->assertEquals([10, 5], $result);
     }
 
     public function testFindManyMethod()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -46,6 +46,19 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('baz', $result);
     }
 
+    public function testFindMethodOrdered()
+    {
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->andReturn('int');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [10,5]);
+        $builder->shouldReceive('get')->with(['column'])->andReturn([10,5]);
+
+        $result = $builder->find([10,5], ['column']);
+        $this->assertEquals([10,5], $result);
+    }
+
     public function testFindManyMethod()
     {
         // ids are not empty

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -182,7 +182,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model1 = $this->getMockModel();
         $model2 = $this->getMockModel();
         $model1->shouldReceive('getKeyType')->andReturn('int');
+        $model1->shouldReceive('getKey')->andReturn(1);
         $model2->shouldReceive('getKeyType')->andReturn('int');
+        $model2->shouldReceive('getKey')->andReturn(2);
         $builder->setModel($model1);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->twice();
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3])->once();
@@ -210,7 +212,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model1 = $this->getMockModel();
         $model2 = $this->getMockModel();
         $model1->shouldReceive('getKeyType')->andReturn('int');
+        $model1->shouldReceive('getKey')->andReturn(1);
         $model2->shouldReceive('getKeyType')->andReturn('int');
+        $model2->shouldReceive('getKey')->andReturn(2);
         $builder->setModel($model1);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->with('foo_table.foo', [1, 2])->twice();
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->with('foo_table.foo', [1, 2, 3])->once();
@@ -247,6 +251,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
         $model = $this->getMockModel();
         $model->shouldReceive('getKeyType')->andReturn('int');
+        $model->shouldReceive('getKey')->andReturn(1);
         $builder->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('foo_table.foo', [1, 2]);
         $builder->setModel($model);
         $builder->shouldReceive('get')->with(['column'])->andReturn('baz');


### PR DESCRIPTION
When we are working with the model using the method `find` we can retrieve a collection of results, such as:

```php
App\Models\People::find([10,5]);

/*
  0 => [
    "id" => 5
    // ...
  ]
  1 => [
    "id" => 10
    // ...
]*/
```

This PR aims to introduce the ability to **preserve the ordination that was given to the `find` method**:

```php
App\Models\People::find([10,5]);

/*
  0 => [
    "id" => 10
    // ...
  ]
  1 => [
    "id" => 5
    // ...
]*/
```

In the above example, I requested the `find` with the ordination of 10 and 5, so the first result is id 10 and after id 5.