### PR TITLE
[10.x] Add Validation for Callable in Macro Registration

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Traits;
 
 use BadMethodCallException;
 use Closure;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -20,11 +21,15 @@ trait Macroable
      * Register a custom macro.
      *
      * @param  string  $name
-     * @param  object|callable  $macro
+     * @param  callable  $macro
      * @return void
      */
     public static function macro($name, $macro)
     {
+        if (! is_callable($macro)) {
+            throw new InvalidArgumentException('Second argument to macro must be callable');
+        }
+
         static::$macros[$name] = $macro;
     }
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class SupportMacroableTest extends TestCase
@@ -159,6 +160,29 @@ class SupportMacroableTest extends TestCase
 
         $this->assertSame('newMethod', $this->macroable::existingMethod());
     }
+
+    public function testRegisteringInvalidMacroThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->macroable::macro('invalid', 'notACallable');
+    }
+
+    public function testRegisteringNonCallableObjectThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $nonCallableObject = new NonCallableClass();
+        $this->macroable::macro('invalid', $nonCallableObject);
+    }
+
+    public function testRegisterCallableObjectAsMacro()
+    {
+        $callableObject = new CallableClass();
+        $this->macroable::macro('callableMacro', $callableObject);
+
+        $this->assertSame('callable object invoked', $this->macroable->callableMacro());
+    }
 }
 
 class EmptyMacroable
@@ -199,5 +223,17 @@ class TestMixin
         return function () {
             return 'foo';
         };
+    }
+}
+
+class NonCallableClass
+{
+}
+
+class CallableClass
+{
+    public function __invoke()
+    {
+        return 'callable object invoked';
     }
 }


### PR DESCRIPTION
Current method docs specify that the $macro parameter is either an object or callable. However, no error is generated if an invalid, non-callable input is used.
Invoking a non-callable object produces a BadMethodCallException with the message 'Object of type NonCallableObject is not callable.' Therefore, I have removed 'object' from the acceptable input types.

Added validation logic to the `macro()` method in the `Macroable` trait to ensure the registered macro is callable. 
An `InvalidArgumentException` is thrown if the validation fails.



