### PR TITLE
`lazyById` doesn't check availability of id (alias) column in database response and silently ends up with endless loop. `chunkById` does.

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -281,6 +281,10 @@ trait BuildsQueries
                 }
 
                 $lastId = $results->last()->{$alias};
+
+                if ($lastId === null) {
+                    throw new RuntimeException("The lazyById operation was aborted because the [{$alias}] column is not present in the query result.");
+                }
             }
         });
     }


### PR DESCRIPTION
`lazyById` doesn't check availability of id (alias) column in database response and silently ends up with endless loop if DB query has more than 1 page of results. It happens if we don't select alias column.

If we use this code (we don't select `id` column):
```php
// select without id
$users = User::select("name")->lazyById(10);

foreach($users as $user) {
    // endless loop (generator) because lazyById will always return elements from the first page
}
```

So `foreach` will fall into endless loop and never ends if there are more than 1 page of results.

You can say that it's programmer's responsibility to include `id` in select but `chunkById` has this check and `lazyById` documentation doesn't say anything about `id` is required.

In the `chunkById` we have this code which verifies that response has `id` column.

```php
$lastId = data_get($results->last(), $alias);

if ($lastId === null) {
    throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");
}
```

It seems logical to me to add such a check to `lazyById` as well.

Initial issue: https://github.com/laravel/framework/issues/48401