### PR TITLE
[10.x] Updated integer columns to timestamp columns in job_batches table

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -104,7 +104,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             'failed_jobs' => 0,
             'failed_job_ids' => '[]',
             'options' => $this->serialize($batch->options),
-            'created_at' => time(),
+            'created_at' => CarbonImmutable::now(),
             'cancelled_at' => null,
             'finished_at' => null,
         ]);
@@ -203,7 +203,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     public function markAsFinished(string $batchId)
     {
         $this->connection->table($this->table)->where('id', $batchId)->update([
-            'finished_at' => time(),
+            'finished_at' => CarbonImmutable::now(),
         ]);
     }
 
@@ -216,8 +216,8 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     public function cancel(string $batchId)
     {
         $this->connection->table($this->table)->where('id', $batchId)->update([
-            'cancelled_at' => time(),
-            'finished_at' => time(),
+            'cancelled_at' => CarbonImmutable::now(),
+            'finished_at' => CarbonImmutable::now(),
         ]);
     }
 

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -19,9 +19,9 @@ return new class extends Migration
             $table->integer('failed_jobs');
             $table->longText('failed_job_ids');
             $table->mediumText('options')->nullable();
-            $table->integer('cancelled_at')->nullable();
-            $table->integer('created_at');
-            $table->integer('finished_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamp('created_at');
+            $table->timestamp('finished_at')->nullable();
         });
     }
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -59,9 +59,9 @@ class BusBatchTest extends TestCase
             $table->integer('failed_jobs');
             $table->text('failed_job_ids');
             $table->text('options')->nullable();
-            $table->integer('cancelled_at')->nullable();
-            $table->integer('created_at');
-            $table->integer('finished_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamp('created_at');
+            $table->timestamp('finished_at')->nullable();
         });
     }
 
@@ -432,7 +432,7 @@ class BusBatchTest extends TestCase
                 'failed_jobs' => '',
                 'failed_job_ids' => '[]',
                 'options' => $serialize,
-                'created_at' => now()->timestamp,
+                'created_at' => now(),
                 'cancelled_at' => null,
                 'finished_at' => null,
             ]);


### PR DESCRIPTION
Currently, when creating `job_batches` table (e. g. using the command `php artisan queue:batches-table`) it generates integer (timestamp) columns for `created_at`, `cancelled_at` as well as `finished_at`. Since this will occur errors in the future, i thought it's a good way to update them to `timestamp` data type.

I've used the fork in my own project - everything seems to work fine during the tests I did. It's storing datetime instead of timestamp integers now.

Since this is my first pull request directly to laravel/framework, I hope I did everything right.
Can't wait for your feedback!