### PR TITLE
[11.x] Add missing channel params to `sendNow` method in notifications

### DIFF
--- a/src/Illuminate/Contracts/Notifications/Dispatcher.php
+++ b/src/Illuminate/Contracts/Notifications/Dispatcher.php
@@ -18,7 +18,8 @@ interface Dispatcher
      *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification
+     * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification);
+    public function sendNow($notifiables, $notification, array $channels = null);
 }


### PR DESCRIPTION
The `sendNow` method has a `$channels` param, but there isn't one in the Dispatcher contract!!