### PR TITLE
[10.x] Add `notModified` method to HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
+++ b/src/Illuminate/Http/Client/Concerns/DeterminesStatusCode.php
@@ -66,6 +66,16 @@ trait DeterminesStatusCode
     }
 
     /**
+     * Determine if the response code was a 304 "Not Modified" response.
+     *
+     * @return bool
+     */
+    public function notModified()
+    {
+        return $this->status() === 304;
+    }
+
+    /**
      * Determine if the response was a 400 "Bad Request" response.
      *
      * @return bool

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -52,6 +52,8 @@ class HttpClientTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
     public function testStubbedResponsesAreReturnedAfterFaking()
@@ -131,6 +133,20 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory->post('http://forge.laravel.com');
         $this->assertFalse($response->found());
+    }
+
+    public function testNotModifiedRequest(): void
+    {
+        $this->factory->fake([
+            'vapor.laravel.com' => $this->factory::response('', HttpResponse::HTTP_NOT_MODIFIED),
+            'forge.laravel.com' => $this->factory::response('', HttpResponse::HTTP_OK),
+        ]);
+
+        $response = $this->factory->post('https://vapor.laravel.com');
+        $this->assertTrue($response->notModified());
+
+        $response = $this->factory->post('https://forge.laravel.com');
+        $this->assertFalse($response->notModified());
     }
 
     public function testBadRequestRequest()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds `notModified` method for the HTTP client.