### PR TITLE
Allow storing null value in cache when using remember

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -385,13 +385,11 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function remember($key, $ttl, Closure $callback)
     {
-        $value = $this->get($key);
-
         // If the item exists in the cache we will just return this immediately and if
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
-        if (! is_null($value)) {
-            return $value;
+        if ($this->has($key)) {
+            return $this->get($key);
         }
 
         $value = $callback();
@@ -426,13 +424,11 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function rememberForever($key, Closure $callback)
     {
-        $value = $this->get($key);
-
         // If the item exists in the cache we will just return this immediately
         // and if not we will execute the given Closure and cache the result
         // of that forever so it is available for all subsequent requests.
-        if (! is_null($value)) {
-            return $value;
+        if ($this->has($key)) {
+            return $this->get($key);
         }
 
         $this->forever($key, $value = $callback());

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -134,6 +134,19 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
+    public function testRememberReturnsStoredNullValue()
+    {
+        $repo = $this->getRepository();
+        $repo->put('foo', null);
+        $repo->getStore()->shouldReceive('has')->once()->andReturn(true);
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->never();
+        $result = $repo->remember('foo', 10, function () {
+            return 'bar';
+        });
+        $this->assertSame(null, $result);
+    }
+
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()
     {
         $repo = $this->getRepository();
@@ -143,6 +156,19 @@ class CacheRepositoryTest extends TestCase
             return 'bar';
         });
         $this->assertSame('bar', $result);
+    }
+
+    public function testRememberForeverReturnsStoredNullValue()
+    {
+        $repo = $this->getRepository();
+        $repo->put('foo', null);
+        $repo->getStore()->shouldReceive('has')->once()->andReturn(true);
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('forever')->never();
+        $result = $repo->rememberForever('foo', function () {
+            return 'bar';
+        });
+        $this->assertSame(null, $result);
     }
 
     public function testPuttingMultipleItemsInCache()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -137,10 +137,10 @@ class CacheRepositoryTest extends TestCase
     public function testRememberReturnsStoredNullValue()
     {
         $repo = $this->getRepository();
-        $repo->put('foo', null);
         $repo->getStore()->shouldReceive('has')->once()->andReturn(true);
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
-        $repo->getStore()->shouldReceive('put')->never();
+        $repo->getStore()->shouldReceive('put')->once();
+        $repo->put('foo', null);
         $result = $repo->remember('foo', 10, function () {
             return 'bar';
         });
@@ -161,10 +161,10 @@ class CacheRepositoryTest extends TestCase
     public function testRememberForeverReturnsStoredNullValue()
     {
         $repo = $this->getRepository();
-        $repo->put('foo', null);
         $repo->getStore()->shouldReceive('has')->once()->andReturn(true);
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
         $repo->getStore()->shouldReceive('forever')->never();
+        $repo->put('foo', null);
         $result = $repo->rememberForever('foo', function () {
             return 'bar';
         });


### PR DESCRIPTION
This PR aims to correct the behavior of the Cache remember method. This may breaks the default behavior of remember and rememberForever depending if you consider the current behavior is intended or not.

Currently when using Cache::remember, if the key exists in the store but the value stored is null, the cache value is ignored and the callback is called anyway.
This is due to the fact that the method checks for `is_null($value)` but do not check if the key actually exists in the store.

This seems not to be the intended behavior as the item do exists in the cache with a null value.
According to the doc:
> Sometimes you may wish to retrieve an item from the cache, but also store a default value if the requested item doesn't exist.
The remember method should check if the item exists, no matter the value stored.

I think the correct behavior should check for the existence of the key, no matter the value. Otherwise it could make application perform unnecessary work every single time. This is the case when storing Eloquent model for example:

```php
Cache::rememberForever('model', fn() => Foo::query()->first() );
```
If the query result is expected to be null, the cache is hit but never 'used' and the callback is always called if the previous return value was null.