### PR TITLE
[10.x] Add `getSchemaState` stub to Connection class

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -289,10 +289,12 @@ class Connection implements ConnectionInterface
      * @param  \Illuminate\Filesystem\Filesystem|null  $files
      * @param  callable|null  $processFactory
      * @return \Illuminate\Database\Schema\SchemaState|null
+     *
+     * @throws \RuntimeException
      */
     public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
     {
-        //
+        throw new RuntimeException('Database connection does not define a schema state.');
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Traits\Macroable;
@@ -278,6 +279,18 @@ class Connection implements ConnectionInterface
      * @return \Illuminate\Database\Schema\Grammars\Grammar|null
      */
     protected function getDefaultSchemaGrammar()
+    {
+        //
+    }
+
+    /**
+     * Get the schema state for the connection.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem|null  $files
+     * @param  callable|null  $processFactory
+     * @return \Illuminate\Database\Schema\SchemaState|null
+     */
+    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
     {
         //
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This PR adds the `getSchemaState` stub to the parent `Connection` class. All connection implementations define this method, but PHPStan throws an error when this method is called on a `Connection` instance. This stub will allow PHPStan to recognize that this method is defined on the parent class.

Thanks!