### PR TITLE
[10.x] Test Improvements

### DIFF
--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -71,16 +71,14 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         return $connection->getSchemaBuilder();
     }
 
-    /** @test */
-    public function itPluralizesTheTableName()
+    public function testItPluralizesTheTableName()
     {
         $model = new IrregularPluralHuman;
 
         $this->assertSame('irregular_plural_humans', $model->getTable());
     }
 
-    /** @test */
-    public function itTouchesTheParentWithAnIrregularPlural()
+    public function testItTouchesTheParentWithAnIrregularPlural()
     {
         Carbon::setTestNow('2018-05-01 12:13:14');
 
@@ -104,8 +102,7 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
         $this->assertSame('2018-05-01 15:16:17', (string) $human->updated_at);
     }
 
-    /** @test */
-    public function itPluralizesMorphToManyRelationships()
+    public function testItPluralizesMorphToManyRelationships()
     {
         $human = IrregularPluralHuman::create(['email' => 'bobby@example.com']);
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -500,7 +500,6 @@ class FoundationApplicationTest extends TestCase
         );
     }
 
-    /** @test */
     public function testMacroable(): void
     {
         $app = new Application;
@@ -517,7 +516,6 @@ class FoundationApplicationTest extends TestCase
         $this->assertFalse($app->foo());
     }
 
-    /** @test */
     public function testUseConfigPath(): void
     {
         $app = new Application;

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -43,8 +43,7 @@ class ForgotPasswordTest extends TestCase
         })->name('custom.password.reset');
     }
 
-    /** @test */
-    public function it_can_send_forgot_password_email()
+    public function testItCanSendForgotPasswordEmail()
     {
         Notification::fake();
 
@@ -67,8 +66,7 @@ class ForgotPasswordTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_send_forgot_password_email_via_create_url_using()
+    public function testItCanSendForgotPasswordEmailViaCreateUrlUsing()
     {
         Notification::fake();
 
@@ -95,8 +93,7 @@ class ForgotPasswordTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_send_forgot_password_email_via_to_mail_using()
+    public function testItCanSendForgotPasswordEmailViaToMailUsing()
     {
         Notification::fake();
 

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -39,8 +39,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
         })->name('custom.password.reset');
     }
 
-    /** @test */
-    public function it_cannot_send_forgot_password_email()
+    public function testItCannotSendForgotPasswordEmail()
     {
         $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $this->expectExceptionMessage('Route [password.reset] not defined.');
@@ -66,8 +65,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_send_forgot_password_email_via_create_url_using()
+    public function testItCanSendForgotPasswordEmailViaToMailUsing()
     {
         Notification::fake();
 
@@ -94,8 +92,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_send_forgot_password_email_via_to_mail_using()
+    public function testItCanSendForgotPasswordEmailViaToMailUsing()
     {
         Notification::fake();
 

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -65,7 +65,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
         );
     }
 
-    public function testItCanSendForgotPasswordEmailViaToMailUsing()
+    public function testItCanSendForgotPasswordEmailViaCreateUrlUsing()
     {
         Notification::fake();
 

--- a/tests/Integration/Foundation/FoundationServiceProvidersTest.php
+++ b/tests/Integration/Foundation/FoundationServiceProvidersTest.php
@@ -12,8 +12,7 @@ class FoundationServiceProvidersTest extends TestCase
         return [HeadServiceProvider::class];
     }
 
-    /** @test */
-    public function it_can_boot_service_provider_registered_from_another_service_provider()
+    public function testItCanBootServiceProviderRegisteredFromAnotherServiceProvider()
     {
         $this->assertTrue($this->app['tail.registered']);
         $this->assertTrue($this->app['tail.booted']);

--- a/tests/Integration/Generators/FactoryMakeCommandTest.php
+++ b/tests/Integration/Generators/FactoryMakeCommandTest.php
@@ -8,7 +8,6 @@ class FactoryMakeCommandTest extends TestCase
         'database/factories/FooFactory.php',
     ];
 
-    /** @test */
     public function testItCanGenerateFactoryFile()
     {
         $this->artisan('make:factory', ['name' => 'FooFactory'])

--- a/tests/Integration/Generators/ResourceMakeCommandTest.php
+++ b/tests/Integration/Generators/ResourceMakeCommandTest.php
@@ -9,8 +9,7 @@ class ResourceMakeCommandTest extends TestCase
         'app/Http/Resources/FooResourceCollection.php',
     ];
 
-    /** @test */
-    public function it_can_generate_resource_file()
+    public function testItCanGenerateResourceFile()
     {
         $this->artisan('make:resource', ['name' => 'FooResource'])
             ->assertExitCode(0);
@@ -22,8 +21,7 @@ class ResourceMakeCommandTest extends TestCase
         ], 'app/Http/Resources/FooResource.php');
     }
 
-    /** @test */
-    public function it_can_generate_resource_collection_file()
+    public function testItCanGenerateResourceCollectionFile()
     {
         $this->artisan('make:resource', ['name' => 'FooResourceCollection', '--collection' => true])
             ->assertExitCode(0);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -533,8 +533,7 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
-    /** @test */
-    public function TestWhetherTheNumberOfGeneratedCharactersIsEquallyDistributed()
+    public function testWhetherTheNumberOfGeneratedCharactersIsEquallyDistributed()
     {
         $results = [];
         // take 6.200.000 samples, because there are 62 different characters


### PR DESCRIPTION
Remove deprecated `@test` usage and always prefix test method name with `test`.

Using `@test` will trigger a deprecation error in PHPUnit 11, it's best to consistently not use this in our code base.