### PR TITLE
[10.x] Detect transaction inconsistencies by testing with `RefreshDatabase`

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -139,7 +139,7 @@ trait RefreshDatabase
      *
      * @return void
      */
-    public function withCheckTransactionLevel()
+    protected function withCheckTransactionLevel()
     {
         $this->shouldCheckTransactionLevel = true;
     }
@@ -147,7 +147,7 @@ trait RefreshDatabase
     /**
      * Skips the check of matching transaction start and end counts at the end of a test.
      */
-    public function withoutCheckTransactionLevel()
+    protected function withoutCheckTransactionLevel()
     {
         $this->shouldCheckTransactionLevel = false;
     }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -107,7 +107,7 @@ trait RefreshDatabase
         $this->beforeApplicationDestroyed(function () use ($database) {
             foreach ($this->connectionsToTransact() as $name) {
                 $connection = $database->connection($name);
-                $isInvalidTransactionLevel = $this->shouldCheckTransactionLevel && $connection->transactionLevel() !== 1;
+                $isInvalidTransactionLevel = $this->shouldCheckTransactionLevel && $connection->transactionLevel() < 1;
 
                 $dispatcher = $connection->getEventDispatcher();
 

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -121,7 +121,7 @@ trait RefreshDatabase
                 if ($isTransactionExcessive) {
                     throw new LogicException('Transaction level mismatch detected: The number of transaction ends is greater than the number of starts.');
                 }
-                if($isTransactionShortfall) {
+                if ($isTransactionShortfall) {
                     throw new LogicException('Transaction level mismatch detected: The number of transaction starts is greater than the number of ends.');
                 }
             }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
-use RuntimeException;
+use LogicException;
 
 trait RefreshDatabase
 {
@@ -117,7 +117,7 @@ trait RefreshDatabase
                 $connection->disconnect();
 
                 if ($isInvalidTransactionLevel) {
-                    throw new RuntimeException('Transaction level mismatch detected: The number of transaction starts and ends do not match.');
+                    throw new LogicException('Transaction level mismatch detected: The number of transaction starts and ends do not match.');
                 }
             }
         });

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -102,26 +102,24 @@ class RefreshDatabaseTest extends TestCase
     public function testSuccessWithCheckTransactionLevel()
     {
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
-
         $refreshTestDatabaseReflection->invoke($this->traitObject);
 
         $this->traitObject->withCheckTransactionLevel();
-
         $this->traitObject->callBeforeApplicationDestroyedCallbacks();
+
         $this->assertNull($this->traitObject->__getCallbackException());
     }
 
     public function testErrorOnExcessiveTransactionCommit()
     {
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
-
         $refreshTestDatabaseReflection->invoke($this->traitObject);
 
         $this->traitObject->withCheckTransactionExcess();
         $connection = $this->traitObject->__getConnection();
         $connection->commit();
-
         $this->traitObject->callBeforeApplicationDestroyedCallbacks();
+
         $this->assertInstanceOf(LogicException::class, $this->traitObject->__getCallbackException());
         $this->assertStringContainsString('ends is greater than', $this->traitObject->__getCallbackException()->getMessage());
     }
@@ -129,14 +127,13 @@ class RefreshDatabaseTest extends TestCase
     public function testErrorOnTransactionShortfall()
     {
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
-
         $refreshTestDatabaseReflection->invoke($this->traitObject);
 
         $this->traitObject->withCheckTransactionShortfall();
         $connection = $this->traitObject->__getConnection();
         $connection->beginTransaction();
-
         $this->traitObject->callBeforeApplicationDestroyedCallbacks();
+
         $this->assertInstanceOf(LogicException::class, $this->traitObject->__getCallbackException());
         $this->assertStringContainsString('starts is greater than', $this->traitObject->__getCallbackException()->getMessage());
     }
@@ -144,32 +141,28 @@ class RefreshDatabaseTest extends TestCase
     public function testNoErrorThrownWithoutCheckOnExcessiveCommit()
     {
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
-
         $refreshTestDatabaseReflection->invoke($this->traitObject);
 
         // This is the default, so there is no need to actually specify it.
         $this->traitObject->withoutCheckTransactionLevel();
-
         $connection = $this->traitObject->__getConnection();
         $connection->beginTransaction();
-
         $this->traitObject->callBeforeApplicationDestroyedCallbacks();
+
         $this->assertNull($this->traitObject->__getCallbackException());
     }
 
     public function testNoErrorThrownWithoutCheckOnShortfallCommit()
     {
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
-
         $refreshTestDatabaseReflection->invoke($this->traitObject);
 
         // This is the default, so there is no need to actually specify it.
         $this->traitObject->withoutCheckTransactionLevel();
-
         $connection = $this->traitObject->__getConnection();
         $connection->commit();
-
         $this->traitObject->callBeforeApplicationDestroyedCallbacks();
+
         $this->assertNull($this->traitObject->__getCallbackException());
     }
 }

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -125,20 +125,6 @@ class RefreshDatabaseTest extends TestCase
         $this->assertInstanceOf(RuntimeException::class, $this->traitObject->__getCallbackException());
     }
 
-    public function testErrorOnUncommittedTransaction()
-    {
-        $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
-
-        $refreshTestDatabaseReflection->invoke($this->traitObject);
-
-        $this->traitObject->withCheckTransactionLevel();
-        $connection = $this->traitObject->__getConnection();
-        $connection->beginTransaction();
-
-        $this->traitObject->callBeforeApplicationDestroyedCallbacks();
-        $this->assertInstanceOf(RuntimeException::class, $this->traitObject->__getCallbackException());
-    }
-
     public function testNoErrorThrownWithoutCheckTransactionLevel()
     {
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -5,12 +5,12 @@ namespace Illuminate\Tests\Foundation\Testing;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithConsole;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
+use LogicException;
 use Mockery as m;
 use Orchestra\Testbench\Concerns\Testing;
 use Orchestra\Testbench\Foundation\Application as Testbench;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
-use RuntimeException;
 
 use function Orchestra\Testbench\package_path;
 
@@ -122,7 +122,7 @@ class RefreshDatabaseTest extends TestCase
         $connection->commit();
 
         $this->traitObject->callBeforeApplicationDestroyedCallbacks();
-        $this->assertInstanceOf(RuntimeException::class, $this->traitObject->__getCallbackException());
+        $this->assertInstanceOf(LogicException::class, $this->traitObject->__getCallbackException());
     }
 
     public function testNoErrorThrownWithoutCheckTransactionLevel()


### PR DESCRIPTION
Hi.

In this pull request, I propose adding a feature to `RefreshDatabase` that automatically detects transaction inconsistencies.

By explicitly enabling this feature, we can become aware of potential mistakes in testing and implementation.

## Problem Description

As a simple example, consider the following test code:

```php
use RefreshDatabase;

public function test1(): void
{
    User::factory()->create();
    DB::commit();
    $this->assertDatabaseHas('users', []);
}

public function test2(): void
{
    $this->assertDatabaseEmpty('users');
}
```

Focus on *test2*. After performing `RefreshDatabase`, `users` should be empty since no operations have been performed on the database. The test should pass.

But let's focus on *test1*. `rollback` within the `RefreshDatabase` process no longer has any effect due to an incorrect `commit` inside the test. Therefore, *test1*'s database operations are carried over to *test2*, causing tests that should have passed to fail.

The scenario in real code is more complex.

* Transaction operations are done in the implementation, not in the tests. If it happens inside a nested function or try/catch block, it can be very difficult to discover inconsistencies.
* The example test will always fail, but in reality, it often becomes *flaky tests* that fail due to probability.
* Above all, developers are deeply confused by the fact that there is no cause for a failed test itself, and they have to look for the cause from tests that were executed before it.
* This Pull Request focuses on testing, but **cases in which transaction start and end points are inconsistent are likely to have a negative impact on actual operations.**

## Proposed Solution

By explicitly instructing `RefreshDatabase` to perform a transactional integrity check in the test, it becomes easier to identify the test causing the problem.

```diff
 public function test1(): void
 {
+    $this->withCheckTransactionExcess(); // <-- Add this line
     User::factory()->create();
     DB::commit();
     $this->assertDatabaseHas('users', []);
 }
```

This directive causes `RefreshDatabase` to check `transactionLevel()` during `tearDown()` and throw a `RuntimeException` if there are too many commits. The test result looks like this:

```
1) Tests\Feature\ExampleTest::test1
LogicException: Transaction level mismatch detected: The number of transaction ends is greater than the number of starts.
```

Similarly, there is a feature to detect uncompleted transactions at the end of a test.

```diff
 public function test3(): void
 {
+    $this->withCheckTransactionShortfall();  // <-- Add this line
     User::factory()->create();
     DB::beginTransaction(); // This transaction will not complete.
     $this->assertDatabaseHas('users', []);
 }
```

This check is inappropriate if an error is intentionally generated during a transaction. On the other hand, this check may be useful, for example, in cases where a *201 Created* response is returned to the client.

The test will report an error similar to the following:

```
1) Tests\Feature\ExampleTest::test3
LogicException: Transaction level mismatch detected: The number of transaction starts is greater than the number of ends.
```

The above two check modes can be controlled in the test code using the following methods.

```php
/**
 * Enables checking for both excess and shortfall in transactions during a test.
 */
protected function withCheckTransactionLevel();

/**
 * Enables checking for excess transactions like unnecessary commits in a test.
 */
protected function withCheckTransactionExcess();

/**
 * Enables checking for transaction shortfall, such as missing commits or rollbacks.
 */
protected function withCheckTransactionShortfall();

/**
 * Skips the check of matching transaction start and end counts at the end of a test.
 */
protected function withoutCheckTransactionLevel();
```

The default is `withoutCheckTransactionLevel()`. Therefore, **this feature addition is not a breaking change.**

## Remarks

* I recently applied this method to a real project and found several cases that no one had discovered that were making the 5000+ test cases run in paratest unstable and affecting the actual behavior. I was able to quickly find the implementation error. I'm sure it will be useful to you all!
* I'm not a native English speaker. Please point out if there is anything strange about the method name or comment.

Regards.

---

*Update: 2023-10-28T15:46:22Z*

~~Fixed to not check unresolved `beginTransaction()` . There are cases where the developer wants to intentionally interrupt the transaction using `abort()`.~~

*Update: 2023-10-29T09:50:40Z*

* Fixed to report LogicException instead of RuntimeException.
* Fixed to be able to specify and check for insufficient and excessive commits.