### PR TITLE
Add support for PHP native enums in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
+use BackedEnum;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Connection;
@@ -11,6 +12,7 @@ use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
 class Blueprint
 {
@@ -1053,8 +1055,18 @@ class Blueprint
      * @param  array  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|string $allowed)
     {
+        if (is_string($allowed)) {
+            if (!is_subclass_of($allowed, BackedEnum::class)) {
+                throw new InvalidArgumentException(sprintf("Class [%s] must be BackedEnum", $allowed));
+            }
+
+            $allowed = array_map(function (BackedEnum $case) {
+                return $case->value;
+            }, $allowed::cases());
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1058,8 +1058,8 @@ class Blueprint
     public function enum($column, array|string $allowed)
     {
         if (is_string($allowed)) {
-            if (!is_subclass_of($allowed, BackedEnum::class)) {
-                throw new InvalidArgumentException(sprintf("Class [%s] must be BackedEnum", $allowed));
+            if (! is_subclass_of($allowed, BackedEnum::class)) {
+                throw new InvalidArgumentException(sprintf('Class [%s] must be BackedEnum', $allowed));
             }
 
             $allowed = array_map(function (BackedEnum $case) {

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -11,6 +11,9 @@ use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Tests\Database\stubs\TestEnum;
+use Illuminate\Tests\Database\stubs\TestUnitEnum;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseSchemaBlueprintIntegrationTest extends TestCase
@@ -670,6 +673,23 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
             $table->dropForeign('something');
+        });
+    }
+
+    public function testBlueprintEnumAllowsEnumClassStringAsArgument()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $column = $blueprint->getColumns()[0];
+        self::assertEquals(['test'], $column->get('allowed'));
+    }
+
+    public function testBlueprintEnumAcceptsOnlyBackedEnums()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->enum('some_name', TestUnitEnum::class);
         });
     }
 }

--- a/tests/Database/stubs/TestUnitEnum.php
+++ b/tests/Database/stubs/TestUnitEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Database\stubs;
+
+enum TestUnitEnum
+{
+    case test;
+}


### PR DESCRIPTION
This PR adds support for using native PHP enums in migrations.

For exaple if we have enum
```php
enum TestEnum: string
{
    case Test1 = 'test1';
    case Test2 = 'test2';
}
```

Than we can use it in our migration:
```php
Schema::create('some_table', function (Blueprint $table) {
    $table->enum('status', TestEnum::class);
});
```