### PR TITLE
[10.x] throw TransportException instead of Exception in SES mail drivers

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -4,7 +4,7 @@ namespace Illuminate\Mail\Transport;
 
 use Aws\Exception\AwsException;
 use Aws\Ses\SesClient;
-use Exception;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
@@ -75,7 +75,7 @@ class SesTransport extends AbstractTransport
         } catch (AwsException $e) {
             $reason = $e->getAwsErrorMessage() ?? $e->getMessage();
 
-            throw new Exception(
+            throw new TransportException(
                 sprintf('Request to AWS SES API failed. Reason: %s.', $reason),
                 is_int($e->getCode()) ? $e->getCode() : 0,
                 $e

--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -4,7 +4,7 @@ namespace Illuminate\Mail\Transport;
 
 use Aws\Exception\AwsException;
 use Aws\SesV2\SesV2Client;
-use Exception;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
@@ -79,7 +79,7 @@ class SesV2Transport extends AbstractTransport
         } catch (AwsException $e) {
             $reason = $e->getAwsErrorMessage() ?? $e->getMessage();
 
-            throw new Exception(
+            throw new TransportException(
                 sprintf('Request to AWS SES V2 API failed. Reason: %s.', $reason),
                 is_int($e->getCode()) ? $e->getCode() : 0,
                 $e

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Aws\Command;
+use Aws\Exception\AwsException;
 use Aws\Ses\SesClient;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
@@ -10,6 +12,7 @@ use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\View\Factory;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -74,6 +77,23 @@ class MailSesTransportTest extends TestCase
                     strpos($arg['RawMessage']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>') !== false;
             }))
             ->andReturn($sesResult);
+
+        (new SesTransport($client))->send($message);
+    }
+
+    public function testSendError()
+    {
+        $message = new Email();
+        $message->subject('Foo subject');
+        $message->text('Bar body');
+        $message->sender('myself@example.com');
+        $message->to('me@example.com');
+
+        $client = m::mock(SesClient::class);
+        $client->shouldReceive('sendRawEmail')->once()
+            ->andThrow(new AwsException('Email address is not verified.', new Command('sendRawEmail')));
+
+        $this->expectException(TransportException::class);
 
         (new SesTransport($client))->send($message);
     }

--- a/tests/Mail/MailSesV2TransportTest.php
+++ b/tests/Mail/MailSesV2TransportTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Aws\Command;
+use Aws\Exception\AwsException;
 use Aws\SesV2\SesV2Client;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
@@ -10,6 +12,7 @@ use Illuminate\Mail\Transport\SesV2Transport;
 use Illuminate\View\Factory;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -74,6 +77,23 @@ class MailSesV2TransportTest extends TestCase
                     strpos($arg['Content']['Raw']['Data'], 'Reply-To: Taylor Otwell <taylor@example.com>') !== false;
             }))
             ->andReturn($sesResult);
+
+        (new SesV2Transport($client))->send($message);
+    }
+
+    public function testSendError()
+    {
+        $message = new Email();
+        $message->subject('Foo subject');
+        $message->text('Bar body');
+        $message->sender('myself@example.com');
+        $message->to('me@example.com');
+
+        $client = m::mock(SesV2Client::class);
+        $client->shouldReceive('sendEmail')->once()
+            ->andThrow(new AwsException('Email address is not verified.', new Command('sendRawEmail')));
+
+        $this->expectException(TransportException::class);
 
         (new SesV2Transport($client))->send($message);
     }


### PR DESCRIPTION
To resolve https://github.com/laravel/framework/issues/48642

When the SES mail driver encounter an error it throw a regular `Exception`, preventing the failover driver to pass the mail along.

I changed the error for a `TransportException`, allowing the error to be handled and with minimal impact as any other catching mechanism already in place will continue to work.