### PR TITLE
[11.x] Env Encryption: Use environmentFilePath() for all .env file paths

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -73,7 +73,7 @@ class EnvironmentDecryptCommand extends Command
         $key = $this->parseKey($key);
 
         $encryptedFile = ($this->option('env')
-                    ? base_path('.env').'.'.$this->option('env')
+                    ? Str::finish(dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR).'.env.'.$this->option('env')
                     : $this->laravel->environmentFilePath()).'.encrypted';
 
         $outputFile = $this->outputFilePath();
@@ -138,7 +138,7 @@ class EnvironmentDecryptCommand extends Command
      */
     protected function outputFilePath()
     {
-        $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
+        $path = Str::finish($this->option('path') ?: dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR);
 
         $outputFile = $this->option('filename') ?: ('.env'.($this->option('env') ? '.'.$this->option('env') : ''));
         $outputFile = ltrim($outputFile, DIRECTORY_SEPARATOR);

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -64,7 +64,7 @@ class EnvironmentEncryptCommand extends Command
         $keyPassed = $key !== null;
 
         $environmentFile = $this->option('env')
-                            ? base_path('.env').'.'.$this->option('env')
+                            ? Str::finish(dirname($this->laravel->environmentFilePath()), DIRECTORY_SEPARATOR).'.env.'.$this->option('env')
                             : $this->laravel->environmentFilePath();
 
         $encryptedFile = $environmentFile.'.encrypted';


### PR DESCRIPTION
Based on the discussion of PR https://github.com/laravel/framework/pull/47984 and adapted for Laravel 11.x as it is a breaking change:

This is related to the encryption & decryption of `.env`files: https://laravel.com/docs/10.x/configuration#encryption

It is supported to encrypt/decrypt `.env` files as well as environment specific files such as `.env.production`.
Currently there are two different methods in place to get the paths to those files: `$this->laravel->environmentFilePath()` for the first and `base_path('.env') . '.' . $this->option('env')` for the second.
However there is no reason that env specific files (e.g. `.env.production`) are stored somewhere else then the `.env` file and while I can use the following to adjust the path where `.env` files are saved:

```
 app()->useEnvironmentPath(
      dirname(__DIR__, 2)
  );
``` 

That won't apply to env specific files (e.g. `.env.production`) as their path is built differently with `base_path()`.

This PR unifies it by using `$this->laravel->environmentFilePath()` for all `.env` and `.env.*` files.