### PR TITLE
[11.x] Execute the callback or provided default when loaded relation is null

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -270,10 +270,6 @@ trait ConditionallyLoadsAttributes
             return $this->resource->{$relationship};
         }
 
-        if ($this->resource->{$relationship} === null) {
-            return;
-        }
-
         return value($value);
     }
 

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
@@ -11,7 +11,10 @@ class PostResourceWithOptionalRelationship extends PostResource
             'comments' => new CommentCollection($this->whenLoaded('comments')),
             'author' => new AuthorResource($this->whenLoaded('author')),
             'author_name' => $this->whenLoaded('author', function () {
-                return $this->author->name;
+                return $this->author?->name;
+            }),
+            'category' => $this->whenLoaded('category', function () {
+                return $this->category?->name ?? 'No Category';
             }),
         ];
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -537,6 +537,36 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function testResourcesMayExecuteWhenLoadedCallbackWhenLoadedRelationshipValueNull()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ]);
+
+            $post->setRelation('author', new Author(['name' => 'jrrmartin']));
+            $post->setRelation('category', null);
+
+            return new PostResourceWithOptionalRelationship($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'author' => ['name' => 'jrrmartin'],
+                'author_name' => 'jrrmartin',
+                'category' => 'No Category',
+            ],
+        ]);
+    }
+
     public function testResourcesMayHaveOptionalRelationshipsWithDefaultValues()
     {
         Route::get('/', function () {


### PR DESCRIPTION
Currently in Laravel, when using `whenLoaded` in a Json Resource, if the relation is indeed loaded, but the value of the relation is `null`, then the default value or the provided callback is never executed;

```php
$post = new Post();
$post->setRelation('author', null);

class PostResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'author_name' => $this->whenLoaded('author', function () {
                // this is never going to be executed
                return $this->author?->name ?? 'No author';
            }),
        ];
    }
}
```

This behaviour is somewhat confusing because the relation is indeed loaded, and you may want to do something in that callback, like return a default value.

There have been other proposed changes to this;
- https://github.com/laravel/framework/pull/37643
- https://github.com/laravel/framework/pull/37641

Whilst I think the current behaviour is confusing, the proposed change is breaking for users who have been using this method for a long time which is why I've targeted the `master` branch for the `11.x` release.

There is a current workaround - you could do;
```php
$post = new Post();
$post->setRelation('author', null);

class PostResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'author_name' => $this->when($this->relationLoaded('author'), function () {
                // this will now be executed
                return $this->author?->name  ?? 'No author';
            }),
        ];
    }
}
```
However at a glance, I would expect the snippet above and the current work around to be behave exactly the same way, but they don't.