### PR TITLE
[11.x] Improve model make command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Foundation\Console;
 
+use function Laravel\Prompts\multiselect;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 
-use function Laravel\Prompts\multiselect;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:model')]
 class ModelMakeCommand extends GeneratorCommand
@@ -220,9 +220,9 @@ class ModelMakeCommand extends GeneratorCommand
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
             ['morph-pivot', null, InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom polymorphic intermediate table model'],
-            ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
+            ['policy', 'p', InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
-            ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
+            ['pivot', null, InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API resource controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Foundation\Console;
 
-use function Laravel\Prompts\multiselect;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-
 use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\multiselect;
 
 #[AsCommand(name: 'make:model')]
 class ModelMakeCommand extends GeneratorCommand


### PR DESCRIPTION
This PR changes the `-p` flag to generate a policy instead of making a pivot model. 

Currently the `make:model` command accepts various short flags to create model related files: `-f`, `-m`, `-r`, etc., so using the `-p` for the policy generation would improve consistency.

For me, it's a constant struggle, because I always run the `make:model -f -m -p` command and as a result I get a pivot model instead of a policy which was not my intention.

Also, the pivot generation would be consitent as well: `--pivot` and `--morph-pivot` with no short options.