### PR TITLE
[10.x] Add JobTimingOut event to Worker

### DIFF
--- a/src/Illuminate/Queue/Events/JobTimingOut.php
+++ b/src/Illuminate/Queue/Events/JobTimingOut.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobTimingOut
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->job = $job;
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\JobTimedOut;
+use Illuminate\Queue\Events\JobTimingOut;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -213,6 +214,10 @@ class Worker
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
             if ($job) {
+                $this->events->dispatch(new JobTimingOut(
+                    $job->getConnectionName(), $job
+                ));
+
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
                     $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->timeoutExceededException($job)
                 );


### PR DESCRIPTION
Add a `JobTimingOut` event in order to allow developers to resolve the scenario described in #48392.

The main problem described in the issue is that if the job has a transaction that is still running when the job hits timeout, then any database operation that is sent before rolling back the job transaction, will not be executed as expected.

There already exists a `JobTimedOut` event, but this event is emitted after some processes that may involve database access in some scenarios. So, by adding this new event, developers can roll back database transactions before these mentioned processes are executed.

I prepared a [repository](https://github.com/sebapastore/test-laravel-job-timeout) in order to test this.

There are two jobs `TimeOutJobWithoutTransactionRollback` and `TimeOutJobWithTransactionRollback`:

```
class TimeOutJobWithoutTransactionRollback implements ShouldQueue
{
    ...

    public function handle(): void
    {
        DB::transaction(fn() => sleep(999));
    }
}
```
```
class TimeOutJobWithTransactionRollback implements ShouldQueue
{
    ...

    public function handle(): void
    {
        DB::transaction(fn() => sleep(999));
    }
}
```

There is also a event listener that will make DB rollback only for `TimeOutJobWithTransactionRollback `:

```
class HandleJobTimingOut
{
    ...

    {
        if ($event->job->resolveName() === TimeOutJobWithTransactionRollback::class) {
            DB::rollBack();
        }
    }
}
``` 

So you can try for example:

```
\Bus::batch([new TimeOutJobWithoutTransactionRollback(), new TimeOutJobWithoutTransactionRollback()])
    ->allowFailures()
    ->dispatch();
```

and that will reproduce the mentioned issue. Then you can try:

```
\Bus::batch([new TimeOutJobWithTransactionRollback(), new TimeOutJobWithTransactionRollback()])
    ->allowFailures()
    ->dispatch();
```

and the issue is solved with the rollback.

So, this PR resolve #48392.