### PR TITLE
changed type hint in Stringable class's constructor's phpdoc

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -25,7 +25,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Create a new instance of the class.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return void
      */
     public function __construct($value = '')


### PR DESCRIPTION
Changed type hint for constructor argument `$value` from "string" to "mixed".

## motivation
When developers want to use `Stringable` class, the `$value` is not string. If the `$value` is already string, developers do not have to use `Stringable`
Type of `$value` may vary, so "mixed" will be appropriate.