### PR TITLE
[10.x] Set prompt interactivity mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "egulias/email-validator": "^3.2.1|^4.0",
         "fruitcake/php-cors": "^1.2",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.1",
+        "laravel/prompts": "^0.2",
         "laravel/serializable-closure": "^1.3",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "egulias/email-validator": "^3.2.1|^4.0",
         "fruitcake/php-cors": "^1.2",
         "guzzlehttp/uri-template": "^1.0",
-        "laravel/prompts": "^0.2",
+        "laravel/prompts": "^0.1.9",
         "laravel/serializable-closure": "^1.3",
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -24,7 +24,9 @@ trait ConfiguresPrompts
     {
         Prompt::setOutput($this->output);
 
-        Prompt::fallbackWhen(! $input->isInteractive() || windows_os() || $this->laravel->runningUnitTests());
+        Prompt::interactive(($input->isInteractive() && stream_isatty(STDIN)) || $this->laravel->runningUnitTests());
+
+        Prompt::fallbackWhen(windows_os() || $this->laravel->runningUnitTests());
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -19,7 +19,7 @@
         "illuminate/collections": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
-        "laravel/prompts": "^0.2",
+        "laravel/prompts": "^0.1.9",
         "illuminate/support": "^10.0",
         "illuminate/view": "^10.0",
         "nunomaduro/termwind": "^1.13",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -19,7 +19,7 @@
         "illuminate/collections": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
-        "laravel/prompts": "^0.1",
+        "laravel/prompts": "^0.2",
         "illuminate/support": "^10.0",
         "illuminate/view": "^10.0",
         "nunomaduro/termwind": "^1.13",

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\CommandMutex;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Foundation\Application;
 use Mockery as m;

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\CommandMutex;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Isolatable;
+use Illuminate\Foundation\Application;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -37,9 +38,9 @@ class CommandMutexTest extends TestCase
 
         $this->commandMutex = m::mock(CommandMutex::class);
 
-        $container = Container::getInstance();
-        $container->instance(CommandMutex::class, $this->commandMutex);
-        $this->command->setLaravel($container);
+        $app = new Application;
+        $app->instance(CommandMutex::class, $this->commandMutex);
+        $this->command->setLaravel($app);
     }
 
     public function testCanRunIsolatedCommandIfNotBlocked()

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -81,12 +81,14 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputPromptsWhenRequiredArgumentIsMissing()
     {
         $app = new Application(
-            $app = new \Illuminate\Foundation\Application(__DIR__),
+            $laravel = new \Illuminate\Foundation\Application(__DIR__),
             $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
             'testing'
         );
 
         $app->addCommands([$command = new FakeCommandWithInputPrompting()]);
+
+        $command->setLaravel($laravel);
 
         $statusCode = $app->call('fake-command-for-testing');
 

--- a/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
@@ -15,7 +15,7 @@ class FakeCommandWithInputPrompting extends Command implements PromptsForMissing
 
     public $prompted = false;
 
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function configurePrompts(InputInterface $input)
     {
         Prompt::fallbackWhen(true);
         TextPrompt::fallbackUsing(function () {
@@ -23,8 +23,6 @@ class FakeCommandWithInputPrompting extends Command implements PromptsForMissing
 
             return 'foo';
         });
-
-        parent::interact($input, $output);
     }
 
     public function handle(): int

--- a/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
@@ -17,7 +17,9 @@ class FakeCommandWithInputPrompting extends Command implements PromptsForMissing
 
     protected function configurePrompts(InputInterface $input)
     {
+        Prompt::interactive(true);
         Prompt::fallbackWhen(true);
+
         TextPrompt::fallbackUsing(function () {
             $this->prompted = true;
 

--- a/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithInputPrompting.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\TextPrompt;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class FakeCommandWithInputPrompting extends Command implements PromptsForMissingInput
 {


### PR DESCRIPTION
This PR adds support for Prompts in non-interactive mode, introduced in https://github.com/laravel/prompts/pull/73.

Previously, Laravel would rely on the Prompts fallback behaviour (using Symfony) to handle commands that use the `-n` argument to make them non-interactive, which is unrelated to whether `STDIN` is a tty. This did not handle scenarios like CI, scheduled tasks, queued jobs, etc.

A simpler solution would have been to enable the fallbacks when `STDIN` is not a TTY. However, I found Symfony's non-interactive behaviour a little unexpected. This feature also unlocks the ability for Prompts to provide default fallbacks (https://github.com/laravel/prompts/pull/57) which removes the need for specifying them in the Laravel installer and other places where Laravel doesn't provide defaults.