### PR TITLE
[11.x] Per-second rate limiting

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
+++ b/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
@@ -8,11 +8,11 @@ class GlobalLimit extends Limit
      * Create a new limit instance.
      *
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return void
      */
-    public function __construct(int $maxAttempts, int $decayMinutes = 1)
+    public function __construct(int $maxAttempts, int $decaySeconds = 60)
     {
-        parent::__construct('', $maxAttempts, $decayMinutes);
+        parent::__construct('', $maxAttempts, $decaySeconds);
     }
 }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -12,18 +12,18 @@ class Limit
     public $key;
 
     /**
-     * The maximum number of attempts allowed within the given number of minutes.
+     * The maximum number of attempts allowed within the given number of seconds.
      *
      * @var int
      */
     public $maxAttempts;
 
     /**
-     * The number of minutes until the rate limit is reset.
+     * The number of seconds until the rate limit is reset.
      *
      * @var int
      */
-    public $decayMinutes;
+    public $decaySeconds;
 
     /**
      * The response generator callback.
@@ -37,14 +37,25 @@ class Limit
      *
      * @param  mixed  $key
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return void
      */
-    public function __construct($key = '', int $maxAttempts = 60, int $decayMinutes = 1)
+    public function __construct($key = '', int $maxAttempts = 60, int $decaySeconds = 60)
     {
         $this->key = $key;
         $this->maxAttempts = $maxAttempts;
-        $this->decayMinutes = $decayMinutes;
+        $this->decaySeconds = $decaySeconds;
+    }
+
+    /**
+     * Create a new rate limit.
+     *
+     * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perSecond($maxAttempts)
+    {
+        return new static('', $maxAttempts, 1);
     }
 
     /**
@@ -55,7 +66,7 @@ class Limit
      */
     public static function perMinute($maxAttempts)
     {
-        return new static('', $maxAttempts);
+        return new static('', $maxAttempts, 60);
     }
 
     /**
@@ -67,7 +78,7 @@ class Limit
      */
     public static function perMinutes($decayMinutes, $maxAttempts)
     {
-        return new static('', $maxAttempts, $decayMinutes);
+        return new static('', $maxAttempts, 60 * $decayMinutes);
     }
 
     /**
@@ -79,7 +90,7 @@ class Limit
      */
     public static function perHour($maxAttempts, $decayHours = 1)
     {
-        return new static('', $maxAttempts, 60 * $decayHours);
+        return new static('', $maxAttempts, 60 * 60 * $decayHours);
     }
 
     /**
@@ -91,7 +102,7 @@ class Limit
      */
     public static function perDay($maxAttempts, $decayDays = 1)
     {
-        return new static('', $maxAttempts, 60 * 24 * $decayDays);
+        return new static('', $maxAttempts, 60 * 60 * 24 * $decayDays);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -360,7 +360,7 @@ class Handler implements ExceptionHandlerContract
                 with($throttle->key ?: 'illuminate:foundation:exceptions:'.$e::class, fn ($key) => $this->hashThrottleKeys ? md5($key) : $key),
                 $throttle->maxAttempts,
                 fn () => true,
-                60 * $throttle->decayMinutes
+                $throttle->decaySeconds
             );
         }), rescue: false, report: false);
     }

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -69,7 +69,7 @@ class RateLimited
                 return (object) [
                     'key' => md5($this->limiterName.$limit->key),
                     'maxAttempts' => $limit->maxAttempts,
-                    'decayMinutes' => $limit->decayMinutes,
+                    'decaySeconds' => $limit->decaySeconds,
                 ];
             })->all()
         );
@@ -92,7 +92,7 @@ class RateLimited
                         : false;
             }
 
-            $this->limiter->hit($limit->key, $limit->decayMinutes * 60);
+            $this->limiter->hit($limit->key, $limit->decaySeconds);
         }
 
         return $next($job);

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -49,7 +49,7 @@ class RateLimitedWithRedis extends RateLimited
     protected function handleJob($job, $next, array $limits)
     {
         foreach ($limits as $limit) {
-            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
+            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
                 return $this->shouldRelease
                     ? $job->release($this->getTimeUntilNextRetry($limit->key))
                     : false;
@@ -64,13 +64,13 @@ class RateLimitedWithRedis extends RateLimited
      *
      * @param  string  $key
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return bool
      */
-    protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+    protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
     {
         $limiter = new DurationLimiter(
-            $this->redis, $key, $maxAttempts, $decayMinutes * 60
+            $this->redis, $key, $maxAttempts, $decaySeconds
         );
 
         return tap(! $limiter->acquire(), function () use ($key, $limiter) {

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -30,11 +30,11 @@ class ThrottlesExceptions
     protected $maxAttempts;
 
     /**
-     * The number of minutes until the maximum attempts are reset.
+     * The number of seconds until the maximum attempts are reset.
      *
      * @var int
      */
-    protected $decayMinutes;
+    protected $decaySeconds;
 
     /**
      * The number of minutes to wait before retrying the job after an exception.
@@ -68,13 +68,13 @@ class ThrottlesExceptions
      * Create a new middleware instance.
      *
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return void
      */
-    public function __construct($maxAttempts = 10, $decayMinutes = 10)
+    public function __construct($maxAttempts = 10, $decaySeconds = 600)
     {
         $this->maxAttempts = $maxAttempts;
-        $this->decayMinutes = $decayMinutes;
+        $this->decaySeconds = $decaySeconds;
     }
 
     /**
@@ -101,7 +101,7 @@ class ThrottlesExceptions
                 throw $throwable;
             }
 
-            $this->limiter->hit($jobKey, $this->decayMinutes * 60);
+            $this->limiter->hit($jobKey, $this->decaySeconds);
 
             return $job->release($this->retryAfterMinutes * 60);
         }

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -38,7 +38,7 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
         $this->redis = Container::getInstance()->make(Redis::class);
 
         $this->limiter = new DurationLimiter(
-            $this->redis, $this->getKey($job), $this->maxAttempts, $this->decayMinutes * 60
+            $this->redis, $this->getKey($job), $this->maxAttempts, $this->decaySeconds
         );
 
         if ($this->limiter->tooManyAttempts()) {

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -94,7 +94,7 @@ class ThrottleRequests
                 (object) [
                     'key' => $prefix.$this->resolveRequestSignature($request),
                     'maxAttempts' => $this->resolveMaxAttempts($request, $maxAttempts),
-                    'decayMinutes' => $decayMinutes,
+                    'decaySeconds' => 60 * $decayMinutes,
                     'responseCallback' => null,
                 ],
             ]
@@ -129,7 +129,7 @@ class ThrottleRequests
                 return (object) [
                     'key' => self::$shouldHashKeys ? md5($limiterName.$limit->key) : $limiterName.':'.$limit->key,
                     'maxAttempts' => $limit->maxAttempts,
-                    'decayMinutes' => $limit->decayMinutes,
+                    'decaySeconds' => $limit->decaySeconds,
                     'responseCallback' => $limit->responseCallback,
                 ];
             })->all()
@@ -153,7 +153,7 @@ class ThrottleRequests
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
 
-            $this->limiter->hit($limit->key, $limit->decayMinutes * 60);
+            $this->limiter->hit($limit->key, $limit->decaySeconds);
         }
 
         $response = $next($request);

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -57,7 +57,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function handleRequest($request, Closure $next, array $limits)
     {
         foreach ($limits as $limit) {
-            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
+            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
         }
@@ -80,13 +80,13 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      *
      * @param  string  $key
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return mixed
      */
-    protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+    protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
     {
         $limiter = new DurationLimiter(
-            $this->getRedisConnection(), $key, $maxAttempts, $decayMinutes * 60
+            $this->getRedisConnection(), $key, $maxAttempts, $decaySeconds
         );
 
         return tap(! $limiter->acquire(), function () use ($key, $limiter) {

--- a/tests/Cache/LimitTest.php
+++ b/tests/Cache/LimitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\RateLimiting\GlobalLimit;
+use Illuminate\Cache\RateLimiting\Limit;
+use PHPUnit\Framework\TestCase;
+
+class LimitTest extends TestCase
+{
+    public function testConstructors()
+    {
+        $limit = new Limit('', 3, 1);
+        $this->assertSame(1, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perSecond(3);
+        $this->assertSame(1, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perMinute(3);
+        $this->assertSame(60, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perMinutes(2, 3);
+        $this->assertSame(120, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perHour(3);
+        $this->assertSame(3600, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = Limit::perDay(3);
+        $this->assertSame(86400, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+
+        $limit = new GlobalLimit(3);
+        $this->assertSame(60, $limit->decaySeconds);
+        $this->assertSame(3, $limit->maxAttempts);
+    }
+}

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\GlobalLimit;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Middleware\ThrottleRequests;
@@ -115,5 +116,130 @@ class ThrottleRequestsTest extends TestCase
 
         $signature = (string) ThrottleRequests::with(prefix: 'foo');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:60,1,foo', $signature);
+    }
+
+    public static function perMinuteThrottlingDataSet()
+    {
+        return [
+            [ThrottleRequests::using('test')],
+            [ThrottleRequests::with(maxAttempts: 3, decayMinutes: 1)],
+            ['throttle:3,1'],
+        ];
+    }
+
+    /** @dataProvider perMinuteThrottlingDataSet */
+    public function testItCanThrottlePerMinute(string $middleware)
+    {
+        $rateLimiter = Container::getInstance()->make(RateLimiter::class);
+        $rateLimiter->for('test', fn () => Limit::perMinute(3));
+        Route::get('/', fn () => 'ok')->middleware($middleware);
+
+        Carbon::setTestNow('2000-01-01 00:00:00.000');
+
+        // Make 3 requests, each a second apart, that should all be successful.
+
+        for ($i = 0; $i < 3; $i++) {
+            match ($i) {
+                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:01.000', now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:02.000', now()->toDateTimeString('m')),
+            };
+
+            $response = $this->get('/');
+            $response->assertOk();
+            $response->assertContent('ok');
+            $response->assertHeader('X-RateLimit-Limit', 3);
+            $response->assertHeader('X-RateLimit-Remaining', 3 - ($i + 1));
+
+            Carbon::setTestNow(now()->addSecond());
+        }
+
+        // It is now 3 seconds past and we will make another request that
+        // should be rate limited.
+
+        $this->assertSame('2000-01-01 00:00:03.000', now()->toDateTimeString('m'));
+
+        $response = $this->get('/');
+        $response->assertStatus(429);
+        $response->assertHeader('Retry-After', 57);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(57)->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We will now make it the very end of the minute, to check boundaries,
+        // and make another request that should be rate limited and tell us to
+        // try again in 1 second.
+        Carbon::setTestNow('2000-01-01 00:00:59.999');
+
+        $response = $this->get('/');
+        $response->assertStatus(429);
+        $response->assertHeader('Retry-After', 1);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(1)->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We now tick over into the next second. We should now be able to make
+        // requests again.
+        Carbon::setTestNow('2000-01-01 00:01:00.000');
+
+        $response = $this->get('/');
+        $response->assertOk();
+    }
+
+    public function testItCanThrottlePerSecond()
+    {
+        $rateLimiter = Container::getInstance()->make(RateLimiter::class);
+        $rateLimiter->for('test', fn () => Limit::perSecond(3));
+        Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using('test'));
+
+        Carbon::setTestNow('2000-01-01 00:00:00.000');
+
+        // Make 3 requests, each a 100ms apart, that should all be successful.
+
+        for ($i = 0; $i < 3; $i++) {
+            match ($i) {
+                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:00.100', now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:00.200', now()->toDateTimeString('m')),
+            };
+
+            $response = $this->get('/');
+            $response->assertOk();
+            $response->assertContent('ok');
+            $response->assertHeader('X-RateLimit-Limit', 3);
+            $response->assertHeader('X-RateLimit-Remaining', 3 - ($i + 1));
+
+            Carbon::setTestNow(now()->addMilliseconds(100));
+        }
+
+        // It is now 300 milliseconds past and we will make another request
+        // that should be rate limited.
+
+        $this->assertSame('2000-01-01 00:00:00.300', now()->toDateTimeString('m'));
+
+        $response = $this->get('/');
+        $response->assertStatus(429);
+        $response->assertHeader('Retry-After', 1);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSecond()->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We will now make it the very end of the minute, to check boundaries,
+        // and make another request that should be rate limited and tell us to
+        // try again in 1 second.
+        Carbon::setTestNow('2000-01-01 00:00:00.999');
+
+        $response = $this->get('/');
+        $response->assertHeader('Retry-After', 1);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSecond()->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We now tick over into the next second. We should now be able to make
+        // requests again.
+        Carbon::setTestNow('2000-01-01 00:00:01.000');
+
+        $response = $this->get('/');
+        $response->assertOk();
     }
 }

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -9,8 +9,10 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
 
 class ThrottlesExceptionsTest extends TestCase
 {
@@ -105,6 +107,168 @@ class ThrottlesExceptionsTest extends TestCase
 
         $this->assertTrue($class::$handled);
     }
+
+    public function testItCanLimitPerMinute()
+    {
+        $jobFactory = fn () => new class
+        {
+            public $released = false;
+
+            public $handled = false;
+
+            public function release()
+            {
+                $this->released = true;
+
+                return $this;
+            }
+        };
+        $next = function ($job) {
+            $job->handled = true;
+
+            throw new RuntimeException('Whoops!');
+        };
+
+        $middleware = new ThrottlesExceptions(3, 60);
+
+        Carbon::setTestNow('2000-00-00 00:00:00.000');
+
+        for ($i = 0; $i < 3; $i++) {
+            $result = $middleware->handle($job = $jobFactory(), $next);
+            $this->assertSame($job, $result);
+            $this->assertTrue($job->released);
+            $this->assertTrue($job->handled);
+
+            Carbon::setTestNow(now()->addSeconds(1));
+        }
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->handled);
+
+        Carbon::setTestNow('2000-00-00 00:00:59.999');
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->handled);
+
+        Carbon::setTestNow('2000-00-00 00:01:00.000');
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertTrue($job->handled);
+    }
+
+    public function testItCanLimitPerSecond()
+    {
+        $jobFactory = fn () => new class
+        {
+            public $released = false;
+
+            public $handled = false;
+
+            public function release()
+            {
+                $this->released = true;
+
+                return $this;
+            }
+        };
+        $next = function ($job) {
+            $job->handled = true;
+
+            throw new RuntimeException('Whoops!');
+        };
+
+        $middleware = new ThrottlesExceptions(3, 1);
+
+        Carbon::setTestNow('2000-00-00 00:00:00.000');
+
+        for ($i = 0; $i < 3; $i++) {
+            $result = $middleware->handle($job = $jobFactory(), $next);
+            $this->assertSame($job, $result);
+            $this->assertTrue($job->released);
+            $this->assertTrue($job->handled);
+
+            Carbon::setTestNow(now()->addMilliseconds(100));
+        }
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->handled);
+
+        Carbon::setTestNow('2000-00-00 00:00:00.999');
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->handled);
+
+        Carbon::setTestNow('2000-00-00 00:00:01.000');
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertTrue($job->handled);
+    }
+
+    public function testLimitingWithDefaultValues()
+    {
+        $jobFactory = fn () => new class
+        {
+            public $released = false;
+
+            public $handled = false;
+
+            public function release()
+            {
+                $this->released = true;
+
+                return $this;
+            }
+        };
+        $next = function ($job) {
+            $job->handled = true;
+
+            throw new RuntimeException('Whoops!');
+        };
+
+        $middleware = new ThrottlesExceptions();
+
+        Carbon::setTestNow('2000-00-00 00:00:00.000');
+
+        for ($i = 0; $i < 10; $i++) {
+            $result = $middleware->handle($job = $jobFactory(), $next);
+            $this->assertSame($job, $result);
+            $this->assertTrue($job->released);
+            $this->assertTrue($job->handled);
+
+            Carbon::setTestNow(now()->addSeconds(1));
+        }
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->handled);
+
+        Carbon::setTestNow('2000-00-00 00:09:59.999');
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertFalse($job->handled);
+
+        Carbon::setTestNow('2000-00-00 00:10:00.000');
+
+        $result = $middleware->handle($job = $jobFactory(), $next);
+        $this->assertSame($job, $result);
+        $this->assertTrue($job->released);
+        $this->assertTrue($job->handled);
+    }
 }
 
 class CircuitBreakerTestJob
@@ -122,7 +286,7 @@ class CircuitBreakerTestJob
 
     public function middleware()
     {
-        return [(new ThrottlesExceptions(2, 10))->by('test')];
+        return [(new ThrottlesExceptions(2, 10 * 60))->by('test')];
     }
 }
 
@@ -139,6 +303,6 @@ class CircuitBreakerSuccessfulJob
 
     public function middleware()
     {
-        return [(new ThrottlesExceptions(2, 10))->by('test')];
+        return [(new ThrottlesExceptions(2, 10 * 60))->by('test')];
     }
 }

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -145,7 +145,7 @@ class CircuitBreakerWithRedisTestJob
 
     public function middleware()
     {
-        return [(new ThrottlesExceptionsWithRedis(2, 10))->by($this->key)];
+        return [(new ThrottlesExceptionsWithRedis(2, 10 * 60))->by($this->key)];
     }
 }
 
@@ -169,6 +169,6 @@ class CircuitBreakerWithRedisSuccessfulJob
 
     public function middleware()
     {
-        return [(new ThrottlesExceptionsWithRedis(2, 10))->by($this->key)];
+        return [(new ThrottlesExceptionsWithRedis(2, 10 * 60))->by($this->key)];
     }
 }


### PR DESCRIPTION
This PR introduces first-party support for per-second rate limiting via the `Limit::perSecond` API.

Per-second limits may be created like the following:

```php
RateLimiter::for('api', fn () => [
    Limit::perMinute(60)->by($request->user()->id),
    Limit::perSecond(5)->by($request->user()->id),
]);
```

The framework only really support per-minute rate limiting officially (although you can kinda do it with the middleware using the un-named limiters).

Per-second rate limiting is important to protect and smooth out bursts across a longer time period.

You might allow `100` per customer across a whole minute but not want a customer to send 100 request in a single second, for example.

# Testing Redis implementations manually.

Because some of these classes interact with Redis, they are best tested manually.

## Testing `ThrottleRequestsWithRedis`

 You can copy the following and watch the output. You can also swap `perSecond` with `perMinute` and see that it only makes 2 requests per minute still.

```php
public function testItCanThrottlePerSecond()
{
    Redis::command('FLUSHALL');
    RateLimiter::for('test', fn () => Limit::perSecond(2));
    Route::get('/', fn () => 'ok')->middleware(ThrottleRequestsWithRedis::using('test'));

    while (true) {
        $response = $this->get('/');

        if ($response->isOk()) {
            dump('<fg=green>Request successful at '.time().'</>');
        } else {
            dump('<fg=red>Request failed at '.time().'</>');
        }

        Sleep::for(100)->milliseconds();
    }
}
```

Result:

https://github.com/laravel/framework/assets/24803032/cd1f0d89-6f2a-4269-8a91-14de32988023

## Testing `RateLimitedWithRedis`

You can also swap `perSecond` with `perMinute` and see that it only makes 2 requests per minute still.

```php
public function testItCanLimitPerSecond()
{
    Redis::command('FLUSHALL');
    RateLimiter::for('test', fn () => Limit::perSecond(3));
    $jobFactory = fn () => new class {
        public $released = false;

        public function release()
        {
            $this->released = true;
        }
    };

    while (true) {
        $result = (new RateLimitedWithRedis('test'))->handle($job = $jobFactory(), fn ($job) => $job);

        if ($result === $job) {
            $this->assertFalse($job->released);
            dump('<fg=green>Job executed at '.time().'</>');
        } else {
            $this->assertNull($result);
            $this->assertTrue($job->released);
            dump('<fg=red>Job released at '.time().'</>');
        }

        Sleep::for(100)->milliseconds();
    }
}

```

https://github.com/laravel/framework/assets/24803032/fd9f7821-aca0-4cce-b812-b15ea2a3f222

## Testing `ThrottlesExceptionsWithRedis`

You can also swap `perSecond` with `perMinute` and see that it only makes 2 requests per minute still.

```php
public function testItCanLimitPerSecond()
{
    Redis::command('FLUSHALL');
    $jobFactory = fn () => new class {
        public $released = false;
        public $handled = false;

        public function release()
        {
            $this->released = true;

            return $this;
        }
    };

    while (true) {
        (new ThrottlesExceptionsWithRedis(1, 1))->handle($job = $jobFactory(), function ($job) {
            $job->handled = true;

            throw new RuntimeException('Whoops!');
        });

        if ($job->handled) {
            dump('<fg=green>Job exectured at '.time().'</>');
        } else {
            dump('<fg=red>Job released at '.time().'</>');
        }

        Sleep::for(100)->milliseconds();
    }
}
```

https://github.com/laravel/framework/assets/24803032/ec0b22ed-7af1-471c-a314-5787c7237d77

# 🚨 Breaking Changes

Unfortunately there are breaking changes here. Although it seems like a lot, I think it is still worth the change. Most of them can be grep-d pretty easily and some even automated.

## `GlobalLimit`

Constructor now accepts seconds.

💭 Class is not documented.

```diff
- new GlobalLimit($attempts, 2);
+ new GlobalLimit($attempts, 2 * 60);
```

## `Limit`

Constructor now accepts seconds.

💭 Documented use is always via non-breaking static constructors, such as `Limit::perMinute`.

```diff
- new Limit($key, $attempts, 2);
+ new Limit($key, $attempts, 2 * 60);
```

The `decayMinutes` property is now `decaySeconds` and represents seconds, not minutes;

```diff
- $limit->decayMinutes
+ $limit->decaySeconds / 60
```

## `RateLimited` 

The `protected` `handleJobs` method argument `$limits` now each have seconds.

💭 This would impact you if you have: 1. overriden the `RateLimited::handleJob` method or are calling the `handleJob` method yourself and are interacting with `$limit->decayMinutes`.

When calling the method...

```diff
- 'decayMinutes' => $limit->decayMinutes
+ 'decaySeconds' => $limit->decaySeconds
```

When overriding the method...

```diff
- $limit->decayMinutes
+ $limit->decaySeconds / 60
```

## `RateLimitedWithRedis`

Same as above. Also the `protected` `tooManyAttempts` method now accepts seconds.

💭 This would impact you if you have: 1. overriden the `RateLimited::tooManyAttempts` method or are calling the `tooManyAttempts` method yourself.

When calling the method...

```diff
- $this->tooManyAttempts($key, $maxAttempts, 2);
+ $this->tooManyAttempts($key, $maxAttempts, 2 * 60);
```

When overriding the method...

```diff
- protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+ protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
{
-    $decaySeconds = $decayMinutes * 60;
}
```

## `ThrottlesExceptions`

Constructor now accepts seconds.

```diff
- new ThrottlesExceptions($attempts, 2);
+ new ThrottlesExceptions($attempts, 2 * 60);
```

The `protected` property `decayMinutes` is now `decaySeconds` and represents seconds.

```diff
- $this->decayMinutes
+ $this->decaySeconds / 60
```

## `ThrottlesExceptionsWithRedis`

Same as above.

## `ThrottleRequests`


The `protected` `handleRequest` method argument `$limits` now each have seconds.

💭 This would impact you if you have: 1. overriden the `RateLimited::handleRequest` or `RateLimited::handleRequestUsingNamedLimiter` methods or are calling them yourself and are interacting with `$limit->decayMinutes`.

When calling the methods...

```diff
- 'decayMinutes' => $limit->decayMinutes
+ 'decaySeconds' => $limit->decaySeconds
```

When overriding the method...

```diff
- $limit->decayMinutes
+ $limit->decaySeconds / 60
```

## `ThrottleRequestsWithRedis`


Same as above. Also the `protected` `tooManyAttempts` method now accepts seconds.

💭 This would impact you if you have: 1. overriden the `ThrottleRequestsWithRedis::tooManyAttempts` method or are calling the `tooManyAttempts` method yourself.

When calling the method...

```diff
- $this->tooManyAttempts($key, $maxAttempts, 2);
+ $this->tooManyAttempts($key, $maxAttempts, 2 * 60);
```

When overriding the method...

```diff
- protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+ protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
{
-    $decaySeconds = $decayMinutes * 60;
}
```