### PR TITLE
[11.x] Reintroduce inadvertently removed Carbon dependency

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,6 +23,7 @@
         "illuminate/conditionable": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
+        "nesbot/carbon": "^2.67",
         "voku/portable-ascii": "^2.0"
     },
     "conflict": {


### PR DESCRIPTION
When resolving a merge conflict in 8dde5dc3dd02ff9975262d80ecf388a165643e41 , I believe this dependency was wrongly removed. Just one commit before (7dab1c5b4e2afb130b7839fd0e62f6af71c4d982), the Carbon minimal version was increased on the master branch.

The removal broke the testsuite of my eloquent bundle: https://github.com/wouterj/WouterJEloquentBundle/actions/runs/6467928197/job/17558964112