### PR TITLE
[10.x] Add new change pattern to TableGuesser

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,8 +10,9 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
-        '/.+_(to|from|in)_(\w+)_table$/',
-        '/.+_(to|from|in)_(\w+)$/',
+        '/.+_(to|from|in)_(\w+)_table$/' => 2,
+        '/.+_(to|from|in)_(\w+)$/' => 2,
+        '/^alter_(\w+)_table_.+$/' => 1,
     ];
 
     /**
@@ -28,9 +29,9 @@ class TableGuesser
             }
         }
 
-        foreach (self::CHANGE_PATTERNS as $pattern) {
+        foreach (self::CHANGE_PATTERNS as $pattern => $group) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[2], $create = false];
+                return [$matches[$group], $create = false];
             }
         }
     }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -28,6 +28,14 @@ class TableGuesserTest extends TestCase
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('alter_users_table_add_status_column');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('alter_user_roles_table_drop_is_active');
+        $this->assertSame('user_roles', $table);
+        $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()


### PR DESCRIPTION
- Added support for `/^alter_(\w+)_table_.+$/` pattern to detect table name in alter table migrations.
- Updated existing patterns to capture table name correctly for improved accuracy.

I think this migration name pattern may be commonly used. This addition may provide convenience to developers. But this pattern requires `table` word in the migration name. Still, I wanted to make this contribution and get your opinions.

**Note:** This is my first contribution to the laravel framework.

