### PR TITLE
Remove unneeded Return type in Docblock of Illuminate\Database\Eloquent\Builder.php->get()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -709,7 +709,7 @@ class Builder implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function get($columns = ['*'])
     {


### PR DESCRIPTION
Remove unneeded static[] from ret type in docblock of Illuminate\Database\Eloquent\Builder->get()

This function only returns a collection from L:725
```
        return $builder->getModel()->newCollection($models);