### PR TITLE
[11.x] Add Arr::dot() separator override

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -105,15 +105,16 @@ class Arr
      *
      * @param  iterable  $array
      * @param  string  $prepend
+     * @param  string  $separator
      * @return array
      */
-    public static function dot($array, $prepend = '')
+    public static function dot($array, $prepend = '', $separator = '.')
     {
         $results = [];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results = array_merge($results, static::dot($value, $prepend.$key.$separator, $separator));
             } else {
                 $results[$prepend.$key] = $value;
             }
@@ -126,14 +127,15 @@ class Arr
      * Convert a flatten "dot" notation array into an expanded array.
      *
      * @param  iterable  $array
+     * @param  string  $separator
      * @return array
      */
-    public static function undot($array)
+    public static function undot($array, $separator = '.')
     {
         $results = [];
 
         foreach ($array as $key => $value) {
-            static::set($results, $key, $value);
+            static::set($results, $key, $value, $separator);
         }
 
         return $results;
@@ -694,15 +696,16 @@ class Arr
      * @param  array  $array
      * @param  string|int|null  $key
      * @param  mixed  $value
+     * @param  string  $separator
      * @return array
      */
-    public static function set(&$array, $key, $value)
+    public static function set(&$array, $key, $value, $separator = '.')
     {
         if (is_null($key)) {
             return $array = $value;
         }
 
-        $keys = explode('.', $key);
+        $keys = explode($separator, $key);
 
         foreach ($keys as $i => $key) {
             if (count($keys) === 1) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -139,6 +139,43 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]], $array);
     }
 
+    public function testDotArrow()
+    {
+        $array = Arr::dot(['foo' => ['bar' => 'baz', 'foobar' => 'foobaz']], separator: '->');
+        $this->assertEquals(['foo->bar' => 'baz', 'foo->foobar' => 'foobaz'], $array);
+
+        $array = Arr::dot([], separator: '->');
+        $this->assertEquals([], $array);
+
+        $array = Arr::dot(['foo' => []], separator: '->');
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::dot(['foo' => ['bar' => []]], separator: '->');
+        $this->assertEquals(['foo->bar' => []], $array);
+    }
+
+    public function testDotUnarrow()
+    {
+        $array = Arr::undot([
+            'foo->bar' => 'test',
+            'foo->baz->bob' => 'Bob',
+            'foo->baz->alice' => 'Alice',
+            'foo->languages->0' => 'PHP',
+            'foo->languages->1' => 'C#',
+        ], '->');
+
+        $this->assertEquals([
+            'foo' => [
+                'bar' => 'test',
+                'baz' => [
+                    'bob' => 'Bob',
+                    'alice' => 'Alice',
+                ],
+                'languages' => ['PHP', 'C#'],
+            ],
+        ], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];


### PR DESCRIPTION
Eloquent's `$fillable` properties allow the developer to define mass-assignable nested object properties in a way that disallows adding properties that are not in the predefined array. For example, to allow only `first_name` and `last_name` to exist on the `contact` property, one could use this setup:

```php
// MyModel.php
$fillable = [
    'contact->first_name',
    'contact->last_name',
];

$casts = [
    'contact' => 'object',
];
```

Assigning these properties however will have to take place using these exact arrow assignments, like so:
```php
MyModel::create([
    'contact->first_name' => 'Foo',
    'contact->last_name' => 'Bar',
]);
```

This works correctly and will not allow assignment of properties with any other name.

This PR adds an extra option for `Arr::dot()` to use a different separator than `'.'` such that it can be used as a preprocessor when you are working with a nested array like so:

```php
$data = [
    'contact' => [
        'first_name' =>'Foo',
        'last_name' =>'Bar',
    ]
];

MyModel::create(Arr::dot($data, separator = '->'));
```

Sent to 11.x because signatures have been changed in two functions inside `Illuminate\Support\Arr`:
- `public static function dot($array, $prepend = '', $separator = '.')`
- `public static function set(&$array, $key, $value, $separator = '.')`