### PR TITLE
[10.x] Add method to extend cache value for specific TTL

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -224,13 +224,13 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Refresh an item in the cache with a new TTL.
+     * Extend an item in the cache with a new TTL.
      *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function refresh($key, $ttl = null): bool
+    public function extend($key, $ttl = null): bool
     {
         if ($this->has($key)) {
             return $this->put($key, $this->get($key), $ttl);

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -224,6 +224,22 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Refresh an item in the cache with a new TTL.
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @return bool
+     */
+    public function refresh($key, $ttl = null): bool
+    {
+        if ($this->has($key)) {
+            return $this->put($key, $this->get($key), $ttl);
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return bool

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -145,6 +145,31 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
+    public function testRefreshMethodUpdatesKeyAndReturnsNewTTL()
+    {
+        $repo = $this->getRepository();
+        $value = 'bar';
+        $ttl = 60;
+
+        $repo->getStore()->shouldReceive('get')->twice()->with('foo')->andReturn($value);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', $value, $ttl)->andReturn(true);
+
+        $result = $repo->refresh('foo', $ttl);
+
+        $this->assertTrue($result);
+    }
+
+    public function testRefreshMethodReturnsFalseWhenKeyDoesNotExist()
+    {
+        $repo = $this->getRepository();
+        $ttl = 60;
+
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
+        $result = $repo->refresh('foo', $ttl);
+
+        $this->assertFalse($result);
+    }
+
     public function testPuttingMultipleItemsInCache()
     {
         $repo = $this->getRepository();

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -145,7 +145,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testRefreshMethodUpdatesKeyAndReturnsNewTTL()
+    public function testExtendMethodUpdatesKeyAndReturnsNewTTL()
     {
         $repo = $this->getRepository();
         $value = 'bar';
@@ -154,18 +154,18 @@ class CacheRepositoryTest extends TestCase
         $repo->getStore()->shouldReceive('get')->twice()->with('foo')->andReturn($value);
         $repo->getStore()->shouldReceive('put')->once()->with('foo', $value, $ttl)->andReturn(true);
 
-        $result = $repo->refresh('foo', $ttl);
+        $result = $repo->extend('foo', $ttl);
 
         $this->assertTrue($result);
     }
 
-    public function testRefreshMethodReturnsFalseWhenKeyDoesNotExist()
+    public function testExtendMethodReturnsFalseWhenKeyDoesNotExist()
     {
         $repo = $this->getRepository();
         $ttl = 60;
 
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
-        $result = $repo->refresh('foo', $ttl);
+        $result = $repo->extend('foo', $ttl);
 
         $this->assertFalse($result);
     }


### PR DESCRIPTION
 * This method allows extending the life of a specific cached value with a new TTL.
 * It is useful when needing to renew an existing cache key for an additional duration without needing to recreate the cached value.

```
Cache::put($key, User::all(), $ttl);

// Somewhere later in the code or in another function or route:
Cache::extend($key, $ttl);
```