### PR TITLE
[10.x] Handle JsonSerializable into JsonResource toArray

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -129,7 +129,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             return [];
         }
 
-        return is_array($this->resource)
+        return is_array($this->resource) || $this->resource instanceof JsonSerializable
             ? $this->resource
             : $this->resource->toArray();
     }

--- a/tests/Integration/Http/Fixtures/JsonSerializableObject.php
+++ b/tests/Integration/Http/Fixtures/JsonSerializableObject.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use JsonSerializable;
+
+class JsonSerializableObject implements JsonSerializable
+{
+    public $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Tests\Integration\Http\Fixtures\Author;
 use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
+use Illuminate\Tests\Integration\Http\Fixtures\JsonSerializableObject;
 use Illuminate\Tests\Integration\Http\Fixtures\ObjectResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResource;
@@ -670,6 +671,25 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'title' => 'Test Title',
             ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'id' => 5,
+            ],
+        ]);
+    }
+
+    public function testJsonSerializableCanBeUsedAsResource()
+    {
+        Route::get('/', function () {
+            return JsonResource::make(new JsonSerializableObject(5));
         });
 
         $response = $this->withoutExceptionHandling()->get(


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/48310

There is an issue using a JsonSerializable class with a JsonResource.
JsonSerializable is declared as a possibile return type of JsonResource::toArray but was not handled properly.

Recreation example:

```
Route::get('/test', function() {
  $dto = new class implements JsonSerializable {
    public function jsonSerialize()
    {
      return ['foo' => 'bar'];
    }
  };

  return JsonResource::make($dto);
});
```
