### PR TITLE
[10.x] PHP deprecated warning on passing null to non-nullable parameters of built-in functions 

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -251,6 +251,7 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        $haystack ??= '';
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -291,6 +291,7 @@ class SupportStrTest extends TestCase
      */
     public function testStrContains($haystack, $needles, $expected, $ignoreCase = false)
     {
+        error_reporting(E_ALL);
         $this->assertEquals($expected, Str::contains($haystack, $needles, $ignoreCase));
     }
 
@@ -984,6 +985,7 @@ class SupportStrTest extends TestCase
             ['Taylor', ['xxx'], false],
             ['Taylor', '', false],
             ['', '', false],
+            [null, 'xxx', false],
         ];
     }
 


### PR DESCRIPTION
Due to the `PHP Deprecated str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated` deprecation error that occurs in the `Illuminate\Support\Str::contains` method, I decided to fix this on this PR. The solution is simple, just a null safety check on the first line of the `contains` method. As mentioned here #48290, this deprecation error is also throwing in the validator and other places for sure.