### PR TITLE
[10.x] allow withPivot to include all columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Facades\Schema;
 
 trait InteractsWithPivotTable
 {
@@ -581,11 +582,15 @@ trait InteractsWithPivotTable
      * @param  array|mixed  $columns
      * @return $this
      */
-    public function withPivot($columns)
+    public function withPivot($columns = "*")
     {
-        $this->pivotColumns = array_merge(
-            $this->pivotColumns, is_array($columns) ? $columns : func_get_args()
-        );
+        if($columns === "*") {
+            $this->pivotColumns = Schema::getColumnListing($this->getTable());
+        } else {
+            $this->pivotColumns = array_merge(
+                $this->pivotColumns, is_array($columns) ? $columns : func_get_args()
+            );
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -582,9 +582,9 @@ trait InteractsWithPivotTable
      * @param  array|mixed  $columns
      * @return $this
      */
-    public function withPivot($columns = "*")
+    public function withPivot($columns = '*')
     {
-        if($columns === "*") {
+        if($columns === '*') {
             $this->pivotColumns = Schema::getColumnListing($this->getTable());
         } else {
             $this->pivotColumns = array_merge(

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -584,7 +584,7 @@ trait InteractsWithPivotTable
      */
     public function withPivot($columns = '*')
     {
-        if($columns === '*') {
+        if ($columns === '*') {
             $this->pivotColumns = Schema::getColumnListing($this->getTable());
         } else {
             $this->pivotColumns = array_merge(


### PR DESCRIPTION
# Problem
When working with pivot tables where there is quite a few pivot table columns is is frustrating to define each column inside `->withPivot(...columns)`

# Solution
I suggest that `withPivot` columns parameter by default would be `*` and that would include all pivot columns when loading relationship.

# Example
```php
public function users(): BelongsToMany
{
      return $this->belongsToMany(User::class)
                  ->withPivot();
}
```