### PR TITLE
[11.x] TrimStrings: support nested attribute

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Str;
 
 class TrimStrings extends TransformsRequest
 {
@@ -49,7 +50,9 @@ class TrimStrings extends TransformsRequest
      */
     protected function transform($key, $value)
     {
-        if (in_array($key, $this->except, true) || ! is_string($value)) {
+        $attribute = Str::afterLast($key, '.');
+
+        if (in_array($key, $this->except, true) || in_array($attribute, $this->except, true) || ! is_string($value)) {
             return $value;
         }
 

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -17,6 +17,22 @@ class TrimStringsTest extends TestCase
             'xyz' => '  456  ',
             'foo' => '  789  ',
             'bar' => '  010  ',
+            /**/
+            'temp' => [
+                'abc' => '  123  ',
+                'xyz' => '  456  ',
+                'foo' => '  789  ',
+                'bar' => '  010  ',
+            ],
+            /**/
+            'temps' => [
+                [
+                    'abc' => '  123  ',
+                    'xyz' => '  456  ',
+                    'foo' => '  789  ',
+                    'bar' => '  010  ',
+                ],
+            ],
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);
@@ -26,6 +42,16 @@ class TrimStringsTest extends TestCase
             $this->assertSame('456', $request->get('xyz'));
             $this->assertSame('  789  ', $request->get('foo'));
             $this->assertSame('  010  ', $request->get('bar'));
+            /**/
+            $this->assertSame('123', $request->input('temp.abc'));
+            $this->assertSame('456', $request->input('temp.xyz'));
+            $this->assertSame('  789  ', $request->input('temp.foo'));
+            $this->assertSame('  010  ', $request->input('temp.bar'));
+            /**/
+            $this->assertSame('123', $request->input('temps.0.abc'));
+            $this->assertSame('456', $request->input('temps.0.xyz'));
+            $this->assertSame('  789  ', $request->input('temps.0.foo'));
+            $this->assertSame('  010  ', $request->input('temps.0.bar'));
         });
     }
 
@@ -42,6 +68,28 @@ class TrimStringsTest extends TestCase
             'bar' => '   だ    ',
             'baz' => '   ム    ',
             'binary' => " \xE9  ",
+            /**/
+            'temp' => [
+                'abc' => '   123    ',
+                'zwnbsp' => '﻿  ha  ﻿﻿',
+                'xyz' => 'だ',
+                'foo' => 'ム',
+                'bar' => '   だ    ',
+                'baz' => '   ム    ',
+                'binary' => " \xE9  ",
+            ],
+            /**/
+            'temps' => [
+                [
+                    'abc' => '   123    ',
+                    'zwnbsp' => '﻿  ha  ﻿﻿',
+                    'xyz' => 'だ',
+                    'foo' => 'ム',
+                    'bar' => '   だ    ',
+                    'baz' => '   ム    ',
+                    'binary' => " \xE9  ",
+                ],
+            ],
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);
@@ -54,6 +102,22 @@ class TrimStringsTest extends TestCase
             $this->assertSame('だ', $request->get('bar'));
             $this->assertSame('ム', $request->get('baz'));
             $this->assertSame("\xE9", $request->get('binary'));
+            /**/
+            $this->assertSame('123', $request->input('temp.abc'));
+            $this->assertSame('ha', $request->input('temp.zwnbsp'));
+            $this->assertSame('だ', $request->input('temp.xyz'));
+            $this->assertSame('ム', $request->input('temp.foo'));
+            $this->assertSame('だ', $request->input('temp.bar'));
+            $this->assertSame('ム', $request->input('temp.baz'));
+            $this->assertSame("\xE9", $request->input('temp.binary'));
+            /**/
+            $this->assertSame('123', $request->input('temps.0.abc'));
+            $this->assertSame('ha', $request->input('temps.0.zwnbsp'));
+            $this->assertSame('だ', $request->input('temps.0.xyz'));
+            $this->assertSame('ム', $request->input('temps.0.foo'));
+            $this->assertSame('だ', $request->input('temps.0.bar'));
+            $this->assertSame('ム', $request->input('temps.0.baz'));
+            $this->assertSame("\xE9", $request->input('temps.0.binary'));
         });
     }
 }


### PR DESCRIPTION
```php
protected $except = [
        'current_password',
        'password',
        'password_confirmation',
];
```

sometimes I send form request as 

Create many users
```php
[
	'users' => [
		[
			'email' => '',
			'password' => '',
		],
		[
			'email' => '',
			'password' => '',
		],
	],
],
```

or create company with a new admin

```
[
	'name' => '',
	'location' => '',
	'admin' => [
		'email' => '',
		'password' => '',
	],
],
```

I need define except like `admin.password`, `users.0.password`, `users.1.password`, .... , `users.n.password`. I cant define all of it

I think TrimStrings should support nested attribute, when define `password` it match `*.password`, `*.*.password` ... etc

my english is not good, sorry if i write curtly or hard to understand
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
