### PR TITLE
[10.x] Add DatabaseChannel::requireDatabaseType() method

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -2,11 +2,19 @@
 
 namespace Illuminate\Notifications\Channels;
 
+use Illuminate\Notifications\Exceptions\DatabaseTypeNotificationMissingException;
 use Illuminate\Notifications\Notification;
 use RuntimeException;
 
 class DatabaseChannel
 {
+    /**
+     * Prevents database notification without a database type.
+     *
+     * @var bool
+     */
+    protected static $requireDatabaseType = false;
+
     /**
      * Send the given notification.
      *
@@ -32,12 +40,26 @@ class DatabaseChannel
     {
         return [
             'id' => $notification->id,
-            'type' => method_exists($notification, 'databaseType')
-                        ? $notification->databaseType($notifiable)
-                        : get_class($notification),
+            'type' => $this->getDatabaseType($notifiable, $notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];
+    }
+
+    /**
+     * Return the database type.
+     */
+    protected function getDatabaseType(mixed $notifiable, Notification $notification): string
+    {
+        if (method_exists($notification, 'databaseType')) {
+            return $notification->databaseType($notifiable);
+        }
+
+        if (static::requiresDatabaseType()) {
+            throw new DatabaseTypeNotificationMissingException($notification);
+        }
+
+        return get_class($notification);
     }
 
     /**
@@ -61,5 +83,21 @@ class DatabaseChannel
         }
 
         throw new RuntimeException('Notification is missing toDatabase / toArray method.');
+    }
+
+    /**
+     * Prevent database notification from being used without database type.
+     */
+    public static function requireDatabaseType(bool $requireDatabaseType = true): void
+    {
+        static::$requireDatabaseType = $requireDatabaseType;
+    }
+
+    /**
+     * Determine if database notification require database type.
+     */
+    public static function requiresDatabaseType(): bool
+    {
+        return static::$requireDatabaseType;
     }
 }

--- a/src/Illuminate/Notifications/Exceptions/DatabaseTypeNotificationMissingException.php
+++ b/src/Illuminate/Notifications/Exceptions/DatabaseTypeNotificationMissingException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Notifications\Exceptions;
+
+use Illuminate\Notifications\Notification;
+
+class DatabaseTypeNotificationMissingException extends \RuntimeException
+{
+    /**
+     * The name of the affected Notification.
+     */
+    public Notification $notification;
+
+    /**
+     * Create a new exception instance.
+     */
+    public function __construct(Notification $notification)
+    {
+        $class = get_class($notification);
+
+        parent::__construct("No database type defined for notification [{$class}].");
+
+        $this->notification = $notification;
+    }
+}

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Notifications;
 
 use Illuminate\Notifications\Channels\DatabaseChannel;
+use Illuminate\Notifications\Exceptions\DatabaseTypeNotificationMissingException;
 use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Notification;
 use Mockery as m;
@@ -65,6 +66,31 @@ class NotificationDatabaseChannelTest extends TestCase
         ]);
 
         $channel = new ExtendedDatabaseChannel;
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testRequireDatabaseTypeThrowsAnExceptionWhenEnabled()
+    {
+        DatabaseChannel::requireDatabaseType();
+        $notification = new NotificationDatabaseChannelTestNotification;
+        $notifiable = m::mock();
+
+        $notifiable->shouldReceive('routeNotificationFor->create');
+        $this->expectException(DatabaseTypeNotificationMissingException::class);
+
+        $channel = new DatabaseChannel;
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testRequireDatabaseTypeDoesNotThrowAnExceptionWhenDisabled()
+    {
+        DatabaseChannel::requireDatabaseType(false);
+        $notification = new NotificationDatabaseChannelTestNotification;
+        $notifiable = m::mock();
+
+        $notifiable->shouldReceive('routeNotificationFor->create');
+
+        $channel = new DatabaseChannel;
         $channel->send($notifiable, $notification);
     }
 }


### PR DESCRIPTION
This PR is inspired by the `Relation::enforceMorphMap` feature. It allows to require the definition of a type for database notification.

**Why**
To ensure consistency for the notification type saved in the database, it may be useful to require the existence of the `databaseType` method on notifications which use the database channel.
Indeed, by default when the notification does not have the `databaseType` method, the type saved in database is the notification class name. If a notification class name changes, the previously database notifications type saved will not be updated, leading to inconsistency.

**Solution**
Adding a `DatabaseChannel::requireDatabaseType()` allows to require the usage of a `databaseType` method on all database notifications.
When sending a notification via the database channel, if the notification do not have a `databaseType` method, an `DatabaseTypeNotificationMissingException` exception is thrown.

```php
// Enable database type requirement
DatabaseChannel::requireDatabaseType()
DatabaseChannel::requireDatabaseType(true)

// Disable database type requirement
DatabaseChannel::requireDatabaseType(false)
``` 

You may call the `requireDatabaseType` method in the boot method of your `App\Providers\AppServiceProvider` class or create a separate service provider if you wish.

There is no breaking changes as  the database type requirement is disabled by default.
