### PR TITLE
[10.x] Batch remove transaction for sync

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -183,15 +183,13 @@ class Batch implements Arrayable, JsonSerializable
             return $job;
         });
 
-        $this->repository->transaction(function () use ($jobs, $count) {
-            $this->repository->incrementTotalJobs($this->id, $count);
+        $this->repository->incrementTotalJobs($this->id, $count);
 
-            $this->queue->connection($this->options['connection'] ?? null)->bulk(
-                $jobs->all(),
-                $data = '',
-                $this->options['queue'] ?? null
-            );
-        });
+        $this->queue->connection($this->options['connection'] ?? null)->bulk(
+            $jobs->all(),
+            $data = '',
+            $this->options['queue'] ?? null
+        );
 
         return $this->fresh();
     }

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\SyncQueue;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use JsonSerializable;
@@ -183,7 +184,7 @@ class Batch implements Arrayable, JsonSerializable
             return $job;
         });
 
-        $this->getQueueConnection()->getConnectionName() === 'sync' ?
+        $this->getQueueConnection() instanceof SyncQueue ?
             $this->bulk($jobs, $count) :
             $this->repository->transaction(function () use ($jobs, $count) {
                 $this->bulk($jobs, $count);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -98,7 +98,7 @@ class BusBatchTest extends TestCase
         $thirdJob = function () {
         };
 
-        $queue->shouldReceive('connection')->once()
+        $queue->shouldReceive('connection')
                         ->with('test-connection')
                         ->andReturn($connection = m::mock(stdClass::class));
 
@@ -188,7 +188,7 @@ class BusBatchTest extends TestCase
             use Batchable;
         };
 
-        $queue->shouldReceive('connection')->once()
+        $queue->shouldReceive('connection')
                         ->with('test-connection')
                         ->andReturn($connection = m::mock(stdClass::class));
 
@@ -226,7 +226,7 @@ class BusBatchTest extends TestCase
             use Batchable;
         };
 
-        $queue->shouldReceive('connection')->once()
+        $queue->shouldReceive('connection')
                         ->with('test-connection')
                         ->andReturn($connection = m::mock(stdClass::class));
 
@@ -267,7 +267,7 @@ class BusBatchTest extends TestCase
             use Batchable;
         };
 
-        $queue->shouldReceive('connection')->once()
+        $queue->shouldReceive('connection')
                         ->with('test-connection')
                         ->andReturn($connection = m::mock(stdClass::class));
 
@@ -364,7 +364,7 @@ class BusBatchTest extends TestCase
 
         $thirdJob = new ThirdTestJob;
 
-        $queue->shouldReceive('connection')->once()
+        $queue->shouldReceive('connection')
             ->with('test-connection')
             ->andReturn($connection = m::mock(stdClass::class));
 


### PR DESCRIPTION
Follow up on: https://github.com/laravel/framework/pull/48699

I kept the transaction for all other drivers/connections. 

For `sync` connection should not use a transaction since there is no need for one and its causing a bug that when a job fails it rolls back any insert/update queries.