### PR TITLE
[10.x] character "❯" is not common font

### DIFF
--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -64,7 +64,9 @@ class QuestionHelper extends SymfonyQuestionHelper
             }
         }
 
-        $output->write('<options=bold>❯ </>');
+        $text = sprintf('<options=bold>%s </>', OutputFormatter::escape('>'));
+
+        $output->write($text);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
character "❯" cant show on windows
related issue: https://github.com/laravel/prompts/issues/95
![image](https://github.com/laravel/framework/assets/18243451/1018d6e0-076f-41ab-b4a8-13e035d7c30e)
