### PR TITLE
[10.x] Add runningConsoleCommand(...$commands) method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -710,6 +710,24 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Determine if the application is running any of the given console commands.
+     *
+     * @param  string|array  ...$commands
+     * @return bool
+     */
+    public function runningConsoleCommand(...$commands)
+    {
+        if (! $this->runningInConsole()) {
+            return false;
+        }
+
+        return in_array(
+            $_SERVER['argv'][1] ?? null,
+            is_array($commands[0]) ? $commands[0] : $commands
+        );
+    }
+
+    /**
      * Determine if the application is running unit tests.
      *
      * @return bool

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -38,6 +38,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool isProduction()
  * @method static string detectEnvironment(\Closure $callback)
  * @method static bool runningInConsole()
+ * @method static bool runningConsoleCommand(string|array ...$commands)
  * @method static bool runningUnitTests()
  * @method static bool hasDebugModeEnabled()
  * @method static void registerConfiguredProviders()


### PR DESCRIPTION
# What
This PR adds a method `runningConsoleCommand(...$commands)` which returns `true` if the application is running a given artisan console command.

Note: This is the same as https://github.com/laravel/framework/pull/48731 except I decided not to update the interface so it can be released in 10.x.

# How to Use
The method can be used like so:

```php
app()->runningConsoleCommand('db:seed'); // True if running db:seed
app()->runningConsoleCommand('db:seed', 'migrate:fresh'); // True if running db:seed OR migrate:fresh
app()->runningConsoleCommand(['db:seed', 'migrate:fresh']); // Also accepts arrays
```

# Why
In our local environment we enable things like [PreventLazyLoading](https://laravel.com/docs/10.x/eloquent-relationships#preventing-lazy-loading) and [PreventSilentlyDiscardingAttributes](https://laravel.com/docs/10.x/eloquent#configuring-eloquent-strictness). We ran into an issue where our Seeders were throwing these exceptions, and wanted a way to disable them when seeding the database. But there wasn't an easy way to determine if the `db:seed` or the `migrate:fresh` commands were being run.

Methods with similar purposes are `app()->runningInConsole()` and `app()->runningUnitTests()`.

# Inspiration
This code is based on a similar method already present in [laravel/telescope](https://github.com/laravel/telescope/blob/3a250a44faa89ba4790ad6207060e90f79f49d1e/src/Telescope.php#L171-L190):

```php
    /**
     * Determine if the application is running an approved command.
     *
     * @param  \Illuminate\Foundation\Application  $app
     * @return bool
     */
    protected static function runningApprovedArtisanCommand($app)
    {
        return $app->runningInConsole() && ! in_array(
            $_SERVER['argv'][1] ?? null,
            array_merge([
                // 'migrate',
                'migrate:rollback',
                'migrate:fresh',
                // 'migrate:refresh',
                'migrate:reset',
                'migrate:install',
                'package:discover',
                'queue:listen',
                'queue:work',
                'horizon',
                'horizon:work',
                'horizon:supervisor',
            ], config('telescope.ignoreCommands', []), config('telescope.ignore_commands', []))
        );
    }
```