### PR TITLE
[10.x] Add `not_hashed` validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -110,6 +110,7 @@ return [
     'missing_with' => 'The :attribute field must be missing when :values is present.',
     'missing_with_all' => 'The :attribute field must be missing when :values are present.',
     'multiple_of' => 'The :attribute field must be a multiple of :value.',
+    'not_hashed' => 'The :attribute field must not be hashed.',
     'not_in' => 'The selected :attribute is invalid.',
     'not_regex' => 'The :attribute field format is invalid.',
     'numeric' => 'The :attribute field must be a number.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1689,6 +1689,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate an attribute is not hashed.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateNotHashed($attribute, $value, $parameters)
+    {
+        return password_get_info($value)['algo'] === null;
+    }
+
+    /**
      * Validate an attribute is not contained within a list of values.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8894,6 +8894,20 @@ class ValidationValidatorTest extends TestCase
         $validator->passes();
     }
 
+    public function test_not_hashed_rule()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.not_hashed' => 'The :attribute field must not be hashed.'], 'en');
+        $validator = new Validator($trans, ['password_1' => '$2y$10$i0RXVShQYw25byk7sy48NOLV3mRMzWfoawutQoyXB00Ly.UCK54PK', 'password_2' => 'correct horse battery staple'], ['password_1' => 'not_hashed', 'password_2' => 'not_hashed']);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'password_1' => [
+                'The password 1 field must not be hashed.'
+            ]
+        ], $validator->errors()->messages());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8903,8 +8903,8 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($validator->passes());
         $this->assertSame([
             'password_1' => [
-                'The password 1 field must not be hashed.'
-            ]
+                'The password 1 field must not be hashed.',
+            ],
         ], $validator->errors()->messages());
     }
 


### PR DESCRIPTION
This validation rule will ensure that the provided value is not recognized as a hash by PHP's password hashing algorithms, such as bcrypt.

In a perfect world, this validation rule isn't needed, however mistakes can be made and this can help prevent external hashes entering the system.

I think we should have it on the `Password` rule as well, active by default, but wanted to see if we want it at all before making that change.

If accepted, I'll open a follow up PR to add this to the `Password` rule class by default with an opt-out option.