### PR TITLE
[10.x] Fixes `GeneratorCommand` not able to prevent uppercase reserved name such as  `__CLASS__`

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -449,9 +449,12 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function isReservedName($name)
     {
-        $name = strtolower($name);
-
-        return in_array($name, $this->reservedNames);
+        return in_array(
+            strtolower($name),
+            collect($this->reservedNames)
+                ->transform(fn ($name) => strtolower($name))
+                ->all()
+        );
     }
 
     /**

--- a/tests/Integration/Console/GeneratorCommandTest.php
+++ b/tests/Integration/Console/GeneratorCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Orchestra\Testbench\TestCase;
+
+class GeneratorCommandTest extends TestCase
+{
+    /**
+     * @dataProvider reservedNamesDataProvider
+     */
+    public function testItCannotGenerateClassUsingReservedName($given)
+    {
+        $this->artisan('make:command', ['name' => $given])
+            ->expectsOutputToContain('The name "'.$given.'" is reserved by PHP.')
+            ->assertExitCode(0);
+    }
+
+    public static function reservedNamesDataProvider()
+    {
+        yield ['__halt_compiler'];
+        yield ['__HALT_COMPILER'];
+        yield ['array'];
+        yield ['ARRAY'];
+        yield ['__class__'];
+        yield ['__CLASS__'];
+    }
+}


### PR DESCRIPTION

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
