### PR TITLE
[10.x] Added matchPattern method to Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -860,7 +860,8 @@ class Str
                 ']', '|', ':', ';',
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
-        ]))->filter()->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
+        ]))->filter()->each(
+            fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
         )->flatten();
 
         $length = $length - $password->count();
@@ -1697,6 +1698,21 @@ class Str
 
         return $ulid;
     }
+
+    /**
+     * Get the matched result from the given string using the given pattern.
+     *
+     * @param  string  $pattern
+     * @param  string  $value
+     * @param  mixed  $default
+     * @return mixed
+    */
+    public static function matchPattern($pattern, $value, $default = null)
+    {
+        preg_match($pattern, $value, $matches);
+        return $matches[1] ?? $default;
+    }
+
 
     /**
      * Remove all strings from the casing caches.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -173,9 +173,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('[...]is a beautiful morn[...]', Str::excerpt('This is a beautiful morning', 'beautiful', ['omission' => '[...]', 'radius' => 5]));
         $this->assertSame(
             'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
-            Str::excerpt('This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
+            Str::excerpt(
+                'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?',
+                'very',
                 ['omission' => '[...]'],
-            ));
+            )
+        );
 
         $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
         $this->assertSame('...ayl...', Str::excerpt('taylor', 'Y', ['radius' => 1]));
@@ -1296,6 +1299,16 @@ class SupportStrTest extends TestCase
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }
+
+    public function testMatchPattern()
+    {
+        $this->assertEquals('John', Str::matchPattern('/name is (\w+)!/', 'Hello, my name is John!'));
+        $this->assertEquals('Doe', Str::matchPattern('/surname is (\w+)!/', 'Hello, my surname is Doe!'));
+        $this->assertNull(Str::matchPattern('/surname is (\w+)!/', 'Hello, my name is John!'));
+        $this->assertEquals('Unknown', Str::matchPattern('/surname is (\w+)!/', 'Hello, my name is John!', 'Unknown'));
+    }
+
+
 }
 
 class StringableObjectStub


### PR DESCRIPTION
### Introduction

This pull request introduces a new `matchPattern` method to the `Str` class. This method provides a simplified interface for extracting matches from strings using regular expressions, aiming to make common regex tasks more straightforward and readable.

### Implementation Details

- The method uses `preg_match` internally.
- It returns the first match by default or a provided default value if no match is found.
- The method signature is: `public static function matchPattern($pattern, $value, $default = null)`

### Usage Example:

```php
$result = Str::matchPattern('/name is (\w+)!/', 'Hello, my name is John!', 'Unknown');
echo $result;  // Outputs: John

