### PR TITLE
[10.x] Add new MapIntoEnum method in collection class

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -417,7 +417,7 @@ trait EnumeratesValues
      * @param  class-string<TEnum>  $enumClass
      * @return static<TKey, TEnum>
      */
-    public function mapEnum($enumClass)
+    public function mapIntoEnum($enumClass)
     {
         return $this->map(fn ($value) => enum_exists($enumClass) && method_exists($enumClass, 'tryFrom') ? $enumClass::tryFrom($value) : null);
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -424,9 +424,9 @@ trait EnumeratesValues
         throw_unless($validEnum, \InvalidArgumentException::class, $enumClass.' is not a valid BackedEnum class');
 
         return $this
-            ->filter(fn($value) => is_string($value) || is_int($value))
+            ->filter(fn ($value) => is_string($value) || is_int($value))
             ->map(fn ($value) => $enumClass::tryFrom($value))
-            ->filter(fn($value) => $value instanceof $enumClass);
+            ->filter(fn ($value) => $value instanceof $enumClass);
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -419,7 +419,14 @@ trait EnumeratesValues
      */
     public function mapIntoEnum($enumClass)
     {
-        return $this->map(fn ($value) => enum_exists($enumClass) && method_exists($enumClass, 'tryFrom') ? $enumClass::tryFrom($value) : null);
+        $validEnum = enum_exists($enumClass) && method_exists($enumClass, 'tryFrom');
+
+        throw_unless($validEnum, \InvalidArgumentException::class, $enumClass .' is not a valid BackedEnum class');
+
+        return $this
+            ->filter(fn($value) => is_string($value) || is_int($value))
+            ->map(fn ($value) => $enumClass::tryFrom($value))
+            ->filter(fn($value) => $value instanceof $enumClass);
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -412,7 +412,7 @@ trait EnumeratesValues
     /**
      * Map the values into a new Enum class.
      *
-     * @template TMapIntoValue
+     * @template TEnum
      *
      * @param  class-string<TEnum>  $enumClass
      * @return static<TKey, TEnum>
@@ -421,7 +421,7 @@ trait EnumeratesValues
     {
         $validEnum = enum_exists($enumClass) && method_exists($enumClass, 'tryFrom');
 
-        throw_unless($validEnum, \InvalidArgumentException::class, $enumClass .' is not a valid BackedEnum class');
+        throw_unless($validEnum, \InvalidArgumentException::class, $enumClass.' is not a valid BackedEnum class');
 
         return $this
             ->filter(fn($value) => is_string($value) || is_int($value))

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -410,6 +410,19 @@ trait EnumeratesValues
     }
 
     /**
+     * Map the values into a new Enum class.
+     *
+     * @template TMapIntoValue
+     *
+     * @param  class-string<TEnum>  $enumClass
+     * @return static<TKey, TEnum>
+     */
+    public function mapEnum($enumClass)
+    {
+        return $this->map(fn ($value) => enum_exists($enumClass) && method_exists($enumClass, 'tryFrom') ? $enumClass::tryFrom($value) : null);
+    }
+
+    /**
      * Get the min value of a given key.
      *
      * @param  (callable(TValue):mixed)|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5722,7 +5722,7 @@ class SupportCollectionTest extends TestCase
     public function testMapIntoEnumIgnoresMissingValues($collection)
     {
         $data = new $collection([
-            1, 2, 3
+            1, 2, 3,
         ]);
 
         $data = $data->mapIntoEnum(TestBackedEnum::class);
@@ -5740,7 +5740,7 @@ class SupportCollectionTest extends TestCase
         $data = new $collection();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(Collection::class . ' is not a valid BackedEnum class');
+        $this->expectExceptionMessage(Collection::class .' is not a valid BackedEnum class');
         $data->mapIntoEnum(Collection::class);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5700,6 +5700,21 @@ class SupportCollectionTest extends TestCase
             [LazyCollection::class],
         ];
     }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapEnum($collection)
+    {
+        $data = new $collection([
+            1, 2,
+        ]);
+
+        $data = $data->mapEnum(TestBackedEnum::class);
+
+        $this->assertSame(TestBackedEnum::A, $data->get(0));
+        $this->assertSame(TestBackedEnum::B, $data->get(1));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5740,7 +5740,7 @@ class SupportCollectionTest extends TestCase
         $data = new $collection();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(Collection::class .' is not a valid BackedEnum class');
+        $this->expectExceptionMessage(Collection::class.' is not a valid BackedEnum class');
         $data->mapIntoEnum(Collection::class);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5715,6 +5715,22 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(TestBackedEnum::A, $data->get(0));
         $this->assertSame(TestBackedEnum::B, $data->get(1));
     }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapIntoEnumIgnoresMissingValues($collection)
+    {
+        $data = new $collection([
+            1, 2, 3
+        ]);
+
+        $data = $data->mapIntoEnum(TestBackedEnum::class);
+
+        $this->assertSame(TestBackedEnum::A, $data->get(0));
+        $this->assertSame(TestBackedEnum::B, $data->get(1));
+        $this->assertSame(null, $data->get(2));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5731,6 +5731,18 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(TestBackedEnum::B, $data->get(1));
         $this->assertSame(null, $data->get(2));
     }
+    
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapIntoEnumThrowsInvalidArgumentException($collection)
+    {
+        $data = new $collection();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(Collection::class . ' is not a valid BackedEnum class');
+        $data->mapIntoEnum(Collection::class);
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5704,13 +5704,13 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testMapEnum($collection)
+    public function testMapIntoEnum($collection)
     {
         $data = new $collection([
             1, 2,
         ]);
 
-        $data = $data->mapEnum(TestBackedEnum::class);
+        $data = $data->mapIntoEnum(TestBackedEnum::class);
 
         $this->assertSame(TestBackedEnum::A, $data->get(0));
         $this->assertSame(TestBackedEnum::B, $data->get(1));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5731,7 +5731,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(TestBackedEnum::B, $data->get(1));
         $this->assertSame(null, $data->get(2));
     }
-    
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This method would (and should) be used as a shortcut to :

`$collection->map(fn($value) => $enumClass::tryFrom($value))`

And it filters the collection in case not all the values are not an instance of the enum.