### PR TITLE
[10.x] Add ability to pass closures on columns to assertDatabaseHas and assertDatabaseMissing

### DIFF
--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -124,8 +124,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             ProductStub::class,
             [
                 'title' => 'Spark',
-                'name' => fn(mixed $value) => in_array($value, ['Laravel', 'Value2']),
-                'type' => fn(string $value) => $value !== 'Library',
+                'name' => fn (mixed $value) => in_array($value, ['Laravel', 'Value2']),
+                'type' => fn (string $value) => $value !== 'Library',
             ],
         );
     }
@@ -163,8 +163,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             ProductStub::class,
             [
                 'title' => 'Spark',
-                'name' => fn(mixed $value) => $value === 'PHP',
-                'type' => fn(string $value) => $value === 'Library',
+                'name' => fn (mixed $value) => $value === 'PHP',
+                'type' => fn (string $value) => $value === 'Library',
             ],
         );
     }
@@ -202,9 +202,9 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             ProductStub::class,
             [
                 'title' => 'Spark',
-                'name' => fn(mixed $value) => $value === 'PHP',
-                'type' => fn(string $value) => $value === 'Library',
-                'non_existing_column' => fn($value) => false,
+                'name' => fn (mixed $value) => $value === 'PHP',
+                'type' => fn (string $value) => $value === 'Library',
+                'non_existing_column' => fn ($value) => false,
             ],
         );
     }
@@ -263,8 +263,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             ProductStub::class,
             [
                 'title' => 'Spark',
-                'name' => fn(mixed $value) => $value === 'PHP',
-                'type' => fn(string $value) => $value === 'Library',
+                'name' => fn (mixed $value) => $value === 'PHP',
+                'type' => fn (string $value) => $value === 'Library',
             ],
         );
     }
@@ -302,8 +302,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
             ProductStub::class,
             [
                 'title' => 'Spark',
-                'name' => fn(mixed $value) => $value === 'PHP',
-                'type' => fn(string $value) => $value === 'Vanilla',
+                'name' => fn (mixed $value) => $value === 'PHP',
+                'type' => fn (string $value) => $value === 'Vanilla',
             ],
         );
     }


### PR DESCRIPTION
Hi Laravel team and community!

I am enhancing how `assertDatabaseHas` and `assertDatabaseMissing` works. The idea is to allow users when testing to pass a closure to test some columns that may not be known at the time of assertion (but there are expected values). This also works for any processing that it may require, similar to factories' columns.

Instead of this code:
```php
$admin = User::factory()->admin()->create();

$this->actingAs($admin)
    ->postJson('/article', ['content' => 'abc'])
    ->assertCreated();

$this->assertDatabaseHas(
    'articles',
    [
        'is_anonymous' => false,
        'user_id' => $admin->id,
    ],
);

$article = Article::first();

$this->assertContainsEquals($article->type, ['news', 'info']);
```

(Imagine having some more fields to test)

Use this one:
```php
$admin = User::factory()->admin()->create();

$this->actingAs($admin)
    ->postJson('/article', ['content' => 'abc'])
    ->assertCreated();

$this->assertDatabaseHas(
    'articles',
    [
        'is_anonymous' => false,
        'user_id' => $admin->id,
        'type' => fn (string $type) => in_array($type, ['news', 'info']),
    ],
);
```

When data is not found (for either method), it will ignore the closure columns on the reporting, for example:
```none
$this->assertDatabaseHas(
    'articles',
    [
        'is_anonymous' => false,
        'user_id' => $admin->id,
        'type' => fn (string $type) => in_array($type, ['news', 'info']),
    ],
);

Failed asserting that a row in the table [articles] does not match the attributes {
    "is_anonymous": 0,
    "user_id": 1
}.

Found similar results: [
    {
        "is_anonymous": 0,
        "user_id": 1,
        "type": "blog"
    },
    {
        "is_anonymous": 0,
        "name": 1,
        "type": "special"
    }
].
```

#### How this works
1. It first tries to find the data (ignoring columns having closures), if nothing is found, an error will be thrown.
2. If it finds data, the method will check if it has any columns with closures, if none, it will succeed else it will continue execution.
3. Run each closure on each found row, if any fails, an error will be thrown.
4. If all closures pass, then it will succeed.

Of course, this is also true for `assertDatabaseMissing` but on the inverse.

#### Tests
I added the needed tests, please let me know if I am missing any or if they are not correctly written.

Feel free to make any edits!