### PR TITLE
[10.x] Prevent `session:table` command from creating duplicates

### DIFF
--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -94,6 +94,8 @@ class SessionTableCommand extends Command
      */
     protected function migrationExists()
     {
-        return count($this->files->glob($this->laravel->databasePath('migrations/*_*_*_*_create_sessions_table.php'))) !== 0;
+        return count($this->files->glob(
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_sessions_table.php')
+        )) !== 0;
     }
 }

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -88,7 +88,7 @@ class SessionTableCommand extends Command
     }
 
     /**
-     * Check whether the sessions migration already exists.
+     * Determine whether the session table migration already exists.
      *
      * @return bool
      */

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -60,6 +60,12 @@ class SessionTableCommand extends Command
      */
     public function handle()
     {
+        if ($this->migrationExists()) {
+            $this->components->error('Migration already exists.');
+
+            return 1;
+        }
+
         $fullPath = $this->createBaseMigration();
 
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/database.stub'));
@@ -79,5 +85,15 @@ class SessionTableCommand extends Command
         $path = $this->laravel->databasePath().'/migrations';
 
         return $this->laravel['migration.creator']->create($name, $path);
+    }
+
+    /**
+     * Check whether the sessions migration already exists.
+     *
+     * @return bool
+     */
+    protected function migrationExists()
+    {
+        return count($this->files->glob($this->laravel->databasePath('migrations/*_*_*_*_create_sessions_table.php'))) !== 0;
     }
 }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -33,6 +33,7 @@ class SessionTableCommandTest extends TestCase
         $command->setLaravel($app);
         $path = __DIR__.'/migrations';
         $creator->shouldReceive('create')->once()->with('create_sessions_table', $path)->andReturn($path);
+        $files->shouldReceive('glob')->once()->with($app->databasePath('/migrations/*_*_*_*_create_sessions_table.php'))->andReturn([]);
         $files->shouldReceive('get')->once()->andReturn('foo');
         $files->shouldReceive('put')->once()->with($path, 'foo');
 

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -33,7 +33,7 @@ class SessionTableCommandTest extends TestCase
         $command->setLaravel($app);
         $path = __DIR__.'/migrations';
         $creator->shouldReceive('create')->once()->with('create_sessions_table', $path)->andReturn($path);
-        $files->shouldReceive('glob')->once()->with($app->databasePath('/migrations/*_*_*_*_create_sessions_table.php'))->andReturn([]);
+        $files->shouldReceive('glob')->once()->with($app->joinPaths($app->databasePath('migrations'), '*_*_*_*_create_sessions_table.php'))->andReturn([]);
         $files->shouldReceive('get')->once()->andReturn('foo');
         $files->shouldReceive('put')->once()->with($path, 'foo');
 


### PR DESCRIPTION
This PR adds a check to prevent the `session:table` command from creating multiple migrations for the session table, which will fail when migrating.

![image](https://github.com/laravel/framework/assets/4977161/4ed49862-a1e9-411c-885a-7b594ba47fae)

We have a check for this in the Jetstream installer, but it doesn't work with anonymous migrations. Rather than fix it there, I've created https://github.com/laravel/jetstream/pull/1385 to remove the check in favour of doing it here.