### PR TITLE
ValidatesWhenResolvedTrait trait return type added

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -14,7 +14,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    public function validateResolved()
+    public function validateResolved():void
     {
         $this->prepareForValidation();
 
@@ -40,7 +40,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    protected function prepareForValidation()
+    protected function prepareForValidation():void
     {
         //
     }
@@ -60,7 +60,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    protected function passedValidation()
+    protected function passedValidation():void
     {
         //
     }
@@ -83,7 +83,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return bool
      */
-    protected function passesAuthorization()
+    protected function passesAuthorization():bool
     {
         if (method_exists($this, 'authorize')) {
             return $this->authorize();
@@ -99,7 +99,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @throws \Illuminate\Validation\UnauthorizedException
      */
-    protected function failedAuthorization()
+    protected function failedAuthorization():void
     {
         throw new UnauthorizedException;
     }

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -14,7 +14,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    public function validateResolved():void
+    public function validateResolved(): void
     {
         $this->prepareForValidation();
 
@@ -40,7 +40,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    protected function prepareForValidation():void
+    protected function prepareForValidation(): void
     {
         //
     }
@@ -60,7 +60,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    protected function passedValidation():void
+    protected function passedValidation(): void
     {
         //
     }
@@ -83,7 +83,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return bool
      */
-    protected function passesAuthorization():bool
+    protected function passesAuthorization(): bool
     {
         if (method_exists($this, 'authorize')) {
             return $this->authorize();
@@ -99,7 +99,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @throws \Illuminate\Validation\UnauthorizedException
      */
-    protected function failedAuthorization():void
+    protected function failedAuthorization(): void
     {
         throw new UnauthorizedException;
     }

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -50,7 +50,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return \Illuminate\Validation\Validator
      */
-    protected function getValidatorInstance()
+    protected function getValidatorInstance(): Validator
     {
         return $this->validator();
     }
@@ -73,7 +73,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    protected function failedValidation(Validator $validator)
+    protected function failedValidation(Validator $validator): void
     {
         throw new ValidationException($validator);
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -410,12 +410,12 @@ class FoundationTestFormRequestHooks extends FormRequest
         return true;
     }
 
-    public function prepareForValidation()
+    public function prepareForValidation():void
     {
         $this->replace(['name' => 'Taylor']);
     }
 
-    public function passedValidation()
+    public function passedValidation():void
     {
         $this->replace(['name' => 'Adam']);
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -410,12 +410,12 @@ class FoundationTestFormRequestHooks extends FormRequest
         return true;
     }
 
-    public function prepareForValidation():void
+    public function prepareForValidation(): void
     {
         $this->replace(['name' => 'Taylor']);
     }
 
-    public function passedValidation():void
+    public function passedValidation(): void
     {
         $this->replace(['name' => 'Adam']);
     }


### PR DESCRIPTION
In this pull request, I've made a few changes to the ValidatesWhenResolvedTrait to improve its documentation and usability. Here's a summary of the updates:

Added Return Type: I've added the return type to the methods in the ValidatesWhenResolvedTrait. This addition helps provide clarity to users and IDEs about the expected return value of the method.

These changes aim to enhance the maintainability and readability of our codebase while ensuring that our API remains well-documented. Please review the modifications and let me know if any further adjustments are needed.

Thank you for your time and consideration.