### PR TITLE
[10.x] Fixed type hint in constructor of support class `Stringable`

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -26,7 +26,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Create a new instance of the class.
      *
-     * @param  string|int|float|NativeStringable|null  $value
+     * @param  string|int|float|bool|NativeStringable|null  $value
      * @return void
      */
     public function __construct($value = '')

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
+use Stringable as NativeStringable;
 use Symfony\Component\VarDumper\VarDumper;
 
 class Stringable implements JsonSerializable, ArrayAccess
@@ -25,7 +26,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Create a new instance of the class.
      *
-     * @param  string  $value
+     * @param  string|int|float|NativeStringable|null  $value
      * @return void
      */
     public function __construct($value = '')


### PR DESCRIPTION
Hi

I had some thoughts about this PR, so I opened this.
https://github.com/laravel/framework/pull/48671

### What is the problem in the first place?

For projects that have `strict_types=1` and run static analysis such as `phpstan`, specifying `string` as a type hint can cause problems due to gaps in the actual signature.

In terms of whether it actually works or not, it does work, but static analysis treats it as an error, so this is inconvenient.

### Signature is `mixed` and accepts anything

As you can see, the signature has no type specification, so it accepts anything. However, when setting a value to a property, it cast the value to `string`, so it's essentially accepting a type that can be cast to `string`.

Therefore, current type hints are completely pointless and only cause unnecessary errors in static analysis and display errors in the editor.

### What should we do?

Add all types that can be cast to string in addition to string to the type specified in the type hint. I believe that the idea that "it's fine as long as it works" is inappropriate in this day and age, and the `phpdoc` should take into account things like static analysis tools.

Best regards.