### PR TITLE
[10.x] Add method Str::chunk

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -239,7 +239,7 @@ class Str
      *
      * @param  string  $string  The string to split into characters or chunks.
      * @param  int  $length  If specified, each element of the returned array will be composed of multiple characters instead of a single character.
-     * @param  string|null  $encoding  The character encoding (default: UTF-8, If it is null, the function will use the internal encoding.
+     * @param  string|null  $encoding  The character encoding (default: UTF-8, If it is null, the function will use the internal encoding).
      * @return array returns an array of strings.
      */
     public static function chunk(string $string, int $length = 1, ?string $encoding = 'UTF-8')

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -235,6 +235,19 @@ class Str
     }
 
     /**
+     * Given a multibyte string, return an array of its characters.
+     *
+     * @param  string  $string  The string to split into characters or chunks.
+     * @param  int  $length  If specified, each element of the returned array will be composed of multiple characters instead of a single character.
+     * @param  string|null  $encoding  The character encoding (default: null, which uses the internal encoding).
+     * @return array returns an array of strings.
+     */
+    public static function chunk(string $string, int $length = 1, ?string $encoding = null)
+    {
+        return mb_str_split($string, $length, $encoding);
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -239,10 +239,10 @@ class Str
      *
      * @param  string  $string  The string to split into characters or chunks.
      * @param  int  $length  If specified, each element of the returned array will be composed of multiple characters instead of a single character.
-     * @param  string|null  $encoding  The character encoding (default: null, which uses the internal encoding).
+     * @param  string|null  $encoding  The character encoding (default: UTF-8, If it is null, the function will use the internal encoding.
      * @return array returns an array of strings.
      */
-    public static function chunk(string $string, int $length = 1, ?string $encoding = null)
+    public static function chunk(string $string, int $length = 1, ?string $encoding = 'UTF-8')
     {
         return mb_str_split($string, $length, $encoding);
     }


### PR DESCRIPTION
## Pull Request Summary

This pull request introduces a new function, `Str::chunk`, to the Laravel Framework. This function enables the conversion of a string into an array, supporting variable character size encodings as well as fixed-size encodings of 1, 2, or 4-byte characters. When a length parameter is provided, the string will be divided into chunks of the specified length in characters (not bytes). The encoding parameter is optional.
returns an array of strings.

## Description

In response to a need for more versatile string manipulation, this pull request extends the functionality of the `Str` facade. Developers will benefit from this feature when working with strings in various encoding scenarios.

## Changes Made

- Added a new function `Str::chunk` to convert a string into an array.
- Provided support for variable character size encodings and fixed-size encodings.
- Implemented the ability to specify the chunk length in characters (not bytes).
- Made the encoding parameter optional for enhanced flexibility.
