### PR TITLE
Regression Test for PostgreSQL reserved word column names w/ guarded attributes broken in native column attributes implementation

### DIFF
--- a/tests/Integration/Database/EloquentCreateTest.php
+++ b/tests/Integration/Database/EloquentCreateTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentCreateTest extends DatabaseTestCase
+{
+    public function testInsertRecordWithReservedWordFieldName()
+    {
+        Schema::create('actions', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->timestamp('start');
+            $table->timestamp('end');
+            $table->boolean('analyze');
+        });
+
+        $model = new class extends Model
+        {
+            protected $table = 'actions';
+            protected $guarded = ['id'];
+            public $timestamps = false;
+        };
+
+        $result = $model->newInstance()->create([
+            'label' => 'test',
+            'start' => '2023-01-01 00:00:00',
+            'end' => '2024-01-01 00:00:00',
+            'analyze' => true,
+        ]);
+
+        $this->assertDatabaseHas('actions', [
+            'label' => 'test',
+            'start' => '2023-01-01 00:00:00',
+            'end' => '2024-01-01 00:00:00',
+            'analyze' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
verify issue #48870
