### PR TITLE
[10.x] Add support to `UploadedFile` in JSON validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1398,6 +1398,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if ($value instanceof UploadedFile && $value->getMimeType() === 'application/json') {
+            $value = $value->getContent();
+        }
+
         json_decode($value);
 
         return json_last_error() === JSON_ERROR_NONE;

--- a/tests/Validation/Concerns/ValidatesAttributesTest.php
+++ b/tests/Validation/Concerns/ValidatesAttributesTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Tests\Validation\Concerns;
+
+use Illuminate\Validation\Concerns\ValidatesAttributes;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class ValidatesAttributesTest extends TestCase
+{
+    use ValidatesAttributes;
+
+    /**
+     * @dataProvider validJsonDataProvider
+     */
+    public function testValidateJsonWithValidJson(mixed $validJson): void
+    {
+        $isJsonValid = $this->validateJson('json_content', $validJson);
+
+        $this->assertTrue($isJsonValid);
+    }
+
+    /**
+     * @dataProvider invalidJsonDataProvider
+     */
+    public function testValidateJsonWithInvalidJson(mixed $invalidJson): void
+    {
+        $isJsonValid = $this->validateJson('json_content', $invalidJson);
+
+        $this->assertFalse($isJsonValid);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public static function validJsonDataProvider(): \Generator
+    {
+        $jsonClass = new class {
+            public function __toString()
+            {
+                return '{"message": "Olá!"}';
+            }
+        };
+
+        $mockedUploadedFile = self::createFakeUploadedFile('{"message": "Hola"}', 'json');
+
+        yield 'json string' => ['{"message": "Hi!"}'];
+        yield 'class with json __toString' => [$jsonClass];
+        yield 'uploaded json file' => [$mockedUploadedFile];
+    }
+
+    /**
+     * @return \Generator
+     */
+    public static function invalidJsonDataProvider(): \Generator
+    {
+        $invalidClass = new class {
+            public function sayHi()
+            {
+                return 'Hi!';
+            }
+        };
+
+        $invalidContentFile = self::createFakeUploadedFile('{"message":,,}', 'json');
+        $invalidExtensionFile = self::createFakeUploadedFile('{"message":"Hello"}', 'pdf');
+
+        yield 'array' => [['message' => 'konnichiwa']];
+        yield 'class without json __toString' => [$invalidClass];
+        yield 'invalid json string' => ['{"message":,,,}'];
+        yield 'invalid uploaded file json' => [$invalidContentFile];
+        yield 'invalid uploaded file extension' => [$invalidExtensionFile];
+    }
+
+    private static function createFakeUploadedFile(string $fileContent, string $fileExtension): UploadedFile
+    {
+        /** @var UploadedFile&MockInterface */
+        $mockedUploadedFile = mock(UploadedFile::class);
+
+        $mockedUploadedFile
+            ->shouldReceive('getContent')
+            ->once()
+            ->andReturn($fileContent);
+
+        $mockedUploadedFile
+            ->shouldReceive('getExtension')
+            ->once()
+            ->andReturn($fileExtension);
+
+        return $mockedUploadedFile;
+    }
+}


### PR DESCRIPTION
## Description

This involves a simple adjustment in json validation, enabling it to validate JSONs of type Symfony\Component\HttpFoundation\File\UploadedFile.

This adjustment proves particularly useful in scenarios where we need to enforce the _json rule_ for file uploads throughout the application.

## Changes

- Added a condition in the ValidatesAttributes::validateJson trait method to check if `$value` is an instance of `UploadedFile` and if the _mimetype_ is application/json.
    - If these conditions are met, `$value` will be reassigned with the contents of the file.
- Unit tests were added to validate this behavior.

## Additional information

I have successfully tested this change within an Laravel project, and it functioned as expected for JSON file uploads.