### PR TITLE
[10.x] Adds the `firstOrCreate` and `createOrFirst` methods to the `HasManyThrough` relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -280,9 +280,7 @@ class HasManyThrough extends Relation
     }
 
     /**
-     * Get the first record matching the attributes. If the record is not found, create it.
-     * Attempt to create the record with the given attribute and values. If a unique contraint
-     * violation is triggered,
+     * Attempt to create the record. If a unique constraint violation occurs, attempt to find the matching record.
      *
      * @param  array  $attributes
      * @param  array  $values

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -272,7 +272,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
-        if ($instance = $this->where($attributes)->first()) {
+        if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -291,7 +291,7 @@ class HasManyThrough extends Relation
     public function createOrFirst(array $attributes = [], array $values = [])
     {
         try {
-            return $this->create(array_merge($attributes, $values));
+            return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values)));
         } catch (UniqueConstraintViolationException $exception) {
             return $this->where($attributes)->first() ?? throw $exception;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -271,11 +271,11 @@ class HasManyThrough extends Relation
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->create(array_merge($attributes, $values));
+        if ($instance = $this->where($attributes)->first()) {
+            return $instance;
         }
 
-        return $instance;
+        return $this->create(array_merge($attributes, $values));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -263,6 +263,22 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Get the first record matching the attributes. If the record is not found, create it.
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrCreate(array $attributes = [], array $values = [])
+    {
+        if (is_null($instance = $this->where($attributes)->first())) {
+            $instance = $this->create(array_merge($attributes, $values));
+        }
+
+        return $instance;
+    }
+
+    /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\UniqueConstraintViolationException;
 
 class HasManyThrough extends Relation
 {
@@ -276,6 +277,24 @@ class HasManyThrough extends Relation
         }
 
         return $this->create(array_merge($attributes, $values));
+    }
+
+    /**
+     * Get the first record matching the attributes. If the record is not found, create it.
+     * Attempt to create the record with the given attribute and values. If a unique contraint
+     * violation is triggered,
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function createOrFirst(array $attributes = [], array $values = [])
+    {
+        try {
+            return $this->create(array_merge($attributes, $values));
+        } catch (UniqueConstraintViolationException $exception) {
+            return $this->where($attributes)->first() ?? throw $exception;
+        }
     }
 
     /**

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -140,6 +140,19 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertEquals([1], $categories->pluck('id')->all());
     }
 
+    public function testFirstOrCreateWhenModelDoesntExist()
+    {
+        $owner = User::create(['name' => 'Taylor']);
+        Team::create(['owner_id' => $owner->id]);
+
+        $mate = $owner->teamMates()->firstOrCreate(['slug' => 'adam'], ['name' => 'Adam']);
+
+        $this->assertTrue($mate->wasRecentlyCreated);
+        $this->assertNull($mate->team_id);
+        $this->assertEquals('Adam', $mate->name);
+        $this->assertEquals('adam', $mate->slug);
+    }
+
     public function testUpdateOrCreateAffectingWrongModelsRegression()
     {
         // On Laravel 10.21.0, a bug was introduced that would update the wrong model when using `updateOrCreate()`,


### PR DESCRIPTION
### Added

- Adds the `firstOrCreate` method to the `HasManyThrough` relation
- Adds the `createOrFirst` method to the `HasManyThrough` relation

---

In https://github.com/laravel/framework/pull/48529 we found a bug in the `updateOrCreate`. The issue was because that method was changed to use the `firstOrCreate` behind the scenes. Since the `firstOrCreate` method didn't exist in the relation, the method call was forwarded to the query builder, so the query changed from `select users.* from users ... inner join teams ...` to `select * from users ... inner join teams ...`, which resulted in a bug that was causing updates on the wrong model when using `updateOrCreate` (I shared more [context here](https://github.com/laravel/framework/pull/48531#issuecomment-1734420132)).

The `updateOrCreate` was [reverted to the previous implementation](https://github.com/laravel/framework/pull/48531). However, this bug will still happen if someone calls the `->firstOrCreate()` or the `->createOrFirst()` methods on a `HasManyThrough` relation (for the same reason, the method calls would be forwarded to the query builder and it would run a `select * from users ... inner join teams ...` causing the result to have 2 `id` columns, which caused the original bug).

We're adding the missing `firstOrCreate` and `createOrFirst` methods to fix the issue on the `HasManyThrough` relation. I was also able to reproduce the original regression error on both methods.