### PR TITLE
[10.x] allow resolving view from closure

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -143,6 +143,10 @@ abstract class Component
         }
 
         $resolver = function ($view) {
+            if ($view instanceof ViewContract) {
+                return $view;
+            }
+
             return $this->extractBladeViewFromString($view);
         };
 

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -105,7 +105,7 @@ class ComponentTest extends TestCase
         $this->assertInstanceOf(Closure::class, $closure);
         $this->assertSame('__components::9cc08f5001b343c093ee1a396da820dc', $viewPath);
 
-        $hash = str_replace('__components::', '',$viewPath);
+        $hash = str_replace('__components::', '', $viewPath);
         $this->assertSame('<p>Hello World</p>', file_get_contents("/tmp/{$hash}.blade.php"));
     }
 

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View;
 
+use Closure;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -70,6 +71,42 @@ class ComponentTest extends TestCase
         $component = new TestRegularViewComponentUsingViewHelper;
 
         $this->assertSame($view, $component->resolveView());
+    }
+
+    public function testRenderingStringClosureFromComponent()
+    {
+        $this->config->shouldReceive('get')->once()->with('view.compiled')->andReturn('/tmp');
+        $this->viewFactory->shouldReceive('exists')->once()->andReturn(false);
+        $this->viewFactory->shouldReceive('addNamespace')->once()->with('__components', '/tmp');
+
+        $component = new class() extends Component
+        {
+            protected $title;
+
+            public function __construct($title = 'World')
+            {
+                $this->title = $title;
+            }
+
+            public function render()
+            {
+                return function (array $data) {
+                    return "<p>Hello {$this->title}</p>";
+                };
+            }
+        };
+
+        $closure = $component->resolveView();
+
+        $viewPath = $closure([]);
+
+        $this->viewFactory->shouldReceive('make')->with($viewPath, [], [])->andReturn('<p>Hello World</p>');
+
+        $this->assertInstanceOf(Closure::class, $closure);
+        $this->assertSame('__components::9cc08f5001b343c093ee1a396da820dc', $viewPath);
+
+        $hash = str_replace('__components::', '',$viewPath);
+        $this->assertSame('<p>Hello World</p>', file_get_contents("/tmp/{$hash}.blade.php"));
     }
 
     public function testRegularViewsGetReturnedUsingViewMethod()


### PR DESCRIPTION
Hi, this PR purpose is to add support to blade view when using closure to access the component **$data** and **attributes.**
It's really useful for building components

Before
![image](https://github.com/laravel/framework/assets/38913462/2f6d9191-f37d-479c-b389-159580942f2c)

After
![image](https://github.com/laravel/framework/assets/38913462/9dc58245-326c-4fc4-9a41-d5a715b85c4b)

Passing the view instance directly will prevent double-view rendering issues.

Thanks

PS: I've added a test to cover the current feature using string, however, I was not able to add a unit test for the view instance.