### PR TITLE
[10.x] Call `renderForAssertions` in all Mailable assertions

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1204,6 +1204,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertFrom($address, $name = null)
     {
+        $this->renderForAssertions();
+
         $recipient = $this->formatAssertionRecipient($address, $name);
 
         PHPUnit::assertTrue(
@@ -1223,6 +1225,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertTo($address, $name = null)
     {
+        $this->renderForAssertions();
+
         $recipient = $this->formatAssertionRecipient($address, $name);
 
         PHPUnit::assertTrue(
@@ -1254,6 +1258,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasCc($address, $name = null)
     {
+        $this->renderForAssertions();
+
         $recipient = $this->formatAssertionRecipient($address, $name);
 
         PHPUnit::assertTrue(
@@ -1273,6 +1279,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasBcc($address, $name = null)
     {
+        $this->renderForAssertions();
+
         $recipient = $this->formatAssertionRecipient($address, $name);
 
         PHPUnit::assertTrue(
@@ -1292,6 +1300,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasReplyTo($address, $name = null)
     {
+        $this->renderForAssertions();
+
         $replyTo = $this->formatAssertionRecipient($address, $name);
 
         PHPUnit::assertTrue(
@@ -1543,6 +1553,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasTag($tag)
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasTag($tag),
             "Did not see expected tag [{$tag}] in email tags."
@@ -1560,6 +1572,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasMetadata($key, $value)
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasMetadata($key, $value),
             "Did not see expected key [{$key}] and value [{$value}] in email metadata."

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -24,6 +24,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsRecipientsCorrectly()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $mailable = new WelcomeMailableStub;
         $mailable->to('taylor@laravel.com');
         $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->to);
@@ -106,6 +114,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsCcRecipientsCorrectly()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $mailable = new WelcomeMailableStub;
         $mailable->cc('taylor@laravel.com');
         $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->cc);
@@ -195,6 +211,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsBccRecipientsCorrectly()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $mailable = new WelcomeMailableStub;
         $mailable->bcc('taylor@laravel.com');
         $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->bcc);
@@ -284,6 +308,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsReplyToCorrectly()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $mailable = new WelcomeMailableStub;
         $mailable->replyTo('taylor@laravel.com');
         $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->replyTo);
@@ -362,6 +394,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableSetsFromCorrectly()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $mailable = new WelcomeMailableStub;
         $mailable->from('taylor@laravel.com');
         $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->from);
@@ -589,6 +629,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableMetadataGetsSent()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $view = m::mock(Factory::class);
 
         $mailer = new Mailer('array', $view, new ArrayTransport);
@@ -622,6 +670,14 @@ class MailMailableTest extends TestCase
 
     public function testMailableTagGetsSent()
     {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
         $view = m::mock(Factory::class);
 
         $mailer = new Mailer('array', $view, new ArrayTransport);

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1158,6 +1158,42 @@ class MailMailableTest extends TestCase
         $this->assertEquals('X-Custom-Header', $sentMessage->getOriginalMessage()->getHeaders()->get('x-custom-header')->getName());
         $this->assertEquals('Custom Value', $sentMessage->getOriginalMessage()->getHeaders()->get('x-custom-header')->getValue());
     }
+
+    public function testMailableAttributesInBuild()
+    {
+        Container::getInstance()->instance('mailer', new class
+        {
+            public function render()
+            {
+                //
+            }
+        });
+
+        $mailable = new class() extends Mailable
+        {
+            public function build()
+            {
+                $this
+                    ->to('hello@laravel.com')
+                    ->replyTo('taylor@laravel.com')
+                    ->cc('cc@laravel.com', 'Taylor Otwell')
+                    ->bcc('bcc@laravel.com', 'Taylor Otwell')
+                    ->tag('test-tag')
+                    ->metadata('origin', 'test-suite')
+                    ->metadata('user_id', 1)
+                    ->subject('test subject');
+            }
+        };
+
+        $mailable->assertTo('hello@laravel.com');
+        $mailable->assertHasReplyTo('taylor@laravel.com');
+        $mailable->assertHasCc('cc@laravel.com', 'Taylor Otwell');
+        $mailable->assertHasBcc('bcc@laravel.com', 'Taylor Otwell');
+        $mailable->assertHasTag('test-tag');
+        $mailable->assertHasMetadata('origin', 'test-suite');
+        $mailable->assertHasMetadata('user_id', 1);
+        $mailable->assertHasSubject('test subject');
+    }
 }
 
 class MailableHeadersStub extends Mailable


### PR DESCRIPTION
In the Laravel docs for Mail -- https://laravel.com/docs/10.x/mail the following code snippet is shown:

```php
use App\Mail\InvoicePaid;
use App\Models\User;
 
public function test_mailable_content(): void
{
    $user = User::factory()->create();
 
    $mailable = new InvoicePaid($user);
 
    $mailable->assertFrom('jeffrey@example.com');
```

The `$mailable->assertFrom('jeffrey@example.com');` example here will fail the test because the mailable's `render()` hasn't been called yet. I noticed in the PR https://github.com/laravel/framework/pull/47728 - the `renderForAssertions` function was called for `assertHasSubject` but I could not see why this isn't being called for the other Mailable assertion functions, such as `assertFrom` taken from the docs. 

So, in summary I've added the `renderForAssertions` to the following functions:

```php
$mailable->assertFrom("");
$mailable->assertTo("");
$mailable->assertHasCc("");
$mailable->assertHasBcc("");
$mailable->assertHasReplyTo("");
$mailable->assertHasTag("");
$mailable->assertHasMetadata("");
```

Which will no longer mean that the user needs to call a specific `$mailable->assertHasSubject()` or `$mailable->assertSeeInHtml()` before being able to call the above methods.