### PR TITLE
Fixes unable to create MySQL database with `null` collation using `Schema::createDatabase()`

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -43,11 +43,13 @@ class MySqlGrammar extends Grammar
      */
     public function compileCreateDatabase($name, $connection)
     {
+        $collation = $connection->getConfig('collation');
+
         return sprintf(
             'create database %s default character set %s default collate %s',
             $this->wrapValue($name),
             $this->wrapValue($connection->getConfig('charset')),
-            $this->wrapValue($connection->getConfig('collation')),
+            ! empty($collation) ? $this->wrapValue($collation) : $collation,
         );
     }
 


### PR DESCRIPTION
Reported via https://github.com/orchestral/testbench-core/discussions/148