### PR TITLE
[10.x] Return from maintenance middleware early if URL is excluded

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -45,6 +45,10 @@ class PreventRequestsDuringMaintenance
      */
     public function handle($request, Closure $next)
     {
+        if ($this->inExceptArray($request)) {
+            return $next($request);
+        }
+
         if ($this->app->maintenanceMode()->active()) {
             $data = $this->app->maintenanceMode()->data();
 
@@ -52,8 +56,7 @@ class PreventRequestsDuringMaintenance
                 return $this->bypassResponse($data['secret']);
             }
 
-            if ($this->hasValidBypassCookie($request, $data) ||
-                $this->inExceptArray($request)) {
+            if ($this->hasValidBypassCookie($request, $data)) {
                 return $next($request);
             }
 


### PR DESCRIPTION
Laravel's maintenance mode unnecessarily checks if the application is down in the event that the URL has been excluded. This causes unnecessary hits to the application's cache or filesystem.