### PR TITLE
[10.x] Support for phpredis 6.0.0

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -188,15 +188,15 @@ class PhpRedisConnector implements Connector
 
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
             if (! empty($options['prefix'])) {
-                $client->setOption(RedisCluster::OPT_PREFIX, $options['prefix']);
+                $client->setOption(Redis::OPT_PREFIX, $options['prefix']);
             }
 
             if (! empty($options['scan'])) {
-                $client->setOption(RedisCluster::OPT_SCAN, $options['scan']);
+                $client->setOption(Redis::OPT_SCAN, $options['scan']);
             }
 
             if (! empty($options['failover'])) {
-                $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $options['failover']);
+                $client->setOption(Redis::OPT_SLAVE_FAILOVER, $options['failover']);
             }
 
             if (! empty($options['name'])) {
@@ -204,15 +204,15 @@ class PhpRedisConnector implements Connector
             }
 
             if (array_key_exists('serializer', $options)) {
-                $client->setOption(RedisCluster::OPT_SERIALIZER, $options['serializer']);
+                $client->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
             }
 
             if (array_key_exists('compression', $options)) {
-                $client->setOption(RedisCluster::OPT_COMPRESSION, $options['compression']);
+                $client->setOption(Redis::OPT_COMPRESSION, $options['compression']);
             }
 
             if (array_key_exists('compression_level', $options)) {
-                $client->setOption(RedisCluster::OPT_COMPRESSION_LEVEL, $options['compression_level']);
+                $client->setOption(Redis::OPT_COMPRESSION_LEVEL, $options['compression_level']);
             }
         });
     }


### PR DESCRIPTION
See also: #48361

The PHPRedis library removed `RedisCluster::` constants since 6.0.0. Released on [pecl](https://pecl.php.net/package/redis) today 2023-09-11

The author of PHPREDIS recommends not using the constants of `RedisCluster` anymore but using the constants in `Redis` instead here: https://github.com/phpredis/phpredis/issues/2262#issuecomment-1327916568:

> We updated how we create these class constants which is when I noticed I was duplicating all the constants for both classes. I think we want to only define them for Redis in the next version (which will be a major version bump)

This PR changes the use of `RedisCluster::` for constants to `Redis::`.

This is backward compatible since the underlying values of these constants are the same, so it will still work for older phpredis versions
