### PR TITLE
[10.x] Fix subquery tests with mysql builder

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5708,7 +5708,7 @@ SQL;
         $grammar = new MySqlGrammar;
         $processor = m::mock(Processor::class);
 
-        return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
+        return new Builder($this->getConnection(), $grammar, $processor);
     }
 
     protected function getSQLiteBuilder()


### PR DESCRIPTION
Hey guys I think I found an issue

in the `DatabaseQueryBuilderTest.php` file if I want to create a subQuery test like this

```php
$builder = $this->getMySqlBuilder();
        $builder->select('*')->from('users')->whereIn('id', function ($query) {
            $query->select('id')->from('users')->orderBy('id', 'desc')->take(3);
        });
```
the test is going to throw this error

```
Mockery\Exception\BadMethodCallException: Received Mockery_1_Illuminate_Database_ConnectionInterface::getDatabaseName(), but no expectations were specified
```
that happens because in the `getMysqlBuilder()` method we mock the `ConnectionInterface::class` without the expectation of `getDatabaseName()` method to be called

This PR fixes this issue

please let me know If I'm missing something 
thanks for your awesome work 