### PR TITLE
[10.x] Support generating classes in sub-namespaces

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Finder\Finder;
 
 abstract class GeneratorCommand extends Command implements PromptsForMissingInput
@@ -129,6 +130,13 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             $this->addTestOptions();
         }
 
+        $this->getDefinition()->addOption(new InputOption(
+            'in',
+            null,
+            InputOption::VALUE_REQUIRED,
+            "Specify a sub-namespace to generate the {$this->type} class in"
+        ));
+
         $this->files = $files;
     }
 
@@ -206,6 +214,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
         if (Str::startsWith($name, $rootNamespace)) {
             return $name;
+        }
+
+        if ($subNamespace = $this->option('in')) {
+            $rootNamespace .= Str::finish($subNamespace, '\\');
         }
 
         return $this->qualifyClass(

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -216,9 +216,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             return $name;
         }
 
-        if ($subNamespace = $this->option('in')) {
-            $rootNamespace .= Str::finish($subNamespace, '\\');
-        }
+        $rootNamespace .= implode('\\', array_filter([
+            $this->laravel['config']->get('app.generator_namespace'),
+            $this->option('in'),
+        ]));
 
         return $this->qualifyClass(
             $this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name


### PR DESCRIPTION
This pull request adds support for generating classes in sub-namespaces using a new `--in` option. The new option is automatically added to all `GeneratorCommand` commands, which makes it compatible with all packages that use it.

Currently, generating classes in specific namespaces is rather cumbersome:

```sh
php artisan make:model Dashboard/Feature/PilotTracking/Pilot
```

This pull requests makes it so that you may avoid having to type the root namespace:

```sh
php artisan make:model Pilot --in=Feature/PilotTracking

# Model [src/Feature/PilotTracking/Pilot.php] created successfully.
```

This may not seem like much, but it allows to type the familiar `make:something <name>` and figure out after where it should be created.

Additionally, it would be possible to specify an `app.generator_namespace` configuration option to have a default sub-namespace in which classes would be generated:

```php
// config/app.php

return [
    // ...
    'generator_namespace' => 'Feature',
];
```


```sh
php artisan make:model Pilot

# Model [src/Feature/Pilot.php] created successfully.

php artisan make:model Pilot --in=PilotTracking

# Model [src/Feature/PilotTracking/Pilot.php] created successfully.
```

---

For more context, I have mostly been working in medium/big projects, in which my teams and I followed slice or module-based architectures. Unfortunately, this had the downside of making most generator commands a real pain to use.

There are a few existing packages which purpose is to override all existing commands to add this functionality, but it's an extra (often opinionated) dependency that doesn't work in combination with other packages.

---

Notes: 
- The new `--in` option could be breaking packages using this name. Alternatively, we could:
	- Rename it to something with a lesser chance of being breaking,
	- Conditionally add it after checking if it is already defined,
	- Or target 11.x.
- The `generator_namespace` option could totally be named something else, or placed in another config file than `app.php`. Or this part of the PR could be discarded, though I'd prefer not.
