### PR TITLE
[10.x] Make possible to use Str macros in Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -43,7 +43,9 @@ class Stringable implements JsonSerializable, ArrayAccess
         } catch (BadMethodCallException $exception) {}
 
         try {
-            return Str::$method(...[ ...$parameters]);
+            return is_string($result = Str::$method(...[(string)$this, ...$parameters]))
+                ? new static($result)
+                : $result;
         } catch (BadMethodCallException) {
             throw $exception;
         }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -40,10 +40,11 @@ class Stringable implements JsonSerializable, ArrayAccess
     {
         try {
             return $this->macroCall($method, $parameters);
-        } catch (BadMethodCallException $exception) {}
+        } catch (BadMethodCallException $exception) {
+        }
 
         try {
-            return is_string($result = Str::$method(...[(string)$this, ...$parameters]))
+            return is_string($result = Str::$method(...[(string) $this, ...$parameters]))
                 ? new static($result)
                 : $result;
         } catch (BadMethodCallException) {

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1308,7 +1308,7 @@ class SupportStringableTest extends TestCase
 
         Str::macro(
             'test_macro_method',
-            fn (string $firstArgument, int $secondArgument): string => $firstArgument . $secondArgument
+            fn (string $firstArgument, int $secondArgument): string => $firstArgument.$secondArgument
         );
         $macroResult = $this->stringable('hello')->test_macro_method(123);
         $this->assertNotSame(
@@ -1331,7 +1331,7 @@ class SupportStringableTest extends TestCase
         Stringable::flushMacros();
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessageMatches(
-            $this->stringable(Stringable::class . '::test_macro_method')
+            $this->stringable(Stringable::class.'::test_macro_method')
                 ->prepend('/')
                 ->append('/')
                 ->replace('\\', '\\\\')

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1306,6 +1306,18 @@ class SupportStringableTest extends TestCase
             $this->stringable('hello')->test_macro_method(123),
         );
 
+        Str::macro(
+            'test_macro_method',
+            fn (string $firstArgument, int $secondArgument): string => $firstArgument . $secondArgument
+        );
+        $macroResult = $this->stringable('hello')->test_macro_method(123);
+        $this->assertNotSame(
+            Str::test_macro_method('hello', 123),
+            $macroResult,
+        );
+        $this->assertInstanceOf(Stringable::class, $macroResult);
+        $this->assertSame('hello123', $macroResult->toString());
+
         Stringable::macro('test_macro_method', fn (string $name) => new static ($name));
         $macroResult = $this->stringable()->test_macro_method('world');
         $this->assertInstanceOf(Stringable::class, $macroResult);


### PR DESCRIPTION
### Description: 
PR allows **Stringable** to use **Str helper defined macros** (which seems pretty logical). This implementation brings a possibility not to duplicate code and more important -  no breaking change because **it`s still possible to define macros for Stringable** and they obviously **have higher priority above Str ones**. 

### Examples
```
Str::macro(
            'someMethod',
            fn (string $firstArgument, int $secondArgument): string => 'something'
        );

// Returns Stringable instance if Str macro returns string

$stringable->someMethod($secondArgument);  // Stringable('something')
```
```
Str::macro(
            'someMethod',
            fn (): array => []
        );

// Returns raw data if Str macro returns another type

$stringable->someMethod(); // []
```
```
Str::macro(
            'someMethod',
            fn (): string => 'hello'
        );
Stringable::macro(
            'someMethod',
            fn (): string => new static('world')
        );

// Stringable macro has higher priority than Str one

$stringable->someMethod();  // Stringable('world')
```


### Issue:
This PR relates to this [issue](https://github.com/laravel/framework/issues/34901)  (however no breaking change afaik)