### PR TITLE
[10.x] Ensure array cache considers milliseconds

### DIFF
--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Sleep;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -14,6 +15,21 @@ class CacheArrayStoreTest extends TestCase
         parent::tearDown();
 
         Carbon::setTestNow(null);
+    }
+
+    public function testCacheTtl(): void
+    {
+        $store = new ArrayStore();
+
+        while ((microtime(true) - time()) <= .9800) {
+            usleep(1000);
+        }
+
+        $store->put('hello', 'world', 1);
+
+        Sleep::for(20)->milliseconds();
+
+        $this->assertSame('world', $store->get('hello'));
     }
 
     public function testItemsCanBeSetAndRetrieved()

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Sleep;
 use Orchestra\Testbench\TestCase;
 
 class RedisStoreTest extends TestCase
@@ -22,6 +23,21 @@ class RedisStoreTest extends TestCase
         parent::tearDown();
 
         $this->tearDownRedis();
+    }
+
+    public function testCacheTtl(): void
+    {
+        $store = Cache::store('redis');
+
+        while ((microtime(true) - time()) <= .9800) {
+            usleep(1000);
+        }
+
+        $store->put('hello', 'world', 1);
+
+        Sleep::for(20)->milliseconds();
+
+        $this->assertSame('world', $store->get('hello'));
     }
 
     public function testItCanStoreInfinite()

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\GlobalLimit;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Middleware\ThrottleRequests;
@@ -115,5 +116,63 @@ class ThrottleRequestsTest extends TestCase
 
         $signature = (string) ThrottleRequests::with(prefix: 'foo');
         $this->assertSame('Illuminate\Routing\Middleware\ThrottleRequests:60,1,foo', $signature);
+    }
+
+    public function testItCanThrottlePerMinute()
+    {
+        $rateLimiter = Container::getInstance()->make(RateLimiter::class);
+        $rateLimiter->for(__METHOD__, fn () => Limit::perMinute(3));
+        Route::get('/', fn () => 'ok')->middleware(ThrottleRequests::using(__METHOD__));
+
+        Carbon::setTestNow('2000-01-01 00:00:00.000');
+
+        // Make 3 requests, each a second apart, that should all be successful.
+
+        for ($i = 0; $i < 3; $i++) {
+            match ($i) {
+                0 => $this->assertSame('2000-01-01 00:00:00.000', now()->toDateTimeString('m')),
+                1 => $this->assertSame('2000-01-01 00:00:01.000', now()->toDateTimeString('m')),
+                2 => $this->assertSame('2000-01-01 00:00:02.000', now()->toDateTimeString('m')),
+            };
+
+            $response = $this->get('/');
+            $response->assertOk();
+            $response->assertContent('ok');
+            $response->assertHeader('X-RateLimit-Limit', 3);
+            $response->assertHeader('X-RateLimit-Remaining', 3 - ($i + 1));
+
+            Carbon::setTestNow(now()->addSecond());
+        }
+
+        // It is now 3 seconds past and we will make another request that
+        // should be rate limited.
+
+        $this->assertSame('2000-01-01 00:00:03.000', now()->toDateTimeString('m'));
+
+        $response = $this->get('/');
+        $response->assertStatus(429);
+        $response->assertHeader('Retry-After', 57);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(57)->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We will now make it the very end of the minute, to check boundaries,
+        // and make another request that should be rate limited and tell us to
+        // try again in 1 second.
+        Carbon::setTestNow(now()->endOfMinute());
+        $this->assertSame('2000-01-01 00:00:59.999', now()->toDateTimeString('m'));
+
+        $response = $this->get('/');
+        $response->assertHeader('Retry-After', 1);
+        $response->assertHeader('X-RateLimit-Reset', now()->addSeconds(1)->timestamp);
+        $response->assertHeader('X-RateLimit-Limit', 3);
+        $response->assertHeader('X-RateLimit-Remaining', 0);
+
+        // We now tick over into the next second. We should now be able to make
+        // requests again.
+        Carbon::setTestNow('2000-01-01 00:01:00.001');
+
+        $response = $this->get('/');
+        $response->assertOk();
     }
 }


### PR DESCRIPTION
@timacdonald Hello. I brought the ArrayCache fix. True, I did not return the condition greater than equal, because RateLimiter breaks. Because of this, I have .001ms in my test, not .000ms.

Text from PR #48573:

With the recent fix to the array cache driver, https://github.com/laravel/framework/pull/48497, it has surfaced another problem with it that was previously hidden by the initial issue.

The array cache driver, unlike the redis cache driver, does not take milliseconds into account.

This PR fixes that.

This is technically a breaking change - but one I think we should make as it is more of a bugfix. I think the use of the array driver in prod is somewhat of an edgecase.

fixes https://github.com/laravel/framework/issues/48569

