### PR TITLE
[10.x] Implement a new `--open` option for the `artisan serve` command

### DIFF
--- a/src/Illuminate/Console/Concerns/HandleUrl.php
+++ b/src/Illuminate/Console/Concerns/HandleUrl.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Support\Collection;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+trait HandleUrl
+{
+    /**
+     * The custom URL opener.
+     *
+     * @var callable|null
+     */
+    protected $urlOpener;
+
+    /**
+     * The operating system family.
+     *
+     * @var string
+     */
+    protected $systemOsFamily = PHP_OS_FAMILY;
+
+    /**
+     * Open the URL in the user's browser.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function open($url)
+    {
+        ($this->urlOpener ?? function ($url) {
+            if (in_array($this->systemOsFamily, ['Darwin', 'Windows', 'Linux'])) {
+                $this->openViaBuiltInStrategy($url);
+            } else {
+                $this->components->warn('Unable to open the URL on your system. You will need to open it yourself or create a custom opener for your system.');
+            }
+        })($url);
+    }
+
+    /**
+     * Open the URL via the built in strategy.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function openViaBuiltInStrategy($url)
+    {
+        if ($this->systemOsFamily === 'Windows') {
+            $process = tap(Process::fromShellCommandline(escapeshellcmd("start {$url}")))->run();
+
+            if (! $process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+
+            return;
+        }
+
+        $binary = Collection::make(match ($this->systemOsFamily) {
+            'Darwin' => ['open'],
+            'Linux' => ['xdg-open', 'wslview'],
+        })->first(fn ($binary) => (new ExecutableFinder)->find($binary) !== null);
+
+        if ($binary === null) {
+            $this->components->warn('Unable to open the URL on your system. You will need to open it yourself or create a custom opener for your system.');
+
+            return;
+        }
+
+        $process = tap(Process::fromShellCommandline(escapeshellcmd("{$binary} {$url}")))->run();
+
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
+use Illuminate\Console\Concerns\HandleUrl;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -15,6 +16,8 @@ use function Termwind\terminal;
 #[AsCommand(name: 'serve')]
 class ServeCommand extends Command
 {
+    use HandleUrl;
+
     /**
      * The console command name.
      *
@@ -241,6 +244,13 @@ class ServeCommand extends Command
                 }
 
                 $this->components->info("Server running on [http://{$this->host()}:{$this->port()}].");
+
+                if ($this->option('open')) {
+                    $this->comment('  Opening the application in the browser...');
+                    $this->newLine();
+                    $this->open("http://{$this->host()}:{$this->port()}");
+                }
+
                 $this->comment('  <fg=yellow;options=bold>Press Ctrl+C to stop the server</>');
 
                 $this->newLine();
@@ -337,6 +347,7 @@ class ServeCommand extends Command
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', Env::get('SERVER_PORT')],
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
             ['no-reload', null, InputOption::VALUE_NONE, 'Do not reload the development server on .env file changes'],
+            ['open', null, InputOption::VALUE_NONE, 'Open the application in your browser'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Concerns\HandleUrl;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
-use Illuminate\Console\Concerns\HandleUrl;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;


### PR DESCRIPTION
This PR adds a new `--open` option to the `artisan serve` command which when supplied, will open the application URL in the browser automatically.

Here's what that will look like!

https://github.com/laravel/framework/assets/3647841/5c582ce5-4f2f-49d5-9d51-44a4eb87ed41

Let me know what you think about it.

P.S.:- Regarding tests, I wasn't able to find any test cases for the serve command. So, haven't added them for now.