### PR TITLE
[10.x] Fix undefined constant `STDIN` error with `Artisan::call` during a request

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -24,7 +24,7 @@ trait ConfiguresPrompts
     {
         Prompt::setOutput($this->output);
 
-        Prompt::interactive(($input->isInteractive() && stream_isatty(STDIN)) || $this->laravel->runningUnitTests());
+        Prompt::interactive(($input->isInteractive() && defined('STDIN') && stream_isatty(STDIN)) || $this->laravel->runningUnitTests());
 
         Prompt::fallbackWhen(windows_os() || $this->laravel->runningUnitTests());
 


### PR DESCRIPTION
This PR fixes a bug introduced in #48468 where an "Undefined constant" error would occur in environments where a command is used in an environment where `STDIN` is not defined. For example, when using `Artisan::call` in the request lifecycle.

Fixes https://github.com/laravel/prompts/issues/86