### PR TITLE
[10.x] Adding a Str::initials() method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -401,7 +401,7 @@ class Str
 
         return implode(array_map(fn ($word) => static::substr($word, 0, 1), $words));
     }
-    
+
     /**
      * Determine if a given string matches a given pattern.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -390,7 +390,7 @@ class Str
     }
 
     /**
-     * Returns the initials version of the string.
+     * Returns the initials of the string.
      *
      * @param  string  $string
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -390,6 +390,19 @@ class Str
     }
 
     /**
+     * Returns the initials version of the string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function initials($string)
+    {
+        $words = explode(' ', static::replace(['-', '_'], ' ', $string));
+
+        return implode(array_map(fn ($word) => static::substr($word, 0, 1), $words));
+    }
+    
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -304,6 +304,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Returns the initials of the string.
+     *
+     * @return string
+     */
+    public function initials()
+    {
+        return Str::initials($this->value);
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern


### PR DESCRIPTION
Adding an initials() method to `Illuminate\Support\Str` that receives a string and returns an initials representation of that string.

Example:

   Joe Pistachio
   Joe_Pistachio
   Joe-Pistachio

returns

   JP

This is especially helpful for things like avatars, user profiles, etc.