### PR TITLE
[10.x] Add default argument to enum method in `InteractsWithInput`

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -397,7 +397,7 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  class-string<TEnum>  $enumClass
-     * @param  string|int|float $default
+     * @param  string|int|float  $default
      * @return TEnum|null
      */
     public function enum($key, $enumClass, $default = null)

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -397,17 +397,18 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  class-string<TEnum>  $enumClass
+     * @param  string|int|float $default
      * @return TEnum|null
      */
-    public function enum($key, $enumClass)
+    public function enum($key, $enumClass, $default = null)
     {
-        if ($this->isNotFilled($key) ||
+        if ($this->isNotFilled($key) && is_null($default) ||
             ! enum_exists($enumClass) ||
             ! method_exists($enumClass, 'tryFrom')) {
             return null;
         }
 
-        return $enumClass::tryFrom($this->input($key));
+        return $enumClass::tryFrom($this->input($key, $default));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -763,6 +763,11 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
 
         $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
+
+        $this->assertEquals(
+            TestEnum::test,
+            $request->enum('doesnt_exists', TestEnum::class, 'test')
+        );
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
This PR provides the default value for the method of enum in FormRequest when the key has not been sent.
There is no conflict with the previous use and it does not affect the current codes.
Example:
```php
$request->enum('doesnt_exists', PostStatus::class, 'active');
// PostStatus::Active

```
Similar to these methods of FormRequest:
```php
$request->boolean('doesnt_exists', true); // true
$request->integer('doesnt_exists', 10); // 10
```