### PR TITLE
[10.x] Improve InvokableValidationRule::make() return type

### DIFF
--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -64,7 +64,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
      * Create a new implicit or explicit Invokable validation rule.
      *
      * @param  \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\InvokableRule  $invokable
-     * @return \Illuminate\Contracts\Validation\Rule
+     * @return InvokableValidationRule
      */
     public static function make($invokable)
     {


### PR DESCRIPTION
The code below is rejected by PHPStan while it is valid.
The proposed change will fix this situation.

```php
class ValidationServiceProvider extends ServiceProvider
{
    public function boot(
        ValidatorFactory $validator,
    ): void {
        $validator->extend(
            MyCustonRule::handle(),
            fn (
                string $attribute, mixed $value, array $parameters, Validator $validator,
            ): bool => InvokableValidationRule::make(new MyCustonRule(...$parameters))
                ->setValidator($validator)
                ->passes($attribute, $value),
        );
    }
}
```

```
Call to an undefined method Illuminate\Contracts\Validation\Rule::setValidator(). 
```