### PR TITLE
[10.x] Dispatch 'connection failed' event in async http client request

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1008,6 +1008,10 @@ class PendingRequest
                 });
             })
             ->otherwise(function (TransferException $e) {
+                if ($e instanceof ConnectException) {
+                    $this->dispatchConnectionFailedEvent();
+                }
+
                 return $e instanceof RequestException && $e->hasResponse() ? $this->populateResponse($this->newResponse($e->getResponse())) : $e;
             });
     }


### PR DESCRIPTION
When sending a synchronous request using the Http Client, a 'connection failed' event is dispatched when the url could not be reached. This PR ensures that event is also dispatched when a asynchronous request fails because of a connection issue.