### PR TITLE
[10.x] Allow listeners to be dispatched when testing

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Testing\Fakes;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Collection;
@@ -404,7 +405,9 @@ class QueueFake extends QueueManager implements Fake, Queue
         }
 
         return $this->jobsToBeQueued->contains(
-            fn ($jobToQueue) => $job instanceof ((string) $jobToQueue)
+            fn ($jobToQueue) => $job instanceof ((string) CallQueuedListener::class) ?
+                $job->class === (string) $jobToQueue :
+                $job instanceof ((string) $jobToQueue)
         );
     }
 


### PR DESCRIPTION
Currently, if you pass a listener to the except function of QueueFake.php, for example, Queue::fake()->except(Test::class), it will still be faked due to the listener being wrapped in the CallQueuedListener class.

This update fixes this issue by checking if the job is an instance of the CallQueuedListener class and then checking if the underlying listener class matches any of the jobs, which should be dispatched.

Any jobs, which aren't wrapped in the CallQueuedListener, should process as normal.
