### PR TITLE
[10.x] Use the dedicated key getters in BelongsTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -172,7 +172,7 @@ class BelongsTo extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $attribute = $this->getDictionaryKey($this->getForeignKeyFrom($result));
+            $attribute = $this->getDictionaryKey($this->getRelatedKeyFrom($result));
 
             $dictionary[$attribute] = $result;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -166,17 +166,13 @@ class BelongsTo extends Relation
      */
     public function match(array $models, Collection $results, $relation)
     {
-        $foreign = $this->foreignKey;
-
-        $owner = $this->ownerKey;
-
         // First we will get to build a dictionary of the child models by their primary
         // key of the relationship, then we can easily match the children back onto
         // the parents using that dictionary and the primary key of the children.
         $dictionary = [];
 
         foreach ($results as $result) {
-            $attribute = $this->getDictionaryKey($result->getAttribute($owner));
+            $attribute = $this->getDictionaryKey($this->getForeignKeyFrom($result));
 
             $dictionary[$attribute] = $result;
         }
@@ -185,7 +181,7 @@ class BelongsTo extends Relation
         // and match back onto their children using these keys of the dictionary and
         // the primary key of the children to map them onto the correct instances.
         foreach ($models as $model) {
-            $attribute = $this->getDictionaryKey($model->{$foreign});
+            $attribute = $this->getDictionaryKey($this->getForeignKeyFrom($model));
 
             if (isset($dictionary[$attribute])) {
                 $model->setRelation($relation, $dictionary[$attribute]);

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -99,15 +99,18 @@ class DatabaseEloquentBelongsToTest extends TestCase
     {
         $relation = $this->getRelation();
 
-        $result1 = new class extends Model {
+        $result1 = new class extends Model
+        {
             protected $attributes = ['id' => 1];
         };
 
-        $result2 = new class extends Model {
+        $result2 = new class extends Model
+        {
             protected $attributes = ['id' => 2];
         };
 
-        $result3 = new class extends Model {
+        $result3 = new class extends Model
+        {
             protected $attributes = ['id' => 3];
 
             public function __toString()

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 class DatabaseEloquentBelongsToTest extends TestCase
 {
@@ -99,18 +98,24 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testModelsAreProperlyMatchedToParents()
     {
         $relation = $this->getRelation();
-        $result1 = m::mock(stdClass::class);
-        $result1->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $result2 = m::mock(stdClass::class);
-        $result2->shouldReceive('getAttribute')->with('id')->andReturn(2);
-        $result3 = m::mock(stdClass::class);
-        $result3->shouldReceive('getAttribute')->with('id')->andReturn(new class
-        {
+
+        $result1 = new class extends Model {
+            protected $attributes = ['id' => 1];
+        };
+
+        $result2 = new class extends Model {
+            protected $attributes = ['id' => 2];
+        };
+
+        $result3 = new class extends Model {
+            protected $attributes = ['id' => 3];
+
             public function __toString()
             {
                 return '3';
             }
-        });
+        };
+
         $model1 = new EloquentBelongsToModelStub;
         $model1->foreign_key = 1;
         $model2 = new EloquentBelongsToModelStub;


### PR DESCRIPTION
It is possible to customize the resolution of the owner and foreign keys. However in the `match` method the code uses the keys directly, so the custom getters would not have any effect.

Related PR: #47378