### PR TITLE
[10.x] Support rehashing user passwords with BC support

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -179,7 +179,7 @@ class DatabaseUserProvider implements UserProvider
     {
         $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
 
-        if (! $attribute || ! isset($user->{$attribute})) {
+        if (! $attribute || ! isset($user->{$attribute}) || ! hash_equals($hash, $user->{$attribute})) {
             return;
         }
 

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -170,7 +170,7 @@ class DatabaseUserProvider implements UserProvider
     /**
      * Rehash the user's password if required.
      *
-     * @param  UserContract  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string  $hash
      * @param  string  $plain
      * @return void

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -179,7 +179,7 @@ class DatabaseUserProvider implements UserProvider
     {
         $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
 
-        if (! $attribute || ! isset($user->{$attribute}) || ! hash_equals($hash, $user->{$attribute})) {
+        if (! isset($user->{$attribute}) || ! hash_equals($hash, $user->{$attribute})) {
             return;
         }
 

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -175,7 +175,7 @@ class DatabaseUserProvider implements UserProvider
      * @param  string  $plain
      * @return void
      */
-    public function rehashIfRequired(UserContract $user, string $hash, string $plain)
+    protected function rehashIfRequired(UserContract $user, string $hash, string $plain)
     {
         $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
 

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -170,9 +170,9 @@ class DatabaseUserProvider implements UserProvider
     /**
      * Rehash the user's password if required.
      *
-     * @param UserContract $user
-     * @param string $hash
-     * @param string $plain
+     * @param  UserContract  $user
+     * @param  string  $hash
+     * @param  string  $plain
      * @return void
      */
     public function rehashIfRequired(UserContract $user, string $hash, string $plain)

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -164,7 +164,7 @@ class EloquentUserProvider implements UserProvider
     /**
      * Rehash the user's password if required.
      *
-     * @param  UserContract  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string  $hash
      * @param  string  $plain
      * @return void

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -169,7 +169,7 @@ class EloquentUserProvider implements UserProvider
      * @param  string  $plain
      * @return void
      */
-    public function rehashIfRequired(UserContract $user, string $hash, string $plain)
+    protected function rehashIfRequired(UserContract $user, string $hash, string $plain)
     {
         $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -173,7 +173,7 @@ class EloquentUserProvider implements UserProvider
     {
         $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
 
-        if (! $attribute || ! isset($user->{$attribute})) {
+        if (! $attribute || ! isset($user->{$attribute}) || ! hash_equals($hash, $user->{$attribute})) {
             return;
         }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -173,7 +173,7 @@ class EloquentUserProvider implements UserProvider
     {
         $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
 
-        if (! $attribute || ! isset($user->{$attribute}) || ! hash_equals($hash, $user->{$attribute})) {
+        if (! isset($user->{$attribute}) || ! hash_equals($hash, $user->{$attribute})) {
             return;
         }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -164,9 +164,9 @@ class EloquentUserProvider implements UserProvider
     /**
      * Rehash the user's password if required.
      *
-     * @param UserContract $user
-     * @param string $hash
-     * @param string $plain
+     * @param  UserContract  $user
+     * @param  string  $hash
+     * @param  string  $plain
      * @return void
      */
     public function rehashIfRequired(UserContract $user, string $hash, string $plain)

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -152,7 +152,38 @@ class EloquentUserProvider implements UserProvider
             return false;
         }
 
-        return $this->hasher->check($plain, $user->getAuthPassword());
+        if (! $this->hasher->check($plain, $hash = $user->getAuthPassword())) {
+            return false;
+        }
+
+        $this->rehashIfRequired($user, $hash, $plain);
+
+        return true;
+    }
+
+    /**
+     * Rehash the user's password if required.
+     *
+     * @param UserContract $user
+     * @param string $hash
+     * @param string $plain
+     * @return void
+     */
+    public function rehashIfRequired(UserContract $user, string $hash, string $plain)
+    {
+        $attribute = method_exists($user, 'getAuthPasswordName') ? $user->getAuthPasswordName() : 'password';
+
+        if (! $attribute || ! isset($user->{$attribute})) {
+            return;
+        }
+
+        if (! $this->hasher->needsRehash($hash)) {
+            return;
+        }
+
+        $user->forceFill([
+            $attribute => $this->hasher->make($plain),
+        ])->save();
     }
 
     /**

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -7,6 +7,7 @@ use Illuminate\Auth\GenericUser;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -159,5 +160,55 @@ class AuthDatabaseUserProviderTest extends TestCase
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
         $this->assertTrue($result);
+    }
+
+    public function testCredentialValidationWithPasswordAttributeWithoutRehashing()
+    {
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
+        $hasher->shouldReceive('needsRehash')->once()->with('hash')->andReturn(false);
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->password = 'hash';
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertTrue($result);
+    }
+
+    public function testCredentialValidationRequiresRehash()
+    {
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
+        $hasher->shouldReceive('needsRehash')->once()->with('hash')->andReturn(true);
+        $hasher->shouldReceive('make')->once()->with('plain')->andReturn('rehashed');
+        $conn = m::mock(Connection::class);
+        $table = m::mock(ConnectionInterface::class);
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('id', 1)->andReturnSelf();
+        $table->shouldReceive('update')->once()->with(['password' => 'rehashed']);
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->password = 'hash';
+        $user->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $user->shouldReceive('getAuthIdentifier')->once()->andReturn(1);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertTrue($result);
+    }
+
+    public function testCredentialValidationFailed()
+    {
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(false);
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertFalse($result);
     }
 }


### PR DESCRIPTION
Following from the comments on https://github.com/laravel/framework/pull/48665, this is a backwards compatible version of the password rehashing fix. Unlike the Laravel 11 targeted PR, this doesn't require any changes to the User contract or model. 

It will check for the existence of the `getAuthPasswordName()` method on the User model - allowing for custom password attributes, and if that doesn't exist, it checks for the existence of the `password` attribute. If the attribute exists, and the hashes match, it assumes this is the valid password hash field and checks if it needs to rehash it.

I'll mark the other PR as a draft for now - it will need changes to finish the upgrade and remove the BC checks when this has been merged.

Here is the summary and impacts from the other PR, to save a click:

## Summary

As was discovered after updating bcrypt rounds from 10 to 12 in https://github.com/laravel/laravel/pull/6245 and https://github.com/laravel/framework/pull/48494, user passwords are not currently being rehashed during login when the hashing configuration has changed. This should be considered a security risk as rehashing passwords is an important part of the authentication process. Rehashing passwords during login ensures updates to the hashing configuration, such as increasing rounds/cost, is applied to existing hashes when the plaintext password is available during login.

This PR implements rehashing directly within the Eloquent and Database User Providers, making it a part of the core framework authentication system. The rehashing will happen automatically when user credentials are validated by `*UserProvider::validateCredentials()`, which is called by the `Auth::attempt()` helper. This helper is used by both Breeze and Fortify/Jetstream to authenticate users, and is the recommended method in the Laravel docs. This ensures that with Laravel 11, any apps using the authentication system will be properly rehashing passwords.

I modelled the new `DatabaseUserProvider::rehashUserPassword()` method on the existing `rehashUserPassword()` method, to ensure it is compatible for apps that don't use Eloquent.

## Upgrade Impacts

1. Rehashing passwords incurs a performance hit, and after this is deployed, every user who logs in will trigger a password rehash. This is unlike to have an impact as logins are generally spread out and servers usually have spare resources. However apps with large numbers of concurrent logins and limited resources may notice increased resource usage.
1. It's not technically a breaking change, but when a password is rehashed it will force all other active sessions, remember-me tokens, and anything else that relies on the current password hash to be reset automatically. This may cause an increase in login attempts as users reauthenticate different devices.
