### PR TITLE
[10.x] Add Enum Support to the In and NotIn Validation Rules

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
+use UnitEnum;
+
 class In
 {
     /**
@@ -39,13 +42,11 @@ class In
     public function __toString()
     {
         $values = array_map(function ($value) {
-            if ($value instanceof \BackedEnum) {
-                $value = $value->value;
-            }
-
-            if ($value instanceof \UnitEnum) {
-                $value = $value->name;
-            }
+            $value = match (true) {
+                $value instanceof BackedEnum => $value->value,
+                $value instanceof UnitEnum => $value->name,
+                default => $value,
+            };
 
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -39,6 +39,14 @@ class In
     public function __toString()
     {
         $values = array_map(function ($value) {
+            if ($value instanceof \BackedEnum) {
+                $value = $value->value;
+            }
+
+            if ($value instanceof \UnitEnum) {
+                $value = $value->name;
+            }
+
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
+use UnitEnum;
+
 class NotIn
 {
     /**
@@ -37,13 +40,11 @@ class NotIn
     public function __toString()
     {
         $values = array_map(function ($value) {
-            if ($value instanceof \BackedEnum) {
-                $value = $value->value;
-            }
-
-            if ($value instanceof \UnitEnum) {
-                $value = $value->name;
-            }
+            $value = match (true) {
+                $value instanceof BackedEnum => $value->value,
+                $value instanceof UnitEnum => $value->name,
+                default => $value,
+            };
 
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -37,6 +37,14 @@ class NotIn
     public function __toString()
     {
         $values = array_map(function ($value) {
+            if ($value instanceof \BackedEnum) {
+                $value = $value->value;
+            }
+
+            if ($value instanceof \UnitEnum) {
+                $value = $value->name;
+            }
+
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -11,7 +11,7 @@ use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class ValidationEnumRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -7,6 +7,8 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use PHPUnit\Framework\TestCase;
 
+include 'Enums.php';
+
 class ValidationInRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
@@ -38,5 +40,17 @@ class ValidationInRuleTest extends TestCase
         $rule = Rule::in('1', '2', '3', '4');
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::in([StringStatus::done,]);
+
+        $this->assertSame('in:"done"', (string) $rule);
+
+        $rule = Rule::in([IntegerStatus::done,]);
+
+        $this->assertSame('in:"2"', (string) $rule);
+
+        $rule = Rule::in([PureEnum::one,]);
+
+        $this->assertSame('in:"one"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -41,15 +41,15 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::in([StringStatus::done,]);
+        $rule = Rule::in([StringStatus::done]);
 
         $this->assertSame('in:"done"', (string) $rule);
 
-        $rule = Rule::in([IntegerStatus::done,]);
+        $rule = Rule::in([IntegerStatus::done]);
 
         $this->assertSame('in:"2"', (string) $rule);
 
-        $rule = Rule::in([PureEnum::one,]);
+        $rule = Rule::in([PureEnum::one]);
 
         $this->assertSame('in:"one"', (string) $rule);
     }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -7,7 +7,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use PHPUnit\Framework\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class ValidationInRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -6,6 +6,8 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\NotIn;
 use PHPUnit\Framework\TestCase;
 
+include 'Enums.php';
+
 class ValidationNotInRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
@@ -25,5 +27,17 @@ class ValidationNotInRuleTest extends TestCase
         $rule = Rule::notIn('1', '2', '3', '4');
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::notIn([StringStatus::done,]);
+
+        $this->assertSame('not_in:"done"', (string) $rule);
+
+        $rule = Rule::notIn([IntegerStatus::done,]);
+
+        $this->assertSame('not_in:"2"', (string) $rule);
+
+        $rule = Rule::notIn([PureEnum::one,]);
+
+        $this->assertSame('not_in:"one"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -6,7 +6,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\NotIn;
 use PHPUnit\Framework\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class ValidationNotInRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -28,15 +28,15 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
-        $rule = Rule::notIn([StringStatus::done,]);
+        $rule = Rule::notIn([StringStatus::done]);
 
         $this->assertSame('not_in:"done"', (string) $rule);
 
-        $rule = Rule::notIn([IntegerStatus::done,]);
+        $rule = Rule::notIn([IntegerStatus::done]);
 
         $this->assertSame('not_in:"2"', (string) $rule);
 
-        $rule = Rule::notIn([PureEnum::one,]);
+        $rule = Rule::notIn([PureEnum::one]);
 
         $this->assertSame('not_in:"one"', (string) $rule);
     }


### PR DESCRIPTION
Greetings Laravel Team,

This pull request introduces enhanced support for Enum types within the In and NotIn validation rules.

## Motivation:

In many scenarios, developers might want to validate an input against a specific subset of enum values. Unfortunately, the current Laravel validation rules for In and NotIn do not natively support this functionality.

## Changes Introduced:

With this PR, the validation against enum values can be seamlessly performed using the provided syntax:

```PHP
enum Color: string
{
   case RED = 'red';
   case GREEN = 'green';
   case BLUE = 'blue';
}

Validator::validate(['color'=>'green'], ['color'=> [Rule::in([Color::RED, Color::GREEN])]]);
```

Looking forward to your feedback and hoping for a positive consideration.