### PR TITLE
[10.x] Update DocBlock for `convertCase` Method to Reflect Optional $encoding Parameter

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -297,7 +297,7 @@ class Str
      *
      * @param  string  $string
      * @param  int  $mode
-     * @param  string  $encoding
+     * @param  string|null  $encoding
      * @return string
      */
     public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')


### PR DESCRIPTION
Update the DocBlock comments for the `convertCase` method to reflect that the `$encoding` parameter can be `null`.