### PR TITLE
[11.x] Support retry and throw on async http client request (in a http client request pool)

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -997,9 +997,10 @@ class PendingRequest
      * @param  string  $method
      * @param  string  $url
      * @param  array  $options
+     * @param  integer  $attempt
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    protected function makePromise(string $method, string $url, array $options = [])
+    protected function makePromise(string $method, string $url, array $options = [], int $attempt = 1)
     {
         return $this->promise = $this->sendRequest($method, $url, $options)
             ->then(function (MessageInterface $message) {
@@ -1011,9 +1012,50 @@ class PendingRequest
             ->otherwise(function (TransferException $e) {
                 if ($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
+
+                    return new ConnectionException($e->getMessage(), 0, $e);
                 }
 
                 return $e instanceof RequestException && $e->hasResponse() ? $this->populateResponse($this->newResponse($e->getResponse())) : $e;
+            })
+            ->then(function (Response|TransferException $response) use ($method, $url, $options, $attempt) {
+                if ($response instanceof Response && $response->successful()) {
+                    return $response;
+                }
+
+                if ($response instanceof RequestException) {
+                    $response = $this->populateResponse($this->newResponse($response->getResponse()));
+                }
+
+                try {
+                    $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this) : true;
+                } catch (Exception $exception) {
+                    $shouldRetry = false;
+
+                    return $exception;
+                }
+
+                if ($this->throwCallback && ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
+                    try {
+                        $response->throw($this->throwCallback);
+                    } catch (Exception $exception) {
+                        return $exception;
+                    }
+                }
+
+                if ($attempt < $this->tries && $shouldRetry) {
+                    if ($this->retryDelay) {
+                        $options['delay'] = $this->retryDelay;
+                    }
+
+                    return $this->makePromise($method, $url, $options, $attempt + 1);
+                }
+
+                if ($this->tries > 1 && $this->retryThrow) {
+                    return $response->toException();
+                }
+
+                return $response;
             });
     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -998,7 +998,7 @@ class PendingRequest
      * @param  string  $method
      * @param  string  $url
      * @param  array  $options
-     * @param  integer  $attempt
+     * @param  int  $attempt
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
     protected function makePromise(string $method, string $url, array $options = [], int $attempt = 1)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1018,45 +1018,62 @@ class PendingRequest
 
                 return $e instanceof RequestException && $e->hasResponse() ? $this->populateResponse($this->newResponse($e->getResponse())) : $e;
             })
-            ->then(function (Response|TransferException|ConnectionException $response) use ($method, $url, $options, $attempt) {
-                if ($response instanceof Response && $response->successful()) {
-                    return $response;
-                }
-
-                if ($response instanceof RequestException) {
-                    $response = $this->populateResponse($this->newResponse($response->getResponse()));
-                }
-
-                try {
-                    $shouldRetry = $this->retryWhenCallback ? call_user_func(
-                        $this->retryWhenCallback,
-                        $response instanceof Response ? $response->toException() : $response,
-                        $this
-                    ) : true;
-                } catch (Exception $exception) {
-                    return $exception;
-                }
-
-                if ($attempt < $this->tries && $shouldRetry) {
-                    $options['delay'] = value($this->retryDelay, $attempt, $response->toException());
-
-                    return $this->makePromise($method, $url, $options, $attempt + 1);
-                }
-
-                if ($response instanceof Response && $this->throwCallback && ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
-                    try {
-                        $response->throw($this->throwCallback);
-                    } catch (Exception $exception) {
-                        return $exception;
-                    }
-                }
-
-                if ($this->tries > 1 && $this->retryThrow) {
-                    return $response instanceof Response ? $response->toException() : $response;
-                }
-
-                return $response;
+            ->then(function (Response|ConnectionException|TransferException $response) use ($method, $url, $options, $attempt) {
+                return $this->handlePromiseResponse($response, $method, $url, $options, $attempt);
             });
+    }
+
+    /**
+     * Handle the response of an asynchronous request.
+     *
+     * @param  \Illuminate\Http\Client\Response  $response
+     * @param  string  $method
+     * @param  string  $url
+     * @param  array  $options
+     * @param  int  $attempt
+     * @return mixed
+     */
+    protected function handlePromiseResponse(Response|ConnectionException|TransferException $response, $method, $url, $options, $attempt)
+    {
+        if ($response instanceof Response && $response->successful()) {
+            return $response;
+        }
+
+        if ($response instanceof RequestException) {
+            $response = $this->populateResponse($this->newResponse($response->getResponse()));
+        }
+
+        try {
+            $shouldRetry = $this->retryWhenCallback ? call_user_func(
+                $this->retryWhenCallback,
+                $response instanceof Response ? $response->toException() : $response,
+                $this
+            ) : true;
+        } catch (Exception $exception) {
+            return $exception;
+        }
+
+        if ($attempt < $this->tries && $shouldRetry) {
+            $options['delay'] = value($this->retryDelay, $attempt, $response->toException());
+
+            return $this->makePromise($method, $url, $options, $attempt + 1);
+        }
+
+        if ($response instanceof Response &&
+            $this->throwCallback &&
+            ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
+            try {
+                $response->throw($this->throwCallback);
+            } catch (Exception $exception) {
+                return $exception;
+            }
+        }
+
+        if ($this->tries > 1 && $this->retryThrow) {
+            return $response instanceof Response ? $response->toException() : $response;
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1038,7 +1038,7 @@ class PendingRequest
                 }
 
                 if ($attempt < $this->tries && $shouldRetry) {
-                    $options['delay'] = value($this->retryDelay);
+                    $options['delay'] = value($this->retryDelay, $attempt, $response->toException());
 
                     return $this->makePromise($method, $url, $options, $attempt + 1);
                 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1037,18 +1037,18 @@ class PendingRequest
                     return $exception;
                 }
 
+                if ($attempt < $this->tries && $shouldRetry) {
+                    $options['delay'] = value($this->retryDelay);
+
+                    return $this->makePromise($method, $url, $options, $attempt + 1);
+                }
+
                 if ($response instanceof Response && $this->throwCallback && ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
                     try {
                         $response->throw($this->throwCallback);
                     } catch (Exception $exception) {
                         return $exception;
                     }
-                }
-
-                if ($attempt < $this->tries && $shouldRetry) {
-                    $options['delay'] = value($this->retryDelay);
-
-                    return $this->makePromise($method, $url, $options, $attempt + 1);
                 }
 
                 if ($this->tries > 1 && $this->retryThrow) {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -16,7 +16,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
-use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1866,8 +1866,7 @@ class HttpClientTest extends TestCase
                 $whenAttempts->push($exception);
 
                 return $exception->response->status() === 403;
-            }, true)
-            ->get('http://foo.com/get')
+            }, true)->get('http://foo.com/get'),
         ]);
 
         $this->assertNotNull($exception);
@@ -1908,7 +1907,7 @@ class HttpClientTest extends TestCase
                 $whenAttempts->push($exception);
 
                 return $exception->response->status() === 403;
-            }, false)->get('http://foo.com/get')
+            }, false)->get('http://foo.com/get'),
         ]);
 
         $this->assertNotNull($response);
@@ -1935,7 +1934,7 @@ class HttpClientTest extends TestCase
                 $request->withHeaders(['Foo' => 'Bar']);
 
                 return true;
-            }, false)->get('http://foo.com/get')
+            }, false)->get('http://foo.com/get'),
         ]);
 
         $this->assertTrue($response->successful());
@@ -2215,7 +2214,7 @@ class HttpClientTest extends TestCase
         ]);
 
         [$response] = $this->factory->pool(fn ($pool) => [
-            $pool->throw()->get('http://foo.com/get')
+            $pool->throw()->get('http://foo.com/get'),
         ]);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -2229,7 +2228,7 @@ class HttpClientTest extends TestCase
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
-            $pool->throw()->get('http://foo.com/get')
+            $pool->throw()->get('http://foo.com/get'),
         ]);
 
         $this->assertNotNull($exception);
@@ -2243,7 +2242,7 @@ class HttpClientTest extends TestCase
         ]);
 
         [$exception] = $this->factory->pool(fn ($pool) => [
-            $pool->throwIf(true)->get('http://foo.com/get')
+            $pool->throwIf(true)->get('http://foo.com/get'),
         ]);
 
         $this->assertNotNull($exception);
@@ -2257,7 +2256,7 @@ class HttpClientTest extends TestCase
         ]);
 
         [$response] = $this->factory->pool(fn ($pool) => [
-            $pool->throwIf(false)->get('http://foo.com/get')
+            $pool->throwIf(false)->get('http://foo.com/get'),
         ]);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -2285,7 +2284,7 @@ class HttpClientTest extends TestCase
                 $this->assertInstanceOf(RequestException::class, $e);
 
                 $hitThrowCallback->push(true);
-            })->get('http://foo.com/get')
+            })->get('http://foo.com/get'),
         ]);
 
         $this->assertNotNull($exception);
@@ -2327,7 +2326,7 @@ class HttpClientTest extends TestCase
         [$exception] = $this->factory->pool(fn ($pool) => [
             $pool->throw(function ($exception) use (&$flag) {
                 $flag->push(true);
-            })->get('http://foo.com/get')
+            })->get('http://foo.com/get'),
         ]);
 
         $this->assertCount(1, $flag);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1837,6 +1837,133 @@ class HttpClientTest extends TestCase
         ]);
     }
 
+    public function testRequestExceptionReturnedWhenRetriesExhaustedInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(2, 1000, null, true)->get('http://foo.com/get'),
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $this->factory->assertSentCount(2);
+    }
+
+    public function testRequestExceptionIsReturnedWithoutRetriesIfRetryNotNecessaryInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        $whenAttempts = collect();
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(2, 1000, function ($exception) use ($whenAttempts) {
+                $whenAttempts->push($exception);
+
+                return $exception->response->status() === 403;
+            }, true)
+            ->get('http://foo.com/get')
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $this->assertCount(1, $whenAttempts);
+
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testRequestExceptionIsNotReturnedWhenDisabledAndRetriesExhaustedInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        [$response] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(2, 1000, null, false)->get('http://foo.com/get'),
+        ]);
+
+        $this->assertNotNull($response);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->failed());
+
+        $this->factory->assertSentCount(2);
+    }
+
+    public function testRequestExceptionIsNotReturnedWithoutRetriesIfRetryNotNecessaryInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        $whenAttempts = collect();
+
+        [$response] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(2, 1000, function ($exception) use ($whenAttempts) {
+                $whenAttempts->push($exception);
+
+                return $exception->response->status() === 403;
+            }, false)->get('http://foo.com/get')
+        ]);
+
+        $this->assertNotNull($response);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->failed());
+
+        $this->assertCount(1, $whenAttempts);
+
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testRequestCanBeModifiedInRetryCallbackInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push(['error'], 500)
+                ->push(['ok'], 200),
+        ]);
+
+        [$response] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(2, 1000, function ($exception, $request) {
+                $this->assertInstanceOf(PendingRequest::class, $request);
+
+                $request->withHeaders(['Foo' => 'Bar']);
+
+                return true;
+            }, false)->get('http://foo.com/get')
+        ]);
+
+        $this->assertTrue($response->successful());
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('Foo') && $request->header('Foo') === ['Bar'];
+        });
+    }
+
+    public function testExceptionThrownInRetryCallbackIsReturnedWithoutRetryingInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(2, 1000, function ($exception) {
+                throw new Exception('Foo bar');
+            }, false)->get('http://foo.com/get'),
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertEquals('Foo bar', $exception->getMessage());
+
+        $this->factory->assertSentCount(1);
+    }
+
     public function testMiddlewareRunsWhenFaked()
     {
         $this->factory->fake(function (Request $request) {
@@ -2079,6 +2206,134 @@ class HttpClientTest extends TestCase
         $response = $this->factory->get('http://foo.com/api')->throw();
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+    }
+
+    public function testRequestExceptionIsNotReturnedIfThePendingRequestIsSetToThrowOnFailureButTheResponseIsSuccessfulInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['success'], 200),
+        ]);
+
+        [$response] = $this->factory->pool(fn ($pool) => [
+            $pool->throw()->get('http://foo.com/get')
+        ]);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->status());
+    }
+
+    public function testRequestExceptionIsReturnedIfThePendingRequestIsSetToThrowOnFailureInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->throw()->get('http://foo.com/get')
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionIsReturnedIfTheThrowIfOnThePendingRequestIsSetToTrueOnFailureInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->throwIf(true)->get('http://foo.com/get')
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionIsNotReturnedIfTheThrowIfOnThePendingRequestIsSetToFalseOnFailureInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        [$response] = $this->factory->pool(fn ($pool) => [
+            $pool->throwIf(false)->get('http://foo.com/get')
+        ]);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(403, $response->status());
+    }
+
+    public function testRequestExceptionIsReturnedIfTheThrowIfClosureOnThePendingRequestReturnsTrueInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $hitThrowCallback = collect();
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->throwIf(function ($response) {
+                $this->assertInstanceOf(Response::class, $response);
+                $this->assertSame(403, $response->status());
+
+                return true;
+            }, function ($response, $e) use (&$hitThrowCallback) {
+                $this->assertInstanceOf(Response::class, $response);
+                $this->assertSame(403, $response->status());
+
+                $this->assertInstanceOf(RequestException::class, $e);
+
+                $hitThrowCallback->push(true);
+            })->get('http://foo.com/get')
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertCount(1, $hitThrowCallback);
+    }
+
+    public function testRequestExceptionIsNotReturnedIfTheThrowIfClosureOnThePendingRequestReturnsFalseInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $hitThrowCallback = collect();
+
+        [$response] = $this->factory->pool(fn ($pool) => [
+            $pool->throwIf(function ($response) {
+                $this->assertInstanceOf(Response::class, $response);
+                $this->assertSame(403, $response->status());
+
+                return false;
+            }, function ($response, $e) use (&$hitThrowCallback) {
+                $hitThrowCallback->push(true);
+            })->get('http://foo.com/get'),
+        ]);
+
+        $this->assertCount(0, $hitThrowCallback);
+        $this->assertSame(403, $response->status());
+    }
+
+    public function testRequestExceptionIsReturnedWithCallbackIfThePendingRequestIsSetToThrowOnFailureInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $flag = collect();
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->throw(function ($exception) use (&$flag) {
+                $flag->push(true);
+            })->get('http://foo.com/get')
+        ]);
+
+        $this->assertCount(1, $flag);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
     }
 
     public function testRequestExceptionIsThrowIfConditionIsSatisfied()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2335,6 +2335,22 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
+    public function testRequestExceptionIsReturnedAfterLastRetryInPool()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        [$exception] = $this->factory->pool(fn ($pool) => [
+            $pool->retry(3)->throw()->get('http://foo.com/get'),
+        ]);
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $this->factory->assertSentCount(3);
+    }
+
     public function testRequestExceptionIsThrowIfConditionIsSatisfied()
     {
         $this->factory->fake([


### PR DESCRIPTION
## Issue

The Http Client allows you to add "retry" functionality and "throw" functionality to a request. 
```php
Http::retry(3, 1000)->get('https://foo.bar');

Http::throw()->get('https://foo.bar');
```
These are synchronous requests, but the Http Client also gives you the option to create asynchronous requests by creating a pool. The problem is asynchronous requests in a pool do not support the retry and throw functionality. If you want that functionality, then you would have to write that yourself which is not easy to do (especially if you want the retries to also happen asynchronously).
```php
// This does not work. The request will only be tried once.
Http::pool(fn ($pool) => [$pool->retry(3, 1000)->get('https://foo.bar')]);

// This also does not work. Unless a connection issue occurs, a response will always be returned.
Http::pool(fn ($pool) => [$pool->throw()->get('https://foo.bar')]);
```

This issue has also been reported by others: https://github.com/laravel/framework/issues/44955 and https://github.com/laravel/framework/issues/41790#issuecomment-1143319214

## Solution

This PR fixes that by adding all that behavior to an asynchronous request, so that it behaves exactly the same as a synchronous request.

We first add an extra `then` to the request promise. This allows us to add the same retry and throw functionality as a synchronous request. 

```php
protected function makePromise(string $method, string $url, array $options = [], int $attempt = 1)
{
    return $this->promise = $this->sendRequest($method, $url, $options)
        ->then(function (MessageInterface $message) {
            // existing code: this is executed when the request received a response
        })
        ->otherwise(function (TransferException $e) {
            // existing code: this is executed when the request did not receive response
        })
        ->then(function (Response|TransferException|ConnectionException $response) use ($method, $url, $options, $attempt) {
			// new code: this method is executed after either the "then" or "otherwise" method above this "then" method.
        })
}
```

First, we check if the response has a successful status code. In that case, we can return that response.

```php
if ($response instanceof Response && $response->successful()) {
    return $response;
}
```

If the response is not successful, we need to check if the request needs to be retried. The execution of the "retryWhenCallback" is wrapped in a try-catch because an exception that occurs in that closure should just cause the return of that exception (exactly the same as a synchronous request, except the exception is returned instead of throw)
```php
try {
    $shouldRetry = $this->retryWhenCallback ? call_user_func(
		$this->retryWhenCallback,
		$response instanceof Response ? $response->toException() : $response,
		$this
	) : true;
} catch (Exception $exception) {
    return $exception;
}
```

Next, we need to check if our current attempt does not exceed our maximum tries. If that is the case, we can start a new attempt by creating and returning a new promise by calling the `makePromise` method again. Guzzle also provides [the option to provide a delay](https://docs.guzzlephp.org/en/stable/request-options.html#delay) so the new attempt is not immediately executed if that is what is defined on the pending request.

```php
if ($attempt < $this->tries && $shouldRetry) {
    $options['delay'] = value($this->retryDelay);

    return $this->makePromise($method, $url, $options, $attempt + 1);
}
```

Next, we need to check if we need to return the response or the exception. If the exception needs to be returned, we wrap the `$response->throw($this->throwCallback)` code in a try-catch. The `$response->throw()` method immediately throws the generated exception but in the case of async requests we need to return the exception instead. The try-catch enables us to do that.

```php
if ($response instanceof Response && $this->throwCallback && ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
    try {
        $response->throw($this->throwCallback);
    } catch (Exception $exception) {
        return $exception;
    }
}
```

Finally, if we exceed our maximum tries, we have to return the final exception (if the $response is not a response object, then it's a connection exception so we can just return that exception). Otherwise, the response should just be returned.

```php
if ($this->tries > 1 && $this->retryThrow) {
    return $response instanceof Response ? $response->toException() : $response;
}

return $response;
```

## Tests

All the tests in this PR are copies of existing tests but the synchronous requests are converted to asynchronous requests so we test the exact same cases.

## Breaking Changes

- When a connection issue occurs, a `\Illuminate\Http\Client\ConnectionException` is returned instead of the `GuzzleHttp\Exception\ConnectException`. This makes the behavior the same as the synchronous requests.
- When the `throw` method is used on an async request in a pool, the response exception will be returned instead of always returning the response if a response is available. This makes the behavior the same as the synchronous requests.
- When the `retry` method is used on an async request in a pool, the method will now work.
- The protected `makePromise` method on the `PendingRequest` class has an extra parameter called `attempt`
