### PR TITLE
[10.x] Ability to configure default session block timeouts

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -80,7 +80,7 @@ class StartSession
 
         $lockFor = $request->route() && $request->route()->locksFor()
                         ? $request->route()->locksFor()
-                        : 10;
+                        : $this->manager->blocksFor();
 
         $lock = $this->cache($this->manager->blockDriver())
                     ->lock('session:'.$session->getId(), $lockFor)
@@ -90,7 +90,7 @@ class StartSession
             $lock->block(
                 ! is_null($request->route()->waitsFor())
                         ? $request->route()->waitsFor()
-                        : 10
+                        : $this->manager->waitsFor()
             );
 
             return $this->handleStatefulRequest($request, $session, $next);

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -80,7 +80,7 @@ class StartSession
 
         $lockFor = $request->route() && $request->route()->locksFor()
                         ? $request->route()->locksFor()
-                        : $this->manager->blocksFor();
+                        : $this->manager->defaultRouteBlockLockSeconds();
 
         $lock = $this->cache($this->manager->blockDriver())
                     ->lock('session:'.$session->getId(), $lockFor)
@@ -90,7 +90,7 @@ class StartSession
             $lock->block(
                 ! is_null($request->route()->waitsFor())
                         ? $request->route()->waitsFor()
-                        : $this->manager->waitsFor()
+                        : $this->manager->defaultRouteBlockWaitSeconds()
             );
 
             return $this->handleStatefulRequest($request, $session, $next);

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -227,26 +227,6 @@ class SessionManager extends Manager
     }
 
     /**
-     * Get the maximum number of seconds the session lock should be held for.
-     *
-     * @return int
-     */
-    public function blocksFor()
-    {
-        return $this->config->get('session.block__lock_timeout', 10);
-    }
-
-    /**
-     * Get the maximum number of seconds to wait while attempting to acquire a session lock.
-     *
-     * @return int
-     */
-    public function waitsFor()
-    {
-        return $this->config->get('session.block_wait_timeout', 10);
-    }
-
-    /**
      * Get the name of the cache store / driver that should be used to acquire session locks.
      *
      * @return string|null
@@ -254,6 +234,26 @@ class SessionManager extends Manager
     public function blockDriver()
     {
         return $this->config->get('session.block_store');
+    }
+
+    /**
+     * Get the maximum number of seconds the session lock should be held for.
+     *
+     * @return int
+     */
+    public function defaultRouteBlockLockSeconds()
+    {
+        return $this->config->get('session.block_lock_seconds', 10);
+    }
+
+    /**
+     * Get the maximum number of seconds to wait while attempting to acquire a route block session lock.
+     *
+     * @return int
+     */
+    public function defaultRouteBlockWaitSeconds()
+    {
+        return $this->config->get('session.block_wait_seconds', 10);
     }
 
     /**

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -227,6 +227,26 @@ class SessionManager extends Manager
     }
 
     /**
+     * Get the maximum number of seconds the session lock should be held for.
+     *
+     * @return int
+     */
+    public function blocksFor()
+    {
+        return $this->config->get('session.block__lock_timeout', 10);
+    }
+
+    /**
+     * Get the maximum number of seconds to wait while attempting to acquire a session lock.
+     *
+     * @return int
+     */
+    public function waitsFor()
+    {
+        return $this->config->get('session.block_wait_timeout', 10);
+    }
+
+    /**
      * Get the name of the cache store / driver that should be used to acquire session locks.
      *
      * @return string|null


### PR DESCRIPTION
Session blocking can be enabled globally using the `session.block` config directive. At the moment, the `lockSeconds` and `waitSeconds` are hard coded to `10` seconds. This PR adds two new config directives enabling a developer to increase/decrease those hard coded values.