### PR TITLE
[10.x] Passthru test options

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -144,6 +144,8 @@ class ModelMakeCommand extends GeneratorCommand
             '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
             '--requests' => $this->option('requests') || $this->option('all'),
+            '--test' => $this->option('test'),
+            '--pest' => $this->option('pest'),
         ]));
     }
 


### PR DESCRIPTION
This is a replacement for #48319 to simply passthru the `--test` or `--pest` option to the underlying `make:controller` call. This allows the controller test to also be created.

~~In addition, the `--test` option is automatically set to `true` when the `-a` option is used to generate a default test, unless the `--pest` option is set to specifically generate Pest tests.~~ After sleeping on it, the hard truth is most devs don't write tests. As such, I think forcing tests with the `-a` option would make "extra" files. Those that write tests can run: `make:model -a --test`. Once this PR is merged, running that would properly generate a test for the model and the controller.