### PR TITLE
[10.x] Make ComponentAttributeBag JsonSerializable

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -461,7 +461,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate,
      *
      * @return mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->attributes;
     }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -11,9 +11,10 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
+use JsonSerializable;
 use Traversable;
 
-class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
+class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate, JsonSerializable
 {
     use Conditionable, Macroable;
 
@@ -453,6 +454,16 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->attributes);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->attributes;
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -14,7 +14,7 @@ use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
 
-class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate, JsonSerializable
+class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable
 {
     use Conditionable, Macroable;
 
@@ -457,7 +457,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate,
     }
 
     /**
-     * Convert the object into something JSON serializable.
+     * Convert the object into a JSON serializable form.
      *
      * @return mixed
      */

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -459,7 +459,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate,
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array
+     * @return mixed
      */
     public function jsonSerialize()
     {


### PR DESCRIPTION
Currently it is not possible to automatically convert to array or JSON serialize the `ComponentAttributeBag`, but in some cases it would be handy.

```php
json_encode(['attributes' => new ComponentAttributeBag(['class' => 'form-control'])]);

// {"attributes":{}}
```

We can use `(new ComponentAttributeBag(['class' => 'form-control']))->getAttributes()`, but it would be a better DX to handle this automatically, in my opinion.