### PR TITLE
[10.x] Fix typos in tests

### DIFF
--- a/tests/Database/DatabaseEloquentDynamicRelationsTest.php
+++ b/tests/Database/DatabaseEloquentDynamicRelationsTest.php
@@ -48,7 +48,7 @@ class DatabaseEloquentDynamicRelationsTest extends TestCase
 
     public function testInheritedDynamicRelationsOverride()
     {
-        // Inherited Dynamic Relations can be overriden
+        // Inherited Dynamic Relations can be overridden
         DynamicRelationModel::resolveRelationUsing('dynamicRelConflict', fn ($m) => $m->hasOne(Related::class));
         $model = new DynamicRelationModel;
         $model4 = new DynamicRelationModel4;

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -463,7 +463,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertNotNull($user->latest_login_with_soft_deletes);
     }
 
-    public function testWithContraintNotInAggregate()
+    public function testWithConstraintNotInAggregate()
     {
         $user = HasOneOfManyTestUser::create();
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -73,7 +73,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema('default')->create('users_with_space_in_colum_name', function ($table) {
+        $this->schema('default')->create('users_with_space_in_column_name', function ($table) {
             $table->increments('id');
             $table->string('name')->nullable();
             $table->string('email address');
@@ -734,7 +734,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUserWithSpaceInColumnName::create(['id' => 1, 'email address' => 'taylorotwell@gmail.com']);
         EloquentTestUserWithSpaceInColumnName::create(['id' => 2, 'email address' => 'abigailotwell@gmail.com']);
 
-        $simple = EloquentTestUserWithSpaceInColumnName::oldest('id')->pluck('users_with_space_in_colum_name.email address')->all();
+        $simple = EloquentTestUserWithSpaceInColumnName::oldest('id')->pluck('users_with_space_in_column_name.email address')->all();
         $keyed = EloquentTestUserWithSpaceInColumnName::oldest('id')->pluck('email address', 'id')->all();
 
         $this->assertEquals(['taylorotwell@gmail.com', 'abigailotwell@gmail.com'], $simple);
@@ -2266,7 +2266,7 @@ class EloquentTestUserWithCustomFriendPivot extends EloquentTestUser
 
 class EloquentTestUserWithSpaceInColumnName extends EloquentTestUser
 {
-    protected $table = 'users_with_space_in_colum_name';
+    protected $table = 'users_with_space_in_column_name';
 }
 
 class EloquentTestNonIncrementing extends Eloquent

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -271,7 +271,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
     public function testIsRelationIgnoresAttribute()
     {
-        $model = new EloquentRelationAndAtrributeModelStub;
+        $model = new EloquentRelationAndAttributeModelStub;
 
         $this->assertTrue($model->isRelation('parent'));
         $this->assertFalse($model->isRelation('field'));
@@ -339,7 +339,7 @@ class EloquentNoTouchingAnotherModelStub extends Model
     ];
 }
 
-class EloquentRelationAndAtrributeModelStub extends Model
+class EloquentRelationAndAttributeModelStub extends Model
 {
     protected $table = 'one_more_table';
 

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -296,7 +296,7 @@ Working directory: expected-working-directory');
             ->assertSuccessful();
     }
 
-    public function testGuessedMatchesThatDirectlyContainTheGivenStringRankHigerThanArbitraryMatches()
+    public function testGuessedMatchesThatDirectlyContainTheGivenStringRankHigherThanArbitraryMatches()
     {
         $this->artisan('docs ora')
             ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/filesystem')

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -273,17 +273,17 @@ class FoundationExceptionsHandlerTest extends TestCase
             $redirector = m::mock(Redirector::class);
 
             $redirector->shouldReceive('to')->once()
-                ->andReturn($responser = m::mock(RedirectResponse::class));
+                ->andReturn($responder = m::mock(RedirectResponse::class));
 
-            $responser->shouldReceive('withInput')->once()->with(m::on(
+            $responder->shouldReceive('withInput')->once()->with(m::on(
                 function ($argument) use (&$argumentActual) {
                     $argumentActual = $argument;
 
                     return true;
-                }))->andReturn($responser);
+                }))->andReturn($responder);
 
-            $responser->shouldReceive('withErrors')->once()
-                ->andReturn($responser);
+            $responder->shouldReceive('withErrors')->once()
+                ->andReturn($responder);
 
             return $redirector;
         });

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -75,19 +75,19 @@ class InteractsWithContainerTest extends TestCase
 
     public function testForgetMock()
     {
-        $this->mock(IntanceStub::class)
+        $this->mock(InstanceStub::class)
             ->shouldReceive('execute')
             ->once()
             ->andReturn('bar');
 
-        $this->assertSame('bar', $this->app->make(IntanceStub::class)->execute());
+        $this->assertSame('bar', $this->app->make(InstanceStub::class)->execute());
 
-        $this->forgetMock(IntanceStub::class);
-        $this->assertSame('foo', $this->app->make(IntanceStub::class)->execute());
+        $this->forgetMock(InstanceStub::class);
+        $this->assertSame('foo', $this->app->make(InstanceStub::class)->execute());
     }
 }
 
-class IntanceStub
+class InstanceStub
 {
     public function execute()
     {

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -120,7 +120,7 @@ class TrustProxiesTest extends TestCase
     /**
      * Test X-Forwarded-For header with multiple IP addresses, with some of those being trusted.
      */
-    public function test_get_client_ip_with_muliple_ip_addresses_some_of_which_are_trusted()
+    public function test_get_client_ip_with_multiple_ip_addresses_some_of_which_are_trusted()
     {
         $trustedProxy = $this->createTrustedProxy($this->headerAll, ['192.168.10.10', '192.0.2.199']);
 
@@ -143,7 +143,7 @@ class TrustProxiesTest extends TestCase
     /**
      * Test X-Forwarded-For header with multiple IP addresses, with * wildcard trusting of all proxies.
      */
-    public function test_get_client_ip_with_muliple_ip_addresses_all_proxies_are_trusted()
+    public function test_get_client_ip_with_multiple_ip_addresses_all_proxies_are_trusted()
     {
         $trustedProxy = $this->createTrustedProxy($this->headerAll, '*');
 

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -50,7 +50,7 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->assertExitCode(1);
     }
 
-    public function testItFailsWhenEncyptionFileCannotBeFound()
+    public function testItFailsWhenEncryptionFileCannotBeFound()
     {
         $this->filesystem->shouldReceive('exists')->andReturn(true);
 

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -96,7 +96,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->assertExitCode(1);
     }
 
-    public function testItFailsWhenEncyptionFileExists()
+    public function testItFailsWhenEncryptionFileExists()
     {
         $this->filesystem->shouldReceive('exists')->andReturn(true);
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -76,14 +76,14 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertFalse($user->isDirty());
         $this->assertFalse($user->wasChanged());
 
-        $user->name = $overideName = Str::random();
+        $user->name = $overrideName = Str::random();
 
-        $this->assertEquals(['name' => $overideName], $user->getDirty());
+        $this->assertEquals(['name' => $overrideName], $user->getDirty());
         $this->assertEmpty($user->getChanges());
         $this->assertTrue($user->isDirty());
         $this->assertFalse($user->wasChanged());
         $this->assertSame($originalName, $user->getOriginal('name'));
-        $this->assertSame($overideName, $user->getAttribute('name'));
+        $this->assertSame($overrideName, $user->getAttribute('name'));
 
         $user->discardChanges();
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -138,7 +138,7 @@ class EloquentWhereTest extends DatabaseTestCase
         $this->assertCount(2, $users);
     }
 
-    public function testWhereInCanAcceptQueriable()
+    public function testWhereInCanAcceptQueryable()
     {
         $user1 = UserWhereTest::create([
             'name' => 'test-name1',

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1220,7 +1220,7 @@ class ResourceTest extends TestCase
         });
     }
 
-    public function testCollectionResourceWithPaginationInfomation()
+    public function testCollectionResourceWithPaginationInformation()
     {
         $posts = collect([
             new Post(['id' => 5, 'title' => 'Test Title']),
@@ -1251,7 +1251,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function testResourceWithPaginationInfomation()
+    public function testResourceWithPaginationInformation()
     {
         $posts = collect([
             new Post(['id' => 5, 'title' => 'Test Title']),
@@ -1346,7 +1346,7 @@ class ResourceTest extends TestCase
         $response->assertJson(['data' => $data]);
     }
 
-    public function testKeysArePreservedInAnAnonymousColletionIfTheResourceIsFlaggedToPreserveKeys()
+    public function testKeysArePreservedInAnAnonymousCollectionIfTheResourceIsFlaggedToPreserveKeys()
     {
         $data = Collection::make([
             [

--- a/tests/Integration/Queue/typed-properties.php
+++ b/tests/Integration/Queue/typed-properties.php
@@ -11,7 +11,7 @@ class TypedPropertyTestClass
 
     public ModelSerializationTestUser $user;
 
-    public ModelSerializationTestUser $unitializedUser;
+    public ModelSerializationTestUser $uninitializedUser;
 
     protected int $id;
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -169,7 +169,7 @@ class UrlSigningTest extends TestCase
         $this->assertSame('valid', $this->get($url.'&two=value&one=&three')->original);
     }
 
-    public function testUnusualExceptedParametersWorksAsExpexted()
+    public function testUnusualExceptedParametersWorksAsExpected()
     {
         $this->withoutExceptionHandling();
         Route::get('/foo/{id}', function (Request $request, $id) {

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -24,7 +24,7 @@ class MultipleInstanceManagerTest extends TestCase
         $this->assertEquals(spl_object_hash($barInstance), spl_object_hash($duplicateBarInstance));
     }
 
-    public function test_unresolvable_isntances_throw_errors()
+    public function test_unresolvable_instances_throw_errors()
     {
         $this->expectException(RuntimeException::class);
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -616,7 +616,7 @@ class LogManagerTest extends TestCase
         $this->assertSame(['invocation-id' => 'expected-id'], $context);
     }
 
-    public function testContextCanBePublicallyAccessedByOtherLoggingSystems()
+    public function testContextCanBePubliclyAccessedByOtherLoggingSystems()
     {
         $manager = new LogManager($this->app);
         $context = null;

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -320,7 +320,7 @@ class ProcessTest extends TestCase
         $result = $factory->run('ls -la');
     }
 
-    public function testStrayProcessesCanBePreventedWithStringComand()
+    public function testStrayProcessesCanBePreventedWithStringCommand()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Attempted process [');

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -298,7 +298,7 @@ class RouteCollectionTest extends TestCase
         $this->routeCollection->match($request);
     }
 
-    public function testHasNameRouteMehod()
+    public function testHasNameRouteMethod()
     {
         $this->routeCollection->add(
             new Route('GET', 'users', ['uses' => 'UsersController@index', 'as' => 'users'])

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4739,7 +4739,7 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testSplitCollectionWithADivisableCount($collection)
+    public function testSplitCollectionWithADivisibleCount($collection)
     {
         $data = new $collection(['a', 'b', 'c', 'd']);
         $split = $data->split(2);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -172,8 +172,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('...abc...', Str::excerpt('z  abc  d', 'b', ['radius' => 1]));
         $this->assertSame('[...]is a beautiful morn[...]', Str::excerpt('This is a beautiful morning', 'beautiful', ['omission' => '[...]', 'radius' => 5]));
         $this->assertSame(
-            'This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
-            Str::excerpt('This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
+            'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
+            Str::excerpt('This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
                 ['omission' => '[...]'],
             ));
 

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -385,7 +385,7 @@ class AssertTest extends TestCase
         $assert->where('baz', 'invalid');
     }
 
-    public function testAssertWhereFailsWhenMachingLoosely()
+    public function testAssertWhereFailsWhenMatchingLoosely()
     {
         $assert = AssertableJson::fromArray([
             'bar' => 1,

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -113,7 +113,7 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('required="required" x-data=""', (string) $bag);
     }
 
-    public function testAttibuteExistence()
+    public function testAttributeExistence()
     {
         $bag = new ComponentAttributeBag(['name' => 'test']);
 


### PR DESCRIPTION
Found a few dozen misspellings in tests.

_supercalifragilisticexpialidocious_ had a typo
![image](https://github.com/laravel/framework/assets/952007/694a92e5-0c15-405a-ae36-dc8195a1aee2)
