### PR TITLE
[10.x] Throw exception when trying to escape array for database connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1101,6 +1101,8 @@ class Connection implements ConnectionInterface
             return (string) $value;
         } elseif (is_bool($value)) {
             return $this->escapeBool($value);
+        } elseif (is_array($value)) {
+            return $this->escapeArray($value);
         } else {
             if (str_contains($value, "\00")) {
                 throw new RuntimeException('Strings with null bytes cannot be escaped. Use the binary escape option.');
@@ -1134,6 +1136,16 @@ class Connection implements ConnectionInterface
     protected function escapeBool($value)
     {
         return $value ? '1' : '0';
+    }
+
+    /**
+     * Escape an array value for safe SQL embedding.
+     *
+     * @param  array  $value
+     */
+    protected function escapeArray(array $value)
+    {
+        throw new RuntimeException('The database connection does not support escaping array values.');
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1102,7 +1102,7 @@ class Connection implements ConnectionInterface
         } elseif (is_bool($value)) {
             return $this->escapeBool($value);
         } elseif (is_array($value)) {
-            return $this->escapeArray($value);
+            throw new RuntimeException('The database connection does not support escaping arrays.');
         } else {
             if (str_contains($value, "\00")) {
                 throw new RuntimeException('Strings with null bytes cannot be escaped. Use the binary escape option.');
@@ -1136,16 +1136,6 @@ class Connection implements ConnectionInterface
     protected function escapeBool($value)
     {
         return $value ? '1' : '0';
-    }
-
-    /**
-     * Escape an array value for safe SQL embedding.
-     *
-     * @param  array  $value
-     */
-    protected function escapeArray(array $value)
-    {
-        throw new RuntimeException('The database connection does not support escaping array values.');
     }
 
     /**

--- a/tests/Integration/Database/MySql/EscapeTest.php
+++ b/tests/Integration/Database/MySql/EscapeTest.php
@@ -61,4 +61,11 @@ class EscapeTest extends MySqlTestCase
 
         $this->app['db']->escape("I am hiding a \00 byte");
     }
+
+    public function testEscapeArray()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape(['a', 'b']);
+    }
 }

--- a/tests/Integration/Database/Postgres/EscapeTest.php
+++ b/tests/Integration/Database/Postgres/EscapeTest.php
@@ -61,4 +61,11 @@ class EscapeTest extends PostgresTestCase
 
         $this->app['db']->escape("I am hiding a \00 byte");
     }
+
+    public function testEscapeArray()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape(['a', 'b']);
+    }
 }

--- a/tests/Integration/Database/SqlServer/EscapeTest.php
+++ b/tests/Integration/Database/SqlServer/EscapeTest.php
@@ -57,4 +57,11 @@ class EscapeTest extends SqlServerTestCase
 
         $this->app['db']->escape("I am hiding a \00 byte");
     }
+
+    public function testEscapeArray()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape(['a', 'b']);
+    }
 }

--- a/tests/Integration/Database/Sqlite/EscapeTest.php
+++ b/tests/Integration/Database/Sqlite/EscapeTest.php
@@ -73,4 +73,11 @@ class EscapeTest extends DatabaseTestCase
 
         $this->app['db']->escape("I am hiding a \00 byte");
     }
+
+    public function testEscapeArray()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->app['db']->escape(['a', 'b']);
+    }
 }


### PR DESCRIPTION
When trying to escape an array value with the database connection class, typeError is thrown due to str_contains() expecting a string. Now a correct exception is thrown. 

It happens for example when you try to substitute bindings into raw SQL and this part has for some reason array values in it.

Simplified version

```
        $queryBuilder = DB::query();
        $queryBuilder->getGrammar()->substituteBindingsIntoRawSql(
            '?', [ [ 'a', 'b'] ]
        );
```