### PR TITLE
Addition getOrFail to Illuminate\Support\Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -335,28 +335,28 @@ class Arr
     }
 
     /**
-    * Get an item from an array using "dot" notation or throw an exception if not found.
-    *
-    * @param  \ArrayAccess|array  $array
-    * @param  string|int|null  $key
-    * @return mixed
-    *
-    * @throws \Illuminate\Support\ItemNotFoundException
-    */
+     * Get an item from an array or throw an exception if not found.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @return mixed
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
     public static function getOrFail($array, $key)
     {
         $value = static::get($array, $key);
-        $message = "The array does not contain an element with the specified key.";
+        $message = 'The array does not contain an element with the specified key.';
 
         if (empty($array)) {
             throw new \Illuminate\Support\ItemNotFoundException($message);
         }
 
-        if(is_null($key) || is_null($value)) {
+        if (is_null($key) || is_null($value)) {
             throw new \Illuminate\Support\ItemNotFoundException($message);
         }
 
-        if (is_string($value) && trim($value) === "") {
+        if (is_string($value) && trim($value) === '') {
             throw new \Illuminate\Support\ItemNotFoundException($message);
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -335,6 +335,35 @@ class Arr
     }
 
     /**
+    * Get an item from an array using "dot" notation or throw an exception if not found.
+    *
+    * @param  \ArrayAccess|array  $array
+    * @param  string|int|null  $key
+    * @return mixed
+    *
+    * @throws \Illuminate\Support\ItemNotFoundException
+    */
+    public static function getOrFail($array, $key)
+    {
+        $value = static::get($array, $key);
+        $message = "The array does not contain an element with the specified key.";
+
+        if (empty($array)) {
+            throw new \Illuminate\Support\ItemNotFoundException($message);
+        }
+
+        if(is_null($key) || is_null($value)) {
+            throw new \Illuminate\Support\ItemNotFoundException($message);
+        }
+
+        if (is_string($value) && trim($value) === "") {
+            throw new \Illuminate\Support\ItemNotFoundException($message);
+        }
+
+        return $value;
+    }
+
+    /**
      * Check if an item or items exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -456,7 +456,7 @@ class SupportArrTest extends TestCase
     public function testGetOrFailExceptionScenarios()
     {
         $exceptions = 0;
-        $expectedMessage = "The array does not contain an element with the specified key.";
+        $expectedMessage = 'The array does not contain an element with the specified key.';
 
         // Testing for a non-existent key
         try {


### PR DESCRIPTION
Addition of the getOrFail Method to the Arr Class

This Pull Request introduces a new method, getOrFail, to Laravel's Arr class. This method attempts to retrieve an item from an array. If the item is not found, an ItemNotFoundException will be thrown.

```php
    try {
      $array = ["names" => ["developer" => "taylor"]];
      Arr::getOrFail($array, "names.otherDeveloper");
    } catch (ItemNotFoundException) {
      //
    }
```

This method throws an ItemNotFoundException exception that should be handled by the developer when using the getOrFail method.
