### PR TITLE
[10.x] Added config option to allow unsafe links in the markdown parser

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -106,7 +106,7 @@ class Markdown
     public static function parse($text)
     {
         $environment = new Environment([
-            'allow_unsafe_links' => false,
+            'allow_unsafe_links' => config('mail.markdown.allow_unsafe_links', false),
         ]);
 
         $environment->addExtension(new CommonMarkCoreExtension);

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Config\Repository as Config;
 use Illuminate\Mail\Markdown;
 use Illuminate\View\Factory;
 use Mockery as m;
@@ -12,6 +13,13 @@ class MailMarkdownTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createConfig();
     }
 
     public function testRenderFunctionReturnsHtml()
@@ -86,5 +94,19 @@ class MailMarkdownTest extends TestCase
         $result = $markdown->parse('# Something')->toHtml();
 
         $this->assertSame("<h1>Something</h1>\n", $result);
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'mail' => [
+                'markdown' => ['allow_unsafe_links' => false],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
I have the need to inline embed `file://` pathed images, however the current implementation strictly forbids this.

My change allows the end-user to change the behaviour via the `mail` config, while maintaining the default disabled state.

To further go into why I need this, we write content for a generic mailable in markdown format.

The attached images to be used inline cannot be accessed remotely, and so need to be either embedded or base64 encoded.

I would rather not base64 the images as it has the potential to swell the filesize of the mailable, which could be sent to thousands of users.

This change should have no-impact on anyone who doesn't need this behaviour.