### PR TITLE
[10.x] Adding the ability to define rate limiting in dedicated classes

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -32,9 +32,12 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         });
 
         $this->app->singleton(RateLimiter::class, function ($app) {
-            return new RateLimiter($app->make('cache')->driver(
-                $app['config']->get('cache.limiter')
-            ));
+            return new RateLimiter(
+                $app->make('cache')->driver(
+                    $app['config']->get('cache.limiter')
+                ),
+                $app
+            );
         });
     }
 

--- a/src/Illuminate/Cache/Contracts/RateLimit.php
+++ b/src/Illuminate/Cache/Contracts/RateLimit.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Cache\Contracts;
+
+interface RateLimit
+{
+    /**
+     * Resolve rate limit for the given request or job.
+     *
+     * @param  \Illuminate\Http\Request|mixed  $request
+     * @return \Illuminate\Cache\RateLimiting\Limit|array<int, \Illuminate\Cache\RateLimiting\Limit>
+     */
+    public function __invoke($request);
+}

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
+use Illuminate\Cache\Contracts\RateLimit;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -112,7 +113,7 @@ class ThrottleRequests
      *
      * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
      */
-    protected function handleRequestUsingNamedLimiter($request, Closure $next, $limiterName, Closure $limiter)
+    protected function handleRequestUsingNamedLimiter($request, Closure $next, $limiterName, Closure|RateLimit $limiter)
     {
         $limiterResponse = $limiter($request);
 

--- a/src/Illuminate/Routing/RateLimit/ApiRateLimit.php
+++ b/src/Illuminate/Routing/RateLimit/ApiRateLimit.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Routing\RateLimit;
+
+use Illuminate\Cache\Contracts\RateLimit;
+use Illuminate\Cache\RateLimiting\Limit;
+
+class ApiRateLimit implements RateLimit
+{
+    public function __invoke($request)
+    {
+        return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+    }
+}

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Cache\RateLimiter for(string $name, \Closure $callback)
+ * @method static \Illuminate\Cache\RateLimiter for(string $name, \Closure|string $callback)
  * @method static \Closure|null limiter(string $name)
  * @method static mixed attempt(string $key, int $maxAttempts, \Closure $callback, int $decaySeconds = 60)
  * @method static bool tooManyAttempts(string $key, int $maxAttempts)


### PR DESCRIPTION
I want to add ability to define dedicated classes with DI possibility for rate limiting. 
Sometimes I want to create more complex logic based on config values or whatever.

By this change I'm able to do it easily and in pretty way.
That change is backward compatible because it is using `__invoke` method with subject parameter (request or job).
Also, `api` limiter is moved to dedicated class to encourage new developers to use it.
