### PR TITLE
[10.x] Enhancing Laravel Blade Component Attributes with filterByPrefix

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -164,10 +164,11 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
     /**
      * Filter the attributes, returning a bag of attributes start with the prefix without the prefix.
      *
-     * @param string $prefix
+     * @param  string  $prefix
      * @return static
      */
-    public function filterByPrefix(string $prefix): static {
+    public function filterByPrefix(string $prefix): static 
+    {
         $inputAttributes = collect($this->whereStartsWith($prefix)->getAttributes())
             ->mapWithKeys(fn ($value, $key) => [str_replace($prefix, '', $key) => $value])
             ->toArray();

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -167,7 +167,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      * @param  string  $prefix
      * @return static
      */
-    public function filterByPrefix(string $prefix): static 
+    public function filterByPrefix(string $prefix): static
     {
         $inputAttributes = collect($this->whereStartsWith($prefix)->getAttributes())
             ->mapWithKeys(fn ($value, $key) => [str_replace($prefix, '', $key) => $value])

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -266,6 +266,14 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
         return $this->merge(['style' => Arr::toCssStyles($styleList)]);
     }
 
+    public function filterByPrefix(string $prefix): self {
+        $inputAttributes = collect($this->whereStartsWith($prefix)->getAttributes())
+            ->mapWithKeys(fn ($value, $key) => [str_replace($prefix, '', $key) => $value])
+            ->toArray();
+
+        return new self($inputAttributes);
+    }
+
     /**
      * Merge additional attributes / values into the attribute bag.
      *

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -161,6 +161,14 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
         return new static(collect($this->attributes)->filter($callback)->all());
     }
 
+    public function filterByPrefix(string $prefix): self {
+        $inputAttributes = collect($this->whereStartsWith($prefix)->getAttributes())
+            ->mapWithKeys(fn ($value, $key) => [str_replace($prefix, '', $key) => $value])
+            ->toArray();
+
+        return new static($inputAttributes);
+    }
+
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.
      *
@@ -264,14 +272,6 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
         $styleList = Arr::wrap($styleList);
 
         return $this->merge(['style' => Arr::toCssStyles($styleList)]);
-    }
-
-    public function filterByPrefix(string $prefix): self {
-        $inputAttributes = collect($this->whereStartsWith($prefix)->getAttributes())
-            ->mapWithKeys(fn ($value, $key) => [str_replace($prefix, '', $key) => $value])
-            ->toArray();
-
-        return new self($inputAttributes);
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -161,7 +161,13 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
         return new static(collect($this->attributes)->filter($callback)->all());
     }
 
-    public function filterByPrefix(string $prefix): self {
+    /**
+     * Filter the attributes, returning a bag of attributes start with the prefix without the prefix.
+     *
+     * @param string $prefix
+     * @return static
+     */
+    public function filterByPrefix(string $prefix): static {
         $inputAttributes = collect($this->whereStartsWith($prefix)->getAttributes())
             ->mapWithKeys(fn ($value, $key) => [str_replace($prefix, '', $key) => $value])
             ->toArray();

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -101,6 +101,17 @@ class ViewComponentAttributeBagTest extends TestCase
             'test-extract-1',
             'test-extract-2' => 'defaultValue',
         ]));
+
+        $bag = (new ComponentAttributeBag([
+            'box:class' => 'bg-yellow-500 text-yellow-900',
+            'msg:class' => 'italic',
+            'link:url' => '#',
+            'link:class' => 'underline',
+            'link:label' => 'label'
+        ]));
+
+        $this->assertSame('class="underline" label="label"', (string) $bag->except('link:url')->filterByPrefix('link:'));
+
     }
 
     public function testItMakesAnExceptionForAlpineXdata()

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -111,7 +111,6 @@ class ViewComponentAttributeBagTest extends TestCase
         ]));
 
         $this->assertSame('class="underline" label="label"', (string) $bag->except('link:url')->filterByPrefix('link:'));
-
     }
 
     public function testItMakesAnExceptionForAlpineXdata()

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -107,7 +107,7 @@ class ViewComponentAttributeBagTest extends TestCase
             'msg:class' => 'italic',
             'link:url' => '#',
             'link:class' => 'underline',
-            'link:label' => 'label'
+            'link:label' => 'label',
         ]));
 
         $this->assertSame('class="underline" label="label"', (string) $bag->except('link:url')->filterByPrefix('link:'));


### PR DESCRIPTION
## Summary

**Component:** ComponentAttributeBag

**Change Proposed:** Introducing `filterByPrefix` function to extract and manage attributes with specific prefixes.

## Rationale for `filterByPrefix` Function

In Blade components, the standard approach involves using named props and slots for customizing components. However, in certain cases, this method may prove insufficient to meet the specific requirements of a highly flexible and granular customization, e.g. when the types of attributes a user would like to offer are not know yet. An example for this may be libraries like Laravel Livewire or htmx which add custom attributes.

This PR introduces the `filterByPrefix` function within the `ComponentAttributeBag` class to address these limitations.

## Challenges with Slots and Named Props

While named props and slots are effective for customizing components, they fall short in scenarios that demand precise control over individual attributes, especially when dealing with different sections or parts of a component. In such cases, relying solely on named props and slots could result in a cluttered component API and hinder maintainability.

Considering a hypothetical component called `ProductCard` that displays product information. It has several parts, each with its own set of attributes:

1. **Product Image**: Requires attributes like `src`, `alt`, and `class` for styling.
2. **Product Title**: Needs attributes like `class` for styling.
3. **Product Description**: Needs attributes like `class` for styling.
4. **Product Price**: Requires attributes like `class` for styling and `currency` for formatting.
5. **Product Rating**: Requires attributes like `class` for styling.

Using named props and slots, you might structure the `ProductCard` component like this:

```blade
<x-product-card
    image-src="product-image.jpg"
    image-alt="Product Image"
    image-class="rounded-lg"

    title-class="text-lg font-semibold"
    description-class="text-sm"
    price-class="text-xl font-bold"
    price-currency="$"

    rating-class="text-yellow-500"
>
    <x-slot name="title">Product Title</x-slot>
    <x-slot name="description">Product Description</x-slot>
    <x-slot name="price">19.99</x-slot>
    <x-slot name="rating">4.5</x-slot>
</x-product-card>
```
The above approach does provide some degree of customization for each section of the `ProductCard`. However, it has several drawbacks:

1. **API Clutter**: The abundance of named props (`image-src`, `image-alt`, etc.) can confuse users and make the component's usage less clear.

2. **Granularity Hurdle**: Achieving precision in styling is challenging. Applying different styles to specific elements within sections requires additional named props, compounding the clutter.

3. **Maintenance Complexity**: As sections and attributes accumulate, managing and documenting the component becomes more intricate.

## The `filterByPrefix` Solution

To address these challenges and provide more precise attribute control without cluttering the API, the `filterByPrefix` function is introduced. With this function, you can manage attributes for each section more granularly without adding a multitude of named props. Here's how the same `ProductCard` could be customized using `filterByPrefix`:

```blade
<x-product-card
    image:src="product-image.jpg"
    image:alt="Product Image"
    image:class="rounded-lg"

    title:class="text-lg font-semibold"
    description:class="text-sm"
    price:class="text-xl font-bold"
    price:currency="$"

    rating:class="text-yellow-500"
>
    <x-slot name="title">Product Title</x-slot>
    <x-slot name="description">Product Description</x-slot>
    <x-slot name="price">19.99</x-slot>
    <x-slot name="rating">4.5</x-slot>
</x-product-card>
```

With an implementation like this:
```blade
<div>
    <img {{ $attributes->filterByPrefix('img:')->merge(['class' => 'some classes']) }}
    <h2 {{ $attributes->filterByPrefix('title:') }}>{{ $title }}</h2>
    <p {{ $attributes->filterByPrefix('description:') }}>
        {{ $description }}
    </p>
    <p {{ $attributes->except('price:currency')->filterByPrefix('price:') }}>
        {{ $price }} {{ $attributes->get('price:currency', '€') }}
    </p>
    <p {{ $attributes->filterByPrefix('rating:')->except('unit') }}>
        {{ $rating }} {{ $attributes->get('rating:unit', '★') }}
    </p>
</div>
```

In this updated approach, the `filterByPrefix` function allows for more structured and precise control over attributes for each section. It's cleaner, more maintainable, and provides the desired granularity of customization without introducing excessive complexity to the component's API.

## Summary
- Introduced `filterByPrefix` in `ComponentAttributeBag`.
- Addressed limitations of named props, slots, and their combination.
- Showcased how `filterByPrefix` enhances component flexibility.
- PHPUnit tests for this change were written.

## Closing notes

This PR is based on [this blog post](https://jeffochoa.me/efficient-laravel-blade-components-reusability-customization) by @jeffochoa.