### PR TITLE
[10.x] Strip token from config options when making new AWS (DynamoDB) clients

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -264,7 +264,7 @@ class CacheManager implements FactoryContract
             );
         }
 
-        return new DynamoDbClient($dynamoConfig);
+        return new DynamoDbClient(Arr::except($dynamoConfig, ['token']));
     }
 
     /**


### PR DESCRIPTION
* strip token from config options on DynamoDB clients
* only strip token for now