### PR TITLE
[10.x] Add affected row count to QueryExecuted event log

### DIFF
--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -40,20 +40,29 @@ class QueryExecuted
     public $connectionName;
 
     /**
+     * The affected row count.
+     *
+     * @var int|null
+     */
+    public $count;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $sql
      * @param  array  $bindings
      * @param  float|null  $time
      * @param  \Illuminate\Database\Connection  $connection
+     * @param  int|null  $count
      * @return void
      */
-    public function __construct($sql, $bindings, $time, $connection)
+    public function __construct($sql, $bindings, $time, $connection, $count = null)
     {
         $this->sql = $sql;
         $this->time = $time;
         $this->bindings = $bindings;
         $this->connection = $connection;
         $this->connectionName = $connection->getName();
+        $this->count = $count;
     }
 }


### PR DESCRIPTION
**THIS IS NOT ONLY  FOR `update`/`delete`, IT IS FOR ALL THE QUERIES**

Currently, `Illuminate\Database\Events\QueryExecuted` holds executed SQL query, connection and the time it took to run. While logging the queries it's quite handy to know how much rows it has affected:

```php
use Illuminate\Support\Facades\DB;
use Illuminate\Database\Events\QueryExecuted;

DB::listen(function(QueryExecuted $query) {
    /**
     * $query->sql             The SQL query that was executed.
     * $query->time            The number of milliseconds it took to execute the query.
     * $query->connectionName  The database connection name.
     * $query->count           The quantity of rows query has affected.
     */
});
```
