### PR TITLE
[10.x] Preserve validated data order, based on original data

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -11,7 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void replacer(string $rule, \Closure|string $replacer)
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
- * @method static void ensureValidatedArrayDataIsSortedAsOriginal()
+ * @method static void ensureValidatedDataIsSortedAsOriginal()
  * @method static void resolver(\Closure $resolver)
  * @method static \Illuminate\Contracts\Translation\Translator getTranslator()
  * @method static \Illuminate\Validation\PresenceVerifierInterface getPresenceVerifier()

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void replacer(string $rule, \Closure|string $replacer)
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
+ * @method static void ensureValidatedArrayDataIsSortedAsOriginal()
  * @method static void resolver(\Closure $resolver)
  * @method static \Illuminate\Contracts\Translation\Translator getTranslator()
  * @method static \Illuminate\Validation\PresenceVerifierInterface getPresenceVerifier()

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -74,11 +74,11 @@ class Factory implements FactoryContract
     protected $excludeUnvalidatedArrayKeys = true;
 
     /**
-     * Indicates that it is ensured that validated array data will be ordered as original.
+     * Indicates that it is ensured that validated data will be ordered as original.
      *
      * @var bool
      */
-    public $ensureValidatedArrayDataIsSortedAsOriginal = false;
+    public $ensureValidatedDataIsSortedAsOriginal = false;
 
     /**
      * The Validator resolver instance.
@@ -131,7 +131,7 @@ class Factory implements FactoryContract
 
         $validator->excludeUnvalidatedArrayKeys = $this->excludeUnvalidatedArrayKeys;
 
-        $validator->ensureValidatedArrayDataIsSortedAsOriginal = $this->ensureValidatedArrayDataIsSortedAsOriginal;
+        $validator->ensureValidatedDataIsSortedAsOriginal = $this->ensureValidatedDataIsSortedAsOriginal;
 
         $this->addExtensions($validator);
 
@@ -278,13 +278,13 @@ class Factory implements FactoryContract
     }
 
     /**
-     * Indicate that it is ensured that validated array data will be ordered as original.
+     * Indicate that it is ensured that validated data will be ordered as original.
      *
      * @return void
      */
-    public function ensureValidatedArrayDataIsSortedAsOriginal()
+    public function ensureValidatedDataIsSortedAsOriginal()
     {
-        $this->ensureValidatedArrayDataIsSortedAsOriginal = true;
+        $this->ensureValidatedDataIsSortedAsOriginal = true;
     }
 
     /**

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -74,6 +74,13 @@ class Factory implements FactoryContract
     protected $excludeUnvalidatedArrayKeys = true;
 
     /**
+     * Indicates that it is ensured that validated array data will be ordered as original.
+     *
+     * @var bool
+     */
+    public $ensureValidatedArrayDataIsSortedAsOriginal = false;
+
+    /**
      * The Validator resolver instance.
      *
      * @var \Closure
@@ -123,6 +130,8 @@ class Factory implements FactoryContract
         }
 
         $validator->excludeUnvalidatedArrayKeys = $this->excludeUnvalidatedArrayKeys;
+
+        $validator->ensureValidatedArrayDataIsSortedAsOriginal = $this->ensureValidatedArrayDataIsSortedAsOriginal;
 
         $this->addExtensions($validator);
 
@@ -266,6 +275,16 @@ class Factory implements FactoryContract
     public function excludeUnvalidatedArrayKeys()
     {
         $this->excludeUnvalidatedArrayKeys = true;
+    }
+
+    /**
+     * Indicate that it is ensured that validated array data will be ordered as original.
+     *
+     * @return void
+     */
+    public function ensureValidatedArrayDataIsSortedAsOriginal()
+    {
+        $this->ensureValidatedArrayDataIsSortedAsOriginal = true;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -388,6 +388,28 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Sort validated data to match original data order.
+     *
+     * @param  array  $originalData
+     * @param  array  $validatedData
+     * @return array
+     */
+    protected function sortValidatedDataBasedOnOriginal($originalData, $validatedData)
+    {
+        $validatedDataSorted = [];
+
+        foreach ($originalData as $key => $value) {
+            if (array_key_exists($key, $validatedData)) {
+                $validatedDataSorted[$key] = is_array($validatedData[$key])
+                    ? $this->sortValidatedDataBasedOnOriginal($originalData[$key], $validatedData[$key])
+                    : $validatedData[$key];
+            }
+        }
+
+        return $validatedDataSorted;
+    }
+
+    /**
      * Add an after validation callback.
      *
      * @param  callable|array|string  $callback
@@ -577,7 +599,7 @@ class Validator implements ValidatorContract
             }
         }
 
-        return $this->replacePlaceholders($results);
+        return $this->sortValidatedDataBasedOnOriginal($this->data, $this->replacePlaceholders($results));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -166,11 +166,11 @@ class Validator implements ValidatorContract
     public $excludeUnvalidatedArrayKeys = false;
 
     /**
-     * Indicates that it is ensured that validated array data will be ordered as original.
+     * Indicates that it is ensured that validated data will be ordered as original.
      *
      * @var bool
      */
-    public $ensureValidatedArrayDataIsSortedAsOriginal = false;
+    public $ensureValidatedDataIsSortedAsOriginal = false;
 
     /**
      * All of the custom validator extensions.
@@ -608,7 +608,7 @@ class Validator implements ValidatorContract
             }
         }
 
-        return $this->ensureValidatedArrayDataIsSortedAsOriginal
+        return $this->ensureValidatedDataIsSortedAsOriginal
             ? $this->sortValidatedDataBasedOnOriginal($this->data, $this->replacePlaceholders($results))
             : $this->replacePlaceholders($results);
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -166,6 +166,13 @@ class Validator implements ValidatorContract
     public $excludeUnvalidatedArrayKeys = false;
 
     /**
+     * Indicates that it is ensured that validated array data will be ordered as original.
+     *
+     * @var bool
+     */
+    public $ensureValidatedArrayDataIsSortedAsOriginal = false;
+
+    /**
      * All of the custom validator extensions.
      *
      * @var array
@@ -601,7 +608,9 @@ class Validator implements ValidatorContract
             }
         }
 
-        return $this->sortValidatedDataBasedOnOriginal($this->data, $this->replacePlaceholders($results));
+        return $this->ensureValidatedArrayDataIsSortedAsOriginal
+            ? $this->sortValidatedDataBasedOnOriginal($this->data, $this->replacePlaceholders($results))
+            : $this->replacePlaceholders($results);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -399,10 +399,12 @@ class Validator implements ValidatorContract
         $validatedDataSorted = [];
 
         foreach ($originalData as $key => $value) {
-            if (array_key_exists($key, $validatedData)) {
-                $validatedDataSorted[$key] = is_array($validatedData[$key])
-                    ? $this->sortValidatedDataBasedOnOriginal($originalData[$key], $validatedData[$key])
-                    : $validatedData[$key];
+            $originalKey = $this->replacePlaceholderInString($key);
+
+            if (array_key_exists($originalKey, $validatedData)) {
+                $validatedDataSorted[$originalKey] = is_array($validatedData[$originalKey])
+                    ? $this->sortValidatedDataBasedOnOriginal($value, $validatedData[$originalKey])
+                    : $validatedData[$originalKey];
             }
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8999,8 +8999,8 @@ class ValidationValidatorTest extends TestCase
                         ],
                     ],
                     'first_name' => 'Jon',
-                ]
-            ]
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR resolves  #48440 and take into account the contributions made in #48493

The validated data is ensured to be in the same order as the original data with the new method `sortValidatedDataBasedOnOriginal()`.

There is also a new property `$ensureValidatedDataIsSortedAsOriginal` in `Validator` class, that is false by default. This is just to prevent any possible breaking change.