### PR TITLE
[10.x] Add `Arr::arrow()` + `Arr::flattenWith()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -109,11 +109,58 @@ class Arr
      */
     public static function dot($array, $prepend = '')
     {
+        return static::flattenWith($array, '.', $prepend);
+    }
+
+    /**
+     * Convert a flattened "dot" notation array into an expanded array.
+     *
+     * @param  iterable  $array
+     * @return array
+     */
+    public static function undot($array)
+    {
+        return static::unflattenWith($array, '.');
+    }
+
+    /**
+     * Flatten a multi-dimensional associative array with JSON arrows.
+     *
+     * @param  iterable  $array
+     * @param  string  $prepend
+     * @return array
+     */
+    public static function arrow($array, $prepend = '')
+    {
+        return static::flattenWith($array, '->', $prepend);
+    }
+
+    /**
+     * Convert a flattened "arrow" notation array into an expanded array.
+     *
+     * @param  iterable  $array
+     * @return array
+     */
+    public static function unarrow($array)
+    {
+        return static::unflattenWith($array, '->');
+    }
+
+    /**
+     * Flatten a multi-dimensional associative array with a specific separator.
+     *
+     * @param  iterable  $array
+     * @param  string  $separator
+     * @param  string  $prepend
+     * @return array
+     */
+    public static function flattenWith($array, $separator, $prepend = '')
+    {
         $results = [];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results = array_merge($results, static::flattenWith($value, $separator, $prepend.$key.$separator));
             } else {
                 $results[$prepend.$key] = $value;
             }
@@ -123,17 +170,18 @@ class Arr
     }
 
     /**
-     * Convert a flatten "dot" notation array into an expanded array.
+     * Convert a flattened notation array into an expanded array.
      *
      * @param  iterable  $array
+     * @param  string  $separator
      * @return array
      */
-    public static function undot($array)
+    public static function unflattenWith($array, $separator)
     {
         $results = [];
 
         foreach ($array as $key => $value) {
-            static::set($results, $key, $value);
+            static::set($results, $key, $value, $separator);
         }
 
         return $results;
@@ -694,15 +742,16 @@ class Arr
      * @param  array  $array
      * @param  string|int|null  $key
      * @param  mixed  $value
+     * @param  string  $separator
      * @return array
      */
-    public static function set(&$array, $key, $value)
+    public static function set(&$array, $key, $value, $separator = '.')
     {
         if (is_null($key)) {
             return $array = $value;
         }
 
-        $keys = explode('.', $key);
+        $keys = explode($separator, $key);
 
         foreach ($keys as $i => $key) {
             if (count($keys) === 1) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -139,6 +139,77 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]], $array);
     }
 
+    public function testArrow()
+    {
+        $array = Arr::arrow(['foo' => ['bar' => 'baz', 'foobar' => 'foobaz']]);
+        $this->assertEquals(['foo->bar' => 'baz', 'foo->foobar' => 'foobaz'], $array);
+
+        $array = Arr::arrow([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::arrow(['foo' => []]);
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::arrow(['foo' => ['bar' => []]]);
+        $this->assertEquals(['foo->bar' => []], $array);
+    }
+
+    public function testUnarrow()
+    {
+        $array = Arr::unarrow([
+            'foo->bar' => 'test',
+            'foo->baz->bob' => 'Bob',
+            'foo->baz->alice' => 'Alice',
+            'foo->languages->0' => 'PHP',
+            'foo->languages->1' => 'C#',
+        ]);
+
+        $this->assertEquals([
+            'foo' => [
+                'bar' => 'test',
+                'baz' => [
+                    'bob' => 'Bob',
+                    'alice' => 'Alice'
+                ],
+                'languages' => ['PHP', 'C#'],
+            ],
+        ], $array);
+    }
+
+    public function testFlattenWith()
+    {
+        $array = Arr::flattenWith([
+            'path' => [
+                'to' => [
+                    'files' => 'somefile',
+                    'logs' => 'somelog',
+                ],
+            ],
+        ], '/');
+
+        $this->assertEquals([
+            'path/to/files' => 'somefile',
+            'path/to/logs' => 'somelog',
+        ], $array);
+    }
+
+    public function testUnflattenWith()
+    {
+        $array = Arr::unflattenWith([
+            'path/to/files' => ['somefile', 'someotherfile'],
+            'path/to/logs' => ['somelog', 'someotherlog'],
+        ], '/');
+
+        $this->assertEquals([
+            'path' => [
+                'to' => [
+                    'files' => ['somefile', 'someotherfile'],
+                    'logs' => ['somelog', 'someotherlog'],
+                ],
+            ],
+        ], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -169,7 +169,7 @@ class SupportArrTest extends TestCase
                 'bar' => 'test',
                 'baz' => [
                     'bob' => 'Bob',
-                    'alice' => 'Alice'
+                    'alice' => 'Alice',
                 ],
                 'languages' => ['PHP', 'C#'],
             ],


### PR DESCRIPTION
I ran into an issue recently where mass-assigning JSON columns (https://laravel.com/docs/10.x/eloquent#mass-assignment-json-columns) required some pre-parsing of the input, because my input was a nested array.

The use-case is as follows: Create a user with a JSON `address` column which has a few fillable properties:

```php
class User extends Model
{
    protected $fillable = [
        'address->street',
        'address->number',
    ];

    protected $casts = [
        'address' => 'object',
    ];
}
```
Now create a user from a nested array:
```php
$data = [
    'address' => [
        'street' => 'High Avenue',
        'number' => 5,
    ]
];

$arrowed = Arr::arrow($data);
// [
//     'address->street' => 'High Avenue',
//     'address->number' => 5,
// ];

$user = User::create($arrowed);
// Happy developer: creating the user will now make use of the allowed
// `$fillable` properties, and properties that are not fillable will not be assigned.
```

Assigning the `$data` as-is will not work since it would require the root `'address'` to be fillable. This automatically allows any key inside the `'address'` object (e.g. `'address' => ['foobar' => 'test']`) which is not desired.

To make working with this easier, I have added the following methods which function similar to `Arr::dot()`/`Arr::undot()`:
- `Arr::arrow($array)`
- `Arr::unarrow($array)`
- `Arr::flattenWith($array, $separator)`
- `Arr::unflattenWith($array, $separator)`

I have also changed the signature for `Arr::set()` by adding a `$separator`:
```php
public static function set(&$array, $key, $value, $separator = '.')
```

Since this is an optional argument I dont know if this is considered a BC and should therefore target 11.x.
