### PR TITLE
[10.x] Add conflict for DBAL 4

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -224,7 +224,7 @@ abstract class DatabaseInspectionCommand extends Command
     protected function installDependencies()
     {
         $command = collect($this->composer->findComposer())
-            ->push('require doctrine/dbal')
+            ->push('require doctrine/dbal^3.5.1')
             ->implode(' ');
 
         $process = Process::fromShellCommandline($command, null, null, null, null);

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -24,6 +24,9 @@
         "illuminate/macroable": "^10.0",
         "illuminate/support": "^10.0"
     },
+    "conflict": {
+        "doctrine/dbal": ">=4"
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Database\\": ""


### PR DESCRIPTION
Based on #48752 I assume that Laravel v10 will not support DBAL 4.

I therefor added `doctrine/dbal` to conflicts and also added v3 constraints to the `DatabaseInspectionCommand`

Ping @crynobone as the DBAL 4 PR is from you.