### PR TITLE
[10.x] Handle JsonSerializable into JsonResource toArray

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -129,7 +129,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             return [];
         }
 
-        return is_array($this->resource)
+        return is_array($this->resource) || $this->resource instanceof JsonSerializable
             ? $this->resource
             : $this->resource->toArray();
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/48310

There is an issue using a JsonSerializable class with a JsonResource.
JsonSerializable is declared as a possibile return type of JsonResource::toArray but was not handled properly.