### PR TITLE
[10.x] Add Number class; convert given number to percentage.

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -2,36 +2,38 @@
 
 namespace Illuminate\Support;
 
-class Number {
+class Number
+{
     protected static array $formatsByLocale = [
         'en' => [
             'precision' => 2,
             'format' => '%s%s',
             'thousands_separator' => ',',
-            'decimal_separator' => '.'
+            'decimal_separator' => '.',
         ],
         'fr' => [
             'precision' => 2,
             'format' => '%s %s',
             'thousands_separator' => ' ',
-            'decimal_separator' => ','
+            'decimal_separator' => ',',
         ],
         'de' => [
             'precision' => 2,
             'format' => '%s %s',
             'thousands_separator' => '.',
-            'decimal_separator' => ','
+            'decimal_separator' => ',',
         ]
     ];
 
     /**
      * Percentage format with locale support.
      *
-     * @param int|float $value
-     * @param array $options
+     * @param  int|float  $value
+     * @param  array  $options
      * @return string
      */
-    public static function percentage(int|float $value, array $options = []): string {
+    public static function percentage(int|float $value, array $options = []): string
+    {
         $defaults = [
             'strip_insignificant_zeros' => false,
         ];
@@ -43,17 +45,18 @@ class Number {
             $formatted = rtrim($formatted, '0\.');
         }
 
-        return sprintf($options['format'],$formatted, '%');
+        return sprintf($options['format'], $formatted, '%');
     }
 
     /**
      * Format the given number.
      *
-     * @param int|float $value
-     * @param array $options
+     * @param  int|float  $value
+     * @param  array  $options
      * @return string
      */
-    public static function format(int|float $value, array $options = []): string {
+    public static function format(int|float $value, array $options = []): string
+    {
         $locale = $options['locale'] ?? 'en';
 
         $options = array_merge(self::getFormatByLocale($locale), $options);
@@ -63,10 +66,11 @@ class Number {
     /**
      * Return the format options for the given locale.
      *
-     * @param string $locale
+     * @param  string  $locale
      * @return array
      */
-    protected static function getFormatByLocale(string $locale = 'en'): array {
+    protected static function getFormatByLocale(string $locale = 'en'): array
+    {
         if (isset(self::$formatsByLocale[$locale])) {
             return self::$formatsByLocale[$locale];
         }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Number {
+    protected static array $formatsByLocale = [
+        'en' => [
+            'precision' => 2,
+            'format' => '%s%s',
+            'thousands_separator' => ',',
+            'decimal_separator' => '.'
+        ],
+        'fr' => [
+            'precision' => 2,
+            'format' => '%s %s',
+            'thousands_separator' => ' ',
+            'decimal_separator' => ','
+        ],
+        'de' => [
+            'precision' => 2,
+            'format' => '%s %s',
+            'thousands_separator' => '.',
+            'decimal_separator' => ','
+        ]
+    ];
+
+    /**
+     * Percentage format with locale support.
+     *
+     * @param int|float $value
+     * @param array $options
+     * @return string
+     */
+    public static function percentage(int|float $value, array $options = []): string {
+        $defaults = [
+            'strip_insignificant_zeros' => false,
+        ];
+        $locale = $options['locale'] ?? 'en';
+        $options = array_merge($defaults, self::getFormatByLocale($locale), $options);
+
+        $formatted = self::format($value, $options);
+        if ($options['strip_insignificant_zeros']) {
+            $formatted = rtrim($formatted, '0\.');
+        }
+
+        return sprintf($options['format'],$formatted, '%');
+    }
+
+    /**
+     * Format the given number.
+     *
+     * @param int|float $value
+     * @param array $options
+     * @return string
+     */
+    public static function format(int|float $value, array $options = []): string {
+        $locale = $options['locale'] ?? 'en';
+
+        $options = array_merge(self::getFormatByLocale($locale), $options);
+        return number_format($value, $options['precision'], $options['decimal_separator'], $options['thousands_separator']);
+    }
+
+    /**
+     * Return the format options for the given locale.
+     *
+     * @param string $locale
+     * @return array
+     */
+    protected static function getFormatByLocale(string $locale = 'en'): array {
+        if (isset(self::$formatsByLocale[$locale])) {
+            return self::$formatsByLocale[$locale];
+        }
+
+        throw new \RuntimeException("Unsupported locale '$locale'");
+    }
+}

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
-    public function testPercentage() {
+    public function testPercentage()
+    {
         $this->assertSame('23.50%', Number::percentage(23.5));
         $this->assertSame('23.50 %', Number::percentage(23.5, ['format' => '%s %s']));
         $this->assertSame('23.501%', Number::percentage(23.501, ['precision' => 3]));
@@ -23,7 +24,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('306%', Number::percentage(306.00, ['strip_insignificant_zeros' => true]));
         $this->assertSame('307.11%', Number::percentage(307.110, ['precision' => 3, 'strip_insignificant_zeros' => true]));
 
-        $this->expectException(\RuntimeException::class, );
+        $this->expectException(\RuntimeException::class);
         Number::percentage(23.5, ['locale' => 'es']);
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Number;
+use PHPUnit\Framework\TestCase;
+
+class SupportNumberTest extends TestCase
+{
+    public function testPercentage() {
+        $this->assertSame('23.50%', Number::percentage(23.5));
+        $this->assertSame('23.50 %', Number::percentage(23.5, ['format' => '%s %s']));
+        $this->assertSame('23.501%', Number::percentage(23.501, ['precision' => 3]));
+        $this->assertSame('1 305,01 %', Number::percentage(1305.01, ['locale' => 'fr']));
+        $this->assertSame('9 988 776,65 %', Number::percentage(9988776.65, ['locale' => 'fr']));
+        $this->assertSame('9.988.776,65 %', Number::percentage(9988776.65, ['locale' => 'de']));
+        $this->assertSame('9,988,776.65%', Number::percentage(9988776.65, ['locale' => 'en']));
+        $this->assertSame('135,00 %', Number::percentage(135.0, ['locale' => 'fr']));
+        $this->assertSame('1,305.04%', Number::percentage(1305.04, ['locale' => 'en']));
+        $this->assertSame('1,305%', Number::percentage(1305.034, ['precision' => 0]));
+        $this->assertSame('1,305.4%', Number::percentage(1305.400, ['strip_insignificant_zeros' => true]));
+        $this->assertSame('305%', Number::percentage(305, ['strip_insignificant_zeros' => true]));
+        $this->assertSame('306%', Number::percentage(306.00, ['strip_insignificant_zeros' => true]));
+        $this->assertSame('307.11%', Number::percentage(307.110, ['precision' => 3, 'strip_insignificant_zeros' => true]));
+
+        $this->expectException(\RuntimeException::class, );
+        Number::percentage(23.5, ['locale' => 'es']);
+    }
+}


### PR DESCRIPTION
### About
This is follow up for initiative to add ```Number``` utility as part of core Laravel framework. More on that in the conversation started in https://github.com/laravel/framework/pull/48827#issuecomment-1781232805 and https://github.com/laravel/framework/pull/48845. 

### What I'm trying to achieve
Adding proof of concept for formatting percentage value using different locales. Currently supporting 3 locales (en, fr, de) but others can be added later once path forward is clear. 

**Main question to answer: should number formatting depend on php-intl extension (and [NumberFormatter](https://www.php.net/manual/en/class.numberformatter.php)) or have locale implementation 'in-house' as shown in the draft PR?**

Both implementations have pros and cons. 
- php-intl extension: adding another dependency; handling cases where extension is not enabled; most likely using small fraction extension capabilities. However it adds wide variety of locale support out of the box. 
- in-house implementation: lower number for supported locales. However, no extra dependencies; more control and flexibility.  
 
All ideas and feedback are welcome, thanks!

