### PR TITLE
[10.x] Fix "Text file busy" error when call deleteDirectory

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -749,6 +749,8 @@ class Filesystem
             }
         }
 
+        unset($items);
+
         if (! $preserve) {
             @rmdir($directory);
         }

--- a/tests/Integration/Filesystem/FilesystemTest.php
+++ b/tests/Integration/Filesystem/FilesystemTest.php
@@ -70,4 +70,17 @@ class FilesystemTest extends TestCase
         clearstatcache(true, $this->stubFile);
         $this->assertFalse(File::isFile($this->stubFile));
     }
+
+    public function testItCanDeleteDirectoryViaFilesystem()
+    {
+        if (! File::exists(storage_path('app/public/testdir'))) {
+            File::makeDirectory(storage_path('app/public/testdir'));
+        }
+
+        $this->assertTrue(File::exists(storage_path('app/public/testdir')));
+
+        File::deleteDirectory(storage_path('app/public/testdir'));
+
+        $this->assertFalse(File::exists(storage_path('app/public/testdir')));
+    }
 }

--- a/tests/Integration/Filesystem/StorageTest.php
+++ b/tests/Integration/Filesystem/StorageTest.php
@@ -79,4 +79,19 @@ class StorageTest extends TestCase
         Storage::disk('public')->assertMissing('StardewTaylor.png');
         $this->assertFalse(Storage::disk('public')->exists('StardewTaylor.png'));
     }
+
+    public function testItCanDeleteDirectoryViaStorage()
+    {
+        if (! Storage::disk('public')->exists('testdir')) {
+            Storage::disk('public')->makeDirectory('testdir');
+        }
+
+        Storage::disk('public')->assertExists('testdir');
+        $this->assertTrue(Storage::disk('public')->exists('testdir'));
+
+        Storage::disk('public')->deleteDirectory('testdir');
+
+        Storage::disk('public')->assertMissing('testdir');
+        $this->assertFalse(Storage::disk('public')->exists('testdir'));
+    }
 }


### PR DESCRIPTION
This PR is based on #41433 and adds tests

---

If you call the `File::deleteDirectory($dir)` to delete a directory, you can see the files in the directory will be deleted, but the directory will keep it. If change the `@rmdir()` to `rmdir()` into `deleteDirectory()` it will be throws the `ErrorException: rmdir(/home/vagrant/packages/laravel-framework/vendor/orchestra/testbench-core/laravel/storage/app/public/testdir): Text file busy` error.

So this PR fixed the "Text file busy" error on call `File::deleteDirectory($dir)`, unset the `$items` in `deleteDirectory()` to release the directory lock before calling `rmdir()`, does not break existing features.

Reference PR: https://github.com/thephpleague/flysystem/issues/1103, https://github.com/thephpleague/flysystem/commit/d03f7e1e0f2fa47f52d445a60ec8ed93d433ddc1
