### PR TITLE
[10.x] Add str()->take($limit) and Str::take($string, $limit)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1387,6 +1387,22 @@ class Str
     }
 
     /**
+     * Take the first or last {$limit} characters of a string.
+     *
+     * @param  string  $string
+     * @param  int  $limit
+     * @return string
+     */
+    public static function take($string, int $limit): string
+    {
+        if ($limit < 0) {
+            return static::substr($string, $limit);
+        }
+
+        return static::substr($string, 0, $limit);
+    }
+
+    /**
      * Make a string's first character lowercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -903,7 +903,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Take the first or last {$limit} characters.
      *
-     * @param  int $limit
+     * @param  int  $limit
      * @return static
      */
     public function take(int $limit)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -901,6 +901,21 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Take the first or last {$limit} characters.
+     *
+     * @param int $limit
+     * @return static
+     */
+    public function take(int $limit)
+    {
+        if ($limit < 0) {
+            return $this->substr($limit);
+        }
+
+        return $this->substr(0, $limit);
+    }
+
+    /**
      * Trim the string of the given characters.
      *
      * @param  string  $characters

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -903,7 +903,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Take the first or last {$limit} characters.
      *
-     * @param int $limit
+     * @param  int $limit
      * @return static
      */
     public function take(int $limit)

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -847,6 +847,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
     }
 
+    public function testTake()
+    {
+        $this->assertSame('ab', Str::take('abcdef', 2));
+        $this->assertSame('ef', Str::take('abcdef', -2));
+    }
+
     public function testLcfirst()
     {
         $this->assertSame('laravel', Str::lcfirst('Laravel'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -123,6 +123,12 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($stringable->matchAll('/nothing/')->isEmpty());
     }
 
+    public function testTake()
+    {
+        $this->assertSame('ab', (string) $this->stringable('abcdef')->take(2));
+        $this->assertSame('ef', (string) $this->stringable('abcdef')->take(-2));
+    }
+
     public function testTest()
     {
         $stringable = $this->stringable('foo bar');


### PR DESCRIPTION
Take the first or last {$limit} characters.

## Before
```
str('abcdef')->substr(0, 2) // 'ab'
Str::substr('abcdef', 0, 2); // 'ab'
```

## After
```
str('abcdef')->take(2) // 'ab'
Str::take('abcdef', 2); // 'ab'
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
