### PR TITLE
[10.x] Update Type Hint for macro Method to callable

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -20,7 +20,7 @@ trait Macroable
      * Register a custom macro.
      *
      * @param  string  $name
-     * @param  object|callable  $macro
+     * @param  callable  $macro
      * @return void
      */
     public static function macro($name, $macro)


### PR DESCRIPTION
The current implementation allows for an object or a callable to be passed to the macro method. However, a macro must always be a callable entity in order to function correctly.

Invoking a non-callable object produces a BadMethodCallException with the message 'Object of type NonCallableObject is not callable.' Therefore, I have removed 'object' from the acceptable input types.