### PR TITLE
[10.x] Add "getArray" method

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -507,4 +507,15 @@ trait BuildsQueries
 
         return $this;
     }
+
+    /**
+     * Execute the query and get the array.
+     *
+     * @param  array|string  $columns
+     * @return array
+     */
+    public function getArray($columns = ['*'])
+    {
+        return $this->get($columns)->toArray();
+    }
 }


### PR DESCRIPTION
I was thinking it would be practical to have this method to return the eloquent callback directly as an array without having to do ->get()->toArray(), thank you!

kind regards
Borja