### PR TITLE
[10.x] Add methods `dumpWhen` and `ddWhen` to Str and Collection

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -197,6 +197,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function dump();
 
     /**
+     * Dump the collection if the condition is true.
+     *
+     * @param  mixed $condition
+     * @return $this
+     */
+    public function dumpWhen(mixed $condition);
+
+    /**
      * Get the items that are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -182,7 +182,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function dd(...$args);
 
     /**
-     * Dump the collection and end the script if the condition is true.
+     * Dump the collection and end the script when the given condition is true.
      *
      * @param  mixed  $condition
      * @return never
@@ -197,7 +197,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function dump();
 
     /**
-     * Dump the collection if the condition is true.
+     * Dump the collection when the given condition is true.
      *
      * @param  mixed $condition
      * @return $this

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -185,9 +185,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Dump the collection and end the script when the given condition is true.
      *
      * @param  mixed  $condition
+     * @param  mixed ...$args
      * @return never
      */
-    public function ddWhen(mixed $condition);
+    public function ddWhen(mixed $condition, ...$args);
 
     /**
      * Dump the collection.
@@ -200,9 +201,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Dump the collection when the given condition is true.
      *
      * @param  mixed $condition
+     * @param  mixed ...$args
      * @return $this
      */
-    public function dumpWhen(mixed $condition);
+    public function dumpWhen(mixed $condition, ...$args);
 
     /**
      * Get the items that are not present in the given items.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -182,6 +182,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function dd(...$args);
 
     /**
+     * Dump the collection and end the script if the condition is true.
+     *
+     * @param  mixed  $condition
+     * @return never
+     */
+    public function ddWhen(mixed $condition);
+
+    /**
      * Dump the collection.
      *
      * @return $this

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -185,7 +185,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Dump the collection and end the script when the given condition is true.
      *
      * @param  mixed  $condition
-     * @param  mixed ...$args
+     * @param  mixed  ...$args
      * @return never
      */
     public function ddWhen(mixed $condition, ...$args);
@@ -200,8 +200,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Dump the collection when the given condition is true.
      *
-     * @param  mixed $condition
-     * @param  mixed ...$args
+     * @param  mixed  $condition
+     * @param  mixed  ...$args
      * @return $this
      */
     public function dumpWhen(mixed $condition, ...$args);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -209,6 +209,17 @@ trait EnumeratesValues
     }
 
     /**
+     * Dump the collection and end the script if the condition is true.
+     *
+     * @param  mixed  $condition
+     * @return never|EnumeratesValues
+     */
+    public function ddWhen(mixed $condition)
+    {
+        return $this->when($condition, fn ($items) => dd($items));
+    }
+
+    /**
      * Dump the items.
      *
      * @return $this

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -212,7 +212,7 @@ trait EnumeratesValues
      * Dump the collection and end the script when the given condition is true.
      *
      * @param  mixed  $condition
-     * @param  mixed ...$args
+     * @param  mixed  ...$args
      * @return never|EnumeratesValues
      */
     public function ddWhen(mixed $condition, ...$args)
@@ -239,6 +239,8 @@ trait EnumeratesValues
     /**
      * Dump the collection when the given condition is true.
      *
+     * @param  mixed  $condition
+     * @param  mixed  ...$args
      * @return $this
      */
     public function dumpWhen(mixed $condition, ...$args)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -236,6 +236,16 @@ trait EnumeratesValues
     }
 
     /**
+     * Dump the collection if the condition is true.
+     *
+     * @return $this
+     */
+    public function dumpWhen(mixed $condition)
+    {
+        return $this->when($condition, fn () => $this->dump());
+    }
+
+    /**
      * Execute a callback over each item.
      *
      * @param  callable(TValue, TKey): mixed  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -209,7 +209,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Dump the collection and end the script if the condition is true.
+     * Dump the collection and end the script when the given condition is true.
      *
      * @param  mixed  $condition
      * @return never|EnumeratesValues
@@ -236,7 +236,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Dump the collection if the condition is true.
+     * Dump the collection when the given condition is true.
      *
      * @return $this
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -212,11 +212,12 @@ trait EnumeratesValues
      * Dump the collection and end the script when the given condition is true.
      *
      * @param  mixed  $condition
+     * @param  mixed ...$args
      * @return never|EnumeratesValues
      */
-    public function ddWhen(mixed $condition)
+    public function ddWhen(mixed $condition, ...$args)
     {
-        return $this->when($condition, fn ($items) => dd($items));
+        return $this->when($condition, fn () => $this->dd(...$args));
     }
 
     /**
@@ -240,9 +241,9 @@ trait EnumeratesValues
      *
      * @return $this
      */
-    public function dumpWhen(mixed $condition)
+    public function dumpWhen(mixed $condition, ...$args)
     {
-        return $this->when($condition, fn () => $this->dump());
+        return $this->when($condition, fn () => $this->dump(...$args));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1208,6 +1208,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Dump the string and end the script when the given condition is true.
+     *
+     * @param  mixed $condition
+     * @return never|$this
+     */
+    public function ddWhen(mixed $condition)
+    {
+        return $this->when($condition, fn () => $this->dd());
+    }
+
+    /**
      * Get the underlying string value.
      *
      * @return string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1187,7 +1187,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Dump the string when the given condition is true.
      *
-     * @param  mixed $condition
+     * @param  mixed  $condition
      * @return $this
      */
     public function dumpWhen(mixed $condition)
@@ -1210,7 +1210,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Dump the string and end the script when the given condition is true.
      *
-     * @param  mixed $condition
+     * @param  mixed  $condition
      * @return never|$this
      */
     public function ddWhen(mixed $condition)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1185,6 +1185,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Dump the string when the given condition is true.
+     *
+     * @param  mixed $condition
+     * @return $this
+     */
+    public function dumpWhen(mixed $condition)
+    {
+        return $this->when($condition, fn () => $this->dump());
+    }
+
+    /**
      * Dump the string and end the script.
      *
      * @return never

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4421,6 +4421,42 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testDumpWhenTrue($collection)
+    {
+        $log = new Collection;
+
+        VarDumper::setHandler(function ($value) use ($log) {
+            $log->add($value);
+        });
+
+        (new $collection([1, 2, 3]))->dumpWhen(true, 'one', 'two');
+
+        $this->assertSame(['one', 'two', [1, 2, 3]], $log->all());
+
+        VarDumper::setHandler(null);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDumpWhenFalse($collection)
+    {
+        $log = new Collection;
+
+        VarDumper::setHandler(function ($value) use ($log) {
+            $log->add($value);
+        });
+
+        (new $collection([1, 2, 3]))->dumpWhen(false, 'one', 'two');
+
+        $this->assertSame([], $log->all());
+
+        VarDumper::setHandler(null);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testReduce($collection)
     {
         $data = new $collection([1, 2, 3]);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
+use Symfony\Component\VarDumper\VarDumper;
 
 class SupportStrTest extends TestCase
 {
@@ -1158,6 +1159,36 @@ class SupportStrTest extends TestCase
     public function testPasswordCreation()
     {
         $this->assertTrue(strlen(Str::password()) === 32);
+    }
+
+    public function testDumpWhenTrue()
+    {
+        $log = Str::of('');
+
+        VarDumper::setHandler(function ($value) use (&$log) {
+            $log = $log->append($value);
+        });
+
+        Str::of('Laravel')->dumpWhen(true);
+
+        $this->assertSame('Laravel', $log->toString());
+
+        VarDumper::setHandler(null);
+    }
+
+    public function testDumpWhenFalse()
+    {
+        $log = Str::of('');
+
+        VarDumper::setHandler(function ($value) use (&$log) {
+            $log = $log->append($value);
+        });
+
+        Str::of('Laravel')->dumpWhen(fn () => false);
+
+        $this->assertSame('', $log->toString());
+
+        VarDumper::setHandler(null);
     }
 }
 


### PR DESCRIPTION
I believe it would be useful to have such a shortcut for dumping things especially when working in large nested arrays/objects.


usage: 
```php
// Collection / EloquentCollection

collect([1,2,3]) // or User::get()
    ->dumpWhen(fn ($items) => $items->count() === 3) // or ddWhen()
    ->toArray();


// Str
Str::of($firstName)
    ->append($lastName)
    ->dumpWhen(fn ($str) => $str->endsWith('A')) // or ddWhen()
    ->toString();

