### PR TITLE
[10.x] Added "userOrFail" auth method.

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -74,6 +74,7 @@ trait GuardHelpers
      * Get the currently authenticated user or throw an exception if not authenticated.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
      * @throws \Illuminate\Auth\AuthenticationException
      */
     public function userOrFail()

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -71,6 +71,18 @@ trait GuardHelpers
     }
 
     /**
+     * Get the currently authenticated user or throw an exception if not authenticated.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @throws AuthenticationException
+     */
+    public function userOrFail()
+    {
+        return $this->user()
+            ?? throw new AuthenticationException('There is no authenticated user.');
+    }
+
+    /**
      * Get the ID for the currently authenticated user.
      *
      * @return int|string|null

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -74,7 +74,7 @@ trait GuardHelpers
      * Get the currently authenticated user or throw an exception if not authenticated.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
-     * @throws AuthenticationException
+     * @throws \Illuminate\Auth\AuthenticationException
      */
     public function userOrFail()
     {

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -606,6 +606,26 @@ class AuthGuardTest extends TestCase
         $this->assertNull($guard->getUser());
     }
 
+    public function testUserIsReturnedWhenUsingUserOrFail()
+    {
+        $user = m::mock(Authenticatable::class);
+        $guard = $this->getGuard();
+        $guard->setUser($user);
+
+        $this->assertSame($user, $guard->userOrFail());
+    }
+
+    public function testExceptionIsThrownIfUsingUserOrFailAndThereIsNoAuthenticatedUser()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('There is no authenticated user.');
+
+        $guard = $this->getGuard();
+        $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
+
+        $guard->userOrFail();
+    }
+
     protected function getGuard()
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();


### PR DESCRIPTION
Hey! This PR is only a small one and proposes a new `userOrFail` method for getting the authenticated user.

You can use the method like so:

```php
$user = auth()->userOrFail();

// or...

$user = Auth::userOrFail();
```

This method works in a similar way to the `auth()-user()` method and will return the authenticated user if there is one. However, if there isn't one, an `\Illuminate\Auth\AuthenticationException` will be thrown.

The idea behind this is that I sometimes want to be double-sure that I have all the necessary data needed in my controllers, views, etc. So I see this as being an extra defence to ensure that there is an authenticated user before we try acting on them (calling any methods or properties).

I'd like to think of it as being a similar sort of approach to using `sole()` in DB queries or Collections, whereby you're 99% sure that your data is correct, but you just want that extra confidence at runtime.

I get that this is a really small (and possibly unneeded) addition, but I thought I'd propose it because I like to use something similar in some of my projects. So it's totally cool if you think it's unneeded!

If it's something you think might be handy to other developers, please give me a shout if you need anything changed. Apologies if I've missed anything.

P.s. - If you do think this is useful, and it gets merged, would you also be open to me adding a similar method to requests classes (e.g. - `$request->userOrFail()`)? 🙂