### PR TITLE
[11.x] Remove deprecated `Illuminate\Support\Composer` usage in `MigratorGeneratorCommand`

### DIFF
--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Console;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Composer;
 
 abstract class MigrationGeneratorCommand extends Command
 {
@@ -15,27 +14,16 @@ abstract class MigrationGeneratorCommand extends Command
     protected $files;
 
     /**
-     * The Composer instance.
-     *
-     * @var \Illuminate\Support\Composer
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     */
-    protected $composer;
-
-    /**
      * Create a new migration generator command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer  $composer
      * @return void
      */
-    public function __construct(Filesystem $files, Composer $composer)
+    public function __construct(Filesystem $files)
     {
         parent::__construct();
 
         $this->files = $files;
-        $this->composer = $composer;
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -292,7 +292,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerCacheTableCommand()
     {
         $this->app->singleton(CacheTableCommand::class, function ($app) {
-            return new CacheTableCommand($app['files'], $app['composer']);
+            return new CacheTableCommand($app['files']);
         });
     }
 
@@ -508,7 +508,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerNotificationTableCommand()
     {
         $this->app->singleton(NotificationTableCommand::class, function ($app) {
-            return new NotificationTableCommand($app['files'], $app['composer']);
+            return new NotificationTableCommand($app['files']);
         });
     }
 
@@ -638,7 +638,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerQueueFailedTableCommand()
     {
         $this->app->singleton(FailedTableCommand::class, function ($app) {
-            return new FailedTableCommand($app['files'], $app['composer']);
+            return new FailedTableCommand($app['files']);
         });
     }
 
@@ -650,7 +650,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerQueueTableCommand()
     {
         $this->app->singleton(TableCommand::class, function ($app) {
-            return new TableCommand($app['files'], $app['composer']);
+            return new TableCommand($app['files']);
         });
     }
 
@@ -662,7 +662,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerQueueBatchesTableCommand()
     {
         $this->app->singleton(BatchesTableCommand::class, function ($app) {
-            return new BatchesTableCommand($app['files'], $app['composer']);
+            return new BatchesTableCommand($app['files']);
         });
     }
 
@@ -722,7 +722,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerSeederMakeCommand()
     {
         $this->app->singleton(SeederMakeCommand::class, function ($app) {
-            return new SeederMakeCommand($app['files'], $app['composer']);
+            return new SeederMakeCommand($app['files']);
         });
     }
 
@@ -734,7 +734,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerSessionTableCommand()
     {
         $this->app->singleton(SessionTableCommand::class, function ($app) {
-            return new SessionTableCommand($app['files'], $app['composer']);
+            return new SessionTableCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
