### PR TITLE
[10.x] Render mailable inline images

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -253,10 +253,9 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        $renderedView = $this->renderView($view ?: $plain, $data);
-
         return $this->replaceEmbeddedAttachments(
-            $renderedView, $data['message']->getSymfonyMessage()->getAttachments()
+            $this->renderView($view ?: $plain, $data),
+            $data['message']->getSymfonyMessage()->getAttachments()
         );
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -253,7 +253,25 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        return $this->renderView($view ?: $plain, $data);
+        $renderedView = $this->renderView($view ?: $plain, $data);
+
+        $attachments = $data['message']->getSymfonyMessage()->getAttachments();
+
+        //search all images to replace cids by data-uris to show in browser
+        if(preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/i', $renderedView, $matches))
+        {
+            $images = array_unique($matches[1]);
+            foreach($images as $image){
+                foreach ($attachments as $attachment){
+                    if($attachment->getFilename() == $image){
+                        $renderedView = str_replace('cid:'.$image, 'data:'.$attachment->getContentType().';base64,'.$attachment->bodyToString(), $renderedView);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $renderedView;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -258,7 +258,7 @@ class Mailer implements MailerContract, MailQueueContract
         $attachments = $data['message']->getSymfonyMessage()->getAttachments();
 
         //search all images to replace cids by data-uris to show in browser
-        if(preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/i', $renderedView, $matches)) {
+        if (preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/i', $renderedView, $matches)) {
             $images = array_unique($matches[1]);
             foreach ($images as $image) {
                 foreach ($attachments as $attachment) {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -258,12 +258,11 @@ class Mailer implements MailerContract, MailQueueContract
         $attachments = $data['message']->getSymfonyMessage()->getAttachments();
 
         //search all images to replace cids by data-uris to show in browser
-        if(preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/i', $renderedView, $matches))
-        {
+        if(preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/i', $renderedView, $matches)) {
             $images = array_unique($matches[1]);
-            foreach($images as $image){
-                foreach ($attachments as $attachment){
-                    if($attachment->getFilename() == $image){
+            foreach ($images as $image) {
+                foreach ($attachments as $attachment) {
+                    if ($attachment->getFilename() == $image) {
                         $renderedView = str_replace('cid:'.$image, 'data:'.$attachment->getContentType().';base64,'.$attachment->bodyToString(), $renderedView);
                         break;
                     }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -260,7 +260,7 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
-     * Replace the embedded image attachments when raw, inline image data for browser rendering.
+     * Replace the embedded image attachments with raw, inline image data for browser rendering.
      *
      * @param  string  $renderedView
      * @param  array  $attachments


### PR DESCRIPTION
This PR adds support to render inline images when previewing mailables in the browser.

This code

```php
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
</head>
<body>
<div style="text-align: center">
    <img src="{{ $message->embed(public_path('1x1-000000ff.png')) }}" alt="img alt">
</div>
</body>
</html>
```
was rendered as

```html
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
</head>
<body>
<div style="text-align: center">
<img src="cid:GRM6dF7cV3" alt="img alt">
</div>
</body>
</html>
```

But this commit renders it as 

```html
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
</head>
<body>
<div style="text-align: center">
<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YA
AAAASUVORK5CYII=" alt="img alt">
</div>
</body>
</html>
```