### PR TITLE
[10.x] Added ability to flatten and expand arrays similar to Arr:dot() and Arr::undot() but with custom keys.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -109,17 +109,7 @@ class Arr
      */
     public static function dot($array, $prepend = '')
     {
-        $results = [];
-
-        foreach ($array as $key => $value) {
-            if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
-            } else {
-                $results[$prepend.$key] = $value;
-            }
-        }
-
-        return $results;
+        return self::compress($array, $prepend);
     }
 
     /**
@@ -130,13 +120,7 @@ class Arr
      */
     public static function undot($array)
     {
-        $results = [];
-
-        foreach ($array as $key => $value) {
-            static::set($results, $key, $value);
-        }
-
-        return $results;
+        return self::expand($array);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -140,6 +140,47 @@ class Arr
     }
 
     /**
+     * Flatten a multi-dimensional associative array with a custom parameter.
+     *
+     * @param  iterable  $array
+     * @param  string  $prepend
+     * @param  string  $separator
+     * @return array
+     */
+    public static function compress($array, $prepend = '', $separator = '.')
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) && ! empty($value)) {
+                $results = array_merge($results, static::compress($value, $prepend.$key.$separator, $separator));
+            } else {
+                $results[$prepend.$key] = $value;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Convert a flatten array into an expanded array. Defaults to a "dot" as a separator.
+     *
+     * @param  iterable  $array
+     * @param  string  $separator
+     * @return array
+     */
+    public static function expand($array, $separator = '.')
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            static::set($results, $key, $value, $separator);
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array
@@ -696,13 +737,13 @@ class Arr
      * @param  mixed  $value
      * @return array
      */
-    public static function set(&$array, $key, $value)
+    public static function set(&$array, $key, $value, $separator = '.')
     {
         if (is_null($key)) {
             return $array = $value;
         }
 
-        $keys = explode('.', $key);
+        $keys = explode($separator, $key);
 
         foreach ($keys as $i => $key) {
             if (count($keys) === 1) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1224,4 +1224,41 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testDotArrow()
+    {
+        $array = Arr::compress(['foo' => ['bar' => 'baz', 'foobar' => 'foobaz']], separator: '->');
+        $this->assertEquals(['foo->bar' => 'baz', 'foo->foobar' => 'foobaz'], $array);
+
+        $array = Arr::compress([], separator: '->');
+        $this->assertEquals([], $array);
+
+        $array = Arr::compress(['foo' => []], separator: '->');
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::compress(['foo' => ['bar' => []]], separator: '->');
+        $this->assertEquals(['foo->bar' => []], $array);
+    }
+
+    public function testDotUnarrow()
+    {
+        $array = Arr::expand([
+            'foo->bar' => 'test',
+            'foo->baz->bob' => 'Bob',
+            'foo->baz->alice' => 'Alice',
+            'foo->languages->0' => 'PHP',
+            'foo->languages->1' => 'C#',
+        ], '->');
+
+        $this->assertEquals([
+            'foo' => [
+                'bar' => 'test',
+                'baz' => [
+                    'bob' => 'Bob',
+                    'alice' => 'Alice',
+                ],
+                'languages' => ['PHP', 'C#'],
+            ],
+        ], $array);
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1225,7 +1225,7 @@ class SupportArrTest extends TestCase
         ], Arr::prependKeysWith($array, 'test.'));
     }
 
-    public function testDotArrow()
+    public function testCompressArrow()
     {
         $array = Arr::compress(['foo' => ['bar' => 'baz', 'foobar' => 'foobaz']], separator: '->');
         $this->assertEquals(['foo->bar' => 'baz', 'foo->foobar' => 'foobaz'], $array);
@@ -1240,7 +1240,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo->bar' => []], $array);
     }
 
-    public function testDotUnarrow()
+    public function testExpandUnarrow()
     {
         $array = Arr::expand([
             'foo->bar' => 'test',


### PR DESCRIPTION
Arr::dot() and Arr::undot() currently do not take any parameter to specify the separator to be used and default to a '.'.
However, in some extended use cases, an array name might need to contain a dot and use it as it is. With the current scenario, Arr::undot() separates those names too. With this PR, I introduced two similar methods to dot() and undot() that can be used to specify what to use as a separator unlike Arr::dot() and Arr::undot().

The end users will be able to use these methods in advanced use cases where Arr::dot() and Arr::undot() are not sufficient.

I was planning to name the method flatten but it's already been used. Therefore, I named it compress.

**Based on discussion at PR:**
https://github.com/laravel/framework/pull/48739

**Tests based on: (Note: This also shows that other users seek similar functionality #48739)**
https://github.com/laravel/framework/pull/48334

Kind regards,