### PR TITLE
[10.x] Returnable raw jsonSerializable from JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -125,13 +125,13 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray(Request $request)
     {
-        if (is_null($this->resource)) {
-            return [];
-        }
-
-        return is_array($this->resource)
-            ? $this->resource
-            : $this->resource->toArray();
+        return match (true) {
+            is_null($this->resource) => [],
+            is_array($this->resource) => $this->resource,
+            $this->resource instanceof Arrayable => $this->resource->toArray(),
+            $this->resource instanceof JsonSerializable => $this->resource,
+            default => $this->resource->toArray(),
+        };
     }
 
     /**

--- a/tests/Testing/Stubs/JsonSerializableStubObject.php
+++ b/tests/Testing/Stubs/JsonSerializableStubObject.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Stubs;
+
+use JsonSerializable;
+
+class JsonSerializableStubObject implements JsonSerializable
+{
+    protected $data;
+
+    public function __construct($data = [])
+    {
+        $this->data = $data;
+    }
+
+    public static function make($data = [])
+    {
+        return new self($data);
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
Follow-up of https://github.com/laravel/framework/pull/48323

Actually the JsonResouce::toArray method cannot return a raw JsonSerializable object, although is documented as a possibile return type.

My previous PR was a breaking change because of a possibile case of an object implementing both Arrayable and JsonSerializable.

This PR take that into account, preserving the actual behaviour and supporting a raw JsonSerialiazable object.
I'm more for adding this new capability, instead of remove JsonSerializable from the return type, in case.

Feel free to close wihout comment if not interested in this change, this is the third PR on the subject, I'm stopping here :)