### PR TITLE
[10.x] Fix `QueriesRelationships@getRelationHashedColumn()` typehint

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -686,7 +686,7 @@ trait QueriesRelationships
      * Get the relation hashed column name for the given column and relation.
      *
      * @param  string  $column
-     * @param  \Illuminate\Database\Eloquent\Relations\Relationship  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
      * @return string
      */
     protected function getRelationHashedColumn($column, $relation)


### PR DESCRIPTION
Typehint is currently `Relationship` which does not exist. I believe it is a typo and was intended to be `Relation`