### PR TITLE
[11.x] Allow multiple events to be dispatched at once

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -49,6 +49,14 @@ interface Dispatcher
     public function dispatch($event, $payload = [], $halt = false);
 
     /**
+     * Dispatch multiple events and call their listeners.
+     *
+     * @param  array<int|string, mixed>  $events
+     * @return void
+     */
+    public function dispatchMultiple($events);
+
+    /**
      * Register an event and payload to be fired later.
      *
      * @param  string  $event

--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -54,7 +54,7 @@ interface Dispatcher
      * @param  array<int|string, mixed>  $events
      * @return void
      */
-    public function dispatchMultiple($events);
+    public function dispatchMany($events);
 
     /**
      * Register an event and payload to be fired later.

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -277,14 +277,13 @@ class Dispatcher implements DispatcherContract
     public function dispatchMultiple($events)
     {
         foreach ($events as $event => $payload) {
-            if (is_object($payload)) {
+            // If the key is an integer, we can assume we are dealing with an array and not a hashmap.
+            if (is_int($event)) {
                 // The payload is the event itself.
                 $this->dispatch($payload);
 
                 continue;
             }
-
-            [$event, $payload] = $this->parseEventAndPayload($event, $payload);
 
             $this->dispatch($event, $payload);
         }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -269,6 +269,28 @@ class Dispatcher implements DispatcherContract
     }
 
     /**
+     * Dispatch multiple events and call their listeners.
+     *
+     * @param  array<int|string, mixed>  $events
+     * @return void
+     */
+    public function dispatchMultiple($events)
+    {
+        foreach ($events as $event => $payload) {
+            if (is_object($payload)) {
+                // The payload is the event itself.
+                $this->dispatch($payload);
+
+                continue;
+            }
+
+            [$event, $payload] = $this->parseEventAndPayload($event, $payload);
+
+            $this->dispatch($event, $payload);
+        }
+    }
+
+    /**
      * Parse the given event and payload and prepare them for dispatching.
      *
      * @param  mixed  $event

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -274,7 +274,7 @@ class Dispatcher implements DispatcherContract
      * @param  array<int|string, mixed>  $events
      * @return void
      */
-    public function dispatchMultiple($events)
+    public function dispatchMany($events)
     {
         foreach ($events as $event => $payload) {
             // If the key is an integer, we can assume we are dealing with an array and not a hashmap.

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -46,7 +46,7 @@ class NullDispatcher implements DispatcherContract
      * @param  array<int|string, mixed>  $events
      * @return void
      */
-    public function dispatchMultiple($events)
+    public function dispatchMany($events)
     {
         //
     }

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -41,6 +41,17 @@ class NullDispatcher implements DispatcherContract
     }
 
     /**
+     * Don't fire multiple events.
+     *
+     * @param  array<int|string, mixed>  $events
+     * @return void
+     */
+    public function dispatchMultiple($events)
+    {
+        //
+    }
+
+    /**
      * Don't register an event and payload to be fired later.
      *
      * @param  string  $event

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void subscribe(object|string $subscriber)
  * @method static mixed until(string|object $event, mixed $payload = [])
  * @method static array|null dispatch(string|object $event, mixed $payload = [], bool $halt = false)
- * @method static void dispatchMultiple(array $events)
+ * @method static void dispatchMany(array $events)
  * @method static array getListeners(string $eventName)
  * @method static \Closure makeListener(\Closure|string|array $listener, bool $wildcard = false)
  * @method static \Closure createClassListener(string $listener, bool $wildcard = false)

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void subscribe(object|string $subscriber)
  * @method static mixed until(string|object $event, mixed $payload = [])
  * @method static array|null dispatch(string|object $event, mixed $payload = [], bool $halt = false)
+ * @method static void dispatchMultiple(array $events)
  * @method static array getListeners(string $eventName)
  * @method static \Closure makeListener(\Closure|string|array $listener, bool $wildcard = false)
  * @method static \Closure createClassListener(string $listener, bool $wildcard = false)

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -309,7 +309,7 @@ class EventFake implements Dispatcher, Fake
      * @param  array<int|string, mixed>  $events
      * @return void
      */
-    public function dispatchMultiple($events)
+    public function dispatchMany($events)
     {
         foreach ($events as $event => $payload) {
             if (is_int($event)) {

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -304,6 +304,26 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
+     * Dispatch multiple events and call their listeners.
+     *
+     * @param  array<int|string, mixed>  $events
+     * @return void
+     */
+    public function dispatchMultiple($events)
+    {
+        foreach ($events as $event => $payload) {
+            if (is_int($event)) {
+                // The payload is the event itself.
+                $this->dispatch($payload);
+
+                continue;
+            }
+
+            $this->dispatch($event, $payload);
+        }
+    }
+
+    /**
      * Determine if an event should be faked or actually dispatched.
      *
      * @param  string  $eventName

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -53,6 +53,22 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('baz', $_SERVER['__event.test_bar']);
     }
 
+    public function testMultipleEventsCanBeDispatchedArrayNoPayload()
+    {
+        unset($_SERVER['__event.test_foo']);
+        unset($_SERVER['__event.test_bar']);
+        $d = new Dispatcher;
+        $d->listen('foo', fn () => $_SERVER['__event.test_foo'] = 1);
+        $d->listen('bar', fn () => $_SERVER['__event.test_bar'] = 2);
+        $d->dispatchMultiple([
+            'foo',
+            'bar'
+        ]);
+
+        $this->assertSame(1, $_SERVER['__event.test_foo']);
+        $this->assertSame(2, $_SERVER['__event.test_bar']);
+    }
+
     public function testMultipleEventsCanBeDispatchedObject()
     {
         unset($_SERVER['__event.test_foo']);

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -44,7 +44,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
         $d->listen('foo', fn ($foo) => $_SERVER['__event.test_foo'] = $foo);
         $d->listen('bar', fn ($bar) => $_SERVER['__event.test_bar'] = $bar);
-        $d->dispatchMultiple([
+        $d->dispatchMany([
             'foo' => 'bar',
             'bar' => 'baz',
         ]);
@@ -60,7 +60,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
         $d->listen('foo', fn () => $_SERVER['__event.test_foo'] = 1);
         $d->listen('bar', fn () => $_SERVER['__event.test_bar'] = 2);
-        $d->dispatchMultiple([
+        $d->dispatchMany([
             'foo',
             'bar'
         ]);
@@ -81,7 +81,7 @@ class EventsDispatcherTest extends TestCase
         $d->listen(AnotherEvent::class, function () {
             $_SERVER['__event.test_bar'] = 'two';
         });
-        $d->dispatchMultiple([
+        $d->dispatchMany([
             new ExampleEvent,
             new AnotherEvent
         ]);

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -37,6 +37,43 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('barbar', $_SERVER['__event.test']);
     }
 
+    public function testMultipleEventsCanBeDispatchedArray()
+    {
+        unset($_SERVER['__event.test_foo']);
+        unset($_SERVER['__event.test_bar']);
+        $d = new Dispatcher;
+        $d->listen('foo', fn ($foo) => $_SERVER['__event.test_foo'] = $foo);
+        $d->listen('bar', fn ($bar) => $_SERVER['__event.test_bar'] = $bar);
+        $d->dispatchMultiple([
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ]);
+
+        $this->assertSame('bar', $_SERVER['__event.test_foo']);
+        $this->assertSame('baz', $_SERVER['__event.test_bar']);
+    }
+
+    public function testMultipleEventsCanBeDispatchedObject()
+    {
+        unset($_SERVER['__event.test_foo']);
+        unset($_SERVER['__event.test_bar']);
+        $d = new Dispatcher;
+
+        $d->listen(ExampleEvent::class, function () {
+            $_SERVER['__event.test_foo'] = 'one';
+        });
+        $d->listen(AnotherEvent::class, function () {
+            $_SERVER['__event.test_bar'] = 'two';
+        });
+        $d->dispatchMultiple([
+            new ExampleEvent,
+            new AnotherEvent
+        ]);
+
+        $this->assertSame('one', $_SERVER['__event.test_foo']);
+        $this->assertSame('two', $_SERVER['__event.test_bar']);
+    }
+
     public function testHaltingEventExecution()
     {
         unset($_SERVER['__event.test']);

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -138,6 +138,42 @@ class EventFakeTest extends TestCase
         $this->assertEquals(['important'], Event::dispatch('important-event'));
     }
 
+    public function testEventsAreFakedWhenMultipleDispatchedObject()
+    {
+        Event::fake();
+
+        Event::dispatchMultiple([new NonImportantEvent(), new AnotherEvent()]);
+
+        Event::assertDispatched(NonImportantEvent::class);
+        Event::assertDispatched(AnotherEvent::class);
+    }
+
+    public function testEventsAreFakedWhenMultipleDispatchedArray()
+    {
+        Event::fake();
+
+        Event::dispatchMultiple([
+            NonImportantEvent::class => 'foo',
+            AnotherEvent::class => 'bar'
+        ]);
+
+        Event::assertDispatched(NonImportantEvent::class);
+        Event::assertDispatched(AnotherEvent::class);
+    }
+
+    public function testEventsAreFakedWhenMultipleDispatchedArrayNoPayload()
+    {
+        Event::fake();
+
+        Event::dispatchMultiple([
+            NonImportantEvent::class,
+            AnotherEvent::class
+        ]);
+
+        Event::assertDispatched(NonImportantEvent::class);
+        Event::assertDispatched(AnotherEvent::class);
+    }
+
     public function testAssertListening()
     {
         Event::fake();
@@ -199,6 +235,11 @@ class Post extends Model
 class NonImportantEvent
 {
     //
+}
+
+class AnotherEvent
+{
+
 }
 
 class PostEventSubscriber

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -142,7 +142,7 @@ class EventFakeTest extends TestCase
     {
         Event::fake();
 
-        Event::dispatchMultiple([new NonImportantEvent(), new AnotherEvent()]);
+        Event::dispatchMany([new NonImportantEvent(), new AnotherEvent()]);
 
         Event::assertDispatched(NonImportantEvent::class);
         Event::assertDispatched(AnotherEvent::class);
@@ -152,7 +152,7 @@ class EventFakeTest extends TestCase
     {
         Event::fake();
 
-        Event::dispatchMultiple([
+        Event::dispatchMany([
             NonImportantEvent::class => 'foo',
             AnotherEvent::class => 'bar'
         ]);
@@ -165,7 +165,7 @@ class EventFakeTest extends TestCase
     {
         Event::fake();
 
-        Event::dispatchMultiple([
+        Event::dispatchMany([
             NonImportantEvent::class,
             AnotherEvent::class
         ]);


### PR DESCRIPTION
A common use case I have for events is dispatching several at once. For example, I might have models store events to be published at a later time (e.g outside a transaction).

```php 
DB::transaction(function () {
    $cart->doSomeAction(); // adds an event
    $cart->finalize(); // adds another event
});

Event::dispatchMany($cart->flushEvents());
```

It also supports an array syntax to keep it similar to `dispatch`:
```php
Event::dispatchMany([
    'foo' => [1, 'payload'],
    'bar' => [2', 'more payload']
]);
```

This PR provides simple syntatic sugar for that use case.