### PR TITLE
[10.x] Improve tests for `Arr::first` and `Arr::last`

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -244,10 +244,10 @@ class SupportArrTest extends TestCase
         $this->assertEquals(300, Arr::last($array));
 
         // Callback is not null and array is not empty
-        $last = Arr::last($array, function ($value) {
+        $value = Arr::last($array, function ($value) {
             return $value < 250;
         });
-        $this->assertEquals(200, $last);
+        $this->assertEquals(200, $value);
 
         // Callback is not null, array is not empty but no satisfied item
         $value2 = Arr::last($array, function ($value) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -207,9 +207,13 @@ class SupportArrTest extends TestCase
         }, function () {
             return 'baz';
         });
+        $value5 = Arr::first($array, function ($value, $key) {
+            return $key < 2;
+        });
         $this->assertNull($value2);
         $this->assertSame('bar', $value3);
         $this->assertSame('baz', $value4);
+        $this->assertEquals(100, $value5);
     }
 
     public function testJoin()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -233,6 +233,17 @@ class SupportArrTest extends TestCase
     {
         $array = [100, 200, 300];
 
+        // Callback is null and array is empty
+        $this->assertNull(Arr::last([], null));
+        $this->assertSame('foo', Arr::last([], null, 'foo'));
+        $this->assertSame('bar', Arr::last([], null, function () {
+            return 'bar';
+        }));
+
+        // Callback is null and array is not empty
+        $this->assertEquals(300, Arr::last($array));
+
+        // Callback is not null and array is not empty
         $last = Arr::last($array, function ($value) {
             return $value < 250;
         });

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -249,12 +249,25 @@ class SupportArrTest extends TestCase
         });
         $this->assertEquals(200, $last);
 
-        $last = Arr::last($array, function ($value, $key) {
+        // Callback is not null, array is not empty but no satisfied item
+        $value2 = Arr::last($array, function ($value) {
+            return $value > 300;
+        });
+        $value3 = Arr::last($array, function ($value) {
+            return $value > 300;
+        }, 'bar');
+        $value4 = Arr::last($array, function ($value) {
+            return $value > 300;
+        }, function () {
+            return 'baz';
+        });
+        $value5 = Arr::last($array, function ($value, $key) {
             return $key < 2;
         });
-        $this->assertEquals(200, $last);
-
-        $this->assertEquals(300, Arr::last($array));
+        $this->assertNull($value2);
+        $this->assertSame('bar', $value3);
+        $this->assertSame('baz', $value4);
+        $this->assertEquals(200, $value5);
     }
 
     public function testFlatten()


### PR DESCRIPTION
Since the tests for `Arr::last` were not sufficient compared to `Arr::first`, I added tests to `testLast()` that were almost identical to those included in `testFirst()`.

In addition, there was a test for `Arr::last` that was not contained in `Arr::first`, thus I added it to `testFirst()`.

As a result, the tests for `Arr::first` and `Arr::last` are now nearly equivalent, which is reasonable since `Arr::first` and `Arr::last` are expected to be symmetrical in their behavior.