### PR TITLE
Fix Cache::many() with small numeric keys

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -163,7 +163,6 @@ class Repository implements ArrayAccess, CacheContract
         if (is_null($value)) {
             $this->event(new CacheMissed($key));
 
-            // Use the default value only if keys are key-value pairs, not just values
             return (isset($keys[$key]) && ! array_is_list($keys)) ? value($keys[$key]) : null;
         }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -163,7 +163,8 @@ class Repository implements ArrayAccess, CacheContract
         if (is_null($value)) {
             $this->event(new CacheMissed($key));
 
-            return isset($keys[$key]) ? value($keys[$key]) : null;
+            // Use the default value only if keys are key-value pairs, not just values
+            return (isset($keys[$key]) && !array_is_list($keys)) ? value($keys[$key]) : null;
         }
 
         // If we found a valid value we will fire the "hit" event and return the value

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -164,7 +164,7 @@ class Repository implements ArrayAccess, CacheContract
             $this->event(new CacheMissed($key));
 
             // Use the default value only if keys are key-value pairs, not just values
-            return (isset($keys[$key]) && !array_is_list($keys)) ? value($keys[$key]) : null;
+            return (isset($keys[$key]) && ! array_is_list($keys)) ? value($keys[$key]) : null;
         }
 
         // If we found a valid value we will fire the "hit" event and return the value

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -58,6 +58,13 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals(['foo' => 'default', 'bar' => 'baz'], $repo->get(['foo' => 'default', 'bar']));
     }
 
+    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayOfOneTwoThree()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('many')->once()->with([1, 2, 3])->andReturn([1 => null, 2 => null, 3 => null]);
+        $this->assertEquals([1 => null, 2 => null, 3 => null], $repo->get([1, 2, 3]));
+    }
+
     public function testDefaultValueIsReturned()
     {
         $repo = $this->getRepository();


### PR DESCRIPTION
`Cache::many([1,2,3])` for an empty cache returns `[1 => 2, 2 => 3, 3 => null]` instead of `[1 => null, 2 => null, 3 => null]`.
String keys like this \Cache::many(['1','2','3']) make no difference.

The issue is that `Illuminate\Cache\Repository` tries to set default values for missing keys, and in case of small numeric keys it treats those as positions: e.g. when `$keys = [1, 2, 3]` the value of `$keys[1]` is `2`.

This code in this PR tests if `$keys` is not an associative array (in other words, it doesn't contain the defaults, just the keys) and if so, just returns `null` for missed cache keys.