### PR TITLE
[11.x] Allow arguments to be passed in Stringable::pipe() method

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -547,11 +547,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Call the given callback and return a new string.
      *
      * @param  callable  $callback
+     * @param  mixed  $args
      * @return static
      */
-    public function pipe(callable $callback)
+    public function pipe(callable $callback, ...$args)
     {
-        return new static($callback($this));
+        return new static($callback($this, ...$args));
     }
 
     /**


### PR DESCRIPTION
Did you know guys we can use any php functions with `pipe` function?

```php
str('example string')->pipe('sha1');

// 97bfb022441d7a760a1eef6c7d706641dbd02536
```

This is because the `callable` type also accept functions as string.

But there is only one issue right there, We can't use a function with a parameters we can't pass arguments to it because pipe method only accept 1 argument.

With this change i made we can use _all_ functions! just like:

```php
str('a')->pipe('str_repeat', 3); //aaa

str('example string')->pipe('strtr', ['example' => 'changed']); //changed string
```

I sent this to master branch but i believe we can move it to 10