### PR TITLE
[10.x] Fix issue with table prefix duplication in DatabaseTruncation trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -98,7 +98,7 @@ trait DatabaseTruncation
      * @param  string  $table
      * @return string
      */
-    protected function withoutTablePrefix(ConnectionInterface $connection, string $table): string
+    protected function withoutTablePrefix(ConnectionInterface $connection, string $table)
     {
         $prefix = $connection->getTablePrefix();
 

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -85,10 +85,32 @@ trait DatabaseTruncation
                 fn ($tables) => $tables->intersect($this->tablesToTruncate),
                 fn ($tables) => $tables->diff($this->exceptTables($name))
             )
-            ->filter(fn ($table) => $connection->table($table)->exists())
-            ->each(fn ($table) => $connection->table($table)->truncate());
+            ->filter(fn ($table) => $connection->table($this->removeTablePrefix($connection, $table))->exists())
+            ->each(fn ($table) => $connection->table($this->removeTablePrefix($connection, $table))->truncate());
 
         $connection->setEventDispatcher($dispatcher);
+    }
+
+    /**
+     * Remove the table prefix from a table name, if it exists.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return string
+     */
+    protected function removeTablePrefix(ConnectionInterface $connection, string $table): string
+    {
+        // Retrieve the table prefix associated with the connection
+        $prefix = $connection->getTablePrefix();
+
+        // Check if the table name contains the prefix
+        if (strpos($table, $prefix) === 0) {
+            // If the prefix is found, remove it from the table name
+            return substr($table, strlen($prefix));
+        }
+
+        // If no prefix is found, return the original table name
+        return $table;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -85,8 +85,8 @@ trait DatabaseTruncation
                 fn ($tables) => $tables->intersect($this->tablesToTruncate),
                 fn ($tables) => $tables->diff($this->exceptTables($name))
             )
-            ->filter(fn ($table) => $connection->table($this->removeTablePrefix($connection, $table))->exists())
-            ->each(fn ($table) => $connection->table($this->removeTablePrefix($connection, $table))->truncate());
+            ->filter(fn ($table) => $connection->table($this->withoutTablePrefix($connection, $table))->exists())
+            ->each(fn ($table) => $connection->table($this->withoutTablePrefix($connection, $table))->truncate());
 
         $connection->setEventDispatcher($dispatcher);
     }
@@ -98,19 +98,13 @@ trait DatabaseTruncation
      * @param  string  $table
      * @return string
      */
-    protected function removeTablePrefix(ConnectionInterface $connection, string $table): string
+    protected function withoutTablePrefix(ConnectionInterface $connection, string $table): string
     {
-        // Retrieve the table prefix associated with the connection
         $prefix = $connection->getTablePrefix();
 
-        // Check if the table name contains the prefix
-        if (strpos($table, $prefix) === 0) {
-            // If the prefix is found, remove it from the table name
-            return substr($table, strlen($prefix));
-        }
-
-        // If no prefix is found, return the original table name
-        return $table;
+        return strpos($table, $prefix) === 0
+            ? substr($table, strlen($prefix))
+            : $table;
     }
 
     /**


### PR DESCRIPTION
This pull request addresses the issue documented in [#48264](https://github.com/laravel/framework/issues/48264)
where the DatabaseTruncation trait would attempt to truncate a table with a prefix being applied twice when using a DB connection configured to prefix all tables.

**Changes Made:**
- Added a new function `removeTablePrefix` to remove the table prefix from a table name if it exists.
- Modified the `truncateTablesForConnection` method to utilize `removeTablePrefix` when checking for table existence and performing truncation.

**Steps to Reproduce:**
- More details has been provided in the issue itself

**Expected Outcome:**
- With this pull request, tests should pass successfully, and the issue with table prefix duplication should be resolved.

**Additional Context:**
- This change ensures that the table prefix is correctly handled when checking for table existence and performing truncation, preventing the issue where the prefix was applied twice.

**Testing:**
- I have tested this fix with the steps mentioned in the "Steps to Reproduce" section and confirmed that the tests now pass as expected.