### PR TITLE
[10.x] add missing method to message bag class

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -160,6 +160,19 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     }
 
     /**
+     * Determine if messages don't exist for all of the given keys.
+     *
+     * @param  array|string|null  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        return ! $this->hasAny($keys);
+    }
+
+    /**
      * Get the first message from the message bag for a given key.
      *
      * @param  string|null  $key

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -115,6 +115,19 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->has('bar'));
     }
 
+    public function testMissingIndicatesNonExistence()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo', 'bar');
+        $this->assertFalse($container->missing('foo'));
+        $this->assertFalse($container->missing(['foo', 'baz']));
+        $this->assertFalse($container->missing('foo', 'baz'));
+        $this->assertTrue($container->missing('baz'));
+        $this->assertTrue($container->missing(['baz', 'biz']));
+        $this->assertTrue($container->missing('baz', 'biz'));
+    }
+
     public function testAddIf()
     {
         $container = new MessageBag;


### PR DESCRIPTION
Hi everyone,

I've introduced a minor enhancement to the `MessageBag` class by adding the `missing` method. This change was primarily motivated by the need for a more intuitive code reading and to bring a more descriptive method name that communicates its functionality with clarity.

### Changes:
- Added the `missing` method in the `MessageBag` class.

### Code Example:
**Before**
```blade
<div @class([
    'success-classes' => !$errors->has('some-key'),
    'error-classes'   =>  $errors->has('some-key'),
])>
    ...
</div>
```

**After**
```blade
<div @class([
    'success-classes' => $errors->missing('some-key'),
    'error-classes'   => $errors->has('some-key'),
])>
    ...
</div>
```

### Benefits:
- Promotes easier code reading by providing a self-explanatory method name.
- The method name is intuitive, reducing potential confusion for developers.

---

I believe this addition will be of great benefit to the Laravel community and look forward to your feedback.

Thank you for considering this PR.


Feel free to adjust the wording as necessary to match your style and the specific changes you've made!

