### PR TITLE
[10.x] Disable autoincrement for unsupported column type

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -120,6 +120,10 @@ class ChangeColumn
     {
         $options = ['type' => static::getDoctrineColumnType($fluent['type'])];
 
+        if (! in_array($fluent['type'], ['smallint', 'integer', 'bigint'])) {
+            $options['autoincrement'] = false;
+        }
+
         if (in_array($fluent['type'], ['tinyText', 'text', 'mediumText', 'longText'])) {
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }


### PR DESCRIPTION
ref: https://www.doctrine-project.org/projects/doctrine-dbal/en/3.6/reference/schema-representation.html

If the new column type is not of the correct data type, disable autoincrement.

Currently, if an autoincrement column is converted to a data type that does not support autoincrement, the flag remains true, causing the primary key to not be properly registered by the DBAL schema comparator.

Not sure if this bug fix constitutes as a backwards-breaking change or not.

The following migration demonstrates how this currently affects the generated table schema. You can hack around the issue by supplying a secondary change before the column type change that would remove autoincrement, but this seems to be the wrong approach to take here.

```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\DB;
use Illuminate\Support\Facades\Schema;

return new class () extends Migration {
    /**
     * Run the migrations.
     */
    public function up()
    {
        Schema::create('table_a', function (Blueprint $table) {
            $table->increments('id');
        });

        dump(DB::select("SELECT sql FROM sqlite_schema WHERE name = 'table_a'"));
        // array:1 [
        //   0 => {#724
        //     +"sql": "CREATE TABLE "table_a" ("id" integer primary key autoincrement not null)"
        //   }
        // ]

        Schema::table('table_a', function (Blueprint $table) {
            $table->binary('id')->change();
        });

        dump(DB::select("SELECT sql FROM sqlite_schema WHERE name = 'table_a'"));
        // array:1 [
        //   0 => {#722
        //     +"sql": "CREATE TABLE table_a (id BLOB NOT NULL)"
        //   }
        // ]

        Schema::create('table_b', function (Blueprint $table) {
            $table->increments('id');
        });

        dump(DB::select("SELECT sql FROM sqlite_schema WHERE name = 'table_b'"));
        // array:1 [
        //   0 => {#768
        //     +"sql": "CREATE TABLE "table_b" ("id" integer primary key autoincrement not null)"
        //   }
        // ]

        Schema::table('table_b', function (Blueprint $table) {
            $table->integer('id')->unsigned()->change();
            $table->binary('id')->change();
        });

        dump(DB::select("SELECT sql FROM sqlite_schema WHERE name = 'table_b'"));
        // array:1 [
        //   0 => {#777
        //     +"sql": "CREATE TABLE table_b (id BLOB NOT NULL, PRIMARY KEY(id))"
        //   }
        // ]
    }
};
```