### PR TITLE
[10.x] Refactor assertStructure Method

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -287,7 +287,7 @@ class AssertableJsonString implements ArrayAccess, Countable
             } elseif (is_array($value)) {
                 PHPUnit::assertArrayHasKey($key, $this->decoded);
 
-                $this->assertStructure($structure[$key], $this->decoded[$key]);
+                $this->assertStructure($value, $this->decoded[$key]);
             } else {
                 PHPUnit::assertArrayHasKey($value, $this->decoded);
             }


### PR DESCRIPTION
Replace `$structure[$key]` with `$value` as they hold the same data during each iteration of the `foreach`.
And `$value` also is used in `assertArrayHasKey`