### PR TITLE
[10.x] phpdoc: Auth\Access\Response constructor allows null message

### DIFF
--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -38,7 +38,7 @@ class Response implements Arrayable
      * Create a new response.
      *
      * @param  bool  $allowed
-     * @param  string  $message
+     * @param  string|null  $message
      * @param  mixed  $code
      * @return void
      */


### PR DESCRIPTION
### Problem
`Response::allow()` and `Response::deny()` construct `Response` with a null `$message`.
However, the `Response` constructor's phpdoc only allows string `$message`.
`Response::$message` is passed to `AuthorizationException`, so a null `$message` creates an Exception with the default message `This action is unauthorized`. However, an empty string `$message` creates an Exception with an empty string message.

https://github.com/laravel/framework/blob/master/src/Illuminate/Auth/Access/AuthorizationException.php#L34

### Solution
I modified Phpdoc to allow a null `$message`.

### Users who get benefits from this
Users of static analysis tools (like PHPStan) would not encounter this error when using directly `new Response()`:
```
Parameter #2 $message of class Illuminate\Auth\Access\Response constructor expects string, null given.
```