### PR TITLE
[10.x] Current page items always show on the first page

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -69,7 +69,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 
         $this->hasMore = $this->items->count() > $this->perPage;
 
-        $this->items = $this->items->slice(0, $this->perPage);
+        $this->items = $this->items->slice(($this->currentPage - 1) * $this->perPage, $this->perPage);
     }
 
     /**


### PR DESCRIPTION
When paging from the sample data array with Paginator class, $items variable always has data from the first page, without changing according to the current page number.