### PR TITLE
[10.x] Fix `firstOrNew` on `HasManyThrough` relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -257,11 +257,11 @@ class HasManyThrough extends Relation
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance(array_merge($attributes, $values));
+        if (! is_null($instance = $this->where($attributes)->first())) {
+            return $instance;
         }
 
-        return $instance;
+        return $this->related->newInstance(array_merge($attributes, $values));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -252,12 +252,13 @@ class HasManyThrough extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
+     * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes)
+    public function firstOrNew(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance($attributes);
+            $instance = $this->related->newInstance(array_merge($attributes, $values));
         }
 
         return $instance;

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -148,6 +148,22 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertEquals([1], $categories->pluck('id')->all());
     }
 
+    public function testFirstOrNewOnMissingRecord()
+    {
+        $taylor = User::create(['name' => 'Taylor', 'slug' => 'taylor']);
+        $team = Team::create(['owner_id' => $taylor->id]);
+
+        $user1 = $taylor->teamMates()->firstOrNew(
+            ['slug' => 'tony'],
+            ['name' => 'Tony', 'team_id' => $team->id],
+        );
+
+        $this->assertFalse($user1->exists);
+        $this->assertEquals($team->id, $user1->team_id);
+        $this->assertSame('tony', $user1->slug);
+        $this->assertSame('Tony', $user1->name);
+    }
+
     public function testFirstOrCreateWhenModelDoesntExist()
     {
         $owner = User::create(['name' => 'Taylor']);

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -164,6 +164,27 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $this->assertSame('Tony', $user1->name);
     }
 
+    public function testFirstOrNewWhenRecordExists()
+    {
+        $taylor = User::create(['name' => 'Taylor', 'slug' => 'taylor']);
+        $team = Team::create(['owner_id' => $taylor->id]);
+        $existingTony = $team->members()->create(['name' => 'Tony Messias', 'slug' => 'tony']);
+
+        $newTony = $taylor->teamMates()->firstOrNew(
+            ['slug' => 'tony'],
+            ['name' => 'Tony', 'team_id' => $team->id],
+        );
+
+        $this->assertTrue($newTony->exists);
+        $this->assertEquals($team->id, $newTony->team_id);
+        $this->assertSame('tony', $newTony->slug);
+        $this->assertSame('Tony Messias', $newTony->name);
+
+        $this->assertTrue($existingTony->is($newTony));
+        $this->assertSame('tony', $existingTony->refresh()->slug);
+        $this->assertSame('Tony Messias', $existingTony->name);
+    }
+
     public function testFirstOrCreateWhenModelDoesntExist()
     {
         $owner = User::create(['name' => 'Taylor']);


### PR DESCRIPTION
### Fixed

- Fixes the method signature and implementation of the `firstOrNew` method on `HasManyThrough` relations. The other implementations of the `firstOrNew` method all take the unique attributes plus an array of values to be merged on the new instance. This wasn't the case with the `HasManyThrough` relation. I noticed this as I was trying to identify the root cause on a bug in the `updateOrCreate` method. I've shared more [context here](https://github.com/laravel/framework/pull/48531#issuecomment-1734420132).