### PR TITLE
[10.x] Add support `Enum` class for enum method in Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1056,9 +1056,7 @@ class Blueprint
     public function enum($column, array|string $allowed)
     {
         if (enum_exists($allowed)) {
-            $allowed = collect($allowed::cases())->map(function ($allow) {
-                return $allow->value;
-            });
+            $allowed = collect($allowed::cases())->map(fn ($allow) => $allow->value);
         }
 
         return $this->addColumn('enum', $column, compact('allowed'));

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1055,7 +1055,7 @@ class Blueprint
      */
     public function enum($column, array|string $allowed)
     {
-        if (enum_exists($allowed)) {
+        if (is_string($allowed) && enum_exists($allowed)) {
             $allowed = collect($allowed::cases())->map(fn ($allow) => $allow->value);
         }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1050,11 +1050,17 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  array|string  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|string $allowed)
     {
+        if (enum_exists($allowed)) {
+            $allowed = collect($allowed::cases())->map(function ($allow) {
+                return $allow->value;
+            });
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 


### PR DESCRIPTION
When you want to use the `enum` method in migration, you must pass allowed values as an array!
But if you want to [Enum](https://www.php.net/manual/en/language.types.enumerations.php) class, you need to make some methods or helpers to use it!!

Now you can use the `enum` method like this:
```php
public function up(): void
{
    Schema::create('products', function (Blueprint $table) {
        $table->id();
        $table->string('title');
        $table->enum('status', \App\ProductStatusEnum::class);
        $table->timestamps();
    });
}
```