### PR TITLE
[10.x] Add a `Number` utility class

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -41,7 +41,7 @@ class Number
      * @param  ?string  $locale
      * @return string|false
      */
-    public static function toPercentage(int|float $number, int $precision = 2, ?string $locale = null)
+    public static function toPercentage(int|float $number, int $precision = 0, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
@@ -76,7 +76,7 @@ class Number
      * @param  int  $precision
      * @return string
      */
-    public static function toFileSize(int|float $bytes, int $precision = 2)
+    public static function toFileSize(int|float $bytes, int $precision = 0)
     {
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
@@ -84,7 +84,7 @@ class Number
             $bytes /= 1024;
         }
 
-        return sprintf('%s %s', round($bytes, $precision), $units[$i]);
+        return sprintf('%s %s', number_format($bytes, $precision), $units[$i]);
     }
 
     /**
@@ -94,7 +94,7 @@ class Number
      * @param  int  $precision
      * @return string
      */
-    public static function forHumans(int|float $number, int $precision = 2)
+    public static function forHumans(int|float $number, int $precision = 0)
     {
         $units = [
             3 => 'thousand',
@@ -117,7 +117,7 @@ class Number
         $displayExponent = $numberExponent - ($numberExponent % 3);
         $number /= pow(10, $displayExponent);
 
-        return trim(sprintf('%s %s', round($number, $precision), $units[$displayExponent]));
+        return trim(sprintf('%s %s', number_format($number, $precision), $units[$displayExponent]));
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
+use RuntimeException;
 
 class Number
 {
@@ -18,6 +19,8 @@ class Number
      */
     public static function toHuman($number, $locale = 'en')
     {
+        static::needsIntlExtension();
+
         $formatter = new NumberFormatter($locale, NumberFormatter::SPELLOUT);
 
         return $formatter->format($number);
@@ -39,5 +42,19 @@ class Number
         }
 
         return sprintf('%s %s', round($bytes, $precision), $units[$i]);
+    }
+
+    /**
+     * Some of the helper methods are wrappers for the PHP intl extension,
+     * and thus require it to be installed on the server. If it's not
+     * installed, we instead throw an exception from this method.
+     *
+     * @return void
+     */
+    protected static function needsIntlExtension()
+    {
+        if (! extension_loaded('intl')) {
+            throw new RuntimeException('The intl PHP extension is required to use this helper.');
+        }
     }
 }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -28,13 +28,13 @@ class Number
     }
 
     /**
-     * Format the number to a fluent human-readable string.
+     * Spell out the number according to the current locale.
      *
      * @param  float|int  $number
      * @param  ?string  $locale
      * @return false|string
      */
-    public static function toHuman($number, $locale = null)
+    public static function spellout($number, $locale = null)
     {
         static::needsIntlExtension();
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -12,6 +12,22 @@ class Number
     use Macroable;
 
     /**
+     * Format the number according to the current locale.
+     *
+     * @param  float|int  $number
+     * @param  ?string  $locale
+     * @return false|string
+     */
+    public static function format($number, $locale = null)
+    {
+        static::needsIntlExtension();
+
+        $formatter = new NumberFormatter($locale ?? App::getLocale(), NumberFormatter::DECIMAL);
+
+        return $formatter->format($number);
+    }
+
+    /**
      * Format the number to a fluent human-readable string.
      *
      * @param  float|int  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -114,17 +114,13 @@ class Number
             15 => 'quadrillion',
         ];
 
-        if ($number === 0) {
-            return '0';
-        }
-
-        if ($number < 0) {
-            return sprintf('-%s', static::toHuman(abs($number), $precision));
-        }
-
-        // If over 1 quadrillion
-        if ($number >= pow(10, 15)) {
-            return sprintf('%s quadrillion', static::toHuman($number / pow(10, 15), $precision));
+        switch (true) {
+            case $number === 0:
+                return '0';
+            case $number < 0:
+                return sprintf('-%s', static::toHuman(abs($number), $precision));
+            case $number >= 1e15:
+                return sprintf('%s quadrillion', static::toHuman($number / 1e15, $precision));
         }
 
         $numberExponent = floor(log10($number));

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -8,5 +8,21 @@ class Number
 {
     use Macroable;
 
-    //
+    /**
+     * Format the number of bytes to a human-readable string.
+     *
+     * @param  int  $bytes
+     * @param  int  $precision
+     * @return string
+     */
+    public static function bytesToHuman($bytes, $precision = 2)
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
+            $bytes /= 1024;
+        }
+
+        return sprintf('%s %s', round($bytes, $precision), $units[$i]);
+    }
 }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
 use RuntimeException;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -32,7 +32,7 @@ class Number
      */
     public static function bytesToHuman($bytes, $precision = 2)
     {
-        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
         for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
             $bytes /= 1024;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -98,6 +98,36 @@ class Number
     }
 
     /**
+     * Format the number to a fluent human-readable string.
+     *
+     * @param  int  $number
+     * @param  int  $precision
+     * @return string
+     */
+    public static function toHuman($number, $precision = 2)
+    {
+        $shortScale = [
+            100 => 'Hundred',
+            1000 => 'Thousand',
+            1000000 => 'Million',
+            1000000000 => 'Billion',
+            1000000000000 => 'Trillion',
+            1000000000000000 => 'Quadrillion',
+            1000000000000000000 => 'Quintillion',
+        ];
+
+        $scale = 1;
+        foreach ($shortScale as $value => $name) {
+            if ($number < $value) {
+                break;
+            }
+            $scale = $value;
+        }
+
+        return sprintf('%s %s', round($number / $scale, $precision), $shortScale[$scale]);
+    }
+
+    /**
      * Some of the helper methods are wrappers for the PHP intl extension,
      * and thus require it to be installed on the server. If it's not
      * installed, we instead throw an exception from this method.

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -39,16 +39,16 @@ class Number
      *
      * @param  int|float  $number
      * @param  int  $precision
-     * @param  string  $locale
+     * @param  ?string  $locale
      * @return string|false
      */
-    public static function toPercentage(int|float $number, int $precision = 2, string $locale = 'en')
+    public static function toPercentage(int|float $number, int $precision = 2, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
-        $formatter = new NumberFormatter($locale, NumberFormatter::PERCENT);
+        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::PERCENT);
 
-        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $precision);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
 
         return $formatter->format($number / 100);
     }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -106,25 +106,36 @@ class Number
      */
     public static function toHuman($number, $precision = 2)
     {
-        $shortScale = [
-            100 => 'Hundred',
-            1000 => 'Thousand',
-            1000000 => 'Million',
-            1000000000 => 'Billion',
-            1000000000000 => 'Trillion',
-            1000000000000000 => 'Quadrillion',
-            1000000000000000000 => 'Quintillion',
+        $units = [
+            0 => '',
+            1 => 'ten',
+            2 => 'hundred',
+            3 => 'thousand',
+            6 => 'million',
+            9 => 'billion',
+            12 => 'trillion',
+            15 => 'quadrillion',
+            -1 => 'deci',
+            -2 => 'centi',
+            -3 => 'mili',
+            -6 => 'micro',
+            -9 => 'nano',
+            -12 => 'pico',
+            -15 => 'femto'
         ];
 
-        $scale = 1;
-        foreach ($shortScale as $value => $name) {
-            if ($number < $value) {
-                break;
-            }
-            $scale = $value;
+        $numberExponent = floor(log10($number));
+        $displayExponent = $numberExponent - ($numberExponent % 3);
+        $number /= pow(10, $displayExponent);
+
+        $unit = $units[$displayExponent];
+
+        if (! $unit && $displayExponent > 0) {
+            $unit = $units[max(array_keys($units))];
+            $number *= 1000;
         }
 
-        return sprintf('%s %s', round($number / $scale, $precision), $shortScale[$scale]);
+        return trim(sprintf('%s %s', round($number, $precision), $unit));
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -44,6 +44,25 @@ class Number
     }
 
     /**
+     * Format the number to a percent format.
+     *
+     * @param  float|int  $number
+     * @param  int  $precision
+     * @param  string  $locale
+     * @return false|string
+     */
+    public static function toPercent($number, $precision = 2, $locale = 'en')
+    {
+        static::needsIntlExtension();
+
+        $formatter = new NumberFormatter($locale, NumberFormatter::PERCENT);
+
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $precision);
+
+        return $formatter->format($number / 100);
+    }
+
+    /**
      * Format the number to a currency format.
      *
      * @param  float|int  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -107,35 +107,31 @@ class Number
     public static function toHuman($number, $precision = 2)
     {
         $units = [
-            0 => '',
-            1 => 'ten',
-            2 => 'hundred',
             3 => 'thousand',
             6 => 'million',
             9 => 'billion',
             12 => 'trillion',
             15 => 'quadrillion',
-            -1 => 'deci',
-            -2 => 'centi',
-            -3 => 'mili',
-            -6 => 'micro',
-            -9 => 'nano',
-            -12 => 'pico',
-            -15 => 'femto'
         ];
+
+        if ($number === 0) {
+            return '0';
+        }
+
+        if ($number < 0) {
+            return sprintf('-%s', static::toHuman(abs($number), $precision));
+        }
+
+        // If over 1 quadrillion
+        if ($number >= pow(10, 15)) {
+            return sprintf('%s quadrillion', static::toHuman($number / pow(10, 15), $precision));
+        }
 
         $numberExponent = floor(log10($number));
         $displayExponent = $numberExponent - ($numberExponent % 3);
         $number /= pow(10, $displayExponent);
 
-        $unit = $units[$displayExponent];
-
-        if (! $unit && $displayExponent > 0) {
-            $unit = $units[max(array_keys($units))];
-            $number *= 1000;
-        }
-
-        return trim(sprintf('%s %s', round($number, $precision), $unit));
+        return trim(sprintf('%s %s', round($number, $precision), $units[$displayExponent]));
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -27,6 +27,23 @@ class Number
     }
 
     /**
+     * Format the number to a currency format.
+     *
+     * @param  float|int  $number
+     * @param  string  $currency
+     * @param  string  $locale
+     * @return false|string
+     */
+    public static function toCurrency($number, $currency = 'USD', $locale = 'en')
+    {
+        static::needsIntlExtension();
+
+        $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+
+        return $formatter->formatCurrency($number, $currency);
+    }
+
+    /**
      * Format the number of bytes to a human-readable string.
      *
      * @param  int  $bytes

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -3,10 +3,25 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
+use NumberFormatter;
 
 class Number
 {
     use Macroable;
+
+    /**
+     * Format the number to a fluent human-readable string.
+     *
+     * @param  float|int  $number
+     * @param  string  $locale
+     * @return false|string
+     */
+    public static function toHuman($number, $locale = 'en')
+    {
+        $formatter = new NumberFormatter($locale, NumberFormatter::SPELLOUT);
+
+        return $formatter->format($number);
+    }
 
     /**
      * Format the number of bytes to a human-readable string.

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Traits\Macroable;
 use NumberFormatter;
 use RuntimeException;
@@ -14,14 +15,14 @@ class Number
      * Format the number to a fluent human-readable string.
      *
      * @param  float|int  $number
-     * @param  string  $locale
+     * @param  ?string  $locale
      * @return false|string
      */
-    public static function toHuman($number, $locale = 'en')
+    public static function toHuman($number, $locale = null)
     {
         static::needsIntlExtension();
 
-        $formatter = new NumberFormatter($locale, NumberFormatter::SPELLOUT);
+        $formatter = new NumberFormatter($locale ?? App::getLocale(), NumberFormatter::SPELLOUT);
 
         return $formatter->format($number);
     }
@@ -31,14 +32,14 @@ class Number
      *
      * @param  float|int  $number
      * @param  string  $currency
-     * @param  string  $locale
+     * @param  ?string  $locale
      * @return false|string
      */
-    public static function toCurrency($number, $currency = 'USD', $locale = 'en')
+    public static function toCurrency($number, $currency = 'USD', $locale = null)
     {
         static::needsIntlExtension();
 
-        $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+        $formatter = new NumberFormatter($locale ?? App::getLocale(), NumberFormatter::CURRENCY);
 
         return $formatter->formatCurrency($number, $currency);
     }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Traits\Macroable;
+
+class Number
+{
+    use Macroable;
+
+    //
+}

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -49,8 +49,7 @@
         "symfony/process": "Required to use the composer class (^6.2).",
         "symfony/uid": "Required to use Str::ulid() (^6.2).",
         "symfony/var-dumper": "Required to use the dd function (^6.2).",
-        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1).",
-        "ext-intl": "Required to use certain wrappers in the Number class."
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -49,7 +49,8 @@
         "symfony/process": "Required to use the composer class (^6.2).",
         "symfony/uid": "Required to use Str::ulid() (^6.2).",
         "symfony/var-dumper": "Required to use the dd function (^6.2).",
-        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1)."
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1).",
+        "ext-intl": "Required to use certain wrappers in the Number class."
     },
     "config": {
         "sort-packages": true

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -7,6 +7,40 @@ use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
+    public function testToHuman()
+    {
+        $this->assertSame('zero', Number::toHuman(0));
+        $this->assertSame('one', Number::toHuman(1));
+        $this->assertSame('ten', Number::toHuman(10));
+        $this->assertSame('twenty-five', Number::toHuman(25));
+        $this->assertSame('one hundred', Number::toHuman(100));
+        $this->assertSame('one hundred thousand', Number::toHuman(100000));
+        $this->assertSame('one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine', Number::toHuman(123456789));
+
+        $this->assertSame('one billion', Number::toHuman(1000000000));
+        $this->assertSame('one trillion', Number::toHuman(1000000000000));
+        $this->assertSame('one quadrillion', Number::toHuman(1000000000000000));
+        $this->assertSame('1,000,000,000,000,000,000', Number::toHuman(1000000000000000000));
+
+        $this->assertSame('minus one', Number::toHuman(-1));
+        $this->assertSame('minus ten', Number::toHuman(-10));
+        $this->assertSame('minus twenty-five', Number::toHuman(-25));
+
+        $this->assertSame('zero point two', Number::toHuman(0.2));
+        $this->assertSame('one point two three', Number::toHuman(1.23));
+        $this->assertSame('minus one point two three', Number::toHuman(-1.23));
+        $this->assertSame('one hundred twenty-three point four five six', Number::toHuman(123.456));
+    }
+
+    public function testToHumanWithDifferentLocale()
+    {
+        $this->assertSame('cent vingt-trois', Number::toHuman(123, 'fr'));
+
+        $this->assertSame('ein­hundert­drei­und­zwanzig', Number::toHuman(123, 'de'));
+
+        $this->assertSame('ett­hundra­tjugo­tre', Number::toHuman(123, 'sv'));
+    }
+
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::bytesToHuman(0));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -186,13 +186,15 @@ class SupportNumberTest extends TestCase
 
     public function testToHuman()
     {
-        $this->assertSame('100',      Number::toHuman(100));
-        $this->assertSame('1 thousand',     Number::toHuman(1000));
-        $this->assertSame('1 million',      Number::toHuman(1000000));
-        $this->assertSame('1 billion',      Number::toHuman(1000000000));
-        $this->assertSame('1 trillion',     Number::toHuman(1000000000000));
-        $this->assertSame('1 quadrillion',  Number::toHuman(1000000000000000));
-        $this->assertSame('1000 quadrillion',  Number::toHuman(1000000000000000000));
+        $this->assertSame('1', Number::toHuman(1));
+        $this->assertSame('10', Number::toHuman(10));
+        $this->assertSame('100', Number::toHuman(100));
+        $this->assertSame('1 thousand', Number::toHuman(1000));
+        $this->assertSame('1 million', Number::toHuman(1000000));
+        $this->assertSame('1 billion', Number::toHuman(1000000000));
+        $this->assertSame('1 trillion', Number::toHuman(1000000000000));
+        $this->assertSame('1 quadrillion', Number::toHuman(1000000000000000));
+        $this->assertSame('1 thousand quadrillion', Number::toHuman(1000000000000000000));
 
         $this->assertSame('123', Number::toHuman(123));
         $this->assertSame('1.23 thousand', Number::toHuman(1234));
@@ -201,10 +203,27 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1.23 billion', Number::toHuman(1234567890));
         $this->assertSame('1.23 trillion', Number::toHuman(1234567890123));
         $this->assertSame('1.23 quadrillion', Number::toHuman(1234567890123456));
-        $this->assertSame('1234.57 quadrillion', Number::toHuman(1234567890123456789));
+        $this->assertSame('1.23 thousand quadrillion', Number::toHuman(1234567890123456789));
         $this->assertSame('490 thousand', Number::toHuman(489939, precision: 0));
         $this->assertSame('489.939 thousand', Number::toHuman(489939, precision: 4));
         $this->assertSame('500 million', Number::toHuman(500000000, precision: 5));
+
+        $this->assertSame('1 million quadrillion',  Number::toHuman(1000000000000000000000));
+        $this->assertSame('1 billion quadrillion',  Number::toHuman(1000000000000000000000000));
+        $this->assertSame('1 trillion quadrillion',  Number::toHuman(1000000000000000000000000000));
+        $this->assertSame('1 quadrillion quadrillion',  Number::toHuman(1000000000000000000000000000000));
+        $this->assertSame('1 thousand quadrillion quadrillion',  Number::toHuman(1000000000000000000000000000000000));
+
+        $this->assertSame('0',      Number::toHuman(0));
+        $this->assertSame('-1',      Number::toHuman(-1));
+        $this->assertSame('-10',      Number::toHuman(-10));
+        $this->assertSame('-100',      Number::toHuman(-100));
+        $this->assertSame('-1 thousand',     Number::toHuman(-1000));
+        $this->assertSame('-1 million',      Number::toHuman(-1000000));
+        $this->assertSame('-1 billion',      Number::toHuman(-1000000000));
+        $this->assertSame('-1 trillion',     Number::toHuman(-1000000000000));
+        $this->assertSame('-1 quadrillion',  Number::toHuman(-1000000000000000));
+        $this->assertSame('-1 thousand quadrillion',  Number::toHuman(-1000000000000000000));
     }
 
     protected function needsIntlExtension()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -9,6 +9,8 @@ class SupportNumberTest extends TestCase
 {
     public function testToHuman()
     {
+        $this->needsIntlExtension();
+
         $this->assertSame('zero', Number::toHuman(0));
         $this->assertSame('one', Number::toHuman(1));
         $this->assertSame('ten', Number::toHuman(10));
@@ -34,6 +36,8 @@ class SupportNumberTest extends TestCase
 
     public function testToHumanWithDifferentLocale()
     {
+        $this->needsIntlExtension();
+
         $this->assertSame('cent vingt-trois', Number::toHuman(123, 'fr'));
 
         $this->assertSame('ein­hundert­drei­und­zwanzig', Number::toHuman(123, 'de'));
@@ -55,5 +59,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 ZB', Number::bytesToHuman(1024 ** 7));
         $this->assertSame('1 YB', Number::bytesToHuman(1024 ** 8));
         $this->assertSame('1024 YB', Number::bytesToHuman(1024 ** 9));
+    }
+
+    protected function needsIntlExtension()
+    {
+        if (! extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable '.__CLASS__);
+        }
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -27,6 +27,54 @@ class SupportNumberTest extends TestCase
         parent::tearDown();
     }
 
+    public function testFormat()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('0', Number::format(0));
+        $this->assertSame('1', Number::format(1));
+        $this->assertSame('10', Number::format(10));
+        $this->assertSame('25', Number::format(25));
+        $this->assertSame('100', Number::format(100));
+        $this->assertSame('100,000', Number::format(100000));
+        $this->assertSame('123,456,789', Number::format(123456789));
+
+        $this->assertSame('-1', Number::format(-1));
+        $this->assertSame('-10', Number::format(-10));
+        $this->assertSame('-25', Number::format(-25));
+
+        $this->assertSame('0.2', Number::format(0.2));
+        $this->assertSame('1.23', Number::format(1.23));
+        $this->assertSame('-1.23', Number::format(-1.23));
+        $this->assertSame('123.456', Number::format(123.456));
+
+        $this->assertSame('∞', Number::format(INF));
+        $this->assertSame('NaN', Number::format(NAN));
+    }
+
+    public function testFormatWithDifferentLocale()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('123,456,789', Number::format(123456789, 'en'));
+        $this->assertSame('123.456.789', Number::format(123456789, 'de'));
+        $this->assertSame('123 456 789', Number::format(123456789, 'fr'));
+        $this->assertSame('123 456 789', Number::format(123456789, 'ru'));
+        $this->assertSame('123 456 789', Number::format(123456789, 'sv'));
+    }
+
+    public function testFormatWithAppLocale()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('123,456,789', Number::format(123456789));
+
+        App::clearResolvedInstances();
+        App::shouldReceive('getLocale')->andReturn('de');
+
+        $this->assertSame('123.456.789', Number::format(123456789));
+    }
+
     public function testToHuman()
     {
         $this->needsIntlExtension();

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -45,10 +45,10 @@ class SupportNumberTest extends TestCase
     {
         $this->assertSame('0 B', Number::bytesToHuman(0));
         $this->assertSame('1 B', Number::bytesToHuman(1));
-        $this->assertSame('1 KB', Number::bytesToHuman(1024));
-        $this->assertSame('2 KB', Number::bytesToHuman(2048));
-        $this->assertSame('1.23 KB', Number::bytesToHuman(1264));
-        $this->assertSame('1.234 KB', Number::bytesToHuman(1264, 3));
+        $this->assertSame('1 kB', Number::bytesToHuman(1024));
+        $this->assertSame('2 kB', Number::bytesToHuman(2048));
+        $this->assertSame('1.23 kB', Number::bytesToHuman(1264));
+        $this->assertSame('1.234 kB', Number::bytesToHuman(1264, 3));
         $this->assertSame('5 GB', Number::bytesToHuman(1024 * 1024 * 1024 * 5));
         $this->assertSame('10 TB', Number::bytesToHuman((1024 ** 4) * 10));
         $this->assertSame('10 PB', Number::bytesToHuman((1024 ** 5) * 10));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -2,27 +2,36 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Number;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
+    protected Application $app;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        App::swap(new Container);
-        App::shouldReceive('getLocale')->andReturn('en');
+        $this->app = new class extends Application
+        {
+            public string $locale = 'en';
+
+            public function getLocale(): string
+            {
+                return $this->locale;
+            }
+        };
+
+        App::swap($this->app);
     }
 
     protected function tearDown(): void
     {
-        Mockery::close();
         App::clearResolvedInstances();
-        App::swap(new Container);
+        App::swap(new Application);
 
         parent::tearDown();
     }
@@ -69,8 +78,7 @@ class SupportNumberTest extends TestCase
 
         $this->assertSame('123,456,789', Number::format(123456789));
 
-        App::clearResolvedInstances();
-        App::shouldReceive('getLocale')->andReturn('de');
+        $this->app->locale = 'de';
 
         $this->assertSame('123.456.789', Number::format(123456789));
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -83,42 +83,42 @@ class SupportNumberTest extends TestCase
         $this->assertSame('123.456.789', Number::format(123456789));
     }
 
-    public function testToHuman()
+    public function testSpellout()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('zero', Number::toHuman(0));
-        $this->assertSame('one', Number::toHuman(1));
-        $this->assertSame('ten', Number::toHuman(10));
-        $this->assertSame('twenty-five', Number::toHuman(25));
-        $this->assertSame('one hundred', Number::toHuman(100));
-        $this->assertSame('one hundred thousand', Number::toHuman(100000));
-        $this->assertSame('one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine', Number::toHuman(123456789));
+        $this->assertSame('zero', Number::spellout(0));
+        $this->assertSame('one', Number::spellout(1));
+        $this->assertSame('ten', Number::spellout(10));
+        $this->assertSame('twenty-five', Number::spellout(25));
+        $this->assertSame('one hundred', Number::spellout(100));
+        $this->assertSame('one hundred thousand', Number::spellout(100000));
+        $this->assertSame('one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine', Number::spellout(123456789));
 
-        $this->assertSame('one billion', Number::toHuman(1000000000));
-        $this->assertSame('one trillion', Number::toHuman(1000000000000));
-        $this->assertSame('one quadrillion', Number::toHuman(1000000000000000));
-        $this->assertSame('1,000,000,000,000,000,000', Number::toHuman(1000000000000000000));
+        $this->assertSame('one billion', Number::spellout(1000000000));
+        $this->assertSame('one trillion', Number::spellout(1000000000000));
+        $this->assertSame('one quadrillion', Number::spellout(1000000000000000));
+        $this->assertSame('1,000,000,000,000,000,000', Number::spellout(1000000000000000000));
 
-        $this->assertSame('minus one', Number::toHuman(-1));
-        $this->assertSame('minus ten', Number::toHuman(-10));
-        $this->assertSame('minus twenty-five', Number::toHuman(-25));
+        $this->assertSame('minus one', Number::spellout(-1));
+        $this->assertSame('minus ten', Number::spellout(-10));
+        $this->assertSame('minus twenty-five', Number::spellout(-25));
 
-        $this->assertSame('zero point two', Number::toHuman(0.2));
-        $this->assertSame('one point two three', Number::toHuman(1.23));
-        $this->assertSame('minus one point two three', Number::toHuman(-1.23));
-        $this->assertSame('one hundred twenty-three point four five six', Number::toHuman(123.456));
+        $this->assertSame('zero point two', Number::spellout(0.2));
+        $this->assertSame('one point two three', Number::spellout(1.23));
+        $this->assertSame('minus one point two three', Number::spellout(-1.23));
+        $this->assertSame('one hundred twenty-three point four five six', Number::spellout(123.456));
     }
 
-    public function testToHumanWithDifferentLocale()
+    public function testSpelloutWithDifferentLocale()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('cent vingt-trois', Number::toHuman(123, 'fr'));
+        $this->assertSame('cent vingt-trois', Number::spellout(123, 'fr'));
 
-        $this->assertSame('ein­hundert­drei­und­zwanzig', Number::toHuman(123, 'de'));
+        $this->assertSame('ein­hundert­drei­und­zwanzig', Number::spellout(123, 'de'));
 
-        $this->assertSame('ett­hundra­tjugo­tre', Number::toHuman(123, 'sv'));
+        $this->assertSame('ett­hundra­tjugo­tre', Number::spellout(123, 'sv'));
     }
 
     public function testToPercent()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -208,22 +208,22 @@ class SupportNumberTest extends TestCase
         $this->assertSame('489.939 thousand', Number::toHuman(489939, precision: 4));
         $this->assertSame('500 million', Number::toHuman(500000000, precision: 5));
 
-        $this->assertSame('1 million quadrillion',  Number::toHuman(1000000000000000000000));
-        $this->assertSame('1 billion quadrillion',  Number::toHuman(1000000000000000000000000));
-        $this->assertSame('1 trillion quadrillion',  Number::toHuman(1000000000000000000000000000));
-        $this->assertSame('1 quadrillion quadrillion',  Number::toHuman(1000000000000000000000000000000));
-        $this->assertSame('1 thousand quadrillion quadrillion',  Number::toHuman(1000000000000000000000000000000000));
+        $this->assertSame('1 million quadrillion', Number::toHuman(1000000000000000000000));
+        $this->assertSame('1 billion quadrillion', Number::toHuman(1000000000000000000000000));
+        $this->assertSame('1 trillion quadrillion', Number::toHuman(1000000000000000000000000000));
+        $this->assertSame('1 quadrillion quadrillion', Number::toHuman(1000000000000000000000000000000));
+        $this->assertSame('1 thousand quadrillion quadrillion', Number::toHuman(1000000000000000000000000000000000));
 
-        $this->assertSame('0',      Number::toHuman(0));
-        $this->assertSame('-1',      Number::toHuman(-1));
-        $this->assertSame('-10',      Number::toHuman(-10));
-        $this->assertSame('-100',      Number::toHuman(-100));
-        $this->assertSame('-1 thousand',     Number::toHuman(-1000));
-        $this->assertSame('-1 million',      Number::toHuman(-1000000));
-        $this->assertSame('-1 billion',      Number::toHuman(-1000000000));
-        $this->assertSame('-1 trillion',     Number::toHuman(-1000000000000));
-        $this->assertSame('-1 quadrillion',  Number::toHuman(-1000000000000000));
-        $this->assertSame('-1 thousand quadrillion',  Number::toHuman(-1000000000000000000));
+        $this->assertSame('0', Number::toHuman(0));
+        $this->assertSame('-1', Number::toHuman(-1));
+        $this->assertSame('-10', Number::toHuman(-10));
+        $this->assertSame('-100', Number::toHuman(-100));
+        $this->assertSame('-1 thousand', Number::toHuman(-1000));
+        $this->assertSame('-1 million', Number::toHuman(-1000000));
+        $this->assertSame('-1 billion', Number::toHuman(-1000000000));
+        $this->assertSame('-1 trillion', Number::toHuman(-1000000000000));
+        $this->assertSame('-1 quadrillion', Number::toHuman(-1000000000000000));
+        $this->assertSame('-1 thousand quadrillion', Number::toHuman(-1000000000000000000));
     }
 
     protected function needsIntlExtension()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -91,17 +91,18 @@ class SupportNumberTest extends TestCase
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('0%', Number::toPercentage(0));
-        $this->assertSame('1%', Number::toPercentage(1));
-        $this->assertSame('10%', Number::toPercentage(10));
-        $this->assertSame('100%', Number::toPercentage(100));
+        $this->assertSame('0%', Number::toPercentage(0, precision: 0));
+        $this->assertSame('0.00%', Number::toPercentage(0));
+        $this->assertSame('1.00%', Number::toPercentage(1));
+        $this->assertSame('10.00%', Number::toPercentage(10));
+        $this->assertSame('100.00%', Number::toPercentage(100));
 
-        $this->assertSame('300%', Number::toPercentage(300));
-        $this->assertSame('1,000%', Number::toPercentage(1000));
+        $this->assertSame('300.00%', Number::toPercentage(300));
+        $this->assertSame('1,000.00%', Number::toPercentage(1000));
 
         $this->assertSame('1.75%', Number::toPercentage(1.75));
         $this->assertSame('0.12%', Number::toPercentage(0.12345));
-        $this->assertSame('0.1235%', Number::toPercentage(0.12345, 4));
+        $this->assertSame('0.1235%', Number::toPercentage(0.12345, precision: 4));
     }
 
     public function testToCurrency()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Number;
+use PHPUnit\Framework\TestCase;
+
+class SupportNumberTest extends TestCase
+{
+    //
+}

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -45,6 +45,36 @@ class SupportNumberTest extends TestCase
         $this->assertSame('ett­hundra­tjugo­tre', Number::toHuman(123, 'sv'));
     }
 
+    public function testToCurrency()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('$0.00', Number::toCurrency(0));
+        $this->assertSame('$1.00', Number::toCurrency(1));
+        $this->assertSame('$10.00', Number::toCurrency(10));
+
+        $this->assertSame('€0.00', Number::toCurrency(0, 'EUR'));
+        $this->assertSame('€1.00', Number::toCurrency(1, 'EUR'));
+        $this->assertSame('€10.00', Number::toCurrency(10, 'EUR'));
+
+        $this->assertSame('-$5.00', Number::toCurrency(-5));
+        $this->assertSame('$5.00', Number::toCurrency(5.00));
+        $this->assertSame('$5.32', Number::toCurrency(5.325));
+    }
+
+    public function testToCurrencyWithDifferentLocale()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('1,00 €', Number::toCurrency(1, 'EUR', 'de'));
+        $this->assertSame('1,00 $', Number::toCurrency(1, 'USD', 'de'));
+        $this->assertSame('1,00 £', Number::toCurrency(1, 'GBP', 'de'));
+
+        $this->assertSame('123.456.789,12 $', Number::toCurrency(123456789.12345, 'USD', 'de'));
+        $this->assertSame('123.456.789,12 €', Number::toCurrency(123456789.12345, 'EUR', 'de'));
+        $this->assertSame('1 234,56 $US', Number::toCurrency(1234.56, 'USD', 'fr'));
+    }
+
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::bytesToHuman(0));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -186,25 +186,25 @@ class SupportNumberTest extends TestCase
 
     public function testToHuman()
     {
-        $this->assertSame('1 Hundred',      Number::toHuman(100));
-        $this->assertSame('1 Thousand',     Number::toHuman(1000));
-        $this->assertSame('1 Million',      Number::toHuman(1000000));
-        $this->assertSame('1 Billion',      Number::toHuman(1000000000));
-        $this->assertSame('1 Trillion',     Number::toHuman(1000000000000));
-        $this->assertSame('1 Quadrillion',  Number::toHuman(1000000000000000));
-        $this->assertSame('1 Quintillion',  Number::toHuman(1000000000000000000));
+        $this->assertSame('100',      Number::toHuman(100));
+        $this->assertSame('1 thousand',     Number::toHuman(1000));
+        $this->assertSame('1 million',      Number::toHuman(1000000));
+        $this->assertSame('1 billion',      Number::toHuman(1000000000));
+        $this->assertSame('1 trillion',     Number::toHuman(1000000000000));
+        $this->assertSame('1 quadrillion',  Number::toHuman(1000000000000000));
+        $this->assertSame('1000 quadrillion',  Number::toHuman(1000000000000000000));
 
-        $this->assertSame('1.23 Hundred', Number::toHuman(123));
-        $this->assertSame('1.23 Thousand', Number::toHuman(1234));
-        $this->assertSame('12.35 Thousand', Number::toHuman(12345));
-        $this->assertSame('1.23 Million', Number::toHuman(1234567));
-        $this->assertSame('1.23 Billion', Number::toHuman(1234567890));
-        $this->assertSame('1.23 Trillion', Number::toHuman(1234567890123));
-        $this->assertSame('1.23 Quadrillion', Number::toHuman(1234567890123456));
-        $this->assertSame('1.23 Quintillion', Number::toHuman(1234567890123456789));
-        $this->assertSame('490 Thousand', Number::toHuman(489939, precision: 0));
-        $this->assertSame('489.939 Thousand', Number::toHuman(489939, precision: 4));
-        $this->assertSame('500 Million', Number::toHuman(500000000, precision: 5));
+        $this->assertSame('123', Number::toHuman(123));
+        $this->assertSame('1.23 thousand', Number::toHuman(1234));
+        $this->assertSame('12.35 thousand', Number::toHuman(12345));
+        $this->assertSame('1.23 million', Number::toHuman(1234567));
+        $this->assertSame('1.23 billion', Number::toHuman(1234567890));
+        $this->assertSame('1.23 trillion', Number::toHuman(1234567890123));
+        $this->assertSame('1.23 quadrillion', Number::toHuman(1234567890123456));
+        $this->assertSame('1234.57 quadrillion', Number::toHuman(1234567890123456789));
+        $this->assertSame('490 thousand', Number::toHuman(489939, precision: 0));
+        $this->assertSame('489.939 thousand', Number::toHuman(489939, precision: 4));
+        $this->assertSame('500 million', Number::toHuman(500000000, precision: 5));
     }
 
     protected function needsIntlExtension()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -184,6 +184,29 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1024 YB', Number::bytesToHuman(1024 ** 9));
     }
 
+    public function testToHuman()
+    {
+        $this->assertSame('1 Hundred',      Number::toHuman(100));
+        $this->assertSame('1 Thousand',     Number::toHuman(1000));
+        $this->assertSame('1 Million',      Number::toHuman(1000000));
+        $this->assertSame('1 Billion',      Number::toHuman(1000000000));
+        $this->assertSame('1 Trillion',     Number::toHuman(1000000000000));
+        $this->assertSame('1 Quadrillion',  Number::toHuman(1000000000000000));
+        $this->assertSame('1 Quintillion',  Number::toHuman(1000000000000000000));
+
+        $this->assertSame('1.23 Hundred', Number::toHuman(123));
+        $this->assertSame('1.23 Thousand', Number::toHuman(1234));
+        $this->assertSame('12.35 Thousand', Number::toHuman(12345));
+        $this->assertSame('1.23 Million', Number::toHuman(1234567));
+        $this->assertSame('1.23 Billion', Number::toHuman(1234567890));
+        $this->assertSame('1.23 Trillion', Number::toHuman(1234567890123));
+        $this->assertSame('1.23 Quadrillion', Number::toHuman(1234567890123456));
+        $this->assertSame('1.23 Quintillion', Number::toHuman(1234567890123456789));
+        $this->assertSame('490 Thousand', Number::toHuman(489939, precision: 0));
+        $this->assertSame('489.939 Thousand', Number::toHuman(489939, precision: 4));
+        $this->assertSame('500 Million', Number::toHuman(500000000, precision: 5));
+    }
+
     protected function needsIntlExtension()
     {
         if (! extension_loaded('intl')) {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -78,64 +78,30 @@ class SupportNumberTest extends TestCase
 
         $this->assertSame('123,456,789', Number::format(123456789));
 
+        Number::useLocale('de');
+
         $this->app->locale = 'de';
 
         $this->assertSame('123.456.789', Number::format(123456789));
-    }
 
-    public function testSpellout()
-    {
-        $this->needsIntlExtension();
-
-        $this->assertSame('zero', Number::spellout(0));
-        $this->assertSame('one', Number::spellout(1));
-        $this->assertSame('ten', Number::spellout(10));
-        $this->assertSame('twenty-five', Number::spellout(25));
-        $this->assertSame('one hundred', Number::spellout(100));
-        $this->assertSame('one hundred thousand', Number::spellout(100000));
-        $this->assertSame('one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine', Number::spellout(123456789));
-
-        $this->assertSame('one billion', Number::spellout(1000000000));
-        $this->assertSame('one trillion', Number::spellout(1000000000000));
-        $this->assertSame('one quadrillion', Number::spellout(1000000000000000));
-        $this->assertSame('1,000,000,000,000,000,000', Number::spellout(1000000000000000000));
-
-        $this->assertSame('minus one', Number::spellout(-1));
-        $this->assertSame('minus ten', Number::spellout(-10));
-        $this->assertSame('minus twenty-five', Number::spellout(-25));
-
-        $this->assertSame('zero point two', Number::spellout(0.2));
-        $this->assertSame('one point two three', Number::spellout(1.23));
-        $this->assertSame('minus one point two three', Number::spellout(-1.23));
-        $this->assertSame('one hundred twenty-three point four five six', Number::spellout(123.456));
-    }
-
-    public function testSpelloutWithDifferentLocale()
-    {
-        $this->needsIntlExtension();
-
-        $this->assertSame('cent vingt-trois', Number::spellout(123, 'fr'));
-
-        $this->assertSame('ein­hundert­drei­und­zwanzig', Number::spellout(123, 'de'));
-
-        $this->assertSame('ett­hundra­tjugo­tre', Number::spellout(123, 'sv'));
+        Number::useLocale('en');
     }
 
     public function testToPercent()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('0%', Number::toPercent(0));
-        $this->assertSame('1%', Number::toPercent(1));
-        $this->assertSame('10%', Number::toPercent(10));
-        $this->assertSame('100%', Number::toPercent(100));
+        $this->assertSame('0%', Number::toPercentage(0));
+        $this->assertSame('1%', Number::toPercentage(1));
+        $this->assertSame('10%', Number::toPercentage(10));
+        $this->assertSame('100%', Number::toPercentage(100));
 
-        $this->assertSame('300%', Number::toPercent(300));
-        $this->assertSame('1,000%', Number::toPercent(1000));
+        $this->assertSame('300%', Number::toPercentage(300));
+        $this->assertSame('1,000%', Number::toPercentage(1000));
 
-        $this->assertSame('1.75%', Number::toPercent(1.75));
-        $this->assertSame('0.12%', Number::toPercent(0.12345));
-        $this->assertSame('0.1235%', Number::toPercent(0.12345, 4));
+        $this->assertSame('1.75%', Number::toPercentage(1.75));
+        $this->assertSame('0.12%', Number::toPercentage(0.12345));
+        $this->assertSame('0.1235%', Number::toPercentage(0.12345, 4));
     }
 
     public function testToCurrency()
@@ -170,60 +136,60 @@ class SupportNumberTest extends TestCase
 
     public function testBytesToHuman()
     {
-        $this->assertSame('0 B', Number::bytesToHuman(0));
-        $this->assertSame('1 B', Number::bytesToHuman(1));
-        $this->assertSame('1 kB', Number::bytesToHuman(1024));
-        $this->assertSame('2 kB', Number::bytesToHuman(2048));
-        $this->assertSame('1.23 kB', Number::bytesToHuman(1264));
-        $this->assertSame('1.234 kB', Number::bytesToHuman(1264, 3));
-        $this->assertSame('5 GB', Number::bytesToHuman(1024 * 1024 * 1024 * 5));
-        $this->assertSame('10 TB', Number::bytesToHuman((1024 ** 4) * 10));
-        $this->assertSame('10 PB', Number::bytesToHuman((1024 ** 5) * 10));
-        $this->assertSame('1 ZB', Number::bytesToHuman(1024 ** 7));
-        $this->assertSame('1 YB', Number::bytesToHuman(1024 ** 8));
-        $this->assertSame('1024 YB', Number::bytesToHuman(1024 ** 9));
+        $this->assertSame('0 B', Number::toFileSize(0));
+        $this->assertSame('1 B', Number::toFileSize(1));
+        $this->assertSame('1 KB', Number::toFileSize(1024));
+        $this->assertSame('2 KB', Number::toFileSize(2048));
+        $this->assertSame('1.23 KB', Number::toFileSize(1264));
+        $this->assertSame('1.234 KB', Number::toFileSize(1264, 3));
+        $this->assertSame('5 GB', Number::toFileSize(1024 * 1024 * 1024 * 5));
+        $this->assertSame('10 TB', Number::toFileSize((1024 ** 4) * 10));
+        $this->assertSame('10 PB', Number::toFileSize((1024 ** 5) * 10));
+        $this->assertSame('1 ZB', Number::toFileSize(1024 ** 7));
+        $this->assertSame('1 YB', Number::toFileSize(1024 ** 8));
+        $this->assertSame('1024 YB', Number::toFileSize(1024 ** 9));
     }
 
     public function testToHuman()
     {
-        $this->assertSame('1', Number::toHuman(1));
-        $this->assertSame('10', Number::toHuman(10));
-        $this->assertSame('100', Number::toHuman(100));
-        $this->assertSame('1 thousand', Number::toHuman(1000));
-        $this->assertSame('1 million', Number::toHuman(1000000));
-        $this->assertSame('1 billion', Number::toHuman(1000000000));
-        $this->assertSame('1 trillion', Number::toHuman(1000000000000));
-        $this->assertSame('1 quadrillion', Number::toHuman(1000000000000000));
-        $this->assertSame('1 thousand quadrillion', Number::toHuman(1000000000000000000));
+        $this->assertSame('1', Number::forHumans(1));
+        $this->assertSame('10', Number::forHumans(10));
+        $this->assertSame('100', Number::forHumans(100));
+        $this->assertSame('1 thousand', Number::forHumans(1000));
+        $this->assertSame('1 million', Number::forHumans(1000000));
+        $this->assertSame('1 billion', Number::forHumans(1000000000));
+        $this->assertSame('1 trillion', Number::forHumans(1000000000000));
+        $this->assertSame('1 quadrillion', Number::forHumans(1000000000000000));
+        $this->assertSame('1 thousand quadrillion', Number::forHumans(1000000000000000000));
 
-        $this->assertSame('123', Number::toHuman(123));
-        $this->assertSame('1.23 thousand', Number::toHuman(1234));
-        $this->assertSame('12.35 thousand', Number::toHuman(12345));
-        $this->assertSame('1.23 million', Number::toHuman(1234567));
-        $this->assertSame('1.23 billion', Number::toHuman(1234567890));
-        $this->assertSame('1.23 trillion', Number::toHuman(1234567890123));
-        $this->assertSame('1.23 quadrillion', Number::toHuman(1234567890123456));
-        $this->assertSame('1.23 thousand quadrillion', Number::toHuman(1234567890123456789));
-        $this->assertSame('490 thousand', Number::toHuman(489939, precision: 0));
-        $this->assertSame('489.939 thousand', Number::toHuman(489939, precision: 4));
-        $this->assertSame('500 million', Number::toHuman(500000000, precision: 5));
+        $this->assertSame('123', Number::forHumans(123));
+        $this->assertSame('1.23 thousand', Number::forHumans(1234));
+        $this->assertSame('12.35 thousand', Number::forHumans(12345));
+        $this->assertSame('1.23 million', Number::forHumans(1234567));
+        $this->assertSame('1.23 billion', Number::forHumans(1234567890));
+        $this->assertSame('1.23 trillion', Number::forHumans(1234567890123));
+        $this->assertSame('1.23 quadrillion', Number::forHumans(1234567890123456));
+        $this->assertSame('1.23 thousand quadrillion', Number::forHumans(1234567890123456789));
+        $this->assertSame('490 thousand', Number::forHumans(489939, precision: 0));
+        $this->assertSame('489.939 thousand', Number::forHumans(489939, precision: 4));
+        $this->assertSame('500 million', Number::forHumans(500000000, precision: 5));
 
-        $this->assertSame('1 million quadrillion', Number::toHuman(1000000000000000000000));
-        $this->assertSame('1 billion quadrillion', Number::toHuman(1000000000000000000000000));
-        $this->assertSame('1 trillion quadrillion', Number::toHuman(1000000000000000000000000000));
-        $this->assertSame('1 quadrillion quadrillion', Number::toHuman(1000000000000000000000000000000));
-        $this->assertSame('1 thousand quadrillion quadrillion', Number::toHuman(1000000000000000000000000000000000));
+        $this->assertSame('1 million quadrillion', Number::forHumans(1000000000000000000000));
+        $this->assertSame('1 billion quadrillion', Number::forHumans(1000000000000000000000000));
+        $this->assertSame('1 trillion quadrillion', Number::forHumans(1000000000000000000000000000));
+        $this->assertSame('1 quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000));
+        $this->assertSame('1 thousand quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000000));
 
-        $this->assertSame('0', Number::toHuman(0));
-        $this->assertSame('-1', Number::toHuman(-1));
-        $this->assertSame('-10', Number::toHuman(-10));
-        $this->assertSame('-100', Number::toHuman(-100));
-        $this->assertSame('-1 thousand', Number::toHuman(-1000));
-        $this->assertSame('-1 million', Number::toHuman(-1000000));
-        $this->assertSame('-1 billion', Number::toHuman(-1000000000));
-        $this->assertSame('-1 trillion', Number::toHuman(-1000000000000));
-        $this->assertSame('-1 quadrillion', Number::toHuman(-1000000000000000));
-        $this->assertSame('-1 thousand quadrillion', Number::toHuman(-1000000000000000000));
+        $this->assertSame('0', Number::forHumans(0));
+        $this->assertSame('-1', Number::forHumans(-1));
+        $this->assertSame('-10', Number::forHumans(-10));
+        $this->assertSame('-100', Number::forHumans(-100));
+        $this->assertSame('-1 thousand', Number::forHumans(-1000));
+        $this->assertSame('-1 million', Number::forHumans(-1000000));
+        $this->assertSame('-1 billion', Number::forHumans(-1000000000));
+        $this->assertSame('-1 trillion', Number::forHumans(-1000000000000));
+        $this->assertSame('-1 quadrillion', Number::forHumans(-1000000000000000));
+        $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
     }
 
     protected function needsIntlExtension()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -2,11 +2,31 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Number;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        App::swap(new Container);
+        App::shouldReceive('getLocale')->andReturn('en');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        App::clearResolvedInstances();
+        App::swap(new Container);
+
+        parent::tearDown();
+    }
+
     public function testToHuman()
     {
         $this->needsIntlExtension();

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -121,6 +121,23 @@ class SupportNumberTest extends TestCase
         $this->assertSame('ett­hundra­tjugo­tre', Number::toHuman(123, 'sv'));
     }
 
+    public function testToPercent()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('0%', Number::toPercent(0));
+        $this->assertSame('1%', Number::toPercent(1));
+        $this->assertSame('10%', Number::toPercent(10));
+        $this->assertSame('100%', Number::toPercent(100));
+
+        $this->assertSame('300%', Number::toPercent(300));
+        $this->assertSame('1,000%', Number::toPercent(1000));
+
+        $this->assertSame('1.75%', Number::toPercent(1.75));
+        $this->assertSame('0.12%', Number::toPercent(0.12345));
+        $this->assertSame('0.1235%', Number::toPercent(0.12345, 4));
+    }
+
     public function testToCurrency()
     {
         $this->needsIntlExtension();

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -7,5 +7,19 @@ use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
-    //
+    public function testBytesToHuman()
+    {
+        $this->assertSame('0 B', Number::bytesToHuman(0));
+        $this->assertSame('1 B', Number::bytesToHuman(1));
+        $this->assertSame('1 KB', Number::bytesToHuman(1024));
+        $this->assertSame('2 KB', Number::bytesToHuman(2048));
+        $this->assertSame('1.23 KB', Number::bytesToHuman(1264));
+        $this->assertSame('1.234 KB', Number::bytesToHuman(1264, 3));
+        $this->assertSame('5 GB', Number::bytesToHuman(1024 * 1024 * 1024 * 5));
+        $this->assertSame('10 TB', Number::bytesToHuman((1024 ** 4) * 10));
+        $this->assertSame('10 PB', Number::bytesToHuman((1024 ** 5) * 10));
+        $this->assertSame('1 ZB', Number::bytesToHuman(1024 ** 7));
+        $this->assertSame('1 YB', Number::bytesToHuman(1024 ** 8));
+        $this->assertSame('1024 YB', Number::bytesToHuman(1024 ** 9));
+    }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -2,40 +2,11 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Foundation\Application;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Number;
 use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
-    protected Application $app;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->app = new class extends Application
-        {
-            public string $locale = 'en';
-
-            public function getLocale(): string
-            {
-                return $this->locale;
-            }
-        };
-
-        App::swap($this->app);
-    }
-
-    protected function tearDown(): void
-    {
-        App::clearResolvedInstances();
-        App::swap(new Application);
-
-        parent::tearDown();
-    }
-
     public function testFormat()
     {
         $this->needsIntlExtension();
@@ -80,8 +51,6 @@ class SupportNumberTest extends TestCase
 
         Number::useLocale('de');
 
-        $this->app->locale = 'de';
-
         $this->assertSame('123.456.789', Number::format(123456789));
 
         Number::useLocale('en');
@@ -92,16 +61,20 @@ class SupportNumberTest extends TestCase
         $this->needsIntlExtension();
 
         $this->assertSame('0%', Number::toPercentage(0, precision: 0));
-        $this->assertSame('0.00%', Number::toPercentage(0));
-        $this->assertSame('1.00%', Number::toPercentage(1));
-        $this->assertSame('10.00%', Number::toPercentage(10));
-        $this->assertSame('100.00%', Number::toPercentage(100));
+        $this->assertSame('0%', Number::toPercentage(0));
+        $this->assertSame('1%', Number::toPercentage(1));
+        $this->assertSame('10.00%', Number::toPercentage(10, precision: 2));
+        $this->assertSame('100%', Number::toPercentage(100));
+        $this->assertSame('100.00%', Number::toPercentage(100, precision: 2));
 
-        $this->assertSame('300.00%', Number::toPercentage(300));
-        $this->assertSame('1,000.00%', Number::toPercentage(1000));
+        $this->assertSame('300%', Number::toPercentage(300));
+        $this->assertSame('1,000%', Number::toPercentage(1000));
 
-        $this->assertSame('1.75%', Number::toPercentage(1.75));
-        $this->assertSame('0.12%', Number::toPercentage(0.12345));
+        $this->assertSame('2%', Number::toPercentage(1.75));
+        $this->assertSame('1.75%', Number::toPercentage(1.75, precision: 2));
+        $this->assertSame('1.750%', Number::toPercentage(1.75, precision: 3));
+        $this->assertSame('0%', Number::toPercentage(0.12345));
+        $this->assertSame('0.12%', Number::toPercentage(0.12345, precision: 2));
         $this->assertSame('0.1235%', Number::toPercentage(0.12345, precision: 4));
     }
 
@@ -141,14 +114,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 B', Number::toFileSize(1));
         $this->assertSame('1 KB', Number::toFileSize(1024));
         $this->assertSame('2 KB', Number::toFileSize(2048));
-        $this->assertSame('1.23 KB', Number::toFileSize(1264));
+        $this->assertSame('2.00 KB', Number::toFileSize(2048, precision: 2));
+        $this->assertSame('1.23 KB', Number::toFileSize(1264, precision: 2));
         $this->assertSame('1.234 KB', Number::toFileSize(1264, 3));
         $this->assertSame('5 GB', Number::toFileSize(1024 * 1024 * 1024 * 5));
         $this->assertSame('10 TB', Number::toFileSize((1024 ** 4) * 10));
         $this->assertSame('10 PB', Number::toFileSize((1024 ** 5) * 10));
         $this->assertSame('1 ZB', Number::toFileSize(1024 ** 7));
         $this->assertSame('1 YB', Number::toFileSize(1024 ** 8));
-        $this->assertSame('1024 YB', Number::toFileSize(1024 ** 9));
+        $this->assertSame('1,024 YB', Number::toFileSize(1024 ** 9));
     }
 
     public function testToHuman()
@@ -164,16 +138,18 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 thousand quadrillion', Number::forHumans(1000000000000000000));
 
         $this->assertSame('123', Number::forHumans(123));
-        $this->assertSame('1.23 thousand', Number::forHumans(1234));
-        $this->assertSame('12.35 thousand', Number::forHumans(12345));
-        $this->assertSame('1.23 million', Number::forHumans(1234567));
-        $this->assertSame('1.23 billion', Number::forHumans(1234567890));
-        $this->assertSame('1.23 trillion', Number::forHumans(1234567890123));
-        $this->assertSame('1.23 quadrillion', Number::forHumans(1234567890123456));
-        $this->assertSame('1.23 thousand quadrillion', Number::forHumans(1234567890123456789));
-        $this->assertSame('490 thousand', Number::forHumans(489939, precision: 0));
-        $this->assertSame('489.939 thousand', Number::forHumans(489939, precision: 4));
-        $this->assertSame('500 million', Number::forHumans(500000000, precision: 5));
+        $this->assertSame('1 thousand', Number::forHumans(1234));
+        $this->assertSame('1.23 thousand', Number::forHumans(1234, precision: 2));
+        $this->assertSame('12 thousand', Number::forHumans(12345));
+        $this->assertSame('1 million', Number::forHumans(1234567));
+        $this->assertSame('1 billion', Number::forHumans(1234567890));
+        $this->assertSame('1 trillion', Number::forHumans(1234567890123));
+        $this->assertSame('1.23 trillion', Number::forHumans(1234567890123, precision: 2));
+        $this->assertSame('1 quadrillion', Number::forHumans(1234567890123456));
+        $this->assertSame('1.23 thousand quadrillion', Number::forHumans(1234567890123456789, precision: 2));
+        $this->assertSame('490 thousand', Number::forHumans(489939));
+        $this->assertSame('489.9390 thousand', Number::forHumans(489939, precision: 4));
+        $this->assertSame('500.00000 million', Number::forHumans(500000000, precision: 5));
 
         $this->assertSame('1 million quadrillion', Number::forHumans(1000000000000000000000));
         $this->assertSame('1 billion quadrillion', Number::forHumans(1000000000000000000000000));


### PR DESCRIPTION
## Abstract

Adds a new `Number` utility class, in the `Illuminate\Support` namespace, as suggested by Taylor in https://github.com/laravel/framework/pull/48827#issuecomment-1781232805.

```php
use Illuminate\Support\Number;

Number::format(123456789) // 123,456,789
Number::toCurrency(59.99) // $59.99
Number::bytesToHuman(1536) // 1.5 KB
Number::toHuman(10000) // ten thousand
```

### PR Development

The class ports the `bytesToHuman()` helper from https://github.com/laravel/framework/pull/48827, and after discussion here and in `#internals` adds some wrappers for the [`NumberFormatter`](https://www.php.net/manual/en/class.numberformatter.php) class. As this requires the `php-intl` extension, I added a check for those wrappers that throws a `RuntimeException`. I also added the extension as a suggestion to the `Support` package `composer.json`.

Please let me know if this route works, otherwise I'm happy to make changes.

**If anyone has ideas on more helpers, please let me know!**

### Future development

If this gets merged, I'll also make a PR that adds a `Numberable` (or something better named), similar to `Stringable`, that allows `Number::of(100)->toHuman()` and other neat stuff like that.