### PR TITLE
[10.x] Added the ability to forget nested collection items

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1756,6 +1756,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function offsetUnset($key): void
     {
-        unset($this->items[$key]);
+        data_forget($this->items, $key);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -811,6 +811,50 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue(isset($c['name']));
     }
 
+    public function testForgetNestedKey()
+    {
+        $c = new Collection([
+            [
+                'name' => 'John',
+                'age' => 25,
+            ],
+            [
+                'name' => 'Jane',
+                'age' => 26,
+            ],
+        ]);
+        $c = $c->forget('*.name')->all();
+        $this->assertEquals([
+            [
+                'age' => 25,
+            ],
+            [
+                'age' => 26,
+            ],
+        ], $c);
+
+        $c = new Collection([
+            'a' => [
+                'name' => 'John',
+                'age' => 25,
+            ],
+            'b' => [
+                'name' => 'Jane',
+                'age' => 26,
+            ]
+        ]);
+        $c = $c->forget('a.name')->all();
+        $this->assertEquals([
+            'a' => [
+                'age' => 25,
+            ],
+            'b' => [
+                'name' => 'Jane',
+                'age' => 26,
+            ]
+        ], $c);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
Updated the `Collection::forget()` method to support dot notation and nested keys as [discussed here](https://github.com/laravel/framework/discussions/40749)
