### PR TITLE
[11.x] Use PHPUnit's `transformException()` introduced in PHPUnit 10.1 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "orchestra/testbench-core": "^9.0",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
-        "phpunit/phpunit": "^10.0.7",
+        "phpunit/phpunit": "^10.1",
         "predis/predis": "^2.0.2",
         "symfony/cache": "^7.0",
         "symfony/http-client": "^7.0"

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -162,21 +162,16 @@ abstract class TestCase extends BaseTestCase
     /**
      * {@inheritdoc}
      */
-    protected function runTest(): mixed
+    protected function transformException(Throwable $error): Throwable
     {
-        $result = null;
+        /** @var \Illuminate\Testing\TestResponse|null $response */
+        $response = static::$latestResponse ?? null;
 
-        try {
-            $result = parent::runTest();
-        } catch (Throwable $e) {
-            if (! is_null(static::$latestResponse)) {
-                static::$latestResponse->transformNotSuccessfulException($e);
-            }
-
-            throw $e;
+        if (! \is_null($response)) {
+            $response->transformNotSuccessfulException($error);
         }
 
-        return $result;
+        return $error;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -164,10 +164,9 @@ abstract class TestCase extends BaseTestCase
      */
     protected function transformException(Throwable $error): Throwable
     {
-        /** @var \Illuminate\Testing\TestResponse|null $response */
         $response = static::$latestResponse ?? null;
 
-        if (! \is_null($response)) {
+        if (! is_null($response)) {
             $response->transformNotSuccessfulException($error);
         }
 


### PR DESCRIPTION
This removed the need to override `runTest()` method which is marked as `final` in the upcoming PHPUnit 11.