### PR TITLE
[10.x] fix Mailable html content

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1721,7 +1721,7 @@ class Mailable implements MailableContract, Renderable
         }
 
         if ($content->html) {
-            $this->view($content->html);
+            $this->html($content->html);
         }
 
         if ($content->text) {


### PR DESCRIPTION
Currently with this code 
```php
if ($content->html) {
     $this->view($content->html);
}
```
an exception is thrown `View [htmlcontent] not found. at vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php:137` if 

```php
public function content(): Content
{
    return new Content(
        html: '<html></html>'
    );
}
```


