### PR TITLE
[10.x] Allow route:list command to filter middleware

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -270,6 +270,14 @@ class RouteListCommand extends Command
             }
         }
 
+        if ($this->option('middleware') &&
+            Str::of($route['middleware'])->explode("\n")->filter(function (string $middleware) {
+                return Str::contains($middleware, $this->option('middleware'));
+            })->isEmpty()
+        ) {
+            return;
+        }
+
         return $route;
     }
 
@@ -494,6 +502,7 @@ class RouteListCommand extends Command
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
             ['only-vendor', null, InputOption::VALUE_NONE, 'Only display routes defined by vendor packages'],
+            ['middleware', null, InputOption::VALUE_NONE, 'Filter the routes by middleware'],
         ];
     }
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -147,4 +147,21 @@ class RouteListCommandTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
+
+    public function testMiddlewareFilterable()
+    {
+        $this->app->call('route:list', ['--middleware' => 'exampleMiddleware']);
+        $outputCli = $this->app->output();
+        $this->assertStringContainsString('exampleMiddleware', $outputCli);
+        $this->assertStringNotContainsString('Middleware 1', $outputCli);
+
+        $this->app->call('route:list', ['--middleware' => 'Middleware 1', '--json' => true]);
+        $outputJson = $this->app->output();
+        $this->assertStringContainsString('Middleware 1', $outputJson);
+        $this->assertStringNotContainsString('exampleMiddleware', $outputJson);
+
+        $this->app->call('route:list', ['--middleware' => 'notExistsMiddleware']);
+        $notExistsOutputCli = $this->app->output();
+        $this->assertStringContainsString('Your application doesn\'t have any routes matching the given criteria.', $notExistsOutputCli);
+    }
 }


### PR DESCRIPTION
This PR allows filter middleware in `route:list` command by using `--middleware` option