### PR TITLE
[10.x] introduce `Str::substrPos`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1343,6 +1343,20 @@ class Str
     }
 
     /**
+     * Find multi-byte safe position of first occurrence of substring in a string.
+     * If substr is not found, it returns false.
+     *
+     * @param string $haystack The string to search in
+     * @param string $needle The string to search for in $haystack
+     * @param int $offset Search offset. A negative offset counts from the end of the string
+     * @param string|null $encoding If it is omitted or null, the internal character encoding value will be used
+     * @return int|false
+     */
+    public static function substrPos($haystack, $needle, $offset = 0, $encoding = null) {
+        return mb_strpos($haystack, (string) $needle, $offset, $encoding);
+    }
+
+    /**
      * Replace text within a portion of a string.
      *
      * @param  string|string[]  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1346,13 +1346,14 @@ class Str
      * Find multi-byte safe position of first occurrence of substring in a string.
      * If substr is not found, it returns false.
      *
-     * @param string $haystack The string to search in
-     * @param string $needle The string to search for in $haystack
-     * @param int $offset Search offset. A negative offset counts from the end of the string
-     * @param string|null $encoding If it is omitted or null, the internal character encoding value will be used
+     * @param  string  $haystack  The string to search in
+     * @param  string  $needle  The string to search for in $haystack
+     * @param  int  $offset  Search offset. A negative offset counts from the end of the string
+     * @param  string|null  $encoding  If it is omitted or null, the internal character encoding value will be used
      * @return int|false
      */
-    public static function substrPos($haystack, $needle, $offset = 0, $encoding = null) {
+    public static function substrPos($haystack, $needle, $offset = 0, $encoding = null)
+    {
         return mb_strpos($haystack, (string) $needle, $offset, $encoding);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -862,6 +862,20 @@ class Str
     }
 
     /**
+     * Find the multi-byte safe position of the first occurrence of a given substring in a string.
+     *
+     * @param  string  $haystack
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  string|null  $encoding
+     * @return int|false
+     */
+    public static function position($haystack, $needle, $offset = 0, $encoding = null)
+    {
+        return mb_strpos($haystack, (string) $needle, $offset, $encoding);
+    }
+
+    /**
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length
@@ -1340,20 +1354,6 @@ class Str
         }
 
         return substr_count($haystack, $needle, $offset);
-    }
-
-    /**
-     * Find the multi-byte safe position of the first occurrence of a given substring in a string.
-     *
-     * @param  string  $haystack
-     * @param  string  $needle
-     * @param  int  $offset
-     * @param  string|null  $encoding
-     * @return int|false
-     */
-    public static function substrPos($haystack, $needle, $offset = 0, $encoding = null)
-    {
-        return mb_strpos($haystack, (string) $needle, $offset, $encoding);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1343,13 +1343,12 @@ class Str
     }
 
     /**
-     * Find multi-byte safe position of first occurrence of substring in a string.
-     * If substr is not found, it returns false.
+     * Find the multi-byte safe position of the first occurrence of a given substring in a string.
      *
-     * @param  string  $haystack  The string to search in
-     * @param  string  $needle  The string to search for in $haystack
-     * @param  int  $offset  Search offset. A negative offset counts from the end of the string
-     * @param  string|null  $encoding  If it is omitted or null, the internal character encoding value will be used
+     * @param  string  $haystack
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  string|null  $encoding
      * @return int|false
      */
     public static function substrPos($haystack, $needle, $offset = 0, $encoding = null)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -576,6 +576,19 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Find the multi-byte safe position of the first occurrence of the given substring.
+     *
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  string|null  $encoding
+     * @return int|false
+     */
+    public function position($needle, $offset = 0, $encoding = null)
+    {
+        return Str::position($this->value, $needle, $offset, $encoding);
+    }
+
+    /**
      * Prepend the given values to the string.
      *
      * @param  string  ...$values
@@ -861,19 +874,6 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function substrCount($needle, $offset = 0, $length = null)
     {
         return Str::substrCount($this->value, $needle, $offset, $length);
-    }
-
-    /**
-     * Find the multi-byte safe position of the first occurrence of the given substring.
-     *
-     * @param  string  $needle
-     * @param  int  $offset
-     * @param  string|null  $encoding
-     * @return int|false
-     */
-    public function substrPos($needle, $offset = 0, $encoding = null)
-    {
-        return Str::substrPos($this->value, $needle, $offset, $encoding);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -864,12 +864,11 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Find multi-byte safe position of first occurrence of given substring.
-     * If substr is not found, it returns false.
+     * Find the multi-byte safe position of the first occurrence of the given substring.
      *
-     * @param  string  $needle  The string to search for in $haystack
-     * @param  int  $offset  Search offset. A negative offset counts from the end of the string
-     * @param  string|null  $encoding  If it is omitted or null, the internal character encoding value will be used
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  string|null  $encoding
      * @return int|false
      */
     public function substrPos($needle, $offset = 0, $encoding = null)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -864,6 +864,20 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Find multi-byte safe position of first occurrence of given substring.
+     * If substr is not found, it returns false.
+     *
+     * @param string $needle The string to search for in $haystack
+     * @param int $offset Search offset. A negative offset counts from the end of the string
+     * @param string|null $encoding If it is omitted or null, the internal character encoding value will be used
+     * @return int|false
+     */
+    public function substrPos($needle, $offset = 0, $encoding = null)
+    {
+        return Str::substrPos($this->value, $needle, $offset, $encoding);
+    }
+
+    /**
      * Replace text within a portion of a string.
      *
      * @param  string|string[]  $replace

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -867,9 +867,9 @@ class Stringable implements JsonSerializable, ArrayAccess
      * Find multi-byte safe position of first occurrence of given substring.
      * If substr is not found, it returns false.
      *
-     * @param string $needle The string to search for in $haystack
-     * @param int $offset Search offset. A negative offset counts from the end of the string
-     * @param string|null $encoding If it is omitted or null, the internal character encoding value will be used
+     * @param  string  $needle  The string to search for in $haystack
+     * @param  int  $offset  Search offset. A negative offset counts from the end of the string
+     * @param  string|null  $encoding  If it is omitted or null, the internal character encoding value will be used
      * @return int|false
      */
     public function substrPos($needle, $offset = 0, $encoding = null)

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -823,19 +823,20 @@ class SupportStrTest extends TestCase
         $this->assertSame(1, Str::substrCount('laravelPHPFramework', 'a', -10, -3));
     }
 
-    public function testSubstrPos() {
-        $this->assertSame(7, Str::substrPos("Hello, World!", "W"));
-        $this->assertSame(10, Str::substrPos("This is a test string.", "test"));
-        $this->assertSame(23, Str::substrPos("This is a test string, test again.", "test", 15));
-        $this->assertSame(0, Str::substrPos("Hello, World!", "Hello"));
-        $this->assertSame(7, Str::substrPos("Hello, World!", "World!"));
-        $this->assertSame(10, Str::substrPos("This is a tEsT string.", "tEsT", 0, 'UTF-8'));
-        $this->assertSame(7, Str::substrPos("Hello, World!", "W", -6));
-        $this->assertSame(18, Str::substrPos("Äpfel, Birnen und Kirschen", "Kirschen", -10, 'UTF-8'));
-        $this->assertFalse(Str::substrPos("Hello, World!", "w", 0, 'UTF-8'));
-        $this->assertFalse(Str::substrPos("Hello, World!", "X", 0, 'UTF-8'));
-        $this->assertFalse(Str::substrPos("", "test"));
-        $this->assertFalse(Str::substrPos("Hello, World!", "X"));
+    public function testSubstrPos()
+    {
+        $this->assertSame(7, Str::substrPos('Hello, World!', 'W'));
+        $this->assertSame(10, Str::substrPos('This is a test string.', 'test'));
+        $this->assertSame(23, Str::substrPos('This is a test string, test again.', 'test', 15));
+        $this->assertSame(0, Str::substrPos('Hello, World!', 'Hello'));
+        $this->assertSame(7, Str::substrPos('Hello, World!', 'World!'));
+        $this->assertSame(10, Str::substrPos('This is a tEsT string.', 'tEsT', 0, 'UTF-8'));
+        $this->assertSame(7, Str::substrPos('Hello, World!', 'W', -6));
+        $this->assertSame(18, Str::substrPos('Äpfel, Birnen und Kirschen', 'Kirschen', -10, 'UTF-8'));
+        $this->assertFalse(Str::substrPos('Hello, World!', 'w', 0, 'UTF-8'));
+        $this->assertFalse(Str::substrPos('Hello, World!', 'X', 0, 'UTF-8'));
+        $this->assertFalse(Str::substrPos('', 'test'));
+        $this->assertFalse(Str::substrPos('Hello, World!', 'X'));
     }
 
     public function testSubstrReplace()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -833,6 +833,7 @@ class SupportStrTest extends TestCase
         $this->assertSame(10, Str::substrPos('This is a tEsT string.', 'tEsT', 0, 'UTF-8'));
         $this->assertSame(7, Str::substrPos('Hello, World!', 'W', -6));
         $this->assertSame(18, Str::substrPos('Äpfel, Birnen und Kirschen', 'Kirschen', -10, 'UTF-8'));
+        $this->assertSame(9, Str::substrPos('@%€/=!"][$', '$', 0, 'UTF-8'));
         $this->assertFalse(Str::substrPos('Hello, World!', 'w', 0, 'UTF-8'));
         $this->assertFalse(Str::substrPos('Hello, World!', 'X', 0, 'UTF-8'));
         $this->assertFalse(Str::substrPos('', 'test'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -823,21 +823,21 @@ class SupportStrTest extends TestCase
         $this->assertSame(1, Str::substrCount('laravelPHPFramework', 'a', -10, -3));
     }
 
-    public function testSubstrPos()
+    public function testPosition()
     {
-        $this->assertSame(7, Str::substrPos('Hello, World!', 'W'));
-        $this->assertSame(10, Str::substrPos('This is a test string.', 'test'));
-        $this->assertSame(23, Str::substrPos('This is a test string, test again.', 'test', 15));
-        $this->assertSame(0, Str::substrPos('Hello, World!', 'Hello'));
-        $this->assertSame(7, Str::substrPos('Hello, World!', 'World!'));
-        $this->assertSame(10, Str::substrPos('This is a tEsT string.', 'tEsT', 0, 'UTF-8'));
-        $this->assertSame(7, Str::substrPos('Hello, World!', 'W', -6));
-        $this->assertSame(18, Str::substrPos('Äpfel, Birnen und Kirschen', 'Kirschen', -10, 'UTF-8'));
-        $this->assertSame(9, Str::substrPos('@%€/=!"][$', '$', 0, 'UTF-8'));
-        $this->assertFalse(Str::substrPos('Hello, World!', 'w', 0, 'UTF-8'));
-        $this->assertFalse(Str::substrPos('Hello, World!', 'X', 0, 'UTF-8'));
-        $this->assertFalse(Str::substrPos('', 'test'));
-        $this->assertFalse(Str::substrPos('Hello, World!', 'X'));
+        $this->assertSame(7, Str::position('Hello, World!', 'W'));
+        $this->assertSame(10, Str::position('This is a test string.', 'test'));
+        $this->assertSame(23, Str::position('This is a test string, test again.', 'test', 15));
+        $this->assertSame(0, Str::position('Hello, World!', 'Hello'));
+        $this->assertSame(7, Str::position('Hello, World!', 'World!'));
+        $this->assertSame(10, Str::position('This is a tEsT string.', 'tEsT', 0, 'UTF-8'));
+        $this->assertSame(7, Str::position('Hello, World!', 'W', -6));
+        $this->assertSame(18, Str::position('Äpfel, Birnen und Kirschen', 'Kirschen', -10, 'UTF-8'));
+        $this->assertSame(9, Str::position('@%€/=!"][$', '$', 0, 'UTF-8'));
+        $this->assertFalse(Str::position('Hello, World!', 'w', 0, 'UTF-8'));
+        $this->assertFalse(Str::position('Hello, World!', 'X', 0, 'UTF-8'));
+        $this->assertFalse(Str::position('', 'test'));
+        $this->assertFalse(Str::position('Hello, World!', 'X'));
     }
 
     public function testSubstrReplace()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -823,6 +823,21 @@ class SupportStrTest extends TestCase
         $this->assertSame(1, Str::substrCount('laravelPHPFramework', 'a', -10, -3));
     }
 
+    public function testSubstrPos() {
+        $this->assertSame(7, Str::substrPos("Hello, World!", "W"));
+        $this->assertSame(10, Str::substrPos("This is a test string.", "test"));
+        $this->assertSame(23, Str::substrPos("This is a test string, test again.", "test", 15));
+        $this->assertSame(0, Str::substrPos("Hello, World!", "Hello"));
+        $this->assertSame(7, Str::substrPos("Hello, World!", "World!"));
+        $this->assertSame(10, Str::substrPos("This is a tEsT string.", "tEsT", 0, 'UTF-8'));
+        $this->assertSame(7, Str::substrPos("Hello, World!", "W", -6));
+        $this->assertSame(18, Str::substrPos("Äpfel, Birnen und Kirschen", "Kirschen", -10, 'UTF-8'));
+        $this->assertFalse(Str::substrPos("Hello, World!", "w", 0, 'UTF-8'));
+        $this->assertFalse(Str::substrPos("Hello, World!", "X", 0, 'UTF-8'));
+        $this->assertFalse(Str::substrPos("", "test"));
+        $this->assertFalse(Str::substrPos("Hello, World!", "X"));
+    }
+
     public function testSubstrReplace()
     {
         $this->assertSame('12:00', Str::substrReplace('1200', ':', 2, 0));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1018,19 +1018,20 @@ class SupportStringableTest extends TestCase
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
 
-    public function testSubstrPos() {
-        $this->assertSame(7, $this->stringable("Hello, World!")->substrPos("W"));
-        $this->assertSame(10, $this->stringable("This is a test string.")->substrPos("test"));
-        $this->assertSame(23, $this->stringable("This is a test string, test again.")->substrPos("test", 15));
-        $this->assertSame(0, $this->stringable("Hello, World!")->substrPos("Hello"));
-        $this->assertSame(7, $this->stringable("Hello, World!")->substrPos("World!"));
-        $this->assertSame(10, $this->stringable("This is a tEsT string.")->substrPos("tEsT", 0, 'UTF-8'));
-        $this->assertSame(7, $this->stringable("Hello, World!")->substrPos("W", -6));
-        $this->assertSame(18, $this->stringable("Äpfel, Birnen und Kirschen")->substrPos("Kirschen", -10, 'UTF-8'));
-        $this->assertFalse($this->stringable("Hello, World!")->substrPos("w", 0, 'UTF-8'));
-        $this->assertFalse($this->stringable("Hello, World!")->substrPos("X", 0, 'UTF-8'));
-        $this->assertFalse($this->stringable("")->substrPos("test"));
-        $this->assertFalse($this->stringable("Hello, World!")->substrPos("X"));
+    public function testSubstrPos()
+    {
+        $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('W'));
+        $this->assertSame(10, $this->stringable('This is a test string.')->substrPos('test'));
+        $this->assertSame(23, $this->stringable('This is a test string, test again.')->substrPos('test', 15));
+        $this->assertSame(0, $this->stringable('Hello, World!')->substrPos('Hello'));
+        $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('World!'));
+        $this->assertSame(10, $this->stringable('This is a tEsT string.')->substrPos('tEsT', 0, 'UTF-8'));
+        $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('W', -6));
+        $this->assertSame(18, $this->stringable('Äpfel, Birnen und Kirschen')->substrPos('Kirschen', -10, 'UTF-8'));
+        $this->assertFalse($this->stringable('Hello, World!')->substrPos('w', 0, 'UTF-8'));
+        $this->assertFalse($this->stringable('Hello, World!')->substrPos('X', 0, 'UTF-8'));
+        $this->assertFalse($this->stringable('')->substrPos('test'));
+        $this->assertFalse($this->stringable('Hello, World!')->substrPos('X'));
     }
 
     public function testSubstrReplace()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1020,19 +1020,19 @@ class SupportStringableTest extends TestCase
 
     public function testSubstrPos()
     {
-        $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('W'));
-        $this->assertSame(10, $this->stringable('This is a test string.')->substrPos('test'));
-        $this->assertSame(23, $this->stringable('This is a test string, test again.')->substrPos('test', 15));
-        $this->assertSame(0, $this->stringable('Hello, World!')->substrPos('Hello'));
-        $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('World!'));
-        $this->assertSame(10, $this->stringable('This is a tEsT string.')->substrPos('tEsT', 0, 'UTF-8'));
-        $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('W', -6));
-        $this->assertSame(18, $this->stringable('Äpfel, Birnen und Kirschen')->substrPos('Kirschen', -10, 'UTF-8'));
-        $this->assertSame(9, $this->stringable('@%€/=!"][$')->substrPos('$', 0, 'UTF-8'));
-        $this->assertFalse($this->stringable('Hello, World!')->substrPos('w', 0, 'UTF-8'));
-        $this->assertFalse($this->stringable('Hello, World!')->substrPos('X', 0, 'UTF-8'));
-        $this->assertFalse($this->stringable('')->substrPos('test'));
-        $this->assertFalse($this->stringable('Hello, World!')->substrPos('X'));
+        $this->assertSame(7, $this->stringable('Hello, World!')->position('W'));
+        $this->assertSame(10, $this->stringable('This is a test string.')->position('test'));
+        $this->assertSame(23, $this->stringable('This is a test string, test again.')->position('test', 15));
+        $this->assertSame(0, $this->stringable('Hello, World!')->position('Hello'));
+        $this->assertSame(7, $this->stringable('Hello, World!')->position('World!'));
+        $this->assertSame(10, $this->stringable('This is a tEsT string.')->position('tEsT', 0, 'UTF-8'));
+        $this->assertSame(7, $this->stringable('Hello, World!')->position('W', -6));
+        $this->assertSame(18, $this->stringable('Äpfel, Birnen und Kirschen')->position('Kirschen', -10, 'UTF-8'));
+        $this->assertSame(9, $this->stringable('@%€/=!"][$')->position('$', 0, 'UTF-8'));
+        $this->assertFalse($this->stringable('Hello, World!')->position('w', 0, 'UTF-8'));
+        $this->assertFalse($this->stringable('Hello, World!')->position('X', 0, 'UTF-8'));
+        $this->assertFalse($this->stringable('')->position('test'));
+        $this->assertFalse($this->stringable('Hello, World!')->position('X'));
     }
 
     public function testSubstrReplace()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1028,6 +1028,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(10, $this->stringable('This is a tEsT string.')->substrPos('tEsT', 0, 'UTF-8'));
         $this->assertSame(7, $this->stringable('Hello, World!')->substrPos('W', -6));
         $this->assertSame(18, $this->stringable('Äpfel, Birnen und Kirschen')->substrPos('Kirschen', -10, 'UTF-8'));
+        $this->assertSame(9, $this->stringable('@%€/=!"][$')->substrPos('$', 0, 'UTF-8'));
         $this->assertFalse($this->stringable('Hello, World!')->substrPos('w', 0, 'UTF-8'));
         $this->assertFalse($this->stringable('Hello, World!')->substrPos('X', 0, 'UTF-8'));
         $this->assertFalse($this->stringable('')->substrPos('test'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1018,6 +1018,21 @@ class SupportStringableTest extends TestCase
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
 
+    public function testSubstrPos() {
+        $this->assertSame(7, $this->stringable("Hello, World!")->substrPos("W"));
+        $this->assertSame(10, $this->stringable("This is a test string.")->substrPos("test"));
+        $this->assertSame(23, $this->stringable("This is a test string, test again.")->substrPos("test", 15));
+        $this->assertSame(0, $this->stringable("Hello, World!")->substrPos("Hello"));
+        $this->assertSame(7, $this->stringable("Hello, World!")->substrPos("World!"));
+        $this->assertSame(10, $this->stringable("This is a tEsT string.")->substrPos("tEsT", 0, 'UTF-8'));
+        $this->assertSame(7, $this->stringable("Hello, World!")->substrPos("W", -6));
+        $this->assertSame(18, $this->stringable("Äpfel, Birnen und Kirschen")->substrPos("Kirschen", -10, 'UTF-8'));
+        $this->assertFalse($this->stringable("Hello, World!")->substrPos("w", 0, 'UTF-8'));
+        $this->assertFalse($this->stringable("Hello, World!")->substrPos("X", 0, 'UTF-8'));
+        $this->assertFalse($this->stringable("")->substrPos("test"));
+        $this->assertFalse($this->stringable("Hello, World!")->substrPos("X"));
+    }
+
     public function testSubstrReplace()
     {
         $this->assertSame('12:00', (string) $this->stringable('1200')->substrReplace(':', 2, 0));


### PR DESCRIPTION
This pull request introduces a multi-byte safe method to determine the position of the first occurrence of substring in a string. It's basically a wrapper for [mb_strpos()](https://www.php.net/manual/en/function.mb-strpos.php).

I've implemented the helper method as static call and in fluent style. The naming follow's other `substr*` methods like `Str::substrCount()` or `Str::substrReplace()`.
