### PR TITLE
[10.x] Fix route caching of first class callables

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -60,6 +60,7 @@ class RouteCacheCommand extends Command
             return $this->components->error("Your application doesn't have any routes.");
         }
 
+        /** @var \Illuminate\Routing\Route $route */
         foreach ($routes as $route) {
             $route->prepareForSerialization();
         }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1339,10 +1339,15 @@ class Route
      */
     public function prepareForSerialization()
     {
-        if ($this->action['uses'] instanceof Closure) {
-            $this->action['uses'] = serialize(
-                SerializableClosure::unsigned($this->action['uses'])
-            );
+        if (is_callable($this->action['uses'])) {
+            if (! Str::contains((new \ReflectionFunction($this->action['uses']))->name, '{closure}')) {
+                $name = (new \ReflectionFunction($this->action['uses']))->name;
+                $this->action['uses'] = "\\{$name}";
+            } elseif ($this->action['uses'] instanceof Closure) {
+                $this->action['uses'] = serialize(
+                    SerializableClosure::unsigned($this->action['uses'])
+                );
+            }
         }
 
         if (isset($this->action['missing']) && $this->action['missing'] instanceof Closure) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1340,9 +1340,8 @@ class Route
     public function prepareForSerialization()
     {
         if (is_callable($this->action['uses'])) {
-            if (! Str::contains((new \ReflectionFunction($this->action['uses']))->name, '{closure}')) {
-                $name = (new \ReflectionFunction($this->action['uses']))->name;
-                $this->action['uses'] = "\\{$name}";
+            if (! Str::contains($name = (new \ReflectionFunction($this->action['uses']))->name, '{closure}')) {
+                $this->action['uses'] = $name;
             } elseif ($this->action['uses'] instanceof Closure) {
                 $this->action['uses'] = serialize(
                     SerializableClosure::unsigned($this->action['uses'])

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -218,7 +218,7 @@ class Route
      */
     protected function isControllerAction()
     {
-        return is_string($this->action['uses']) && ! $this->isSerializedClosure();
+        return is_string($this->action['uses']) && $this->getControllerMethod() && ! $this->isSerializedClosure();
     }
 
     /**

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -43,7 +43,7 @@ class RouteAction
             $action['uses'] = static::findCallable($action);
         }
 
-        if (! static::containsSerializedClosure($action) && is_string($action['uses']) && ! str_contains($action['uses'], '@')) {
+        if (! static::containsSerializedClosure($action) && is_string($action['uses']) && ! str_contains($action['uses'], '@') && class_exists($action['uses'])) {
             $action['uses'] = static::makeInvokable($action['uses']);
         }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -22,15 +22,20 @@ class RouteSignatureParameters
                         ? unserialize($action['uses'])->getClosure()
                         : $action['uses'];
 
-        $parameters = is_string($callback)
-                        ? static::fromClassMethodString($callback)
-                        : (new ReflectionFunction($callback))->getParameters();
+        $parameters = static::isClassMethodString($callback)
+            ? static::fromClassMethodString($callback)
+            : (new ReflectionFunction($callback))->getParameters();
 
         return match (true) {
             ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
             ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
             default => $parameters,
         };
+    }
+
+    protected static function isClassMethodString($string)
+    {
+        return is_string($string) && Str::contains($string, '@');
     }
 
     /**

--- a/tests/Integration/Routing/Fixtures/wildcard_catch_all_routes.php
+++ b/tests/Integration/Routing/Fixtures/wildcard_catch_all_routes.php
@@ -1,11 +1,27 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 
-Route::get('/foo', function () {
-    return 'Regular route';
-});
+namespace Test {
+    function firstClassCallable(): string
+    {
+        return 'First class callable';
+    }
+}
 
-Route::get('{slug}', function () {
-    return 'Wildcard route';
-});
+namespace {
+    use Illuminate\Support\Facades\Route;
+
+    Route::get('/foo', function () {
+        return 'Regular route';
+    });
+
+
+    Route::get('/baz', \Test\firstClassCallable(...));
+
+    Route::get('/bag', ['Controller', 'method']);
+
+    Route::get('{slug}', function () {
+        return 'Wildcard route';
+    });
+
+}

--- a/tests/Integration/Routing/Fixtures/wildcard_catch_all_routes.php
+++ b/tests/Integration/Routing/Fixtures/wildcard_catch_all_routes.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Test {
     function firstClassCallable(): string
     {
@@ -15,13 +14,9 @@ namespace {
         return 'Regular route';
     });
 
-
     Route::get('/baz', \Test\firstClassCallable(...));
-
-    Route::get('/bag', ['Controller', 'method']);
 
     Route::get('{slug}', function () {
         return 'Wildcard route';
     });
-
 }

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -11,6 +11,7 @@ class RouteCachingTest extends TestCase
         $this->routes(__DIR__.'/Fixtures/wildcard_catch_all_routes.php');
 
         $this->get('/foo')->assertSee('Regular route');
+        $this->get('/baz')->assertSee('First class callable');
         $this->get('/bar')->assertSee('Wildcard route');
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
[First-class callables](https://www.php.net/manual/en/functions.first_class_callable_syntax.php) were added in PHP 8.1 (which Laravel 10.x requires as a minimum)

They can be used for routes just fine. However, when you want to employ route caching, it breaks because these functions are neither class-based controllers nor anonymous closures.

This PR fixes that, enabling first-class callables to be used as _cacheable_ route actions.

There [seems to be](https://x.com/simonhamp/status/1710312308050686352?s=20) a reasonable amount of interest in this feature.