### PR TITLE
[10.x] Correct parameter type on MakesHttpRequests:followRedirects()

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -684,7 +684,7 @@ trait MakesHttpRequests
     /**
      * Follow a redirect chain until a non-redirect is received.
      *
-     * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Response|\Illuminate\Testing\TestResponse  $response
      * @return \Illuminate\Http\Response|\Illuminate\Testing\TestResponse
      */
     protected function followRedirects($response)


### PR DESCRIPTION
TestResponse does not directly extend Response, instead it uses @mixin and so must be hinted explicitly to not cause errors when analyzed.