### PR TITLE
fix: check `model:prune` command options as intended

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -113,16 +113,17 @@ class PruneCommand extends Command
      */
     protected function models()
     {
-        if (! empty($models = $this->option('model'))) {
+        $models = $this->option('model');
+        $except = $this->option('except');
+
+        if (! empty($models)) {
+            if (! empty($except)) {
+                throw new InvalidArgumentException('The --model and --except options cannot be combined.');
+            }
+
             return collect($models)->filter(function ($model) {
                 return class_exists($model);
             })->values();
-        }
-
-        $except = $this->option('except');
-
-        if (! empty($models) && ! empty($except)) {
-            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 
         return collect((new Finder)->in($this->getDefaultPath())->files()->name('*.php'))

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -218,7 +218,6 @@ class PruneCommandTest extends TestCase
         $this->artisan(['--model' => PrunableTestModelWithPrunableRecords::class]);
     }
 
-
     public function testTheCommandDoesntAcceptIncompatibleOptions()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -215,6 +216,17 @@ class PruneCommandTest extends TestCase
         Application::getInstance()->singleton(DispatcherContract::class, fn () => $dispatcher);
 
         $this->artisan(['--model' => PrunableTestModelWithPrunableRecords::class]);
+    }
+
+
+    public function testTheCommandDoesntAcceptIncompatibleOptions()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->artisan([
+            '--model' => PrunableTestModelWithPrunableRecords::class,
+            '--except' => PrunableTestModelWithoutPrunableRecords::class,
+        ]);
     }
 
     protected function artisan($arguments)


### PR DESCRIPTION
`php artisan model:prune` cannot, by design, use the `--model` and `--except` options together. 

But currently, `InvalidArgumentException` could never been thrown previously because if the `--model` option was used, `$models` would be non-empty and so, the first return would stop the function execution before the check.

It can break existings workflows if the user call both options, as an exception is now thrown instead of the `--except` option being silently ignored.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
