### PR TITLE
[10.x] Add alpha underscore validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -400,6 +400,28 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute contains only alpha-numeric characters and underscores.
+     * If the 'ascii' option is passed, validate that an attribute contains only ascii alpha-numeric characters and
+     * underscores.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAlphaUnderscore($attribute, $value, $parameters): bool
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        if (isset($parameters[0]) && $parameters[0] === 'ascii') {
+            return preg_match('/\A[a-zA-Z0-9_]+\z/u', $value) > 0;
+        }
+
+        return preg_match('/\A[\pL\pM\pN_]+\z/u', $value) > 0;
+    }
+
+    /**
      * Validate that an attribute is an array.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4680,6 +4680,43 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateAlphaUnderscore()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls1_3dlks'], ['x' => 'AlphaUnderscore']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'asls1-3dlks'], ['x' => 'AlphaUnderscore']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AlphaUnderscore']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'https://_g232oogle.com'], ['x' => 'AlphaUnderscore']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'tai.chi'], ['x' => 'AlphaUnderscore']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार_'], ['x' => 'AlphaUnderscore']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AlphaUnderscore']); // numbers in Hindi
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaUnderscore']); // eastern arabic numerals
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaUnderscore']); // ends with newline
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abcdef'], ['x' => 'AlphaUnderscore']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abc def'], ['x' => 'AlphaUnderscore']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateAlphaWithAsciiOption()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -4775,6 +4812,37 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDash:ascii']); // ends with newline
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateAlphaUnderscoreWithAsciiOption()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls1_3dlks'], ['x' => 'AlphaUnderscore:ascii']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'https://_g232oogle.com'], ['x' => 'AlphaUnderscore:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'tai.chi'], ['x' => 'AlphaUnderscore:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार_'], ['x' => 'AlphaUnderscore:ascii']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AlphaUnderscore:ascii']); // numbers in Hindi
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaUnderscore:ascii']); // eastern arabic numerals
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaUnderscore:ascii']); // ends with newline
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abcdef'], ['x' => 'AlphaUnderscore:ascii']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abcd ef'], ['x' => 'AlphaUnderscore:ascii']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
## Introduction
This PR adds `alpha_underscore` validation rule, useful for some apps that need usernames (or other attributes) to be only characters, numbers and underscores (and not dashes like alpha_dash rule). if this PR gets accepted and merged, i will make a PR to documentation as well.

### Usage/Example
Like other validation rules:
```php
'username' => [
     'required',
     'alpha_underscore',
     'min:4',
     'max:255',
]
```
Also like alpha_dash, ascii parameter can be passed to validation rule

```php
'username' => [
     'required',
     'alpha_underscore:ascii',
     'min:4',
     'max:255',
]
```

