### PR TITLE
[11.x] Make floating-point types consistent

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -958,28 +958,23 @@ class Blueprint
      * Create a new float column on the table.
      *
      * @param  string  $column
-     * @param  int  $total
-     * @param  int  $places
-     * @param  bool  $unsigned
+     * @param  int  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function float($column, $total = 8, $places = 2, $unsigned = false)
+    public function float($column, $precision = 53)
     {
-        return $this->addColumn('float', $column, compact('total', 'places', 'unsigned'));
+        return $this->addColumn('float', $column, compact('precision'));
     }
 
     /**
      * Create a new double column on the table.
      *
      * @param  string  $column
-     * @param  int|null  $total
-     * @param  int|null  $places
-     * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function double($column, $total = 15, $places = 6, $unsigned = false)
+    public function double($column)
     {
-        return $this->addColumn('double', $column, compact('total', 'places', 'unsigned'));
+        return $this->addColumn('double', $column);
     }
 
     /**
@@ -988,51 +983,11 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
-     * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function decimal($column, $total = 8, $places = 2, $unsigned = false)
+    public function decimal($column, $total = 8, $places = 2)
     {
-        return $this->addColumn('decimal', $column, compact('total', 'places', 'unsigned'));
-    }
-
-    /**
-     * Create a new unsigned float column on the table.
-     *
-     * @param  string  $column
-     * @param  int  $total
-     * @param  int  $places
-     * @return \Illuminate\Database\Schema\ColumnDefinition
-     */
-    public function unsignedFloat($column, $total = 8, $places = 2)
-    {
-        return $this->float($column, $total, $places, true);
-    }
-
-    /**
-     * Create a new unsigned double column on the table.
-     *
-     * @param  string  $column
-     * @param  int  $total
-     * @param  int  $places
-     * @return \Illuminate\Database\Schema\ColumnDefinition
-     */
-    public function unsignedDouble($column, $total = null, $places = null)
-    {
-        return $this->double($column, $total, $places, true);
-    }
-
-    /**
-     * Create a new unsigned decimal column on the table.
-     *
-     * @param  string  $column
-     * @param  int  $total
-     * @param  int  $places
-     * @return \Illuminate\Database\Schema\ColumnDefinition
-     */
-    public function unsignedDecimal($column, $total = 8, $places = 2)
-    {
-        return $this->decimal($column, $total, $places, true);
+        return $this->addColumn('decimal', $column, compact('total', 'places'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -716,7 +716,11 @@ class MySqlGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        return $this->typeDouble($column);
+        if ($column->precision) {
+            return "float({$column->precision})";
+        }
+
+        return 'float';
     }
 
     /**
@@ -727,10 +731,6 @@ class MySqlGrammar extends Grammar
      */
     protected function typeDouble(Fluent $column)
     {
-        if ($column->total && $column->places) {
-            return "double({$column->total}, {$column->places})";
-        }
-
         return 'double';
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -756,7 +756,11 @@ class PostgresGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        return $this->typeDouble($column);
+        if ($column->precision) {
+            return "float({$column->precision})";
+        }
+
+        return 'float';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -636,7 +636,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeDouble(Fluent $column)
     {
-        return 'float';
+        return 'double';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -653,6 +653,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
+        if ($column->precision) {
+            return "float({$column->precision})";
+        }
+
         return 'float';
     }
 
@@ -664,7 +668,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDouble(Fluent $column)
     {
-        return 'float';
+        return 'double precision';
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -742,11 +742,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     public function testAddingFloat()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->float('foo', 5, 2);
+        $blueprint->float('foo', 5);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` double(5, 2) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` float(5) not null', $statements[0]);
     }
 
     public function testAddingDouble()
@@ -756,17 +756,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` double(15, 6) not null', $statements[0]);
-    }
-
-    public function testAddingDoubleSpecifyingPrecision()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->double('foo', 15, 8);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` double not null', $statements[0]);
     }
 
     public function testAddingDecimal()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -605,17 +605,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testAddingFloat()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->float('foo', 5, 2);
+        $blueprint->float('foo', 5);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" double precision not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" float(5) precision not null', $statements[0]);
     }
 
     public function testAddingDouble()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->double('foo', 15, 8);
+        $blueprint->double('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -609,7 +609,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" float(5) precision not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" float(5) not null', $statements[0]);
     }
 
     public function testAddingDouble()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -463,7 +463,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingFloat()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->float('foo', 5, 2);
+        $blueprint->float('foo', 5);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
@@ -473,11 +473,11 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingDouble()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->double('foo', 15, 8);
+        $blueprint->double('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" double not null', $statements[0]);
     }
 
     public function testAddingDecimal()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -146,18 +146,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
-    public function testUnsignedDecimalTable()
-    {
-        $base = new Blueprint('users', function ($table) {
-            $table->unsignedDecimal('money', 10, 2)->useCurrent();
-        });
-
-        $connection = m::mock(Connection::class);
-
-        $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `money` decimal(10, 2) unsigned not null'], $blueprint->toSql($connection, new MySqlGrammar));
-    }
-
     public function testRemoveColumn()
     {
         $base = new Blueprint('users', function ($table) {

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -509,21 +509,21 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testAddingFloat()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->float('foo', 5, 2);
+        $blueprint->float('foo', 5);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" float(5) not null', $statements[0]);
     }
 
     public function testAddingDouble()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->double('foo', 15, 2);
+        $blueprint->double('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" double precision not null', $statements[0]);
     }
 
     public function testAddingDecimal()

--- a/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
@@ -123,7 +123,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $schema->useNativeSchemaOperationsIfPossible();
 
         $blueprint = new Blueprint('users', function ($table) {
-            $table->double('amount', 6, 2)->nullable()->invisible()->after('name')->change();
+            $table->double('amount')->nullable()->invisible()->after('name')->change();
             $table->timestamp('added_at', 4)->nullable(false)->useCurrent()->useCurrentOnUpdate()->change();
             $table->enum('difficulty', ['easy', 'hard'])->default('easy')->charset('utf8mb4')->collation('unicode')->change();
             $table->multiPolygon('positions')->srid(1234)->storedAs('expression')->change();
@@ -133,7 +133,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `users` '
-            .'modify `amount` double(6, 2) null invisible after `name`, '
+            .'modify `amount` double null invisible after `name`, '
             .'modify `added_at` timestamp(4) not null default CURRENT_TIMESTAMP(4) on update CURRENT_TIMESTAMP(4), '
             ."modify `difficulty` enum('easy', 'hard') character set utf8mb4 collate 'unicode' not null default 'easy', "
             .'modify `positions` multipolygon as (expression) stored srid 1234, '


### PR DESCRIPTION
Fixes #3151, #7298, #9089, #9103, #13258, #18776, #21032, #21827, #42308 Related to https://github.com/laravel/ideas/issues/1527 and #47080

This PR makes `float` and `double` column types consistent across all databases and also removes `unsignedDecimal`, `unsignedDouble`, and `unsignedFloat` column types.

## Why?

Almost all databases have 4-bytes single-precision and 8-bytes double-precision storage types when declaring floating-point types (approximate numeric data values). Current syntax is inconsistent on Laravel and there is no way to declare precision value.

* As of MySQL 8.0.17, the nonstandard `FLOAT(M,D)` and `DOUBLE(M,D)` syntax is deprecated and you should expect support for it to be removed in a future version of MySQL. [Source](https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html#:~:text=As%20of%20MySQL%208.0.17%2C%20the%20nonstandard%20FLOAT(M%2CD)%20and%20DOUBLE(M%2CD)%20syntax%20is%20deprecated%20and%20you%20should%20expect%20support%20for%20it%20to%20be%20removed%20in%20a%20future%20version%20of%20MySQL.)
* As of MySQL 8.0.17, the `UNSIGNED` attribute is deprecated for columns of type `FLOAT`, `DOUBLE`, and `DECIMAL` (and any synonyms); you should expect support for it to be removed in a future version of MySQL. [Source](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html#:~:text=As%20of%20MySQL%208.0.17%2C%20the%20UNSIGNED%20attribute%20is%20deprecated%20for%20columns%20of%20type%20FLOAT%2C%20DOUBLE%2C%20and%20DECIMAL%20(and%20any%20synonyms)%3B%20you%20should%20expect%20support%20for%20it%20to%20be%20removed%20in%20a%20future%20version%20of%20MySQL.%20Consider%20using%20a%20simple%20CHECK%20constraint%20instead%20for%20such%20columns.)

## Changes

* Changes `$blueprint->float($column, $total = 8, $places = 2, $unsigned = false)` to `$blueprint->float($column, $precision = 53)`
* Changes `$blueprint->double($column, $total = 8, $places = 2, $unsigned = false)` to `$blueprint->double($column)`
* Changes `$blueprint->decimal($column, $total = 8, $places = 2, $unsigned = false)` to `$blueprint->decimal($column, $total = 8, $places = 2)`
* Removes  `$blueprint->unsignedFloat()`
* Removes `$blueprint->unsignedDouble()`
* Removes `$blueprint->unsignedDecimal()`

### Before this PR

| Syntax | MySQL | PostgreSQL | SQL Server | SQLite |
| --- | --- | --- | --- | --- |
| `$table->float('foo')`                    | `double(8, 2)` | `double precision` | `float` | `float` |
| `$table->float('foo', 9)`                | `double(9, 2)` | `double precision` | `float` | `float` |
| `$table->float('foo', 9, 3)`             | `double(9, 3)` | `double precision` | `float` | `float` |
| `$table->float('foo', 9, null)`         | `double`       | `double precision` | `float` | `float` |
| `$table->float('foo', null, null)`     | `double`       | `double precision` | `float` | `float` |
| `$table->double('foo')`                 | `double(8, 2)` | `double precision` | `float` | `float` |
| `$table->double('foo', 9)`             | `double(9, 2)` | `double precision` | `float` | `float` |
| `$table->double('foo', 9, 3)`         | `double(9, 3)` | `double precision` | `float` | `float` |
| `$table->double('foo', 9, null)`     | `double`       | `double precision` | `float` | `float` |
| `$table->double('foo', null, null)` | `double`       | `double precision` | `float` | `float` |

### After this PR

| Syntax | [MySQL](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html#:~:text=A%20floating%2Dpoint,in%20this%20section.) | [PostgreSQL](https://www.postgresql.org/docs/11/datatype-numeric.html#:~:text=PostgreSQL%20also%20supports%20the,mean%20double%20precision.) | [SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=sql-server-2017#:~:text=float%20%5B%20(n)%20%5D%20Where%20n%20is%20the%20number%20of%20bits%20that%20are%20used%20to%20store%20the%20mantissa%20of%20the%20float%20number%20in%20scientific%20notation%20and%2C%20therefore%2C%20dictates%20the%20precision%20and%20storage%20size.%20If%20n%20is%20specified%2C%20it%20must%20be%20a%20value%20between%201%20and%2053.%20The%20default%20value%20of%20n%20is%2053.) | [SQLite](https://www.sqlite.org/datatype3.html#:~:text=REAL.%20The%20value%20is%20a%20floating%20point%20value%2C%20stored%20as%20an%208%2Dbyte%20IEEE%20floating%20point%20number.) |
| --- | --- | --- | --- | --- |
| `$table->float('foo')`      | `float(53)` | `float(53)`        | `float(53)`        | `float`  |
| `$table->float('foo', 24)`    | `float(24)` | `float(24)`        | `float(24)`        | `float`  |
| `$table->float('foo', null)`  | `float`     | `float`            | `float`            | `float`  |
| `$table->double('foo')`     | `double`    | `double precision` | `double precision` | `double` |

## Comparison of Floating-Point Types on Different DBs

| Syntax | [MySQL](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html#:~:text=FLOAT%5B,than%20DOUBLE.) | [PostgreSQL](https://www.postgresql.org/docs/11/datatype-numeric.html#:~:text=The%20assumption%20that%20real%20and%20double%20precision%20have%20exactly%2024%20and%2053%20bits%20in%20the%20mantissa%20respectively%20is%20correct%20for%20IEEE%2Dstandard%20floating%20point%20implementations.%20On%20non%2DIEEE%20platforms%20it%20might%20be%20off%20a%20little%2C%20but%20for%20simplicity%20the%20same%20ranges%20of%20p%20are%20used%20on%20all%20platforms.) | [SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=sql-server-2017#:~:text=SQL%20Server%20treats,float(53).) | [SQLite](https://www.sqlite.org/datatype3.html#:~:text=If%20the%20declared%20type%20for%20a%20column%20contains%20any%20of%20the%20strings%20%22REAL%22%2C%20%22FLOA%22%2C%20or%20%22DOUB%22%20then%20the%20column%20has%20REAL%20affinity.) |
| --- | --- | --- | --- | --- |
| `FLOAT(M, D)`      | Deprecated        | _N/A_                       | _N/A_                | Double (`REAL`) |
| `DOUBLE(M, D)`     | Deprecated        | _N/A_                       | _N/A_                | Double (`REAL`) |
| `FLOAT(1 to 24)`   | Single (`FLOAT`)  | Single (`real`)             | Single (`float(24)`) | Double (`REAL`) |
| `FLOAT(25 to 53)`  | Double (`DOUBLE`) | Double (`double precision`) | Double (`float(53)`) | Double (`REAL`) |
| `FLOAT`            | Single (`FLOAT`)  | Double (`double precision`) | Double (`float(53)`) | Double (`REAL`) |
| `DOUBLE`           | Double (`DOUBLE`) | _N/A_                       | _N/A_                | Double (`REAL`) |
| `DOUBLE PRECISION` | Double (`DOUBLE`) | Double (`double precision`) | Double (`float(53)`) | Double (`REAL`) |
| `REAL`             | Double (`DOUBLE`) | Single (`real`)             | Single (`float(24)`) | Double (`REAL`) |

## Upgrade guide
The `double` and `float` column types of database migrations have been rewritten to make these types consistent across all databases:
* The `double` column type now creates a `DOUBLE` equivalent column without total digits and places (digits after decimal point), which is the standard syntax in SQL. Therefore, you may remove the arguments for `$total` and `$places`:

  ```diff
  - $table->double('amount', $total = 8, $places = 2, $unsigned = false);
  // `DOUBLE(8, 2)` on MySQL, `DOUBLE PRECISION` on PostgreSQL, and `FLOAT` on SQLite and SQL Server
  + $table->double('amount');
  // `DOUBLE` on MySQL and SQLite, `DOUBLE PRECISION` on PostgreSQL and SQL Server
  ```

* The `float` column type now creates a `FLOAT` equivalent column without total digits and places (digits after decimal point), but with an optional `$precision` specification to determine storage size as a 4-byte single-precision column or an 8-byte double-precision column. Therefore, you may remove the arguments for `$total` and `$places` and specify the optional `$precision` to your desired value and according to your database's documentation. The default `$precision` is set to 53 that would result in 8-byte double-precision column on all database drivers:

  ```diff
  - $table->float('amount', $total = 8, $places = 2, $unsigned = false);
  // `DOUBLE(8, 2)` on MySQL, `DOUBLE PRECISION` on PostgreSQL, and `FLOAT` on SQLite and SQL Server
  + $table->float('amount', $precision = 53);
  // `FLOAT(53)` on MySQL, PostgreSQL, and SQL Server. `FLOAT` on SQLite
  ```

* The `$unsigned` parameter of the `$table->decimal()`, `$table->double()`, and `$table->float()` methods has been removed. Actually, this were only supported on MySQL. However, You may force deprecated `UNSIGNED` attribute using `->unsigned()` modifier:

  ```diff
  - $table->decimal('foo', $total = 8, $places = 2, $unsigned = true);
  - $table->double('bar', $total = 8, $places = 2, $unsigned = true);
  - $table->float('baz', $total = 8, $places = 2, $unsigned = true);
  + $table->decimal('foo', $total = 8, $places = 2)->unsigned();
  + $table->double('bar')->unsigned();
  + $table->float('baz', $precision = 53)->unsigned();
  ```

* The `unsignedDecimal`, `unsignedDouble`, and `unsignedFloat` column types have been removed. Therefore, you may use equivalent column types and forcing deprecated `UNSIGNED` attribute using `->unsigned()` modifier. Actually, this were only supported on MySQL:

  ```diff
  - $table->unsignedDecimal('foo', $total = 8, $places = 2);
  - $table->unsignedDouble('bar', $total = 8, $places = 2);
  - $table->unsignedFloat('baz', $total = 8, $places = 2)
  + $table->decimal('foo', $total = 8, $places = 2)->unsigned();
  + $table->double('bar')->unsigned();
  + $table->float('baz', $precision = 53)->unsigned();
  ```

