### PR TITLE
Enhancing Seeder Functionality with "--rollback" Option

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -67,7 +67,8 @@ class SeedCommand extends Command
         $this->resolver->setDefaultConnection($this->getDatabase());
 
         Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
+            $params = $this->input->getOption('rollback') ? ['rollback'] : [];
+            $this->getSeeder()->__invoke($params);
         });
 
         if ($previousConnection) {
@@ -135,6 +136,7 @@ class SeedCommand extends Command
             ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+            ['rollback', null, InputOption::VALUE_NONE, 'To run the rollback function which aims to revert any db changes made'],
         ];
     }
 }

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -170,18 +170,27 @@ abstract class Seeder
      * Run the database seeds.
      *
      * @param  array  $parameters
+     * @param  string $methodToExecute
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function __invoke(array $parameters = [])
+    public function __invoke(array $parameters = [], string $methodToExecute = 'run')
     {
         if (! method_exists($this, 'run')) {
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
+        if (in_array('rollback', $parameters)) {
+            if (! method_exists($this, 'down')) {
+                throw new InvalidArgumentException('Method [down] missing from '.get_class($this));
+            }
+            unset($parameters[array_flip($parameters)['rollback']]);
+            $methodToExecute = 'down';
+        }
+
         $callback = fn () => isset($this->container)
-            ? $this->container->call([$this, 'run'], $parameters)
+            ? $this->container->call([$this, $methodToExecute], $parameters)
             : $this->run(...$parameters);
 
         $uses = array_flip(class_uses_recursive(static::class));


### PR DESCRIPTION
**Introduction**
In the context of package development, particularly those involving database seeders, I propose the introduction of the   
`--rollback` option for the `db:seed` command. This feature complements the existing `migrate:rollback` command and offers a solution for efficient database seeding management.

**The Problem**
Currently, many projects rely on packages that utilize seeders to alter the database. However, when complications arise, such as errors, changes in requirements, or the need to remove packages, there is a lack of streamlined mechanisms to revert these seeding changes. While the `migrate:rollback` command helps with migrations, the absence of a corresponding option for seeders presents challenges in complex projects where multiple custom packages are involved.

**The Solution**
By introducing the `--rollback` option for the `db:seed` command, we provide package developers and maintainers with a powerful tool to address these issues. This feature empowers users to efficiently undo changes made by seeders. Incorporating the `--rollback` option into the `db:seed` command enhances the functionality of our tool, providing users with a versatile and robust solution to manage database seeding.

**Use Case**
```php
class DatabaseSeeder extends Seeder
{
    /**
     * Seed the application's database.
     */
    public function run(): void
    {
         //\App\Models\User::factory(10)->create();

        // \App\Models\User::factory()->create([
        //     'name' => 'Test User',
        //     'email' => 'test@example.com',
        // ]);
    }

    /**
     * Reverse the effects of the database seeding operation.
     */
    public function down(): void
    {
        \App\Models\User::where('email', 'foo@bar.com')->delete();
    }
}
```