### PR TITLE
[10.x] Do not add token to AWS credentials without validating it first

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -260,7 +260,7 @@ class CacheManager implements FactoryContract
 
         if (! empty($config['key']) && ! empty($config['secret'])) {
             $dynamoConfig['credentials'] = Arr::only(
-                $config, ['key', 'secret', 'token']
+                $config, ['key', 'secret']
             );
         }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -264,6 +264,10 @@ class CacheManager implements FactoryContract
             );
         }
 
+        if (! empty($config['token'])) {
+            $dynamoConfig['credentials']['token'] = $config['token'];
+        }
+
         return new DynamoDbClient($dynamoConfig);
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -263,7 +263,11 @@ class FilesystemManager implements FactoryContract
         $config += ['version' => 'latest'];
 
         if (! empty($config['key']) && ! empty($config['secret'])) {
-            $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
+            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+        }
+
+        if (! empty($config['token'])) {
+            $config['credentials']['token'] = $config['token'];
         }
 
         return Arr::except($config, ['token']);


### PR DESCRIPTION
In the `CacheManager` and `FilesystemManager` the config that is used to instantiate a new AWS client checks for `key` and `secret` values within provided array, before adding those to the `credentials` element of the config. Unfortunately it _also_ adds a `token` value, without a similar validation - which can lead to including a blank `token` value unnecessarily.

Worse still, including a blank `token` value within that config's `credentials` array can cause requests using these clients to fail - producing errors such as this when using a `DynamoDbClient` (which extends the `AwsClient`) created by  a `CacheManager` that has included such a blank `token` value:

```
UnrecognizedClientException (client): The security token included in the request is invalid. - {
    "__type": "com.amazon.coral.service#UnrecognizedClientException",
    "message": "The security token included in the request is invalid."
} {"exception":"[object] (Aws\\DynamoDb\\Exception\\DynamoDbException(code: 0): Error executing \"PutItem\" on \"https://dynamodb.ap-southeast-2.amazonaws.com\"; AWS HTTP error: Client error: `POST https://dynamodb.ap-southeast-2.amazonaws.com` resulted in a `400 Bad Request` response:
{\"__type\":\"com.amazon.coral.service#UnrecognizedClientException\",\"message\":\"The security token included in the request i (truncated...)
UnrecognizedClientException (client): The security token included in the request is invalid. - {\"__type\":\"com.amazon.coral.service#UnrecognizedClientException\",\"message\":\"The security token included in the request is invalid.\"} at /var/task/vendor/aws/aws-sdk-php/src/WrappedHttpHandler.php:195)
[stacktrace]
```

Not including a (blank) `token` value in the config fixes this problem.