### PR TITLE
[10.x] Simplify Array Filter Check in parseConnectionConfiguration Method

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -192,7 +192,7 @@ class RedisManager implements Factory
         }
 
         return array_filter($parsed, function ($key) {
-            return ! in_array($key, ['driver'], true);
+            return $key !== 'driver';
         }, ARRAY_FILTER_USE_KEY);
     }
 


### PR DESCRIPTION
Before PR #36299, an array was used to check for multiple potential values. 

However, since that PR, the array has been reduced to a single-value array containing only 'driver'. Given this change, the use of `in_array` is not necessary.