### PR TITLE
[10.x] Allow older jobs to be faked

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -387,7 +387,7 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         return $this->jobsToFake->contains(
-            fn ($jobToFake) => $job instanceof ((string) $jobToFake)
+            fn ($jobToFake) => $job instanceof ((string) $jobToFake) || $job === (string) $jobToFake
         );
     }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -392,6 +392,19 @@ class SupportTestingQueueFakeTest extends TestCase
             fn ($job) => $job->value === 'hello-serialized-unserialized'
         );
     }
+
+    public function testItCanFakePushedJobsWithClassAndPayload()
+    {
+        $fake = new QueueFake(new Application, ['JobStub']);
+
+        $this->assertTrue($fake->shouldFakeJob('JobStub'));
+
+        $fake->push('JobStub', ['job' => 'payload']);
+
+        $fake->assertPushed('JobStub');
+        $fake->assertPushed('JobStub', 1);
+        $fake->assertPushed('JobStub', fn ($job, $queue, $payload) => $payload === ['job' => 'payload']);
+    }
 }
 
 class JobStub


### PR DESCRIPTION
Older style queued job pushing, where you are referencing the job class and passing the payload as an array, is not currently supported. This fixes that.

```php
Queue::fake([MyJob::class]);

Queue::push(MyJob::class, ['job' => 'payload']);

Queue::assertPushed(MyJob::class);
```