### PR TITLE
[10.x] Hide `dev` commands by default on production environment.

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -234,6 +234,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCommands(array $commands, bool $dev = false)
     {
+        $shouldBeHidden = $dev === true && $this->app->isProduction();
+
         foreach ($commands as $commandName => $command) {
             $method = "register{$commandName}Command";
 
@@ -243,7 +245,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
                 $this->app->singleton($command);
             }
 
-            if ($dev === true && $this->app->isProduction()) {
+            if ($shouldBeHidden === true) {
                 $this->callAfterResolving($command, fn ($console) => $console->setHidden(true));
             }
         }


### PR DESCRIPTION
Command is still accessible, just hidden via `php artisan list`

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
