### PR TITLE
[10.x] Require DBAL 3 when installing

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -224,7 +224,7 @@ abstract class DatabaseInspectionCommand extends Command
     protected function installDependencies()
     {
         $command = collect($this->composer->findComposer())
-            ->push('require doctrine/dbal')
+            ->push('require doctrine/dbal:^3.5.1')
             ->implode(' ');
 
         $process = Process::fromShellCommandline($command, null, null, null, null);


### PR DESCRIPTION
Based on https://github.com/laravel/framework/pull/48752 I assume that Laravel v10 will not support DBAL 4.

While a conflict statement in composer.json is not possible (because composer would downgrade the versions), the require command should install only DBAL 3.