### PR TITLE
[10.x] Introduce `LazilyRefreshDatabaseOnce` and `RefreshDatabaseOnce` Traits for One-Time Database Refresh in Unit Tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabaseOnce.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabaseOnce.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+trait LazilyRefreshDatabaseOnce
+{
+    use RefreshDatabase {
+        refreshDatabase as baseRefreshDatabase;
+    }
+
+    /**
+     * Refresh the database, but only if it hasn't been refreshed before in the current test run.
+     *
+     * @return void
+     */
+    public function refreshDatabase()
+    {
+        $database = $this->app->make('db');
+
+        $database->beforeExecuting(function () {
+            if (RefreshDatabaseState::$migrated) {
+                return;
+            }
+
+            RefreshDatabaseState::$migrated = true;
+
+            $this->baseRefreshDatabase();
+        });
+    }
+}

--- a/src/Illuminate/Foundation/Testing/RefreshDatabaseOnce.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabaseOnce.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+trait RefreshDatabaseOnce
+{
+    use RefreshDatabase {
+        refreshDatabase as baseRefreshDatabase;
+    }
+
+    /**
+     * Refresh the database, but only if it hasn't been refreshed before in the current test run.
+     *
+     * @return void
+     */
+    public function refreshDatabase()
+    {
+        if (RefreshDatabaseState::$migrated) {
+            return;
+        }
+
+        RefreshDatabaseState::$migrated = true;
+
+        $this->baseRefreshDatabase();
+    }
+}


### PR DESCRIPTION
**What's this PR about?**
This PR introduces two new traits, `LazilyRefreshDatabaseOnce` and `RefreshDatabaseOnce`, that make it easier for Laravel developers to manage their database refresh operations during unit tests. These traits help improve test suite performance by refreshing the database only when necessary.

**Why is it needed?**
In large test suites, repeatedly refreshing the database can slow down test execution. These traits provide a way to refresh the database just once per test run, saving time and resources.

**What do these traits do?**
1. **LazilyRefreshDatabaseOnce**: This trait refreshes the database the first time a test requiring database interaction is run. It avoids repeated database migrations and seedings for subsequent tests in the same run.

2. **RefreshDatabaseOnce**: This trait refreshes the database only once when the entire test suite starts running. It ensures that the database is in a clean state for the entire test run.

**How to use these traits:**
Include the desired trait in your test class.

```php
use Illuminate\Foundation\Testing\LazilyRefreshDatabaseOnce;

class YourTestTest extends TestCase
{
    use LazilyRefreshDatabaseOnce;
}

// or

use Illuminate\Foundation\Testing\RefreshDatabaseOnce;

class YourTestTest extends TestCase
{
    use RefreshDatabaseOnce;
}
```
