### PR TITLE
[10.x] fix typo in comment

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -111,7 +111,7 @@ class AuthenticateSession implements AuthenticatesSessions
     }
 
     /**
-     * Get the path the user should be redirected to when their session is not autheneticated.
+     * Get the path the user should be redirected to when their session is not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return string|null


### PR DESCRIPTION
`autheneticated` → `authenticated`