### PR TITLE
[10.x] Uses `stefanzweifel/git-auto-commit-action@v5`

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -81,7 +81,7 @@ jobs:
             Illuminate\\Support\\Facades\\Vite
 
       - name: Commit facade docblocks
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update facade docblocks
           file_pattern: src/


### PR DESCRIPTION
This pull request bumps the `stefanzweifel/git-auto-commit-action` from 4 to 5.