### PR TITLE
[10.x] Update MySqlSchemaState.php - Import schemas from different databases

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -19,7 +19,7 @@ class MySqlSchemaState extends SchemaState
     public function dump(Connection $connection, $path)
     {
         $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand().' --routines --result-file="${:LARAVEL_LOAD_PATH}" --no-data'
+            $this->baseDumpCommand().' --routines --result-file="${:LARAVEL_LOAD_PATH}" --no-data --databases'
         ), $this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));


### PR DESCRIPTION
Hello,

This a simple PR that adds `--databases` to the `schema:dump` command.

At the moment, any sche:dump will assume that the user uses only 1 dababase.
This will be very usefull when importing schemas that uses different database.

Regards,
Helder