### PR TITLE
[10.x] fix(Eloquent/Builder): calling the methods on passthru base object should be case-insensitive

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -89,6 +89,9 @@ class Builder implements BuilderContract
     /**
      * The methods that should be returned from query builder.
      *
+     * Note that the names in the array need to be lowercase so that PHP's case-insensitivity
+     * regarding method calls can be achieved when forwarding the call to the base object.
+     *
      * @var string[]
      */
     protected $passthru = [
@@ -97,29 +100,29 @@ class Builder implements BuilderContract
         'avg',
         'count',
         'dd',
-        'ddRawSql',
-        'doesntExist',
-        'doesntExistOr',
+        'ddrawsql',
+        'doesntexist',
+        'doesntexistor',
         'dump',
-        'dumpRawSql',
+        'dumprawsql',
         'exists',
-        'existsOr',
+        'existsor',
         'explain',
-        'getBindings',
-        'getConnection',
-        'getGrammar',
+        'getbindings',
+        'getconnection',
+        'getgrammar',
         'implode',
         'insert',
-        'insertGetId',
-        'insertOrIgnore',
-        'insertUsing',
+        'insertgetid',
+        'insertorignore',
+        'insertusing',
         'max',
         'min',
         'raw',
-        'rawValue',
+        'rawvalue',
         'sum',
-        'toSql',
-        'toRawSql',
+        'tosql',
+        'torawsql',
     ];
 
     /**
@@ -1964,7 +1967,7 @@ class Builder implements BuilderContract
             return $this->callNamedScope($method, $parameters);
         }
 
-        if (in_array($method, $this->passthru)) {
+        if (in_array(strtolower($method), $this->passthru)) {
             return $this->toBase()->{$method}(...$parameters);
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -89,9 +89,6 @@ class Builder implements BuilderContract
     /**
      * The methods that should be returned from query builder.
      *
-     * Note that the names in the array need to be lowercase so that PHP's case-insensitivity
-     * regarding method calls can be achieved when forwarding the call to the base object.
-     *
      * @var string[]
      */
     protected $passthru = [


### PR DESCRIPTION
fix(Eloquent/Builder): calling the methods on passthru base object should be case-insensitive

Fixes: https://github.com/laravel/framework/issues/48825

The fix is quite straightforward: when deciding if the method called should be proxied to the base Builder object, compare the lowercased name of the method being called instead of the raw name.

There is an alternative proposal for a more robust solution in the linked Github issue, but I only saw the discussion after committing.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
