### PR TITLE
[10.x] Guess table name correctly in migrations if column's name have ('to', 'from' and/or 'in') terms

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,8 +10,8 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
-        '/_(to|from|in)_(\w+)_table$/',
-        '/_(to|from|in)_(\w+)$/',
+        '/_(to|from|in)_(?!.*?(\_to\_|\_in\_|\_from\_))(\w+)_table$/',
+        '/_(to|from|in)_(?!.*?(\_to\_|\_in\_|\_from\_))(\w+)$/',
     ];
 
     /**
@@ -30,7 +30,7 @@ class TableGuesser
 
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[2], $create = false];
+                return [$matches[3], $create = false];
             }
         }
     }

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,8 +10,8 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
-        '/_(to|from|in)_(?!.*?(\_to\_|\_in\_|\_from\_))(\w+)_table$/',
-        '/_(to|from|in)_(?!.*?(\_to\_|\_in\_|\_from\_))(\w+)$/',
+        '/.+_(to|from|in)_(\w+)_table$/',
+        '/.+_(to|from|in)_(\w+)$/',
     ];
 
     /**
@@ -30,7 +30,7 @@ class TableGuesser
 
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[3], $create = false];
+                return [$matches[2], $create = false];
             }
         }
     }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -17,6 +17,10 @@ class TableGuesserTest extends TestCase
         $this->assertSame('users', $table);
         $this->assertFalse($create);
 
+        [$table, $create] = TableGuesser::guess('add_is_sent_to_crm_column_to_users_table');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
         [$table, $create] = TableGuesser::guess('change_status_column_in_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
@@ -33,6 +37,10 @@ class TableGuesserTest extends TestCase
         $this->assertTrue($create);
 
         [$table, $create] = TableGuesser::guess('add_status_column_to_users');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('add_is_sent_to_crm_column_column_to_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR improves the table guesser, to work correctly if the user trying make migration that add/update/delete column have one of the terms ("to", "from" or/and "in")

For example, if the user executed the command 
```
php artisan make:migration add_is_sent_to_3rd_party_service_column_to_users_table
```  
The table name guesser before this update will return "3rd_party_service_column_to_users" as a table name, but after the update, it returns "users"