### PR TITLE
[10.x] Add `displayName` for queued Artisan commands

### DIFF
--- a/src/Illuminate/Foundation/Console/QueuedCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedCommand.php
@@ -47,6 +47,6 @@ class QueuedCommand implements ShouldQueue
      */
     public function displayName()
     {
-        return $this->data[0];
+        return array_values($this->data)[0];
     }
 }

--- a/src/Illuminate/Foundation/Console/QueuedCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedCommand.php
@@ -39,4 +39,14 @@ class QueuedCommand implements ShouldQueue
     {
         $kernel->call(...array_values($this->data));
     }
+
+    /**
+     * Get the display name for the queued job.
+     *
+     * @return string
+     */
+    public function displayName()
+    {
+        return $this->data[0];
+    }
 }

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Integration\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Console\QueuedCommand;
+use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
 
 class ConsoleApplicationTest extends TestCase
@@ -64,6 +66,19 @@ class ConsoleApplicationTest extends TestCase
         $this->artisan('foo:schedule');
 
         $this->assertTrue($this->app->resolved(Schedule::class));
+    }
+
+    public function testArtisanQueue()
+    {
+        Queue::fake();
+
+        $this->app[Kernel::class]->queue('foo:bar', [
+            'id' => 1,
+        ]);
+
+        Queue::assertPushed(QueuedCommand::class, function ($job) {
+            return $job->displayName() === 'foo:bar';
+        });
     }
 }
 


### PR DESCRIPTION
This PR adds a `displayName` method for commands queued using the `Artisan::queue` method that allows the underlying command name to be used for display purposes.

This matches other queued wrappers:

* https://github.com/laravel/framework/blob/a47df681bf4b72cb11e38f7ee7c285406ca934e0/src/Illuminate/Events/CallQueuedListener.php#L159-L167
* https://github.com/laravel/framework/blob/a47df681bf4b72cb11e38f7ee7c285406ca934e0/src/Illuminate/Queue/CallQueuedClosure.php#L100-L111
* https://github.com/laravel/framework/blob/a47df681bf4b72cb11e38f7ee7c285406ca934e0/src/Illuminate/Mail/SendQueuedMailable.php#L121-L129
* https://github.com/laravel/framework/blob/a47df681bf4b72cb11e38f7ee7c285406ca934e0/src/Illuminate/Notifications/SendQueuedNotifications.php#L115-L123