### PR TITLE
[10.x] Add Closure Type Hinting for Query Builders

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -65,7 +65,7 @@ trait BuildsQueries
     /**
      * Run a map over each item while chunking.
      *
-     * @param  callable  $callback
+     * @param  callable(object): mixed  $callback
      * @param  int  $count
      * @return \Illuminate\Support\Collection
      */
@@ -85,7 +85,7 @@ trait BuildsQueries
     /**
      * Execute a callback over each item while chunking.
      *
-     * @param  callable  $callback
+     * @param  callable(object, int): bool  $callback
      * @param  int  $count
      * @return bool
      *
@@ -159,7 +159,7 @@ trait BuildsQueries
     /**
      * Execute a callback over each item while chunking by ID.
      *
-     * @param  callable  $callback
+     * @param  callable(object, int): bool  $callback
      * @param  int  $count
      * @param  string|null  $column
      * @param  string|null  $alias

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -73,7 +73,7 @@ class Builder implements BuilderContract
     /**
      * A replacement for the typical delete function.
      *
-     * @var \Closure
+     * @var \Closure(self): mixed
      */
     protected $onDelete;
 
@@ -125,7 +125,7 @@ class Builder implements BuilderContract
     /**
      * Applied global scopes.
      *
-     * @var array
+     * @var array<(\Closure(static): void)>
      */
     protected $scopes = [];
 
@@ -162,7 +162,7 @@ class Builder implements BuilderContract
      * Register a new global scope.
      *
      * @param  string  $identifier
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope|(\Closure(static): void)  $scope
      * @return $this
      */
     public function withGlobalScope($identifier, $scope)
@@ -285,7 +285,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -307,7 +307,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -321,7 +321,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self): void)|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -338,7 +338,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic "where not" clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -352,7 +352,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self): void)|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -519,8 +519,8 @@ class Builder implements BuilderContract
      * Find a model by its primary key or call a callback.
      *
      * @param  mixed  $id
-     * @param  \Closure|array|string  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array|string  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)
@@ -620,8 +620,8 @@ class Builder implements BuilderContract
     /**
      * Execute the query and get the first result or call a callback.
      *
-     * @param  \Closure|array|string  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array|string  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|static|mixed
      */
     public function firstOr($columns = ['*'], Closure $callback = null)
@@ -761,7 +761,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $models
      * @param  string  $name
-     * @param  \Closure  $constraints
+     * @param  \Closure(\Illuminate\Database\Eloquent\Relations\Relation): void  $constraints
      * @return array
      */
     protected function eagerLoadRelation(array $models, $name, Closure $constraints)
@@ -903,11 +903,10 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query.
      *
-     * @param  int|null|\Closure  $perPage
+     * @param  int|null|(\Closure(int): int|null)  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @param  \Closure|int|null  $total
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
@@ -1284,7 +1283,7 @@ class Builder implements BuilderContract
     /**
      * Register a replacement for the default delete function.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(static): mixed  $callback
      * @return void
      */
     public function onDelete(Closure $callback)
@@ -1373,7 +1372,7 @@ class Builder implements BuilderContract
     /**
      * Apply the given scope on the current builder instance.
      *
-     * @param  callable  $scope
+     * @param  (callable(mixed $parameters...): mixed)  $scope
      * @param  array  $parameters
      * @return mixed
      */
@@ -1479,8 +1478,8 @@ class Builder implements BuilderContract
     /**
      * Set the relationships that should be eager loaded.
      *
-     * @param  string|array  $relations
-     * @param  string|\Closure|null  $callback
+     * @param  string|array<string|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation): self|null)>  $relations
+     * @param  string|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation): self|null)|null  $callback
      * @return $this
      */
     public function with($relations, $callback = null)
@@ -1619,8 +1618,8 @@ class Builder implements BuilderContract
     /**
      * Combine an array of constraints into a single constraint.
      *
-     * @param  array  $constraints
-     * @return \Closure
+     * @param  array<(\Closure(\Illuminate\Database\Eloquent\Relations\Relation): self|null)>  $constraints
+     * @return \Closure(\Illuminate\Database\Eloquent\Relations\Relation): self
      */
     protected function combineConstraints(array $constraints)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -755,8 +755,8 @@ class BelongsToMany extends Relation
      * Find a related model by its primary key or call a callback.
      *
      * @param  mixed  $id
-     * @param  \Closure|array  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)
@@ -785,7 +785,7 @@ class BelongsToMany extends Relation
     /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|string|array  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder): void)|string|array  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -829,8 +829,8 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result or call a callback.
      *
-     * @param  \Closure|array  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|static|mixed
      */
     public function firstOr($columns = ['*'], Closure $callback = null)
@@ -1021,7 +1021,7 @@ class BelongsToMany extends Relation
     /**
      * Execute a callback over each item while chunking.
      *
-     * @param  callable  $callback
+     * @param  callable(object, int): bool  $callback
      * @param  int  $count
      * @return bool
      */

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsDefaultModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsDefaultModels.php
@@ -11,7 +11,7 @@ trait SupportsDefaultModels
      *
      * Alternatively, may be a Closure or array.
      *
-     * @var \Closure|array|bool
+     * @var (\Closure(\Illuminate\Database\Eloquent\Model, \Illuminate\Database\Eloquent\Model): \Illuminate\Database\Eloquent\Model|null)|array|bool
      */
     protected $withDefault;
 
@@ -26,7 +26,7 @@ trait SupportsDefaultModels
     /**
      * Return a new model instance in case the relationship does not exist.
      *
-     * @param  \Closure|array|bool  $callback
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Model, \Illuminate\Database\Eloquent\Model): \Illuminate\Database\Eloquent\Model|null)|array|bool  $callback
      * @return $this
      */
     public function withDefault($callback = true)

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -315,7 +315,7 @@ class HasManyThrough extends Relation
     /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|string|array  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder): void)|string|array  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -359,8 +359,8 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first result or call a callback.
      *
-     * @param  \Closure|array  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|static|mixed
      */
     public function firstOr($columns = ['*'], Closure $callback = null)
@@ -446,8 +446,8 @@ class HasManyThrough extends Relation
      * Find a related model by its primary key or call a callback.
      *
      * @param  mixed  $id
-     * @param  \Closure|array  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)
@@ -603,7 +603,7 @@ class HasManyThrough extends Relation
     /**
      * Execute a callback over each item while chunking by ID.
      *
-     * @param  callable  $callback
+     * @param  callable(object, int): bool  $callback
      * @param  int  $count
      * @param  string|null  $column
      * @param  string|null  $alias
@@ -631,7 +631,7 @@ class HasManyThrough extends Relation
     /**
      * Execute a callback over each item while chunking.
      *
-     * @param  callable  $callback
+     * @param  callable(object, int): bool  $callback
      * @param  int  $count
      * @return bool
      */

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -94,8 +94,10 @@ abstract class Relation implements BuilderContract
     /**
      * Run a callback with constraints disabled on the relation.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TValue
+     *
+     * @param  \Closure(): TValue  $callback
+     * @return TValue
      */
     public static function noConstraints(Closure $callback)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -196,7 +196,7 @@ class Builder implements BuilderContract
     /**
      * The callbacks that should be invoked before the query is executed.
      *
-     * @var array
+     * @var array<(callable(static): void)>
      */
     public $beforeQueryCallbacks = [];
 
@@ -274,7 +274,7 @@ class Builder implements BuilderContract
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @return $this
      *
@@ -310,7 +310,7 @@ class Builder implements BuilderContract
     /**
      * Makes "from" fetch from a subquery.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @return $this
      *
@@ -342,7 +342,7 @@ class Builder implements BuilderContract
     /**
      * Creates a subquery and parse it.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @return array
      */
     protected function createSub($query)
@@ -452,7 +452,7 @@ class Builder implements BuilderContract
     /**
      * Set the table which the query is targeting.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $table
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $table
      * @param  string|null  $as
      * @return $this
      */
@@ -510,7 +510,7 @@ class Builder implements BuilderContract
      * Add a join clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @param  string  $type
@@ -550,7 +550,7 @@ class Builder implements BuilderContract
      * Add a "join where" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $second
      * @param  string  $type
@@ -564,9 +564,9 @@ class Builder implements BuilderContract
     /**
      * Add a subquery join clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @param  string  $type
@@ -590,7 +590,7 @@ class Builder implements BuilderContract
      * Add a left join to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return $this
@@ -604,7 +604,7 @@ class Builder implements BuilderContract
      * Add a "join where" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return $this
@@ -617,9 +617,9 @@ class Builder implements BuilderContract
     /**
      * Add a subquery left join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return $this
@@ -633,7 +633,7 @@ class Builder implements BuilderContract
      * Add a right join to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return $this
@@ -647,7 +647,7 @@ class Builder implements BuilderContract
      * Add a "right join where" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $second
      * @return $this
@@ -660,9 +660,9 @@ class Builder implements BuilderContract
     /**
      * Add a subquery right join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return $this
@@ -676,7 +676,7 @@ class Builder implements BuilderContract
      * Add a "cross join" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string|null  $first
+     * @param  (\Closure(\Illuminate\Database\Query\JoinClause): void)|string|null  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return $this
@@ -695,7 +695,7 @@ class Builder implements BuilderContract
     /**
      * Add a subquery cross join to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @return $this
      */
@@ -746,7 +746,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -933,7 +933,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -950,7 +950,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic "where not" clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -970,7 +970,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -1612,7 +1612,7 @@ class Builder implements BuilderContract
     /**
      * Add a nested where statement to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(\Illuminate\Database\Query\Builder): void  $callback
      * @param  string  $boolean
      * @return $this
      */
@@ -1658,7 +1658,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $operator
-     * @param  \Closure||\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)||\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
      * @param  string  $boolean
      * @return $this
      */
@@ -1687,7 +1687,7 @@ class Builder implements BuilderContract
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -1711,7 +1711,7 @@ class Builder implements BuilderContract
     /**
      * Add an or exists clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
      * @param  bool  $not
      * @return $this
      */
@@ -1723,7 +1723,7 @@ class Builder implements BuilderContract
     /**
      * Add a where not exists clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
      * @param  string  $boolean
      * @return $this
      */
@@ -1735,7 +1735,7 @@ class Builder implements BuilderContract
     /**
      * Add a where not exists clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $callback
      * @return $this
      */
     public function orWhereNotExists($callback)
@@ -2086,7 +2086,7 @@ class Builder implements BuilderContract
     /**
      * Add a "having" clause to the query.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
+     * @param  \Illuminate\Contracts\Database\Query\Expression|(\Closure(\Illuminate\Database\Query\Builder): void)|string  $column
      * @param  string|int|float|null  $operator
      * @param  string|int|float|null  $value
      * @param  string  $boolean
@@ -2138,7 +2138,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or having" clause to the query.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
+     * @param  \Illuminate\Contracts\Database\Query\Expression|(\Closure(\Illuminate\Database\Query\Builder): void)|string  $column
      * @param  string|int|float|null  $operator
      * @param  string|int|float|null  $value
      * @return $this
@@ -2155,7 +2155,7 @@ class Builder implements BuilderContract
     /**
      * Add a nested having statement to the query.
      *
-     * @param  \Closure  $callback
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)  $callback
      * @param  string  $boolean
      * @return $this
      */
@@ -2297,7 +2297,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -2330,7 +2330,7 @@ class Builder implements BuilderContract
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function orderByDesc($column)
@@ -2341,7 +2341,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function latest($column = 'created_at')
@@ -2352,7 +2352,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function oldest($column = 'created_at')
@@ -2498,7 +2498,7 @@ class Builder implements BuilderContract
     /**
      * Remove all existing orders and optionally add a new order.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|null  $column
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|null  $column
      * @param  string  $direction
      * @return $this
      */
@@ -2534,7 +2534,7 @@ class Builder implements BuilderContract
     /**
      * Add a union statement to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
      * @param  bool  $all
      * @return $this
      */
@@ -2554,7 +2554,7 @@ class Builder implements BuilderContract
     /**
      * Add a union all statement to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
      * @return $this
      */
     public function unionAll($query)
@@ -2602,7 +2602,7 @@ class Builder implements BuilderContract
     /**
      * Register a closure to be invoked before the query is executed.
      *
-     * @param  callable  $callback
+     * @param  callable(static): void  $callback
      * @return $this
      */
     public function beforeQuery(callable $callback)
@@ -2666,8 +2666,8 @@ class Builder implements BuilderContract
      * Execute a query for a single record by ID or call a callback.
      *
      * @param  mixed  $id
-     * @param  \Closure|array|string  $columns
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(): mixed)|array|string  $columns
+     * @param  (\Closure(): mixed)|null  $callback
      * @return mixed|static
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)
@@ -2756,11 +2756,10 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query into a simple paginator.
      *
-     * @param  int|\Closure  $perPage
+     * @param  int|(\Closure(int): int)  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @param  \Closure|int|null  $total
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
@@ -3119,8 +3118,10 @@ class Builder implements BuilderContract
     /**
      * Execute the given callback if no rows exist for the current query.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TValue
+     *
+     * @param  \Closure(): TValue  $callback
+     * @return TValue|bool
      */
     public function existsOr(Closure $callback)
     {
@@ -3130,8 +3131,10 @@ class Builder implements BuilderContract
     /**
      * Execute the given callback if rows exist for the current query.
      *
-     * @param  \Closure  $callback
-     * @return mixed
+     * @template TValue
+     *
+     * @param  \Closure(): TValue  $callback
+     * @return TValue|bool
      */
     public function doesntExistOr(Closure $callback)
     {
@@ -3391,7 +3394,7 @@ class Builder implements BuilderContract
      * Insert new records into the table using a subquery.
      *
      * @param  array  $columns
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @return int
      */
     public function insertUsing(array $columns, $query)

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -82,7 +82,7 @@ class JoinClause extends Builder
      *
      * on `contacts`.`user_id` = `users`.`id` and `contacts`.`info_id` = `info`.`id`
      *
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @param  string  $boolean
@@ -102,7 +102,7 @@ class JoinClause extends Builder
     /**
      * Add an "or on" clause to the join.
      *
-     * @param  \Closure|string  $first
+     * @param  (\Closure(\Illuminate\Database\Query\Builder): void)|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return \Illuminate\Database\Query\JoinClause


### PR DESCRIPTION
This pull request adds type hinting for closures in Laravel's query builders and Eloquent, enhancing IDE support by providing hints about expected input functions and available operations for the passed builder type.

This improvement follows the existing pattern applied to some closures, such as in `Illuminate\Database\Eloquent\Builder::withSavepointIfNeeded()`. For more information on callable types in PHPDoc, refer to [phpstan.org phpdoc callables](https://phpstan.org/writing-php-code/phpdoc-types#callables).

Additionally, this PR removes obsolete `@param` annotations for parameters that have long been removed from the functions themselves.

Your feedback and review are greatly appreciated.