### PR TITLE
[10.x] Add `replaceMatches` to Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1071,24 +1071,6 @@ class Str
     }
 
     /**
-     * Replace the patterns matching the given regular expression.
-     *
-     * @param  string  $pattern
-     * @param  \Closure|string  $replace
-     * @param  array|string  $subject
-     * @param  int  $limit
-     * @return string|string[]|null
-     */
-    public function replaceMatches($pattern, $replace, $subject, $limit = -1)
-    {
-        if ($replace instanceof Closure) {
-            return preg_replace_callback($pattern, $replace, $subject, $limit);
-        }
-
-        return preg_replace($pattern, $replace, $subject, $limit);
-    }
-
-    /**
      * Replace the first occurrence of the given value if it appears at the start of the string.
      *
      * @param  string  $search
@@ -1157,6 +1139,24 @@ class Str
         }
 
         return $subject;
+    }
+
+    /**
+     * Replace the patterns matching the given regular expression.
+     *
+     * @param  string  $pattern
+     * @param  \Closure|string  $replace
+     * @param  array|string  $subject
+     * @param  int  $limit
+     * @return string|string[]|null
+     */
+    public function replaceMatches($pattern, $replace, $subject, $limit = -1)
+    {
+        if ($replace instanceof Closure) {
+            return preg_replace_callback($pattern, $replace, $subject, $limit);
+        }
+
+        return preg_replace($pattern, $replace, $subject, $limit);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1071,6 +1071,24 @@ class Str
     }
 
     /**
+     * Replace the patterns matching the given regular expression.
+     *
+     * @param  string  $pattern
+     * @param  \Closure|string  $replace
+     * @param  array|string  $subject
+     * @param  int  $limit
+     * @return string|string[]|null
+     */
+    public function replaceMatches($pattern, $replace, $subject, $limit = -1)
+    {
+        if ($replace instanceof Closure) {
+            return preg_replace_callback($pattern, $replace, $subject, $limit);
+        }
+
+        return preg_replace($pattern, $replace, $subject, $limit);
+    }
+
+    /**
      * Replace the first occurrence of the given value if it appears at the start of the string.
      *
      * @param  string  $search


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request adds the `replaceMatches` method to the Str class, which is already used in the Stringable class.

I don't think using the `Stringable` class to call this method is necessary.

This is my use case.

```php
$result = (string) Str::of(file_get_contents($file))->replaceMatches(
    '/^(.*data-public-url=")([^"]*)(".*)$/m',
    '$1<?= e(Storage::disk(\'s3\')->temporaryUrl(\$item->path, now()->addHours(2))) ?>$3'
);
```

That could be.

```php
$result = Str::replaceMatches(
    '/^(.*data-public-url=")([^"]*)(".*)$/m',
    '$1<?= e(Storage::disk(\'s3\')->temporaryUrl(\$item->path, now()->addHours(2))) ?>$3',
    file_get_contents($file)
);
```

Thank You!