### PR TITLE
[10.x] Extract SQL generation from Builder into Grammar class

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -290,4 +290,16 @@ abstract class Grammar
 
         return $this;
     }
+
+    /**
+     * Compile an aliased select statement.
+     *
+     * @param  string  $query
+     * @param  string  $alias
+     * @return string
+     */
+    public function compileSelectAs($query, $alias)
+    {
+        return '('.$query.') as '.$alias;
+    }
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -285,7 +285,7 @@ class Builder implements BuilderContract
         [$query, $bindings] = $this->createSub($query);
 
         return $this->selectRaw(
-            '('.$query.') as '.$this->grammar->wrap($as), $bindings
+            $this->grammar->compileSelectAs($query, $this->grammar->wrap($as)), $bindings
         );
     }
 
@@ -320,7 +320,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        return $this->fromRaw('('.$query.') as '.$this->grammar->wrapTable($as), $bindings);
+        return $this->fromRaw($this->grammar->compileSelectAs($query, $this->grammar->wrapTable($as)), $bindings);
     }
 
     /**
@@ -579,7 +579,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+        $expression = $this->grammar->compileSelectAs($query, $this->grammar->wrapTable($as));
 
         $this->addBinding($bindings, 'join');
 
@@ -703,7 +703,7 @@ class Builder implements BuilderContract
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+        $expression = $this->grammar->compileSelectAs($query, $this->grammar->wrapTable($as));
 
         $this->addBinding($bindings, 'join');
 


### PR DESCRIPTION
This piece of code is a template of SQL which belongs to the Grammer class and not the Query\Builder class. 😬