### PR TITLE
[10.x] Fix model:prune command error with non-class php files

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -139,9 +139,9 @@ class PruneCommand extends Command
                     return in_array($model, $except);
                 });
             })->filter(function ($model) {
-                return $this->isPrunable($model);
-            })->filter(function ($model) {
                 return class_exists($model);
+            })->filter(function ($model) {
+                return $this->isPrunable($model);
             })->values();
     }
 


### PR DESCRIPTION
It's advisable to first verify if the PHP file contains a class. If not, the `isPrunable` check will fail as it utilizes the `class_uses_recursive` function.

Also `Prunable` trait uses Eloquent methods (like `delete`). It would be better to check that a class is a `Model` before checking for used traits (`class_uses_recursive`).