### PR TITLE
[10.x] Add `up` option to make:migration command to omit the down method

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -19,6 +19,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+        {--up : Only generate the `up` method}
         {--fullpath : Output the full path of the migration (Deprecated)}';
 
     /**
@@ -75,6 +76,8 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 
         $create = $this->input->getOption('create') ?: false;
 
+        $upOnly = $this->input->getOption('up');
+
         // If no table was given as an option but a create option is given then we
         // will use the "create" option as the table name. This allows the devs
         // to pass a table name into this option as a short-cut for creating.
@@ -94,7 +97,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $table, $create, $upOnly);
     }
 
     /**
@@ -103,12 +106,13 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      * @param  string  $name
      * @param  string  $table
      * @param  bool  $create
+     * @param  bool  $upOnly
      * @return void
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $table, $create, $upOnly)
     {
         $file = $this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $table, $create, $upOnly
         );
 
         $this->components->info(sprintf('Migration [%s] created successfully.', $file));

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -50,18 +50,19 @@ class MigrationCreator
      * @param  string  $path
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  bool  $upOnly
      * @return string
      *
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $table = null, $create = false, $upOnly = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($table, $create);
+        $stub = $this->getStub($table, $create, $upOnly);
 
         $path = $this->getPath($name, $path);
 
@@ -108,23 +109,22 @@ class MigrationCreator
      *
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  bool  $upOnly
      * @return string
      */
-    protected function getStub($table, $create)
+    protected function getStub($table, $create, $upOnly)
     {
+        $stubFileName = $upOnly ? '/migration.update.up.stub' : '/migration.update.stub';
+
         if (is_null($table)) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.stub')
-                            ? $customPath
-                            : $this->stubPath().'/migration.stub';
+            $stubFileName = $upOnly ? '/migration.up.stub' : '/migration.stub';
         } elseif ($create) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create.stub')
-                            ? $customPath
-                            : $this->stubPath().'/migration.create.stub';
-        } else {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update.stub')
-                            ? $customPath
-                            : $this->stubPath().'/migration.update.stub';
+            $stubFileName = $upOnly ? '/migration.create.up.stub' : '/migration.create.stub';
         }
+
+        $stub = $this->files->exists($customPath = $this->customStubPath.$stubFileName)
+            ? $customPath
+            : $this->stubPath().$stubFileName;
 
         return $this->files->get($stub);
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.up.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.up.stub
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+};

--- a/src/Illuminate/Database/Migrations/stubs/migration.up.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.up.stub
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+    }
+};

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.up.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.up.stub
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -30,6 +30,21 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo');
     }
 
+    public function testBasicCreateMethodWithUpOnlyStoresMigrationFile()
+    {
+        $creator = $this->getCreator();
+
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.up.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.up.stub')->andReturn('return new class');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+
+        $creator->create('create_bar', 'foo', upOnly: true);
+    }
+
     public function testBasicCreateMethodCallsPostCreateHooks()
     {
         $table = 'baz';
@@ -71,6 +86,20 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz');
     }
 
+    public function testTableUpdateMigrationWithUpOnlyStoresMigrationFile()
+    {
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.up.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.up.stub')->andReturn('return new class DummyTable');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class baz');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+
+        $creator->create('create_bar', 'foo', 'baz', upOnly: true);
+    }
+
     public function testTableCreationMigrationStoresMigrationFile()
     {
         $creator = $this->getCreator();
@@ -83,6 +112,20 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
         $creator->create('create_bar', 'foo', 'baz', true);
+    }
+
+    public function testTableCreationMigrationWithUpOnlyStoresMigrationFile()
+    {
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.up.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.up.stub')->andReturn('return new class DummyTable');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class baz');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+
+        $creator->create('create_bar', 'foo', 'baz', true, true);
     }
 
     public function testTableUpdateMigrationWontCreateDuplicateClass()

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -44,7 +44,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -60,7 +60,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
@@ -76,7 +76,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, false)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
@@ -92,7 +92,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+                ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, false)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
 
         $this->runCommand($command, ['name' => 'create_users_table']);
@@ -108,9 +108,25 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
+                ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true, false)
                 ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
+    public function testBasicCreateGivesCreatorProperArgumentsWhenUpOnlyIsTrue()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('update_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false, true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_update_foo.php');
+
+        $this->runCommand($command, ['name' => 'update_foo', '--up' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
It's seemingly becoming more popular to omit the `down` method in migrations and only migrate forwards.

Recently I saw a thread - https://twitter.com/ianlandsman/status/1705276749842424025 and thought perhaps this could be added to the make:migration command in Laravel by default as I always delete the down method once generated manually and it seems others are doing so as well.

I wasn't sure on the "by default" part but I figured the first step would at least have the command support "up-only" migrations.

Initially I had the option name be `--up-only` but figured `--up` would be clear enough.

```bash
php artisan make:migration add_external_id_to_users_table --up
```

```php
return new class extends Migration
{
    /**
     * Run the migrations.
     */
    public function up(): void
    {
        Schema::table('users', function (Blueprint $table) {
            //
        });
    }
};
```

Happy to PR to the docs for this addition if merged.