### PR TITLE
[10.x] Throw exception when too many files in file session handler lottery is running.

### DIFF
--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -118,7 +118,7 @@ class FileSessionHandler implements SessionHandlerInterface
                     ->ignoreDotFiles(true)
                     ->date('<= now - '.$lifetime.' seconds');
 
-        if ( ini_get('max_execution_time') <= 30 && $files->count() > 1000 ) {
+        if (ini_get('max_execution_time') <= 30 && $files->count() > 1000) {
             throw new RuntimeException('Session driver [file] has accumulated too many files which is preventing garbage collection.');
         }
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -118,7 +118,7 @@ class FileSessionHandler implements SessionHandlerInterface
                     ->ignoreDotFiles(true)
                     ->date('<= now - '.$lifetime.' seconds');
 
-        if ( ini_get('max_execution_time') <= 30 && $files->count() > 5000 ) {
+        if ( ini_get('max_execution_time') <= 30 && $files->count() > 1000 ) {
             throw new RuntimeException('Session driver [file] has accumulated too many files which is preventing garbage collection.');
         }
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -118,7 +118,9 @@ class FileSessionHandler implements SessionHandlerInterface
                     ->ignoreDotFiles(true)
                     ->date('<= now - '.$lifetime.' seconds');
 
-        if (ini_get('max_execution_time') !== 0 && ini_get('max_execution_time') <= 30 && $files->count() > 1000) {
+        $maxExecutionTime = ini_get('max_execution_time');
+
+        if ($maxExecutionTime !== 0 && $maxExecutionTime <= 30 && $files->count() > 1000) {
             throw new RuntimeException('Session driver [file] has accumulated too many files which is preventing garbage collection.');
         }
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -118,7 +118,7 @@ class FileSessionHandler implements SessionHandlerInterface
                     ->ignoreDotFiles(true)
                     ->date('<= now - '.$lifetime.' seconds');
 
-        if (ini_get('max_execution_time') <= 30 && $files->count() > 1000) {
+        if (ini_get('max_execution_time') !== 0 && ini_get('max_execution_time') <= 30 && $files->count() > 1000) {
             throw new RuntimeException('Session driver [file] has accumulated too many files which is preventing garbage collection.');
         }
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -4,6 +4,7 @@ namespace Illuminate\Session;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
+use RuntimeException;
 use SessionHandlerInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -116,6 +117,10 @@ class FileSessionHandler implements SessionHandlerInterface
                     ->files()
                     ->ignoreDotFiles(true)
                     ->date('<= now - '.$lifetime.' seconds');
+
+        if ( ini_get('max_execution_time') <= 30 && $files->count() > 5000 ) {
+            throw new RuntimeException('Session driver [file] has accumulated too many files which is preventing garbage collection.');
+        }
 
         $deletedSessions = 0;
 


### PR DESCRIPTION
This requests purpose is to better inform developers in the event of a file session handler having too many files when lottery garbage collecting. Without an error before iterating across the files, you'll be presented a maximum execution time exceeded error. Majority of bug trackers don't do a good job at explaining what exactly is the issue and the traces/breadcrumbs tend to be all over the place depending on when the runtime was terminated.

I have an idea of dispatching an async job when the batch size hits a certain threshold which I don't mind doing if this request is seriously considered. Also either making a .env variable or having a programmatic way of determining what is the max of files before alerting.