### PR TITLE
Removed preg_match from "words" helper to eliminate PCRE quantifier limit

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -518,13 +518,15 @@ class Str
      */
     public static function words($value, $words = 100, $end = '...')
     {
-        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
+        $word_array = explode(' ', $value);
+        $sliced_words = array_slice($word_array, 0, $words);
+        $result = implode(' ', $sliced_words);
 
-        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
-            return $value;
+        if (count($word_array) > $words) {
+            $result .= $end;
         }
 
-        return rtrim($matches[0]).$end;
+        return $result;
     }
 
     /**


### PR DESCRIPTION
PCRE has a quantifier limit of 65535, meaning that the value of $words can only go up to 65,535. In this commit, we use a non-regex technique to limit the words in the string.

See: https://github.com/wp-cli/db-command/issues/54

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
