### PR TITLE
[10.x] Added support for `Arr::of`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -480,6 +480,17 @@ class Arr
     }
 
     /**
+     * Get a new ArrayableHelper object from the given array.
+     *
+     * @param  array  $array
+     * @return ArrayableHelper
+     */
+    public static function of($array): ArrayableHelper
+    {
+        return new ArrayableHelper($array);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/ArrayableHelper.php
+++ b/src/Illuminate/Collections/ArrayableHelper.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayAccess;
+use BadFunctionCallException;
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * @method bool accessible()
+ * @method self add(string|int|float $key, mixed $value)
+ * @method self collapse()
+ * @method self crossJoin(iterable ...$arrays)
+ * @method self divide()
+ * @method self dot(string $prepend = '')
+ * @method self undot()
+ * @method self except(array|string|int|float $keys)
+ * @method bool exists(string|int $key)
+ * @method self first(callable $callback = null, $default = null)
+ * @method self last(callable $callback = null, $default = null)
+ * @method self flatten(int $depth = INF)
+ * @method self forget(array|string|int|float $keys)
+ * @method mixed|self get(string|int $key, $default = null)
+ * @method bool has(string|array $keys)
+ * @method bool hasAny(array|string|int|float $keys)
+ * @method bool isAssoc()
+ * @method bool isList()
+ * @method string join(string $glue, string $finalGlue = '')
+ * @method self keyBy(callable|array|string $keyBy)
+ * @method self prependKeysWith(string $prependWith)
+ * @method self only(array|string $keys)
+ * @method self pluck(string|array|int|null $value, string|array|null $key = null)
+ * @method self explodePluckParameters(string|array|null $key = null)
+ * @method self map(callable $callback)
+ * @method self mapWithKeys(callable $callback)
+ * @method self prepend(mixed $value, mixed $key = null)
+ * @method self pull(string|int $key, mixed $default = null)
+ * @method string query()
+ * @method self random(int|null $number = null, bool $preserveKeys = false)
+ * @method self set(string|int|null $key, mixed $value)
+ * @method self shuffle(int|null $seed = null)
+ * @method self sort(callable $callback = null)
+ * @method self sortDesc(callable $callback = null)
+ * @method self sortRecursive(int $options = SORT_REGULAR, bool $descending = false)
+ * @method self sortRecursiveDesc(int $options = SORT_REGULAR)
+ * @method self toCssClasses()
+ * @method self toCssStyles()
+ * @method self where(callable $callback)
+ * @method self whereNotNull()
+ * @method self wrap()
+ */
+class ArrayableHelper implements Arrayable, ArrayAccess
+{
+    /**
+     * Create a new arrayable instance.
+     *
+     * @param  $array
+     */
+    public function __construct(protected $array)
+    {
+        //
+    }
+
+    /**
+     * When a method is called on the arrayable instance, we'll
+     * call the method on the Arr class and return a new Arrayable
+     * instance, or the resulting value.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @return mixed|self
+     */
+    public function __call(string $name, array $arguments)
+    {
+        if (! method_exists(Arr::class, $name)) {
+            throw new BadFunctionCallException("$name function does not exist");
+        }
+
+        $response = Arr::$name($this->array, ...$arguments);
+
+        if (is_array($response)) {
+            return new self($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns a traditional array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->array;
+    }
+
+    /**
+     * Returns the array in JSON format.
+     *
+     * @param  int  $flags
+     * @param  int  $depth
+     * @return string
+     */
+    public function toJson(int $flags = 0, int $depth = 512): string
+    {
+        return json_encode($this->array, $flags, $depth);
+    }
+
+    /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  $offset
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->array[$offset]);
+    }
+
+    /**
+     * Get an item at a given offset.
+     *
+     * @param  $offset
+     * @return array
+     */
+    public function offsetGet($offset): mixed
+    {
+        return $this->array[$offset];
+    }
+
+    /**
+     * Set the item at a given offset.
+     *
+     * @param  string  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($offset, mixed $value): void
+    {
+        if (is_null($offset)) {
+            $this->array[] = $value;
+        } else {
+            $this->array[$offset] = $value;
+        }
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $offset
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->array[$offset]);
+    }
+}


### PR DESCRIPTION
I love the ability to use the `Str::of()` helper, it makes modifying strings much easier.

While working with various projects I've long felt that this would be useful to have rather than having to map my array into a collection, manipulating it and pulling it back out.

With the `Arr::of()` helper, it proxies all the pre-existing methods provided by the Arr helper via an `ArrayableHelper` class. This allows anyone to quickly and easily perform method chaining to perform multiple actions on an array. All chainable methods are documented and there is room for expansion within the `ArrayableHelper` class.

Due to the way this is developed, there are no regressions, features removed, etc, only improvements. And as I listened to  Matt's Laravel podcast with @taylorotwell, I think this feature provides good bang for its buck 😄 

Example:

```php
$users = [
    [
        'id' => 1,
        'name' => 'John',
        'email' => 'john@example.com',
        'role' => 'none',
    ],
    [
        'id' => 2,
        'name' => 'Jane',
        'email' => 'jane@example.com',
        'role' => 'editor',
    ],
    [
        'id' => 3,
        'name' => 'Jim',
        'email' => 'jim@example.com',
        'role' => 'admin',
    ]
];


$emails = Arr::of($users)
    ->where(fn($user) => $user['role'] !== 'none')
    ->pluck('email')
    ->prepend('admin@app.com')
    ->sort()
    ->toArray();
```

Look forward to your thoughts!


