### PR TITLE
[10.x] Add `createWith` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1047,6 +1047,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Save a new model and return the instance with the given relation.
+     *
+     * @param  array  $attributes
+     * @param  array|string  $relation
+     * @return \Illuminate\Database\Eloquent\Model|$this
+     */
+    public function createWith(array $attributes = [], $relation)
+    {
+        $modelInstance = $this->create($attributes);
+
+        return $modelInstance->load($relation);
+    }
+
+    /**
      * Update records in the database.
      *
      * @param  array  $values

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1049,11 +1049,11 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance with the given relation.
      *
-     * @param  array  $attributes
      * @param  array|string  $relation
+     * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function createWith(array $attributes = [], $relation)
+    public function createWith($relation, array $attributes = [])
     {
         $modelInstance = $this->create($attributes);
 


### PR DESCRIPTION
I working on some updates relayed to my blog where I save the post and then return the post instance with its relations `field`, and `category` using **EagerLoading** to use these data in the sending email process. Let's illustrate this case with the next code

## BEFORE using the EagerLoading

```PHP
$post = Post::create($this->getPostDate($data));

$this->sendNewsletter($post);
```
Then I use the post instance in the email

```BLADE
@component('mail::message')
Hey You,

How are things? Good? Good 😃.

I wanna happily advertise the new <b>{{ $post->is_paid ? 'PAID' : 'FREE' }}</b> article that has been published with the <b>{{ $post->title }}</b> title. You can check it out by clicking the next button 🚀

@php
$URL = env("APP_URL") . "/" . $post->field->slug_name . "/". $post->category->slug_name . "/" . $post->slug_title;
@endphp

@component('mail::button', ['url' => $URL])
Show Post
@endcomponent

@endcomponent
```

Then I realized that there is an awesome **EagerLoading** feature so, I updated the code to be like

## AFTER using the EagerLoading

```PHP
$post = Post::create($this->getPostDate($data))
    ->load(['field:id,slug_name', 'category:id,slug_name'])
    ->only(['id', 'title', 'slug_title', 'is_visible', 'is_paid', 'field', 'category']);

$this->sendNewsletter($post);
```

**So, I asked myself why there is no function to create a new model and return this instance with the given relations in one line that is why I  create this PR**

## AFTER merged this PR

```PHP
$post = Post::createWith(['field:id,slug_name', 'category:id,slug_name'], $this->getPostDate($data));

$this->sendNewsletter($post);
```

I think it looks like Awesome 🥳