### PR TITLE
[10.] Add dynamic property access to Support\Collection

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5673,6 +5673,33 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    public function testDynamicItemAccess()
+    {
+        $collection = new Collection(['name' => 'foo']);
+
+        $this->assertSame('foo', $collection->name);
+    }
+
+    public function testDynamicAccessThrowsExceptionForMissingItem()
+    {
+        $this->expectException(Exception::class);
+
+        $collection = new Collection(['baz' => 'foo']);
+
+        $collection->name;
+    }
+
+    public function testDynamicItemSetting()
+    {
+        $collection = new Collection(['name' => 'foo']);
+
+        $collection->name = 'baz';
+        $collection->bar = 'buzz';
+
+        $this->assertSame('baz', $collection->get('name'));
+        $this->assertSame('buzz', $collection->get('bar'));
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

This PR allows dynamic property access to `Support\Collection` (through `__get`/`__set`). Collections already allow array access, however, some folks (myself included) prefer object access over array access and this allows the end user to use what they prefer.

```php
// array access
$c = new Collection(['name' => 'taylor']);
$c['name'];
$c['name'] = 'dayle';

// object access
$c = new Collection(['name' => 'taylor']);
$c->name;
$c->name = 'dayle';
```

Thanks!


