### PR TITLE
[10.x] Add float validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1106,7 +1106,7 @@ trait ValidatesAttributes
      */
     public function validateFloat($attribute, $value)
     {
-        return (filter_var($value, FILTER_VALIDATE_FLOAT) !== false) && !is_int($value);
+        return (filter_var($value, FILTER_VALIDATE_FLOAT) !== false) && ! is_int($value);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1106,7 +1106,7 @@ trait ValidatesAttributes
      */
     public function validateFloat($attribute, $value)
     {
-        return (filter_var($value, FILTER_VALIDATE_FLOAT) !== false) && ! is_int($value);
+        return filter_var($value, FILTER_VALIDATE_FLOAT) !== false;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1098,6 +1098,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a float.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFloat($attribute, $value)
+    {
+        return (filter_var($value, FILTER_VALIDATE_FLOAT) !== false) && !is_int($value);
+    }
+
+    /**
      * Validate that an attribute is greater than another attribute.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2750,6 +2750,31 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateFloat()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 42], ['foo' => 'Float']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => -42], ['foo' => 'Float']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 42.42], ['foo' => 'Float']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => -42.42], ['foo' => 'Float']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '42.42'], ['foo' => 'Float']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '-42.42'], ['foo' => 'Float']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'abc'], ['foo' => 'Float']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateDecimal()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2754,10 +2754,10 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 42], ['foo' => 'Float']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => -42], ['foo' => 'Float']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 42.42], ['foo' => 'Float']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
## Introduction
While Laravel offers validation rules for various types like integer and bool, there currently is no native validation rule for float. Given that the existing numeric rule allows for more lenient conditions such as whitespaces in numeric strings (" 123 ") and scientific notation (e.g., "123e0"), a more strict validation specifically for floats is needed.

## Implementation
~~In an attempt to align this new float validation with the existing integer rule, the implementation also considers strings that can be evaluated as floats to return true.~~

~~The function utilizes PHP's filter_var with the FILTER_VALIDATE_FLOAT flag. However, filter_var($value, FILTER_VALIDATE_FLOAT) alone would allow integers to pass through, which is not what we aim for in a float validation. Therefore, an additional check for !is_int($value) has been added to ensure only floats (or float-like strings) are considered valid.~~

Initially, the idea was to restrict the validation to only allow true floating-point numbers, excluding integers. However, to align better with PHP's native filter_var behavior, we decided to keep it simple and straightforward.

```php
public function validateFloat($attribute, $value)
{
    return filter_var($value, FILTER_VALIDATE_FLOAT) !== false;
}
```

This implementation uses PHP's filter_var with the FILTER_VALIDATE_FLOAT flag. This follows PHP's built-in logic and will include integers as valid floats, aligning it with PHP's general type loose behavior.