### PR TITLE
[10.x] Add createIfNotExist Method to Schema Facade

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Migrator
 {
@@ -190,6 +191,11 @@ class Migrator
         if ($this->output) {
             $this->output->writeln('');
         }
+    }
+
+    public function informTableExistance($table)
+    {
+        (new ConsoleOutput)->write("\n\tTable {$table} already exists ");
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -21,7 +21,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Migrator
 {
@@ -137,9 +136,9 @@ class Migrator
     protected function pendingMigrations($files, $ran)
     {
         return Collection::make($files)
-                ->reject(function ($file) use ($ran) {
-                    return in_array($this->getMigrationName($file), $ran);
-                })->values()->all();
+            ->reject(function ($file) use ($ran) {
+                return in_array($this->getMigrationName($file), $ran);
+            })->values()->all();
     }
 
     /**
@@ -191,11 +190,6 @@ class Migrator
         if ($this->output) {
             $this->output->writeln('');
         }
-    }
-
-    public function informTableExistance($table)
-    {
-        (new ConsoleOutput)->write("\n\tTable {$table} already exists ");
     }
 
     /**
@@ -420,9 +414,9 @@ class Migrator
         };
 
         $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
-            && $migration->withinTransaction
-                    ? $connection->transaction($callback)
-                    : $callback();
+        && $migration->withinTransaction
+            ? $connection->transaction($callback)
+            : $callback();
     }
 
     /**
@@ -533,8 +527,8 @@ class Migrator
 
         if (is_object($migration)) {
             return method_exists($migration, '__construct')
-                    ? $this->files->getRequire($path)
-                    : clone $migration;
+                ? $this->files->getRequire($path)
+                : clone $migration;
         }
 
         return new $class;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Migrations\Migrator;
 use InvalidArgumentException;
 use LogicException;
 
@@ -283,6 +284,24 @@ class Builder
 
             $callback($blueprint);
         }));
+    }
+
+    /**
+     * Create a new table on the schema if table doesn't exist.
+     *
+     * @param  string  $table
+     * @param Closure $callback
+     * @return void
+     */
+    public function createIfNotExist($table, Closure $callback)
+    {
+        if ($this->hasTable($table)) {
+            $migrator = new Migrator(app('migration.repository'), app('db'), app('files'));
+            $migrator->informTableExistance($table);
+            return;
+        }
+
+        $this->create($table, $callback);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new method, `createIfNotExist`, to the Schema Facade. 

The existing `create` method in the Schema Facade allows us to create tables using the following syntax:

```php
Schema::create('users', function (Blueprint $table) {});
```

However, if we attempt to run another migration to create a table that already exists, it results in a failure. 

To address this issue, the `createIfNotExist` method has been added. This method first checks if the table already exists before attempting to run the migration. If the table exists, it does not throw an error. Instead, it informs the user that the table already exists, exits the current migration, and continues to run any subsequent migrations.

This enhancement improves the robustness of database migrations and provides better feedback to the user during the migration process.
