### PR TITLE
 add search method to Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -363,6 +363,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "search" clause to the query.
+     *
+     * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function search($column, $value)
+    {
+        return $this->where($column, "like", "$value%", 'or');
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1033,6 +1033,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $query->getBindings());
     }
 
+    public function testSearch()
+    {
+        $model = new EloquentBuilderTestStub();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->search('name', 'foo')->search('username', 'bar');
+        $this->assertEquals('select * from "table" where "name" like ? or "username" like ?', $query->toSql());
+        $this->assertEquals(['foo%', 'bar%'], $query->getBindings());
+    }
+
     public function testWhereNot()
     {
         $nestedQuery = m::mock(Builder::class);


### PR DESCRIPTION
Hello!

This PR introduces a new Model::search() method that filter a given column with value.

Why

Easy to filter data.
You can use by:
`Model::search($column, $value)->get();`

or with multiple query like:

`Model::search($column, $value)->search($column, $value)->get();`
