### PR TITLE
[10.x] Introduce `Str::isAlphanumeric()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -437,11 +437,7 @@ class Str
      */
     public static function isAlphanumeric($value)
     {
-        if (function_exists('ctype_alnum')) {
-            return ctype_alnum((string) $value);
-        }
-
-        return preg_match('/^[a-zA-Z0-9]+$/', $value) === 1;
+        return ctype_alnum((string) $value);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -430,6 +430,17 @@ class Str
     }
 
     /**
+     * Determine if a given string is alphanumeric.
+     *
+     * @param $value
+     * @return bool
+     */
+    public static function isAlphanumeric($value)
+    {
+        return ctype_alnum((string) $value);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -432,7 +432,7 @@ class Str
     /**
      * Determine if a given string is alphanumeric.
      *
-     * @param $value
+     * @param  $value
      * @return bool
      */
     public static function isAlphanumeric($value)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -437,7 +437,11 @@ class Str
      */
     public static function isAlphanumeric($value)
     {
-        return ctype_alnum((string) $value);
+        if (function_exists('ctype_alnum')) {
+            return ctype_alnum((string) $value);
+        }
+
+        return preg_match('/^[a-zA-Z0-9]+$/', $value) === 1;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -315,6 +315,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Determine if string is alphanumeric.
+     *
+     * @return bool
+     */
+    public function isAlphanumeric()
+    {
+        return Str::isAlphanumeric($this->value);
+    }
+
+    /**
      * Determine if a given string is 7 bit ASCII.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -405,6 +405,33 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is([null], null));
     }
 
+    public function testIsAlphanumeric()
+    {
+        // Alphanumeric strings
+        $this->assertTrue(Str::isAlphanumeric("abc123"));
+        $this->assertTrue(Str::isAlphanumeric("ABC456"));
+        $this->assertTrue(Str::isAlphanumeric("123XYZ"));
+        $this->assertTrue(Str::isAlphanumeric("123AbC"));
+        $this->assertTrue(Str::isAlphanumeric("xyzXYZ"));
+        $this->assertTrue(Str::isAlphanumeric("987654"));
+
+        // Non-alphanumeric strings
+        $this->assertFalse(Str::isAlphanumeric("abc 123"));
+        $this->assertFalse(Str::isAlphanumeric("abc!123"));
+        $this->assertFalse(Str::isAlphanumeric("   "));
+        $this->assertFalse(Str::isAlphanumeric("abc_123"));
+        $this->assertFalse(Str::isAlphanumeric("1.2.3"));
+        $this->assertFalse(Str::isAlphanumeric("12 34"));
+
+        // Edge cases
+        $this->assertFalse(Str::isAlphanumeric("")); // Empty string
+        $this->assertTrue(Str::isAlphanumeric("1")); // Single alphanumeric character
+        $this->assertFalse(Str::isAlphanumeric(" ")); // Single space
+        $this->assertFalse(Str::isAlphanumeric("\n\t")); // Newlines and tabs
+        $this->assertFalse(Str::isAlphanumeric("Ø12")); // Special characters (UTF-8)
+        $this->assertFalse(Str::isAlphanumeric(" \t")); // Whitespace characters
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue(Str::isUrl('https://laravel.com'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -408,27 +408,27 @@ class SupportStrTest extends TestCase
     public function testIsAlphanumeric()
     {
         // Alphanumeric strings
-        $this->assertTrue(Str::isAlphanumeric("abc123"));
-        $this->assertTrue(Str::isAlphanumeric("ABC456"));
-        $this->assertTrue(Str::isAlphanumeric("123XYZ"));
-        $this->assertTrue(Str::isAlphanumeric("123AbC"));
-        $this->assertTrue(Str::isAlphanumeric("xyzXYZ"));
-        $this->assertTrue(Str::isAlphanumeric("987654"));
+        $this->assertTrue(Str::isAlphanumeric('abc123'));
+        $this->assertTrue(Str::isAlphanumeric('ABC456'));
+        $this->assertTrue(Str::isAlphanumeric('123XYZ'));
+        $this->assertTrue(Str::isAlphanumeric('123AbC'));
+        $this->assertTrue(Str::isAlphanumeric('xyzXYZ'));
+        $this->assertTrue(Str::isAlphanumeric('987654'));
 
         // Non-alphanumeric strings
-        $this->assertFalse(Str::isAlphanumeric("abc 123"));
-        $this->assertFalse(Str::isAlphanumeric("abc!123"));
-        $this->assertFalse(Str::isAlphanumeric("   "));
-        $this->assertFalse(Str::isAlphanumeric("abc_123"));
-        $this->assertFalse(Str::isAlphanumeric("1.2.3"));
-        $this->assertFalse(Str::isAlphanumeric("12 34"));
+        $this->assertFalse(Str::isAlphanumeric('abc 123'));
+        $this->assertFalse(Str::isAlphanumeric('abc!123'));
+        $this->assertFalse(Str::isAlphanumeric('   '));
+        $this->assertFalse(Str::isAlphanumeric('abc_123'));
+        $this->assertFalse(Str::isAlphanumeric('1.2.3'));
+        $this->assertFalse(Str::isAlphanumeric('12 34'));
 
         // Edge cases
-        $this->assertFalse(Str::isAlphanumeric("")); // Empty string
-        $this->assertTrue(Str::isAlphanumeric("1")); // Single alphanumeric character
-        $this->assertFalse(Str::isAlphanumeric(" ")); // Single space
+        $this->assertFalse(Str::isAlphanumeric('')); // Empty string
+        $this->assertTrue(Str::isAlphanumeric('1')); // Single alphanumeric character
+        $this->assertFalse(Str::isAlphanumeric(' ')); // Single space
         $this->assertFalse(Str::isAlphanumeric("\n\t")); // Newlines and tabs
-        $this->assertFalse(Str::isAlphanumeric("Ø12")); // Special characters (UTF-8)
+        $this->assertFalse(Str::isAlphanumeric('Ø12')); // Special characters (UTF-8)
         $this->assertFalse(Str::isAlphanumeric(" \t")); // Whitespace characters
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -30,27 +30,27 @@ class SupportStringableTest extends TestCase
     public function testIsAlphanumeric()
     {
         // Alphanumeric strings
-        $this->assertTrue($this->stringable("abc123")->isAlphanumeric());
-        $this->assertTrue($this->stringable("ABC456")->isAlphanumeric());
-        $this->assertTrue($this->stringable("123XYZ")->isAlphanumeric());
-        $this->assertTrue($this->stringable("123AbC")->isAlphanumeric());
-        $this->assertTrue($this->stringable("xyzXYZ")->isAlphanumeric());
-        $this->assertTrue($this->stringable("987654")->isAlphanumeric());
+        $this->assertTrue($this->stringable('abc123')->isAlphanumeric());
+        $this->assertTrue($this->stringable('ABC456')->isAlphanumeric());
+        $this->assertTrue($this->stringable('123XYZ')->isAlphanumeric());
+        $this->assertTrue($this->stringable('123AbC')->isAlphanumeric());
+        $this->assertTrue($this->stringable('xyzXYZ')->isAlphanumeric());
+        $this->assertTrue($this->stringable('987654')->isAlphanumeric());
 
         // Non-alphanumeric strings
-        $this->assertFalse($this->stringable("abc 123")->isAlphanumeric());
-        $this->assertFalse($this->stringable("abc!123")->isAlphanumeric());
-        $this->assertFalse($this->stringable("   ")->isAlphanumeric());
-        $this->assertFalse($this->stringable("abc_123")->isAlphanumeric());
-        $this->assertFalse($this->stringable("1.2.3")->isAlphanumeric());
-        $this->assertFalse($this->stringable("12 34")->isAlphanumeric());
+        $this->assertFalse($this->stringable('abc 123')->isAlphanumeric());
+        $this->assertFalse($this->stringable('abc!123')->isAlphanumeric());
+        $this->assertFalse($this->stringable('   ')->isAlphanumeric());
+        $this->assertFalse($this->stringable('abc_123')->isAlphanumeric());
+        $this->assertFalse($this->stringable('1.2.3')->isAlphanumeric());
+        $this->assertFalse($this->stringable('12 34')->isAlphanumeric());
 
         // Edge cases
-        $this->assertFalse($this->stringable("")->isAlphanumeric()); // Empty string
-        $this->assertTrue($this->stringable("1")->isAlphanumeric()); // Single alphanumeric character
-        $this->assertFalse($this->stringable(" ")->isAlphanumeric()); // Single space
+        $this->assertFalse($this->stringable('')->isAlphanumeric()); // Empty string
+        $this->assertTrue($this->stringable('1')->isAlphanumeric()); // Single alphanumeric character
+        $this->assertFalse($this->stringable(' ')->isAlphanumeric()); // Single space
         $this->assertFalse($this->stringable("\n\t")->isAlphanumeric()); // Newlines and tabs
-        $this->assertFalse($this->stringable("Ø12")->isAlphanumeric()); // Special characters (UTF-8)
+        $this->assertFalse($this->stringable('Ø12')->isAlphanumeric()); // Special characters (UTF-8)
         $this->assertFalse($this->stringable(" \t")->isAlphanumeric()); // Whitespace characters
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -27,6 +27,33 @@ class SupportStringableTest extends TestCase
         );
     }
 
+    public function testIsAlphanumeric()
+    {
+        // Alphanumeric strings
+        $this->assertTrue($this->stringable("abc123")->isAlphanumeric());
+        $this->assertTrue($this->stringable("ABC456")->isAlphanumeric());
+        $this->assertTrue($this->stringable("123XYZ")->isAlphanumeric());
+        $this->assertTrue($this->stringable("123AbC")->isAlphanumeric());
+        $this->assertTrue($this->stringable("xyzXYZ")->isAlphanumeric());
+        $this->assertTrue($this->stringable("987654")->isAlphanumeric());
+
+        // Non-alphanumeric strings
+        $this->assertFalse($this->stringable("abc 123")->isAlphanumeric());
+        $this->assertFalse($this->stringable("abc!123")->isAlphanumeric());
+        $this->assertFalse($this->stringable("   ")->isAlphanumeric());
+        $this->assertFalse($this->stringable("abc_123")->isAlphanumeric());
+        $this->assertFalse($this->stringable("1.2.3")->isAlphanumeric());
+        $this->assertFalse($this->stringable("12 34")->isAlphanumeric());
+
+        // Edge cases
+        $this->assertFalse($this->stringable("")->isAlphanumeric()); // Empty string
+        $this->assertTrue($this->stringable("1")->isAlphanumeric()); // Single alphanumeric character
+        $this->assertFalse($this->stringable(" ")->isAlphanumeric()); // Single space
+        $this->assertFalse($this->stringable("\n\t")->isAlphanumeric()); // Newlines and tabs
+        $this->assertFalse($this->stringable("Ø12")->isAlphanumeric()); // Special characters (UTF-8)
+        $this->assertFalse($this->stringable(" \t")->isAlphanumeric()); // Whitespace characters
+    }
+
     public function testIsAscii()
     {
         $this->assertTrue($this->stringable('A')->isAscii());


### PR DESCRIPTION
Introducing the `Str` helper method `isAlphanumeric()`. The methods purpose is to check if the string contains only alphanumeric characters in a more convenient style than using the existing `Str:is()` method with a regex like `/^[a-zA-Z0-9]+$/`. I think it's a pretty common use case and having a shortcut seems helpful and more readable.

I did some performance tests and using the php internal method [`ctype_alnum`](https://www.php.net/manual/en/function.ctype-alnum.php) turns out to be faster than the regex as well.

**Definition of "alphanumeric characters"**
Alphanumeric characters include all 26 Latin letters (case insensitive), and the digits from 0-9.
