### PR TITLE
[10.x] Add new SQL error messages

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -66,6 +66,10 @@ trait DetectsLostConnections
             'SQLSTATE[08006] [7] SSL error: sslv3 alert unexpected message',
             'SQLSTATE[08006] [7] unrecognized SSL error code:',
             'SQLSTATE[HY000] [2002] No connection could be made because the target machine actively refused it',
+            'SQLSTATE[HY000] [2002] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond',
+            'SQLSTATE[HY000] [2002] Network is unreachable',
+            'SQLSTATE[HY000] [2002] The requested address is not valid in its context',
+            'SQLSTATE[HY000] [2002] A socket operation was attempted to an unreachable network',
         ]);
     }
 }


### PR DESCRIPTION
Add new connection error messages for mysql PDO

These messages comes from when ip is set to like ```0.0.0.0```, ```255.255.255.255``` and so on. I got these messages Windows, not on linux. MySQL database is running on linux inside docker container.

My error handling is checking against the trait ```Illuminate\Database\DetectsLostConnections::causedByLostConnection($exception)```
