### PR TITLE
[10.x] Fix blade failing to compile when mixing inline/block @php directives

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -401,7 +401,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storePhpBlocks($value)
     {
-        return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
+        return preg_replace_callback('/(?<!@)@php((?:.(?!(?<!@)@php))*?)@endphp/s', function ($matches) {
             return $this->storeRawBlock("<?php{$matches[1]}?>");
         }, $value);
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -11,6 +11,59 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testMixedPhpStatementsAreCompiled()
+    {
+        $string = <<<'BLADE'
+            @php($set = true)
+            @php($set = true) @php ($set = false;) @endphp
+            @php ($set = true) @php($set = false;)@endphp
+            <div>{{ $set }}</div>
+            @php
+                $set = false;
+            @endphp
+            @php (
+                $set = false;
+            )@endphp
+            @php(
+                $set = false;
+            )@endphp
+            @php (
+                $set = false
+            )
+            @php(
+                $set = false
+            )
+            @php
+                $set = '@@php';
+            @endphp
+            BLADE;
+        $expected = <<<'PHP'
+            <?php ($set = true); ?>
+            <?php ($set = true); ?> <?php ($set = false;) ?>
+            <?php ($set = true); ?> <?php($set = false;)?>
+            <div><?php echo e($set); ?></div>
+            <?php
+                $set = false;
+            ?>
+            <?php (
+                $set = false;
+            )?>
+            <?php(
+                $set = false;
+            )?>
+            <?php (
+                $set = false
+            ); ?>
+            <?php (
+                $set = false
+            ); ?>
+            <?php
+                $set = '@@php';
+            ?>
+            PHP;
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testStringWithParenthesisWithEndPHP()
     {
         $string = "@php(\$data = ['related_to' => 'issue#45388'];) {{ \$data }} @endphp";

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -64,6 +64,78 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testCompilationOfMixedPhpStatements()
+    {
+        $string = '@php($set = true) @php ($hello = \'hi\') @php echo "Hello world" @endphp';
+        $expected = '<?php ($set = true); ?> <?php ($hello = \'hi\'); ?> <?php echo "Hello world" ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testCompilationOfMixedUsageStatements()
+    {
+        $string = '@php (
+            $classes = [
+                \'admin-font-mono\', // Font weight
+            ])
+        @endphp';
+        $expected = '<?php (
+            $classes = [
+                \'admin-font-mono\', // Font weight
+            ])
+        ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMultilinePhpStatementsWithParenthesesCanBeCompiled()
+    {
+        $string = <<<'BLADE'
+            @php (
+                $classes = [
+                    'admin-font-mono'
+                ])
+            @endphp
+
+            <span class="{{ implode(' ', $classes) }}">Laravel</span>
+            BLADE;
+
+        $expected = <<<'PHP'
+            <?php (
+                $classes = [
+                    'admin-font-mono'
+                ])
+            ?>
+
+            <span class="<?php echo e(implode(' ', $classes)); ?>">Laravel</span>
+            PHP;
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMixedOfPhpStatementsCanBeCompiled()
+    {
+        $string = <<<'BLADE'
+            @php($total = 0)
+            {{-- ... --}}
+            <div>{{ $total }}</div>
+            @php
+                // ...
+            @endphp
+            BLADE;
+
+        $expected = <<<'PHP'
+            <?php ($total = 0); ?>
+
+            <div><?php echo e($total); ?></div>
+            <?php
+                // ...
+            ?>
+            PHP;
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testStringWithParenthesisWithEndPHP()
     {
         $string = "@php(\$data = ['related_to' => 'issue#45388'];) {{ \$data }} @endphp";


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #48407

Updated the php regex from `.*?` to `(?:.(?!(?<!@)@php))*?`---long story short this is just a negative lookahead that matches everything that is not followed by `@php` while also allowing `@@pphp`.

Partial credit goes to @rikvdh 