### PR TITLE
[10.x] Fire event after commands have been handled

### DIFF
--- a/src/Illuminate/Foundation/Console/Events/CommandHandled.php
+++ b/src/Illuminate/Foundation/Console/Events/CommandHandled.php
@@ -9,7 +9,7 @@ class CommandHandled
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface|null  $output
-     * @param  int  $output
+     * @param  int  $exitCode
      */
     public function __construct(public $input, public $output, public $exitCode)
     {

--- a/src/Illuminate/Foundation/Console/Events/CommandHandled.php
+++ b/src/Illuminate/Foundation/Console/Events/CommandHandled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Foundation\Console\Events;
+
+class CommandHandled
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface|null  $output
+     * @param  int  $output
+     */
+    public function __construct(public $input, public $output, public $exitCode)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Console\Events\CommandHandled;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
@@ -198,14 +199,20 @@ class Kernel implements KernelContract
 
             $this->bootstrap();
 
-            return $this->getArtisan()->run($input, $output);
+            $exitCode = $this->getArtisan()->run($input, $output);
         } catch (Throwable $e) {
             $this->reportException($e);
 
             $this->renderException($output, $e);
 
-            return 1;
+            $exitCode = 1;
         }
+
+        $this->events->dispatch(
+            new CommandHandled($input, $output, $exitCode)
+        );
+
+        return $exitCode;
     }
 
     /**


### PR DESCRIPTION
Fires an event after commands have been handled.

Creates symmetry with the HTTP Kernel's `RequestHandled` event.

It is _slightly_ different as the console renders the exception to the user before firing the event, where as the HTTP response is not actually sent until afterwards - but I think that is okay.

https://github.com/laravel/framework/blob/e80bc1ac5c4994e658b881f4c9d203571ada369a/src/Illuminate/Foundation/Http/Kernel.php#L137C5-L156