### PR TITLE
[10.x] Throttle exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -357,7 +357,7 @@ class Handler implements ExceptionHandlerContract
             }
 
             return ! $this->container->make(RateLimiter::class)->attempt(
-                with($throttle->key ?: $e::class, fn ($key) => $this->hashThrottleKeys ? md5($key) : $key),
+                with($throttle->key ?: 'illuminate:foundation:exceptions:'.$e::class, fn ($key) => $this->hashThrottleKeys ? md5($key) : $key),
                 $throttle->maxAttempts,
                 fn () => true,
                 $throttle->decayMinutes

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -6,6 +6,9 @@ use Closure;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Console\View\Components\BulletList;
 use Illuminate\Console\View\Components\Error;
 use Illuminate\Contracts\Container\Container;
@@ -24,6 +27,8 @@ use Illuminate\Routing\Router;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Lottery;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;
@@ -332,7 +337,26 @@ class Handler implements ExceptionHandlerContract
 
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        return ! is_null(Arr::first($dontReport, fn ($type) => $e instanceof $type));
+        if (! is_null(Arr::first($dontReport, fn ($type) => $e instanceof $type))) {
+            return true;
+        }
+
+        return rescue(fn () => with($this->throttle($e), function ($throttle) use ($e) {
+            if ($throttle instanceof Unlimited || $throttle === null) {
+                return false;
+            }
+
+            if ($throttle instanceof Lottery) {
+                return ! $throttle($e);
+            }
+
+            return ! $this->container->make(RateLimiter::class)->attempt(
+                $throttle->key ?: $e::class,
+                $throttle->maxAttempts,
+                fn () => true,
+                $throttle->decayMinutes
+            );
+        }), rescue: false, report: false);
     }
 
     /**
@@ -830,5 +854,16 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Throwable $e)
     {
         return $e instanceof HttpExceptionInterface;
+    }
+
+    /**
+     * Throttle the given exception.
+     *
+     * @param  \Throwable $e
+     * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
+     */
+    protected function throttle(Throwable $e)
+    {
+        return Limit::none();
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -366,6 +366,17 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
+     * Throttle the given exception.
+     *
+     * @param  \Throwable  $e
+     * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
+     */
+    protected function throttle(Throwable $e)
+    {
+        return Limit::none();
+    }
+
+    /**
      * Remove the given exception class from the list of exceptions that should be ignored.
      *
      * @param  string  $exception
@@ -860,16 +871,5 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Throwable $e)
     {
         return $e instanceof HttpExceptionInterface;
-    }
-
-    /**
-     * Throttle the given exception.
-     *
-     * @param  \Throwable  $e
-     * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
-     */
-    protected function throttle(Throwable $e)
-    {
-        return Limit::none();
     }
 }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -2,7 +2,13 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Closure;
 use Exception;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\NullStore;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Cache\Repository;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
@@ -15,6 +21,8 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Lottery;
 use Illuminate\Support\MessageBag;
 use Illuminate\Testing\Assert;
 use Illuminate\Validation\ValidationException;
@@ -469,6 +477,224 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report($two = new RuntimeException('foo'));
 
         $this->assertSame($reported, [$one, $two]);
+    }
+
+    public function testItDoesNotThrottleExceptionsByDefault()
+    {
+        $reported = [];
+        $this->handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        for ($i = 0; $i < 100; $i++) {
+            $this->handler->report(new RuntimeException("Exception {$i}"));
+        }
+
+        $this->assertCount(100, $reported);
+    }
+
+    public function testItDoesNotThrottleExceptionsWhenNullReturned()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                //
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        for ($i = 0; $i < 100; $i++) {
+            $handler->report(new RuntimeException("Exception {$i}"));
+        }
+
+        $this->assertCount(100, $reported);
+    }
+
+    public function testItDoesNotThrottleExceptionsWhenUnlimitedLimit()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                return Limit::none();
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        for ($i = 0; $i < 100; $i++) {
+            $handler->report(new RuntimeException("Exception {$i}"));
+        }
+
+        $this->assertCount(100, $reported);
+    }
+
+    public function testItCanSampleExceptionsByClass()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                return match (true) {
+                    $e instanceof RuntimeException => Lottery::odds(2, 10),
+                    default => parent::throttle($e),
+                };
+            }
+        };
+        Lottery::forceResultWithSequence([
+            true, false, false, false, false,
+            true, false, false, false, false,
+        ]);
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        for ($i = 0; $i < 10; $i++) {
+            $handler->report(new Exception("Exception {$i}"));
+            $handler->report(new RuntimeException("RuntimeException {$i}"));
+        }
+
+        [$runtimeExceptions, $baseExceptions] = collect($reported)->partition(fn ($e) => $e instanceof RuntimeException);
+        $this->assertCount(10, $baseExceptions);
+        $this->assertCount(2, $runtimeExceptions);
+    }
+
+    public function testItRescuesExceptionsWhileThrottlingAndReports()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                throw new RuntimeException('Something went wrong in the throttle method.');
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $handler->report(new Exception('Something in the app went wrong.'));
+
+        $this->assertCount(1, $reported);
+        $this->assertSame('Something in the app went wrong.', $reported[0]->getMessage());
+    }
+
+    public function testItRescuesExceptionsIfThereIsAnIssueResolvingTheRateLimiter()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                return Limit::perDay(1);
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+        $resolved = false;
+        $this->container->bind(RateLimiter::class, function () use (&$resolved) {
+            $resolved = true;
+
+            throw new Exception('Error resolving rate limiter.');
+        });
+
+        $handler->report(new Exception('Something in the app went wrong.'));
+
+        $this->assertTrue($resolved);
+        $this->assertCount(1, $reported);
+        $this->assertSame('Something in the app went wrong.', $reported[0]->getMessage());
+    }
+
+    public function testItRescuesExceptionsIfThereIsAnIssueWithTheRateLimiter()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                return Limit::perDay(1);
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+        $this->container->instance(RateLimiter::class, $limiter = new class (new Repository(new NullStore)) extends RateLimiter {
+            public $attempted = false;
+
+            public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
+            {
+                $this->attempted = true;
+
+                throw new Exception('Unable to connect to Redis.');
+            }
+        });
+
+        $handler->report(new Exception('Something in the app went wrong.'));
+
+        $this->assertTrue($limiter->attempted);
+        $this->assertCount(1, $reported);
+        $this->assertSame('Something in the app went wrong.', $reported[0]->getMessage());
+    }
+
+    public function testItCanRateLimitExceptions()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function throttle($e)
+            {
+                return Limit::perMinute(7);
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+        $this->container->instance(RateLimiter::class, $limiter = new class (new Repository(new ArrayStore)) extends RateLimiter {
+            public $attempted = 0;
+
+            public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
+            {
+                $this->attempted++;
+
+                return parent::attempt(...func_get_args());
+            }
+        });
+        Carbon::setTestNow(Carbon::now()->startOfDay());
+
+        for ($i = 0; $i < 100; $i++) {
+            $handler->report(new Exception('Something in the app went wrong.'));
+        }
+
+        $this->assertSame(100, $limiter->attempted);
+        $this->assertCount(7, $reported);
+        $this->assertSame('Something in the app went wrong.', $reported[0]->getMessage());
+
+        Carbon::setTestNow(Carbon::now()->addMinute());
+
+        for ($i = 0; $i < 100; $i++) {
+            $handler->report(new Exception('Something in the app went wrong.'));
+        }
+
+        $this->assertSame(200, $limiter->attempted);
+        $this->assertCount(14, $reported);
+        $this->assertSame('Something in the app went wrong.', $reported[0]->getMessage());
     }
 }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -497,7 +497,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItDoesNotThrottleExceptionsWhenNullReturned()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 //
@@ -519,7 +520,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItDoesNotThrottleExceptionsWhenUnlimitedLimit()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 return Limit::none();
@@ -541,7 +543,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItCanSampleExceptionsByClass()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 return match (true) {
@@ -573,7 +576,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItRescuesExceptionsWhileThrottlingAndReports()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 throw new RuntimeException('Something went wrong in the throttle method.');
@@ -594,7 +598,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItRescuesExceptionsIfThereIsAnIssueResolvingTheRateLimiter()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 return Limit::perDay(1);
@@ -622,7 +627,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItRescuesExceptionsIfThereIsAnIssueWithTheRateLimiter()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 return Limit::perDay(1);
@@ -634,7 +640,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
             return false;
         });
-        $this->container->instance(RateLimiter::class, $limiter = new class (new Repository(new NullStore)) extends RateLimiter {
+        $this->container->instance(RateLimiter::class, $limiter = new class(new Repository(new NullStore)) extends RateLimiter
+        {
             public $attempted = false;
 
             public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
@@ -654,7 +661,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItCanRateLimitExceptions()
     {
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             protected function throttle($e)
             {
                 return Limit::perMinute(7);
@@ -666,7 +674,8 @@ class FoundationExceptionsHandlerTest extends TestCase
 
             return false;
         });
-        $this->container->instance(RateLimiter::class, $limiter = new class (new Repository(new ArrayStore)) extends RateLimiter {
+        $this->container->instance(RateLimiter::class, $limiter = new class(new Repository(new ArrayStore)) extends RateLimiter
+        {
             public $attempted = 0;
 
             public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)


### PR DESCRIPTION
Adds the ability to sample and rate limit exception reporting.

These two approaches are similar, but differ in their outcome. Sampling is useful to get an "overall" feel for how the exception is impacting your system while rate limiting is useful to now chew through your exception reporting plan threshold when there is a massive spike in errors. Rate limiting also ensures that you know when the error starts happening and continues at a regular interval.

## Sampling


```php
<?php

namespace App\Exceptions;

use Aceme\ApiMonitoringException;
use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
use Illuminate\Support\Lottery;
use Throwable;

class Handler extends ExceptionHandler
{
    /**
     * Throttle the given exception.
     *
     * @param  \Throwable  $e
     * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
     */
    protected function throttle(Throwable $e)
    {
        if ($e instanceof ApiMonitoringException) {
            return Lottery::odds(1, 1000);
        }
    }


    // ...
}
```

Sampling exceptions is something that is usually built into exception tracking packages. For example, Sentry offers a [`sample_rate` config option](https://docs.sentry.io/platforms/php/guides/laravel/configuration/sampling/).

I've only ever seen this as a global option, i.e., I cannot sample a specific exception or an exception based on the message.

It also means re-configuring it if you change error tracker.

Lastly, if you are using a log aggregate tool instead, e.g., you report logs to your syslog that something like Papertrail then ingests, you might not have this configuration option specifically for exceptions.

So now we can sample exceptions based on their type or message regardless of the error tracking approach or tooling we are using.

To sample, you may return a `Illuminate\Support]Lottery` class with the sample rate.

```php
if ($e instanceof ApiMonitoringException) {
    return Lottery::odds(1, 1000);
}
```

## Rate Limiting

```php
<?php

namespace App\Exceptions;

use Illuminate\Broadcasting\BroadcastException;
use Illuminate\Cache\RateLimiting\Limit;
use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
use Throwable;

class Handler extends ExceptionHandler
{
    /**
     * Throttle the given exception.
     *
     * @param  \Throwable  $e
     * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
     */
    protected function throttle(Throwable $e)
    {
        if ($e instanceof BroadcastException) {
            return Limit::perMinute(100);
        }
    }

    // ...
}
```

If a service like Pusher goes down and you are sending a LOT of exceptions, you are going to have a bad time. You quota for exceptions is likely to be exceeded pretty quickly.

With this feature you may rate limit the exceptions to ensure that there is a maximum number of exceptions per minute, hour, or day.

Unlike sampling, you will know as soon as the issue starts and each minute, for this example, you will know if it is continuing. You will have a high fidelity signal that something is wrong without having to flood your exception tracker with potentially thousands of errors per minute.

```php
if ($e instanceof BroadcastException) {
    return Limit::perMinute(100);
}
```

### Customising the rate limit key

By default, the rate limit will be applied against the `$exception::class`. If you want to limit the exception based on other factors, for example, the exception message, you may use the `by` method on the limit.

```php
if ($e->getCode() === 987) {
    return Limit::perMinute(5)->by('Error 987');
}

if (str_starts_with($e->getMessage(), 'INTERNAL_ERROR')) {
    return Limit::perMinute(100)->by($e->getMessage());
}
```

### Hashing keys

By default, rate limit keys will be hashed using `md5`. This is nice as developers can just pass an entire exception message through in the `Limit::by` method without needing to format it into something sensible.

If you want to turn off hashing to have complete control over the cache keys used you can set the handlers `$hashThrottleKeys` property to `false`.

```php
<?php

namespace App\Exceptions;

use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
use Throwable;

class Handler extends ExceptionHandler
{
    /**
     * Indicates that throttled keys should be hashed.
     *
     * @var bool
     */
    protected $hashThrottleKeys = false;

    // ...
}
```

## Handling exceptions while throttling

All the throttling logix is wrapped in a `rescue` to ensure that exceptions that occur while attempting to throttle do not interfere with the reporting of the original exception.

You could imagine a scenario where the cache connection is down. If we attempt to throttle that exception using the cache we are going to end up in an infinite loop.

If an exception occurs while throttling, we do not throttle the original exception and it is reported normally without throttling applied.

## Bringing it all together

You may mix and match as needed.


```php
<?php

namespace App\Exceptions;

use Aceme\ApiMonitoringException;
use Illuminate\Broadcasting\BroadcastException;
use Illuminate\Cache\RateLimiting\Limit;
use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
use Illuminate\Support\Lottery;
use Throwable;

class Handler extends ExceptionHandler
{
    /**
     * Throttle the given exception.
     *
     * @param  \Throwable  $e
     * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
     */
    protected function throttle(Throwable $e)
    {
        return match (true) {
            $e->getCode() === 987 => Limit::perMinute(5)->by('Error 987'),
            str_starts_with($e->getMessage(), 'INTERNAL_ERROR: ') => Limit::perMinute(60)->by($e->getMessage()),
            $e instanceof ApiMonitoringException => Lottery::odds(1, 1000),
            $e instanceof BroadcastException => Limit::perMinute(100),
            default => Limit::none(),
        };
    }
}
```