### PR TITLE
refactor: stub traits in psr-12 standard

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -12,7 +12,9 @@ use Illuminate\Queue\SerializesModels;
 
 class {{ class }}
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Foundation/Console/stubs/job.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.queued.stub
@@ -11,7 +11,10 @@ use Illuminate\Queue\SerializesModels;
 
 class {{ class }} implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
     /**
      * Create a new job instance.

--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -11,7 +11,8 @@ use Illuminate\Queue\SerializesModels;
 
 class {{ class }} extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     /**
      * Create a new message instance.

--- a/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
@@ -11,7 +11,8 @@ use Illuminate\Queue\SerializesModels;
 
 class {{ class }} extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     /**
      * Create a new message instance.


### PR DESCRIPTION
PSR-12: Extended Coding Style - 4.2 Using traits:

> Each individual trait that is imported into a class MUST be included one-per-line and each inclusion MUST have its own `use` import statement.

See: https://www.php-fig.org/psr/psr-12/#42-using-traits
