### PR TITLE
[10.x] Refactored LazyCollection::except() to save memory

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -479,6 +479,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                     unset($data[$k]);
                 }
             }
+
             return $data;
         };
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -434,7 +434,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
         return new static(function () use ($keys) {
             foreach ($this as $key => $value) {
-                if (!in_array($key, $keys)) {
+                if (! in_array($key, $keys)) {
                     yield $key => $value;
                 }
             }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -430,9 +430,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             return $this;
         }
 
+        $keys = array_flip($keys);
         return new static(function () use ($keys) {
             foreach ($this as $key => $value) {
-                if (! in_array($key, $keys)) {
+                if (! array_key_exists($key, $keys)) {
                     yield $key => $value;
                 }
             }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -427,9 +427,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         };
 
         if (count($keys) === 0) {
-            return new static(function () {
-                yield from $this;
-            });
+            return $this;
         }
 
         return new static(function () use ($keys) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -431,6 +431,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         }
 
         $keys = array_flip($keys);
+
         return new static(function () use ($keys) {
             foreach ($this as $key => $value) {
                 if (! array_key_exists($key, $keys)) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -352,8 +352,12 @@ class SupportLazyCollectionIsLazyTest extends TestCase
             $collection->except([1, 2])->all();
         });
 
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->except([1, 2])->take(1)->all();
+        $this->assertEnumerates(3, function ($collection) {
+            // $collection contains a list of [1, 2, 3, ..., 100]
+            // Using except to exclude offset 0, 1, and then take(1),
+            // 1 and 2 are excluded, leaving 3 as the value in $collection.
+            // Therefore, Enumerates Count will be 3.
+            $collection->except([0, 1])->take(1)->all();
         });
     }
 

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -351,6 +351,10 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         $this->assertEnumeratesOnce(function ($collection) {
             $collection->except([1, 2])->all();
         });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->except([1, 2])->take(1)->all();
+        });
     }
 
     public function testFilterIsLazy()


### PR DESCRIPTION
## Overview
I've reduced the memory usage by reimplementing the except() method of LazyCollection::class to use lazy evaluation.

## Motivation
LazyCollection is a sibling of the Collection class that utilizes Generators for lazy evaluation.
I believe that methods implemented by LazyCollection should be lazily evaluated using yield wherever possible.

However, while it's often unavoidable to use passthru() to delegate to the Collection class, doing so defeats the purpose of using LazyCollection. This is because all the data gets loaded into memory, negating the benefits of lazy evaluation.

## Tests
As this is a refactoring, the fact that no test modifications were needed indicates that the functionality remains unbroken.

## References
I previously refactored LazyCollection::take() for similar reasons in PR #48382.

## Performance Metrics
I measured the performance before and after the refactoring using the following test code, focusing on both execution time and memory usage. Please use these metrics to evaluate the effectiveness of this refactoring.

### Code
```php
<?php

declare(strict_types=1);

use Illuminate\Support\Enumerable;
use Illuminate\Support\Facades\Artisan;
use Illuminate\Support\LazyCollection;

Artisan::command('except:before {size}', function () {
    $factory = function (): Generator {
        $size = $this->argument('size');

        for ($index = 0; $index < $size; $index++) {
            yield "key-{$index}" => "value-{$index}";
        }
    };

    $collection = new LazyCollection($factory);
    $value = $collection->except(array_map(fn (int $i) => 'key-' . (10 ** $i), range(0, 8)))->first();

    dump(
        \memory_get_usage(true),
        \microtime(true) - \LARAVEL_START,
    );
});

Artisan::command('except:after {size}', function () {
    $factory = function (): Generator {
        $size = $this->argument('size');

        for ($index = 0; $index < $size; $index++) {
            yield "key-{$index}" => "value-{$index}";
        }
    };

    $collection = new class ($factory) extends LazyCollection {
        public function except($keys)
        {
            $keys = match (true) {
                $keys instanceof Enumerable => $keys->all(),
                is_array($keys) => $keys,
                is_null($keys) => [],
                default => func_get_args(),
            };

            if (count($keys) === 0) {
                return new static(function () {
                    yield from $this;
                });
            }

            return new static(function () use ($keys) {
                foreach ($this as $key => $value) {
                    if (!in_array($key, $keys)) {
                        yield $key => $value;
                    }
                }
            });
        }
    };
    $value = $collection->except(array_map(fn (int $i) => 'key-' . (10 ** $i), range(0, 8)))->first();

    dump(
        \memory_get_usage(true),
        \microtime(true) - \LARAVEL_START,
    );
});
```

### Results
About memory usage:
||100|10000|1000000|100000000|
|---|---|---|---|---|
|before|23068672|23068672|Fatal error|Fatal error|
|after|23068672|23068672|23068672|23068672|

About execution time:
||100|10000|1000000|100000000|
|---|---|---|---|---|
|before|0.058702945709229|0.062233924865723|Fatal error|Fatal error|
|after|0.059131860733032|0.058793067932129|0.05843710899353|0.059433937072754|