### PR TITLE
[10.x] Fix bug in `Model::incrementOrDecrement()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -967,6 +967,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
+        $extra = array_merge($extra, $this->getDirty());
+
         return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
             $this->syncChanges();
 


### PR DESCRIPTION
This PR fixes a bug with the `increment`/`decrement` methods on the Eloquent `Model`, described in this issue https://github.com/laravel/framework/issues/48350

Currently, Eloquent's `incrementOrDecrement()` method fires an `updating` event, however, if a developer is listening for this event and sets an attribute on the model, this attribute's value is not saved to the database (but Eloquent thinks it is).

For example, imagine we have an observer that sets the `updated_by` attribute of a model to the auth user's id whenever the model is updating. The following code describes this bug.

```php
$product = Product::find(1);

$product->updated_by; // null

$product->increment('stock'); 

$product->wasChanged('updated_by'); // true
$product->updated_by; // 1

$product->refresh();

$product->updated_by; // null ???????????
```

The current solution is to ensure that all dirty attributes are merged with the `$extra` attributes before invoking the Builder's `increment` or `decrement` methods.
