### PR TITLE
[10.x] Introduce `requireEnv` helper

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -66,6 +66,31 @@ class Env
     }
 
     /**
+     * Get the value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function get($key, $default = null)
+    {
+        return self::getOption($key)->getOrCall(fn () => value($default));
+    }
+
+    /**
+     * Get the value of a required environment variable.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public static function getOrFail($key)
+    {
+        return self::getOption($key)->getOrThrow(new RuntimeException("Environment variable [$key] has no value."));
+    }
+
+    /**
      * Get the possible option for this environment variable.
      *
      * @param  string  $key
@@ -96,30 +121,5 @@ class Env
 
                 return $value;
             });
-    }
-
-    /**
-     * Gets the value of a required environment variable.
-     *
-     * @param  string  $key
-     * @return mixed
-     *
-     * @throws \RuntimeException
-     */
-    public static function getRequired($key)
-    {
-        return self::getOption($key)->getOrThrow(new RuntimeException("[$key] has no value"));
-    }
-
-    /**
-     * Gets the value of an environment variable.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    public static function get($key, $default = null)
-    {
-        return self::getOption($key)->getOrCall(fn () => value($default));
     }
 }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use Dotenv\Repository\Adapter\PutenvAdapter;
 use Dotenv\Repository\RepositoryBuilder;
 use PhpOption\Option;
+use RuntimeException;
 
 class Env
 {
@@ -65,13 +66,12 @@ class Env
     }
 
     /**
-     * Gets the value of an environment variable.
+     * Get the possible option for this environment variable.
      *
      * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @return \PhpOption\Option|\PhpOption\Some
      */
-    public static function get($key, $default = null)
+    protected static function getOption($key)
     {
         return Option::fromValue(static::getRepository()->get($key))
             ->map(function ($value) {
@@ -95,7 +95,31 @@ class Env
                 }
 
                 return $value;
-            })
-            ->getOrCall(fn () => value($default));
+            });
+    }
+
+    /**
+     * Gets the value of a required environment variable.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public static function getRequired($key)
+    {
+        return self::getOption($key)->getOrThrow(new RuntimeException("[$key] has no value"));
+    }
+
+    /**
+     * Gets the value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function get($key, $default = null)
+    {
+        return self::getOption($key)->getOrCall(fn () => value($default));
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -139,21 +139,6 @@ if (! function_exists('env')) {
     }
 }
 
-if (! function_exists('requireEnv')) {
-    /**
-     * Gets the value of a required environment variable.
-     *
-     * @param  string  $key
-     * @return mixed
-     *
-     * @throws \RuntimeException
-     */
-    function requireEnv($key)
-    {
-        return Env::getRequired($key);
-    }
-}
-
 if (! function_exists('filled')) {
     /**
      * Determine if a value is "filled".

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -139,6 +139,21 @@ if (! function_exists('env')) {
     }
 }
 
+if (! function_exists('requireEnv')) {
+    /**
+     * Gets the value of a required environment variable.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    function requireEnv($key)
+    {
+        return Env::getRequired($key);
+    }
+}
+
 if (! function_exists('filled')) {
     /**
      * Determine if a value is "filled".

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1017,13 +1017,13 @@ class SupportHelpersTest extends TestCase
     {
         $this->expectExceptionObject(new RuntimeException('[required-does-not-exist] has no value'));
 
-        requireEnv('required-does-not-exist');
+        Env::getOrFail('required-does-not-exist');
     }
 
     public function testRequiredEnvReturnsValue(): void
     {
         $_SERVER['required-exists'] = 'some-value';
-        $this->assertSame('some-value', requireEnv('required-exists'));
+        $this->assertSame('some-value', Env::getOrFail('required-exists'));
     }
 
     public static function providesPregReplaceArrayData()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -26,6 +26,8 @@ class SupportHelpersTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
     public function testE()
@@ -1009,6 +1011,19 @@ class SupportHelpersTest extends TestCase
         $_ENV['foo'] = 'From $_ENV';
         $_SERVER['foo'] = 'From $_SERVER';
         $this->assertSame('From $_SERVER', env('foo'));
+    }
+
+    public function testRequiredEnvVariableThrowsAnExceptionWhenNotFound(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('[required-does-not-exist] has no value'));
+
+        requireEnv('required-does-not-exist');
+    }
+
+    public function testRequiredEnvReturnsValue(): void
+    {
+        $_SERVER['required-exists'] = 'some-value';
+        $this->assertSame('some-value', requireEnv('required-exists'));
     }
 
     public static function providesPregReplaceArrayData()


### PR DESCRIPTION
It sometimes happens that we want to ensure that some environment variables are set, without relying on their default value, in case they are not found.

This is very much the case when working as a team with new joiners when setting up their Laravel project locally.

I believe it is valuable to have a way to defined if a given environment variable needs to be explicitly set.

This pull-request introduces the `requireEnv()` helper and the 
`\Illuminate\Support\Env::getRequired()` method for this purpose.

They don't accept any default value, and an exception is thrown if the environment variable is not found.

---

**Note:**

The helper could also be named `requiredEnv()` (with a `d`), I don't have a strong opinion about this.
