### PR TITLE
[10.x] Don't crash if replacement cannot be represented as a string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -15,6 +15,7 @@ use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Symfony\Component\Uid\Ulid;
+use Throwable;
 use Traversable;
 use voku\helper\ASCII;
 
@@ -986,10 +987,24 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= (array_shift($replace) ?? $search).$segment;
+            $result .= self::toStringOr(array_shift($replace) ?? $search, $search).$segment;
         }
 
         return $result;
+    }
+
+    /**
+     * @param  mixed  $value
+     * @param  string  $fallback
+     * @return string
+     */
+    private static function toStringOr($value, $fallback)
+    {
+        try {
+            return (string) $value;
+        } catch (Throwable $e) {
+            return $fallback;
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -994,6 +994,8 @@ class Str
     }
 
     /**
+     * Convert the given value to a string or return the given fallback on failure.
+     *
      * @param  mixed  $value
      * @param  string  $fallback
      * @return string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -594,6 +594,8 @@ class SupportStrTest extends TestCase
         // Test for associative array support
         $this->assertSame('foo/bar', Str::replaceArray('?', [1 => 'foo', 2 => 'bar'], '?/?'));
         $this->assertSame('foo/bar', Str::replaceArray('?', ['x' => 'foo', 'y' => 'bar'], '?/?'));
+        // Test does not crash on bad input
+        $this->assertSame('?', Str::replaceArray('?', [(object) ['foo' => 'bar']], '?'));
     }
 
     public function testReplaceFirst()


### PR DESCRIPTION
Fixes

```
Error Object of class stdClass could not be converted to string 
    vendor/laravel/framework/src/Illuminate/Support/Str.php:989 Illuminate\Support\Str::replaceArray
    vendor/laravel/framework/src/Illuminate/Database/QueryException.php:67 Illuminate\Database\QueryException::formatMessage
    vendor/laravel/framework/src/Illuminate/Database/QueryException.php:49 Illuminate\Database\QueryException::__construct
    vendor/laravel/framework/src/Illuminate/Database/Connection.php:801 Illuminate\Database\Connection::runQueryCallback
    vendor/laravel/framework/src/Illuminate/Database/Connection.php:755 Illuminate\Database\Connection::run
    vendor/laravel/framework/src/Illuminate/Database/Connection.php:407 Illuminate\Database\Connection::select
    vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php:469 Illuminate\Database\DatabaseManager::__call
    vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:353 Illuminate\Support\Facades\Facade::__callStatic
```
