### PR TITLE
[10.x] Add Str::betweenLast

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -192,7 +192,7 @@ class Str
     }
 
     /**
-     * Get the smallest possible portion of a string between two given values.
+     * Get the portion of a string between two given values, starting at the first occurence of the $from and ending at the first occurence of the $to.
      *
      * @param  string  $subject
      * @param  string  $from
@@ -206,6 +206,23 @@ class Str
         }
 
         return static::before(static::after($subject, $from), $to);
+    }
+
+    /**
+     * Get the portion of a string between two given values, starting at the last occurence of the $from and ending at the first occurence of the $to.
+     *
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
+     * @return string
+     */
+    public static function betweenLast($subject, $from, $to)
+    {
+        if ($from === '' || $to === '') {
+            return $subject;
+        }
+
+        return static::before(static::afterLast($subject, $from), $to);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -155,7 +155,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Get the smallest possible portion of a string between two given values.
+     * Get the portion of a string between two given values, starting at the first occurence of the $from and ending at the first occurence of the $to.
      *
      * @param  string  $from
      * @param  string  $to
@@ -164,6 +164,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function betweenFirst($from, $to)
     {
         return new static(Str::betweenFirst($this->value, $from, $to));
+    }
+
+    /**
+     * Get the portion of a string between two given values, starting at the last occurence of the $from and ending at the first occurence of the $to.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @return static
+     */
+    public function betweenLast($from, $to)
+    {
+        return new static(Str::betweenLast($this->value, $from, $to));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -260,6 +260,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::betweenFirst('foobarbar', 'foo', 'bar'));
     }
 
+    public function testStrBetweenLast()
+    {
+        $this->assertSame('file', Str::betweenLast('/home/user/file.txt', '/', '.'));
+        $this->assertSame('a', Str::betweenLast('hannah', 'n', 'h'));
+        $this->assertSame('', Str::betweenLast('foobarbar', 'r', 'r'));
+    }
+
     public function testStrAfter()
     {
         $this->assertSame('nah', Str::after('hannah', 'han'));


### PR DESCRIPTION
Hi all!

I'm writing a file processing and needed to strip out the file name without extension from the path provided, and noted in #31603 that there was suggestion for this. Please accept this as a humble contribution

The description of the `Str::betweenFirst` being ```Get the smallest possible portion of a string between two given values``` has created a bit of confusion as it's not entirely accurate. 

**An example use** 
I have a file path input, e.g. `/home/count/BigBuckBunny/BigBuckBunny.mp4`
I need to run this through a process and create a new output file called `/tmp/home/count/BigBuckBunny/BigBuckBunny_OnAir.mp4`
I need to get just the filename without the extension - `BigBuckBunny`

Although the method name states it is for first, the description says the smallest possible portion which isn't the case as it will output `home/count/BigBuckBunny/BigBuckBunny_OnAir.mp4`

In this scenario, I have used 
```php
$file_name = Str::before(Str::afterLast($this->file, '/'), '.');
```

I'm not the best at wording, so I am open to suggestions please.

The accompanying docs PR is accessible at laravel/docs#9050

I would appreciate any and all feedback to this ❤️ 