### PR TITLE
[10.x] Deduplicate exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -42,6 +42,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
+use WeakMap;
 
 class Handler implements ExceptionHandlerContract
 {
@@ -120,6 +121,20 @@ class Handler implements ExceptionHandlerContract
     ];
 
     /**
+     * Indicates that exception reporting should be deduplicated.
+     *
+     * @var bool
+     */
+    protected $deduplicateReporting = false;
+
+    /**
+     * The already reported exception map.
+     *
+     * @var \WeakMap
+     */
+    protected $reportedExceptionMap;
+
+    /**
      * Create a new exception handler instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -128,6 +143,8 @@ class Handler implements ExceptionHandlerContract
     public function __construct(Container $container)
     {
         $this->container = $container;
+
+        $this->reportedExceptionMap = new WeakMap;
 
         $this->register();
     }
@@ -260,6 +277,8 @@ class Handler implements ExceptionHandlerContract
      */
     protected function reportThrowable(Throwable $e): void
     {
+        $this->reportedExceptionMap[$e] = true;
+
         if (Reflector::isCallable($reportCallable = [$e, 'report']) &&
             $this->container->call($reportCallable) !== false) {
             return;
@@ -307,6 +326,10 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldntReport(Throwable $e)
     {
+        if ($this->deduplicateReporting && ($this->reportedExceptionMap[$e] ?? false)) {
+            return true;
+        }
+
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
         return ! is_null(Arr::first($dontReport, fn ($type) => $e instanceof $type));
@@ -795,5 +818,17 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Throwable $e)
     {
         return $e instanceof HttpExceptionInterface;
+    }
+
+    /**
+     * Do not report duplicate exceptions.
+     *
+     * @return $this
+     */
+    public function deduplicateReporting()
+    {
+        $this->deduplicateReporting = true;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -810,6 +810,18 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
+     * Do not report duplicate exceptions.
+     *
+     * @return $this
+     */
+    public function dontReportDuplicates()
+    {
+        $this->deduplicateReporting = true;
+
+        return $this;
+    }
+
+    /**
      * Determine if the given exception is an HTTP exception.
      *
      * @param  \Throwable  $e
@@ -818,17 +830,5 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Throwable $e)
     {
         return $e instanceof HttpExceptionInterface;
-    }
-
-    /**
-     * Do not report duplicate exceptions.
-     *
-     * @return $this
-     */
-    public function deduplicateReporting()
-    {
-        $this->deduplicateReporting = true;
-
-        return $this;
     }
 }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -13,7 +13,6 @@ use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Log\Logger;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\MessageBag;
@@ -34,7 +33,6 @@ use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Throwable;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -463,7 +463,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             return false;
         });
 
-        $this->handler->deduplicateReporting();
+        $this->handler->dontReportDuplicates();
         $this->handler->report($one = new RuntimeException('foo'));
         $this->handler->report($one);
         $this->handler->report($two = new RuntimeException('foo'));

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -465,7 +465,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             return false;
         });
 
-        $this->handler->dedupeReporting();
+        $this->handler->deduplicateReporting();
         $this->handler->report($one = new RuntimeException('foo'));
         $this->handler->report($one);
         $this->handler->report($two = new RuntimeException('foo'));


### PR DESCRIPTION
Adds the ability to deduplicate exception reporting.

Exceptions may sometimes be caught, reported, re-thrown only to be re-reported at a higher level - potentially a few times throughout the application layers.

This adds a lever to the exception handler to deduplicate exceptions to ensure a single instance of an exception is only reported on time.

```php
use Illuminate\Contracts\Debug\ExceptionHandler;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function register()
    {
        // …

        $this->callAfterResolving(ExceptionHandler::class, function ($handler) {
            $handler->deduplicateReporting();
        });
    }
}
```

If the same exception is now reported more than once, it will only actually report a single time.


```php
$e = new RuntimeException('abc');

report($e);

report($e);

try {
    throw $e;
} catch (Exception $exception) {
    report($exception);
}

// only reported once
```

There is already precedent for this kind of feature in the framework with something like middleware.

```php
Route::middleware(MyMiddleware::class)->group(function () {
     Route::get(/* ... */)->middleware(MyMiddleware::class);
});
```

The `MyMiddleware` is not executed twice, as the framework deduplicates them for us.