### PR TITLE
[10.x] Fix postgreSQL reserved word column names w/ guarded attributes broken in native column attributes implementation

### DIFF
--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -59,7 +59,7 @@ class PostgresProcessor extends Processor
             $autoincrement = $result->default !== null && str_starts_with($result->default, 'nextval(');
 
             return [
-                'name' => str_starts_with($result->name, '"') ? str_replace('"', '', $result->name): $result->name,
+                'name' => str_starts_with($result->name, '"') ? str_replace('"', '', $result->name) : $result->name,
                 'type_name' => $result->type_name,
                 'type' => $result->type,
                 'collation' => $result->collation,

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -59,7 +59,7 @@ class PostgresProcessor extends Processor
             $autoincrement = $result->default !== null && str_starts_with($result->default, 'nextval(');
 
             return [
-                'name' => $result->name,
+                'name' => str_starts_with($result->name, '"') ? str_replace('"', '', $result->name): $result->name,
                 'type_name' => $result->type_name,
                 'type' => $result->type,
                 'collation' => $result->collation,

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -238,9 +238,9 @@ class Builder
      */
     public function getColumnType($table, $column, $fullDefinition = false)
     {
-        $table = $this->connection->getTablePrefix().$table;
-
         if (! $this->connection->usingNativeSchemaOperations()) {
+            $table = $this->connection->getTablePrefix().$table;
+
             return $this->connection->getDoctrineColumn($table, $column)->getType()->getName();
         }
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -101,6 +101,7 @@ class EloquentModelTest extends DatabaseTestCase
             $table->id();
             $table->string('label');
             $table->timestamp('start');
+            $table->timestamp('end')->nullable();
             $table->boolean('analyze');
         });
 
@@ -114,12 +115,14 @@ class EloquentModelTest extends DatabaseTestCase
         $model->newInstance()->create([
             'label' => 'test',
             'start' => '2023-01-01 00:00:00',
+            'end' => '2024-01-01 00:00:00',
             'analyze' => true,
         ]);
 
         $this->assertDatabaseHas('actions', [
             'label' => 'test',
             'start' => '2023-01-01 00:00:00',
+            'end' => '2024-01-01 00:00:00',
             'analyze' => true,
         ]);
     }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -94,6 +94,38 @@ class EloquentModelTest extends DatabaseTestCase
         $user->save();
         $this->assertFalse($user->wasChanged());
     }
+
+    public function testInsertRecordWithReservedWordFieldName()
+    {
+        Schema::create('actions', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->timestamp('start');
+            $table->timestamp('end');
+            $table->boolean('analyze');
+        });
+
+        $model = new class extends Model
+        {
+            protected $table = 'actions';
+            protected $guarded = ['id'];
+            public $timestamps = false;
+        };
+
+        $model->newInstance()->create([
+            'label' => 'test',
+            'start' => '2023-01-01 00:00:00',
+            'end' => '2024-01-01 00:00:00',
+            'analyze' => true,
+        ]);
+
+        $this->assertDatabaseHas('actions', [
+            'label' => 'test',
+            'start' => '2023-01-01 00:00:00',
+            'end' => '2024-01-01 00:00:00',
+            'analyze' => true,
+        ]);
+    }
 }
 
 class TestModel1 extends Model

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -101,7 +101,6 @@ class EloquentModelTest extends DatabaseTestCase
             $table->id();
             $table->string('label');
             $table->timestamp('start');
-            $table->timestamp('end');
             $table->boolean('analyze');
         });
 
@@ -115,14 +114,12 @@ class EloquentModelTest extends DatabaseTestCase
         $model->newInstance()->create([
             'label' => 'test',
             'start' => '2023-01-01 00:00:00',
-            'end' => '2024-01-01 00:00:00',
             'analyze' => true,
         ]);
 
         $this->assertDatabaseHas('actions', [
             'label' => 'test',
             'start' => '2023-01-01 00:00:00',
-            'end' => '2024-01-01 00:00:00',
             'analyze' => true,
         ]);
     }


### PR DESCRIPTION
Fixes #48870

The solution was to unquote quoted reserved names on PostgreSQL processor, [the same approach is used on Doctrine DBAL](https://github.com/doctrine/dbal/blob/45941c67dd0505dab2fb970786d93055b7cbd2b6/src/Schema/AbstractAsset.php#L154-L169).

Thanks @crynobone and @damiantw for reporting the issue.