### PR TITLE
[10.x] hash improvements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -39,6 +39,7 @@ use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
+use RuntimeException;
 
 trait HasAttributes
 {
@@ -1316,7 +1317,19 @@ trait HasAttributes
      */
     protected function castAttributeAsHashedString($key, $value)
     {
-        return $value !== null && ! Hash::isHashed($value) ? Hash::make($value) : $value;
+        if ($value === null) {
+            return;
+        }
+
+        if (! Hash::isHashed($value)) {
+            return Hash::make($value);
+        }
+
+        if (Hash::needsRehash($value)) {
+            throw new RuntimeException('The hash does not match the configured hashing options.');
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
This will break:

- Existing applications that are using a hard coded hash. The fix for apps is seen in https://github.com/laravel/laravel/pull/6259.
- Applications that are manually duplicating user records and re-setting their password. If they are using `$model->replicate()` it won't be an issue.

Aside from that I don't see concrete examples that a new value is passing through the setter where you expect it not to be using the current algorithm. No doubt there will be edge cases out there.