### PR TITLE
[10.x] Option to generate views for resource controllers

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -206,19 +206,11 @@ class ControllerMakeCommand extends GeneratorCommand
             return $replace;
         }
 
-        $options = [];
-
-        if ($this->option('views')) {
-            $options['--extension'] = $this->option('views');
-        }
-
-        if ($this->option('test')) {
-            $options['--test'] = true;
-        }
-
-        if ($this->option('pest')) {
-            $options['--pest'] = true;
-        }
+        $options = array_filter([
+            '--extension' => $this->option('views'),
+            '--test' => $this->option('test'),
+            '--pest' => $this->option('pest'),
+        ]);
 
         $path = Str::of($this->qualifyClass($this->getNameInput()))
             ->after($this->getDefaultNamespace(rtrim($this->rootNamespace(), '\\')).'\\')

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -284,7 +284,8 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function generateViews()
     {
-        if (! $this->option('resource') && ! $this->option('parent') && ! $this->option('model')) {
+        if (! $this->option('resource') && ! $this->option('parent') && ! $this->option('model') &&
+            ! $this->option('singleton') && ! $this->option('creatable')) {
             return;
         }
 
@@ -301,8 +302,14 @@ class ControllerMakeCommand extends GeneratorCommand
             ->map(fn ($part) => Str::kebab($part))
             ->join('.');
 
-        $this->call('make:view', array_merge($options, ['name' => $path.'.index']));
-        $this->call('make:view', array_merge($options, ['name' => $path.'.create']));
+        if (! $this->option('singleton') && ! $this->option('creatable')) {
+            $this->call('make:view', array_merge($options, ['name' => $path.'.index']));
+        }
+
+        if (! $this->option('singleton')) {
+            $this->call('make:view', array_merge($options, ['name' => $path.'.create']));
+        }
+
         $this->call('make:view', array_merge($options, ['name' => $path.'.edit']));
         $this->call('make:view', array_merge($options, ['name' => $path.'.show']));
     }


### PR DESCRIPTION
This adds a `--views` option (with optional value for the view extension) to automatically generate views for resource controllers (`resource`, `parent`, `singleton`, `creatable`, and `model` options).

By default, views are `index.blade.php`, `create.blade.php`, `edit.blade.php`, and `show.blade.php`. Note: _singleton_ resources do not generate `index.blade.php`, only `creatable` generates `create.blade.php`.

<img width="814" alt="Screenshot 2023-09-07 at 3 04 09 PM" src="https://github.com/laravel/framework/assets/161071/27b0d8db-c997-49ab-b467-853d8bbbe70c">

Underneath, it uses the new `make:view` command, passing thru the `extension`, `test`, and `pest` options that were passed to `make:controller`. However, it does not pass the `--force` option. I figured in the case of views it would be poor DX to overwrite existing.

~~It also sets a new `viewPath` placeholder value so developers may update their stubs to auto generate `view()` code. This path is determined by using the controller name (without any `Controller` suffix). Controllers made with a sub-namespace will generate views with sub-paths (i.e. `Account/DashboardController` saves views under `account/dashboard`).~~

There's more that may be added here like view stubs for each resource type, injection of `return view(...)`, _Prompts_, etc. But I think this provides a foundation for most use cases and improves Laravel DX.