### PR TITLE
Broadcast notification event name to be "Illuminate\\Notifications\\Events\\BroadcastNotificationCreated" by default

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -130,6 +130,6 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return method_exists($this->notification, 'broadcastAs')
         ? $this->notification->broadcastAs()
-        : get_class($this->notification);
+        : get_class($this);
     }
 }


### PR DESCRIPTION

This is done in order for laravel-echo to detect that it's a notification event, it enables the .notification method in laravel-echo to function as intended.
