### PR TITLE
[10.x] Add `relation` as a second parameter to `has` callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -58,7 +58,7 @@ trait QueriesRelationships
         // proper logical grouping of the where clauses if needed by this Eloquent query
         // builder. Then, we will be ready to finalize and return this query instance.
         if ($callback) {
-            $hasQuery->callScope($callback);
+            $hasQuery->callScope($callback, [$relation]);
         }
 
         return $this->addHasWhere(


### PR DESCRIPTION
This PR adds `Relation` object as a second parameter to any `has` callback. 

```php
User::whereHas('organization', function(Builder $builder, BelongsToMany $relation) {
    //
});

User::whereHas('comments', function(Builder $builder, HasMany $relation) {
    //
});

Comment::whereHas('user', function(Builder $builder, BelongsTo $relation) {
    //
});
```

It may be useful to make safe queries to pivot table:

```php
User::whereHas('organization', function(Builder $builder, BelongsToMany $relation) {
    $relation->wherePivot('role', 'manager');
    // or
    $builder->where($relation->qualifyPivotColumn('role', 'manager'));
});
```