### PR TITLE
[10.x] Remove unnecessary spread operator usage

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -366,8 +366,7 @@ trait ConditionallyLoadsAttributes
         }
 
         return $this->when(
-            $this->hasPivotLoadedAs($accessor, $table),
-            ...[$value, $default]
+            $this->hasPivotLoadedAs($accessor, $table), $value, $default
         );
     }
 


### PR DESCRIPTION
Remove unnecessary use of the spread operator in the `whenPivotLoadedAs` method to simplify and increase readability. 