### PR TITLE
[10.x] Add percentage to be used as High Order Messages

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -37,6 +37,7 @@ use UnitEnum;
  * @property-read HigherOrderCollectionProxy $max
  * @property-read HigherOrderCollectionProxy $min
  * @property-read HigherOrderCollectionProxy $partition
+ * @property-read HigherOrderCollectionProxy $percentage
  * @property-read HigherOrderCollectionProxy $reject
  * @property-read HigherOrderCollectionProxy $skipUntil
  * @property-read HigherOrderCollectionProxy $skipWhile
@@ -83,6 +84,7 @@ trait EnumeratesValues
         'max',
         'min',
         'partition',
+        'percentage',
         'reject',
         'skipUntil',
         'skipWhile',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5666,6 +5666,21 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testHighOrderPercentage($collection)
+    {
+        $collection = new $collection([
+            ['name' => 'Taylor', 'active' => true],
+            ['name' => 'Nuno', 'active' => true],
+            ['name' => 'Dries', 'active' => false],
+            ['name' => 'Jess', 'active' => true],
+        ]);
+
+        $this->assertSame(75.00, $collection->percentage->active);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testPercentageReturnsNullForEmptyCollections($collection)
     {
         $collection = new $collection([]);


### PR DESCRIPTION
## Changes

This PR adds the ability to use the percentage method in the Collections as High Order Messages.

## Why

Sometimes when we need to calculate percentages based on some property, instead of doing:

```php
$collection = new $collection([
    ['name' => 'Taylor', 'active' => true],
    ['name' => 'Nuno', 'active' => true],
    ['name' => 'Dries', 'active' => false],
    ['name' => 'Jess', 'active' => true],
]);

$this->assertSame(75.00, $collection->percentage(fn ($value) => $value['active']));
```

We can simply do:

```php
$collection = new $collection([
    ['name' => 'Taylor', 'active' => true],
    ['name' => 'Nuno', 'active' => true],
    ['name' => 'Dries', 'active' => false],
    ['name' => 'Jess', 'active' => true],
]);

$this->assertSame(75.00, $collection->percentage->active);
```

It's a simple life improvement that if needed many times can save some time and effort