### PR TITLE
[10.x] Allow `Sleep::until()` to be passed a timestamp as a string

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -80,12 +80,12 @@ class Sleep
     /**
      * Sleep until the given timestamp.
      *
-     * @param  \DateTimeInterface|int  $timestamp
+     * @param  \DateTimeInterface|int|float|numeric-string  $timestamp
      * @return static
      */
     public static function until($timestamp)
     {
-        if (is_int($timestamp)) {
+        if (is_numeric($timestamp)) {
             $timestamp = Carbon::createFromTimestamp($timestamp);
         }
 

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -229,6 +229,18 @@ class SleepTest extends TestCase
         ]);
     }
 
+    public function testItCanSleepTillGivenTimestampAsString()
+    {
+        Sleep::fake();
+        Carbon::setTestNow(now()->startOfDay());
+
+        Sleep::until(strval(now()->addMinute()->timestamp));
+
+        Sleep::assertSequence([
+            Sleep::for(60)->seconds(),
+        ]);
+    }
+
     public function testItSleepsForZeroTimeWithNegativeDateTime()
     {
         Sleep::fake();

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -241,6 +241,20 @@ class SleepTest extends TestCase
         ]);
     }
 
+    public function testItCanSleepTillGivenTimestampAsStringWithMilliseconds()
+    {
+        Sleep::fake();
+        Carbon::setTestNow('2000-01-01 00:00:00.000'); // 946684800
+
+        Sleep::until('946684899.123');
+
+        Sleep::assertSequence([
+            Sleep::for(1)->minute()
+                ->and(39)->seconds()
+                ->and(123)->milliseconds(),
+        ]);
+    }
+
     public function testItSleepsForZeroTimeWithNegativeDateTime()
     {
         Sleep::fake();


### PR DESCRIPTION
We were caught out by this because we pulled a timestamp that was saved in redis and it came back as a string.

`Carbon::createFromTimestamp(...)` handles numeric strings happily, so I have loosened the restriction in `Sleep::until` from requiring an int to allowing numeric strings; hence the change from `is_int` to `is_numeric`.
