### PR TITLE
[10.x] Adds `Template Inheritance` ability of the generated view

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -47,11 +47,15 @@ class ViewMakeCommand extends GeneratorCommand
     protected function buildClass($name)
     {
         $contents = parent::buildClass($name);
+        $layout = $this->option('layout');
+
+        $replace = [
+            '{{ layout }}' => $layout ? "@extends('{$layout}')\n\n" : null,
+            '{{ quote }}' => Inspiring::quotes()->random()
+        ];
 
         return str_replace(
-            '{{ quote }}',
-            Inspiring::quotes()->random(),
-            $contents,
+            array_keys($replace), array_values($replace), $contents
         );
     }
 
@@ -229,6 +233,7 @@ class ViewMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
+            ['layout', null, InputOption::VALUE_OPTIONAL, 'The parent of the generated view', null],
             ['extension', null, InputOption::VALUE_OPTIONAL, 'The extension of the generated view', 'blade.php'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the view even if the view already exists'],
         ];

--- a/src/Illuminate/Foundation/Console/stubs/view.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view.stub
@@ -1,3 +1,3 @@
-<div>
+{{ layout }}<div>
     <!-- {{ quote }} -->
 </div>


### PR DESCRIPTION
The command for generating a view was introduced in this #48330 PR by @nunomaduro and I think that it would be nice if we could specify the parent of the generated view, to use this new feature you can type the next command

```ARTISAN
php artisan make:view users.index --layout=layouts.app
```

Here are the contents of the generated `resources/views/users/index.blade.ph`

```BLADE
@extends('layouts.app')

<div>
    <!-- Nothing in life is to be feared, it is only to be understood. Now is the time to understand more, so that we may fear less. - Marie Curie -->
</div>
```