### PR TITLE
[10.x] Convert Expression to string for from in having subqueries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -802,7 +802,7 @@ trait QueriesRelationships
         $wheres = $from->getQuery()->from !== $this->getQuery()->from
             ? $this->requalifyWhereTables(
                 $from->getQuery()->wheres,
-                $from->getQuery()->from,
+                $from->getQuery()->grammar->getValue($from->getQuery()->from),
                 $this->getModel()->getTable()
             ) : $from->getQuery()->wheres;
 


### PR DESCRIPTION
Attempting to override the having from inside of the `whereHaving()` callback will fail due to the removal of `__toString()` logic with Laravel 10.x.

This adds back the ability to override the local table with a subquery in the having, which worked on previous versions of Laravel before 10.x.
