### PR TITLE
[slim-skeleton-11.x] Test Improvements

### DIFF
--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -15,23 +15,25 @@ class JobChainingTest extends TestCase
 {
     public static $catchCallbackRan = false;
 
-    protected function getEnvironmentSetUp($app)
+    protected function setUp(): void
     {
-        $app['config']->set('queue.connections.sync1', [
-            'driver' => 'sync',
-        ]);
+        $this->beforeApplicationDestroyed(function () {
+            JobChainingTestFirstJob::$ran = false;
+            JobChainingTestSecondJob::$ran = false;
+            JobChainingTestThirdJob::$ran = false;
+            static::$catchCallbackRan = false;
+        });
 
-        $app['config']->set('queue.connections.sync2', [
-            'driver' => 'sync',
-        ]);
+        parent::setUp();
     }
 
-    protected function tearDown(): void
+    protected function defineEnvironment($app)
     {
-        JobChainingTestFirstJob::$ran = false;
-        JobChainingTestSecondJob::$ran = false;
-        JobChainingTestThirdJob::$ran = false;
-        static::$catchCallbackRan = false;
+        $app['config']->set([
+            'queue.default' => 'sync',
+            'queue.connections.sync1' => ['driver' => 'sync'],
+            'queue.connections.sync2' => ['driver' => 'sync'],
+        ]);
     }
 
     public function testJobsCanBeChainedOnSuccess()

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -8,10 +8,13 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\TestCase;
 
 class JobDispatchingTest extends TestCase
 {
+    use WithLaravelMigrations;
+
     protected function setUp(): void
     {
         $this->beforeApplicationDestroyed(function () {
@@ -20,6 +23,11 @@ class JobDispatchingTest extends TestCase
         });
 
         parent::setUp();
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set(['queue.default' => 'sync']);
     }
 
     public function testJobCanUseCustomMethodsAfterDispatch()

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -8,13 +8,10 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\TestCase;
 
 class JobDispatchingTest extends TestCase
 {
-    use WithLaravelMigrations;
-
     protected function setUp(): void
     {
         $this->beforeApplicationDestroyed(function () {


### PR DESCRIPTION
Ensure Queue integrations tests would still work if Testbench change the default `QUEUE_CONNECTION=sync` to `QUEUE_CONNECTION=database` to match with Laravel default strucutre.