### PR TITLE
[10.x] Allow creation of PSR request with merged data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,9 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: |
+            composer require symfony/psr-http-message-bridge:^2.0 nyholm/psr7:^1.0 --no-interaction --no-update
+            composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --display-deprecation
@@ -152,7 +154,9 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: |
+            composer require symfony/psr-http-message-bridge:^^^^2.0 nyholm/psr7:^^^^1.0 --no-interaction --no-update
+            composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,9 +82,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: |
-            composer require symfony/psr-http-message-bridge:^2.0 nyholm/psr7:^1.0 --no-interaction --no-update
-            composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --display-deprecation
@@ -154,9 +152,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: |
-            composer require symfony/psr-http-message-bridge:^^^^2.0 nyholm/psr7:^^^^1.0 --no-interaction --no-update
-            composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/console": "^6.2",
         "symfony/error-handler": "^6.2",
         "symfony/finder": "^6.2",
-        "symfony/http-foundation": "^6.2",
+        "symfony/http-foundation": "^6.3",
         "symfony/http-kernel": "^6.2",
         "symfony/mailer": "^6.2",
         "symfony/mime": "^6.2",

--- a/composer.json
+++ b/composer.json
@@ -104,13 +104,15 @@
         "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
+        "nyholm/psr7": "^1.2",
         "orchestra/testbench-core": "^8.12",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^10.0.7",
         "predis/predis": "^2.0.2",
         "symfony/cache": "^6.2",
-        "symfony/http-client": "^6.2.4"
+        "symfony/http-client": "^6.2.4",
+        "symfony/psr-http-message-bridge": "^2.0"
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -137,8 +137,10 @@ class RoutingServiceProvider extends ServiceProvider
             if (class_exists(Psr17Factory::class) && class_exists(PsrHttpFactory::class)) {
                 $psr17Factory = new Psr17Factory;
 
-                return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
-                    ->createRequest($app->make('request'));
+                return with((new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
+                    ->createRequest($illuminateRequest = $app->make('request')), fn ($request) => $request->withParsedBody(
+                        array_merge($request->getParsedBody(), $illuminateRequest->getPayload()->all())
+                    ));
             }
 
             throw new BindingResolutionException('Unable to resolve PSR request. Please install the symfony/psr-http-message-bridge and nyholm/psr7 packages.');

--- a/tests/Integration/Foundation/RoutingServiceProviderTest.php
+++ b/tests/Integration/Foundation/RoutingServiceProviderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class RoutingServiceProviderTest extends TestCase
+{
+    public function testItIncludesMergedDataInServerRequestInterfaceInstancesUsingGetRequests()
+    {
+        Route::get('test-route', function (ServerRequestInterface $request) {
+            return $request->getParsedBody();
+        })->middleware(MergeDataMiddleware::class);
+
+        $response = $this->withoutExceptionHandling()->get('test-route?'.http_build_query([
+            'sent' => 'sent-data',
+            'overridden' => 'overriden-sent-data',
+        ]));
+
+        $response->assertOk();
+        $response->assertExactJson([
+            'request-data' => 'request-data',
+        ]);
+    }
+
+    public function testItIncludesMergedDataInServerRequestInterfaceInstancesUsingGetJsonRequests()
+    {
+        Route::get('test-route', function (ServerRequestInterface $request) {
+            return $request->getParsedBody();
+        })->middleware(MergeDataMiddleware::class);
+
+        $response = $this->getJson('test-route?'.http_build_query([
+            'sent' => 'sent-data',
+            'overridden' => 'overriden-sent-data',
+        ]));
+
+        $response->assertOk();
+        $response->assertExactJson([
+            'json-data' => 'json-data',
+            'merged' => 'replaced-merged-data',
+            'overridden' => 'overriden-merged-data',
+            'request-data' => 'request-data',
+        ]);
+    }
+
+    public function testItIncludesMergedDataInServerRequestInterfaceInstancesUsingPostRequests()
+    {
+        Route::post('test-route', function (ServerRequestInterface $request) {
+            return $request->getParsedBody();
+        })->middleware(MergeDataMiddleware::class);
+
+        $response = $this->post('test-route', [
+            'sent' => 'sent-data',
+            'overridden' => 'overriden-sent-data',
+        ]);
+
+        $response->assertOk();
+        $response->assertExactJson([
+            'sent' => 'sent-data',
+            'merged' => 'replaced-merged-data',
+            'overridden' => 'overriden-merged-data',
+            'request-data' => 'request-data',
+        ]);
+    }
+
+    public function testItIncludesMergedDataInServerRequestInterfaceInstancesUsingPostJsonRequests()
+    {
+        Route::post('test-route', function (ServerRequestInterface $request) {
+            return $request->getParsedBody();
+        })->middleware(MergeDataMiddleware::class);
+
+        $response = $this->postJson('test-route', [
+            'sent' => 'sent-data',
+            'overridden' => 'overriden-sent-data',
+        ]);
+
+        $response->assertOk();
+        $response->assertExactJson([
+            'json-data' => 'json-data',
+            'sent' => 'sent-data',
+            'merged' => 'replaced-merged-data',
+            'overridden' => 'overriden-merged-data',
+            'request-data' => 'request-data',
+        ]);
+    }
+}
+
+class MergeDataMiddleware
+{
+    public function handle(Request $request, $next)
+    {
+        $request->merge(['merged' => 'first-merged-data']);
+
+        $request->merge(['merged' => 'replaced-merged-data']);
+
+        $request->merge(['overridden' => 'overriden-merged-data']);
+
+        $request->request->set('request-data', 'request-data');
+
+        $request->query->set('query-data', 'query-data');
+
+        $request->json()->set('json-data', 'json-data');
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
There was a breaking change, for us, in `symfony/psr-http-message-bridge` (https://github.com/symfony/psr-http-message-bridge/pull/122) that means merged data for JSON requests is no longer added to the PSR request. 

The original PR was a fix for a different Laravel issue (although I'm not entirely sure what as the issue tracker for that repo is no longer visible).

fixes #48626