### PR TITLE
[10.x] Add missing methods to `ProcessResult` contract

### DIFF
--- a/src/Illuminate/Contracts/Process/ProcessResult.php
+++ b/src/Illuminate/Contracts/Process/ProcessResult.php
@@ -40,11 +40,27 @@ interface ProcessResult
     public function output();
 
     /**
+     * Determine if the output contains the given string.
+     *
+     * @param  string  $output
+     * @return bool
+     */
+    public function seeInOutput(string $output);
+
+    /**
      * Get the error output of the process.
      *
      * @return string
      */
     public function errorOutput();
+
+    /**
+     * Determine if the error output contains the given string.
+     *
+     * @param  string  $output
+     * @return bool
+     */
+    public function seeInErrorOutput(string $output);
 
     /**
      * Throw an exception if the process failed.


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Extending the`ProcessResult` contract to include missing methods that are implemented on [`ProcessResult`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Process/ProcessResult.php#L79-L109) and [`FakeProcessResult`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Process/FakeProcessResult.php#L144-L168).
