### PR TITLE
[11.x] Allow `SyncQueue` to dispatch jobs after a transaction is committed

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -326,7 +326,7 @@ abstract class Queue
      */
     protected function shouldDispatchAfterCommit($job)
     {
-        if (is_object($job) && $job instanceof ShouldQueueAfterCommit) {
+        if ($job instanceof ShouldQueueAfterCommit) {
             return true;
         }
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -55,7 +55,7 @@ class SyncQueue extends Queue implements QueueContract
      *
      * @throws \Throwable
      */
-    public function executeJob($job, $data = '', $queue = null)
+    protected function executeJob($job, $data = '', $queue = null)
     {
         $queueJob = $this->resolveJob($this->createPayload($job, $queue, $data), $queue);
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -35,6 +35,28 @@ class SyncQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
+        if ($this->shouldDispatchAfterCommit($job) &&
+            $this->container->bound('db.transactions')) {
+            return $this->container->make('db.transactions')->addCallback(
+                fn () => $this->executeJob($job, $data, $queue)
+            );
+        }
+
+        return $this->executeJob($job, $data, $queue);
+    }
+
+    /**
+     * Execute a given job synchronously.
+     *
+     * @param  string  $job
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    public function executeJob($job, $data = '', $queue = null)
+    {
         $queueJob = $this->resolveJob($this->createPayload($job, $queue, $data), $queue);
 
         try {

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Queue\SyncQueue;
@@ -77,6 +78,19 @@ class QueueSyncQueueTest extends TestCase
             $this->assertSame('extraValue', $e->getMessage());
         }
     }
+
+    public function testItAddsATransactionCallbackForAfterCommitJobs()
+    {
+        $sync = new SyncQueue;
+        $container = new Container;
+        $container->bind(\Illuminate\Contracts\Container\Container::class, \Illuminate\Container\Container::class);
+        $transactionManager = m::mock(DatabaseTransactionsManager::class);
+        $transactionManager->shouldReceive('addCallback')->once()->andReturn(null);
+        $container->instance('db.transactions', $transactionManager);
+
+        $sync->setContainer($container);
+        $sync->push(new SyncQueueAfterCommitJob());
+    }
 }
 
 class SyncQueueTestEntity implements QueueableEntity
@@ -132,5 +146,17 @@ class SyncQueueJob implements ShouldQueue
         $payload = $this->job->payload();
 
         return $payload['data'][$key] ?? null;
+    }
+}
+
+class SyncQueueAfterCommitJob
+{
+    use InteractsWithQueue;
+
+    public $afterCommit = true;
+
+    public function handle()
+    {
+
     }
 }


### PR DESCRIPTION
While testing https://github.com/laravel/framework/pull/48705 we discovered that the `sync` driver doesn't support pushing jobs after a transaction commits — that's because it's `push` implementation is different from "real" queue drivers.

This PR adds that functionality to sync. I personally don't think it's a big deal because I imagine most people are using real queue drivers, but I think it's good to have them all behave the same. 
Although there are no contract changes, I targeted 11.x since it changes existing behavior.