### PR TITLE
[10.x] Validate version and variant in `Str::isUuid()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -516,7 +516,11 @@ class Str
             return false;
         }
 
-        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
+        if ($value === '00000000-0000-0000-0000-000000000000') {
+            return true;
+        }
+
+        return preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iD', $value) > 0;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -965,6 +965,8 @@ class SupportStrTest extends TestCase
             ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],
             ['af6f8cb0c57d11e19b210800200c9a66'],
             ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-11e1-cb21-0800200c9a66'], // Invalid variant
+            ['ff6f8cb0-c57d-61e1-9b21-0800200c9a66'], // Invalid version
         ];
     }
 


### PR DESCRIPTION
Right now, `Str::isUuid()` will return `true` for UUIDs that are not RFC4122-compliant. In addition to the 8-4-4-4-12 format, UUIDs have two special characters:

- The 13th character (not counting dashes) is the "version" — which can be `1–5`
- The 17th character (not counting dashes) is the "variant" — which can be `8`, `9`, `a`, or `b`

(These special values are actually defined [by specific bits in the UUID](https://www.ietf.org/rfc/rfc4122.txt), but in practice it works out to the above rules.)

Here are two UUIDs that look valid but actually are not:

```
ff6f8cb0-c57d-11e1-cb21-0800200c9a66
                   ^ "c" is not a valid variant

ff6f8cb0-c57d-61e1-9b21-0800200c9a66
              ^ "6" is not a valid version
```

This PR updates the regular expression to account for these constraints on validity. It also accounts for the one outlier case, which is the "NIL" UUID `00000000-0000-0000-0000-000000000000`. Rather than complicating the regular expression, I've just added an additional check for this exact string, because it's the only of its kind.