### PR TITLE
[10.x] Added ability to specify seperator on Arr::dot() and Arr::undot()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -105,6 +105,7 @@ class Arr
      *
      * @param  iterable  $array
      * @param  string  $prepend
+     * @param  string  $separator
      * @return array
      */
     public static function dot($array, $prepend = '', $separator = '.')
@@ -126,6 +127,7 @@ class Arr
      * Convert a flatten array into an expanded array. Defaults to a "dot" as a separator.
      *
      * @param  iterable  $array
+     * @param  string  $separator
      * @return array
      */
     public static function undot($array, $separator = '.')
@@ -694,6 +696,7 @@ class Arr
      * @param  array  $array
      * @param  string|int|null  $key
      * @param  mixed  $value
+     * @param  string  $separator
      * @return array
      */
     public static function set(&$array, $key, $value, $separator = '.')

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -101,7 +101,7 @@ class Arr
     }
 
     /**
-     * Flatten a multi-dimensional associative array with dots. (default)
+     * Flatten a multi-dimensional associative array with dots (default).
      *
      * @param  iterable  $array
      * @param  string  $prepend

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -101,7 +101,7 @@ class Arr
     }
 
     /**
-     * Flatten a multi-dimensional associative array with dots.
+     * Flatten a multi-dimensional associative array with dots. (default)
      *
      * @param  iterable  $array
      * @param  string  $prepend
@@ -123,7 +123,7 @@ class Arr
     }
 
     /**
-     * Convert a flatten "dot" notation array into an expanded array.
+     * Convert a flatten array into an expanded array. Defaults to a "dot" as a separator.
      *
      * @param  iterable  $array
      * @return array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -113,7 +113,7 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.$separator), $separator);
+                $results = array_merge($results, static::dot($value, $prepend.$key.$separator, $separator));
             } else {
                 $results[$prepend.$key] = $value;
             }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -107,13 +107,13 @@ class Arr
      * @param  string  $prepend
      * @return array
      */
-    public static function dot($array, $prepend = '')
+    public static function dot($array, $prepend = '', $separator = '.')
     {
         $results = [];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results = array_merge($results, static::dot($value, $prepend.$key.$separator));
             } else {
                 $results[$prepend.$key] = $value;
             }
@@ -128,12 +128,12 @@ class Arr
      * @param  iterable  $array
      * @return array
      */
-    public static function undot($array)
+    public static function undot($array, $separator = '.')
     {
         $results = [];
 
         foreach ($array as $key => $value) {
-            static::set($results, $key, $value);
+            static::set($results, $key, $value, $separator);
         }
 
         return $results;
@@ -696,13 +696,13 @@ class Arr
      * @param  mixed  $value
      * @return array
      */
-    public static function set(&$array, $key, $value)
+    public static function set(&$array, $key, $value, $separator = '.')
     {
         if (is_null($key)) {
             return $array = $value;
         }
 
-        $keys = explode('.', $key);
+        $keys = explode($separator, $key);
 
         foreach ($keys as $i => $key) {
             if (count($keys) === 1) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -113,7 +113,7 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.$separator));
+                $results = array_merge($results, static::dot($value, $prepend.$key.$separator), $separator);
             } else {
                 $results[$prepend.$key] = $value;
             }


### PR DESCRIPTION
Arr::dot() and Arr::undot() currently do not take any parameter to specify the separator to be used and default to a '.'.
However, in some extended use cases, an array name might need to contain a dot and use that dot as it is. With the current scenario, Arr::undot() separates those names too. With this PR, I introduced an optional parameter that can be used to specify what to use as a separator for  Arr::dot() and Arr::undot(). 

In order to provide backward compatibility the parameters have "." as the default value.

The end users will be able to use Arr::dot() and Arr::undot() more advanced if this PR is merged.

Kind regards,
