### PR TITLE
[10.x] Allow filtering of loaded relations in a model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -893,6 +893,27 @@ trait HasRelationships
     }
 
     /**
+     * Duplicate the instance and only keep the specified relations.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function onlyRelations($relations)
+    {
+        $relations = is_string($relations) ? func_get_args() : $relations;
+
+        $model = clone $this;
+
+        foreach (array_keys($model->getRelations()) as $relation) {
+            if (! in_array($relation, $relations)) {
+                $model->unsetRelation($relation);
+            }
+        }
+
+        return $model;
+    }
+
+    /**
      * Unset all the loaded relations for the instance.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -256,6 +256,57 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertFalse($model->relationLoaded('foo'));
     }
 
+    public function testOnlyRelations()
+    {
+        $original = new EloquentNoTouchingModelStub;
+
+        $original->setRelation('foo', 'baz');
+        $original->setRelation('lorem', 'ipsum');
+        $original->setRelation('bar', 'foo');
+        $original->setRelation('hello', 'world');
+
+        $this->assertSame('baz', $original->getRelation('foo'));
+        $this->assertSame('ipsum', $original->getRelation('lorem'));
+        $this->assertSame('foo', $original->getRelation('bar'));
+        $this->assertSame('world', $original->getRelation('hello'));
+
+        $model = $original->onlyRelations('foo');
+
+        $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertTrue($original->relationLoaded('foo'));
+        $this->assertTrue($model->relationLoaded('foo'));
+        $this->assertTrue($original->relationLoaded('lorem'));
+        $this->assertFalse($model->relationLoaded('lorem'));
+        $this->assertTrue($original->relationLoaded('bar'));
+        $this->assertFalse($model->relationLoaded('bar'));
+        $this->assertTrue($original->relationLoaded('hello'));
+        $this->assertFalse($model->relationLoaded('hello'));
+
+        $model = $original->onlyRelations('foo', 'bar');
+
+        $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertTrue($original->relationLoaded('foo'));
+        $this->assertTrue($model->relationLoaded('foo'));
+        $this->assertTrue($original->relationLoaded('lorem'));
+        $this->assertFalse($model->relationLoaded('lorem'));
+        $this->assertTrue($original->relationLoaded('bar'));
+        $this->assertTrue($model->relationLoaded('bar'));
+        $this->assertTrue($original->relationLoaded('hello'));
+        $this->assertFalse($model->relationLoaded('hello'));
+
+        $model = $original->onlyRelations(['lorem', 'hello']);
+
+        $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertTrue($original->relationLoaded('foo'));
+        $this->assertFalse($model->relationLoaded('foo'));
+        $this->assertTrue($original->relationLoaded('lorem'));
+        $this->assertTrue($model->relationLoaded('lorem'));
+        $this->assertTrue($original->relationLoaded('bar'));
+        $this->assertFalse($model->relationLoaded('bar'));
+        $this->assertTrue($original->relationLoaded('hello'));
+        $this->assertTrue($model->relationLoaded('hello'));
+    }
+
     public function testMacroable()
     {
         Relation::macro('foo', function () {


### PR DESCRIPTION
Added a new method named "onlyRelations" to the HasRelationships class. This method allows us to duplicate the model instance while only keeping the specified relationships. This addition provides enhanced control when managing model relations and helps to optimize performance by reducing unnecessary data processing. 

Additionally, as part of this commit, relevant tests were also added to the DatabaseEloquentRelationTest class ensuring the correct functioning of the new feature.
