### PR TITLE
[10.x] fix unable to use optional parameters in closure commands

### DIFF
--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -46,7 +46,7 @@ class ClosureCommand extends Command
         $parameters = [];
 
         foreach ((new ReflectionFunction($this->callback))->getParameters() as $parameter) {
-            if (isset($inputs[$parameter->getName()])) {
+            if (isset($inputs[$parameter->getName()]) || is_null($inputs[$parameter->getName()])) {
                 $parameters[$parameter->getName()] = $inputs[$parameter->getName()];
             }
         }


### PR DESCRIPTION
Currently passing optional parameters in the closure command causes a bug.
```php
Artisan::command('mail:send {user?}', function (string $user) {
    $this->info("Sending email to: {$user}!");
});
```
This resolves to `Unable to resolve dependency [Parameter #0 [ <required> ?string $user ]] in class Illuminate\Foundation\Console\ClosureCommand` because using `isset` also checks if the variable is not null

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
