### PR TITLE
[10.x] Set morph type for MorphToMany pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -150,6 +150,7 @@ class MorphToMany extends BelongsToMany
     public function newPivot(array $attributes = [], $exists = false)
     {
         $using = $this->using;
+
         $attributes = array_merge([$this->morphType => $this->morphClass], $attributes);
 
         $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -150,6 +150,7 @@ class MorphToMany extends BelongsToMany
     public function newPivot(array $attributes = [], $exists = false)
     {
         $using = $this->using;
+        $attributes = array_merge([$this->morphType => $this->morphClass], $attributes);
 
         $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
                         : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -140,7 +140,7 @@ class EloquentPivotEventsTest extends DatabaseTestCase
             'name' => 'Test Project',
         ]);
 
-        PivotEventsTestModelEquipment::deleting(function($model) use ($project) {
+        PivotEventsTestModelEquipment::deleting(function ($model) use ($project) {
             $this->assertInstanceOf(PivotEventsTestProject::class, $model->equipmentable);
             $this->assertEquals($project->id, $model->equipmentable->id);
         });

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -29,6 +30,18 @@ class EloquentPivotEventsTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
+        });
+
+        Schema::create('equipments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('equipmentables', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('equipmentable');
+            $table->foreignId('equipment_id');
         });
 
         Schema::create('project_users', function (Blueprint $table) {
@@ -120,11 +133,45 @@ class EloquentPivotEventsTest extends DatabaseTestCase
 
         $this->assertSame(['role' => 'Lead Developer'], $_SERVER['pivot_dirty_attributes']);
     }
+
+    public function testCustomMorphPivotClassDetachAttributes()
+    {
+        $project = PivotEventsTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        PivotEventsTestModelEquipment::deleting(function($model) use ($project) {
+            $this->assertInstanceOf(PivotEventsTestProject::class, $model->equipmentable);
+            $this->assertEquals($project->id, $model->equipmentable->id);
+        });
+
+        $equipment = PivotEventsTestEquipment::forceCreate([
+            'name' => 'important-equipment',
+        ]);
+
+        $project->equipments()->save($equipment);
+        $equipment->projects()->sync([]);
+    }
 }
 
 class PivotEventsTestUser extends Model
 {
     public $table = 'users';
+}
+
+class PivotEventsTestEquipment extends Model
+{
+    public $table = 'equipments';
+
+    public function getForeignKey()
+    {
+        return 'equipment_id';
+    }
+
+    public function projects()
+    {
+        return $this->morphedByMany(PivotEventsTestProject::class, 'equipmentable')->using(PivotEventsTestModelEquipment::class);
+    }
 }
 
 class PivotEventsTestProject extends Model
@@ -143,6 +190,26 @@ class PivotEventsTestProject extends Model
         return $this->belongsToMany(PivotEventsTestUser::class, 'project_users', 'project_id', 'user_id')
             ->using(PivotEventsTestCollaborator::class)
             ->wherePivot('role', 'contributor');
+    }
+
+    public function equipments()
+    {
+        return $this->morphToMany(PivotEventsTestEquipment::class, 'equipmentable')->using(PivotEventsTestModelEquipment::class);
+    }
+}
+
+class PivotEventsTestModelEquipment extends MorphPivot
+{
+    public $table = 'equipmentables';
+
+    public function equipment()
+    {
+        return $this->belongsTo(PivotEventsTestEquipment::class);
+    }
+
+    public function equipmentable()
+    {
+        return $this->morphTo();
     }
 }
 


### PR DESCRIPTION
Discussion: https://github.com/laravel/framework/discussions/43760

> If you have a MorphPivot entity with a custom class, when attaching a record, you get the pivot with all the fields loaded on the model, but if you detach it, you only get the IDs of both sides, so in case of morphPivots, you do not get the type/class of the entity so there's information missing and you cannot obtain the morph relation from the pivot because it throws an error.

With this change the morph type will be automatically added to the pivot attributes, so you can query the relation model from a listener for example.