### PR TITLE
[10.x] Optimize `exists` validation for empty array input

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -864,6 +864,10 @@ trait ValidatesAttributes
 
         $expected = is_array($value) ? count(array_unique($value)) : 1;
 
+        if ($expected === 0) {
+            return true;
+        }
+
         return $this->getExistCount(
             $connection, $table, $column, $value, $parameters
         ) >= $expected;


### PR DESCRIPTION
This PR addresses a minor efficiency issue in the `exists` validation method.

Previously, an unnecessary SQL query was executed when validating an empty array:
```SQL
select count(distinct id) as aggregate from users where 0 = 1
```

The added check for a zero `$expected` value now bypasses this query, saving resources while keeping the intended validation behavior.