### PR TITLE
[10.x] GeneratorCommand - Sorting possible models and events

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -247,6 +247,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         return collect((new Finder)->files()->depth(0)->in($modelPath))
             ->map(fn ($file) => $file->getBasename('.php'))
+            ->sort()
             ->values()
             ->all();
     }
@@ -266,6 +267,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         return collect((new Finder)->files()->depth(0)->in($eventPath))
             ->map(fn ($file) => $file->getBasename('.php'))
+            ->sort()
             ->values()
             ->all();
     }


### PR DESCRIPTION
With Laravel Prompts and the new dropdown combobox, you have the opportunity to open the dropdown and see a list of all possible models and events for the various commands. Currently the models and events are not sorted in any logical order that is readily visible.

This PR sorts the models and events by name to ensure the dropdown looks just a bit nicer.