### PR TITLE
[11.x] Add row count to QueryExecuted event and query log

### DIFF
--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -40,20 +40,29 @@ class QueryExecuted
     public $connectionName;
 
     /**
+     * The affected row count.
+     *
+     * @var int|null
+     */
+    public $count;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $sql
      * @param  array  $bindings
      * @param  float|null  $time
      * @param  \Illuminate\Database\Connection  $connection
+     * @param  int|null  $count
      * @return void
      */
-    public function __construct($sql, $bindings, $time, $connection)
+    public function __construct($sql, $bindings, $time, $connection, $count = null)
     {
         $this->sql = $sql;
         $this->time = $time;
         $this->bindings = $bindings;
         $this->connection = $connection;
         $this->connectionName = $connection->getName();
+        $this->count = $count;
     }
 }


### PR DESCRIPTION
**THIS IS NOT ONLY  FOR `update`/`delete`, IT IS FOR ALL THE QUERIES (_MAINLY THIRD PARTY PACKAGES_)**
**TESTING AND DEBUGGING PURPOSES**

Currently, `Illuminate\Database\Events\QueryExecuted`/`$queryLog` holds executed SQL query, connection and the time it took to run. While logging the queries it's quite handy to know how much rows it has affected:

```php
use Illuminate\Support\Facades\DB;
use Illuminate\Database\Events\QueryExecuted;

DB::listen(function(QueryExecuted $query) {
    /**
     * $query->sql             The SQL query that was executed.
     * $query->time            The number of milliseconds it took to execute the query.
     * $query->connectionName  The database connection name.
     * $query->count           The quantity of rows query has affected/returned.
     */
});

//  ------------
DB::enableQueryLog();
// logic with queries
DB::disableQueryLog();
$queryLog = DB::getQueryLog(); /* result
[
    ['query', 'bindings', 'time', 'count'],
    ['query', 'bindings', 'time', 'count'],
    ///
] */
```
In some scenarios (like testing) it would be useful to check that a package that you do not have access to queries assert expected row_count

 I did test this adding it on [laravel-debugbar](https://github.com/barryvdh/laravel-debugbar)

![image](https://github.com/laravel/framework/assets/79208489/beb96b45-1e59-4f58-97ec-60ccf594503a)

we already have the elapsed time, why not the row count?
[**LaravelDebugbar.php**#L346-L34](https://github.com/barryvdh/laravel-debugbar/blob/b7362410434d7f1155e0729e3a75c83384d3b699/src/LaravelDebugbar.php#L346-L347)  already listen `QueryExecuted`, It wouldn't make sense to add events in hundreds of sqls just to debug.