### PR TITLE
[10.x] Fix test name for stringable position

### DIFF
--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1024,7 +1024,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
 
-    public function testSubstrPos()
+    public function testPosition()
     {
         $this->assertSame(7, $this->stringable('Hello, World!')->position('W'));
         $this->assertSame(10, $this->stringable('This is a test string.')->position('test'));


### PR DESCRIPTION
This PR fixes the test name to match the method name. The method name was changed during review of #48421 from `substrPos()` to `position()` and the test name was overlooked.
