### PR TITLE
[10.x] Bring back the mssql database integration tests

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -189,48 +189,48 @@ jobs:
           DB_CONNECTION: pgsql
           DB_PASSWORD: password
 
-  # mssql:
-  #   runs-on: ubuntu-20.04
+  mssql:
+    runs-on: ubuntu-20.04
 
-  #   services:
-  #     sqlsrv:
-  #       image: mcr.microsoft.com/mssql/server:2019-latest
-  #       env:
-  #         ACCEPT_EULA: Y
-  #         SA_PASSWORD: Forge123
-  #       ports:
-  #         - 1433:1433
+    services:
+      sqlsrv:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: Forge123
+        ports:
+          - 1433:1433
 
-  #   strategy:
-  #     fail-fast: true
+    strategy:
+      fail-fast: true
 
-  #   name: SQL Server 2019
+    name: SQL Server 2019
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - name: Setup PHP
-  #       uses: shivammathur/setup-php@v2
-  #       with:
-  #         php-version: 8.1
-  #         extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc
-  #         tools: composer:v2
-  #         coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc
+          tools: composer:v2
+          coverage: none
 
-  #     - name: Install dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 5
-  #         max_attempts: 5
-  #         command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+      - name: Install dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
-  #     - name: Execute tests
-  #       run: vendor/bin/phpunit tests/Integration/Database
-  #       env:
-  #         DB_CONNECTION: sqlsrv
-  #         DB_DATABASE: master
-  #         DB_USERNAME: SA
-  #         DB_PASSWORD: Forge123
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: sqlsrv
+          DB_DATABASE: master
+          DB_USERNAME: SA
+          DB_PASSWORD: Forge123


### PR DESCRIPTION
### Changelog

- [internal] Bring back the mssql database integration tests. The [mssql test suite was commented out](https://github.com/laravel/framework/commit/1a1969c1bb656564fee98e41e0e153b6c487a888) because of an upstream bug in the extension ([see the discussing here](https://github.com/laravel/framework/pull/48158)). A [hotfix was released](https://github.com/laravel/framework/pull/48158#issuecomment-1711386318) on that front, so we can bring the tests back.

---

Thanks @SakiTakamachi for the heads up.