### PR TITLE
[10.x] Add a new validation rule named "column_exists"

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -33,6 +33,7 @@ return [
     ],
     'boolean' => 'The :attribute field must be true or false.',
     'can' => 'The :attribute field contains an unauthorized value.',
+    'column_exists' => 'The :attribute is invalid.',
     'confirmed' => 'The :attribute field confirmation does not match.',
     'current_password' => 'The password is incorrect.',
     'date' => 'The :attribute field must be a valid date.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
@@ -473,6 +474,21 @@ trait ValidatesAttributes
         $acceptable = [true, false, 0, 1, '0', '1'];
 
         return in_array($value, $acceptable, true);
+    }
+
+    /**
+     * Validate that the attribute's value is among the database table's columns.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    protected function validateColumnExists($attribute, $value, $parameters)
+    {
+        return is_array($value)
+            ? Schema::hasColumns($parameters[0], $value)
+            : Schema::hasColumn($parameters[0], $value);
     }
 
     /**


### PR DESCRIPTION
In some requests, especially in admin panels, the column or columns can be selected from a request attribute and they need to be validated.  Although it can currently be done in other ways, I believe having an explicit rule is easy-to-use.
 In rules method of a FormRequest:
```php
return [
     'columns' => 'column_exists:users',
];
```
The rule takes a table's name and validates a value like `"email"`  or an array of values like `['id', 'email', 'created_at']`
