### PR TITLE
[11.x] Allow `Str::limit` to include ellipsis in length calculation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -567,20 +567,15 @@ class Str
      * @param  string  $value
      * @param  int  $limit
      * @param  string  $end
-     * @param  bool  $limitIncludesEnd
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...', $limitIncludesEnd = false)
+    public static function limit($value, $limit = 100, $end = '...')
     {
-        $width = mb_strwidth($value, 'UTF-8');
-
-        if ($width <= $limit) {
+        if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
         }
 
-        if ($limitIncludesEnd) {
-            $limit = $limit - mb_strwidth($end, 'UTF-8');
-        }
+        $limit = $limit - mb_strwidth($end, 'UTF-8');
 
         return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -567,12 +567,19 @@ class Str
      * @param  string  $value
      * @param  int  $limit
      * @param  string  $end
+     * @param  bool  $limitIncludesEnd
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...')
+    public static function limit($value, $limit = 100, $end = '...', $limitIncludesEnd = false)
     {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+        $width = mb_strwidth($value, 'UTF-8');
+
+        if ($width <= $limit) {
             return $value;
+        }
+
+        if ($limitIncludesEnd) {
+            $limit = $limit - mb_strwidth($end, 'UTF-8');
         }
 
         return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -586,7 +586,7 @@ class SupportHelpersTest extends TestCase
 
         $strAccessor = str();
         $this->assertTrue((new ReflectionClass($strAccessor))->isAnonymous());
-        $this->assertSame($strAccessor->limit('string-value', 3), 'str...');
+        $this->assertSame($strAccessor->limit('string-value', 6), 'str...');
 
         $strAccessor = str();
         $this->assertTrue((new ReflectionClass($strAccessor))->isAnonymous());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -488,7 +488,10 @@ class SupportStrTest extends TestCase
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', Str::limit($string, 7));
         $this->assertSame('The PHP', Str::limit($string, 7, ''));
-        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
+        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 35));
+        $this->assertSame('The PHP framework for web artisans...', Str::limit($string, 34));
+        $this->assertSame('The PHP framework for web artis...', Str::limit($string, 34, '...', true));
+        $this->assertSame('The PHP framework for web artisan…', Str::limit($string, 34, '…', true));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -482,19 +482,18 @@ class SupportStrTest extends TestCase
 
     public function testLimit()
     {
-        $this->assertSame('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 10));
-        $this->assertSame('这是一...', Str::limit('这是一段中文', 6));
+        $this->assertSame('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 13));
+        $this->assertSame('这是一...', Str::limit('这是一段中文', 9));
 
         $string = 'The PHP framework for web artisans.';
-        $this->assertSame('The PHP...', Str::limit($string, 7));
+        $this->assertSame('The PHP...', Str::limit($string, 10));
         $this->assertSame('The PHP', Str::limit($string, 7, ''));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 35));
-        $this->assertSame('The PHP framework for web artisans...', Str::limit($string, 34));
-        $this->assertSame('The PHP framework for web artis...', Str::limit($string, 34, '...', true));
-        $this->assertSame('The PHP framework for web artisan…', Str::limit($string, 34, '…', true));
+        $this->assertSame('The PHP framework for web artis...', Str::limit($string, 34));
+        $this->assertSame('The PHP framework for web artisan…', Str::limit($string, 34, '…'));
 
         $nonAsciiString = '这是一段中文';
-        $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
+        $this->assertSame('这是一...', Str::limit($nonAsciiString, 9));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -814,17 +814,17 @@ class SupportStringableTest extends TestCase
     public function testLimit()
     {
         $this->assertSame('Laravel is...',
-            (string) $this->stringable('Laravel is a free, open source PHP web application framework.')->limit(10)
+            (string) $this->stringable('Laravel is a free, open source PHP web application framework.')->limit(13)
         );
-        $this->assertSame('这是一...', (string) $this->stringable('这是一段中文')->limit(6));
+        $this->assertSame('这是一...', (string) $this->stringable('这是一段中文')->limit(9));
 
         $string = 'The PHP framework for web artisans.';
-        $this->assertSame('The PHP...', (string) $this->stringable($string)->limit(7));
+        $this->assertSame('The PHP...', (string) $this->stringable($string)->limit(10));
         $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, ''));
         $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(100));
 
         $nonAsciiString = '这是一段中文';
-        $this->assertSame('这是一...', (string) $this->stringable($nonAsciiString)->limit(6));
+        $this->assertSame('这是一...', (string) $this->stringable($nonAsciiString)->limit(9));
         $this->assertSame('这是一', (string) $this->stringable($nonAsciiString)->limit(6, ''));
     }
 


### PR DESCRIPTION
Right now `Str::limit()` checks the limit before appending the `$end` (three dots, or a faux-ellipsis, by default) to the string. This can result in strings that are truncated and over the limit…

### Before:
```php
Str::limit('Hello world', 10);

// Results in "Hello worl..." which is 13 characters in total
```

This PR includes the length of the `$end` argument in the calculation:

### After:

```php
Str::limit('Hello world', 10);

// Results in "Hello w..." which is 10 characters in total, including the three dots
```