### PR TITLE
Filtered out null model keys on relations that are a self referencing…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -273,7 +273,7 @@ abstract class Relation implements BuilderContract
     }
 
     /**
-     * Get all of the primary keys for an array of models.
+     * Get all of the given, or primary keys for an array of models.
      *
      * @param  array  $models
      * @param  string|null  $key
@@ -283,7 +283,7 @@ abstract class Relation implements BuilderContract
     {
         return collect($models)->map(function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
-        })->values()->unique(null, true)->sort()->all();
+        })->values()->unique(null, true)->filter()->sort()->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -283,7 +283,8 @@ abstract class Relation implements BuilderContract
     {
         return collect($models)->map(function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
-        })->values()->unique(null, true)->filter()->sort()->all();
+        })->filter(fn ($value) => ! is_null($value))->values()
+            ->unique(null, true)->sort()->all();
     }
 
     /**


### PR DESCRIPTION
This MR builds upon the work done in #43724 to prevent impossible eager load queries from running.

Given a `hasMany` used in the following way:

```php
// Event.php

public function schedules()
{
    return $this->hasMany(Event::class, 'schedule_id', 'schedule_id');
}
```

When the `schedule_id` is `null` on the top level model, and the `schedules` relation is eager loaded, a query such as the following is run:

```sql
select * from `events` where `events`.`schedule_id` in ('')
```

In this case, the array of model keys being used to determine whether `eagerKeysWereEmpty` should be set to true was as follows `[null]`. 

The changes in this PR simply add a filter to the collection of keys used to determine whether `eagerKeysWereEmpty` is set to true or not ahead of the eager load query being run.
