### PR TITLE
[10.x] Enhancement of whereIn Method to Support Enums

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -65,11 +65,15 @@ trait CreatesRegularExpressionRouteConstraints
      * Specify that the given route parameters must be one of the given values.
      *
      * @param  array|string  $parameters
-     * @param  array  $values
+     * @param  array|string  $values
      * @return $this
      */
-    public function whereIn($parameters, array $values)
+    public function whereIn($parameters, $values)
     {
+        if (enum_exists($values)) {
+            $values = array_column($values::cases(), 'value');
+        }
+
         return $this->assignExpressionToParameters($parameters, implode('|', $values));
     }
 

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -70,7 +70,7 @@ trait CreatesRegularExpressionRouteConstraints
      */
     public function whereIn($parameters, $values)
     {
-        if (enum_exists($values)) {
+        if (is_string($values) && enum_exists($values)) {
             $values = array_column($values::cases(), 'value');
         }
 


### PR DESCRIPTION
### 🛠 Enhancement of `whereIn` Method to Support Enums

#### 🚀 Changes:
- Adjusted the `whereIn` method to accept either `array` or `string` types for the `$values` parameter, enhancing the route parameter restrictions functionality.
- When `$values` is an Enum, the method will automatically extract the corresponding values.

#### 🌟 Benefits:
- Enables a more expressive and robust way to define route parameter constraints using Enums.
- Maintains compatibility with the existing functionality of accepting arrays of strings.

#### 📖 Usage Example:
```php
Route::get('/route/{parameter}', [Controller::class, 'method'])
    ->whereIn('parameter', SomeEnum::class);
```

#### 📄 Updated Code:
```php
/**
 * Specify that the given route parameters must be one of the given values.
 *
 * @param  array|string  $parameters
 * @param  array|string  $values
 * @return $this
 */
public function whereIn($parameters, $values)
{
    if(is_string($values) && enum_exists($values)) {
        $values = array_column($values::cases(), 'value');
    }

    return $this->assignExpressionToParameters($parameters, implode('|', $values));
}
```
