### PR TITLE
[10.x] Change Arr::sortRecursiveDesc() method to static.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -806,9 +806,9 @@ class Arr
      * @param  int  $options
      * @return array
      */
-    public function sortRecursiveDesc($array, $options = SORT_REGULAR)
+    public static function sortRecursiveDesc($array, $options = SORT_REGULAR)
     {
-        return $this->sortRecursive($array, $options, true);
+        return static::sortRecursive($array, $options, true);
     }
 
     /**


### PR DESCRIPTION
This PR makes the Arr::sortRecursiveDesc() method static, which it should be.