### PR TITLE
[10.x] Add newResponse method to PendingRequest

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1012,17 +1012,6 @@ class PendingRequest
     }
 
     /**
-     * Return a new response instance with the response.
-     *
-     * @param  MessageInterface  $response
-     * @return Response
-     */
-    protected function newResponse($response)
-    {
-        return new Response($response);
-    }
-
-    /**
      * Send a request either synchronously or asynchronously.
      *
      * @param  string  $method
@@ -1307,6 +1296,17 @@ class PendingRequest
             array_merge_recursive($this->options, Arr::only($options, $this->mergableOptions)),
             ...$options
         );
+    }
+
+    /**
+     * Create a new response instance using the given PSR response.
+     *
+     * @param  \Psr\Http\Message\MessageInterface  $response
+     * @return Response
+     */
+    protected function newResponse($response)
+    {
+        return new Response($response);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2523,4 +2523,48 @@ class HttpClientTest extends TestCase
         $this->assertSame('Bar', $responses[0]->header('X-Foo'));
         $this->assertSame('', $responses[1]->header('X-Foo'));
     }
+
+    public function testItReturnsResponse(): void
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('expected content'),
+        ]);
+
+        $response = $this->factory->get('http://laravel.com');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('expected content', $response->body());
+    }
+
+    public function testItCanReturnCustomResponseClass(): void
+    {
+        $factory = new CustomFactory;
+
+        $factory->fake([
+            '*' => $factory::response('expected content'),
+        ]);
+
+        $response = $factory->get('http://laravel.fake');
+
+        $this->assertInstanceOf(TestResponse::class, $response);
+        $this->assertSame('expected content', $response->body());
+    }
+}
+
+class CustomFactory extends Factory
+{
+    protected function newPendingRequest()
+    {
+        return new class extends PendingRequest
+        {
+            protected function newResponse($response)
+            {
+                return new TestResponse($response);
+            }
+        };
+    }
+}
+
+class TestResponse extends Response
+{
 }


### PR DESCRIPTION
Laravel's Http Client is really useful, but it doesn't let you change the type of Response you get.

**Why Do We Need This?**
Some APIs don't use regular HTTP status codes. Instead, they put the status right into the data they send back and always return a 200 status code. Because of this, you might want to change the successful method on the `Response` class to look at the payload instead of the HTTP status.

**The Problem**
You can usually make these changes by making your own version of the PendingRequest class. But, doing this breaks the built-in "retry" feature. This is because of the way `new Response()` is set in the code.

**The Fix**
This PR adds a `newResponse` method to the PendingRequest. Now, you can make your own version of PendingRequest and use this method to return your own type of Response.

**Impact**
This is a small change, but it makes the Http Client much more flexible. This is especially helpful if you're working with APIs that act in non-standard ways.