### PR TITLE
[10.x] Update the visibility of setUp and tearDown

### DIFF
--- a/tests/Foundation/Testing/TestCaseTest.php
+++ b/tests/Foundation/Testing/TestCaseTest.php
@@ -106,9 +106,11 @@ class TestCaseTest extends BaseTestCase
         throw $exception;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         ExampleTestCase::$latestResponse = null;
+
+        parent::tearDown();
     }
 }
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -15,7 +15,7 @@ class HasherTest extends TestCase
 {
     public $hashManager;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
+++ b/tests/Integration/Console/Scheduling/SubMinuteSchedulingTest.php
@@ -12,7 +12,7 @@ class SubMinuteSchedulingTest extends TestCase
 {
     protected Schedule $schedule;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Mail/SentMessageMailTest.php
+++ b/tests/Integration/Mail/SentMessageMailTest.php
@@ -14,7 +14,7 @@ use Orchestra\Testbench\TestCase;
 
 class SentMessageMailTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This updates the visibility of setUp and tearDown methods, to align with the one in `\PHPUnit\Framework\TestCase`

Side note, this could also be a pint rule for the `laravel` preset: 
See https://cs.symfony.com/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.html
cc. @nunomaduro 