### PR TITLE
[10.x] Sync RouteCollection name list when modifying a route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -876,6 +876,10 @@ class Route
     {
         $this->action['as'] = isset($this->action['as']) ? $this->action['as'].$name : $name;
 
+        if (! is_null($this->router)) {
+            $this->router->getRoutes()->addToNameList($this);
+        }
+
         return $this;
     }
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -79,9 +79,7 @@ class RouteCollection extends AbstractRouteCollection
         // If the route has a name, we will add it to the name look-up table so that we
         // will quickly be able to find any route associate with a name and not have
         // to iterate through every route every time we need to perform a look-up.
-        if ($name = $route->getName()) {
-            $this->nameList[$name] = $route;
-        }
+        $this->addToNameList($route);
 
         // When the route is routing to a controller we will also store the action that
         // is used by the route. This will let us reverse route to controllers while
@@ -90,6 +88,19 @@ class RouteCollection extends AbstractRouteCollection
 
         if (isset($action['controller'])) {
             $this->addToActionList($action, $route);
+        }
+    }
+
+    /**
+     * Add a route to the name list.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     */
+    public function addToNameList(Route $route): void
+    {
+        if ($name = $route->getName()) {
+            $this->nameList[$name] = $route;
         }
     }
 
@@ -117,9 +128,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
-            if ($route->getName()) {
-                $this->nameList[$route->getName()] = $route;
-            }
+            $this->addToNameList($route);
         }
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1536,6 +1536,17 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('foos/{foo}/bars/{bar}', $routes[3]->uri());
     }
 
+    public function testSingleRouteNaming()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo', fn () => null)->name('foo.index');
+        $router->name('foo.show')->get('foo/show', fn () => null);
+
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.index'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.show'));
+    }
+
     public function testResourceRouteNaming()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
When registering a single route (in the convinient way), the route name list is not being updated until the `RouteServiceProvider` booted its stuff, including the call of the `refreshNameLookups` method on the `RouteCollection`.

Related issues: #47451, #44077, #46834

-------

Usually this is not a problem, but in some cases this can cause issues. For example:

```php
// service providers (booted in this order)

AppServiceProvider::class,
PackageOneServiceProvider::class, // load some routes
PackageTwoServiceProvider::class, // try to access to the already registered routes – does not work
RouteServiceProvider::class, // the refreshNameLookups called
```

------

By syncing the route collection's name list when (re)naming any of its routes could solve this. Also, I think there is no need to call the `refreshNameLookups` method in the `RouteServiceProvider`.