### PR TITLE
[10.x] Fixed implementation related to `afterCommit` on Postgres and MSSQL database drivers

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -47,6 +47,8 @@ trait ManagesTransactions
                     $this->getPdo()->commit();
                 }
 
+                $this->transactions = max(0, $this->transactions - 1);
+
                 if ($this->afterCommitCallbacksShouldBeExecuted()) {
                     $this->transactionsManager?->commit($this->getName());
                 }
@@ -56,8 +58,6 @@ trait ManagesTransactions
                 );
 
                 continue;
-            } finally {
-                $this->transactions = max(0, $this->transactions - 1);
             }
 
             $this->fireConnectionEvent('committed');
@@ -194,11 +194,11 @@ trait ManagesTransactions
             $this->getPdo()->commit();
         }
 
+        $this->transactions = max(0, $this->transactions - 1);
+
         if ($this->afterCommitCallbacksShouldBeExecuted()) {
             $this->transactionsManager?->commit($this->getName());
         }
-
-        $this->transactions = max(0, $this->transactions - 1);
 
         $this->fireConnectionEvent('committed');
     }
@@ -210,8 +210,7 @@ trait ManagesTransactions
      */
     protected function afterCommitCallbacksShouldBeExecuted()
     {
-        return $this->transactions == 0 ||
-            $this->transactionsManager?->afterCommitCallbacksShouldBeExecuted($this->transactions);
+        return $this->transactionsManager?->afterCommitCallbacksShouldBeExecuted($this->transactions) || $this->transactions == 0;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -127,7 +127,7 @@ class DatabaseTransactionsManager
      */
     public function afterCommitCallbacksShouldBeExecuted($level)
     {
-        return $level === 1;
+        return $level === 0;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -12,13 +12,6 @@ class DatabaseTransactionsManager
     protected $transactions;
 
     /**
-     * The database transaction that should be ignored by callbacks.
-     *
-     * @var \Illuminate\Database\DatabaseTransactionRecord|null
-     */
-    protected $callbacksShouldIgnore;
-
-    /**
      * Create a new database transactions manager instance.
      *
      * @return void
@@ -54,10 +47,6 @@ class DatabaseTransactionsManager
         $this->transactions = $this->transactions->reject(
             fn ($transaction) => $transaction->connection == $connection && $transaction->level > $level
         )->values();
-
-        if ($this->transactions->isEmpty()) {
-            $this->callbacksShouldIgnore = null;
-        }
     }
 
     /**
@@ -75,10 +64,6 @@ class DatabaseTransactionsManager
         $this->transactions = $forOtherConnections->values();
 
         $forThisConnection->map->executeCallbacks();
-
-        if ($this->transactions->isEmpty()) {
-            $this->callbacksShouldIgnore = null;
-        }
     }
 
     /**
@@ -94,19 +79,6 @@ class DatabaseTransactionsManager
         }
 
         $callback();
-    }
-
-    /**
-     * Specify that callbacks should ignore the given transaction when determining if they should be executed.
-     *
-     * @param  \Illuminate\Database\DatabaseTransactionRecord  $transaction
-     * @return $this
-     */
-    public function callbacksShouldIgnore(DatabaseTransactionRecord $transaction)
-    {
-        $this->callbacksShouldIgnore = $transaction;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactionsManager.php
@@ -42,6 +42,6 @@ class DatabaseTransactionsManager extends BaseManager
      */
     public function afterCommitCallbacksShouldBeExecuted($level)
     {
-        return $level === 2;
+        return $level === 1;
     }
 }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
+use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
@@ -287,6 +288,18 @@ class DatabaseConnectionTest extends TestCase
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
         $connection->commit();
+    }
+
+    public function testAfterCommitIsExecutedOnFinalCommit()
+    {
+        $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['beginTransaction','commit'])->getMock();
+        $transactionsManager = $this->getMockBuilder(DatabaseTransactionsManager::class)->onlyMethods(['afterCommitCallbacksShouldBeExecuted'])->getMock();
+        $transactionsManager->expects($this->once())->method('afterCommitCallbacksShouldBeExecuted')->with(0)->willReturn(true);
+
+        $connection = $this->getMockConnection([], $pdo);
+        $connection->setTransactionManager($transactionsManager);
+
+        $connection->transaction(function(){});
     }
 
     public function testRollBackedFiresEventsIfSet()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -292,14 +292,16 @@ class DatabaseConnectionTest extends TestCase
 
     public function testAfterCommitIsExecutedOnFinalCommit()
     {
-        $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['beginTransaction','commit'])->getMock();
+        $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['beginTransaction', 'commit'])->getMock();
         $transactionsManager = $this->getMockBuilder(DatabaseTransactionsManager::class)->onlyMethods(['afterCommitCallbacksShouldBeExecuted'])->getMock();
         $transactionsManager->expects($this->once())->method('afterCommitCallbacksShouldBeExecuted')->with(0)->willReturn(true);
 
         $connection = $this->getMockConnection([], $pdo);
         $connection->setTransactionManager($transactionsManager);
 
-        $connection->transaction(function(){});
+        $connection->transaction(function () {
+            // do nothing
+        });
     }
 
     public function testRollBackedFiresEventsIfSet()

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
@@ -2,7 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Factories\UserFactory;
@@ -39,6 +43,21 @@ trait EloquentTransactionWithAfterCommitTests
 
         $this->assertTrue($user1->exists);
         $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+    }
+
+    public function testObserverCalledWithAfterCommitWhenInsideTransactionWithDispatchSync()
+    {
+        User::observe($observer = EloquentTransactionWithAfterCommitTestsUserObserverUsingDispatchSync::resetting());
+
+        $user1 = DB::transaction(fn () => User::create(UserFactory::new()->raw()));
+
+        $this->assertTrue($user1->exists);
+        $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
+
+        $this->assertDatabaseHas('password_reset_tokens', [
+            'email' => $user1->email,
+            'token' => sha1($user1->email),
+        ]);
     }
 
     public function testObserverIsCalledOnTestsWithAfterCommitWhenUsingSavepoint()
@@ -100,5 +119,34 @@ class EloquentTransactionWithAfterCommitTestsUserObserver
     public function created($user)
     {
         static::$calledTimes++;
+    }
+}
+
+class EloquentTransactionWithAfterCommitTestsUserObserverUsingDispatchSync extends EloquentTransactionWithAfterCommitTestsUserObserver
+{
+    public function created($user)
+    {
+        dispatch_sync(new EloquentTransactionWithAfterCommitTestsJob($user));
+
+        parent::created($user);
+    }
+}
+
+class EloquentTransactionWithAfterCommitTestsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(public string $email)
+    {
+        // ...
+    }
+
+    public function handle(): void
+    {
+        DB::transaction(function () {
+            DB::table('password_reset_tokens')->insert([
+                ['email' => $this->email, 'token' => sha1($this->email), 'created_at' => now()],
+            ]);
+        });
     }
 }

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
@@ -126,7 +126,7 @@ class EloquentTransactionWithAfterCommitTestsUserObserverUsingDispatchSync exten
 {
     public function created($user)
     {
-        dispatch_sync(new EloquentTransactionWithAfterCommitTestsJob($user));
+        dispatch_sync(new EloquentTransactionWithAfterCommitTestsJob($user->email));
 
         parent::created($user);
     }


### PR DESCRIPTION
### Overview
fixes #48658

Hi

I checked the implementation regarding `afterCommit`, fixed defects, and deleted unused functions.

### Cause of the problem

The cause was that by calling `afterCommit` before lowering the transaction level, the transaction behaved as if it existed, even though it actually did not.

I solved this problem by lowering the transaction level before calling `afterCommit`, and by lowering the level expected by `afterCommitCallbacksShouldBeExecuted()` by one step.

I also fixed commit() in the same way.

### Other problem

The `finally` of `ManagesTransactions::transaction` is unnecessary, so it has been removed. Since the transaction level is lowered with `handleCommitTransactionException()`, using finally will lower the transaction level by two levels.

### Removed unnecessary features

I removed the functionality related to `callbacksShouldIgnore` as it is no longer used anywhere.

### How should TransactionsManager behave?

During normal execution, `afterCommit` is expected to be executed when the transaction no longer exists. That is, when the transaction level is 0.

When testing using `RefreshDatabase`, the transaction level is increased by +1 first, as shown in the following link.
https://github.com/laravel/framework/blob/cddb4f3bb5231f44f18fce304dbf190ad8348ddc/src/Illuminate/Foundation/Testing/RefreshDatabase.php#L100

So in this case, transaction level 1 will be the lowest, and we would expect `afterCommit` to be called when level drops to 1.

### notes

I swapped the order of the `OR` in `afterCommitCallbacksShouldBeExecuted`.
This should basically all be handled with `$this->transactionsManager?->afterCommitCallbacksShouldBeExecuted($this->transactions)`, and to make it clear that `$this->transactions == 0` is a fallback is.

Best regards.