### PR TITLE
[10.x] Store blocks after prepare strings

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -256,11 +256,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         [$this->footer, $result] = [[], ''];
 
-        $value = $this->storeUncompiledBlocks($value);
-
         foreach ($this->prepareStringsForCompilationUsing as $callback) {
             $value = $callback($value);
         }
+        
+        $value = $this->storeUncompiledBlocks($value);
 
         // First we will compile the Blade component tags. This is a precompile style
         // step which compiles the component Blade tags into @component directives

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -259,7 +259,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         foreach ($this->prepareStringsForCompilationUsing as $callback) {
             $value = $callback($value);
         }
-        
+
         $value = $this->storeUncompiledBlocks($value);
 
         // First we will compile the Blade component tags. This is a precompile style


### PR DESCRIPTION
This pull request fixes this particular test: https://github.com/livewire/volt/pull/58, so `@php` blocks are stored after templates are extracted.