### PR TITLE
[10.x] Preserve array data order after validation

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -812,6 +812,32 @@ class Arr
     }
 
     /**
+     * Recursively sort numerically indexed array by keys.
+     *
+     *
+     * @param  array  $array
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return array
+     */
+    public static function sortRecursiveNumericallyIndexed($array, $options = SORT_REGULAR, $descending = false)
+    {
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = static::sortRecursiveNumericallyIndexed($value, $options, $descending);
+            }
+        }
+
+        if (self::isNumericallyIndexed($array)) {
+            $descending
+                ? rsort($array, $options)
+                : sort($array, $options);
+        }
+
+        return $array;
+    }
+
+    /**
      * Conditionally compile classes from an array into a CSS class list.
      *
      * @param  array  $array
@@ -893,5 +919,24 @@ class Arr
         }
 
         return is_array($value) ? $value : [$value];
+    }
+
+    /**
+     * Determine if an array is numerically indexed
+     *
+     * @param  mixed  $array
+     * @return boolean
+     */
+    public static function isNumericallyIndexed($array) {
+        if (!is_array($array)) {
+            return false;
+        }
+
+        foreach ($array as $key => $value) {
+            if (!is_int($key)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -922,21 +922,23 @@ class Arr
     }
 
     /**
-     * Determine if an array is numerically indexed
+     * Determine if an array is numerically indexed.
      *
      * @param  mixed  $array
-     * @return boolean
+     * @return bool
      */
-    public static function isNumericallyIndexed($array) {
-        if (!is_array($array)) {
+    public static function isNumericallyIndexed($array)
+    {
+        if (! is_array($array)) {
             return false;
         }
 
         foreach ($array as $key => $value) {
-            if (!is_int($key)) {
+            if (! is_int($key)) {
                 return false;
             }
         }
+
         return true;
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -830,8 +830,8 @@ class Arr
 
         if (self::isNumericallyIndexed($array)) {
             $descending
-                ? rsort($array, $options)
-                : sort($array, $options);
+                ? krsort($array, $options)
+                : ksort($array, $options);
         }
 
         return $array;

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void replacer(string $rule, \Closure|string $replacer)
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
+ * @method static void sortValidatedArrayDataByKey()
  * @method static void resolver(\Closure $resolver)
  * @method static \Illuminate\Contracts\Translation\Translator getTranslator()
  * @method static \Illuminate\Validation\PresenceVerifierInterface getPresenceVerifier()

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -115,7 +115,6 @@ class Factory implements FactoryContract
             $data, $rules, $messages, $attributes
         );
 
-
         // The presence verifier is responsible for checking the unique and exists data
         // for the validator. It is behind an interface so that multiple versions of
         // it may be written besides database. We'll inject it into the validator.

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -74,6 +74,13 @@ class Factory implements FactoryContract
     protected $excludeUnvalidatedArrayKeys = true;
 
     /**
+     * Indicates that validated array data will be sorted by key.
+     *
+     * @var bool
+     */
+    protected $sortValidatedArrayDataByKey = false;
+
+    /**
      * The Validator resolver instance.
      *
      * @var \Closure
@@ -108,6 +115,7 @@ class Factory implements FactoryContract
             $data, $rules, $messages, $attributes
         );
 
+
         // The presence verifier is responsible for checking the unique and exists data
         // for the validator. It is behind an interface so that multiple versions of
         // it may be written besides database. We'll inject it into the validator.
@@ -123,6 +131,8 @@ class Factory implements FactoryContract
         }
 
         $validator->excludeUnvalidatedArrayKeys = $this->excludeUnvalidatedArrayKeys;
+
+        $validator->sortValidatedArrayDataByKey = $this->sortValidatedArrayDataByKey;
 
         $this->addExtensions($validator);
 
@@ -266,6 +276,16 @@ class Factory implements FactoryContract
     public function excludeUnvalidatedArrayKeys()
     {
         $this->excludeUnvalidatedArrayKeys = true;
+    }
+
+    /**
+     * Indicates that validated array data should be sorted by key.
+     *
+     * @return void
+     */
+    public function sortValidatedArrayDataByKey()
+    {
+        $this->sortValidatedArrayDataByKey = true;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -396,7 +396,7 @@ class Validator implements ValidatorContract
     protected function sortArraysByKey($data)
     {
         foreach ($data as &$value) {
-            if(is_array($value)) {
+            if (is_array($value)) {
                 ksort($value);
             }
         }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -388,23 +388,6 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Sort arrays by key to preserve original order.
-     *
-     * @param  array  $data
-     * @return array
-     */
-    protected function sortArraysByKey($data)
-    {
-        foreach ($data as &$value) {
-            if (is_array($value)) {
-                ksort($value);
-            }
-        }
-
-        return $data;
-    }
-
-    /**
      * Add an after validation callback.
      *
      * @param  callable|array|string  $callback
@@ -594,7 +577,7 @@ class Validator implements ValidatorContract
             }
         }
 
-        return $this->sortArraysByKey($this->replacePlaceholders($results));
+        return Arr::sortRecursiveNumericallyIndexed($this->replacePlaceholders($results));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -388,6 +388,23 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Sort arrays by key to preserve original order.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    protected function sortArraysByKey($data)
+    {
+        foreach ($data as &$value) {
+            if(is_array($value)) {
+                ksort($value);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
      * Add an after validation callback.
      *
      * @param  callable|array|string  $callback
@@ -577,7 +594,7 @@ class Validator implements ValidatorContract
             }
         }
 
-        return $this->replacePlaceholders($results);
+        return $this->sortArraysByKey($this->replacePlaceholders($results));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -166,6 +166,13 @@ class Validator implements ValidatorContract
     public $excludeUnvalidatedArrayKeys = false;
 
     /**
+     * Indicates that validated array data will be sorted by key.
+     *
+     * @var bool
+     */
+    public $sortValidatedArrayDataByKey = false;
+
+    /**
      * All of the custom validator extensions.
      *
      * @var array
@@ -577,7 +584,9 @@ class Validator implements ValidatorContract
             }
         }
 
-        return Arr::sortRecursiveNumericallyIndexed($this->replacePlaceholders($results));
+        return $this->sortValidatedArrayDataByKey
+            ? Arr::sortRecursiveNumericallyIndexed($this->replacePlaceholders($results))
+            : $this->replacePlaceholders($results);
     }
 
     /**


### PR DESCRIPTION
This PR solves #48440.

As explained in the issue, in some scenarios the order of the array data changes.

This PR adds a `Illuminate\Support\Arr::sortRecursiveNumericallyIndexed()`. This method is called at the end of `validated()` method to ensure that original array data order is preserved.

In order to prevent breaking changes and allow and extend functionalities instead of restrict them, there is a new bool property `$sortValidatedArrayDataByKey` in `Validator` class. Based on this property the array data will be sorted by key or not.

There is also new method `Illuminate\Support\Arr::isNumericallyIndexed()` that is used in `sortRecursiveNumericallyIndexed()`.