### PR TITLE
[10.x] Allow failed jobs to be counted by "connection" and "queue"

### DIFF
--- a/src/Illuminate/Queue/Failed/CountableFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/CountableFailedJobProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+interface CountableFailedJobProvider
+{
+    /**
+     * Count the failed jobs.
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function count($connection = null, $queue = null);
+}

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -2,12 +2,11 @@
 
 namespace Illuminate\Queue\Failed;
 
-use Countable;
 use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseFailedJobProvider implements Countable, FailedJobProviderInterface, PrunableFailedJobProvider
+class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.
@@ -133,10 +132,17 @@ class DatabaseFailedJobProvider implements Countable, FailedJobProviderInterface
 
     /**
      * Count the failed jobs.
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
+     * @return int
      */
-    public function count(): int
+    public function count($connection = null, $queue = null)
     {
-        return $this->getTable()->count();
+        return $this->getTable()
+            ->when($connection, fn ($builder) => $builder->whereConnection($connection))
+            ->when($queue, fn ($builder) => $builder->whereQueue($queue))
+            ->count();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -148,8 +148,9 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      *
      * @param  string|null  $connection
      * @param  string|null  $queue
+     * @return int
      */
-    public function count($connection = null, $queue = null): int
+    public function count($connection = null, $queue = null)
     {
         return $this->getTable()
             ->when($connection, fn ($builder) => $builder->whereConnection($connection))

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -2,12 +2,11 @@
 
 namespace Illuminate\Queue\Failed;
 
-use Countable;
 use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseUuidFailedJobProvider implements Countable, FailedJobProviderInterface, PrunableFailedJobProvider
+class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.
@@ -146,10 +145,16 @@ class DatabaseUuidFailedJobProvider implements Countable, FailedJobProviderInter
 
     /**
      * Count the failed jobs.
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
      */
-    public function count(): int
+    public function count($connection = null, $queue = null): int
     {
-        return $this->getTable()->count();
+        return $this->getTable()
+            ->when($connection, fn ($builder) => $builder->whereConnection($connection))
+            ->when($queue, fn ($builder) => $builder->whereQueue($queue))
+            ->count();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -206,9 +206,19 @@ class FileFailedJobProvider implements Countable, FailedJobProviderInterface, Pr
 
     /**
      * Count the failed jobs.
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
+     * @return int
      */
-    public function count(): int
+    public function count($connection = null, $queue = null)
     {
-        return count($this->read());
+        if (($connection ?? $queue) === null) {
+            return count($this->read());
+        }
+
+        return collect($this->read())
+            ->filter(fn ($job) => $job->connection === ($connection ?? $job->connection) && $job->queue === ($queue ?? $job->queue))
+            ->count();
     }
 }

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -7,7 +7,7 @@ use Countable;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 
-class FileFailedJobProvider implements Countable, FailedJobProviderInterface, PrunableFailedJobProvider
+class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The file path where the failed job file should be stored.

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue\Failed;
 
 use Closure;
-use Countable;
 use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -65,8 +65,12 @@ class NullFailedJobProvider implements Countable, FailedJobProviderInterface
 
     /**
      * Count the failed jobs.
+     *
+     * @param  string|null  $connection
+     * @param  string|null  $queue
+     * @return int
      */
-    public function count(): int
+    public function count($connection = null, $queue = null)
     {
         return 0;
     }

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Failed;
 
 use Countable;
 
-class NullFailedJobProvider implements Countable, FailedJobProviderInterface
+class NullFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface
 {
     /**
      * Log a failed job into storage.

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Queue\Failed;
 
-use Countable;
-
 class NullFailedJobProvider implements CountableFailedJobProvider, FailedJobProviderInterface
 {
     /**

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -90,13 +90,96 @@ class DatabaseFailedJobProviderTest extends TestCase
         });
         $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
 
-        $this->assertCount(0, $provider);
+        $this->assertSame(0, $provider->count());
 
         $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertCount(1, $provider);
+        $this->assertSame(1, $provider->count());
 
         $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertCount(3, $provider);
+        $provider->log('another-connection', 'another-queue', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(3, $provider->count());
+    }
+
+    public function testJobsCanBeCountedByConnection()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $provider->count('connection-1'));
+        $this->assertSame(1, $provider->count('connection-2'));
+
+        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $provider->count('connection-1'));
+        $this->assertSame(1, $provider->count('connection-2'));
+    }
+
+    public function testJobsCanBeCountedByQueue()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('database', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $provider->count(queue: 'queue-2'));
+
+        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $provider->count(queue: 'queue-2'));
+    }
+
+    public function testJobsCanBeCountedByQueueAndConnection()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $provider->count('connection-1', 'queue-99'));
+        $this->assertSame(1, $provider->count('connection-2', 'queue-99'));
+        $this->assertSame(1, $provider->count('connection-1', 'queue-1'));
+        $this->assertSame(2, $provider->count('connection-2', 'queue-1'));
     }
 }

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -28,13 +28,96 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         });
         $provider = new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
 
-        $this->assertCount(0, $provider);
+        $this->assertSame(0, $provider->count());
 
-        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertCount(1, $provider);
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $provider->count());
 
-        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $provider->log('database', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
-        $this->assertCount(3, $provider);
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(3, $provider->count());
+    }
+
+    public function testJobsCanBeCountedByConnection()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->uuid();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $provider->count('connection-1'));
+        $this->assertSame(1, $provider->count('connection-2'));
+
+        $provider->log('connection-1', 'default', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $provider->count('connection-1'));
+        $this->assertSame(1, $provider->count('connection-2'));
+    }
+
+    public function testJobsCanBeCountedByQueue()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->uuid();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('database', 'queue-2', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(1, $provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $provider->count(queue: 'queue-2'));
+
+        $provider->log('database', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $provider->count(queue: 'queue-2'));
+    }
+
+    public function testJobsCanBeCountedByQueueAndConnection()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->uuid();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+        $provider = new DatabaseUuidFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-99', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $provider->log('connection-2', 'queue-1', json_encode(['uuid' => (string) Str::uuid()]), new RuntimeException());
+        $this->assertSame(2, $provider->count('connection-1', 'queue-99'));
+        $this->assertSame(1, $provider->count('connection-2', 'queue-99'));
+        $this->assertSame(1, $provider->count('connection-1', 'queue-1'));
+        $this->assertSame(2, $provider->count('connection-2', 'queue-1'));
     }
 }

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -142,23 +142,61 @@ class FileFailedJobProviderTest extends TestCase
 
     public function testJobsCanBeCounted()
     {
-        $this->assertCount(0, $this->provider);
+        $this->assertSame(0, $this->provider->count());
 
-        $this->logFailedJob();
-        $this->assertCount(1, $this->provider);
+        $this->logFailedJob('database', 'default');
+        $this->assertSame(1, $this->provider->count());
 
-        $this->logFailedJob();
-        $this->logFailedJob();
-        $this->assertCount(3, $this->provider);
+        $this->logFailedJob('database', 'default');
+        $this->logFailedJob('another-connection', 'another-queue');
+        $this->assertSame(3, $this->provider->count());
     }
 
-    public function logFailedJob()
+    public function testJobsCanBeCountedByConnection()
+    {
+        $this->logFailedJob('connection-1', 'default');
+        $this->logFailedJob('connection-2', 'default');
+        $this->assertSame(1, $this->provider->count('connection-1'));
+        $this->assertSame(1, $this->provider->count('connection-2'));
+
+        $this->logFailedJob('connection-1', 'default');
+        $this->assertSame(2, $this->provider->count('connection-1'));
+        $this->assertSame(1, $this->provider->count('connection-2'));
+    }
+
+    public function testJobsCanBeCountedByQueue()
+    {
+        $this->logFailedJob('database', 'queue-1');
+        $this->logFailedJob('database', 'queue-2');
+        $this->assertSame(1, $this->provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
+
+        $this->logFailedJob('database', 'queue-1');
+        $this->assertSame(2, $this->provider->count(queue: 'queue-1'));
+        $this->assertSame(1, $this->provider->count(queue: 'queue-2'));
+    }
+
+    public function testJobsCanBeCountedByQueueAndConnection()
+    {
+        $this->logFailedJob('connection-1', 'queue-99');
+        $this->logFailedJob('connection-1', 'queue-99');
+        $this->logFailedJob('connection-2', 'queue-99');
+        $this->logFailedJob('connection-1', 'queue-1');
+        $this->logFailedJob('connection-2', 'queue-1');
+        $this->logFailedJob('connection-2', 'queue-1');
+        $this->assertSame(2, $this->provider->count('connection-1', 'queue-99'));
+        $this->assertSame(1, $this->provider->count('connection-2', 'queue-99'));
+        $this->assertSame(1, $this->provider->count('connection-1', 'queue-1'));
+        $this->assertSame(2, $this->provider->count('connection-2', 'queue-1'));
+    }
+
+    public function logFailedJob($connection = 'connection', $queue = 'queue')
     {
         $uuid = Str::uuid();
 
         $exception = new Exception("Something went wrong at job [{$uuid}].");
 
-        $this->provider->log('connection', 'queue', json_encode(['uuid' => (string) $uuid]), $exception);
+        $this->provider->log($connection, $queue, json_encode(['uuid' => (string) $uuid]), $exception);
 
         return [(string) $uuid, $exception];
     }


### PR DESCRIPTION
This PR extends on the work done in https://github.com/laravel/framework/pull/48177 to allow filtering by `connection` and `queue`.

Good bye `\Countable` 🫡