### PR TITLE
[10.x] Display error message if json_encode() fails

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -107,7 +107,7 @@ abstract class Queue
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidPayloadException(
-                'Unable to JSON encode payload. Error code: '.json_last_error(), $value
+                'Unable to JSON encode payload. Error: '.json_last_error_msg(), $value
             );
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -107,7 +107,7 @@ abstract class Queue
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidPayloadException(
-                'Unable to JSON encode payload. Error (' . json_last_error() . '): '.json_last_error_msg(), $value
+                'Unable to JSON encode payload. Error ('.json_last_error().'): '.json_last_error_msg(), $value
             );
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -107,7 +107,7 @@ abstract class Queue
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidPayloadException(
-                'Unable to JSON encode payload. Error: '.json_last_error_msg(), $value
+                'Unable to JSON encode payload. Error (' . json_last_error() . '): '.json_last_error_msg(), $value
             );
         }
 


### PR DESCRIPTION
Adding the error code to the exception isn't useful. Instead, the error message can give details about the problem.
