### PR TITLE
[10.x] Refactored LazyCollection::take() to save memory

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1431,11 +1431,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     $position = ($position + 1) % $limit;
                 }
 
-                for ($i = 0; $i < $limit; $i++) {
-                    if (isset($ringBuffer[($position + $i) % $limit])) {
-                        [$key, $value] = $ringBuffer[($position + $i) % $limit];
-                        yield $key => $value;
-                    }
+                for ($i = 0, $end = min($limit, count($ringBuffer)); $i < $end; $i++) {
+                    $pointer = ($position + $i) % $limit;
+                    yield $ringBuffer[$pointer][0] => $ringBuffer[$pointer][1];
                 }
             });
         }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -231,4 +231,23 @@ class SupportLazyCollectionTest extends TestCase
 
         $this->assertSame([1, 2], $data->all());
     }
+
+    public function testTakeWithNegativeLimit()
+    {
+        $data = LazyCollection::times(10);
+
+        $this->assertSame([
+            7 => 8,
+            8 => 9,
+            9 => 10,
+        ], $data->take(-3)->all());
+
+        $this->assertSame([
+            7 => 8,
+            8 => 9,
+            9 => 10,
+        ], $data->take(-5)->take(-3)->all());
+
+        $this->assertSame($data->take(10)->all(), $data->take(-10)->all());
+    }
 }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -231,23 +231,4 @@ class SupportLazyCollectionTest extends TestCase
 
         $this->assertSame([1, 2], $data->all());
     }
-
-    public function testTakeWithNegativeLimit()
-    {
-        $data = LazyCollection::times(10);
-
-        $this->assertSame([
-            7 => 8,
-            8 => 9,
-            9 => 10,
-        ], $data->take(-3)->all());
-
-        $this->assertSame([
-            7 => 8,
-            8 => 9,
-            9 => 10,
-        ], $data->take(-5)->take(-3)->all());
-
-        $this->assertSame($data->take(10)->all(), $data->take(-10)->all());
-    }
 }


### PR DESCRIPTION
# Introduction
LazyCollection utilizes Generators to process iterators in a memory-efficient manner.

LazyCollection implements the same interface as Collection, so most operations you can do with a Collection can also be done with a LazyCollection. However, there are methods where it's challenging to implement the functionality without using extra memory (e.g., sorting).

For such methods, we use passthru() to convert LazyCollection to Collection and delegate the task. Be cautious when using collect(), as this will load all the data generated by the Generator into memory, defeating the purpose of using LazyCollection.

Ideally, one would want to avoid using passthru() in LazyCollection.

# Main Topic
Originally, the take() method of LazyCollection was implemented like this:

```php
public function take($limit)
{
    if ($limit < 0) {
        return $this->passthru('take', func_get_args());
    }

    return new static(function () use ($limit) {
        $iterator = $this->getIterator();
        while ($limit--) {
            if (! $iterator->valid()) {
                break;
            }
            yield $iterator->key() => $iterator->current();
            if ($limit) {
                $iterator->next();
            }
        }
    });
}

```

When $limit is a positive value, it uses a Generator function and remains memory-efficient. However, when $limit is a negative value, it uses passthru().

Even for negative $limit values, which take values from the end of the Collection, you can implement it using a Generator function.

# Implementation
I've modified the behavior when $limit is negative as follows:

```php
if ($limit < 0) {
            return new static(function () use ($limit) {
                $limit = abs($limit);
                $ringBuffer = [];
                $position = 0;

                foreach ($this as $key => $value) {
                    $ringBuffer[$position] = [$key, $value];
                    $position = ($position + 1) % $limit;
                }

                for ($i = 0; $i < $limit; $i++) {
                    if (isset($ringBuffer[($position + $i) % $limit])) {
                        [$key, $value] = $ringBuffer[($position + $i) % $limit];
                        yield $key => $value;
                    }
                }
            });
        }
```

Although this implementation still loads $limit absolute value elements into memory, it's more memory-efficient than using passthru() to extract all elements.

 P.S.
I first used array_shift to realize queue, but after review, I modified it to use ring buffer.

# About Tests
This is a refactoring, so I haven't modified any tests. The fact that tests didn't require changes proves that the refactoring was done correctly without affecting the outcomes.