### PR TITLE
[10.x] Fix `replaceMatches` in Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1150,7 +1150,7 @@ class Str
      * @param  int  $limit
      * @return string|string[]|null
      */
-    public function replaceMatches($pattern, $replace, $subject, $limit = -1)
+    public static function replaceMatches($pattern, $replace, $subject, $limit = -1)
     {
         if ($replace instanceof Closure) {
             return preg_replace_callback($pattern, $replace, $subject, $limit);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request resolves the previous issue with PR #48727, where the 'static' keyword was missing. I forgot to include it.
