### PR TITLE
[11.x] Add Support/Str method for remove all non-numeric characters from a string or an array of strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -581,7 +581,7 @@ class Str
     /**
      * Remove all non-numeric characters from a string or an array of strings.
      *
-     * @param string|string[]  $value
+     * @param  string|string[]  $value
      * @return string|string[]
      */
     public static function numbers(string|array $value): string|array

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -579,6 +579,17 @@ class Str
     }
 
     /**
+     * Remove all non-numeric characters from a string or an array of strings.
+     *
+     * @param string|string[] $value
+     * @return string|string[]
+     */
+    public static function numbers(string|array $value): string|array
+    {
+        return preg_replace('/[^0-9]/', '', $value);
+    }
+
+    /**
      * Convert the given string to lower-case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -581,7 +581,7 @@ class Str
     /**
      * Remove all non-numeric characters from a string or an array of strings.
      *
-     * @param string|string[] $value
+     * @param string|string[]  $value
      * @return string|string[]
      */
     public static function numbers(string|array $value): string|array

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -501,6 +501,17 @@ class SupportStrTest extends TestCase
         $this->assertEquals(11, Str::length('foo bar baz', 'UTF-8'));
     }
 
+    public function testNumbers()
+    {
+        $this->assertSame('5551234567', Str::numbers('(555) 123-4567'));
+        $this->assertSame('443', Str::numbers('L4r4v3l!'));
+        $this->assertSame('', Str::numbers('Laravel!'));
+
+        $arrayValue = ['(555) 123-4567', 'L4r4v3l', 'Laravel!'];
+        $arrayExpected = ['5551234567', '443', ''];
+        $this->assertSame($arrayExpected, Str::numbers($arrayValue));
+    }
+
     public function testRandom()
     {
         $this->assertEquals(16, strlen(Str::random()));


### PR DESCRIPTION
## Summary
This commit introduces a new method in the Support/Str namespace that allows the removal of all non-numeric characters from a string or array of strings. The numbers method accepts either a string or an array of strings as input and returns the value with all non-numeric characters removed.

This functionality is essential in cases where it is necessary to extract numerical information, such as telephone numbers, credit card codes, identification codes, among others, from a variety of strings with different formats.

This way, the developer saves time in creating a regex to eliminate non-number characters. Furthermore, including this method in the Support/Str namespace enriches the library.

## Examples

```php
$phoneNumber = "+1 (555) 123-4567";
$numbersOnly = Str::numbers($phoneNumber);
// $numbersOnly now contains "15551234567"

$creditCardNumber = "1234-5678-9012-3456";
$numbersOnlyCard = Str::numbers($creditCardNumber);
// $numbersOnlyCard now contains "1234567890123456"


$phoneNumbers = ["+1 (555) 123-4567", "+44 1234 567890", "+33 6 12 34 56 78"];
$numbersOnly = Str::numbers($phoneNumbers);
// $numbersOnly now contains ["15551234567", "441234567890", "361234567878"]
```