### PR TITLE
[10.x] Add method `Str::convertCase`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1548,4 +1548,19 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Convert the case of a string using multibyte support.
+     *
+     * @param string $string The input string to convert.
+     * @param int $mode The conversion mode (default: MB_CASE_FOLD).
+     * @param string $encoding The character encoding (default: null, which uses the internal encoding).
+     * @return string The converted string.
+     */
+    public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
+    {
+        // Use mb_convert_case to perform the case conversion.
+        // If $encoding is not provided, the internal encoding is used.
+        return mb_convert_case($string, $mode, $encoding);
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1552,9 +1552,9 @@ class Str
     /**
      * Convert the case of a string using multibyte support.
      *
-     * @param string $string The input string to convert.
-     * @param int $mode The conversion mode (default: MB_CASE_FOLD).
-     * @param string $encoding The character encoding (default: null, which uses the internal encoding).
+     * @param  string  $string  The input string to convert.
+     * @param  int  $mode  The conversion mode (default: MB_CASE_FOLD).
+     * @param  string  $encoding  The character encoding (default: null, which uses the internal encoding).
      * @return string The converted string.
      */
     public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -285,6 +285,19 @@ class Str
     }
 
     /**
+     * Convert the case of a string.
+     *
+     * @param  string  $string
+     * @param  int  $mode
+     * @param  string  $encoding
+     * @return string
+     */
+    public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
+    {
+        return mb_convert_case($string, $mode, $encoding);
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack
@@ -1547,20 +1560,5 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
-    }
-
-    /**
-     * Convert the case of a string using multibyte support.
-     *
-     * @param  string  $string  The input string to convert.
-     * @param  int  $mode  The conversion mode (default: MB_CASE_FOLD).
-     * @param  string  $encoding  The character encoding (default: null, which uses the internal encoding).
-     * @return string The converted string.
-     */
-    public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
-    {
-        // Use mb_convert_case to perform the case conversion.
-        // If $encoding is not provided, the internal encoding is used.
-        return mb_convert_case($string, $mode, $encoding);
     }
 }


### PR DESCRIPTION
This function, convertCase, serves the purpose of converting the case of a given string while taking into account multibyte characters and character encoding. It offers flexibility by allowing you to specify the conversion mode and character encoding, with sensible defaults provided for ease of use.

Here's a breakdown of its functionality:

String: You provide a string as the input, which is the text you want to change the case of.

Conversion Mode (Optional): The function allows you to specify the conversion mode through the $mode parameter. By default, it uses MB_CASE_FOLD, which converts the string to lowercase. However, you can change this mode according to your requirements.

Character Encoding (Optional): You can also specify the character encoding through the $encoding parameter. The default encoding is 'UTF-8,' but you can set it to a different encoding if needed. If no encoding is provided, it will use the internal encoding.

Output: The function returns the converted string with the specified case and encoding.

**According to PR #48221 the already existing methods are not touched.**

