### PR TITLE
Update MySqlGrammar.php

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -44,7 +44,7 @@ class MySqlGrammar extends Grammar
     public function compileCreateDatabase($name, $connection)
     {
         return sprintf(
-            'create database %s default character set %s default collate %s',
+            'create database if not exists %s default character set %s default collate %s',
             $this->wrapValue($name),
             $this->wrapValue($connection->getConfig('charset')),
             $this->wrapValue($connection->getConfig('collation')),

--- a/tests/Database/DatabaseMySqlBuilderTest.php
+++ b/tests/Database/DatabaseMySqlBuilderTest.php
@@ -24,7 +24,7 @@ class DatabaseMySqlBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8mb4_unicode_ci');
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
-            'create database `my_temporary_database` default character set `utf8mb4` default collate `utf8mb4_unicode_ci`'
+            'create database if not exists `my_temporary_database` default character set `utf8mb4` default collate `utf8mb4_unicode_ci`'
         )->andReturn(true);
 
         $builder = new MySqlBuilder($connection);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1269,7 +1269,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statement = $this->getGrammar()->compileCreateDatabase('my_database_a', $connection);
 
         $this->assertSame(
-            'create database `my_database_a` default character set `utf8mb4_foo` default collate `utf8mb4_unicode_ci_foo`',
+            'create database if not exists `my_database_a` default character set `utf8mb4_foo` default collate `utf8mb4_unicode_ci_foo`',
             $statement
         );
 
@@ -1280,7 +1280,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statement = $this->getGrammar()->compileCreateDatabase('my_database_b', $connection);
 
         $this->assertSame(
-            'create database `my_database_b` default character set `utf8mb4_bar` default collate `utf8mb4_unicode_ci_bar`',
+            'create database if not exists `my_database_b` default character set `utf8mb4_bar` default collate `utf8mb4_unicode_ci_bar`',
             $statement
         );
     }


### PR DESCRIPTION
To increase the security by creating databases for tenants via external service - so the project MySQL user will have access to the project's and tenants' databases only, without site-wide create permission

It also fits older branches and breaks nothing
