### PR TITLE
[10.x] Reset ShouldDispatchAfterCommitEventTest objects properties

### DIFF
--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -14,6 +14,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
     {
         TransactionUnawareTestEvent::$ran = false;
         ShouldDispatchAfterCommitTestEvent::$ran = false;
+        AnotherShouldDispatchAfterCommitTestEvent::$ran = false;
 
         m::close();
     }


### PR DESCRIPTION
Tests from https://github.com/laravel/framework/pull/48705#issuecomment-1785242841 were failing because an object's property wasn't being reset at the end of each test.