### PR TITLE
[10.x] Add Sleep::while helper

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -449,6 +449,38 @@ class Sleep
     }
 
     /**
+     * Sleep while the closure evaluates to falsey.
+     *
+     * @template TReturn of mixed
+     *
+     * @param  (callable(int): TReturn)  $callback
+     * @param  int  $bailAfter
+     * @return TReturn
+     */
+    public function while($callback)
+    {
+        $this->shouldNotSleep();
+
+        $sleeps = 0;
+
+        while (true) {
+            $result = $callback($sleeps);
+
+            if (! $result instanceof Sleep && $result) {
+                return $result;
+            }
+
+            $duration = $result instanceof Sleep
+                ? $result->shouldNotSleep()->duration
+                : $this->duration;
+
+            Sleep::for($duration);
+
+            $sleeps++;
+        }
+    }
+
+    /**
      * Specify a callback that should be invoked when faking sleep within a test.
      *
      * @param  callable  $callback


### PR DESCRIPTION
This adds a `Sleep::while` feature creating a more functional approach to sleeping in while waiting on a resource to become available or state to change.

This is similar to the `retry` function, but it is not expecting exceptions.

Imagine you are waiting on state to change in the database...

```php
use Illuminate\Support\Sleep;
use Illuminate\Support\Facades\Auth;

// before...

while (Auth::user()->payment()->doesntExist()) {
    Sleep::for(100)->milliseconds();
}

// after...

Sleep::for(100)->milliseconds()->while(fn () => Auth::user()->payment()->doesntExist());
```

Or for a API to have processed something async...

```php
use Illuminate\Support\Sleep;
use Illuminate\Support\Facades\Http;

// before...

while (Http::withToken($token)->get('https::/example.com/entity')->json('entity.is_processing')) {
    Sleep::for(30)->seconds();
}

// after...

Sleep::for(30)->seconds()->while(fn () => Http::withToken($token)
    ->get('https::/example.com/entity')
    ->json('entity.is_processing'));
```

The closure accepts the number of times it has slept - which on the first execution will be `0`.

```php
use Illuminate\Support\Sleep;
use Illuminate\Support\Facades\Http;
use RuntimeException;

// before...

$sleeps = 0;

while (true) {
    $isProcessing = match (true) {
        $sleeps === 10 => throw new RuntimeException('Never became ready.'),
        default => Http::withToken($token)
            ->get('https::/example.com/entity')
            ->json('entity.is_processing')
    };

    if ($isProcessing) {
        Sleep::for(30)->seconds();

        $sleep++;
    }
}

// after...

Sleep::for(30)->seconds()->while(fn (int $sleeps) => match (true) {
    $sleeps === 10 => throw new RuntimeException('Never became ready.'),
    default => Http::withToken($token)
        ->get('https::/example.com/entity')
        ->json('entity.is_processing')
});
```

You can also return a `Sleep` instance to create a backoff strategy by returning a sleep instance...

```php
use Illuminate\Support\Sleep;
use Illuminate\Support\Facades\Http;

// before...

$sleeps = 0;

while (true) {
    $isProcessing = Http::withToken($token)
        ->get('https::/example.com/entity')
        ->json('entity.is_procesing');

    if ($isProcessing) {
       break;
    }

    match (true) {
        $sleeps === 10 => throw new RuntimeException('Never became ready.'),
        $sleeps > 1 => Sleep::for($sleeps * 30)->seconds(), // incremental backoff
        default => Sleep::for(30)->seconds(),
    };

    $sleep++;
}


// after...

Sleep::for(30)->seconds()->while(function ($sleeps) {
    $isProcessing = Http::withToken($token)
        ->get('https::/example.com/entity')
        ->json('entity.is_procesing');

    if ($isProcessing) {
       return true;
    }

    return match (true) {
        $sleeps === 10 => throw new RuntimeException('Never became ready.'),
        $sleeps > 1 => Sleep::for($sleeps * 30)->seconds(), // incremental backoff
        default => false,
    };
});

```