### PR TITLE
[10.x] Support logger on symfony mail transport

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -173,7 +173,13 @@ class MailManager implements FactoryContract
      */
     protected function createSmtpTransport(array $config)
     {
-        $factory = new EsmtpTransportFactory;
+        $logger = $this->app->make(LoggerInterface::class);
+
+        if ($logger instanceof LogManager) {
+            $logger = $logger->channel($this->app['config']->get('mail.log_channel', 'null'));
+        }
+
+        $factory = new EsmtpTransportFactory(null, null, $logger);
 
         $scheme = $config['scheme'] ?? null;
 


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/48317

This PR helps to debug symfony smtptransport
`NullHandler` as default
I don't know if it would be better to aim for 9.x