### PR TITLE
[10.x] Update jsonSerialize return type

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -459,9 +459,9 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
     /**
      * Convert the object into a JSON serializable form.
      *
-     * @return mixed
+     * @return array
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize(): array
     {
         return $this->attributes;
     }


### PR DESCRIPTION
The return type of the `jsonSerialize` method is always `array`, so we can safely change it from `mixed` to `array.

```
    /**
     * The raw array of attributes.
     *
     * @var array
     */
    protected $attributes = [];
```