### PR TITLE
[10.x] Ensure array driver expires values at the expiry time

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -57,7 +57,7 @@ class ArrayStore extends TaggableStore implements LockProvider
 
         $expiresAt = $item['expiresAt'] ?? 0;
 
-        if ($expiresAt !== 0 && $this->currentTime() > $expiresAt) {
+        if ($expiresAt !== 0 && $this->currentTime() >= $expiresAt) {
             $this->forget($key);
 
             return;

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\GlobalLimit;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Middleware\ThrottleRequests;
@@ -115,5 +116,63 @@ class ThrottleRequestsTest extends TestCase
 
         $signature = (string) ThrottleRequests::with(prefix: 'foo');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:60,1,foo', $signature);
+    }
+
+    public function testItCanThrottlePerMinute()
+    {
+        $rateLimiter = Container::getInstance()->make(RateLimiter::class);
+        $rateLimiter->for('test', fn () => Limit::perMinute(3));
+        Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
+
+        Carbon::setTestNow('2000-01-01 00:00:00.000');
+
+        // Make 3 requests, each a second apart, that should all be successful.
+
+        for ($i = 0; $i < 3; $i++) {
+            match ($i) {
+                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:01.000', now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:02.000', now()->toDateTimeString('m')),
+            };
+
+            $response = $this->get('/');
+            $response->assertOk();
+            $response->assertContent('ok');
+            $response->assertHeader('X-RateLimit-Limit', 3);
+            $response->assertHeader('X-RateLimit-Remaining', 3 - ($i + 1));
+
+            Carbon::setTestNow(now()->addSecond());
+        }
+
+        // It is now 3 seconds past and we will make another request that
+        // should be rate limited.
+
+        $this->assertSame('2000-01-01 00:00:03.000', now()->toDateTimeString('m'));
+
+        $response = $this->get('/');
+        $response->assertStatus(429);
+        $response->assertHeader('Retry-After', 57);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(57)->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We will now make it the very end of the minute, to check boundaries,
+        // and make another request that should be rate limited and tell us to
+        // try again in 1 second.
+        Carbon::setTestNow(now()->endOfMinute());
+        $this->assertSame('2000-01-01 00:00:59.999', now()->toDateTimeString('m'));
+
+        $response = $this->get('/');
+        $response->assertHeader('Retry-After', 1);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(1)->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We now tick over into the next second. We should now be able to make
+        // requests again.
+        Carbon::setTestNow('2000-01-01 00:01:00.000');
+
+        $response = $this->get('/');
+        $response->assertOk();
     }
 }


### PR DESCRIPTION
The array cache driver's logic for determining when a key has expired is wrong.

It currently requires the time to be PAST the expiry - but the value indicates when the key expires at, thus if it is currently the time that it expires, it should have expired.

This means the array driver does not currently function like Redis. You can demo this yourself using the following script to test.

Make sure to test with `array` and with `redis` to see the difference.

You will notice that the array driver cannot make another hit until 1 second past the NEXT minute while Redis is able to make a hit at the very start of the second (give or take a few hundred milliseconds for communicating with Redis itself).

```php
Artisan::command('limit', function () {
    while (now()->second !== 0) {
        echo '.';

        usleep(100_000);
    }

    echo PHP_EOL;

    $continue = true;

    while ($continue) {
        $continue = RateLimiter::attempt('echo-message', 10, function() {
            echo 'Executing rate limited code at '.now()->toDateTimeString().PHP_EOL;
        });
    }

    sleep(1);

    while (now()->second !== 0) {
        echo '.';

        usleep(100_000);
    }

    echo PHP_EOL;

    $continue = true;

    while (true) {
        $continue = RateLimiter::attempt('echo-message', 10, function() {
            echo 'Executing rate limited code at '.now()->toDateTimeString('m').PHP_EOL;
        });
    }
});
```

## Array

```
Waiting until the start of the minute...
.............................................................................................................................................
.............................................................................................................................................
...............................................................
Executing rate limited code at 2023-09-22 05:56:00
Waiting until the start of the NEXT minute...
.............................................................................................................................................
.............................................................................................................................................
.............................................................................................................................................
.............................................................................................................................................
.........
Executing rate limited code at 2023-09-22 05:57:01.000
```

## Redis

```
Waiting until the start of the minute...
.............................................................................................................................................
.............................................................................................................................................
..................................................................................................................................
Executing rate limited code at 2023-09-22 05:50:00
Waiting until the start of the NEXT minute...
.............................................................................................................................................
.............................................................................................................................................
.............................................................................................................................................
.............................................................................................................................................
.......
Executing rate limited code at 2023-09-22 05:51:00.054
```

The included test is one I was already writing that lead me down the path of testing all of this - so I left it in for us.