### PR TITLE
[10.x] `nullableForeignIdFor` feature request.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -955,6 +955,18 @@ class Blueprint
     }
 
     /**
+     * Create a nullable foreign ID column for the given model.
+     *
+     * @param  string  $model
+     * @param  string|null  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function nullableForeignIdFor($model, $column = null)
+    {
+        return $this->foreignIdFor($model, $column)->nullable();
+    }
+
+    /**
      * Create a new float column on the table.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -355,6 +355,21 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
+    public function testGenerateRelationshipNullableColumnWithIncrementalModel()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->nullableForeignIdFor('Illuminate\Foundation\Auth\User');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `user_id` bigint unsigned null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
     public function testGenerateRelationshipColumnWithUuidModel()
     {
         require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
@@ -369,6 +384,23 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testGenerateRelationshipNullableColumnWithUuidModel()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->nullableForeignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) null',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 


### PR DESCRIPTION
- I know there is a macro feature available but it is nice to have in laravel.

- That's how we improve the code after merge this PR.:

```diff
- Schema::create('posts', function (Blueprint $table) {
-     $table->foreignIdFor(User::class)->nullable()->constrained('users');
- });

+ Schema::create('posts', function (Blueprint $table) {
+     $table->nullableForeignIdFor(User::class)->constrained('users');
+ });
```