### PR TITLE
fix bug for always throwing exception when we pass a callable to throwUnlessStatus method

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -338,9 +338,8 @@ class Response implements ArrayAccess
      */
     public function throwUnlessStatus($statusCode)
     {
-        if (is_callable($statusCode) &&
-            ! $statusCode($this->status(), $this)) {
-            return $this->throw();
+        if (is_callable($statusCode)) {
+            return $statusCode($this->status(), $this) ? $this : $this->throw();
         }
 
         return $this->status() === $statusCode ? $this : $this->throw();


### PR DESCRIPTION
In the current code if the $statusCode is callable and it returns true we correctly do not throw an exception in the if statement but in the ternary condition since $statusCode is callable and $this->status() returns an integer we throw an exception anyway.
This pull request tries to address this problem.