### PR TITLE
[10.x] BelongsToMany improvement: Filtering Queries Via Intermediate Table Columns in a Callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -58,7 +58,7 @@ trait QueriesRelationships
         // proper logical grouping of the where clauses if needed by this Eloquent query
         // builder. Then, we will be ready to finalize and return this query instance.
         if ($callback) {
-            $hasQuery->callScope($callback);
+            $hasQuery->callScope($callback, [$relation]);
         }
 
         return $this->addHasWhere(


### PR DESCRIPTION
For now, the only documented way to filter queries via Intermediate table columns — is to apply it while [defining relations](https://laravel.com/docs/10.x/eloquent-relationships#filtering-queries-via-intermediate-table-columns).

But sometimes we need more flexibility.

For example — `Users` belongs to many `Organization` with `roles` (role of user in organization) in pivot. `Users` has `roles` too (role of user in application). So, we have _ambiguous column name_.

`users` table
| Column | Type |
| --- | --- |
| id |  |
| roles | json, array |

`employees` pivot table
| Column | Type |
| --- | --- |
| user_id |  |
| organization_id |  |
| roles | json, array |

Define relation in `User` model:

```php
class User extends Model {
  public function organizations(): BelongsToMany
  {
    return $this->belongsToMany(Organization::class, 'employees')->withPivot('roles');
  }
}
```

**Now, how to query users, who play some roles?** 

Of course,  we may define some additional relations:

```php
class User extends Model {
  public function organizationManagers(): BelongsToMany
  {
    // I wish I could use wherePivotJsonContains() method
    return $this->organizations()->wherePivot('roles', 'like', '%manager%');
  }
}
```

And use it:

```php
User::query()->whereHas('organizationManagers');
```

It builds such query:

```mysql
select * from `users` where exists 
  (select * from `organizations` inner join `employees` 
    on `organizations`.`id` = `employees`.`organization_id` 
    where `users`.`id` = `employees`.`user_id` and `employees`.`roles` like ?
  )
```

**But what if we have too many possible roles and its combinations? We doomed to define so many relations in User model.**

We could try to filter query in a callback:

```php
User::query()->whereHas('organizations', function(Builder $builder) {
  $builder->where('employees.roles', 'like', '%manager%');
});
```

_Not good. We should explicitly point to pivot table._

**This PR brings a solution**. It provides `Relation` object as second parameter for any `Builder::has*`  method:

```php
User::query()->whereHas('organizations', function(Builder $builder, BelongsToMany $relation) {
  $relation->wherePivot('roles', 'like', '%manager%');
});
```
It produces exactly the same query, as `Relation` is **the** object, we've defined in a model. 

Or:

```php
User::query()->whereHas('organizations', function(Builder $builder, BelongsToMany $relation) {
  $builder->whereJsonContains($relation->qualifyPivotColumn('roles'), 'manager');
});
```

Besides, `Relation` is a very relevant context for `has*` callbacks. It gives us table name, it qualifies columns names etc.

---

Changes in this PR are extremely minimalistic: just one additional parameter passed to a callback. No existing callback will be broken.