### PR TITLE
[10.x] Fix key type in @return tag of EnumeratesValues::ensure() docblock

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -318,7 +318,7 @@ trait EnumeratesValues
      * @template TEnsureOfType
      *
      * @param  class-string<TEnsureOfType>  $type
-     * @return static<mixed, TEnsureOfType>
+     * @return static<TKey, TEnsureOfType>
      *
      * @throws \UnexpectedValueException
      */


### PR DESCRIPTION
Relates to [#48443](https://github.com/laravel/framework/issues/48443)