### PR TITLE
Add File::csv() method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -181,6 +181,35 @@ class Filesystem
     }
 
     /**
+     * Get the contents of a file as parsed CSV fields.
+     *
+     * @param  string  $path
+     * @return \Illuminate\Support\LazyCollection
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function csv($path, $separator = ',', $enclosure = '"', $escape = '\\')
+    {
+        $handle = fopen($path, 'r');
+
+        if ($handle) {
+            $args = func_get_args();
+
+            array_shift($args);
+
+            return LazyCollection::make(function () use ($handle, $args) {
+                while (($item = fgetcsv($handle, null, ...$args)) !== false) {
+                    yield $item;
+                }
+
+                fclose($handle);
+            });
+        }
+
+        throw new FileNotFoundException("File does not exist at path {$path}.");
+    }
+
+    /**
      * Get the hash of the file at the given path.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -76,6 +76,25 @@ class FilesystemTest extends TestCase
         );
     }
 
+    public function testCsv()
+    {
+        $path = self::$tempDir.'/file.csv';
+
+        file_put_contents($path, "a,b,c\nx,y,z");
+
+        $files = new Filesystem;
+
+        $this->assertInstanceOf(LazyCollection::class, $files->csv($path));
+
+        $this->assertSame(
+            [
+                ['a', 'b', 'c'],
+                ['x', 'y', 'z'],
+            ],
+            $files->csv($path)->all()
+        );
+    }
+
     public function testReplaceCreatesFile()
     {
         $tempFile = self::$tempDir.'/file.txt';


### PR DESCRIPTION
This PR adds a convenience method to read and parse csv files.

It uses LazyCollection under the hood to avoid loading the entire file into the memory - the implementation is somewhat similar to the `File::lines()` method which also reads files line by line and returns a LazyCollection. 

Usage:

```php
File::csv('users.csv')->each(function ($item) {
    // Parse line by line
});

// Read entire file into an array
File::csv('users.csv')->all();
```

The native way of doing this looks like this:

```php
$handle = fopen('users.csv', 'r');

if ($handle) {
    while (($item = fgetcsv($handle) !== false) {
        // do something with $item
    }

    fclose($handle);
}
```

I think this would be a nice addition to the framework since we already have the `File::json()` method for json files and CSV is a very common file format. This method makes it easy to work with it efficiently, while also cutting down on boilerplate compared to the native way. The PR also contains a test.