### PR TITLE
[10.x] Correct inconsistent comment at `different` rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -614,7 +614,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is different from another attribute.
+     * Validate that an attribute is different from other attributes.
      *
      * @param  string  $attribute
      * @param  mixed  $value


### PR DESCRIPTION
This PR corrects inconsistent comment at `different` rule.
