### PR TITLE
[10.x] Add a `File::bytesToHuman()` helper

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -799,7 +799,7 @@ class Filesystem
      */
     public function bytesToHuman($bytes, $precision = 2)
     {
-        $units = ['B','KB','MB','GB','TB','PB','EB','ZB','YB'];
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
         for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
             $bytes /= 1024;

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -799,10 +799,12 @@ class Filesystem
      */
     public function bytesToHuman($bytes, $precision = 2)
     {
-        for ($i = 0; ($bytes / 1024) > 0.9; $i++) {
+        $units = ['B','KB','MB','GB','TB','PB','EB','ZB','YB'];
+
+        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
             $bytes /= 1024;
         }
 
-        return round($bytes, $precision).' '.['B', 'KB', 'MB', 'GB', 'TB'][$i];
+        return sprintf('%s %s', round($bytes, $precision), $units[$i]);
     }
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -789,4 +789,20 @@ class Filesystem
     {
         return $this->deleteDirectory($directory, true);
     }
+
+    /**
+     * Format the number of bytes to a human-readable string.
+     *
+     * @param  int  $bytes
+     * @param  int  $precision
+     * @return string
+     */
+    public function bytesToHuman($bytes, $precision = 2)
+    {
+        for ($i = 0; ($bytes / 1024) > 0.9; $i++) {
+            $bytes /= 1024;
+        }
+
+        return round($bytes, $precision).' '.['B', 'KB', 'MB', 'GB', 'TB'][$i];
+    }
 }

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -49,6 +49,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool deleteDirectory(string $directory, bool $preserve = false)
  * @method static bool deleteDirectories(string $directory)
  * @method static bool cleanDirectory(string $directory)
+ * @method static string bytesToHuman(int $bytes, int $precision = 2)
  * @method static \Illuminate\Filesystem\Filesystem|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Filesystem\Filesystem|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static void macro(string $name, object|callable $macro)

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -651,6 +651,10 @@ class FilesystemTest extends TestCase
         $this->assertSame('1.234 KB', $filesystem->bytesToHuman(1264, 3));
         $this->assertSame('5 GB', $filesystem->bytesToHuman(1024 * 1024 * 1024 * 5));
         $this->assertSame('10 TB', $filesystem->bytesToHuman((1024 ** 4) * 10));
+        $this->assertSame('10 PB', $filesystem->bytesToHuman((1024 ** 5) * 10));
+        $this->assertSame('1 ZB', $filesystem->bytesToHuman(1024 ** 7));
+        $this->assertSame('1 YB', $filesystem->bytesToHuman(1024 ** 8));
+        $this->assertSame('1024 YB', $filesystem->bytesToHuman(1024 ** 9));
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -639,6 +639,20 @@ class FilesystemTest extends TestCase
         $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
     }
 
+    public function testBytesToHuman()
+    {
+        $filesystem = new Filesystem;
+
+        $this->assertSame('0 B', $filesystem->bytesToHuman(0));
+        $this->assertSame('1 B', $filesystem->bytesToHuman(1));
+        $this->assertSame('1 KB', $filesystem->bytesToHuman(1024));
+        $this->assertSame('2 KB', $filesystem->bytesToHuman(2048));
+        $this->assertSame('1.23 KB', $filesystem->bytesToHuman(1264));
+        $this->assertSame('1.234 KB', $filesystem->bytesToHuman(1264, 3));
+        $this->assertSame('5 GB', $filesystem->bytesToHuman(1024 * 1024 * 1024 * 5));
+        $this->assertSame('10 TB', $filesystem->bytesToHuman((1024 ** 4) * 10));
+    }
+
     /**
      * @param  string  $file
      * @return int


### PR DESCRIPTION
## Abstract

Adds a `File::bytesToHuman()` helper to format the number of bytes to a human-readable string.

### Functionality

The helper works by iterating through the input byte count and dividing it by `1024`. The iteration count is the used in a lookup array to get the appropriate byte suffix. It supports rounding to a specific precision. Results are also slightly rounded up.

### Development

I was originally thinking this could be a helper in the `Str` class, but after bringing it up in `#internals` we thought it might be better in the `File` facade. I am of course more than happy to move it to the `Str` class. **Thanks to all the great people in the Discord!**

### Added tests

I added a test with 8 assertions to get a broad range of conditions. I also ran some benchmarks on different implementations, and all of them have minuscule performance concerns (~0.00058ms avg/1 million iterations).

### Backwards compatibility 

This adds a new feature, so it will not break any existing features. It can thus also go in a minor release version.

### How this improves Laravel

This is one of those things I often add to Laravel applications as a `Str` macro. And I thought it is so useful, so I wanted to share it with everyone!