### PR TITLE
[10.x] Fix Http::async() calls running in sequence instead of concurrently

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1098,7 +1098,9 @@ class PendingRequest
      */
     public function buildClient()
     {
-        return $this->client ?? $this->createClient($this->buildHandlerStack());
+        return $this->requestsReusableClient()
+               ? $this->getReusableClient()
+               : $this->createClient($this->buildHandlerStack());
     }
 
     /**


### PR DESCRIPTION
Since Laravel 9 `PendingRequest.buildClient()` no longer calls `PendingRequest.getReusableClient()` to reuse the same GuzzleHttp Client across async requests.

- Laravel 8: [PendingRequest.buildClient()](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Http/Client/PendingRequest.php#L825)
- Laravel 9: [PendingRequest.buildClient()](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Http/Client/PendingRequest.php#L1026)

Sample code to reproduce the bug:
```
use Illuminate\Support\Facades\Http;
use GuzzleHttp\Promise\Utils;

$client = Http::async();

$promises = [
    $client->get('https://postman-echo.com/delay/3'),
    $client->get('https://postman-echo.com/delay/3'),
];
$combinedPromise = Utils::all($promises);

$results = $combinedPromise->wait();
```

In Laravel 8 this code runs for ~3 sec (requests run concurrently). In Laravel 9 and 10 this code runs for ~6 sec (requests run sequentially). This PR fixes the bug and brings the execution time back to ~ 3 sec (requests run concurrently again).

This PR uses `PendingRequest.getReusableClient()` again to ensure that async HTTP requests reuse the GuzzleHttp Client to run requests concurrently instead of sequentially.