### PR TITLE
[10.x] Refactor hardcoded lock/wait for integers

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -15,6 +15,20 @@ use Symfony\Component\HttpFoundation\Response;
 class StartSession
 {
     /**
+     * Get the maximum number of seconds to wait while attempting to acquire a session lock.
+     *
+     * @var int
+     */
+    protected $locksFor = 10;
+
+    /**
+     * Get the maximum number of seconds to wait while attempting to acquire a session lock.
+     *
+     * @var int
+     */
+    protected $waitsFor = 10;
+
+    /**
      * The session manager.
      *
      * @var \Illuminate\Session\SessionManager
@@ -80,7 +94,7 @@ class StartSession
 
         $lockFor = $request->route() && $request->route()->locksFor()
                         ? $request->route()->locksFor()
-                        : 10;
+                        : $this->locksFor;
 
         $lock = $this->cache($this->manager->blockDriver())
                     ->lock('session:'.$session->getId(), $lockFor)
@@ -90,7 +104,7 @@ class StartSession
             $lock->block(
                 ! is_null($request->route()->waitsFor())
                         ? $request->route()->waitsFor()
-                        : 10
+                        : $this->waitsFor
             );
 
             return $this->handleStatefulRequest($request, $session, $next);


### PR DESCRIPTION
This is an alternative solution to https://github.com/laravel/framework/pull/48795 which was closed with the reason:
> You can define it on the route / route group.

Contrary to this statement, it cannot be defined on route groups, only individual routes. Regardless of that, I think it's in the best interests of the framework to not hard code values. Developers can now easily override the default `locksFor` and `waitsFor` values without having to rewrite the entire `handleRequestWhileBlocking()` method.

