### PR TITLE
[10.x] Add Arr::filled

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -298,6 +298,34 @@ class Arr
     }
 
     /**
+     * Check if an item or items are filled in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function filled($array, $keys)
+    {
+        $keys = (array) $keys;
+
+        if (! $array || $keys === []) {
+            return false;
+        }
+
+        if (! static::has($array, $keys)) {
+            return false;
+        }
+
+        foreach ($keys as $key) {
+            if (blank(static::get($array, $key))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -323,6 +323,59 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
     }
 
+    public function testFilled()
+    {
+        // Test filled value
+        $array = ['products' => [
+            'desk' => ['price' => 100],
+            'chair' => ['price' => 0],
+            'closet' => ['price' => '0'],
+        ]];
+        $this->assertTrue(Arr::filled($array, 'products.desk.price'));
+        $this->assertTrue(Arr::filled($array, ['products.chair.price']));
+        $this->assertTrue(Arr::filled($array, ['products.closet.price']));
+        $this->assertTrue(Arr::filled($array, ['products.desk.price', 'products.chair.price', 'products.closet.price']));
+
+        // Test blank value
+        $array = [
+            'products' => [
+                'desk' => ['price' => null],
+                'chair' => ['price' => ''],
+                'closet' => ['price' => ' '],
+            ],
+        ];
+        $this->assertFalse(Arr::filled($array, 'products.desk.price'));
+        $this->assertFalse(Arr::filled($array, 'products.chair.price'));
+        $this->assertFalse(Arr::filled($array, 'products.closet.price'));
+        $this->assertFalse(Arr::filled($array, [
+            'products.desk.price',
+            'products.chair.price',
+        ]));
+
+        // Test missing keys in array
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        $this->assertFalse(Arr::filled($array, 'products.chair.price'));
+        $this->assertFalse(Arr::filled($array, [
+            'products.desk.price',
+            'products.chair.price',
+            'products.closet.price',
+        ]));
+
+        // Test array containing ArrayAccess object
+        $array = new ArrayObject(['products' => [
+            'desk' => ['price' => 100],
+            'chair' => ['price' => 100],
+        ]]);
+        $this->assertTrue(Arr::filled($array, 'products'));
+        $this->assertFalse(Arr::filled($array, 'items'));
+
+        $this->assertTrue(Arr::filled($array, 'products.desk.price'));
+        $this->assertFalse(Arr::filled($array, 'products.closet.price'));
+
+        $this->assertTrue(Arr::filled($array, ['products.desk', 'products.chair']));
+        $this->assertFalse(Arr::filled($array, ['products.desk', 'products.closet']));
+    }
+
     public function testGet()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
I suggest to implement `filled` method to `\Illuminate\Support\Arr`.

This method will help avoid additional checks when you need conditions: has key in array and not empty value. With this you can call `Arr::filled()` instead of `Arr::has()` and `filled(Arr::get())`. Obviously in dot notation.

See my example with code comments:

```php
if (
    Arr::has($array, ['sort.field_name', 'sort.direction']) // if has values by keys

    && filled(Arr::get($array, 'sort.field_name')) // and if not empty
    && filled(Arr::get($array, 'sort.direction')) // and if not empty
) {
    // call sort function in my class
    $query = $this->sort(
        query: $query,
        fieldName: Arr::get($array, 'sort.field_name'),
        direction: Arr::get($array, 'sort.direction')
    );
}
```

After implementation `Arr::filled()` i got:

```php
if (Arr::filled($array, ['sort.field_name', 'sort.direction'])) {
    $query = $this->sort(
        query: $query,
        fieldName: Arr::get($array, 'sort.field_name'),
        direction: Arr::get($array, 'sort.direction')
    );
}
```