### PR TITLE
[10.x] Add dedicated ensure methods for primitive types in EnumeratesValues

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -336,6 +336,96 @@ trait EnumeratesValues
     }
 
     /**
+     * Ensure that every item in the collection is a boolean.
+     *
+     * @return static<TKey, bool>
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function ensureBoolean()
+    {
+        return $this->each(function ($item) {
+            if (! is_bool($item)) {
+                throw new UnexpectedValueException(
+                    sprintf("Collection should only include 'bool' items, but '%s' found.", get_debug_type($item))
+                );
+            }
+        });
+    }
+
+    /**
+     * Ensure that every item in the collection is a float.
+     *
+     * @return static<TKey, float>
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function ensureFloat()
+    {
+        return $this->each(function ($item) {
+            if (! is_float($item)) {
+                throw new UnexpectedValueException(
+                    sprintf("Collection should only include 'float' items, but '%s' found.", get_debug_type($item))
+                );
+            }
+        });
+    }
+
+    /**
+     * Ensure that every item in the collection is an integer.
+     *
+     * @return static<TKey, int>
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function ensureInteger()
+    {
+        return $this->each(function ($item) {
+            if (! is_int($item)) {
+                throw new UnexpectedValueException(
+                    sprintf("Collection should only include 'int' items, but '%s' found.", get_debug_type($item))
+                );
+            }
+        });
+    }
+
+    /**
+     * Ensure that every item in the collection is a string.
+     *
+     * @return static<TKey, string>
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function ensureString()
+    {
+        return $this->each(function ($item) {
+            if (! is_string($item)) {
+                throw new UnexpectedValueException(
+                    sprintf("Collection should only include 'string' items, but '%s' found.", get_debug_type($item))
+                );
+            }
+        });
+    }
+
+    /**
+     * Ensure that every item in the collection is an array.
+     *
+     * @return static<TKey, array<array-key, mixed>>
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function ensureArray()
+    {
+        return $this->each(function ($item) {
+            if (! is_array($item)) {
+                throw new UnexpectedValueException(
+                    sprintf("Collection should only include 'array' items, but '%s' found.", get_debug_type($item))
+                );
+            }
+        });
+    }
+
+    /**
      * Determine if the collection is not empty.
      *
      * @return bool

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5635,6 +5635,71 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testEnsureBoolean($collection)
+    {
+        $data = $collection::make([true, false]);
+        $data->ensureBoolean();
+
+        $data = $collection::make([true, false, 1]);
+        $this->expectException(UnexpectedValueException::class);
+        $data->ensureBoolean();
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEnsureFloat($collection)
+    {
+        $data = $collection::make([1.23, 0.5]);
+        $data->ensureFloat();
+
+        $data = $collection::make([1.23, 0.5, 78]);
+        $this->expectException(UnexpectedValueException::class);
+        $data->ensureFloat();
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEnsureInteger($collection)
+    {
+        $data = $collection::make([1, 23]);
+        $data->ensureInteger();
+
+        $data = $collection::make([1, 23, 7.8]);
+        $this->expectException(UnexpectedValueException::class);
+        $data->ensureInteger();
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEnsureString($collection)
+    {
+        $data = $collection::make(['foo', 'bar']);
+        $data->ensureString();
+
+        $data = $collection::make(['foo', 'bar', 123]);
+        $this->expectException(UnexpectedValueException::class);
+        $data->ensureString();
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEnsureArray($collection)
+    {
+        $data = $collection::make([[1], ['foo' => 'bar']]);
+        $data->ensureArray();
+
+        $data = $collection::make([[1], ['foo' => 'bar'], new stdClass]);
+        $this->expectException(UnexpectedValueException::class);
+        $data->ensureArray();
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testPercentageWithFlatCollection($collection)
     {
         $collection = new $collection([1, 1, 2, 2, 2, 3]);


### PR DESCRIPTION
Relates to #48443 

## Summary

This...

> Primitive types such as string, int, float, bool, and array may also be specified:
>
> ```php
> return $collection->ensure('int');
> ```
https://laravel.com/docs/10.x/collections#method-ensure

...in combination with this...

https://github.com/laravel/framework/blob/ca546893cb98a633daf8be6fdd286faa05c9044d/src/Illuminate/Collections/Traits/EnumeratesValues.php#L318-L321

...is incorrect and impossible (although it functionally works in practice).

## Checklist

- [ ] Is this addition acceptable?
- [ ] Should method names use short or long type names (`ensureBool` vs `ensureBoolean`)?
- [ ] Should method names be singular of plural (`ensureInteger` vs `ensureIntegers`)?

> If you notice improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem.

:crossed_fingers: 