### PR TITLE
[10.x] Support for phpredis 6.0.0

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -4,7 +4,6 @@ parameters:
   level: 0
   ignoreErrors:
     - "#\\(void\\) is used#"
-    - "#Access to undefined constant#"
     - "#Access to an undefined property#"
     - "#Call to an undefined method#"
     - "#but return statement is missing.#"

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -196,7 +196,7 @@ class PhpRedisConnector implements Connector
             }
 
             if (! empty($options['failover'])) {
-                $client->setOption(Redis::OPT_SLAVE_FAILOVER, $options['failover']);
+                $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $options['failover']);
             }
 
             if (! empty($options['name'])) {


### PR DESCRIPTION
Missed one parameter in the previous PR(https://github.com/laravel/framework/pull/48362), which is still in RedisCluster and shouldn't have been changed.

For reference:
https://github.com/phpredis/phpredis/blob/5bd3138731c4239eba2b2a556a0f81636f1714d0/redis_cluster.stub.php#L16

As a bonus, it looks like the ignored error `Access to undefined constant`, can now be removed. See the failing action [here](https://github.com/laravel/framework/actions/runs/6150866464/job/16689741202)

