### PR TITLE
[10.x] Add Model::search() method 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -362,6 +362,18 @@ class Builder implements BuilderContract
         return $this->whereNot($column, $operator, $value, 'or');
     }
 
+     /**
+     * Add a basic "search" clause to the query. 
+     *
+     * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param mixed $value
+     * @return $this
+     */
+    public function search($column, $value)
+    {
+        return $this->where($column, "like", "$value");
+    }
+
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
@@ -2046,4 +2058,5 @@ class Builder implements BuilderContract
     {
         $this->query = clone $this->query;
     }
+    
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -363,7 +363,7 @@ class Builder implements BuilderContract
     }
 
      /**
-     * Add a basic "search" clause to the query. 
+     * Add a basic "search" clause to the query.
      *
      * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param mixed $value
@@ -371,7 +371,7 @@ class Builder implements BuilderContract
      */
     public function search($column, $value)
     {
-        return $this->where($column, "like", "$value");
+        return $this->where($column, "like", "$value%", 'or');
     }
 
     /**
@@ -2058,5 +2058,5 @@ class Builder implements BuilderContract
     {
         $this->query = clone $this->query;
     }
-    
+
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1080,6 +1080,16 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
+    public function testSearch()
+    {
+        $model = new EloquentBuilderTestStub();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->search('name', 'foo')
+            ->search('username', 'bar');
+        $this->assertEquals('select * from "table" where "name" like ? and "username" like ?', $query->toSql());
+        $this->assertEquals(['foo', 'bar'], $query->getBindings());
+    }
+
     public function testRealQueryHigherOrderOrWhereScopes()
     {
         $model = new EloquentBuilderTestHigherOrderWhereScopeStub;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1086,8 +1086,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->search('name', 'foo')
             ->search('username', 'bar');
-        $this->assertEquals('select * from "table" where "name" like ? and "username" like ?', $query->toSql());
-        $this->assertEquals(['foo', 'bar'], $query->getBindings());
+        $this->assertEquals('select * from "table" where "name" like ? or "username" like ?', $query->toSql());
+        $this->assertEquals(['foo%', 'bar%'], $query->getBindings());
     }
 
     public function testRealQueryHigherOrderOrWhereScopes()


### PR DESCRIPTION
Hello!

This PR introduces a new Model::search() method that filter a given column with value.

Why

Easy to filter data.
You can use by:
`Model::search($column, $value)->get();`

or with multiple query like:

`Model::search($column, $value)->search($column, $value)->get();`