### PR TITLE
[10.x] Fixed issue: Added a call to the `getValue` method

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -246,7 +246,7 @@ class Grammar extends BaseGrammar
      */
     protected function whereRaw(Builder $query, $where)
     {
-        return $where['sql'];
+        return $where['sql']->getValue($this);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use RuntimeException;
@@ -246,7 +247,7 @@ class Grammar extends BaseGrammar
      */
     protected function whereRaw(Builder $query, $where)
     {
-        return $where['sql']->getValue($this);
+        return $where['sql'] instanceof Expression ? $where['sql']->getValue($this) : $where['sql'];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use RuntimeException;

--- a/tests/Database/DatabaseQueryGrammarTest.php
+++ b/tests/Database/DatabaseQueryGrammarTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class DatabaseQueryGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+    public function testWhereRawReturnsStringWhenExpressionPassed()
+    {
+        $builder = m::mock(Builder::class);
+        $grammar = new Grammar;
+        $reflection = new ReflectionClass($grammar);
+        $method = $reflection->getMethod('whereRaw');
+        $expression = ['sql' => new Expression('select * from "users"')];
+
+        $rawQuery = $method->invoke($grammar, $builder, $expression);
+
+        $this->assertSame('select * from "users"', $rawQuery);
+    }
+
+    public function testWhereRawReturnsStringWhenStringPassed()
+    {
+        $builder = m::mock(Builder::class);
+        $grammar = new Grammar;
+        $reflection = new ReflectionClass($grammar);
+        $method = $reflection->getMethod('whereRaw');
+        $array = ['sql' => 'select * from "users"'];
+
+        $rawQuery = $method->invoke($grammar, $builder, $array);
+
+        $this->assertSame('select * from "users"', $rawQuery);
+    }
+}

--- a/tests/Database/DatabaseQueryGrammarTest.php
+++ b/tests/Database/DatabaseQueryGrammarTest.php
@@ -15,6 +15,7 @@ class DatabaseQueryGrammarTest extends TestCase
     {
         m::close();
     }
+
     public function testWhereRawReturnsStringWhenExpressionPassed()
     {
         $builder = m::mock(Builder::class);

--- a/tests/Database/DatabaseQueryGrammarTest.php
+++ b/tests/Database/DatabaseQueryGrammarTest.php
@@ -21,9 +21,9 @@ class DatabaseQueryGrammarTest extends TestCase
         $grammar = new Grammar;
         $reflection = new ReflectionClass($grammar);
         $method = $reflection->getMethod('whereRaw');
-        $expression = ['sql' => new Expression('select * from "users"')];
+        $expressionArray = ['sql' => new Expression('select * from "users"')];
 
-        $rawQuery = $method->invoke($grammar, $builder, $expression);
+        $rawQuery = $method->invoke($grammar, $builder, $expressionArray);
 
         $this->assertSame('select * from "users"', $rawQuery);
     }
@@ -34,9 +34,9 @@ class DatabaseQueryGrammarTest extends TestCase
         $grammar = new Grammar;
         $reflection = new ReflectionClass($grammar);
         $method = $reflection->getMethod('whereRaw');
-        $array = ['sql' => 'select * from "users"'];
+        $stringArray = ['sql' => 'select * from "users"'];
 
-        $rawQuery = $method->invoke($grammar, $builder, $array);
+        $rawQuery = $method->invoke($grammar, $builder, $stringArray);
 
         $this->assertSame('select * from "users"', $rawQuery);
     }


### PR DESCRIPTION
Without this, raw SQL queries in conditions throw an exception, since they were rewritten in v10.x.