### PR TITLE
add "resolve" to `Component::ignoredMethods()` method

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -324,6 +324,7 @@ abstract class Component
         return array_merge([
             'data',
             'render',
+            'resolve',
             'resolveView',
             'shouldRender',
             'view',

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\View;
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 class ViewComponentTest extends TestCase
 {
@@ -17,6 +18,43 @@ class ViewComponentTest extends TestCase
         $this->assertEquals(10, $variables['votes']);
         $this->assertSame('world', $variables['hello']());
         $this->assertSame('taylor', $variables['hello']('taylor'));
+    }
+
+    public function testIgnoredMethodsAreNotExposedToViewData()
+    {
+        $component = new class extends Component {
+            protected $except = ['goodbye'];
+
+            public function render()
+            {
+                return 'test';
+            }
+
+            public function hello()
+            {
+                return 'hello world';
+            }
+
+            public function goodbye()
+            {
+                return 'goodbye';
+            }
+        };
+
+        $data = $component->data();
+
+        $this->assertArrayHasKey('hello', $data);
+        $this->assertArrayNotHasKey('goodbye', $data);
+
+        $reflectionMethod = new ReflectionMethod($component, 'ignoredMethods');
+
+        $reflectionMethod->setAccessible(true);
+
+        $ignoredMethods = $reflectionMethod->invoke($component);
+
+        foreach ($ignoredMethods as $method) {
+            $this->assertArrayNotHasKey($method, $data);
+        }
     }
 
     public function testAttributeParentInheritance()

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -22,7 +22,8 @@ class ViewComponentTest extends TestCase
 
     public function testIgnoredMethodsAreNotExposedToViewData()
     {
-        $component = new class extends Component {
+        $component = new class extends Component
+        {
             protected $except = ['goodbye'];
 
             public function render()


### PR DESCRIPTION
Hi everyone,

I've made a minor change to the `Illuminate\View\Component` class by adding the `resolve()` method into the `ignoredMethods()`.   
This method was introduced in this [commit](https://github.com/laravel/framework/commit/331bf9c2e393e9b459a05c0d01d89cf9fdd20282#diff-1005052c893d685dfa5b9c5c7431e2a880260f9a16cba75e16689ec33549755cR91), and I believe it should not be added to the view data.

### Changes:
- Add `resolve` to `Component::ignoredMethods()`

### Purpose:
- Remove this data exposure from the blade `$data`, since it's not a method to be able to call in a blade view

---

Thank you for considering this PR.

Feel free to adjust the wording as necessary to match your style and the specific changes you've made!

