### PR TITLE
[10.x] Add mailer() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cookie\Factory as CookieFactory;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Contracts\Support\Responsable;
@@ -527,6 +528,18 @@ if (! function_exists('method_field')) {
     function method_field($method)
     {
         return new HtmlString('<input type="hidden" name="_method" value="'.$method.'">');
+    }
+}
+
+if (! function_exists('mailer')) {
+    /**
+     * Get the mailer instance.
+     *
+     * @return \Illuminate\Contracts\Mail\Factory
+     */
+    function mailer()
+    {
+        return app(MailFactory::class);
     }
 }
 


### PR DESCRIPTION
Most of the facades have corresponding helpers (`cache()`, `session()`, `request()`), this PR allow to not import the `Mail` facade to send an email:

```
Mail::to('xxx@example.org')->send(new Mailable);
mailer()->to('xxx@example.org')->send(new Mailable);
```

If this is something we want, we can simplify for the most common case (not currently in the PR):
```
mailer('xxx@example.org', new Mailable);
mailer(new Mailable); // If the `to()` is specify inside the mailable
```

Didn't find the correct place to put a test and I don't know if helpers are tested somewhere?

Cannot use `mail()` because it's already a PHP function. `mailer()` seems to be the closest name but could be something different?