### PR TITLE
[10.x] Allow for validation rule extensions in validator

### DIFF
--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -181,6 +181,8 @@ class TestValidationRule implements ValidationRule
 
     public function validate($attribute, $value, $fail): void
     {
-        if ($this->param !== $value) $fail('');
+        if ($this->param !== $value) {
+            $fail('');
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces support for class-based extensions, which implement the `ValidationRule` interface, into the validator.

In Laravel, you can use the `Validator::extend` method to register custom validation rules. With the release of version 10, a new interface was introduced to define such rules. Since the aforementioned method accepts a class-string, it feels quite intuitive to do the following: 

```php
use Illuminate\Contracts\Validation\ValidationRule;

class Uppercase implements ValidationRule
{
    public function validate(string $attribute, mixed $value, Closure $fail): void
    {
        //
    }
}

...

use Illuminate\Support\Facades\Validator;

Validator::extend('uppercase', Uppercase::class);
```

This fails however, since the expected declaration of the `validate()` method does not match with the new interface. This irks me a bit, since there’s now multiple ways to define a custom rule, but you still have to adhere to the old way to extend the validator. It does not help that it has only been documented up to version 7.x.

I propose a change to the validator, so you may pass a class-string that implements the `ValidationRule` interface.

A current workaround would look something like this:

```php
Validator::extend('uppercase', function ($attribute, $value, $parameters, $validator) {
    $rule = InvokableValidationRule::make(new Uppercase(...$parameters));

    $rule->setValidator($validator);

    return $rule->passes($attribute, $value);
});
```