### PR TITLE
[10.x] Add possibility to append directly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Append.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Append.php
@@ -1,0 +1,10 @@
+<?php
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Append
+{
+
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2155,12 +2155,11 @@ trait HasAttributes
      */
     public function getAttributeAppends(): array
     {
-        $reflectionClass = new ReflectionClass($this);
         $attributeMethods = $this->getAttributeMarkedMutatorMethods($this);
         $results = [];
         foreach ($attributeMethods as $methodName){
-            $method = $reflectionClass->getMethod($methodName);
-            if(!in_array($method, $this->appends) && $method->getAttributes(Append::class)){
+            $method = new ReflectionMethod($this, $methodName);
+            if(!in_array($methodName, $this->appends) && $method->getAttributes(Append::class)){
                 $results[] = $methodName;
             }
         }
@@ -2184,11 +2183,19 @@ trait HasAttributes
     /**
      * Return whether the accessor attribute has been appended.
      *
-     * @param  string  $attribute
+     * @param string $attribute
      * @return bool
+     * @throws ReflectionException
      */
     public function hasAppended($attribute)
     {
+        if(in_array($attribute, $this->getAttributeMarkedMutatorMethods($this))){
+            $method = new ReflectionMethod($this, $attribute);
+            if($method->getAttributes(Append::class)){
+                return true;
+            }
+        }
+
         return in_array($attribute, $this->appends);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2140,7 +2140,7 @@ trait HasAttributes
      * @return array
      * @throws ReflectionException
      */
-    public function getAppends(): array
+    public function getAppends()
     {
         $attributeAppends = $this->getAttributeAppends();
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2138,10 +2138,11 @@ trait HasAttributes
      * Get the accessors that are being appended to model arrays.
      *
      * @return array
+     * @throws ReflectionException
      */
     public function getAppends(): array
     {
-        $attributeAppends = $this->getArrayableAppends();
+        $attributeAppends = $this->getAttributeAppends();
 
         return array_merge($this->appends, $attributeAppends);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1945,8 +1945,9 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('admin', $model->is_admin);
         $this->assertSame('camelCased', $model->camelCased);
         $this->assertSame('StudlyCased', $model->StudlyCased);
+        $this->assertEquals(['admin', 'web_master'], $model->roles);
 
-        $this->assertEquals(['is_admin', 'camelCased', 'StudlyCased'], $model->getAppends());
+        $this->assertEquals(['is_admin', 'camelCased', 'StudlyCased', 'roles'], $model->getAppends());
 
         $this->assertTrue($model->hasAppended('is_admin'));
         $this->assertTrue($model->hasAppended('camelCased'));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Attributes\Append;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -22,6 +23,7 @@ use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
@@ -3033,6 +3035,11 @@ class EloquentModelAppendsStub extends Model
     public function getStudlyCasedAttribute()
     {
         return 'StudlyCased';
+    }
+
+    #[Append] public function roles(): Attribute
+    {
+        return Attribute::make(get: fn() => ['admin', 'web_master']);
     }
 }
 


### PR DESCRIPTION
**Description:**
Improvement: Direct Attribute Appending in Eloquent Model Methods using the `Append` attribute for methods

**Description:**
This pull request introduces a new feature that allows attributes to be appended directly within Eloquent model methods, eliminating the need to manually add them to the `appends` array. This improvement enhances the flexibility and readability of Eloquent models by enabling developers to define appended attributes directly within the method, simplifying the process of exposing custom attributes in API responses.

**Usage Examples:**

1. **Appending Full Name:**
   Before:
   ```php
   class User extends Model {
       protected $appends = ['roles'];
       
       public function roles() : Attribute
       {
           ....
       }
   }
   ```
   
   After:
   ```php
   class User extends Model {
       #[Append]
       public function roles(): Attribute
        {
           return Attribute::make(......)
       }
   }
   ```
   With this enhancement, the `price` attribute is automatically appended without the need to modify the `$appends` array. This results in more concise and organized code.

2. **Dynamic Status Attribute:**
   Before:
   ```php
   class Order extends Model {
       protected $appends = ['price'];
       
       public function price(): Attribute
       {
           return Attribute::make(......)
       }
   }
   ```
   
   After:
   ```php
   class Order extends Model {
       #[Append]
       public function price() : Attribute
       {
           return Attribute::make(......);
       }
   }
   ```

**Benefits:**
- **Simplified Code:** Developers can directly define appended attributes within their respective methods, reducing the need for extra array declarations and improving code clarity.
- **Enhanced Readability:** Attributes are logically associated with their defining methods, making it easier for other developers to understand the purpose of the appended attributes.
- **Reduced Error-Prone Code:** Eliminates the possibility of forgetting to add attributes to the `appends` array, reducing potential bugs.

**Notes:** This feature maintains backward compatibility by still allowing developers to use the traditional method of adding attributes to the `$appends` array and doesn't add any breaking change