### PR TITLE
[10.x] Moves logger instance creation to a protected method

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -302,7 +302,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         try {
-            $logger = $this->makeLogger();
+            $logger = $this->newLogger();
         } catch (Exception) {
             throw $e;
         }
@@ -874,13 +874,11 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Creates a new logger instance.
+     * Create a new logger instance.
      *
      * @return \Psr\Log\LoggerInterface
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function makeLogger()
+    protected function newLogger()
     {
         return $this->container->make(LoggerInterface::class);
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -302,7 +302,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         try {
-            $logger = $this->container->make(LoggerInterface::class);
+            $logger = $this->makeLogger();
         } catch (Exception) {
             throw $e;
         }
@@ -871,5 +871,17 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Throwable $e)
     {
         return $e instanceof HttpExceptionInterface;
+    }
+
+    /**
+     * Creates a new logger instance.
+     *
+     * @return \Psr\Log\LoggerInterface
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    protected function makeLogger()
+    {
+        return $this->container->make(LoggerInterface::class);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR:

- Adds a new protected method to the `Illuminate\Foundation\Exceptions\Handler` class: `makeLogger()`
  - This method allows user-land code to easily override the `LoggerInterface` instance used to report an exception
  - One scenario is when exceptions should be reported to a channel different from the other logging activities within a project
- No tests were added, as it is just a simple method extraction

