### PR TITLE
[10.x] Array to string conversion error exception

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -442,7 +442,7 @@ trait FormatsMessages
             return $this->customValues[$attribute][$value];
         }
 
-        if ( is_array( $value ) ) {
+        if (is_array($value)) {
             return 'array';
         }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -442,6 +442,10 @@ trait FormatsMessages
             return $this->customValues[$attribute][$value];
         }
 
+        if ( is_array( $value ) ) {
+            return 'array';
+        }
+
         $key = "validation.values.{$attribute}.{$value}";
 
         if (($line = $this->translator->get($key)) !== $key) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1416,6 +1416,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('The baz field is required when foo is empty.', $v->messages()->first('baz'));
     }
 
+    public function testRequiredIfArrayToStringConversationErrorException()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator( $trans, [
+            'is_customer' => 1,
+            'fullname' => null,
+        ], [
+            'is_customer' => 'required|boolean',
+            'fullname' => 'required_if:is_customer,true'
+        ] );
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator( $trans, [
+            'is_customer' => ['test'],
+            'fullname' => null,
+        ], [
+            'is_customer' => 'required|boolean',
+            'fullname' => 'required_if:is_customer,true'
+        ] );
+        $this->assertTrue($v->fails());
+    }
+
     public function testRequiredUnless()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1419,23 +1419,23 @@ class ValidationValidatorTest extends TestCase
     public function testRequiredIfArrayToStringConversationErrorException()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator( $trans, [
+        $v = new Validator($trans, [
             'is_customer' => 1,
             'fullname' => null,
         ], [
             'is_customer' => 'required|boolean',
-            'fullname' => 'required_if:is_customer,true'
-        ] );
+            'fullname' => 'required_if:is_customer,true',
+        ]);
         $this->assertTrue($v->fails());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator( $trans, [
+        $v = new Validator($trans, [
             'is_customer' => ['test'],
             'fullname' => null,
         ], [
             'is_customer' => 'required|boolean',
-            'fullname' => 'required_if:is_customer,true'
-        ] );
+            'fullname' => 'required_if:is_customer,true',
+        ]);
         $this->assertTrue($v->fails());
     }
 


### PR DESCRIPTION
Hi, I fixed #48187 issue. The issue was to find the related translation line for a `boolean` validation rule while its value is an array.

Before
```php
$validator = \Illuminate\Support\Facades\Validator::make([
    'is_customer' => ['test'],
    'fullname' => null
], [
    'is_customer' => 'required|boolean',
    'fullname' => 'required_if:is_customer,true'
]);
  
$validator->fails(); // ErrorException
```

After
```php
$validator = \Illuminate\Support\Facades\Validator::make([
    'is_customer' => ['test'],
    'fullname' => null
], [
    'is_customer' => 'required|boolean',
    'fullname' => 'required_if:is_customer,true'
]);
  
$validator->fails(); // Return true
```