### PR TITLE
[10.x] Remember the job on the exception

### DIFF
--- a/src/Illuminate/Queue/MaxAttemptsExceededException.php
+++ b/src/Illuminate/Queue/MaxAttemptsExceededException.php
@@ -7,6 +7,8 @@ use RuntimeException;
 class MaxAttemptsExceededException extends RuntimeException
 {
     /**
+     * The job instance.
+     *
      * @var \Illuminate\Contracts\Queue\Job|null
      */
     public $job;

--- a/src/Illuminate/Queue/MaxAttemptsExceededException.php
+++ b/src/Illuminate/Queue/MaxAttemptsExceededException.php
@@ -6,5 +6,21 @@ use RuntimeException;
 
 class MaxAttemptsExceededException extends RuntimeException
 {
-    //
+    /**
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new instance for the job.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return static
+     */
+    public static function forJob($job)
+    {
+        return tap(new static($job->resolveName().' has been attempted too many times.'), function ($e) use ($job) {
+            $e->job = $job;
+        });
+    }
 }

--- a/src/Illuminate/Queue/MaxAttemptsExceededException.php
+++ b/src/Illuminate/Queue/MaxAttemptsExceededException.php
@@ -7,7 +7,7 @@ use RuntimeException;
 class MaxAttemptsExceededException extends RuntimeException
 {
     /**
-     * @var \Illuminate\Contracts\Queue\Job
+     * @var \Illuminate\Contracts\Queue\Job|null
      */
     public $job;
 

--- a/src/Illuminate/Queue/TimeoutExceededException.php
+++ b/src/Illuminate/Queue/TimeoutExceededException.php
@@ -4,5 +4,16 @@ namespace Illuminate\Queue;
 
 class TimeoutExceededException extends MaxAttemptsExceededException
 {
-    //
+    /**
+     * Create a new instance for the job.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return static
+     */
+    public static function forJob($job)
+    {
+        return tap(new static($job->resolveName().' has timed out.'), function ($e) use ($job) {
+            $e->job = $job;
+        });
+    }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -782,9 +782,7 @@ class Worker
      */
     protected function maxAttemptsExceededException($job)
     {
-        return new MaxAttemptsExceededException(
-            $job->resolveName().' has been attempted too many times.'
-        );
+        return MaxAttemptsExceededException::forJob($job);
     }
 
     /**
@@ -795,9 +793,7 @@ class Worker
      */
     protected function timeoutExceededException($job)
     {
-        return new TimeoutExceededException(
-            $job->resolveName().' has timed out.'
-        );
+        return TimeoutExceededException::forJob($job);
     }
 
     /**

--- a/tests/Queue/QueueExceptionTest.php
+++ b/tests/Queue/QueueExceptionTest.php
@@ -14,7 +14,7 @@ class QueueExceptionTest extends TestCase
     {
         $e = TimeoutExceededException::forJob($job = new MyFakeRedisJob());
 
-        $this->assertSame('App\\Jobs\\UnderlyingJob has timed out.', $e->getmessage());
+        $this->assertSame('App\\Jobs\\UnderlyingJob has timed out.', $e->getMessage());
         $this->assertSame($job, $e->job);
     }
 

--- a/tests/Queue/QueueExceptionTest.php
+++ b/tests/Queue/QueueExceptionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Queue\Jobs\RedisJob;
+use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Queue\MaxAttemptsExceededException;
+use Illuminate\Queue\TimeoutExceededException;
+use PHPUnit\Framework\TestCase;
+
+class QueueExceptionTest extends TestCase
+{
+    public function test_it_can_create_timeout_exception_for_job()
+    {
+        $e = TimeoutExceededException::forJob($job = new MyFakeRedisJob());
+
+        $this->assertSame('App\\Jobs\\UnderlyingJob has timed out.', $e->getmessage());
+        $this->assertSame($job, $e->job);
+    }
+
+    public function test_it_can_create_max_attempts_exception_for_job()
+    {
+        $e = MaxAttemptsExceededException::forJob($job = new MyFakeRedisJob());
+
+        $this->assertSame('App\\Jobs\\UnderlyingJob has been attempted too many times.', $e->getmessage());
+        $this->assertSame($job, $e->job);
+    }
+}
+
+class MyFakeRedisJob extends RedisJob
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function resolveName()
+    {
+        return 'App\\Jobs\\UnderlyingJob';
+    }
+}

--- a/tests/Queue/QueueExceptionTest.php
+++ b/tests/Queue/QueueExceptionTest.php
@@ -22,7 +22,7 @@ class QueueExceptionTest extends TestCase
     {
         $e = MaxAttemptsExceededException::forJob($job = new MyFakeRedisJob());
 
-        $this->assertSame('App\\Jobs\\UnderlyingJob has been attempted too many times.', $e->getmessage());
+        $this->assertSame('App\\Jobs\\UnderlyingJob has been attempted too many times.', $e->getMessage());
         $this->assertSame($job, $e->job);
     }
 }


### PR DESCRIPTION
When these exceptions are triggered they pass through the applications handlers reporting piping.

It is be common for a certain type of job to be okay to timeout and be treated "special", e.g., log it but not to a 3rd party error monitoring.

Currently the only way to do this is to check the error message, .e.g.,

```php
if (
    $e instanceof MaxAttemptsExceededException &&
    str_starts_with($e->getMessage(), MySpecialJob::class.' ')
) {
    //
}
```

While not the end of the world, it feels a flaky and yuck. This exposes the job on the exception.

```php
if (
    $e instanceof MaxAttemptsExceededException &&
    $e->job->getResolvedJob() instanceof MySpecialJob
) {
    //
}
```