### PR TITLE
[10.x] Account for new MariaDB platform

### DIFF
--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1052Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -32,7 +33,8 @@ class TimestampType extends Type implements PhpDateTimeMappingType
             MySQL57Platform::class,
             MySQL80Platform::class,
             MariaDBPlatform::class,
-            MariaDb1027Platform::class => $this->getMySqlPlatformSQLDeclaration($column),
+            MariaDb1027Platform::class,
+            MariaDb1052Platform::class, => $this->getMySqlPlatformSQLDeclaration($column),
             PostgreSQLPlatform::class,
             PostgreSQL94Platform::class,
             PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),


### PR DESCRIPTION
dbal introduced a new platform in `3.7.0` which our switch does not currently account for.

Hoping this fixes the currently failing framework tests.

Note: I have no idea about this part of the framework. Please, send help.