### PR TITLE
[10.x] Add Model::isValidColumn method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -214,18 +214,7 @@ trait GuardsAttributes
      */
     protected function isGuardableColumn($key)
     {
-        if (! isset(static::$guardableColumns[get_class($this)])) {
-            $columns = $this->getConnection()
-                        ->getSchemaBuilder()
-                        ->getColumnListing($this->getTable());
-
-            if (empty($columns)) {
-                return true;
-            }
-            static::$guardableColumns[get_class($this)] = $columns;
-        }
-
-        return in_array($key, static::$guardableColumns[get_class($this)]);
+        return $this->isValidColumn($key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -211,6 +211,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $isBroadcasting = true;
 
     /**
+     * The actual columns that exist on the database.
+     *
+     * @var array<string>
+     */
+    protected static $validColumns = [];
+
+    /**
      * The name of the "created at" column.
      *
      * @var string|null
@@ -1772,6 +1779,25 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function isNot($model)
     {
         return ! $this->is($model);
+    }
+
+    /**
+     * Determine if the given column is a valid database column.
+     */
+    public function isValidColumn(string $column): bool
+    {
+        if (! isset(static::$validColumns[get_class($this)])) {
+            $columns = $this->getConnection()
+                        ->getSchemaBuilder()
+                        ->getColumnListing($this->getTable());
+
+            if (empty($columns)) {
+                return true;
+            }
+            static::$validColumns[get_class($this)] = $columns;
+        }
+
+        return in_array($column, static::$validColumns[get_class($this)]);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR introduces a new `Model::isValidColumn` method that checks if the given column is a valid database column.

### Why
I need to check if a column is a valid column in the database---there's currently not an easy, efficient way to do this.

You can use the `Schema` facade:
```php
Schema::hasColumn($model->getTable(), $column);
```
however, this performs a query for every single check---not good for loops.

The next best solution is to statically cache all the table columns:
```php
protected static array $tableColumns;
//...
if (! isset(static::$tableColumns)) {
    static::$tableColumns = Schema::getColumnListing($model->getTable());
}
//...
if (in_array($column, static::$tableColumns)) {
    //...
}
```

Which works, but then I discovered that the Model is **already doing this** via `GuardsAttributes::isGuardableColumn`---it's just a protected method that I don't have direct access to:

https://github.com/laravel/framework/blob/ff96905683e7035d6d7c9700ef8f722344c27c2f/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php#L215-L229

To keep the logic on the Model and avoid duplication/BCs I moved the logic from `GuardsAttributes::isGuardableColumn` to `Model::isValidColumn` (and update the old location to point to the new logic).

### Alternatives
- Can change the visibility of `GuardsAttributes::isGuardableColumn` from `protected` to `public`, however, 1) I wasn't sure if this would be considered a BC, and 2) it's not the most descriptive in the context that I want to use the method---checking if it's a **valid database** column not just a *guardable* column.


Thanks!