### PR TITLE
Str::password: Adding dashed argument for generating a dash-separated string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -837,14 +837,11 @@ class Str
      * @param  bool  $numbers
      * @param  bool  $symbols
      * @param  bool  $spaces
+     * @param  bool  $dashed
      * @return string
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false, $dashed = false)
     {
-        if(!($letters || $numbers || $symbols)){
-            return '';
-        }
-
         return (new Collection)
                 ->when($letters, fn ($c) => $c->merge([
                     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
@@ -861,9 +858,10 @@ class Str
                     '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
                     ']', '|', ':', ';',
                 ]))
-                ->when($spaces, fn ($c) => $c->merge([' ']))
-                ->pipe(fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)]))
-                ->implode('');
+            ->when($spaces, fn ($c) => $c->merge([' ']))
+            ->pipe(fn ($c) => Collection::times($length, fn ($index) => ($dashed && ($index % 6 === 0) && $index != 0) ? '-' : $c[random_int(0, $c->count() - 1)]))
+            ->implode('');
+
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -839,8 +839,12 @@ class Str
      * @param  bool  $spaces
      * @return string
      */
-    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
+    public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false, $dashed = false)
     {
+        if(!($letters || $numbers || $symbols)){
+            return '';
+        }
+
         return (new Collection)
                 ->when($letters, fn ($c) => $c->merge([
                     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -861,7 +861,6 @@ class Str
             ->when($spaces, fn ($c) => $c->merge([' ']))
             ->pipe(fn ($c) => Collection::times($length, fn ($index) => ($dashed && ($index % 6 === 0) && $index != 0) ? '-' : $c[random_int(0, $c->count() - 1)]))
             ->implode('');
-
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new dashed argument to the Str::password method. When set to true, it generates a string separated by dashes every 5 characters.

## Example

Using the dashed argument, you can generate a password as follows:

```php
> Str::password(23, symbols: false, numbers: true, letters: true, dashed: true);
= "83LwW-V0Rtw-fPiPX-1XgwI"
```

## Use Case

This is a common feature in many password generators and greatly aids in the memorization of passwords, while making the string more readable.