### PR TITLE
[10.x] Allow route:list to expand middleware groups in 'VeryVerbose' mode

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -90,7 +90,7 @@ class RouteListCommand extends Command
      */
     public function handle()
     {
-        if(!$this->output->isVeryVerbose()) {
+        if (! $this->output->isVeryVerbose()) {
             $this->router->flushMiddlewareGroups();
         }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -70,8 +70,6 @@ class RouteListCommand extends Command
         'DELETE' => 'red',
     ];
 
-    private array $cachedGroups;
-
     /**
      * Create a new route command instance.
      *
@@ -83,7 +81,6 @@ class RouteListCommand extends Command
         parent::__construct();
 
         $this->router = $router;
-        $this->cachedGroups = $router->getMiddlewareGroups();
     }
 
     /**
@@ -93,7 +90,9 @@ class RouteListCommand extends Command
      */
     public function handle()
     {
-        $this->router->flushMiddlewareGroups();
+        if(!$this->output->isVeryVerbose()) {
+            $this->router->flushMiddlewareGroups();
+        }
 
         if (! $this->router->getRoutes()->count()) {
             return $this->components->error("Your application doesn't have any routes.");
@@ -325,28 +324,9 @@ class RouteListCommand extends Command
     {
         return $routes
             ->map(function ($route) {
-
                 $route['middleware'] = empty($route['middleware']) ? [] : explode("\n", $route['middleware']);
 
-                if($route['middleware'] === [] || $this->output->isVeryVerbose() === false) {
-                    return $route;
-                }
-
-                foreach ($route['middleware'] as $middleware) {
-                    if (!isset($this->cachedGroups[$middleware])) {
-                        $route['middleware'][] = $middleware;
-                        continue;
-                    }
-
-                    if (($key = array_search($middleware, $route['middleware'])) !== false) {
-                        unset($route['middleware'][$key]);
-                    }
-
-                    $route['middleware'] = array_merge($route['middleware'], $this->cachedGroups[$middleware]);
-                }
-
                 return $route;
-
             })
             ->values()
             ->toJson();
@@ -385,25 +365,7 @@ class RouteListCommand extends Command
 
             $middleware = Str::of($middleware)->explode("\n")->filter()->whenNotEmpty(
                 fn ($collection) => $collection->map(
-                    function ($middleware) use ($maxMethod)
-                    {
-                        if ($this->output->isVeryVerbose() === false) {
-                            return  sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware);
-                        }
-
-                        if (isset($this->cachedGroups[$middleware])) {
-
-                            $middlewareGroup = sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware . " (group)");
-
-                            foreach ($this->cachedGroups[$middleware] as $groupMiddleware) {
-                                $middlewareGroup .= sprintf("\n         %s    %s", str_repeat(' ', $maxMethod), $groupMiddleware);
-                            }
-
-                            return $middlewareGroup;
-                        }
-
-                       return  sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware);
-                    }
+                    fn ($middleware) => sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware)
                 )
             )->implode("\n");
 

--- a/tests/Console/RouteListCommandTest.php
+++ b/tests/Console/RouteListCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Application;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Console\RouteListCommand;
+use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Routing\Router;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RouteListCommandTest extends TestCase
+{
+    protected Application $app;
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $laravel = new \Illuminate\Foundation\Application(__DIR__);
+        $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]);
+        $this->app = new Application($laravel, $events, 'testing');
+        $router = new Router(m::mock('Illuminate\Events\Dispatcher'));
+
+        $kernel = new class($laravel, $router) extends Kernel {
+            protected $middlewareGroups = [
+                'web' => ['Middleware 1', 'Middleware 2'],
+                'auth' => ['Middleware 3', 'Middleware 4'],
+            ];
+        };
+
+        $laravel->singleton(Kernel::class, function () use ($kernel) {
+            return $kernel;
+        });
+
+        $router->get('/example', function () {
+            return 'Hello World';
+        })->middleware('exampleMiddleware');
+
+        $router->get('/example-group', function () {
+            return 'Hello Group';
+        })->middleware(['web', 'auth']);
+
+        $command = new RouteListCommand($router);
+        $command->setLaravel($laravel);
+
+        $this->app->addCommands([$command]);
+    }
+
+    public function testNoMiddlewareIfNotVerbose()
+    {
+        $this->app->call('route:list');
+        $output = $this->app->output();
+
+        $this->assertStringNotContainsString('exampleMiddleware', $output);
+    }
+
+    public function testMiddlewareGroupsAssignmentInCli()
+    {
+        $this->app->call('route:list', ['-v' => true]);
+        $output = $this->app->output();
+
+        $this->assertStringContainsString('exampleMiddleware', $output);
+        $this->assertStringContainsString('web', $output);
+        $this->assertStringContainsString('auth', $output);
+    }
+
+    public function testMiddlewareGroupsExpandInCliIfVeryVerbose()
+    {
+        $this->app->call('route:list', ['-vv' => true,]);
+        $output = $this->app->output();
+
+        $this->assertStringContainsString('exampleMiddleware', $output);
+        $this->assertStringContainsString('Middleware 1', $output);
+        $this->assertStringContainsString('Middleware 2', $output);
+        $this->assertStringContainsString('Middleware 3', $output);
+        $this->assertStringContainsString('Middleware 4', $output);
+
+        $this->assertStringNotContainsString('web', $output);
+        $this->assertStringNotContainsString('auth', $output);
+    }
+
+    public function testMiddlewareGroupsAssignmentInJson()
+    {
+        $this->app->call('route:list', ['--json' => true, '-v' => true]);
+        $output = $this->app->output();
+
+        $this->assertStringContainsString('exampleMiddleware', $output);
+        $this->assertStringContainsString('web', $output);
+        $this->assertStringContainsString('auth', $output);
+    }
+
+    public function testMiddlewareGroupsExpandInJsonIfVeryVerbose()
+    {
+        $this->app->call('route:list', ['--json' => true, '-vv' => true,]);
+        $output = $this->app->output();
+
+        $this->assertStringContainsString('exampleMiddleware', $output);
+        $this->assertStringContainsString('Middleware 1', $output);
+        $this->assertStringContainsString('Middleware 2', $output);
+        $this->assertStringContainsString('Middleware 3', $output);
+        $this->assertStringContainsString('Middleware 4', $output);
+
+        $this->assertStringNotContainsString('web', $output);
+        $this->assertStringNotContainsString('auth', $output);
+    }
+}

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -34,7 +34,7 @@ class RouteListCommandTest extends TestCase
         $kernel = new class($laravel, $router) extends Kernel
         {
             protected $middlewareGroups = [
-                'web' => ['Middleware 1', 'Middleware 2'],
+                'web' => ['Middleware 1', 'Middleware 2', 'Middleware 5'],
                 'auth' => ['Middleware 3', 'Middleware 4'],
             ];
 
@@ -45,6 +45,8 @@ class RouteListCommandTest extends TestCase
                 'Middleware 3',
             ];
         };
+
+        $kernel->prependToMiddlewarePriority('Middleware 5');
 
         $laravel->singleton(Kernel::class, function () use ($kernel) {
             return $kernel;
@@ -80,6 +82,12 @@ class RouteListCommandTest extends TestCase
         $this->assertStringContainsString('exampleMiddleware', $output);
         $this->assertStringContainsString('web', $output);
         $this->assertStringContainsString('auth', $output);
+
+        $this->assertStringNotContainsString('Middleware 1', $output);
+        $this->assertStringNotContainsString('Middleware 2', $output);
+        $this->assertStringNotContainsString('Middleware 3', $output);
+        $this->assertStringNotContainsString('Middleware 4', $output);
+        $this->assertStringNotContainsString('Middleware 5', $output);
     }
 
     public function testMiddlewareGroupsExpandInCliIfVeryVerbose()
@@ -92,6 +100,7 @@ class RouteListCommandTest extends TestCase
         $this->assertStringContainsString('Middleware 2', $output);
         $this->assertStringContainsString('Middleware 3', $output);
         $this->assertStringContainsString('Middleware 4', $output);
+        $this->assertStringContainsString('Middleware 5', $output);
 
         $this->assertStringNotContainsString('web', $output);
         $this->assertStringNotContainsString('auth', $output);
@@ -105,6 +114,12 @@ class RouteListCommandTest extends TestCase
         $this->assertStringContainsString('exampleMiddleware', $output);
         $this->assertStringContainsString('web', $output);
         $this->assertStringContainsString('auth', $output);
+
+        $this->assertStringNotContainsString('Middleware 1', $output);
+        $this->assertStringNotContainsString('Middleware 2', $output);
+        $this->assertStringNotContainsString('Middleware 3', $output);
+        $this->assertStringNotContainsString('Middleware 4', $output);
+        $this->assertStringNotContainsString('Middleware 5', $output);
     }
 
     public function testMiddlewareGroupsExpandInJsonIfVeryVerbose()
@@ -117,6 +132,7 @@ class RouteListCommandTest extends TestCase
         $this->assertStringContainsString('Middleware 2', $output);
         $this->assertStringContainsString('Middleware 3', $output);
         $this->assertStringContainsString('Middleware 4', $output);
+        $this->assertStringContainsString('Middleware 5', $output);
 
         $this->assertStringNotContainsString('web', $output);
         $this->assertStringNotContainsString('auth', $output);
@@ -127,7 +143,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-vv' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 1","Middleware 4","Middleware 2","Middleware 3"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -31,7 +31,8 @@ class RouteListCommandTest extends TestCase
 
         $router = new Router(m::mock('Illuminate\Events\Dispatcher'));
 
-        $kernel = new class($laravel, $router) extends Kernel {
+        $kernel = new class($laravel, $router) extends Kernel
+        {
             protected $middlewareGroups = [
                 'web' => ['Middleware 1', 'Middleware 2'],
                 'auth' => ['Middleware 3', 'Middleware 4'],
@@ -76,7 +77,7 @@ class RouteListCommandTest extends TestCase
 
     public function testMiddlewareGroupsExpandInCliIfVeryVerbose()
     {
-        $this->app->call('route:list', ['-vv' => true,]);
+        $this->app->call('route:list', ['-vv' => true]);
         $output = $this->app->output();
 
         $this->assertStringContainsString('exampleMiddleware', $output);
@@ -101,7 +102,7 @@ class RouteListCommandTest extends TestCase
 
     public function testMiddlewareGroupsExpandInJsonIfVeryVerbose()
     {
-        $this->app->call('route:list', ['--json' => true, '-vv' => true,]);
+        $this->app->call('route:list', ['--json' => true, '-vv' => true]);
         $output = $this->app->output();
 
         $this->assertStringContainsString('exampleMiddleware', $output);

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -37,6 +37,13 @@ class RouteListCommandTest extends TestCase
                 'web' => ['Middleware 1', 'Middleware 2'],
                 'auth' => ['Middleware 3', 'Middleware 4'],
             ];
+
+            protected $middlewarePriority = [
+                'Middleware 1',
+                'Middleware 4',
+                'Middleware 2',
+                'Middleware 3',
+            ];
         };
 
         $laravel->singleton(Kernel::class, function () use ($kernel) {
@@ -113,5 +120,15 @@ class RouteListCommandTest extends TestCase
 
         $this->assertStringNotContainsString('web', $output);
         $this->assertStringNotContainsString('auth', $output);
+    }
+
+    public function testMiddlewareGroupsExpandCorrectlySortedIfVeryVerbose()
+    {
+        $this->app->call('route:list', ['--json' => true, '-vv' => true]);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 1","Middleware 4","Middleware 2","Middleware 3"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -23,9 +23,12 @@ class RouteListCommandTest extends TestCase
     {
         parent::setUp();
 
-        $laravel = new \Illuminate\Foundation\Application(__DIR__);
-        $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]);
-        $this->app = new Application($laravel, $events, 'testing');
+        $this->app = new Application(
+            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing',
+        );
+
         $router = new Router(m::mock('Illuminate\Events\Dispatcher'));
 
         $kernel = new class($laravel, $router) extends Kernel {

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Console;
+namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Console\Application;
 use Illuminate\Contracts\Events\Dispatcher;


### PR DESCRIPTION
Together with @timacdonald I've been exploring the idea of expanding the middleware groups when using `route:list`. We both feel that being able to see the actual middleware being used instead of group names like 'web' adds value to the command. This PR proposes this as _**optional**_ functionality.

## Benefits
Developers see what really is applied, instead of group names. No more jumping to e.g. the Kernel, to see what is in the group. Most importantly, the middleware are listed in the order defined by `$middlewarePriority`.

## When merged

### `route:list` (no change)
![image](https://github.com/laravel/framework/assets/32384907/d05610e8-87eb-4eb6-b752-d35e611381a7)

### `route:list -v` (no change)
![image](https://github.com/laravel/framework/assets/32384907/1ad9b72d-99c1-4283-a438-050c73ac4dab)

### `route:list -vv` (expands middleware groups)
The group name `web` is no longer listed. Instead, the actual middleware from that group are listed. The same behaviour applies when using the `--json` flag.

![image](https://github.com/laravel/framework/assets/32384907/bbf2664e-8101-4492-b1d5-f750c69c9885)

## Consideration

The `-vv` flag until now has **not** been used in the command. If someone were to use it in an automated way for whatever reason, this change could be considered a BC break. 

However, I wanted to get the maintainer's opinion on this first.
If you consider it a BC break, there are two options:

A) Target Laravel 11
B) Add a new flag `--expand-groups` /  `-e`. 

Input welcome. 