### PR TITLE
[10.x] Failing test/bug report in `HasManyThrough` `updateOrCreate()` since Laravel 10.21

### DIFF
--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use Spatie\LaravelRay\RayServiceProvider;
 
 class EloquentHasManyThroughTest extends DatabaseTestCase
 {
@@ -140,53 +139,53 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 
         $this->assertEquals([1], $categories->pluck('id')->all());
     }
-	
-	public function testUpdateOrCreateWillNotUseIdFromParentModel()
-	{
-		// On Laravel 10.21.0, a bug was introduced that would update the wrong model when using `updateOrCreate()`,
-		// because the UPDATE statement would target a model based on the ID from the parent instead of the actual
-		// conditions that the `updateOrCreate()` targeted. This test replicates the case that causes this bug.
-		
-		// Manually provide IDs, keep ID 1 and 2 free for the team-mates.
-		$user1 = User::create(['name' => Str::random(), 'id' => 3]);
-		$user2 = User::create(['name' => Str::random(), 'id' => 4]);
-		
-		$team1 = Team::create(['owner_id' => $user1->id]);
-		$team2 = Team::create(['owner_id' => $user2->id]);
-		
-		$teamMate1 = User::create(['name' => 'John', 'slug' => 'john-slug', 'team_id' => $team1->id, 'id' => 2]);
-		// $teamMate2->id should be the same as the $team1->id for the bug to occur.
-		$teamMate2 = User::create(['name' => 'Jane', 'slug' => 'jane-slug', 'team_id' => $team2->id, 'id' => $team1->id]);
-		
-		$this->assertSame(2, $teamMate1->id);
-		$this->assertSame(1, $teamMate2->id);
-		
-		$this->assertSame(2, $teamMate1->refresh()->id);
-		$this->assertSame(1, $teamMate2->refresh()->id);
-		
-		$this->assertSame('john-slug', $teamMate1->slug);
-		$this->assertSame('jane-slug', $teamMate2->slug);
-		
-		$this->assertSame('john-slug', $teamMate1->refresh()->slug);
-		$this->assertSame('jane-slug', $teamMate2->refresh()->slug);
-		
-		$user1->teamMates()->updateOrCreate([
-			'name' => 'John',
-			// The `updateOrCreate()` method tries to retrieve an existing model first like `->where($conditions)->first()`.
-			// In our case, that will return the model with the name `John`. However, the ID of the model with the name
-			// `John` is hydrated to `1` – where the actual ID should be `2` for the model with the name `John` (see
-			// the assertions above). If the `->where($conditions)->first()` return a model, a `->fill()->save()`
-			// action is executed. Because the ID is incorrectly hydrated to `1`, it will now update the Jane
-			// model with *all* the attributes of the `John` model, instead of updating the `John` model.
-		], [
-			'slug' => 'john-doe',
-		]);
-		
-		// Expect $teamMate1's slug to be updated to john-doe instead of john-old.
-		$this->assertSame('john-doe', $teamMate1->fresh()->slug);
-		// $teamMate2 should not be updated, because it belongs to a different user altogether.
-		$this->assertSame('jane-slug', $teamMate2->fresh()->slug);
-	}
+
+    public function testUpdateOrCreateWillNotUseIdFromParentModel()
+    {
+        // On Laravel 10.21.0, a bug was introduced that would update the wrong model when using `updateOrCreate()`,
+        // because the UPDATE statement would target a model based on the ID from the parent instead of the actual
+        // conditions that the `updateOrCreate()` targeted. This test replicates the case that causes this bug.
+
+        // Manually provide IDs, keep ID 1 and 2 free for the team-mates.
+        $user1 = User::create(['name' => Str::random(), 'id' => 3]);
+        $user2 = User::create(['name' => Str::random(), 'id' => 4]);
+
+        $team1 = Team::create(['owner_id' => $user1->id]);
+        $team2 = Team::create(['owner_id' => $user2->id]);
+
+        $teamMate1 = User::create(['name' => 'John', 'slug' => 'john-slug', 'team_id' => $team1->id, 'id' => 2]);
+        // $teamMate2->id should be the same as the $team1->id for the bug to occur.
+        $teamMate2 = User::create(['name' => 'Jane', 'slug' => 'jane-slug', 'team_id' => $team2->id, 'id' => $team1->id]);
+
+        $this->assertSame(2, $teamMate1->id);
+        $this->assertSame(1, $teamMate2->id);
+
+        $this->assertSame(2, $teamMate1->refresh()->id);
+        $this->assertSame(1, $teamMate2->refresh()->id);
+
+        $this->assertSame('john-slug', $teamMate1->slug);
+        $this->assertSame('jane-slug', $teamMate2->slug);
+
+        $this->assertSame('john-slug', $teamMate1->refresh()->slug);
+        $this->assertSame('jane-slug', $teamMate2->refresh()->slug);
+
+        $user1->teamMates()->updateOrCreate([
+            'name' => 'John',
+            // The `updateOrCreate()` method tries to retrieve an existing model first like `->where($conditions)->first()`.
+            // In our case, that will return the model with the name `John`. However, the ID of the model with the name
+            // `John` is hydrated to `1` – where the actual ID should be `2` for the model with the name `John` (see
+            // the assertions above). If the `->where($conditions)->first()` return a model, a `->fill()->save()`
+            // action is executed. Because the ID is incorrectly hydrated to `1`, it will now update the Jane
+            // model with *all* the attributes of the `John` model, instead of updating the `John` model.
+        ], [
+            'slug' => 'john-doe',
+        ]);
+
+        // Expect $teamMate1's slug to be updated to john-doe instead of john-old.
+        $this->assertSame('john-doe', $teamMate1->fresh()->slug);
+        // $teamMate2 should not be updated, because it belongs to a different user altogether.
+        $this->assertSame('jane-slug', $teamMate2->fresh()->slug);
+    }
 }
 
 class User extends Model

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -143,7 +143,7 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
 	
 	public function testUpdateOrCreateWillNotUseIdFromParentModel()
 	{
-		// On Laravel 10.21.0, a bug was introduced that would update the wroong model when using `updateOrCreate()`,
+		// On Laravel 10.21.0, a bug was introduced that would update the wrong model when using `updateOrCreate()`,
 		// because the UPDATE statement would target a model based on the ID from the parent instead of the actual
 		// conditions that the `updateOrCreate()` targeted. This test replicates the case that causes this bug.
 		


### PR DESCRIPTION
Last week, I had a weird bug in an application, where suddenly records from different users become visible to each other. The bug seemed to be related to a certain `updateOrCreate()` method. Suddenly, old records from one year ago were being updated with recent data from other users.

After much digging, I found that there seems to be a bug introduced in Laravel 10.21.0. Consider the following code:
```php
public function legs(): HasManyThrough
{
    return $this->hasManyThrough(Leg::class, Booking::class, 'user_id', 'booking_id');
}
```
The error happens in the following code:
```php
$user->legs()->updateOrCreate([
    'legs.external_id' => 1234,
], [
   // 
]);
```
Say that User A has a booking with an ID of `1234`. This `updateOrCreate()` statement would just randomly find any leg with an ID of `1234` and update that random leg with the data from the second `updateOrCreate()` parameter. Said again, the error is that this code would retrieve legs by ID instead of the actual conditions specified , and for the leg ID it takes the booking ID. So it could update a leg of User B with data from User A.

This is very dangerous bug in an application. I've been able to reproduce the case in a failing test, which you find attached to this PR. If you run this test on Laravel 10.20.0, the test will pass. If you run this on Laravel 10.21.0 or later, it will fail (like it currently does).

The code where the bug was introduced is #48192 in the `HasManyThrough.php` file, because if I revert the code in the `updateOrCreate()` method there, the code works as expected. However, the code in that file doesn't look too strange, so probably it's an underlying bug in hydrating the model. Please see the test for a better explanation.

I checked the queries that are being run and the full flow from a `->where($conditions)->first()` until executing the statement, but I do not see anything wrong there:
```
select
  *
from
  "users"
  inner join "teams" on "teams"."id" = "users"."team_id"
where
  "teams"."owner_id" = 3
  and ("name" = 'John')
limit
  1
```
```
update "users"
set
  "slug" = 'john-doe'
where
  "id" = 1
```

However, even after double-checking multiple times, the test keeps passing on 10.20.0 and keeps failing on 10.21.0, so the bug must be somewhere in these [53 files](https://github.com/laravel/framework/compare/v10.20.0...v10.21.0).


