### PR TITLE
Use PHP native json_validate in isJson function if available

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -452,6 +452,10 @@ class Str
             return false;
         }
 
+        if (function_exists('json_validate')) {
+            return json_validate($value, 512);
+        }
+
         try {
             json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PHP 8.3 introduces a `json_validate` function, which allows validating if a string contains valid json with less resource and memory consumption than using the `json_encode` function.

This PR uses the new function when it's available and thus is backwards compatible with older PHP versions, while taking advantage of the new function on PHP >= 8.3. 

Note that Symfony has a [polyfill](https://github.com/symfony/polyfill-php83/blob/v1.28.0/Php83.php#L23-L40) for this, which is probably what will be used in practice by most existing Laravel installations using  PHP < 8.3 (as the polyfills are loaded with recent versions of `symfony/http-foundation`), which would allow removing the `json_decode` call sometime in the future.

See also the [RFC](https://wiki.php.net/rfc/json_validate).