### PR TITLE
[10.x] Extend Test Coverage for `Str::take` Function

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -853,6 +853,11 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('ab', Str::take('abcdef', 2));
         $this->assertSame('ef', Str::take('abcdef', -2));
+        $this->assertSame('', Str::take('abcdef', 0));
+        $this->assertSame('', Str::take('', 2));
+        $this->assertSame('abcdef', Str::take('abcdef', 10));
+        $this->assertSame('abcdef', Str::take('abcdef', 6));
+        $this->assertSame('ü', Str::take('üöä', 1));
     }
 
     public function testLcfirst()


### PR DESCRIPTION
Extend the test coverage for the `Str::take` function to include additional edge cases.

### Tests that are added
- test for `$limit = 0`
- test for an empty string as `$string`
- test for `$limit > strlen($string)`
- test for `$limit = strlen($string)`
- test for multi-byte characters in `$string`
