### PR TITLE
[10.x] Support for `BackedEnum` and `UnitEnum` in `Collection::valueRetriever`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -4,11 +4,13 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayIterator;
+use BackedEnum;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 use Traversable;
+use UnitEnum;
 
 /**
  * @template TKey of array-key
@@ -78,7 +80,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the average value of a given key.
      *
-     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @param  (callable(TValue): float|int)|string|BackedEnum|UnitEnum|null  $callback
      * @return float|int|null
      */
     public function avg($callback = null)
@@ -303,7 +305,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Retrieve duplicate items from the collection.
      *
-     * @param  (callable(TValue): bool)|string|null  $callback
+     * @param  (callable(TValue): bool)|string|BackedEnum|UnitEnum|null  $callback
      * @param  bool  $strict
      * @return static
      */
@@ -482,7 +484,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Group an associative array by a field or using a callback.
      *
-     * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy
+     * @param  (callable(TValue, TKey): array-key)|array|string|BackedEnum|UnitEnum  $groupBy
      * @param  bool  $preserveKeys
      * @return static<array-key, static<array-key, TValue>>
      */
@@ -533,7 +535,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
+     * @param  (callable(TValue, TKey): array-key)|array|string|BackedEnum|UnitEnum  $keyBy
      * @return static<array-key, TValue>
      */
     public function keyBy($keyBy)
@@ -1368,7 +1370,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string|BackedEnum|UnitEnum  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -1589,7 +1591,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|BackedEnum|UnitEnum|null  $key
      * @param  bool  $strict
      * @return static
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use ArrayIterator;
+use BackedEnum;
 use Closure;
 use DateTimeInterface;
 use Generator;
@@ -13,6 +14,7 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use stdClass;
 use Traversable;
+use UnitEnum;
 
 /**
  * @template TKey of array-key
@@ -293,7 +295,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Count the number of items in the collection by a field or using a callback.
      *
-     * @param  (callable(TValue, TKey): array-key)|string|null  $countBy
+     * @param  (callable(TValue, TKey): array-key)|string|BackedEnum|UnitEnum|null  $countBy
      * @return static<array-key, int>
      */
     public function countBy($countBy = null)
@@ -549,7 +551,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
+     * @param  (callable(TValue, TKey): array-key)|array|string|BackedEnum|UnitEnum  $keyBy
      * @return static<array-key, TValue>
      */
     public function keyBy($keyBy)
@@ -1556,7 +1558,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|BackedEnum|UnitEnum|null  $key
      * @param  bool  $strict
      * @return static
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Traits;
 
+use BackedEnum;
 use CachingIterator;
 use Closure;
 use Exception;
@@ -259,7 +260,7 @@ trait EnumeratesValues
     /**
      * Determine if all items pass the given truth test.
      *
-     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  (callable(TValue, TKey): bool)|TValue|string|BackedEnum|UnitEnum  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -410,7 +411,7 @@ trait EnumeratesValues
     /**
      * Get the min value of a given key.
      *
-     * @param  (callable(TValue):mixed)|string|null  $callback
+     * @param  (callable(TValue):mixed)|string|BackedEnum|UnitEnum|null  $callback
      * @return mixed
      */
     public function min($callback = null)
@@ -425,7 +426,7 @@ trait EnumeratesValues
     /**
      * Get the max value of a given key.
      *
-     * @param  (callable(TValue):mixed)|string|null  $callback
+     * @param  (callable(TValue):mixed)|string|BackedEnum|UnitEnum|null  $callback
      * @return mixed
      */
     public function max($callback = null)
@@ -456,7 +457,7 @@ trait EnumeratesValues
     /**
      * Partition the collection into two arrays using the given callback or key.
      *
-     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  (callable(TValue, TKey): bool)|TValue|string|BackedEnum|UnitEnum  $key
      * @param  TValue|string|null  $operator
      * @param  TValue|null  $value
      * @return static<int<0, 1>, static<TKey, TValue>>
@@ -503,7 +504,7 @@ trait EnumeratesValues
     /**
      * Get the sum of the given values.
      *
-     * @param  (callable(TValue): mixed)|string|null  $callback
+     * @param  (callable(TValue): mixed)|string|BackedEnum|UnitEnum|null  $callback
      * @return mixed
      */
     public function sum($callback = null)
@@ -859,7 +860,7 @@ trait EnumeratesValues
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|BackedEnum|UnitEnum|null  $key
      * @param  bool  $strict
      * @return static
      */
@@ -1030,7 +1031,7 @@ trait EnumeratesValues
     /**
      * Get an operator checker callback.
      *
-     * @param  callable|string  $key
+     * @param  callable|string|BackedEnum|UnitEnum  $key
      * @param  string|null  $operator
      * @param  mixed  $value
      * @return \Closure
@@ -1039,6 +1040,14 @@ trait EnumeratesValues
     {
         if ($this->useAsCallable($key)) {
             return $key;
+        }
+
+        if ($key instanceof BackedEnum) {
+            $key = $key->value;
+        }
+
+        if ($key instanceof UnitEnum) {
+            $key = $key->name;
         }
 
         if (func_num_args() === 1) {
@@ -1095,13 +1104,21 @@ trait EnumeratesValues
     /**
      * Get a value retrieving callback.
      *
-     * @param  callable|string|null  $value
+     * @param  callable|string|BackedEnum|UnitEnum|null  $value
      * @return callable
      */
     protected function valueRetriever($value)
     {
         if ($this->useAsCallable($value)) {
             return $value;
+        }
+
+        if ($value instanceof BackedEnum) {
+            $value = $value->value;
+        }
+
+        if ($value instanceof UnitEnum) {
+            $value = $value->name;
         }
 
         return fn ($item) => data_get($item, $value);

--- a/tests/Support/Enums.php
+++ b/tests/Support/Enums.php
@@ -12,3 +12,8 @@ enum TestBackedEnum: int
     case A = 1;
     case B = 2;
 }
+
+enum TestStringBackedEnum: string
+{
+    case FOO = 'foo';
+}


### PR DESCRIPTION
In this PR I would like to add support for `BackedEnum` and `UnitEnum` in some Collection functions, which keys are resolved by `valueRetriever` function.

With this support, you can use Enums in Collection functions like: `avg, duplicates, keyBy, groupBy, sortBy, countBy, unique, every, min, max, partition, sum`