### PR TITLE
Add helpers to interact with session

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -347,6 +347,18 @@ class Store implements Session
     }
 
     /**
+     * Retrieve an item as a float value.
+     *
+     * @param  string  $key
+     * @param  float  $default
+     * @return float
+     */
+    public function float($key, $default = 0.0)
+    {
+        return floatval($this->get($key, $default));
+    }
+
+    /**
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -5,6 +5,7 @@ namespace Illuminate\Session;
 use Closure;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -356,6 +357,29 @@ class Store implements Session
     public function float($key, $default = 0.0)
     {
         return floatval($this->get($key, $default));
+    }
+
+    /**
+     * Retrieve an item from the session as a Carbon instance.
+     *
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
+     */
+    public function date($key, $format = null, $tz = null)
+    {
+        if (! $this->has($key)) {
+            return null;
+        }
+
+        if (is_null($format)) {
+            return Date::parse($this->get($key), $tz);
+        }
+
+        return Date::createFromFormat($format, $this->get($key), $tz);
     }
 
     /**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -383,6 +383,26 @@ class Store implements Session
     }
 
     /**
+     * Retrieve an item from the session as an enum.
+     *
+     * @template TEnum
+     *
+     * @param  string  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @return TEnum|null
+     */
+    public function enum($key, $enumClass)
+    {
+        if (! $this->has($key) ||
+            ! enum_exists($enumClass) ||
+            ! method_exists($enumClass, 'tryFrom')) {
+            return null;
+        }
+
+        return $enumClass::tryFrom($this->input($key));
+    }
+
+    /**
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -321,6 +321,20 @@ class Store implements Session
     }
 
     /**
+     * Retrieve an item as a boolean value.
+     *
+     * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.
+     *
+     * @param  string|null  $key
+     * @param  bool  $default
+     * @return bool
+     */
+    public function boolean($key = null, $default = false)
+    {
+        return filter_var($this->get($key, $default), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -403,6 +403,17 @@ class Store implements Session
     }
 
     /**
+     * Retrieve an item from the session as a collection.
+     *
+     * @param  array|string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return collect(is_array($key) ? $this->only($key) : $this->get($key));
+    }
+
+    /**
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -297,6 +297,30 @@ class Store implements Session
     }
 
     /**
+     * Retrieve an item from the session as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function str($key, $default = null)
+    {
+        return $this->string($key, $default);
+    }
+
+    /**
+     * Retrieve an item from the session as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function string($key, $default = null)
+    {
+        return str($this->get($key, $default));
+    }
+
+    /**
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -335,6 +335,18 @@ class Store implements Session
     }
 
     /**
+     * Retrieve an item as an integer value.
+     *
+     * @param  string  $key
+     * @param  int  $default
+     * @return int
+     */
+    public function integer($key, $default = 0)
+    {
+        return intval($this->get($key, $default));
+    }
+
+    /**
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -522,7 +522,7 @@ class Store implements Session
      */
     public function increment($key, $amount = 1)
     {
-        $this->put($key, $value = $this->get($key, 0) + $amount);
+        $this->put($key, $value = $this->integer($key) + $amount);
 
         return $value;
     }

--- a/tests/Session/Enums.php
+++ b/tests/Session/Enums.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Session;
+
+enum TestEnum: string
+{
+    case test = 'test';
+}

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -13,6 +13,11 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Stringable;
+use InvalidArgumentException;
+use Illuminate\Tests\Session\TestEnum;
 
 class SessionStoreTest extends TestCase
 {


### PR DESCRIPTION
Hi, I think it will be nice if we can add session interactions to help users developing typed applications.

```
session(['foo' => '50']);

$thisIsTrue = 50 === session()->integer('foo');
$thisIsTrue = 50.0 === session()->float('foo');
```

```
session(['str' => 'laravel']);

session()->str('str')->append(' forever')->toString();
```

```
session(['birthday' => '1995-06-04']);

session()->date('birthday')->age === 28;
```

```
session(['collection' => [1, 2, 3]]);

session()->collect('collection')->dd();
```

```
session(['enum' => MyEnum::Foo->value]);

session()->enum('enum') === MyEnum::Foo;
```
Hopefully this will help users create more typed and secure by default.