### PR TITLE
[10.x] Replace `get_class` with `class` magic constant

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -472,7 +472,7 @@ class Gate implements GateContract
         }
 
         if (is_array($class)) {
-            $className = is_string($class[0]) ? $class[0] : get_class($class[0]);
+            $className = is_string($class[0]) ? $class[0] : $class[0]::class;
 
             return $this->methodAllowsGuests($className, $class[1]);
         }
@@ -654,7 +654,7 @@ class Gate implements GateContract
     public function getPolicyFor($class)
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $class = $class::class;
         }
 
         if (! is_string($class)) {

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -74,7 +74,7 @@ class BroadcastEvent implements ShouldQueue
     public function handle(BroadcastingFactory $manager)
     {
         $name = method_exists($this->event, 'broadcastAs')
-                ? $this->event->broadcastAs() : get_class($this->event);
+                ? $this->event->broadcastAs() : $this->event::class;
 
         $channels = Arr::wrap($this->event->broadcastOn());
 
@@ -141,7 +141,7 @@ class BroadcastEvent implements ShouldQueue
      */
     public function displayName()
     {
-        return get_class($this->event);
+        return $this->event::class;
     }
 
     /**

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -30,7 +30,7 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
      */
     public function __construct($event)
     {
-        $this->uniqueId = get_class($event);
+        $this->uniqueId = $event::class;
 
         if (method_exists($event, 'uniqueId')) {
             $this->uniqueId .= $event->uniqueId();

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -175,7 +175,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function hasCommandHandler($command)
     {
-        return array_key_exists(get_class($command), $this->handlers);
+        return array_key_exists($command::class, $this->handlers);
     }
 
     /**
@@ -187,7 +187,7 @@ class Dispatcher implements QueueingDispatcher
     public function getCommandHandler($command)
     {
         if ($this->hasCommandHandler($command)) {
-            return $this->container->make($this->handlers[get_class($command)]);
+            return $this->container->make($this->handlers[$command::class]);
         }
 
         return false;

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -70,6 +70,6 @@ class UniqueLock
                     ? $job->uniqueId()
                     : ($job->uniqueId ?? '');
 
-        return 'laravel_unique_job:'.get_class($job).$uniqueId;
+        return 'laravel_unique_job:'.$job::class.$uniqueId;
     }
 }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -162,7 +162,7 @@ class Schedule
             } else {
                 $this->dispatchNow($job);
             }
-        })->name(is_string($job) ? $job : get_class($job));
+        })->name(is_string($job) ? $job : $job::class);
     }
 
     /**

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -101,7 +101,7 @@ class BoundMethod
      */
     protected static function normalizeMethod($callback)
     {
-        $class = is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+        $class = is_string($callback[0]) ? $callback[0] : $callback[0]::class;
 
         return "{$class}@{$callback[1]}";
     }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -689,7 +689,7 @@ class Container implements ArrayAccess, ContainerContract
             return false;
         }
 
-        return is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+        return is_string($callback[0]) ? $callback[0] : $callback[0]::class;
     }
 
     /**

--- a/src/Illuminate/Database/ClassMorphViolationException.php
+++ b/src/Illuminate/Database/ClassMorphViolationException.php
@@ -20,7 +20,7 @@ class ClassMorphViolationException extends RuntimeException
      */
     public function __construct($model)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         parent::__construct("No morph map defined for model [{$class}].");
 

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -179,7 +179,7 @@ class PruneCommand extends Command
         $instance = new $model;
 
         $count = $instance->prunable()
-            ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($instance))), function ($query) {
+            ->when(in_array(SoftDeletes::class, class_uses_recursive($instance::class)), function ($query) {
                 $query->withTrashed();
             })->count();
 

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -78,7 +78,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         try {
             $model = $this->laravel->make($class);
 
-            $class = get_class($model);
+            $class = $model::class;
         } catch (BindingResolutionException $e) {
             return $this->components->error($e->getMessage());
         }
@@ -158,7 +158,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             ->reject(
                 fn (ReflectionMethod $method) => $method->isStatic()
                     || $method->isAbstract()
-                    || $method->getDeclaringClass()->getName() !== get_class($model)
+                    || $method->getDeclaringClass()->getName() !== $model::class
             )
             ->mapWithKeys(function (ReflectionMethod $method) use ($model) {
                 if (preg_match('/^get(.+)Attribute$/', $method->getName(), $matches) === 1) {
@@ -198,7 +198,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             ->reject(
                 fn (ReflectionMethod $method) => $method->isStatic()
                     || $method->isAbstract()
-                    || $method->getDeclaringClass()->getName() !== get_class($model)
+                    || $method->getDeclaringClass()->getName() !== $model::class
             )
             ->filter(function (ReflectionMethod $method) {
                 $file = new SplFileObject($method->getFileName());
@@ -221,8 +221,8 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
                 return [
                     'name' => $method->getName(),
-                    'type' => Str::afterLast(get_class($relation), '\\'),
-                    'related' => get_class($relation->getRelated()),
+                    'type' => Str::afterLast($relation::class, '\\'),
+                    'related' => $relation->getRelated()::class,
                 ];
             })
             ->filter()
@@ -439,7 +439,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
         $unsigned = $column->getUnsigned() ? ' unsigned' : '';
 
-        $details = match (get_class($column->getType())) {
+        $details = match ($column->getType()::class) {
             DecimalType::class => $column->getPrecision().','.$column->getScale(),
             default => $column->getLength(),
         };

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -27,7 +27,7 @@ class TimestampType extends Type implements PhpDateTimeMappingType
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return match (get_class($platform)) {
+        return match ($platform::class) {
             MySQLPlatform::class,
             MySQL57Platform::class,
             MySQL80Platform::class,
@@ -39,7 +39,7 @@ class TimestampType extends Type implements PhpDateTimeMappingType
             SQLServerPlatform::class,
             SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
             SqlitePlatform::class => 'DATETIME',
-            default => throw new DBALException('Invalid platform: '.substr(strrchr(get_class($platform), '\\'), 1)),
+            default => throw new DBALException('Invalid platform: '.substr(strrchr($platform::class, '\\'), 1)),
         };
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -185,7 +185,7 @@ class Builder implements BuilderContract
     public function withoutGlobalScope($scope)
     {
         if (! is_string($scope)) {
-            $scope = get_class($scope);
+            $scope = $scope::class;
         }
 
         unset($this->scopes[$scope]);
@@ -483,7 +483,7 @@ class Builder implements BuilderContract
         if (is_array($id)) {
             if (count($result) !== count(array_unique($id))) {
                 throw (new ModelNotFoundException)->setModel(
-                    get_class($this->model), array_diff($id, $result->modelKeys())
+                    $this->model::class, array_diff($id, $result->modelKeys())
                 );
             }
 
@@ -492,7 +492,7 @@ class Builder implements BuilderContract
 
         if (is_null($result)) {
             throw (new ModelNotFoundException)->setModel(
-                get_class($this->model), $id
+                $this->model::class, $id
             );
         }
 
@@ -616,7 +616,7 @@ class Builder implements BuilderContract
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->model));
+        throw (new ModelNotFoundException)->setModel($this->model::class);
     }
 
     /**
@@ -655,7 +655,7 @@ class Builder implements BuilderContract
         try {
             return $this->baseSole($columns);
         } catch (RecordsNotFoundException) {
-            throw (new ModelNotFoundException)->setModel(get_class($this->model));
+            throw (new ModelNotFoundException)->setModel($this->model::class);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -260,7 +260,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
+            ->groupBy(fn ($model) => $model::class)
             ->each(fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
 
         return $this;
@@ -277,7 +277,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
+            ->groupBy(fn ($model) => $model::class)
             ->each(fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
 
         return $this;
@@ -698,7 +698,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         return method_exists($model, 'getQueueableClassName')
                 ? $model->getQueueableClassName()
-                : get_class($model);
+                : $model::class;
     }
 
     /**
@@ -778,7 +778,7 @@ class Collection extends BaseCollection implements QueueableCollection
             throw new LogicException('Unable to create query for empty collection.');
         }
 
-        $class = get_class($model);
+        $class = $model::class;
 
         if ($this->filter(fn ($model) => ! $model instanceof $class)->isNotEmpty()) {
             throw new LogicException('Unable to create query for collection with mixed types.');

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -214,7 +214,7 @@ trait GuardsAttributes
      */
     protected function isGuardableColumn($key)
     {
-        if (! isset(static::$guardableColumns[get_class($this)])) {
+        if (! isset(static::$guardableColumns[$this::class])) {
             $columns = $this->getConnection()
                         ->getSchemaBuilder()
                         ->getColumnListing($this->getTable());
@@ -222,10 +222,10 @@ trait GuardsAttributes
             if (empty($columns)) {
                 return true;
             }
-            static::$guardableColumns[get_class($this)] = $columns;
+            static::$guardableColumns[$this::class] = $columns;
         }
 
-        return in_array($key, static::$guardableColumns[get_class($this)]);
+        return in_array($key, static::$guardableColumns[$this::class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -611,17 +611,17 @@ trait HasAttributes
      */
     public function hasAttributeMutator($key)
     {
-        if (isset(static::$attributeMutatorCache[get_class($this)][$key])) {
-            return static::$attributeMutatorCache[get_class($this)][$key];
+        if (isset(static::$attributeMutatorCache[$this::class][$key])) {
+            return static::$attributeMutatorCache[$this::class][$key];
         }
 
         if (! method_exists($this, $method = Str::camel($key))) {
-            return static::$attributeMutatorCache[get_class($this)][$key] = false;
+            return static::$attributeMutatorCache[$this::class][$key] = false;
         }
 
         $returnType = (new ReflectionMethod($this, $method))->getReturnType();
 
-        return static::$attributeMutatorCache[get_class($this)][$key] =
+        return static::$attributeMutatorCache[$this::class][$key] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class;
     }
@@ -634,15 +634,15 @@ trait HasAttributes
      */
     public function hasAttributeGetMutator($key)
     {
-        if (isset(static::$getAttributeMutatorCache[get_class($this)][$key])) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key];
+        if (isset(static::$getAttributeMutatorCache[$this::class][$key])) {
+            return static::$getAttributeMutatorCache[$this::class][$key];
         }
 
         if (! $this->hasAttributeMutator($key)) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key] = false;
+            return static::$getAttributeMutatorCache[$this::class][$key] = false;
         }
 
-        return static::$getAttributeMutatorCache[get_class($this)][$key] = is_callable($this->{Str::camel($key)}()->get);
+        return static::$getAttributeMutatorCache[$this::class][$key] = is_callable($this->{Str::camel($key)}()->get);
     }
 
     /**
@@ -696,8 +696,8 @@ trait HasAttributes
     {
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif (isset(static::$getAttributeMutatorCache[$this::class][$key]) &&
+                  static::$getAttributeMutatorCache[$this::class][$key] === true) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface
@@ -1021,7 +1021,7 @@ trait HasAttributes
      */
     public function hasAttributeSetMutator($key)
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (isset(static::$setAttributeMutatorCache[$class][$key])) {
             return static::$setAttributeMutatorCache[$class][$key];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -77,7 +77,7 @@ trait HasEvents
     private function resolveObserverClassName($class)
     {
         if (is_object($class)) {
-            return get_class($class);
+            return $class::class;
         }
 
         if (class_exists($class)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -25,7 +25,7 @@ trait HasGlobalScopes
         } elseif ($scope instanceof Closure) {
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
         } elseif ($scope instanceof Scope) {
-            return static::$globalScopes[static::class][get_class($scope)] = $scope;
+            return static::$globalScopes[static::class][$scope::class] = $scope;
         }
 
         throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
@@ -55,7 +55,7 @@ trait HasGlobalScopes
         }
 
         return Arr::get(
-            static::$globalScopes, static::class.'.'.get_class($scope)
+            static::$globalScopes, static::class.'.'.$scope::class
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -50,11 +50,11 @@ trait HasUlids
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
         if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            throw (new ModelNotFoundException)->setModel($this::class, $value);
         }
 
         if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUlid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            throw (new ModelNotFoundException)->setModel($this::class, $value);
         }
 
         return parent::resolveRouteBindingQuery($query, $value, $field);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -50,11 +50,11 @@ trait HasUuids
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
         if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            throw (new ModelNotFoundException)->setModel($this::class, $value);
         }
 
         if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            throw (new ModelNotFoundException)->setModel($this::class, $value);
         }
 
         return parent::resolveRouteBindingQuery($query, $value, $field);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -647,7 +647,7 @@ abstract class Factory
                 ->merge(
                     Collection::wrap($model instanceof Model ? func_get_args() : $model)
                         ->flatten()
-                )->groupBy(fn ($model) => get_class($model)),
+                )->groupBy(fn ($model) => $model::class),
         ]);
     }
 
@@ -779,7 +779,7 @@ abstract class Factory
     {
         $resolver = static::$modelNameResolver ?? function (self $factory) {
             $namespacedFactoryBasename = Str::replaceLast(
-                'Factory', '', Str::replaceFirst(static::$namespace, '', get_class($factory))
+                'Factory', '', Str::replaceFirst(static::$namespace, '', $factory::class)
             );
 
             $factoryBasename = Str::replaceLast('Factory', '', class_basename($factory));
@@ -912,7 +912,7 @@ abstract class Factory
 
         $relationship = Str::camel(Str::substr($method, 3));
 
-        $relatedModel = get_class($this->newModel()->{$relationship}()->getRelated());
+        $relatedModel = $this->newModel()->{$relationship}()->getRelated()::class;
 
         if (method_exists($relatedModel, 'newFactory')) {
             $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);

--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -13,7 +13,7 @@ trait HasFactory
      */
     public static function factory($count = null, $state = [])
     {
-        $factory = static::newFactory() ?: Factory::factoryForModel(get_called_class());
+        $factory = static::newFactory() ?: Factory::factoryForModel(static::class);
 
         return $factory
                     ->count(is_numeric($count) ? $count : null)

--- a/src/Illuminate/Database/Eloquent/InvalidCastException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidCastException.php
@@ -37,7 +37,7 @@ class InvalidCastException extends RuntimeException
      */
     public function __construct($model, $column, $castType)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         parent::__construct("Call to undefined cast [{$castType}] on column [{$column}] in model [{$class}].");
 

--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -15,7 +15,7 @@ class JsonEncodingException extends RuntimeException
      */
     public static function forModel($model, $message)
     {
-        return new static('Error encoding model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
+        return new static('Error encoding model ['.$model::class.'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
 
     /**
@@ -29,7 +29,7 @@ class JsonEncodingException extends RuntimeException
     {
         $model = $resource->resource;
 
-        return new static('Error encoding resource ['.get_class($resource).'] with model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
+        return new static('Error encoding resource ['.$resource::class.'] with model ['.$model::class.'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
 
     /**
@@ -42,7 +42,7 @@ class JsonEncodingException extends RuntimeException
      */
     public static function forAttribute($model, $key, $message)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         return new static("Unable to encode attribute [{$key}] for model [{$class}] to JSON: {$message}.");
     }

--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -24,7 +24,7 @@ trait MassPrunable
         $total = 0;
 
         do {
-            $total += $count = in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+            $total += $count = in_array(SoftDeletes::class, class_uses_recursive($this::class))
                         ? $query->forceDelete()
                         : $query->delete();
 

--- a/src/Illuminate/Database/Eloquent/MissingAttributeException.php
+++ b/src/Illuminate/Database/Eloquent/MissingAttributeException.php
@@ -17,7 +17,7 @@ class MissingAttributeException extends OutOfBoundsException
     {
         parent::__construct(sprintf(
             'The attribute [%s] either does not exist or was not retrieved for model [%s].',
-            $key, get_class($model)
+            $key, $model::class
         ));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -523,7 +523,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 } else {
                     throw new MassAssignmentException(sprintf(
                         'Add [%s] to fillable property to allow mass assignment on [%s].',
-                        $key, get_class($this)
+                        $key, $this::class
                     ));
                 }
             }
@@ -539,7 +539,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 throw new MassAssignmentException(sprintf(
                     'Add fillable property [%s] to allow mass assignment on [%s].',
                     implode(', ', $keys),
-                    get_class($this)
+                    $this::class
                 ));
             }
         }
@@ -719,7 +719,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this;
         }
 
-        $className = get_class($this->{$relation});
+        $className = $this->{$relation}::class;
 
         $this->{$relation}->load($relations[$className] ?? []);
 
@@ -843,7 +843,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this;
         }
 
-        $className = get_class($this->{$relation});
+        $className = $this->{$relation}::class;
 
         $this->{$relation}->loadAggregate($relations[$className] ?? [], $column, $function);
 
@@ -2201,7 +2201,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function broadcastChannelRoute()
     {
-        return str_replace('\\', '.', get_class($this)).'.{'.Str::camel(class_basename($this)).'}';
+        return str_replace('\\', '.', $this::class).'.{'.Str::camel(class_basename($this)).'}';
     }
 
     /**
@@ -2211,7 +2211,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function broadcastChannel()
     {
-        return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
+        return str_replace('\\', '.', $this::class).'.'.$this->getKey();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -18,7 +18,7 @@ trait Prunable
         $total = 0;
 
         $this->prunable()
-            ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($this))), function ($query) {
+            ->when(in_array(SoftDeletes::class, class_uses_recursive($this::class)), function ($query) {
                 $query->withTrashed();
             })->chunkById($chunkSize, function ($models) use (&$total) {
                 $models->each->prune();
@@ -50,7 +50,7 @@ trait Prunable
     {
         $this->pruning();
 
-        return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+        return in_array(SoftDeletes::class, class_uses_recursive($this::class))
                 ? $this->forceDelete()
                 : $this->delete();
     }

--- a/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
@@ -30,7 +30,7 @@ class RelationNotFoundException extends RuntimeException
      */
     public static function make($model, $relation, $type = null)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         $instance = new static(
             is_null($type)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -748,7 +748,7 @@ class BelongsToMany extends Relation
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+        throw (new ModelNotFoundException)->setModel($this->related::class, $id);
     }
 
     /**
@@ -823,7 +823,7 @@ class BelongsToMany extends Relation
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+        throw (new ModelNotFoundException)->setModel($this->related::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -319,7 +319,7 @@ class HasManyThrough extends Relation
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+        throw (new ModelNotFoundException)->setModel($this->related::class);
     }
 
     /**
@@ -405,7 +405,7 @@ class HasManyThrough extends Relation
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+        throw (new ModelNotFoundException)->setModel($this->related::class, $id);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -140,13 +140,13 @@ class MorphTo extends BelongsTo
                             ->mergeConstraintsFrom($this->getQuery())
                             ->with(array_merge(
                                 $this->getQuery()->getEagerLoads(),
-                                (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
+                                (array) ($this->morphableEagerLoads[$instance::class] ?? [])
                             ))
                             ->withCount(
-                                (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
+                                (array) ($this->morphableEagerLoadCounts[$instance::class] ?? [])
                             );
 
-        if ($callback = ($this->morphableConstraints[get_class($instance)] ?? null)) {
+        if ($callback = ($this->morphableConstraints[$instance::class] ?? null)) {
             $callback($query);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -182,7 +182,7 @@ abstract class Relation implements BuilderContract
         $count = $result->count();
 
         if ($count === 0) {
-            throw (new ModelNotFoundException)->setModel(get_class($this->related));
+            throw (new ModelNotFoundException)->setModel($this->related::class);
         }
 
         if ($count > 1) {

--- a/src/Illuminate/Database/LazyLoadingViolationException.php
+++ b/src/Illuminate/Database/LazyLoadingViolationException.php
@@ -29,7 +29,7 @@ class LazyLoadingViolationException extends RuntimeException
      */
     public function __construct($model, $relation)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         parent::__construct("Attempted to lazy load [{$relation}] on model [{$class}] but lazy loading is disabled.");
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -429,7 +429,7 @@ class Migrator
     protected function pretendToRun($migration, $method)
     {
         try {
-            $name = get_class($migration);
+            $name = $migration::class;
 
             $reflectionClass = new ReflectionClass($migration);
 
@@ -443,7 +443,7 @@ class Migrator
                 return $query['query'];
             }));
         } catch (SchemaException) {
-            $name = get_class($migration);
+            $name = $migration::class;
 
             $this->write(Error::class, sprintf(
                 '[%s] failed to dump queries. This may be due to changing database columns using Doctrine, which is not supported while pretending to run migrations.',

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -60,7 +60,7 @@ class JoinClause extends Builder
     {
         $this->type = $type;
         $this->table = $table;
-        $this->parentClass = get_class($parentQuery);
+        $this->parentClass = $parentQuery::class;
         $this->parentGrammar = $parentQuery->getGrammar();
         $this->parentProcessor = $parentQuery->getProcessor();
         $this->parentConnection = $parentQuery->getConnection();

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -47,7 +47,7 @@ abstract class Seeder
         foreach ($classes as $class) {
             $seeder = $this->resolve($class);
 
-            $name = get_class($seeder);
+            $name = $seeder::class;
 
             if ($silent === false && isset($this->command)) {
                 with(new TwoColumnDetail($this->command->getOutput()))->render(
@@ -177,7 +177,7 @@ abstract class Seeder
     public function __invoke(array $parameters = [])
     {
         if (! method_exists($this, 'run')) {
-            throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
+            throw new InvalidArgumentException('Method [run] missing from '.$this::class);
         }
 
         $callback = fn () => isset($this->container)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -184,7 +184,7 @@ class Dispatcher implements DispatcherContract
             foreach ($events as $event => $listeners) {
                 foreach (Arr::wrap($listeners) as $listener) {
                     if (is_string($listener) && method_exists($subscriber, $listener)) {
-                        $this->listen($event, [get_class($subscriber), $listener]);
+                        $this->listen($event, [$subscriber::class, $listener]);
 
                         continue;
                     }
@@ -278,7 +278,7 @@ class Dispatcher implements DispatcherContract
     protected function parseEventAndPayload($event, $payload)
     {
         if (is_object($event)) {
-            [$payload, $event] = [[$event], get_class($event)];
+            [$payload, $event] = [[$event], $event::class];
         }
 
         return [$event, Arr::wrap($payload)];

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -815,7 +815,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function getProviders($provider)
     {
-        $name = is_string($provider) ? $provider : get_class($provider);
+        $name = is_string($provider) ? $provider : $provider::class;
 
         return Arr::where($this->serviceProviders, fn ($value) => $value instanceof $name);
     }
@@ -841,7 +841,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->serviceProviders[] = $provider;
 
-        $this->loadedProviders[get_class($provider)] = true;
+        $this->loadedProviders[$provider::class] = true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -116,7 +116,7 @@ class ConfigShowCommand extends Command
             is_null($value) => '<fg=#ef8414;options=bold>null</>',
             is_numeric($value) => "<fg=#ef8414;options=bold>{$value}</>",
             is_array($value) => '[]',
-            is_object($value) => get_class($value),
+            is_object($value) => $value::class,
             is_string($value) => $value,
             default => print_r($value, true),
         };

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -52,7 +52,7 @@ class EventCacheCommand extends Command
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
             $providerEvents = array_merge_recursive($provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens());
 
-            $events[get_class($provider)] = $providerEvents;
+            $events[$provider::class] = $providerEvents;
         }
 
         return $events;

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -91,7 +91,7 @@ class EventListCommand extends Command
                     $events[$event][] = $this->stringifyClosure($rawListener);
                 } elseif (is_array($rawListener) && count($rawListener) === 2) {
                     if (is_object($rawListener[0])) {
-                        $rawListener[0] = get_class($rawListener[0]);
+                        $rawListener[0] = $rawListener[0]::class;
                     }
 
                     $events[$event][] = $this->appendListenerInterfaces(implode('@', $rawListener));

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -746,7 +746,7 @@ class Handler implements ExceptionHandlerContract
     {
         return config('app.debug') ? [
             'message' => $e->getMessage(),
-            'exception' => get_class($e),
+            'exception' => $e::class,
             'file' => $e->getFile(),
             'line' => $e->getLine(),
             'trace' => collect($e->getTrace())->map(fn ($trace) => Arr::except($trace, ['args']))->all(),

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -85,7 +85,7 @@ class EventServiceProvider extends ServiceProvider
         if ($this->app->eventsAreCached()) {
             $cache = require $this->app->getCachedEventsPath();
 
-            return $cache[get_class($this)] ?? [];
+            return $cache[$this::class] ?? [];
         } else {
             return array_merge_recursive(
                 $this->discoveredEvents(),

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -89,7 +89,7 @@ trait InteractsWithAuthentication
         $this->assertNotNull($expected, 'The current user is not authenticated.');
 
         $this->assertInstanceOf(
-            get_class($expected), $user,
+            $expected::class, $user,
             'The currently authenticated user is not who was expected'
         );
 

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -52,8 +52,8 @@ trait CollectsResources
         if ($this->collects) {
             $collects = $this->collects;
         } elseif (str_ends_with(class_basename($this), 'Collection') &&
-            (class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
-             class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
+            (class_exists($class = Str::replaceLast('Collection', '', $this::class)) ||
+             class_exists($class = Str::replaceLast('Collection', 'Resource', $this::class)))) {
             $collects = $class;
         }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -106,7 +106,7 @@ class ResourceResponse implements Responsable
      */
     protected function wrapper()
     {
-        return get_class($this->resource)::$wrap;
+        return $this->resource::class::$wrap;
     }
 
     /**

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -125,7 +125,7 @@ class SendQueuedMailable
      */
     public function displayName()
     {
-        return get_class($this->mailable);
+        return $this->mailable::class;
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -34,7 +34,7 @@ class DatabaseChannel
             'id' => $notification->id,
             'type' => method_exists($notification, 'databaseType')
                         ? $notification->databaseType($notifiable)
-                        : get_class($notification),
+                        : $notification::class,
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -154,7 +154,7 @@ class MailChannel
     {
         return [
             '__laravel_notification_id' => $notification->id,
-            '__laravel_notification' => get_class($notification),
+            '__laravel_notification' => $notification::class,
             '__laravel_notification_queued' => in_array(
                 ShouldQueue::class,
                 class_implements($notification)

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -87,7 +87,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $this->notifiable->receivesBroadcastNotificationsOn($this->notification);
         }
 
-        $class = str_replace('\\', '.', get_class($this->notifiable));
+        $class = str_replace('\\', '.', $this->notifiable::class);
 
         return $class.'.'.$this->notifiable->getKey();
     }
@@ -118,7 +118,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return method_exists($this->notification, 'broadcastType')
                     ? $this->notification->broadcastType()
-                    : get_class($this->notification);
+                    : $this->notification::class;
     }
 
     /**
@@ -130,6 +130,6 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return method_exists($this->notification, 'broadcastAs')
         ? $this->notification->broadcastAs()
-        : get_class($this->notification);
+        : $this->notification::class;
     }
 }

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -119,7 +119,7 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function displayName()
     {
-        return get_class($this->notification);
+        return $this->notification::class;
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -160,7 +160,7 @@ class ThrottlesExceptions
             return $this->prefix.$job->job->uuid();
         }
 
-        return $this->prefix.md5(get_class($job));
+        return $this->prefix.md5($job::class);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -157,6 +157,6 @@ class WithoutOverlapping
     {
         return $this->shareKey
             ? $this->prefix.$this->key
-            : $this->prefix.get_class($job).':'.$this->key;
+            : $this->prefix.$job::class.':'.$this->key;
     }
 }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -159,7 +159,7 @@ abstract class Queue
 
         return array_merge($payload, [
             'data' => array_merge($payload['data'], [
-                'commandName' => get_class($job),
+                'commandName' => $job::class,
                 'command' => $command,
             ]),
         ]);
@@ -174,7 +174,7 @@ abstract class Queue
     protected function getDisplayName($job)
     {
         return method_exists($job, 'displayName')
-                        ? $job->displayName() : get_class($job);
+                        ? $job->displayName() : $job::class;
     }
 
     /**

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -27,7 +27,7 @@ trait SerializesAndRestoresModelIdentifiers
                 $withRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
             ))->useCollectionClass(
-                ($collectionClass = get_class($value)) !== EloquentCollection::class
+                ($collectionClass = $value::class) !== EloquentCollection::class
                     ? $collectionClass
                     : null
             );
@@ -35,7 +35,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         if ($value instanceof QueueableEntity) {
             return new ModelIdentifier(
-                get_class($value),
+                $value::class,
                 $value->getQueueableId(),
                 $withRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
@@ -87,7 +87,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collection = $collection->keyBy->getKey();
 
-        $collectionClass = get_class($collection);
+        $collectionClass = $collection::class;
 
         return new $collectionClass(
             collect($value->id)->map(function ($id) use ($collection) {

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -22,7 +22,7 @@ trait SerializesModels
         $reflectionClass = new ReflectionClass($this);
 
         [$class, $properties, $classLevelWithoutRelations] = [
-            get_class($this),
+            $this::class,
             $reflectionClass->getProperties(),
             ! empty($reflectionClass->getAttributes(WithoutRelations::class)),
         ];
@@ -70,7 +70,7 @@ trait SerializesModels
     {
         $properties = (new ReflectionClass($this))->getProperties();
 
-        $class = get_class($this);
+        $class = $this::class;
 
         foreach ($properties as $property) {
             if ($property->isStatic()) {

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -56,10 +56,10 @@ class ImplicitRouteBinding
                 if (! $model = $parent->{$childRouteBindingMethod}(
                     $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
                 )) {
-                    throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+                    throw (new ModelNotFoundException)->setModel($instance::class, [$parameterValue]);
                 }
             } elseif (! $model = $instance->{$routeBindingMethod}($parameterValue, $route->bindingFieldFor($parameterName))) {
-                throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+                throw (new ModelNotFoundException)->setModel($instance::class, [$parameterValue]);
             }
 
             $route->setParameter($parameterName, $model);

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -165,7 +165,7 @@ abstract class Facade
     protected static function getMockableClass()
     {
         if ($root = static::getFacadeRoot()) {
-            return get_class($root);
+            return $root::class;
         }
     }
 

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -33,7 +33,7 @@ class Reflector
             return true;
         }
 
-        $class = is_object($var[0]) ? get_class($var[0]) : $var[0];
+        $class = is_object($var[0]) ? $var[0]::class : $var[0];
 
         $method = $var[1];
 

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -336,7 +336,7 @@ class BusFake implements Fake, QueueingDispatcher
         } elseif (! is_string($command)) {
             $instance = $command;
 
-            $command = get_class($instance);
+            $command = $instance::class;
 
             $callback = function ($job) use ($instance) {
                 return serialize($this->resetChainPropertiesToDefaults($job)) === serialize($instance);
@@ -422,7 +422,7 @@ class BusFake implements Fake, QueueingDispatcher
     {
         $matching = $this->dispatched($command, $callback)->map->chained->map(function ($chain) {
             return collect($chain)->map(
-                fn ($job) => get_class(unserialize($job))
+                fn ($job) => unserialize($job)::class
             );
         })->filter(
             fn ($chain) => $chain->all() === $expectedChain
@@ -592,7 +592,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatch($command)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commands[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatch($command);
         }
@@ -610,7 +610,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchSync($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commandsSync[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commandsSync[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatchSync($command, $handler);
         }
@@ -626,7 +626,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchNow($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commands[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatchNow($command, $handler);
         }
@@ -641,7 +641,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchToQueue($command)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commands[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatchToQueue($command);
         }
@@ -656,7 +656,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchAfterResponse($command)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commandsAfterResponse[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commandsAfterResponse[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatch($command);
         }
@@ -741,7 +741,7 @@ class BusFake implements Fake, QueueingDispatcher
             ->filter(function ($job) use ($command) {
                 return $job instanceof Closure
                             ? $job($command)
-                            : $job === get_class($command);
+                            : $job === $command::class;
             })->isNotEmpty();
     }
 
@@ -757,7 +757,7 @@ class BusFake implements Fake, QueueingDispatcher
             ->filter(function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
-                    : $job === get_class($command);
+                    : $job === $command::class;
             })->isNotEmpty();
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -294,7 +294,7 @@ class EventFake implements Dispatcher, Fake
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
-        $name = is_object($event) ? get_class($event) : (string) $event;
+        $name = is_object($event) ? $event::class : (string) $event;
 
         if ($this->shouldFakeEvent($name, $payload)) {
             $this->events[$name][] = func_get_args();

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -149,7 +149,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertNothingSent()
     {
         $mailableNames = collect($this->mailables)->map(
-            fn ($mailable) => get_class($mailable)
+            fn ($mailable) => $mailable::class
         )->join(', ');
 
         PHPUnit::assertEmpty($this->mailables, 'The following mailables were sent unexpectedly: '.$mailableNames);
@@ -218,7 +218,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertNothingQueued()
     {
         $mailableNames = collect($this->queuedMailables)->map(
-            fn ($mailable) => get_class($mailable)
+            fn ($mailable) => $mailable::class
         )->join(', ');
 
         PHPUnit::assertEmpty($this->queuedMailables, 'The following mailables were queued unexpectedly: '.$mailableNames);

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -181,7 +181,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         }
 
         PHPUnit::assertEmpty(
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()] ?? [],
+            $this->notifications[$notifiable::class][$notifiable->getKey()] ?? [],
             'Notifications were sent unexpectedly.',
         );
     }
@@ -265,7 +265,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        return $this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification] ?? [];
+        return $this->notifications[$notifiable::class][$notifiable->getKey()][$notification] ?? [];
     }
 
     /**
@@ -312,7 +312,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 }
             }
 
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
+            $this->notifications[$notifiable::class][$notifiable->getKey()][$notification::class][] = [
                 'notification' => $notification,
                 'channels' => $notifiableChannels,
                 'notifiable' => $notifiable,

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -215,7 +215,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
             return collect($chain)->map(function ($job) {
-                return get_class(unserialize($job));
+                return unserialize($job)::class;
             });
         })->filter(function ($chain) use ($expectedChain) {
             return $chain->all() === $expectedChain;
@@ -358,7 +358,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                 $job = CallQueuedClosure::create($job);
             }
 
-            $this->jobs[is_object($job) ? get_class($job) : $job][] = [
+            $this->jobs[is_object($job) ? $job::class : $job][] = [
                 'job' =>  $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
                 'queue' => $queue,
                 'data' => $data,

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -28,7 +28,7 @@ trait ForwardsCalls
                 throw $e;
             }
 
-            if ($matches['class'] != get_class($object) ||
+            if ($matches['class'] != $object::class ||
                 $matches['method'] != $method) {
                 throw $e;
             }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -70,7 +70,7 @@ if (! function_exists('class_basename')) {
      */
     function class_basename($class)
     {
-        $class = is_object($class) ? get_class($class) : $class;
+        $class = is_object($class) ? $class::class : $class;
 
         return basename(str_replace('\\', '/', $class));
     }
@@ -86,7 +86,7 @@ if (! function_exists('class_uses_recursive')) {
     function class_uses_recursive($class)
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $class = $class::class;
         }
 
         $results = [];

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -37,7 +37,7 @@ trait TestDatabases
         });
 
         ParallelTesting::setUpTestCase(function ($testCase) {
-            $uses = array_flip(class_uses_recursive(get_class($testCase)));
+            $uses = array_flip(class_uses_recursive($testCase::class));
 
             $databaseTraits = [
                 Testing\DatabaseMigrations::class,

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -244,8 +244,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $shouldReplace = [];
 
         foreach ($replace as $key => $value) {
-            if (is_object($value) && isset($this->stringableHandlers[get_class($value)])) {
-                $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
+            if (is_object($value) && isset($this->stringableHandlers[$value::class])) {
+                $value = call_user_func($this->stringableHandlers[$value::class], $value);
             }
 
             $shouldReplace[':'.Str::ucfirst($key ?? '')] = Str::ucfirst($value ?? '');

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -837,8 +837,8 @@ class Validator implements ValidatorContract
 
         if (! $rule->passes($attribute, $value)) {
             $ruleClass = $rule instanceof InvokableValidationRule ?
-                get_class($rule->invokable()) :
-                get_class($rule);
+                $rule->invokable()::class :
+                $rule::class;
 
             $this->failedRules[$attribute][$ruleClass] = [];
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -158,8 +158,8 @@ trait CompilesEchos
      */
     public function applyEchoHandler($value)
     {
-        if (is_object($value) && isset($this->echoHandlers[get_class($value)])) {
-            return call_user_func($this->echoHandlers[get_class($value)], $value);
+        if (is_object($value) && isset($this->echoHandlers[$value::class])) {
+            return call_user_func($this->echoHandlers[$value::class], $value);
         }
 
         return $value;

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -220,7 +220,7 @@ abstract class Component
      */
     protected function extractPublicProperties()
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (! isset(static::$propertyCache[$class])) {
             $reflection = new ReflectionClass($this);
@@ -253,7 +253,7 @@ abstract class Component
      */
     protected function extractPublicMethods()
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (! isset(static::$methodCache[$class])) {
             $reflection = new ReflectionClass($this);

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -91,7 +91,7 @@ class AuthorizesResourcesTest extends TestCase
         $router = new Router(new Dispatcher);
 
         $router->aliasMiddleware('can', AuthorizesResourcesMiddleware::class);
-        $router->get($method)->uses(get_class($controller).'@'.$method);
+        $router->get($method)->uses($controller::class.'@'.$method);
 
         $this->assertSame(
             'caught '.$middleware,

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -89,8 +89,8 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testSingleConnectionNotCreatedUntilNeeded()
     {
         $connection = $this->db->getConnection();
-        $pdo = new ReflectionProperty(get_class($connection), 'pdo');
-        $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
+        $pdo = new ReflectionProperty($connection::class, 'pdo');
+        $readPdo = new ReflectionProperty($connection::class, 'readPdo');
 
         $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
@@ -99,8 +99,8 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testReadWriteConnectionsNotCreatedUntilNeeded()
     {
         $connection = $this->db->getConnection('read_write');
-        $pdo = new ReflectionProperty(get_class($connection), 'pdo');
-        $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
+        $pdo = new ReflectionProperty($connection::class, 'pdo');
+        $readPdo = new ReflectionProperty($connection::class, 'readPdo');
 
         $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2239,7 +2239,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
-        $class = get_class($model);
+        $class = $model::class;
         $class::setConnectionResolver($resolver);
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -272,7 +272,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             return 'not-a-model';
         });
 
-        $this->assertEquals(BaseCollection::class, get_class($c));
+        $this->assertEquals(BaseCollection::class, $c::class);
     }
 
     public function testMapWithKeys()
@@ -301,7 +301,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             return [$key++ => 'not-a-model'];
         });
 
-        $this->assertEquals(BaseCollection::class, get_class($c));
+        $this->assertEquals(BaseCollection::class, $c::class);
     }
 
     public function testCollectionDiffsWithGivenCollection()
@@ -492,13 +492,13 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
         $b = new Collection(['a', 'b', 'c']);
-        $this->assertEquals(BaseCollection::class, get_class($a->pluck('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($a->keys()));
-        $this->assertEquals(BaseCollection::class, get_class($a->collapse()));
-        $this->assertEquals(BaseCollection::class, get_class($a->flatten()));
-        $this->assertEquals(BaseCollection::class, get_class($a->zip(['a', 'b'], ['c', 'd'])));
-        $this->assertEquals(BaseCollection::class, get_class($a->countBy('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($b->flip()));
+        $this->assertEquals(BaseCollection::class, $a->pluck('foo')::class);
+        $this->assertEquals(BaseCollection::class, $a->keys()::class);
+        $this->assertEquals(BaseCollection::class, $a->collapse()::class);
+        $this->assertEquals(BaseCollection::class, $a->flatten()::class);
+        $this->assertEquals(BaseCollection::class, $a->zip(['a', 'b'], ['c', 'd'])::class);
+        $this->assertEquals(BaseCollection::class, $a->countBy('foo')::class);
+        $this->assertEquals(BaseCollection::class, $b->flip()::class);
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -629,10 +629,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->id = 1;
         $model->foo = 'bar';
@@ -668,7 +668,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(false);
         $model->exists = true;
 
         $this->assertFalse($model->save());
@@ -680,8 +680,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.$model::class, $model)->andReturn(false);
         $model->exists = true;
         $model->foo = 'bar';
 
@@ -727,10 +727,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->id = 1;
         $model->syncOriginal();
@@ -873,10 +873,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('updateTimestamps');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.$model::class, $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model);
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -893,10 +893,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setIncrementing(false);
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.$model::class, $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model);
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -912,8 +912,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.$model::class, $model)->andReturn(false);
 
         $this->assertFalse($model->save());
         $this->assertFalse($model->exists);
@@ -1990,7 +1990,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(function ($m) use ($model) {
+        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.$model::class, m::on(function ($m) use ($model) {
             return $model->is($m);
         }));
 
@@ -2007,7 +2007,7 @@ class DatabaseEloquentModelTest extends TestCase
         $replicated = $model->replicateQuietly();
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '.$model::class, $model)->andReturn(true);
 
         $this->assertNull($replicated->id);
         $this->assertSame('bar', $replicated->foo);
@@ -2050,10 +2050,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('increment');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->never()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->never()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->publicIncrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());
@@ -2077,10 +2077,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('decrement');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->never()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->never()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->publicDecrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -33,7 +33,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
-        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
+        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', $relation->getParent()::class);
 
         $model1 = new EloquentMorphResetModelStub;
         $model1->id = 1;
@@ -57,7 +57,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.morph_id', [1, 2]);
-        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
+        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', $relation->getParent()::class);
 
         $model1 = new EloquentMorphResetModelStub;
         $model1->id = 1;
@@ -73,7 +73,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $instance = m::mock(Model::class);
         $instance->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $instance->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $instance->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $instance->shouldReceive('save')->never();
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($instance);
 
@@ -86,7 +86,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $created = m::mock(Model::class);
         $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $created->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->shouldReceive('save')->once()->andReturn(true);
 
@@ -110,7 +110,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->never();
 
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
@@ -147,7 +147,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->never();
 
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo']));
@@ -160,7 +160,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->never();
 
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
@@ -198,7 +198,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo']));
@@ -212,7 +212,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
@@ -224,7 +224,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andThrow(
             new UniqueConstraintViolationException('mysql', 'example mysql', [], new Exception('SQLSTATE[23000]: Integrity constraint violation: 1062')),
         );
@@ -245,7 +245,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andThrow(
             new UniqueConstraintViolationException('mysql', 'example mysql', [], new Exception('SQLSTATE[23000]: Integrity constraint violation: 1062')),
         );
@@ -266,7 +266,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
@@ -284,7 +284,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
@@ -316,7 +316,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
 
@@ -444,8 +444,8 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
-        $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
+        $builder->shouldReceive('where')->once()->with('table.morph_type', $parent::class);
 
         return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }
@@ -459,8 +459,8 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
-        $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
+        $builder->shouldReceive('where')->once()->with('table.morph_type', $parent::class);
 
         return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -22,7 +22,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation->getParent()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('taggables.taggable_id', [1, 2]);
-        $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($relation->getParent()));
+        $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', $relation->getParent()::class);
         $model1 = new EloquentMorphToManyModelStub;
         $model1->id = 1;
         $model2 = new EloquentMorphToManyModelStub;
@@ -35,7 +35,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
+        $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => $relation->getParent()::class, 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
@@ -49,7 +49,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggable_type', $relation->getParent()::class)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('taggables.tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
@@ -65,7 +65,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggable_type', $relation->getParent()::class)->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
@@ -85,11 +85,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     public function getRelationArguments()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 
         $builder = m::mock(Builder::class);
@@ -99,11 +99,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $related->shouldReceive('getTable')->andReturn('tags');
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('tags.id');
-        $related->shouldReceive('getMorphClass')->andReturn(get_class($related));
+        $related->shouldReceive('getMorphClass')->andReturn($related::class);
 
         $builder->shouldReceive('join')->once()->with('taggables', 'tags.id', '=', 'taggables.tag_id');
         $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
-        $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));
+        $builder->shouldReceive('where')->once()->with('taggables.taggable_type', $parent::class);
 
         return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id', 'relation_name', false];
     }

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -21,13 +21,13 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $schemaState = new MySqlSchemaState($connection);
 
         // test connectionString
-        $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
+        $method = new ReflectionMethod($schemaState::class, 'connectionString');
         $connString = $method->invoke($schemaState);
 
         self::assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
-        $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $method = new ReflectionMethod($schemaState::class, 'baseVariables');
         $variables = $method->invoke($schemaState, $dbConfig);
 
         self::assertEquals($expectedVariables, $variables);

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -10,8 +10,6 @@ use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Events\ModelPruningFinished;
-use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -201,13 +201,13 @@ class PruneCommandTest extends TestCase
         $dispatcher = m::mock(DispatcherContract::class);
 
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
-            return get_class($event) === ModelPruningStarting::class &&
+            return $event instanceof \Illuminate\Database\Events\ModelPruningStarting &&
                 $event->models === [PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('listen')->once()->with(ModelsPruned::class, m::type(Closure::class));
         $dispatcher->shouldReceive('dispatch')->twice()->with(m::type(ModelsPruned::class));
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
-            return get_class($event) === ModelPruningFinished::class &&
+            return $event instanceof \Illuminate\Database\Events\ModelPruningFinished &&
                 $event->models === [PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('forget')->once()->with(ModelsPruned::class);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -35,7 +35,7 @@ class FoundationApplicationTest extends TestCase
     public function testServiceProvidersAreCorrectlyRegistered()
     {
         $provider = m::mock(ApplicationBasicServiceProviderStub::class);
-        $class = get_class($provider);
+        $class = $provider::class;
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
@@ -53,7 +53,7 @@ class FoundationApplicationTest extends TestCase
             ];
         });
 
-        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
+        $this->assertArrayHasKey($provider::class, $app->getLoadedProviders());
 
         $instance = $app->make(AbstractClass::class);
 
@@ -72,7 +72,7 @@ class FoundationApplicationTest extends TestCase
             ];
         });
 
-        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
+        $this->assertArrayHasKey($provider::class, $app->getLoadedProviders());
 
         $instance = $app->make(AbstractClass::class);
 
@@ -88,7 +88,7 @@ class FoundationApplicationTest extends TestCase
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotFilled()
     {
         $provider = m::mock(ServiceProvider::class);
-        $class = get_class($provider);
+        $class = $provider::class;
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
@@ -99,7 +99,7 @@ class FoundationApplicationTest extends TestCase
     public function testServiceProvidersCouldBeLoaded()
     {
         $provider = m::mock(ServiceProvider::class);
-        $class = get_class($provider);
+        $class = $provider::class;
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -34,7 +34,7 @@ class InteractsWithViewsTest extends TestCase
             }
         };
 
-        $component = $this->component(get_class($exampleComponent));
+        $component = $this->component($exampleComponent::class);
 
         $this->assertSame('bar', $component->foo);
         $this->assertSame('hello', $component->speak());

--- a/tests/Foundation/Testing/DatabaseMigrationsTest.php
+++ b/tests/Foundation/Testing/DatabaseMigrationsTest.php
@@ -34,7 +34,7 @@ class DatabaseMigrationsTest extends TestCase
     private function __reflectAndSetupAccessibleForProtectedTraitMethod($methodName)
     {
         $migrateFreshUsingReflection = new ReflectionMethod(
-            get_class($this->traitObject),
+            $this->traitObject::class,
             $methodName
         );
 

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -34,7 +34,7 @@ class RefreshDatabaseTest extends TestCase
     private function __reflectAndSetupAccessibleForProtectedTraitMethod($methodName)
     {
         $migrateFreshUsingReflection = new ReflectionMethod(
-            get_class($this->traitObject),
+            $this->traitObject::class,
             $methodName
         );
 

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -18,7 +18,7 @@ class CanConfigureMigrationCommandsTest extends TestCase
     private function __reflectAndSetupAccessibleForProtectedTraitMethod($methodName)
     {
         $migrateFreshUsingReflection = new ReflectionMethod(
-            get_class($this->traitObject),
+            $this->traitObject::class,
             $methodName
         );
 

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -27,7 +27,7 @@ class EloquentHasOneOfManyTest extends DatabaseTestCase
         $this->retrievedLogins = 0;
         User::getEventDispatcher()->listen('eloquent.retrieved:*', function ($event, $models) {
             foreach ($models as $model) {
-                if (get_class($model) == Login::class) {
+                if ($model::class == Login::class) {
                     $this->retrievedLogins++;
                 }
             }

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -161,7 +161,7 @@ class SendingMailNotificationsTest extends TestCase
 
             $expected = array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]);
 
@@ -295,7 +295,7 @@ class SendingMailNotificationsTest extends TestCase
             ['html', 'plain'],
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]),
             m::on(function ($closure) {
@@ -327,7 +327,7 @@ class SendingMailNotificationsTest extends TestCase
             'html',
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]),
             m::on(function ($closure) {
@@ -359,7 +359,7 @@ class SendingMailNotificationsTest extends TestCase
             [null, 'plain'],
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]),
             m::on(function ($closure) {

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -150,7 +150,7 @@ class UniqueJobTest extends TestCase
 
     protected function getLockKey($job)
     {
-        return 'laravel_unique_job:'.(is_string($job) ? $job : get_class($job));
+        return 'laravel_unique_job:'.(is_string($job) ? $job : $job::class);
     }
 }
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -122,7 +122,7 @@ class LogManagerTest extends TestCase
         $this->assertEquals(Level::Notice, $handlers[0]->getLevel());
         $this->assertFalse($handlers[0]->getBubble());
 
-        $url = new ReflectionProperty(get_class($handlers[0]), 'url');
+        $url = new ReflectionProperty($handlers[0]::class, 'url');
         $this->assertSame('php://stderr', $url->getValue($handlers[0]));
 
         $config->set('logging.channels.logentries', [
@@ -137,7 +137,7 @@ class LogManagerTest extends TestCase
         $logger = $manager->channel('logentries');
         $handlers = $logger->getLogger()->getHandlers();
 
-        $logToken = new ReflectionProperty(get_class($handlers[0]), 'logToken');
+        $logToken = new ReflectionProperty($handlers[0]::class, 'logToken');
 
         $this->assertInstanceOf(LogEntriesHandler::class, $handlers[0]);
         $this->assertSame('123456789', $logToken->getValue($handlers[0]));
@@ -179,7 +179,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(NewRelicHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -239,7 +239,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(MemoryUsageProcessor::class, $processors[0]);
         $this->assertInstanceOf(PsrLogMessageProcessor::class, $processors[1]);
 
-        $removeUsedContextFields = new ReflectionProperty(get_class($processors[1]), 'removeUsedContextFields');
+        $removeUsedContextFields = new ReflectionProperty($processors[1]::class, 'removeUsedContextFields');
 
         $this->assertTrue($removeUsedContextFields->getValue($processors[1]));
     }
@@ -319,7 +319,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertEmpty($logger->getLogger()->getProcessors());
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -364,7 +364,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertEmpty($logger->getLogger()->getProcessors());
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -407,7 +407,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertEmpty($logger->getLogger()->getProcessors());
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -439,7 +439,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(StreamHandler::class, $handler);
 
-        $url = new ReflectionProperty(get_class($handler), 'url');
+        $url = new ReflectionProperty($handler::class, 'url');
 
         $this->assertSame(storage_path('logs/on-demand.log'), $url->getValue($handler));
     }
@@ -464,7 +464,7 @@ class LogManagerTest extends TestCase
         };
         $channel = $manager->build([
             'driver' => 'custom',
-            'via' => get_class($factory),
+            'via' => $factory::class,
         ]);
         $logger = $manager->stack(['test', $channel]);
 
@@ -474,7 +474,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(StreamHandler::class, $handler);
         $this->assertInstanceOf(UidProcessor::class, $processor);
 
-        $url = new ReflectionProperty(get_class($handler), 'url');
+        $url = new ReflectionProperty($handler::class, 'url');
 
         $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
     }
@@ -506,10 +506,10 @@ class LogManagerTest extends TestCase
         $expectedFingersCrossedHandler = $handlers[0];
         $this->assertInstanceOf(FingersCrossedHandler::class, $expectedFingersCrossedHandler);
 
-        $activationStrategyProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'activationStrategy');
+        $activationStrategyProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'activationStrategy');
         $activationStrategyValue = $activationStrategyProp->getValue($expectedFingersCrossedHandler);
 
-        $actionLevelProp = new ReflectionProperty(get_class($activationStrategyValue), 'actionLevel');
+        $actionLevelProp = new ReflectionProperty($activationStrategyValue::class, 'actionLevel');
         $actionLevelValue = $actionLevelProp->getValue($activationStrategyValue);
 
         $this->assertEquals(Level::Critical, $actionLevelValue);
@@ -517,7 +517,7 @@ class LogManagerTest extends TestCase
         if (method_exists($expectedFingersCrossedHandler, 'getHandler')) {
             $expectedStreamHandler = $expectedFingersCrossedHandler->getHandler();
         } else {
-            $handlerProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'handler');
+            $handlerProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'handler');
             $expectedStreamHandler = $handlerProp->getValue($expectedFingersCrossedHandler);
         }
         $this->assertInstanceOf(StreamHandler::class, $expectedStreamHandler);
@@ -547,7 +547,7 @@ class LogManagerTest extends TestCase
 
         $expectedFingersCrossedHandler = $handlers[0];
 
-        $stopBufferingProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'stopBuffering');
+        $stopBufferingProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'stopBuffering');
         $stopBufferingValue = $stopBufferingProp->getValue($expectedFingersCrossedHandler);
 
         $this->assertTrue($stopBufferingValue);
@@ -577,7 +577,7 @@ class LogManagerTest extends TestCase
 
         $expectedFingersCrossedHandler = $handlers[0];
 
-        $stopBufferingProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'stopBuffering');
+        $stopBufferingProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'stopBuffering');
         $stopBufferingValue = $stopBufferingProp->getValue($expectedFingersCrossedHandler);
 
         $this->assertFalse($stopBufferingValue);
@@ -703,7 +703,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(LineFormatter::class, $formatter);
 
-        $format = new ReflectionProperty(get_class($formatter), 'format');
+        $format = new ReflectionProperty($formatter::class, 'format');
 
         $this->assertEquals(
             '[%datetime%] %channel%.%level_name%: %message% %context% %extra%',

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -23,7 +23,7 @@ class NotificationDatabaseChannelTest extends TestCase
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
-            'type' => get_class($notification),
+            'type' => $notification::class,
             'data' => ['invoice_id' => 1],
             'read_at' => null,
         ]);
@@ -40,7 +40,7 @@ class NotificationDatabaseChannelTest extends TestCase
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
-            'type' => get_class($notification),
+            'type' => $notification::class,
             'data' => ['invoice_id' => 1],
             'read_at' => null,
             'something' => 'else',

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2340,7 +2340,7 @@ class RouteTestControllerMiddleware
     {
         $_SERVER['route.test.controller.middleware'] = true;
         $response = $next($request);
-        $_SERVER['route.test.controller.middleware.class'] = get_class($response);
+        $_SERVER['route.test.controller.middleware.class'] = $response::class;
 
         return $response;
     }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -34,41 +34,41 @@ class DateFacadeTest extends TestCase
     public function testUseClosure()
     {
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(function (Carbon $date) {
             return new DateTime($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
         });
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(DateTime::class, get_class(Date::now()));
+        $this->assertSame(DateTime::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testUseClassName()
     {
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(DateTime::class);
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(DateTime::class, get_class(Date::now()));
+        $this->assertSame(DateTime::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testCarbonImmutable()
     {
         DateFactory::use(CarbonImmutable::class);
-        $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
+        $this->assertSame(CarbonImmutable::class, Date::now()::class);
         DateFactory::use(Carbon::class);
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
         DateFactory::use(function (Carbon $date) {
             return $date->toImmutable();
         });
-        $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
+        $this->assertSame(CarbonImmutable::class, Date::now()::class);
         DateFactory::use(function ($date) {
             return $date;
         });
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
 
         DateFactory::use(new Factory([
             'locale' => 'fr',

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -323,7 +323,7 @@ class SupportTestingQueueFakeTest extends TestCase
             $this->fake->undefinedMethod();
         } catch (BadMethodCallException $e) {
             $this->assertSame(sprintf(
-                'Call to undefined method %s::%s()', get_class($this->fake), 'undefinedMethod'
+                'Call to undefined method %s::%s()', $this->fake::class, 'undefinedMethod'
             ), $e->getMessage());
         }
     }


### PR DESCRIPTION
Available since PHP 8.0