### PR TITLE
fix Exception: Cannot traverse an already closed generator when running Arr::first with an empty generator and no callback

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -196,7 +196,7 @@ class Arr
                 return $item;
             }
 
-            return null;
+            return value($default);
         }
 
         foreach ($array as $key => $value) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -195,6 +195,7 @@ class Arr
             foreach ($array as $item) {
                 return $item;
             }
+
             return null;
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -195,6 +195,7 @@ class Arr
             foreach ($array as $item) {
                 return $item;
             }
+            return null;
         }
 
         foreach ($array as $key => $value) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -214,6 +214,13 @@ class SupportArrTest extends TestCase
         $this->assertSame('bar', $value3);
         $this->assertSame('baz', $value4);
         $this->assertEquals(100, $value5);
+
+        $cursor = (function () {
+            while (false) {
+                yield 1;
+            }
+        })();
+        $this->assertNull(Arr::first($cursor));
     }
 
     public function testJoin()


### PR DESCRIPTION
```
$cursor = (function () {
    while (false) {
        yield 1;
    }
})();
```

## Before
```
Arr::first($cursor); //  Exception  Cannot traverse an already closed generator.
```

## After
```
Arr::first($cursor); // null
```


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
