### PR TITLE
[10.x] Handle custom extensions when caching views

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -77,11 +77,17 @@ class ViewCacheCommand extends Command
      */
     protected function bladeFilesIn(array $paths)
     {
+        $extensions = collect($this->laravel['view']->getExtensions())
+            ->filter(fn ($value) => $value === 'blade')
+            ->keys()
+            ->map(fn ($extension) => "*.{$extension}")
+            ->all();
+
         return collect(
             Finder::create()
                 ->in($paths)
                 ->exclude('vendor')
-                ->name('*.blade.php')
+                ->name($extensions)
                 ->files()
         );
     }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -169,20 +169,20 @@ class BladeTest extends TestCase
 </div>', trim($content));
     }
 
-     public function testViewCacheCommandHandlesConfiguredBladeExtensions()
-     {
-         $this->artisan('view:clear');
+    public function testViewCacheCommandHandlesConfiguredBladeExtensions()
+    {
+        $this->artisan('view:clear');
 
-         View::addExtension('sh', 'blade');
-         $this->artisan('view:cache');
+        View::addExtension('sh', 'blade');
+        $this->artisan('view:cache');
 
-         $compiledFiles = Finder::create()->in(Config::get('view.compiled'))->files();
-         $found = collect($compiledFiles)
-             ->contains(fn (SplFileInfo $file) => str_contains($file->getContents(), 'echo "<?php echo e($scriptMessage); ?>" > output.log'));
-         $this->assertTrue($found);
+        $compiledFiles = Finder::create()->in(Config::get('view.compiled'))->files();
+        $found = collect($compiledFiles)
+            ->contains(fn (SplFileInfo $file) => str_contains($file->getContents(), 'echo "<?php echo e($scriptMessage); ?>" > output.log'));
+        $this->assertTrue($found);
 
-         $this->artisan('view:clear');
-     }
+        $this->artisan('view:clear');
+    }
 
     protected function getEnvironmentSetUp($app)
     {

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Tests\Integration\View;
 
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\View;
 use Illuminate\View\Component;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class BladeTest extends TestCase
 {
@@ -165,6 +168,21 @@ class BladeTest extends TestCase
     <input type="text" class="input text-input-lg" name="my_form_field" data-test="data" />
 </div>', trim($content));
     }
+
+     public function testViewCacheCommandHandlesConfiguredBladeExtensions()
+     {
+         $this->artisan('view:clear');
+
+         View::addExtension('sh', 'blade');
+         $this->artisan('view:cache');
+
+         $compiledFiles = Finder::create()->in(Config::get('view.compiled'))->files();
+         $found = collect($compiledFiles)
+             ->contains(fn (SplFileInfo $file) => str_contains($file->getContents(), 'echo "<?php echo e($scriptMessage); ?>" > output.log'));
+         $this->assertTrue($found);
+
+         $this->artisan('view:clear');
+     }
 
     protected function getEnvironmentSetUp($app)
     {

--- a/tests/Integration/View/templates/different-extension.sh
+++ b/tests/Integration/View/templates/different-extension.sh
@@ -1,0 +1,1 @@
+echo "{{ $scriptMessage }}" > output.log


### PR DESCRIPTION
The `view:cache` command does not currently account for custom extensions, so the files are still lazily compiled.

```php
View::addExtension('sh', 'blade');
```

Now when running `php artisan view:cache` files with the `.sh` extension within the configured view directory will now be cached as expected.