### PR TITLE
[10.x] Handle expiration in seconds

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -360,7 +360,7 @@ class Handler implements ExceptionHandlerContract
                 with($throttle->key ?: 'illuminate:foundation:exceptions:'.$e::class, fn ($key) => $this->hashThrottleKeys ? md5($key) : $key),
                 $throttle->maxAttempts,
                 fn () => true,
-                $throttle->decayMinutes
+                60 * $throttle->decayMinutes
             );
         }), rescue: false, report: false);
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -705,6 +705,52 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertCount(14, $reported);
         $this->assertSame('Something in the app went wrong.', $reported[0]->getMessage());
     }
+
+    public function testRateLimitExpiresOnBoundary()
+    {
+        $handler = new class($this->container) extends Handler
+        {
+            protected function throttle($e)
+            {
+                return Limit::perMinute(1);
+            }
+        };
+        $reported = [];
+        $handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+        $this->container->instance(RateLimiter::class, $limiter = new class(new Repository(new ArrayStore)) extends RateLimiter
+        {
+            public $attempted = 0;
+
+            public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
+            {
+                $this->attempted++;
+
+                return parent::attempt(...func_get_args());
+            }
+        });
+
+        Carbon::setTestNow('2000-01-01 00:00:00.000');
+        $handler->report(new Exception('Something in the app went wrong 1.'));
+        Carbon::setTestNow('2000-01-01 00:00:59.999');
+        $handler->report(new Exception('Something in the app went wrong 1.'));
+
+        $this->assertSame(2, $limiter->attempted);
+        $this->assertCount(1, $reported);
+        $this->assertSame('Something in the app went wrong 1.', $reported[0]->getMessage());
+
+        Carbon::setTestNow('2000-01-01 00:01:00.000');
+        $handler->report(new Exception('Something in the app went wrong 2.'));
+        Carbon::setTestNow('2000-01-01 00:01:59.999');
+        $handler->report(new Exception('Something in the app went wrong 2.'));
+
+        $this->assertSame(4, $limiter->attempted);
+        $this->assertCount(2, $reported);
+        $this->assertSame('Something in the app went wrong 2.', $reported[1]->getMessage());
+    }
 }
 
 class CustomException extends Exception


### PR DESCRIPTION
This was reverted in https://github.com/laravel/framework/pull/48576, however this is not related to the issues we were trying to address there.

This change ensures that expiration is treated as seconds as it should be - not related the array cache TTL.