### PR TITLE
Use tmpfs on MySQL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           MYSQL_DATABASE: forge
         ports:
           - 33306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --tmpfs=/var/lib/mysql:rw
       redis:
         image: redis:7.0
         ports:


### PR DESCRIPTION
Taken from https://vladmihalcea.com/how-to-run-integration-tests-at-warp-speed-with-docker-and-tmpfs/ which suggests we should see increased performance when running MySQL tests.

It may be that this option needs to be declared on the actual `mysql` configuration level.