### PR TITLE
[10.x] Ensure array cache considers milliseconds

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -57,7 +57,7 @@ class ArrayStore extends TaggableStore implements LockProvider
 
         $expiresAt = $item['expiresAt'] ?? 0;
 
-        if ($expiresAt !== 0 && $this->currentTime() > $expiresAt) {
+        if ($expiresAt !== 0 && (now()->getPreciseTimestamp(3) / 1000) >= $expiresAt) {
             $this->forget($key);
 
             return;
@@ -181,14 +181,14 @@ class ArrayStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Get the UNIX timestamp for the given number of seconds.
+     * Get the UNIX timestamp, with milliseconds, for the given number of seconds in the future.
      *
      * @param  int  $seconds
-     * @return int
+     * @return float
      */
     protected function toTimestamp($seconds)
     {
-        return $seconds > 0 ? $this->availableAt($seconds) : 0;
+        return $seconds > 0 ? (now()->getPreciseTimestamp(3) / 1000) + $seconds : 0;
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -173,7 +173,7 @@ class ArrayStore extends TaggableStore implements LockProvider
      * Get the expiration time of the key.
      *
      * @param  int  $seconds
-     * @return int
+     * @return float
      */
     protected function calculateExpiration($seconds)
     {

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -24,6 +24,20 @@ class CacheArrayStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
+    public function testCacheTtl(): void
+    {
+        $store = new ArrayStore();
+
+        Carbon::setTestNow('2000-01-01 00:00:00.500'); // 500 milliseconds past
+        $store->put('hello', 'world', 1);
+
+        Carbon::setTestNow('2000-01-01 00:00:01.499'); // progress 0.999 seconds
+        $this->assertSame('world', $store->get('hello'));
+
+        Carbon::setTestNow('2000-01-01 00:00:01.500'); // progress 0.001 seconds. 1 second since putting into cache.
+        $this->assertNull($store->get('hello'));
+    }
+
     public function testMultipleItemsCanBeSetAndRetrieved()
     {
         $store = new ArrayStore;


### PR DESCRIPTION
With the recent fix to the array cache driver, https://github.com/laravel/framework/pull/48497, it has surfaced another problem with it that was previously hidden by the initial issue.

The array cache driver, unlike the redis cache driver, does not take milliseconds into account.

This PR fixes that.

This is technically a breaking change with the return type changes, but one I think we should make as it is really a bugfix. The array driver should always have used milliseconds.

fixes https://github.com/laravel/framework/issues/48569