### PR TITLE
[10.x] Add Str::betweenAll Method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -210,6 +210,22 @@ class Str
     }
 
     /**
+     * Get all occurrences of text between two given values.
+     *
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
+     * @return array
+     */
+    public static function betweenAll($subject, $from, $to)
+    {
+        $pattern = '/'.preg_quote($from, '/').'(.*?)'.preg_quote($to, '/').'/';
+        preg_match_all($pattern, $subject, $matches);
+
+        return $matches[1];
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -167,6 +167,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Get all occurrences of text between two given values.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @return array<int, string|null>
+     */
+    public function betweenAll($from, $to)
+    {
+        return Str::betweenAll($this->value, $from, $to);
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -261,6 +261,26 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::betweenFirst('foobarbar', 'foo', 'bar'));
     }
 
+    public function testStrBetweenAll()
+    {
+        // Single occurrence
+        $this->assertSame(['1'], Str::betweenAll('[1] bla bla', '[', ']'));
+        $this->assertSame(['a'], Str::betweenAll('[a]ab[b', '[', ']'));
+
+        // Multiple occurrences
+        $this->assertSame(['1', '2'], Str::betweenAll('[1] bla bla [2]', '[', ']'));
+        $this->assertSame(['a', 'b', 'c'], Str::betweenAll('[a]ab[b]c[c]', '[', ']'));
+
+        // No occurrence
+        $this->assertSame([], Str::betweenAll('abc', '[', ']'));
+
+        // Edge case: Empty string
+        $this->assertSame([], Str::betweenAll('', '[', ']'));
+
+        // Edge case: Same delimiters
+        $this->assertSame(['1', '2'], Str::betweenAll('[1][2]', '[', ']'));
+    }
+
     public function testStrAfter()
     {
         $this->assertSame('nah', Str::after('hannah', 'han'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -642,6 +642,26 @@ class SupportStringableTest extends TestCase
         $this->assertSame('bar', (string) $this->stringable('foobarbar')->between('foo', 'bar'));
     }
 
+    public function testBetweenAll()
+    {
+        // Single occurrence
+        $this->assertSame(['1'], $this->stringable('[1] bla bla')->betweenAll('[', ']'));
+        $this->assertSame(['a'], $this->stringable('[a]ab[b')->betweenAll('[', ']'));
+
+        // Multiple occurrences
+        $this->assertSame(['1', '2'], $this->stringable('[1] bla bla [2]')->betweenAll('[', ']'));
+        $this->assertSame(['a', 'b', 'c'], $this->stringable('[a]ab[b]c[c]')->betweenAll('[', ']'));
+
+        // No occurrence
+        $this->assertSame([], $this->stringable('abc')->betweenAll('[', ']'));
+
+        // Edge case: Empty string
+        $this->assertSame([], $this->stringable('')->betweenAll('[', ']'));
+
+        // Edge case: Same delimiters
+        $this->assertSame(['1', '2'], $this->stringable('[1][2]')->betweenAll('[', ']'));
+    }
+
     public function testBetweenFirst()
     {
         $this->assertSame('abc', (string) $this->stringable('abc')->betweenFirst('', 'c'));


### PR DESCRIPTION
Introduces Str::betweenAll Method. 

Useful for extracting all occurrences of text between specified delimiters from a given string.

### Usage:
```php
$result = Str::betweenAll('[1] bla bla [2]', '[', ']');  // Output: ['1', '2']
```
```php
$html = '<a href="https://example.com/page1">Page 1</a> <a href="https://example.com/page2">Page 2</a>';
$links = Str::betweenAll($html, 'href="', '"');
// Output: ['https://example.com/page1', 'https://example.com/page2']
```
```php
$logData = '[2023-01-01 12:34:56] - [INFO] - System started
[2023-01-01 12:35:00] - [ERROR] - Connection lost';
$timestamps = Str::betweenAll($logData, '[', '] - [');
// Output: ['2023-01-01 12:34:56', '2023-01-01 12:35:00']
```
