### PR TITLE
Add withCookieJar to HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
@@ -516,6 +517,21 @@ class PendingRequest
         return tap($this, function () use ($cookies, $domain) {
             $this->options = array_merge_recursive($this->options, [
                 'cookies' => CookieJar::fromArray($cookies, $domain),
+            ]);
+        });
+    }
+
+    /**
+     * Specify the CookieJar that should be used with the request.
+     *
+     * @param  CookieJarInterface  $cookieJar
+     * @return $this
+     */
+    public function withCookieJar(CookieJarInterface $cookieJar)
+    {
+        return tap($this, function () use ($cookieJar) {
+            $this->options = array_merge_recursive($this->options, [
+                'cookies' => $cookieJar
             ]);
         });
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -531,7 +531,7 @@ class PendingRequest
     {
         return tap($this, function () use ($cookieJar) {
             $this->options = array_merge_recursive($this->options, [
-                'cookies' => $cookieJar
+                'cookies' => $cookieJar,
             ]);
         });
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -45,6 +45,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withUserAgent(string|bool $userAgent)
  * @method static \Illuminate\Http\Client\PendingRequest withUrlParameters(array $parameters = [])
  * @method static \Illuminate\Http\Client\PendingRequest withCookies(array $cookies, string $domain)
+ * @method static \Illuminate\Http\Client\PendingRequest withCookieJar(\GuzzleHttp\Cookie\CookieJarInterface $cookieJar)
  * @method static \Illuminate\Http\Client\PendingRequest maxRedirects(int $max)
  * @method static \Illuminate\Http\Client\PendingRequest withoutRedirecting()
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Http;
 
 use Exception;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
@@ -791,6 +793,33 @@ class HttpClientTest extends TestCase
         $this->assertSame('foo', $responseCookie['Name']);
         $this->assertSame('bar', $responseCookie['Value']);
         $this->assertSame('https://laravel.com', $responseCookie['Domain']);
+    }
+
+    public function testWithCookieJar()
+    {
+        $this->factory->fakeSequence()->pushStatus(200);
+
+        $cookieJar = new CookieJar(cookieArray: [
+            [
+                'Name' => 'foo',
+                'Value' => 'bar',
+                'Domain' => 'https://laravel.com'
+            ]
+        ]);
+
+        $response = $this->factory->withCookieJar($cookieJar)
+            ->get('https://laravel.com');
+
+        $this->assertCount(1, $response->cookies()->toArray());
+
+        /** @var \GuzzleHttp\Cookie\CookieJarInterface $responseCookies */
+        $responseCookie = $response->cookies()->toArray()[0];
+
+        $this->assertSame('foo', $responseCookie['Name']);
+        $this->assertSame('bar', $responseCookie['Value']);
+        $this->assertSame('https://laravel.com', $responseCookie['Domain']);
+
+        $this->assertSame($response->cookies(), $cookieJar);
     }
 
     public function testWithQueryParameters()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -803,7 +803,7 @@ class HttpClientTest extends TestCase
                 'Name' => 'foo',
                 'Value' => 'bar',
                 'Domain' => 'https://laravel.com',
-            ]
+            ],
         ]);
 
         $response = $this->factory->withCookieJar($cookieJar)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Http;
 
 use Exception;
 use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
@@ -803,7 +802,7 @@ class HttpClientTest extends TestCase
             [
                 'Name' => 'foo',
                 'Value' => 'bar',
-                'Domain' => 'https://laravel.com'
+                'Domain' => 'https://laravel.com',
             ]
         ]);
 


### PR DESCRIPTION
This function lets you set the CookieJar for the request. It is a shortcut for
```php
Http::withOptions(['cookies' => $cookieJar']);
```

Two main benefits:
- you can set multiple cookies with different domains
- the CookieJar is used for response cookies too

Added tests.