### PR TITLE
[10.x] Increase bcrypt rounds to 12

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -12,7 +12,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      *
      * @var int
      */
-    protected $rounds = 10;
+    protected $rounds = 12;
 
     /**
      * Indicates whether to perform an algorithm check.

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -54,6 +54,7 @@ class HasherTest extends TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['rounds' => 1]));
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
+        $this->assertGreaterThanOrEqual(12, password_get_info($value)['options']['cost']);
         $this->assertTrue($this->hashManager->isHashed($value));
     }
 


### PR DESCRIPTION
[PHP is increasing the default bcrypt cost](https://wiki.php.net/rfc/bcrypt_cost_2023) to either 11 or 12 to keep up with increases in computing, so we should do the same within Laravel. The current default of 10 was set in PHP 11 years ago, which is no longer a suitable default.

12 appears to be the sweet spot between performance and security, [as confirmed by a member of the Hashcat team](https://phpc.social/@tychotithonus@infosec.exchange/111104389164750098). [Symfony uses a cost of 13](https://github.com/symfony/password-hasher/blob/6.3/Hasher/NativePasswordHasher.php#L36C1-L37C1), however that may be too high for some servers.

Due to the way hashing works, there are no backwards compatibility issues - older passwords with lower rounds will still be handled properly, and code that automatically rehashes passwords will upgrade them over time. It's also worth pointing out that since rounds are defined in `config/hashing.php`, existing projects won't automatically get the new rounds cost and thus won't have any performance impacts. [The RFC contains hash calculation timings](https://wiki.php.net/rfc/bcrypt_cost_2023) if you'd like more information on the impacts.

Increasing rounds to 12 in `config/hashing.php` should be a recommended upgrade step for Laravel 11 (and possibly added to the guide for 10?).

Application Skeleton PR: https://github.com/laravel/laravel/pull/6245