### PR TITLE
[10.x] Do not bubble exceptions thrown rendering error view when debug is false (prevent infinite loops)

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -725,7 +725,7 @@ class Handler implements ExceptionHandlerContract
                     'exception' => $e,
                 ], $e->getStatusCode(), $e->getHeaders());
             } catch (Throwable $t) {
-                config('app.debug') || throw $t;
+                config('app.debug') && throw $t;
             }
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -719,10 +719,14 @@ class Handler implements ExceptionHandlerContract
         $this->registerErrorViewPaths();
 
         if ($view = $this->getHttpExceptionView($e)) {
-            return response()->view($view, [
-                'errors' => new ViewErrorBag,
-                'exception' => $e,
-            ], $e->getStatusCode(), $e->getHeaders());
+            try {
+                return response()->view($view, [
+                    'errors' => new ViewErrorBag,
+                    'exception' => $e,
+                ], $e->getStatusCode(), $e->getHeaders());
+            } catch (Throwable $t) {
+                config('app.debug') || throw $t;
+            }
         }
 
         return $this->convertExceptionToResponse($e);

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -726,6 +726,8 @@ class Handler implements ExceptionHandlerContract
                 ], $e->getStatusCode(), $e->getHeaders());
             } catch (Throwable $t) {
                 config('app.debug') && throw $t;
+
+                $this->report($t);
             }
         }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -428,10 +428,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         // When debug is false, the exception thrown while rendering the error view
         // should not bubble as this may trigger an infinite loop.
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("Rendering this view throws an exception");
-
-        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(false);
     }
 
     public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugTrue()
@@ -439,6 +435,8 @@ class FoundationExceptionsHandlerTest extends TestCase
         // When debug is true, it is OK to bubble the exception thrown while rendering
         // the error view as the debug handler should handle this gracefully.
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Rendering this view throws an exception");
         $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(true);
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -404,45 +404,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNull($handler->getErrorView(new HttpException(404)));
     }
 
-    private function executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs($debug)
-    {
-        $this->viewFactory->shouldReceive('exists')->once()->with('errors::404')->andReturn(true);
-        $this->viewFactory->shouldReceive('make')->once()->withAnyArgs()->andThrow(new Exception("Rendering this view throws an exception"));
-
-        $this->config->shouldReceive('get')->with('app.debug', null)->andReturn($debug);
-
-        $handler = new class($this->container) extends Handler
-        {
-            protected function registerErrorViewPaths() {}
-
-            public function getErrorView($e)
-            {
-                return $this->renderHttpException($e);
-            }
-        };
-
-        $this->assertInstanceOf(SymfonyResponse::class, $handler->getErrorView(new HttpException(404)));
-    }
-
-    public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugFalse()
-    {
-        // When debug is false, the exception thrown while rendering the error view
-        // should not bubble as this may trigger an infinite loop.
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("Rendering this view throws an exception");
-
-        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(false);
-    }
-
-    public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugTrue()
-    {
-        // When debug is true, it is OK to bubble the exception thrown while rendering
-        // the error view as the debug handler should handle this gracefully.
-
-        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(true);
-    }
-
     public function testAssertExceptionIsThrown()
     {
         $this->assertThrows(function () {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -403,6 +403,45 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNull($handler->getErrorView(new HttpException(404)));
     }
 
+    private function executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs($debug)
+    {
+        $this->viewFactory->shouldReceive('exists')->once()->with('errors::404')->andReturn(true);
+        $this->viewFactory->shouldReceive('make')->once()->withAnyArgs()->andThrow(new Exception("Rendering this view throws an exception"));
+
+        $this->config->shouldReceive('get')->with('app.debug', null)->andReturn($debug);
+
+        $handler = new class($this->container) extends Handler
+        {
+            protected function registerErrorViewPaths() {}
+
+            public function getErrorView($e)
+            {
+                return $this->renderHttpException($e);
+            }
+        };
+
+        $this->assertInstanceOf(SymfonyResponse::class, $handler->getErrorView(new HttpException(404)));
+    }
+
+    public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugFalse()
+    {
+        // When debug is false, the exception thrown while rendering the error view
+        // should not bubble as this may trigger an infinite loop.
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Rendering this view throws an exception");
+
+        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(false);
+    }
+
+    public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugTrue()
+    {
+        // When debug is true, it is OK to bubble the exception thrown while rendering
+        // the error view as the debug handler should handle this gracefully.
+
+        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(true);
+    }
+
     public function testAssertExceptionIsThrown()
     {
         $this->assertThrows(function () {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -39,7 +39,6 @@ use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -39,6 +39,7 @@ use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -48,6 +49,8 @@ class FoundationExceptionsHandlerTest extends TestCase
     use InteractsWithExceptionHandling;
 
     protected $config;
+
+    protected $viewFactory;
 
     protected $container;
 
@@ -59,14 +62,18 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $this->config = m::mock(Config::class);
 
+        $this->viewFactory = m::mock(ViewFactory::class);
+
         $this->request = m::mock(stdClass::class);
 
         $this->container = Container::setInstance(new Container);
 
         $this->container->instance('config', $this->config);
 
+        $this->container->instance(ViewFactory::class, $this->viewFactory);
+
         $this->container->instance(ResponseFactoryContract::class, new ResponseFactory(
-            m::mock(ViewFactory::class),
+            $this->viewFactory,
             m::mock(Redirector::class)
         ));
 
@@ -395,6 +402,45 @@ class FoundationExceptionsHandlerTest extends TestCase
         };
 
         $this->assertNull($handler->getErrorView(new HttpException(404)));
+    }
+
+    private function executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs($debug)
+    {
+        $this->viewFactory->shouldReceive('exists')->once()->with('errors::404')->andReturn(true);
+        $this->viewFactory->shouldReceive('make')->once()->withAnyArgs()->andThrow(new Exception("Rendering this view throws an exception"));
+
+        $this->config->shouldReceive('get')->with('app.debug', null)->andReturn($debug);
+
+        $handler = new class($this->container) extends Handler
+        {
+            protected function registerErrorViewPaths() {}
+
+            public function getErrorView($e)
+            {
+                return $this->renderHttpException($e);
+            }
+        };
+
+        $this->assertInstanceOf(SymfonyResponse::class, $handler->getErrorView(new HttpException(404)));
+    }
+
+    public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugFalse()
+    {
+        // When debug is false, the exception thrown while rendering the error view
+        // should not bubble as this may trigger an infinite loop.
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Rendering this view throws an exception");
+
+        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(false);
+    }
+
+    public function testItDoesNotCrashIfErrorViewThrowsWhileRenderingAndDebugTrue()
+    {
+        // When debug is true, it is OK to bubble the exception thrown while rendering
+        // the error view as the debug handler should handle this gracefully.
+
+        $this->executeScenarioWhereErrorViewThrowsWhileRenderingAndDebugIs(true);
     }
 
     public function testAssertExceptionIsThrown()

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -4,9 +4,13 @@ namespace Illuminate\Tests\Integration\Foundation;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\Process\PhpProcess;
+use Throwable;
 
 class ExceptionHandlerTest extends TestCase
 {
@@ -150,5 +154,47 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
     {
         yield 'Throw exception' => [[Fixtures\Providers\ThrowUncaughtExceptionServiceProvider::class], false];
         yield 'Do not throw exception' => [[Fixtures\Providers\ThrowExceptionServiceProvider::class], true];
+    }
+
+    public function test_it_handles_malformed_error_views_in_production()
+    {
+        Config::set('view.paths', [__DIR__.'/Fixtures/MalformedErrorViews']);
+        Config::set('app.debug', false);
+        $reported = [];
+        $this->app[ExceptionHandler::class]->reportable(function (Throwable $e) use (&$reported) {
+            $reported[] = $e;
+        });
+
+        try {
+            $response = $this->get('foo');
+        } catch (Throwable) {
+            $response ??= null;
+        }
+
+        $this->assertCount(1, $reported);
+        $this->assertSame('Undefined variable $foo (View: '.__DIR__.'/Fixtures/MalformedErrorViews/errors/404.blade.php)', $reported[0]->getMessage());
+        $this->assertNotNull($response);
+        $response->assertStatus(404);
+    }
+
+    public function test_it_handles_malformed_error_views_in_development()
+    {
+        Config::set('view.paths', [__DIR__.'/Fixtures/MalformedErrorViews']);
+        Config::set('app.debug', true);
+        $reported = [];
+        $this->app[ExceptionHandler::class]->reportable(function (Throwable $e) use (&$reported) {
+            $reported[] = $e;
+        });
+
+        try {
+            $response = $this->get('foo');
+        } catch (Throwable) {
+            $response ??= null;
+        }
+
+        $this->assertCount(1, $reported);
+        $this->assertSame('Undefined variable $foo (View: '.__DIR__.'/Fixtures/MalformedErrorViews/errors/404.blade.php)', $reported[0]->getMessage());
+        $this->assertNotNull($response);
+        $response->assertStatus(500);
     }
 }

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -7,7 +7,6 @@ use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\Process\PhpProcess;
 use Throwable;

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -171,7 +171,7 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         }
 
         $this->assertCount(1, $reported);
-        $this->assertSame('Undefined variable $foo (View: '.__DIR__.'/Fixtures/MalformedErrorViews/errors/404.blade.php)', $reported[0]->getMessage());
+        $this->assertSame('Undefined variable $foo (View: '.__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'MalformedErrorViews'.DIRECTORY_SEPARATOR.'errors'.DIRECTORY_SEPARATOR.'404.blade.php)', $reported[0]->getMessage());
         $this->assertNotNull($response);
         $response->assertStatus(404);
     }
@@ -192,7 +192,7 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         }
 
         $this->assertCount(1, $reported);
-        $this->assertSame('Undefined variable $foo (View: '.__DIR__.'/Fixtures/MalformedErrorViews/errors/404.blade.php)', $reported[0]->getMessage());
+        $this->assertSame('Undefined variable $foo (View: '.__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'MalformedErrorViews'.DIRECTORY_SEPARATOR.'errors'.DIRECTORY_SEPARATOR.'404.blade.php)', $reported[0]->getMessage());
         $this->assertNotNull($response);
         $response->assertStatus(500);
     }

--- a/tests/Integration/Foundation/Fixtures/MalformedErrorViews/errors/404.blade.php
+++ b/tests/Integration/Foundation/Fixtures/MalformedErrorViews/errors/404.blade.php
@@ -1,0 +1,2 @@
+My custom 404
+<?php $foo();

--- a/tests/Integration/Foundation/Fixtures/MalformedErrorViews/errors/500.blade.php
+++ b/tests/Integration/Foundation/Fixtures/MalformedErrorViews/errors/500.blade.php
@@ -1,0 +1,2 @@
+My custom 500
+<?php $bar();


### PR DESCRIPTION
I recently upgraded an application and forgot to update the layouts for the custom error pages. This resulted in the custom error pages throwing exceptions. In production, with `app.debug` set to `false`, this had horrible consequences.

If a 404 was requested, this triggered the rendering of the custom 404 error view. Rendering the custom 404 error view resulted in an exception. The same running application instance – still in the same request – would catch this and trigger rendering the custom 500 error view. Rendering that custom 500 error view resulted in an exception...

In my real-life situation, a single 404 error went from reporting one exception (the initial "missing file" exception) to an additional 19 exceptions for failing to render the custom error pages. All within one request.

The resulting error log went from 51 lines to 7,751 lines for the same situation.

This massive spike in log traffic caused a spike in my [Papertrail](https://www.papertrail.com/) usage. Had I not caught this as quickly as I did, it could have cost me a lot of money. As it is, I'm out about $30 from when I realized there was a problem until I solved it in my error views (~1 day).

-----

My proposed fix wraps the error view rendering in `try`/`catch`. 

If `app.debug` is `true`, it throws the *new exception* assuming the debug handler will render an appropriate message.

If `app.debug` is `false`, it ignores the exception and the fallback `convertExceptionToResponse` on the *original exception* is called exactly like it would if no custom error views were defined.

My initial implementation didn't distinguish whether the app was in debug. It treated all error view rendering errors the same and returned the Symfony response. However, the debug handling would actually be helpful in this case (it would tell you *why* the view threw an exception!) I added the `config('app.debug') || throw $t` to cover that case.

*If it turns out my assumption about the debug handler catching the exception is incorrect, I'm happy to simplify this PR and not worry about that edge case.*

-----

This could be added to my own `App\Exceptions\Handler`, but this does not feel like a preference sort of thing. This is something the framework should be protecting people from, even if it is not something that may happen very often.