### PR TITLE
[10.x] Fix whereHasMorph() with nullable morphs

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -230,6 +230,10 @@ trait QueriesRelationships
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
         }
 
+        if (empty($types)) {
+            return $this->whereNotNull($relation->getMorphType(), $boolean);
+        }
+
         foreach ($types as &$type) {
             $type = Relation::getMorphedModel($type) ?? $type;
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
         }
 
         if (empty($types)) {
-            return $this->whereNotNull($relation->getMorphType(), $boolean);
+            return $this->where(new Expression('0'), $operator, $count, $boolean);
         }
 
         foreach ($types as &$type) {

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -109,7 +109,9 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         Comment::whereNotNull('commentable_type')->forceDelete();
 
         $comments = Comment::query()
-            ->whereHasMorph('commentable', '*')
+            ->whereHasMorph('commentable', '*', function (Builder $query) {
+                $query->where('title', 'foo');
+            })
             ->orderBy('id')->get();
 
         $this->assertEmpty($comments->pluck('id')->all());

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -204,6 +204,18 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         $this->assertEquals([1, 4], $comments->pluck('id')->all());
     }
 
+    public function testOrWhereHasMorphWithWildcardAndOnlyNullMorphTypes()
+    {
+        Comment::where('id', '!=', 1)->whereNotNull('commentable_type')->forceDelete();
+
+        $comments = Comment::where('id', 1)
+            ->orWhereHasMorph('commentable', '*', function (Builder $query) {
+                $query->where('title', 'foo');
+            })->orderBy('id')->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+    }
+
     public function testWhereDoesntHaveMorph()
     {
         $comments = Comment::whereDoesntHaveMorph('commentable', Post::class, function (Builder $query) {
@@ -211,6 +223,17 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         })->orderBy('id')->get();
 
         $this->assertEquals([2, 3], $comments->pluck('id')->all());
+    }
+
+    public function testWhereDoesntHaveMorphWithWildcardAndOnlyNullMorphTypes()
+    {
+        Comment::whereNotNull('commentable_type')->forceDelete();
+
+        $comments = Comment::whereDoesntHaveMorph('commentable', [], function (Builder $query) {
+            $query->where('title', 'foo');
+        })->orderBy('id')->get();
+
+        $this->assertEquals([7], $comments->pluck('id')->all());
     }
 
     public function testOrWhereDoesntHaveMorph()

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -42,6 +42,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         $models[] = Video::create(['title' => 'bar']);
         $models[] = Video::create(['title' => 'baz']);
         $models[] = null; // deleted
+        $models[] = null; // deleted
 
         foreach ($models as $model) {
             (new Comment)->commentable()->associate($model)->save();
@@ -206,14 +207,14 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testOrWhereHasMorphWithWildcardAndOnlyNullMorphTypes()
     {
-        Comment::where('id', '!=', 1)->whereNotNull('commentable_type')->forceDelete();
+        Comment::whereNotNull('commentable_type')->forceDelete();
 
-        $comments = Comment::where('id', 1)
+        $comments = Comment::where('id', 7)
             ->orWhereHasMorph('commentable', '*', function (Builder $query) {
                 $query->where('title', 'foo');
             })->orderBy('id')->get();
 
-        $this->assertEquals([1], $comments->pluck('id')->all());
+        $this->assertEquals([7], $comments->pluck('id')->all());
     }
 
     public function testWhereDoesntHaveMorph()
@@ -233,7 +234,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
             $query->where('title', 'foo');
         })->orderBy('id')->get();
 
-        $this->assertEquals([7], $comments->pluck('id')->all());
+        $this->assertEquals([7, 8], $comments->pluck('id')->all());
     }
 
     public function testOrWhereDoesntHaveMorph()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Problem
The project I'm working on has a table with a nullable morph. We query the table and its relations using the `whereHas` method. Toy problem:
```
Model::whereHas('loggable', '*', function (Builder $query)) {
    // some conditions
});
```

Assuming the data in the table is:
| id | loggable_type | loggable_id | message                                     |
|----|---------------|-------------|---------------------------------------------|
| 1  | null          | null        | Something happened not connected to a model |
| 2  | null          | null        | Something else happened                     |

There are some records with the `loggable_type` set to `null`, but no other records. When using the `whereHas` method with a wildcard, [it will query the table to get all types](https://github.com/laravel/framework/blob/0fde761c0f895b30d9a60ac22b323aa9b50662eb/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L230). In this case, `$types` will be an empty array. The result is the same as calling `whereHas('loggable', [], ...)`.

If you have a look at [the source code of `whereHas()`](https://github.com/laravel/framework/blob/0fde761c0f895b30d9a60ac22b323aa9b50662eb/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L238), you'll see that for every type it adds a condition to the query. But when no types are given, no conditions are applied! Therefore it will return the records in the table even though they don't have the relation set and don't satisfy the conditions.

## Benefit to the user
The fix makes `whereHasMorph` and similar functions work like expected for nullable morphs which prevents subtle bugs.

## Backwards compatibility
This fix implements the edge-case for existing features but does not change how other cases work.