### PR TITLE
[10.x] Added random method to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1361,6 +1361,17 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * @param int $length
+     * @return static
+     */
+    public function random($length = 16)
+    {
+        $this->value = Str::random($length);
+
+        return $this;
+    }
+
+    /**
      * Proxy dynamic properties onto methods.
      *
      * @param  string  $key

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1274,4 +1274,12 @@ class SupportStringableTest extends TestCase
         $this->assertTrue(isset($str[2]));
         $this->assertFalse(isset($str[10]));
     }
+
+    public function testRandom()
+    {
+        $str = $this->stringable('my string');
+        $this->assertNotSame('my string', $str->random());
+        $this->assertSame(10, strlen($str->random(10)));
+        $this->assertSame(16, strlen($str->random()));
+    }
 }


### PR DESCRIPTION
This adds a `random($length)` method to the `Stringable` class which was suggested in [this discussion](https://github.com/laravel/framework/discussions/35067)