### PR TITLE
[10.x] Update annotations in wrap method to accommodate Collection instances

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -53,7 +53,7 @@ class ResourceResponse implements Responsable
     /**
      * Wrap the given data if necessary.
      *
-     * @param  array  $data
+     * @param  \Illuminate\Support\Collection|array  $data
      * @param  array  $with
      * @param  array  $additional
      * @return array


### PR DESCRIPTION
Update the annotations for the `wrap` method to reflect that the `$data` parameter can be either an array or an instance of the `Collection` class.

This method can handle Collections too:
```
if ($data instanceof Collection) {
    $data = $data->all();
}
```

