### PR TITLE
[10.x] Fix override router middleware group

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -457,8 +457,10 @@ class Kernel implements KernelContract
     {
         $this->router->middlewarePriority = $this->middlewarePriority;
 
-        foreach ($this->middlewareGroups as $key => $middleware) {
-            $this->router->middlewareGroup($key, $middleware);
+        foreach ($this->middlewareGroups as $key => $middlewares) {
+            foreach ($middlewares as $middleware) {
+                $this->router->pushMiddlewareToGroup($key, $middleware);
+            }
         }
 
         foreach (array_merge($this->routeMiddleware, $this->middlewareAliases) as $key => $middleware) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive https://github.com/laravel/framework/issues/48549title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

To resolve https://github.com/laravel/framework/issues/48549. 

In Kernel.php `syncMiddlewareToRouter`. Router function `pushMiddlewareToGroup` can be used instead of `middlewareGroup` to avoid override router middleware group.




