### PR TITLE
[10.x] Allow searching on `vendor:publish` prompt

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -15,6 +15,7 @@ use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Laravel\Prompts\search;
 use function Laravel\Prompts\select;
 
 #[AsCommand(name: 'vendor:publish')]
@@ -114,11 +115,23 @@ class VendorPublishCommand extends Command
      */
     protected function promptForProviderOrTag()
     {
-        $choice = select(
-            "Which provider or tag's files would you like to publish?",
-            $choices = $this->publishableChoices(),
-            scroll: 15,
-        );
+        $choices = $this->publishableChoices();
+
+        $choice = windows_os()
+            ? select(
+                "Which provider or tag's files would you like to publish?",
+                $choices,
+                scroll: 15,
+            )
+            : search(
+                label: "Which provider or tag's files would you like to publish?",
+                placeholder: 'Search...',
+                options: fn ($search) => array_filter(
+                    $choices,
+                    fn ($choice) => str_contains(strtolower($choice), strtolower($search))
+                ),
+                scroll: 15,
+            );
 
         if ($choice == $choices[0] || is_null($choice)) {
             return;


### PR DESCRIPTION
This PR updates the `php artisan vendor:publish` command to allow filtering the list of providers and tags to more quickly find what you'd like to publish.

[Preview](https://github.com/laravel/framework/assets/4977161/1d3992f5-f6c3-4013-9c27-7bf0b1eacc0a)

The `search` prompt has a Windows fallback, so it doesn't strictly need to be conditional here, but the fallback is better suited to `search` prompts that have very large lists typically involving a database request. For this scenario, keeping the existing `select` prompt on Windows felt better.
