### PR TITLE
[10.x] Enable default retrieval of all fragments in `fragments()` and `fragmentsIf()` methods

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -91,13 +91,31 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
-     * Get the evaluated contents for a given array of fragments.
+     * Get all fragments and return as a single string.
      *
-     * @param  array  $fragments
      * @return string
      */
-    public function fragments(array $fragments)
+    protected function allFragments()
     {
+        $fragments = $this->render(fn() => $this->factory->getFragments());
+
+        return collect($fragments)->implode('');
+    }
+
+    /**
+     * Get the evaluated contents for a given array of fragments.
+     * If no fragments are provided, return all fragments.
+     *
+     * @param  array  $fragments
+     *
+     * @return string
+     */
+    public function fragments(array|null $fragments = null)
+    {
+        if ($fragments === null) {
+            return $this->allFragments();
+        }
+
         return collect($fragments)->map(fn ($f) => $this->fragment($f))->implode('');
     }
 
@@ -121,10 +139,10 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * Get the evaluated contents for a given array of fragments if the given condition is true.
      *
      * @param  bool  $boolean
-     * @param  array  $fragments
+     * @param  array|null  $fragments
      * @return string
      */
-    public function fragmentsIf($boolean, array $fragments)
+    public function fragmentsIf($boolean, array|null $fragments = null)
     {
         if (value($boolean)) {
             return $this->fragments($fragments);

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -108,7 +108,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * @param array|null $fragments
      * @return string
      */
-    public function fragments(array|null $fragments = null)
+    public function fragments(?array $fragments = null)
     {
         if ($fragments === null) {
             return $this->allFragments();

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -91,18 +91,6 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
-     * Get all fragments and return as a single string.
-     *
-     * @return string
-     */
-    protected function allFragments()
-    {
-        $fragments = $this->render(fn() => $this->factory->getFragments());
-
-        return collect($fragments)->implode('');
-    }
-
-    /**
      * Get the evaluated contents for a given array of fragments or return all fragments.
      *
      * @param array|null $fragments
@@ -110,11 +98,9 @@ class View implements ArrayAccess, Htmlable, ViewContract
      */
     public function fragments(?array $fragments = null)
     {
-        if ($fragments === null) {
-            return $this->allFragments();
-        }
-
-        return collect($fragments)->map(fn ($f) => $this->fragment($f))->implode('');
+        return is_null($fragments)
+            ? $this->allFragments()
+            : collect($fragments)->map(fn ($f) => $this->fragment($f))->implode('');
     }
 
     /**
@@ -147,6 +133,16 @@ class View implements ArrayAccess, Htmlable, ViewContract
         }
 
         return $this->render();
+    }
+
+    /**
+     * Get all fragments as a single string.
+     *
+     * @return string
+     */
+    protected function allFragments()
+    {
+        return collect($this->render(fn() => $this->factory->getFragments()))->implode('');
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -142,7 +142,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * @param  array|null  $fragments
      * @return string
      */
-    public function fragmentsIf($boolean, array|null $fragments = null)
+    public function fragmentsIf($boolean, ?array $fragments = null)
     {
         if (value($boolean)) {
             return $this->fragments($fragments);

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -107,7 +107,6 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * If no fragments are provided, return all fragments.
      *
      * @param array|null $fragments
-     *
      * @return string
      */
     public function fragments(array|null $fragments = null)

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -106,7 +106,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * Get the evaluated contents for a given array of fragments.
      * If no fragments are provided, return all fragments.
      *
-     * @param  array  $fragments
+     * @param array|null $fragments
      *
      * @return string
      */

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -103,8 +103,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
-     * Get the evaluated contents for a given array of fragments.
-     * If no fragments are provided, return all fragments.
+     * Get the evaluated contents for a given array of fragments or return all fragments.
      *
      * @param array|null $fragments
      * @return string


### PR DESCRIPTION
This pull request aims to enhance the current implementation of working with [Hotwire](https://hotwired.dev/) in our application. Previously, in order to retrieve fragments using the `fragments()` and `fragmentsIf()` methods, it was mandatory to explicitly specify the desired fragments. However, this pull request introduces default behavior to both methods, enabling them to automatically retrieve and return all detected fragments when no particular fragments are provided.