### PR TITLE
[10.x] Remove PHP 8.1 Check for including Enums in Tests

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -45,9 +45,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
 
-if (PHP_VERSION_ID >= 80100) {
-    include 'Enums.php';
-}
+include_once 'Enums.php';
 
 class DatabaseEloquentModelTest extends TestCase
 {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -20,9 +20,7 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-if (PHP_VERSION_ID >= 80100) {
-    include 'Enums.php';
-}
+include_once 'Enums.php';
 
 class HttpRequestTest extends TestCase
 {

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class EloquentModelEnumCastingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-include 'Enums.php';
+include_once 'Enums.php';
 
 class ImplicitBackedEnumRouteBindingTest extends TestCase
 {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -14,9 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
-if (PHP_VERSION_ID >= 80100) {
-    include_once 'Enums.php';
-}
+include_once 'Enums.php';
 
 class RoutingUrlGeneratorTest extends TestCase
 {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -26,9 +26,7 @@ use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
 
-if (PHP_VERSION_ID >= 80100) {
-    include_once 'Enums.php';
-}
+include_once 'Enums.php';
 
 class SupportCollectionTest extends TestCase
 {


### PR DESCRIPTION
- Some Tests still had Checks for PHP 8.1, these are not needed anymore as Laravel 10 required PHP 8.1
- In some tests `include` was used, but the majority of tests already uses `include_once`, so I changed them to `include_once`