### PR TITLE
[10.x] Show CliDumper source content on last line

### DIFF
--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -94,7 +94,7 @@ class CliDumper extends BaseCliDumper
         $output = (string) $this->dump($data, true);
         $lines = explode("\n", $output);
 
-        $lines[0] .= $this->getDumpSourceContent();
+        $lines[array_key_last($lines) - 1] .= $this->getDumpSourceContent();
 
         $this->output->write(implode("\n", $lines));
 

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -55,7 +55,7 @@ class CliDumperTest extends TestCase
         $output = $this->dump(['string', 1, 1.1, ['string', 1, 1.1]]);
 
         $expected = <<<'EOF'
-        array:4 [ // app/routes/console.php:18
+        array:4 [
           0 => "string"
           1 => 1
           2 => 1.1
@@ -64,7 +64,7 @@ class CliDumperTest extends TestCase
             1 => 1
             2 => 1.1
           ]
-        ]
+        ] // app/routes/console.php:18
 
         EOF;
 
@@ -90,9 +90,9 @@ class CliDumperTest extends TestCase
         $objectId = spl_object_id($user);
 
         $expected = <<<EOF
-        {#$objectId // app/routes/console.php:18
+        {#$objectId
           +"name": "Guus"
-        }
+        } // app/routes/console.php:18
 
         EOF;
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

### Description
Please see https://github.com/laravel/framework/pull/47514 for previous discussion.

This PR moves the CliDumper source content output from the first line to the last (non-empty) line.

### Motivation
Showing the source output on the *first* line works for relatively small output (compared to the display height). However, a flaw is noticed as soon as the output significantly exceeds the display---a user is forced to scroll through all the lines just find the source or must resort to other means to track down the dump location in the codebase (such as redirecting stdout to a file and then viewing the head of the file). In essence, the convenience of locating the source with the content is lost for large outputs. Moving the source to the *last* line rectifies this and maintains the developer experience regardless of the dump size.


### Screenshots

#### Before
![image](https://github.com/laravel/framework/assets/4176520/dd2d5d09-e89f-4eb4-91f8-0618085dc811)

![image](https://github.com/laravel/framework/assets/4176520/20c67dfc-5853-45c5-bfb0-3e314bba8aa8)

![image](https://github.com/laravel/framework/assets/4176520/e5dd83c2-1837-49fa-b1f9-553be8e65e9a)

#### After

![image](https://github.com/laravel/framework/assets/4176520/2893b909-bd59-41ce-9086-c670d2e3988f)

![image](https://github.com/laravel/framework/assets/4176520/cb9d3d77-f1d0-4824-bf2e-85df98fce305)

![image](https://github.com/laravel/framework/assets/4176520/8b844867-cd64-45a4-a8a9-e494abd2f25a)


Tag: @nunomaduro 

Thanks!