### PR TITLE
[10.x] Match service provider after resolved

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -46,11 +46,11 @@ abstract class Facade
         $accessor = static::getFacadeAccessor();
 
         if (static::$app->resolved($accessor) === true) {
-            $callback(static::getFacadeRoot());
+            $callback(static::getFacadeRoot(), static::$app);
         }
 
-        static::$app->afterResolving($accessor, function ($service) use ($callback) {
-            $callback($service);
+        static::$app->afterResolving($accessor, function ($service, $app) use ($callback) {
+            $callback($service, $app);
         });
     }
 

--- a/tests/Integration/Support/FacadesTest.php
+++ b/tests/Integration/Support/FacadesTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Support;
 
+use Illuminate\Auth\AuthManager;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Facade;
@@ -19,7 +21,7 @@ class FacadesTest extends TestCase
 
     public function testFacadeResolvedCanResolveCallback()
     {
-        Auth::resolved(function () {
+        Auth::resolved(function (AuthManager $auth, Application $app) {
             $_SERVER['__laravel.authResolved'] = true;
         });
 
@@ -36,7 +38,7 @@ class FacadesTest extends TestCase
 
         $this->assertFalse(isset($_SERVER['__laravel.authResolved']));
 
-        Auth::resolved(function () {
+        Auth::resolved(function (AuthManager $auth, Application $app) {
             $_SERVER['__laravel.authResolved'] = true;
         });
 


### PR DESCRIPTION
The application's `afterResolved` callback receives the instance and the app.

The service provider's `callAfterResolving` helper also receives the instance and the app.

https://github.com/laravel/framework/blob/98ffb759b5ac5918aa26dac4676d8fb713c810ea/src/Illuminate/Support/ServiceProvider.php#L263-L267

This changes means that the facade's version matches those.

```php
Log::resolved(function (LogManager $log, Application $app) {
    //
});
```