### PR TITLE
[10.x] Cookies Having Independent Partitioned State (CHIPS)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/console": "^6.2",
         "symfony/error-handler": "^6.2",
         "symfony/finder": "^6.2",
-        "symfony/http-foundation": "^6.3",
+        "symfony/http-foundation": "^6.4",
         "symfony/http-kernel": "^6.2",
         "symfony/mailer": "^6.2",
         "symfony/mime": "^6.2",

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -196,9 +196,16 @@ class EncryptCookies
     protected function duplicate(Cookie $cookie, $value)
     {
         return new Cookie(
-            $cookie->getName(), $value, $cookie->getExpiresTime(),
-            $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(),
-            $cookie->isHttpOnly(), $cookie->isRaw(), $cookie->getSameSite()
+            $cookie->getName(),
+            $value,
+            $cookie->getExpiresTime(),
+            $cookie->getPath(),
+            $cookie->getDomain(),
+            $cookie->isSecure(),
+            $cookie->isHttpOnly(),
+            $cookie->isRaw(),
+            $cookie->getSameSite(),
+            $cookie->isPartitioned()
         );
     }
 

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -195,18 +195,7 @@ class EncryptCookies
      */
     protected function duplicate(Cookie $cookie, $value)
     {
-        return new Cookie(
-            $cookie->getName(),
-            $value,
-            $cookie->getExpiresTime(),
-            $cookie->getPath(),
-            $cookie->getDomain(),
-            $cookie->isSecure(),
-            $cookie->isHttpOnly(),
-            $cookie->isRaw(),
-            $cookie->getSameSite(),
-            $cookie->isPartitioned()
-        );
+        return $cookie->withValue($value);
     }
 
     /**

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
         "illuminate/support": "^10.0",
-        "symfony/http-foundation": "^6.2",
+        "symfony/http-foundation": "^6.4",
         "symfony/http-kernel": "^6.2"
     },
     "autoload": {

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -211,7 +211,8 @@ class VerifyCsrfToken
             $config['secure'],
             false,
             false,
-            $config['same_site'] ?? null
+            $config['same_site'] ?? null,
+            $config['partitioned'] ?? false
         );
     }
 

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -22,7 +22,7 @@
         "illuminate/macroable": "^10.0",
         "illuminate/session": "^10.0",
         "illuminate/support": "^10.0",
-        "symfony/http-foundation": "^6.2",
+        "symfony/http-foundation": "^6.4",
         "symfony/http-kernel": "^6.2",
         "symfony/mime": "^6.2"
     },

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -25,7 +25,7 @@
         "illuminate/pipeline": "^10.0",
         "illuminate/session": "^10.0",
         "illuminate/support": "^10.0",
-        "symfony/http-foundation": "^6.2",
+        "symfony/http-foundation": "^6.4",
         "symfony/http-kernel": "^6.2",
         "symfony/routing": "^6.2"
     },

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -219,9 +219,16 @@ class StartSession
     {
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
-                $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], $config['secure'] ?? false,
-                $config['http_only'] ?? true, false, $config['same_site'] ?? null
+                $session->getName(),
+                $session->getId(),
+                $this->getCookieExpirationDate(),
+                $config['path'],
+                $config['domain'],
+                $config['secure'] ?? false,
+                $config['http_only'] ?? true,
+                false,
+                $config['same_site'] ?? null,
+                $config['partitioned'] ?? false
             ));
         }
     }

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -22,7 +22,7 @@
         "illuminate/filesystem": "^10.0",
         "illuminate/support": "^10.0",
         "symfony/finder": "^6.2",
-        "symfony/http-foundation": "^6.2"
+        "symfony/http-foundation": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -497,7 +497,8 @@ class TestResponse implements ArrayAccess
                     $cookie->isSecure(),
                     $cookie->isHttpOnly(),
                     $cookie->isRaw(),
-                    $cookie->getSameSite()
+                    $cookie->getSameSite(),
+                    $cookie->isPartitioned()
                 );
             }
         }

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -25,7 +25,7 @@
         "illuminate/macroable": "^10.0",
         "illuminate/support": "^10.0",
         "illuminate/translation": "^10.0",
-        "symfony/http-foundation": "^6.2",
+        "symfony/http-foundation": "^6.4",
         "symfony/mime": "^6.2"
     },
     "autoload": {


### PR DESCRIPTION
Implementation of upcoming `partitioned` cookie flag from https://github.com/symfony/symfony/pull/52002.

The modifaction of `Illuminate\Cookie\CookieJar` and `Illuminate\Cookie\CookieServiceProvider` is excluded in this PR since it would require a lot of forward compatibility changes. I would omit these changes in 10.x and extend the signatures with 11.x (possible BC).

Further, there is a separate commit for a cleanup in cookie duplication. Currently, the duplication instantiates a new cookie by passing all attributes again. This is prone to loss of new cookie attributes. It could be simplified to `withValue()` only since this already duplicates the object.

**This PR remains a draft until release of symfony 6.4!**