### PR TITLE
feat: `Manager` contract for `ChannelManager`

### DIFF
--- a/src/Illuminate/Contracts/Notifications/Manager.php
+++ b/src/Illuminate/Contracts/Notifications/Manager.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications;
+
+interface Manager extends Factory, Dispatcher
+{
+    /**
+     * Set the locale of notifications.
+     *
+     * @param  string  $locale
+     * @return $this
+     */
+    public function locale($locale);
+
+    /**
+     * Set the default channel driver name.
+     *
+     * @param  string  $channel
+     * @return void
+     */
+    public function deliverVia($channel);
+
+    /**
+     * Get the default channel driver name.
+     *
+     * @return string
+     */
+    public function deliversVia();
+
+    /**
+     * Get the default channel driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver();
+}

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -4,12 +4,11 @@ namespace Illuminate\Notifications;
 
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Notifications\Dispatcher as DispatcherContract;
-use Illuminate\Contracts\Notifications\Factory as FactoryContract;
+use Illuminate\Contracts\Notifications\Manager as ChannelManagerContract;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
 
-class ChannelManager extends Manager implements DispatcherContract, FactoryContract
+class ChannelManager extends Manager implements ChannelManagerContract
 {
     /**
      * The default channel used to deliver messages.

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Notifications;
 
 use Illuminate\Contracts\Notifications\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Notifications\Factory as FactoryContract;
+use Illuminate\Contracts\Notifications\Manager;
 use Illuminate\Support\ServiceProvider;
 
 class NotificationServiceProvider extends ServiceProvider
@@ -32,6 +33,10 @@ class NotificationServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(ChannelManager::class, fn ($app) => new ChannelManager($app));
+
+        $this->app->alias(
+            ChannelManager::class, Manager::class
+        );
 
         $this->app->alias(
             ChannelManager::class, DispatcherContract::class

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
+use Illuminate\Contracts\Notifications\Manager as ChannelManager;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Collection;
@@ -14,7 +15,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class NotificationFake implements Fake, NotificationDispatcher, NotificationFactory
+class NotificationFake implements Fake, ChannelManager
 {
     use Macroable, ReflectsClosures;
 

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -4,8 +4,6 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
 use Exception;
-use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
-use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Notifications\Manager as ChannelManager;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Notifications\AnonymousNotifiable;
@@ -25,6 +23,13 @@ class NotificationFake implements Fake, ChannelManager
      * @var array
      */
     protected $notifications = [];
+
+    /**
+     * The default channel used to deliver messages.
+     *
+     * @var string
+     */
+    protected $defaultChannel = 'mail';
 
     /**
      * Locale used when sending notifications.
@@ -358,5 +363,36 @@ class NotificationFake implements Fake, ChannelManager
     public function sentNotifications()
     {
         return $this->notifications;
+    }
+
+    /**
+     * Get the default channel driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return $this->defaultChannel;
+    }
+
+    /**
+     * Get the default channel driver name.
+     *
+     * @return string
+     */
+    public function deliversVia()
+    {
+        return $this->getDefaultDriver();
+    }
+
+    /**
+     * Set the default channel driver name.
+     *
+     * @param  string  $channel
+     * @return void
+     */
+    public function deliverVia($channel)
+    {
+        $this->defaultChannel = $channel;
     }
 }


### PR DESCRIPTION
This PR introduces common interface for NotificationManager which will allow to inject ChannelManager using this contract  and call `locale()`. 

More details https://github.com/laravel/framework/discussions/48450
