### PR TITLE
[10.x] New object syntax for the `distinct` rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\Can;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\Distinct;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
@@ -184,5 +185,16 @@ class Rule
     public static function dimensions(array $constraints = [])
     {
         return new Dimensions($constraints);
+    }
+
+    /**
+     * Get a distinct constraint builder instance.
+     *
+     * @param  array  $constraints
+     * @return \Illuminate\Validation\Rules\Distinct
+     */
+    public static function distinct(bool $strict = false, bool $ignoreCase = false)
+    {
+        return new Distinct($strict, $ignoreCase);
     }
 }

--- a/src/Illuminate/Validation/Rules/Distinct.php
+++ b/src/Illuminate/Validation/Rules/Distinct.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class Distinct
+{
+    /**
+     * The name of the rule.
+     *
+     * @var string
+     */
+    protected $rule = 'distinct';
+
+    /**
+     * Use strict mode.
+     *
+     * @var bool
+     */
+    protected $strict;
+
+    /**
+     * Ignore case sensitive
+     *
+     * @var bool
+     */
+    protected $ignoreCase;
+
+    /**
+     * Create a new in rule instance.
+     *
+     * @param  bool  $strict
+     * @return void
+     */
+    public function __construct(bool $strict = false, bool $ignoreCase = false)
+    {
+        $this->strict = $strict;
+        $this->ignoreCase = $ignoreCase;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
+     */
+    public function __toString()
+    {
+        if ($this->ignoreCase) {
+            $mode = 'ignore_case';
+        } else {
+            $mode = $this->strict ? 'strict' : null;
+        }
+
+        return $this->rule.($mode ? ':'. $mode : null);
+    }
+}

--- a/src/Illuminate/Validation/Rules/Distinct.php
+++ b/src/Illuminate/Validation/Rules/Distinct.php
@@ -19,7 +19,7 @@ class Distinct
     protected $strict;
 
     /**
-     * Ignore case sensitive
+     * Ignore case sensitive.
      *
      * @var bool
      */
@@ -52,6 +52,6 @@ class Distinct
             $mode = $this->strict ? 'strict' : null;
         }
 
-        return $this->rule.($mode ? ':'. $mode : null);
+        return $this->rule.($mode ? ':'.$mode : null);
     }
 }

--- a/tests/Validation/ValidationDistinctRuleTest.php
+++ b/tests/Validation/ValidationDistinctRuleTest.php
@@ -2,10 +2,8 @@
 
 namespace Illuminate\Tests\Validation;
 
-use Illuminate\Tests\Validation\fixtures\Values;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Distinct;
-use Illuminate\Validation\Rules\In;
 use PHPUnit\Framework\TestCase;
 
 class ValidationDistinctRuleTest extends TestCase

--- a/tests/Validation/ValidationDistinctRuleTest.php
+++ b/tests/Validation/ValidationDistinctRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Tests\Validation\fixtures\Values;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Distinct;
+use Illuminate\Validation\Rules\In;
+use PHPUnit\Framework\TestCase;
+
+class ValidationDistinctRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new Distinct();
+
+        $this->assertSame('distinct', (string) $rule);
+
+        $rule = new Distinct(ignoreCase: true);
+
+        $this->assertSame('distinct:ignore_case', (string) $rule);
+
+        $rule = new Distinct(strict: true);
+
+        $this->assertSame('distinct:strict', (string) $rule);
+
+        $rule = new Distinct(strict: true, ignoreCase: true);
+
+        $this->assertSame('distinct:ignore_case', (string) $rule);
+
+        $rule = Rule::distinct();
+
+        $this->assertSame('distinct', (string) $rule);
+
+        $rule = Rule::distinct(ignoreCase: true);
+
+        $this->assertSame('distinct:ignore_case', (string) $rule);
+
+        $rule = Rule::distinct(strict: true);
+
+        $this->assertSame('distinct:strict', (string) $rule);
+
+        $rule = Rule::distinct(strict: true, ignoreCase: true);
+
+        $this->assertSame('distinct:ignore_case', (string) $rule);
+    }
+}


### PR DESCRIPTION
This PR adds new object syntax for the `distinct` rule instead of writing `strict` or `ignore_case` many times.
So I think this rule will be useful as well.
