### PR TITLE
[10.x] Use ValidationException class from Validator Property

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -152,7 +152,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function failedValidation(Validator $validator)
     {
-        throw (new ValidationException($validator))
+        $exception = $validator->getException();
+
+        throw (new $exception($validator))
                     ->errorBag($this->errorBag)
                     ->redirectTo($this->getRedirectUrl());
     }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
-use Illuminate\Validation\ValidationException;
 
 class FormRequest extends Request implements ValidatesWhenResolved
 {

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -75,7 +75,9 @@ trait ValidatesWhenResolvedTrait
      */
     protected function failedValidation(Validator $validator)
     {
-        throw new ValidationException($validator);
+        $exception = $validator->getException();
+
+        throw new $exception($validator);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1482,6 +1482,16 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get the exception to throw upon failed validation.
+     *
+     * @return string
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
      * Set the exception to throw upon failed validation.
      *
      * @param  string  $exception

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -87,11 +87,26 @@ class ValidationExceptionTest extends TestCase
         $this->assertNull($exception->getResponse());
     }
 
+    public function testGetExceptionClassFromValidator()
+    {
+        $validator = $this->getValidator();
+
+        $exception = $validator->getException();
+
+        $this->assertEquals(ValidationException::class, $exception);
+    }
+
     protected function getException($data = [], $rules = [])
     {
-        $translator = new Translator(new ArrayLoader, 'en');
-        $validator = new Validator($translator, $data, $rules);
+        $validator = $this->getValidator($data, $rules);
 
         return new ValidationException($validator);
+    }
+
+    protected function getValidator($data = [], $rules = [])
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+
+        return new Validator($translator, $data, $rules);
     }
 }


### PR DESCRIPTION
Currently, the **Validator** class can take custom exception using `setException` method. So one can set custom `ValiadtorException` class as need and that will be used on validation error.

However in files **FormRequest.php** and **ValidatesWhenResolvedTrait.php**, the `ValidationException` class is hardcoded inside method `failedValidation()`. So if we use Form Requests, then it won't use the custom `ValidationException` class.

This PR makes it possible to use `ValidationException` class from the **Validator** class's *$exception* property. And it also makes possible to use custom exception fully throughout app.


**How one can use custom ValidationException**

By adding code like below in **boot** method of `AppServiceProvider`, you can use a custom validation exception.

```
\Illuminate\Support\Facades\Validator::resolver(function ($translator, $data, $rules, $messages, $customAttributes) {
    $validator = new \Illuminate\Validation\Validator($translator, $data, $rules, $messages, $customAttributes);
    $validator->setException(MyValidationException::class);
    return $validator;
});
```
