### PR TITLE
[10.x] Combine prefix with table for `compileDropPrimary` PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1784,8 +1784,10 @@ class Blueprint
     {
         return $this->table;
     }
+
     /**
      * Get the table prefix.
+     *
      * @return string
      */
     public function getPrefix()

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1784,6 +1784,14 @@ class Blueprint
     {
         return $this->table;
     }
+    /**
+     * Get the table prefix.
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
 
     /**
      * Get the columns on the blueprint.

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -427,7 +427,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap("{$blueprint->getTable()}_pkey");
+        $index = $this->wrap("{$blueprint->getPrefix()}{$blueprint->getTable()}_pkey");
 
         return 'alter table '.$this->wrapTable($blueprint)." drop constraint {$index}";
     }


### PR DESCRIPTION
This PR addresses Issue #48189 by modifying the `compileDropPrimary` method in `PostgresGrammar`. The updated implementation now incorporates the table prefix when generating the primary key constraint name to drop.