### PR TITLE
[10.x] Updated `make:model` command to allow creation of feature test file

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -177,7 +177,13 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $test = Str::studly(class_basename($this->argument('name')));
 
-        $this->call('make:test', ['name' => "{$test}Test"]);
+        $options = ['name' => "{$test}Test"];
+
+        if (File::exists(base_path('tests/') . 'Pest.php')) {
+            $options[] = '--pest';
+        }
+
+        $this->call('make:test', $options);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,6 +57,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('controller', true);
             $this->input->setOption('policy', true);
             $this->input->setOption('resource', true);
+            $this->input->setOption('feature-test', true);
         }
 
         if ($this->option('factory')) {
@@ -76,6 +78,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('policy')) {
             $this->createPolicy();
+        }
+
+        if ($this->option('feature-test')) {
+            $this->createFeatureTest();
         }
     }
 
@@ -163,6 +169,18 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a feature test for the model.
+     *
+     * @return void
+     */
+    protected function createFeatureTest()
+    {
+        $test = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:test', ['name' => "{$test}Test"]);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -222,6 +240,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+            ['feature-test', 't', InputOption::VALUE_NONE, 'Create a new feature test file for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API resource controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
         ];
@@ -247,6 +266,7 @@ class ModelMakeCommand extends GeneratorCommand
             'migration' => 'Migration',
             'policy' => 'Policy',
             'resource' => 'Resource Controller',
+            'feature-test' => 'Feature Test'
         ]))->each(fn ($option) => $input->setOption($option, true));
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -266,7 +266,7 @@ class ModelMakeCommand extends GeneratorCommand
             'migration' => 'Migration',
             'policy' => 'Policy',
             'resource' => 'Resource Controller',
-            'feature-test' => 'Feature Test'
+            'feature-test' => 'Feature Test',
         ]))->each(fn ($option) => $input->setOption($option, true));
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -179,7 +179,7 @@ class ModelMakeCommand extends GeneratorCommand
 
         $options = ['name' => "{$test}Test"];
 
-        if (File::exists(base_path('tests/') . 'Pest.php')) {
+        if (File::exists(base_path('tests/').'Pest.php')) {
             $options[] = '--pest';
         }
 


### PR DESCRIPTION
As discussed in [this twitter thread](https://twitter.com/NapVeg/status/1698722896758321214), this adds the `-t`/`--feature-test` options to the `make:model` command.

This is my first "real" contribution to a framework of the size of Laravel so I apologize in advance if I've missed anything important.  I think I've done everything correctly, but if I haven't please let me know what I can do to make it better.