### PR TITLE
[10.x] BUGFIX `data_forget()` with nested collections

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -163,13 +163,14 @@ if (! function_exists('data_forget')) {
 
         if (($segment = array_shift($segments)) === '*' && Arr::accessible($target)) {
             if ($segments) {
-                foreach ($target as &$inner) {
-                    data_forget($inner, $segments);
+                foreach ($target as $segment => &$inner) {
+                    $target[$segment] = data_forget($inner, $segments);
                 }
             }
         } elseif (Arr::accessible($target)) {
             if ($segments && Arr::exists($target, $segment)) {
-                data_forget($target[$segment], $segments);
+                $inner = $target[$segment];
+                $target[$segment] = data_forget($inner, $segments);
             } else {
                 Arr::forget($target, $segment);
             }


### PR DESCRIPTION
This PR has two commits - the first adding more tests around `data_forget()` so that it has better coverage of different common data structures (i.e. explicit testing of objects and collections), as well as tests to show that the function did not behave as expected when attempting to forget nested data in a collection.

As collections are "Array Accessible" the function runs through the `Arr::accessible()` code paths, but because the properties on the collection are set and fetched through the magic `__get()` and `__set()` methods, the actual internal references are not updated meaning that attempting to remove a "nested" value never works. In particular, this notice is thrown:

`NOTICE  Indirect modification of overloaded element of Illuminate\Support\Collection has no effect`

The update is _very slightly_ less pretty, but shouldn't be significantly more memory hungry or inefficient. By explicitly setting the inner item to a variable then re-assigning it based on the key, we will actually update the proper item, thus making `data_forget($collection, 'some.nested.paths.*.id')` actually work.