### PR TITLE
[10.x] Remove unnecessary transaction in Bus::batch causing issues with sync driver

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -183,15 +183,13 @@ class Batch implements Arrayable, JsonSerializable
             return $job;
         });
 
-        $this->repository->transaction(function () use ($jobs, $count) {
-            $this->repository->incrementTotalJobs($this->id, $count);
+        $this->repository->incrementTotalJobs($this->id, $count);
 
-            $this->queue->connection($this->options['connection'] ?? null)->bulk(
-                $jobs->all(),
-                $data = '',
-                $this->options['queue'] ?? null
-            );
-        });
+        $this->queue->connection($this->options['connection'] ?? null)->bulk(
+            $jobs->all(),
+            $data = '',
+            $this->options['queue'] ?? null
+        );
 
         return $this->fresh();
     }


### PR DESCRIPTION
When using the `sync` queue driver together with the `Bus::batch` command, if there are any exceptions triggered inside a Job, the whole transaction gets rolled back, including any queries that were executed inside any of the previous jobs.

This make it impossible to use the `sync` driver with the `Bus::batch` command, since it causes unexpected rollbacks. 

I believe the transaction was added for the use case of `database` queue driver, however I find it unnecessary to be using a transaction even for that case.