### PR TITLE
[10.x] HotFix: throw captured `UniqueConstraintViolationException` if there are no matching records on `SELECT` retry

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -581,8 +581,8 @@ class Builder implements BuilderContract
     {
         try {
             return $this->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values)));
-        } catch (UniqueConstraintViolationException) {
-            return $this->useWritePdo()->where($attributes)->first();
+        } catch (UniqueConstraintViolationException $e) {
+            return $this->useWritePdo()->where($attributes)->first() ?? throw $e;
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -648,16 +648,16 @@ class BelongsToMany extends Relation
     {
         try {
             return $this->getQuery()->withSavePointIfNeeded(fn () => $this->create(array_merge($attributes, $values), $joining, $touch));
-        } catch (UniqueConstraintViolationException $exception) {
+        } catch (UniqueConstraintViolationException $e) {
             // ...
         }
 
         try {
-            return tap($this->related->where($attributes)->first(), function ($instance) use ($joining, $touch) {
+            return tap($this->related->where($attributes)->first() ?? throw $e, function ($instance) use ($joining, $touch) {
                 $this->getQuery()->withSavepointIfNeeded(fn () => $this->attach($instance, $joining, $touch));
             });
-        } catch (UniqueConstraintViolationException) {
-            return (clone $this)->useWritePdo()->where($attributes)->first();
+        } catch (UniqueConstraintViolationException $e) {
+            return (clone $this)->useWritePdo()->where($attributes)->first() ?? throw $e;
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -253,8 +253,8 @@ abstract class HasOneOrMany extends Relation
     {
         try {
             return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values)));
-        } catch (UniqueConstraintViolationException) {
-            return $this->useWritePdo()->where($attributes)->first();
+        } catch (UniqueConstraintViolationException $e) {
+            return $this->useWritePdo()->where($attributes)->first() ?? throw $e;
         }
     }
 


### PR DESCRIPTION
- Fixes #48235
- Related:
  - #47973
  - #48144 
  - #48160 
  - #48161 
  - #48192  
  - #48213
  - #48214

There is an issue with `createOrFirst` up to version `v10.21.0`. This causes the following problems when `createOrFirst()` returns NULL.

- `firstOrCreate()` also inadvertently returns NULL.
- **`updateOrCreate()` causes an error because it tries to access the `->wasRecentlyCreated` property on NULL.**

The latter is particularly critical, so if possible, we would like you to release it as a hot fix in version `v10.21.1`. Please consider it.