### PR TITLE
[11.x] Remove PHP 8.2 Checks

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -676,20 +676,12 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClassForCallable($callback)
     {
-        if (PHP_VERSION_ID >= 80200) {
-            if (is_callable($callback) &&
-                ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
-                return $reflector->getClosureScopeClass()->name ?? false;
-            }
-
-            return false;
+        if (is_callable($callback) &&
+            ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
+            return $reflector->getClosureScopeClass()->name ?? false;
         }
 
-        if (! is_array($callback)) {
-            return false;
-        }
-
-        return is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+        return false;
     }
 
     /**

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -497,11 +497,9 @@ class ContextualBindingTest extends TestCase
         $valueResolvedUsingArraySyntax = $container->call([$object, 'method']);
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingArraySyntax);
 
-        if (PHP_VERSION_ID >= 80200) {
-            // first class callable syntax...
-            $valueResolvedUsingFirstClassSyntax = $container->call($object->method(...));
-            $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingFirstClassSyntax);
-        }
+        // first class callable syntax...
+        $valueResolvedUsingFirstClassSyntax = $container->call($object->method(...));
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $valueResolvedUsingFirstClassSyntax);
     }
 }
 


### PR DESCRIPTION
Laravel 11 requires PHP 8.2, therefor some checks can be removed.