### PR TITLE
Fix retrieving the date from the given PHP server output

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -309,7 +309,11 @@ class ServeCommand extends Command
 
         preg_match($regex, $line, $matches);
 
-        return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
+        if (isset($matches[1])) { 
+            return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
+        } else {
+            Carbon::now();
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -309,10 +309,10 @@ class ServeCommand extends Command
 
         preg_match($regex, $line, $matches);
 
-        if (isset($matches[1])) { 
+        if (isset($matches[1])) {
             return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
         } else {
-            Carbon::now();
+            return Carbon::now();
         }
     }
 


### PR DESCRIPTION
This is a fix to check if `matches` has 2 elements in the PHP server output.

Related issues
https://github.com/laravel/framework/issues/48547
https://github.com/laravel/framework/issues/47930
https://github.com/laravel/framework/issues/46486
https://github.com/laravel/framework/issues/43653
