### PR TITLE
[10.x] Add support for custom $PATH's (like DBngin) for the Schema Dump/import command

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -70,7 +70,7 @@ class MySqlSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = $this->mysqlBinPath() . 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+        $command = $this->binPath() . 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
         $process = $this->makeProcess($command)->setTimeout(null);
 
@@ -86,7 +86,7 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = $this->mysqlBinPath() . 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
+        $command = $this->binPath() . 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
         if (! $this->connection->isMaria()) {
             $command .= ' --set-gtid-purged=OFF';
@@ -143,15 +143,15 @@ class MySqlSchemaState extends SchemaState
 	 *
 	 * @return string
 	 */
-	protected function mysqlBinPath()
+	protected function binPath()
 	{
-		$mysqlBinPath = $this->connection->getConfig()['bin'] ?? '';
+		$binPath = $this->connection->getConfig()['bin'] ?? '';
 		
-		if ($mysqlBinPath) {
-			$mysqlBinPath = Str::finish($mysqlBinPath, DIRECTORY_SEPARATOR);
+		if ($binPath) {
+			$binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
 		}
 		
-		return $mysqlBinPath;
+		return $binPath;
 	}
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
+
 use const DIRECTORY_SEPARATOR;
 
 class MySqlSchemaState extends SchemaState
@@ -70,7 +71,7 @@ class MySqlSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = $this->binPath() . 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+        $command = $this->binPath().'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
         $process = $this->makeProcess($command)->setTimeout(null);
 
@@ -86,7 +87,7 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = $this->binPath() . 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
+        $command = $this->binPath().'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
         if (! $this->connection->isMaria()) {
             $command .= ' --set-gtid-purged=OFF';
@@ -137,22 +138,22 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_SSL_CA' => $config['options'][\PDO::MYSQL_ATTR_SSL_CA] ?? '',
         ];
     }
-	
-	/**
-	 * Get the bin path for the dump / load command.
-	 *
-	 * @return string
-	 */
-	protected function binPath()
-	{
-		$binPath = $this->connection->getConfig()['bin'] ?? '';
-		
-		if ($binPath) {
-			$binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
-		}
-		
-		return $binPath;
-	}
+
+    /**
+     * Get the bin path for the dump / load command.
+     *
+     * @return string
+     */
+    protected function binPath()
+    {
+        $binPath = $this->connection->getConfig()['bin'] ?? '';
+
+        if ($binPath) {
+            $binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
+        }
+
+        return $binPath;
+    }
 
     /**
      * Execute the given dump process.

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Support\Str;
 
 class PostgresSchemaState extends SchemaState
 {
@@ -35,10 +36,10 @@ class PostgresSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"';
+        $command = $this->binPath() . 'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"';
 
         if (str_ends_with($path, '.sql')) {
-            $command = 'psql --file="${:LARAVEL_LOAD_PATH}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
+            $command = $this->binPath() . 'psql --file="${:LARAVEL_LOAD_PATH}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
         }
 
         $process = $this->makeProcess($command);
@@ -55,7 +56,7 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        return 'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
+        return $this->binPath() . 'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**
@@ -76,4 +77,20 @@ class PostgresSchemaState extends SchemaState
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }
+	
+	/**
+	 * Get the bin path for the dump / restore command.
+	 *
+	 * @return string
+	 */
+	protected function binPath()
+	{
+		$binPath = $this->connection->getConfig()['bin'] ?? '';
+		
+		if ($binPath) {
+			$binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
+		}
+		
+		return $binPath;
+	}
 }

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -36,10 +36,10 @@ class PostgresSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = $this->binPath() . 'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"';
+        $command = $this->binPath().'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"';
 
         if (str_ends_with($path, '.sql')) {
-            $command = $this->binPath() . 'psql --file="${:LARAVEL_LOAD_PATH}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
+            $command = $this->binPath().'psql --file="${:LARAVEL_LOAD_PATH}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
         }
 
         $process = $this->makeProcess($command);
@@ -56,7 +56,7 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        return $this->binPath() . 'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
+        return $this->binPath().'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**
@@ -77,20 +77,20 @@ class PostgresSchemaState extends SchemaState
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }
-	
-	/**
-	 * Get the bin path for the dump / restore command.
-	 *
-	 * @return string
-	 */
-	protected function binPath()
-	{
-		$binPath = $this->connection->getConfig()['bin'] ?? '';
-		
-		if ($binPath) {
-			$binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
-		}
-		
-		return $binPath;
-	}
+
+    /**
+     * Get the bin path for the dump / restore command.
+     *
+     * @return string
+     */
+    protected function binPath()
+    {
+        $binPath = $this->connection->getConfig()['bin'] ?? '';
+
+        if ($binPath) {
+            $binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
+        }
+
+        return $binPath;
+    }
 }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Support\Str;
 
 class SqliteSchemaState extends SchemaState
 {
@@ -81,7 +82,7 @@ class SqliteSchemaState extends SchemaState
      */
     protected function baseCommand()
     {
-        return 'sqlite3 "${:LARAVEL_LOAD_DATABASE}"';
+        return $this->binPath() . 'sqlite3 "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**
@@ -96,4 +97,20 @@ class SqliteSchemaState extends SchemaState
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }
+	
+	/**
+	 * Get the bin path for the sqlite3 command.
+	 *
+	 * @return string
+	 */
+	protected function binPath()
+	{
+		$binPath = $this->connection->getConfig()['bin'] ?? '';
+		
+		if ($binPath) {
+			$binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
+		}
+		
+		return $binPath;
+	}
 }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -82,7 +82,7 @@ class SqliteSchemaState extends SchemaState
      */
     protected function baseCommand()
     {
-        return $this->binPath() . 'sqlite3 "${:LARAVEL_LOAD_DATABASE}"';
+        return $this->binPath().'sqlite3 "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**
@@ -97,20 +97,20 @@ class SqliteSchemaState extends SchemaState
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }
-	
-	/**
-	 * Get the bin path for the sqlite3 command.
-	 *
-	 * @return string
-	 */
-	protected function binPath()
-	{
-		$binPath = $this->connection->getConfig()['bin'] ?? '';
-		
-		if ($binPath) {
-			$binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
-		}
-		
-		return $binPath;
-	}
+
+    /**
+     * Get the bin path for the sqlite3 command.
+     *
+     * @return string
+     */
+    protected function binPath()
+    {
+        $binPath = $this->connection->getConfig()['bin'] ?? '';
+
+        if ($binPath) {
+            $binPath = Str::finish($binPath, DIRECTORY_SEPARATOR);
+        }
+
+        return $binPath;
+    }
 }

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Schema\MySqlSchemaState;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+
 use const DIRECTORY_SEPARATOR;
 
 class DatabaseMySqlSchemaStateTest extends TestCase

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -13,18 +14,42 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     /**
      * @dataProvider provider
      */
-    public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
+    public function testConnectionString(string $expectedConnectionString, string $expectedBaseDumpCommand, string $expectedLoadCommand, array $expectedVariables, array $dbConfig): void
     {
         $connection = $this->createMock(MySqlConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);
+		
+		$latestCommand = null;
 
-        $schemaState = new MySqlSchemaState($connection);
-
+        $schemaState = new MySqlSchemaState($connection, processFactory: function(...$arguments) use (&$latestCommand) {
+			$latestCommand = $arguments[0];
+			
+			return new class
+			{
+				public function __call(string $name, $arguments)
+				{
+					 return $this;
+				}
+			};
+        });
+		
         // test connectionString
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
         $connString = $method->invoke($schemaState);
 
         self::assertEquals($expectedConnectionString, $connString);
+	    
+	    // test baseDumpCommand
+	    $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
+	    $baseDumpCommand = $method->invoke($schemaState);
+	    
+	    self::assertEquals(Str::replace('{{CONNECTION_STRING}}', $connString, $expectedBaseDumpCommand), $baseDumpCommand);
+	    
+	    // test load
+	    $method = new ReflectionMethod(get_class($schemaState), 'load');
+	    $method->invoke($schemaState, 'PATH');
+	    
+	    self::assertEquals(Str::replace('{{CONNECTION_STRING}}', $connString, $expectedLoadCommand), $latestCommand);
 
         // test baseVariables
         $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
@@ -36,7 +61,10 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     public static function provider(): Generator
     {
         yield 'default' => [
-            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"', [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"',
+            'mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"',
+            'mysql {{CONNECTION_STRING}} --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"',
+            [
                 'LARAVEL_LOAD_SOCKET' => '',
                 'LARAVEL_LOAD_HOST' => '127.0.0.1',
                 'LARAVEL_LOAD_PORT' => '',
@@ -50,9 +78,32 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'database' => 'forge',
             ],
         ];
+		
+        yield 'default_bin_path' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"',
+            '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"',
+            '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysql {{CONNECTION_STRING}} --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"',
+            [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '127.0.0.1',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'host' => '127.0.0.1',
+                'database' => 'forge',
+                'bin' => '/Users/Shared/DBngin/MySQL/8.0.33/bin'
+            ],
+        ];
 
         yield 'ssl_ca' => [
-            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"', [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"',
+            'mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"',
+            'mysql {{CONNECTION_STRING}} --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"',
+            [
                 'LARAVEL_LOAD_SOCKET' => '',
                 'LARAVEL_LOAD_HOST' => '',
                 'LARAVEL_LOAD_PORT' => '',
@@ -70,7 +121,10 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         ];
 
         yield 'unix socket' => [
-            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"',
+            'mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"',
+            'mysql {{CONNECTION_STRING}} --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"',
+            [
                 'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',
                 'LARAVEL_LOAD_HOST' => '',
                 'LARAVEL_LOAD_PORT' => '',

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Schema\MySqlSchemaState;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+use const DIRECTORY_SEPARATOR;
 
 class DatabaseMySqlSchemaStateTest extends TestCase
 {
@@ -81,8 +82,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
 
         yield 'default_bin_path' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"',
-            '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"',
-            '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysql {{CONNECTION_STRING}} --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"',
+            Str::replace('/', DIRECTORY_SEPARATOR, '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"'),
+            Str::replace('/', DIRECTORY_SEPARATOR, '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysql {{CONNECTION_STRING}} --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"'),
             [
                 'LARAVEL_LOAD_SOCKET' => '',
                 'LARAVEL_LOAD_HOST' => '127.0.0.1',
@@ -95,7 +96,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'host' => '127.0.0.1',
                 'database' => 'forge',
-                'bin' => '/Users/Shared/DBngin/MySQL/8.0.33/bin',
+                'bin' => Str::replace('/', DIRECTORY_SEPARATOR, '/Users/Shared/DBngin/MySQL/8.0.33/bin'),
             ],
         ];
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -18,38 +18,38 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     {
         $connection = $this->createMock(MySqlConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);
-		
-		$latestCommand = null;
 
-        $schemaState = new MySqlSchemaState($connection, processFactory: function(...$arguments) use (&$latestCommand) {
-			$latestCommand = $arguments[0];
-			
-			return new class
-			{
-				public function __call(string $name, $arguments)
-				{
-					 return $this;
-				}
-			};
+        $latestCommand = null;
+
+        $schemaState = new MySqlSchemaState($connection, processFactory: function (...$arguments) use (&$latestCommand) {
+            $latestCommand = $arguments[0];
+
+            return new class
+            {
+                public function __call(string $name, $arguments)
+                {
+                    return $this;
+                }
+            };
         });
-		
+
         // test connectionString
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
         $connString = $method->invoke($schemaState);
 
         self::assertEquals($expectedConnectionString, $connString);
-	    
-	    // test baseDumpCommand
-	    $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
-	    $baseDumpCommand = $method->invoke($schemaState);
-	    
-	    self::assertEquals(Str::replace('{{CONNECTION_STRING}}', $connString, $expectedBaseDumpCommand), $baseDumpCommand);
-	    
-	    // test load
-	    $method = new ReflectionMethod(get_class($schemaState), 'load');
-	    $method->invoke($schemaState, 'PATH');
-	    
-	    self::assertEquals(Str::replace('{{CONNECTION_STRING}}', $connString, $expectedLoadCommand), $latestCommand);
+
+        // test baseDumpCommand
+        $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
+        $baseDumpCommand = $method->invoke($schemaState);
+
+        self::assertEquals(Str::replace('{{CONNECTION_STRING}}', $connString, $expectedBaseDumpCommand), $baseDumpCommand);
+
+        // test load
+        $method = new ReflectionMethod(get_class($schemaState), 'load');
+        $method->invoke($schemaState, 'PATH');
+
+        self::assertEquals(Str::replace('{{CONNECTION_STRING}}', $connString, $expectedLoadCommand), $latestCommand);
 
         // test baseVariables
         $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
@@ -78,7 +78,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'database' => 'forge',
             ],
         ];
-		
+
         yield 'default_bin_path' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"',
             '/Users/Shared/DBngin/MySQL/8.0.33/bin/mysqldump {{CONNECTION_STRING}} --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0 --set-gtid-purged=OFF "${:LARAVEL_LOAD_DATABASE}"',
@@ -95,7 +95,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'host' => '127.0.0.1',
                 'database' => 'forge',
-                'bin' => '/Users/Shared/DBngin/MySQL/8.0.33/bin'
+                'bin' => '/Users/Shared/DBngin/MySQL/8.0.33/bin',
             ],
         ];
 

--- a/tests/Database/DatabasePostgresSchemaStateTest.php
+++ b/tests/Database/DatabasePostgresSchemaStateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Generator;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\Schema\MySqlSchemaState;
+use Illuminate\Database\Schema\PostgresSchemaState;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class DatabasePostgresSchemaStateTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function testConnectionString(string $expectedBaseDumpCommand, string $expectedLoadCommand, array $expectedVariables, array $dbConfig): void
+    {
+        $connection = $this->createMock(PostgresConnection::class);
+        $connection->method('getConfig')->willReturn($dbConfig);
+		
+		$latestCommand = null;
+
+        $schemaState = new PostgresSchemaState($connection, processFactory: function(...$arguments) use (&$latestCommand) {
+			$latestCommand = $arguments[0];
+			
+			return new class
+			{
+				public function __call(string $name, $arguments)
+				{
+					 return $this;
+				}
+			};
+        });
+		
+	    // test baseDumpCommand
+	    $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
+	    $baseDumpCommand = $method->invoke($schemaState);
+	    
+	    self::assertEquals($expectedBaseDumpCommand, $baseDumpCommand);
+	    
+	    // test load
+	    $method = new ReflectionMethod(get_class($schemaState), 'load');
+	    $method->invoke($schemaState, 'PATH');
+	    
+	    self::assertEquals($expectedLoadCommand, $latestCommand);
+
+        // test baseVariables
+        $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $variables = $method->invoke($schemaState, $dbConfig);
+
+        self::assertEquals($expectedVariables, $variables);
+    }
+
+    public static function provider(): Generator
+    {
+        yield 'default' => [
+			'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
+			'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
+            [
+                'LARAVEL_LOAD_HOST' => '127.0.0.1',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'PGPASSWORD' => 'secret',
+            ], [
+                'username' => 'root',
+                'host' => '127.0.0.1',
+                'database' => 'forge',
+                'password' => 'secret',
+            ],
+        ];
+		
+        yield 'default_bin_path' => [
+			'/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
+			'/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
+            [
+                'LARAVEL_LOAD_HOST' => '127.0.0.1',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'PGPASSWORD' => 'secret',
+            ], [
+                'username' => 'root',
+                'host' => '127.0.0.1',
+                'database' => 'forge',
+                'password' => 'secret',
+                'bin' => '/Users/Shared/DBngin/postgresql/15.1/bin'
+            ],
+        ];
+    }
+}

--- a/tests/Database/DatabasePostgresSchemaStateTest.php
+++ b/tests/Database/DatabasePostgresSchemaStateTest.php
@@ -3,11 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Generator;
-use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
-use Illuminate\Database\Schema\MySqlSchemaState;
 use Illuminate\Database\Schema\PostgresSchemaState;
-use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -20,32 +17,32 @@ class DatabasePostgresSchemaStateTest extends TestCase
     {
         $connection = $this->createMock(PostgresConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);
-		
-		$latestCommand = null;
 
-        $schemaState = new PostgresSchemaState($connection, processFactory: function(...$arguments) use (&$latestCommand) {
-			$latestCommand = $arguments[0];
-			
-			return new class
-			{
-				public function __call(string $name, $arguments)
-				{
-					 return $this;
-				}
-			};
+        $latestCommand = null;
+
+        $schemaState = new PostgresSchemaState($connection, processFactory: function (...$arguments) use (&$latestCommand) {
+            $latestCommand = $arguments[0];
+
+            return new class
+            {
+                public function __call(string $name, $arguments)
+                {
+                    return $this;
+                }
+            };
         });
-		
-	    // test baseDumpCommand
-	    $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
-	    $baseDumpCommand = $method->invoke($schemaState);
-	    
-	    self::assertEquals($expectedBaseDumpCommand, $baseDumpCommand);
-	    
-	    // test load
-	    $method = new ReflectionMethod(get_class($schemaState), 'load');
-	    $method->invoke($schemaState, 'PATH');
-	    
-	    self::assertEquals($expectedLoadCommand, $latestCommand);
+
+        // test baseDumpCommand
+        $method = new ReflectionMethod(get_class($schemaState), 'baseDumpCommand');
+        $baseDumpCommand = $method->invoke($schemaState);
+
+        self::assertEquals($expectedBaseDumpCommand, $baseDumpCommand);
+
+        // test load
+        $method = new ReflectionMethod(get_class($schemaState), 'load');
+        $method->invoke($schemaState, 'PATH');
+
+        self::assertEquals($expectedLoadCommand, $latestCommand);
 
         // test baseVariables
         $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
@@ -57,8 +54,8 @@ class DatabasePostgresSchemaStateTest extends TestCase
     public static function provider(): Generator
     {
         yield 'default' => [
-			'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
-			'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
+            'pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
+            'pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
             [
                 'LARAVEL_LOAD_HOST' => '127.0.0.1',
                 'LARAVEL_LOAD_PORT' => '',
@@ -72,10 +69,10 @@ class DatabasePostgresSchemaStateTest extends TestCase
                 'password' => 'secret',
             ],
         ];
-		
+
         yield 'default_bin_path' => [
-			'/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
-			'/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
+            '/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
+            '/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
             [
                 'LARAVEL_LOAD_HOST' => '127.0.0.1',
                 'LARAVEL_LOAD_PORT' => '',
@@ -87,7 +84,7 @@ class DatabasePostgresSchemaStateTest extends TestCase
                 'host' => '127.0.0.1',
                 'database' => 'forge',
                 'password' => 'secret',
-                'bin' => '/Users/Shared/DBngin/postgresql/15.1/bin'
+                'bin' => '/Users/Shared/DBngin/postgresql/15.1/bin',
             ],
         ];
     }

--- a/tests/Database/DatabasePostgresSchemaStateTest.php
+++ b/tests/Database/DatabasePostgresSchemaStateTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Generator;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Schema\PostgresSchemaState;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -71,8 +72,8 @@ class DatabasePostgresSchemaStateTest extends TestCase
         ];
 
         yield 'default_bin_path' => [
-            '/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"',
-            '/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"',
+	        Str::replace('/', DIRECTORY_SEPARATOR,'/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"'),
+	        Str::replace('/', DIRECTORY_SEPARATOR,'/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"'),
             [
                 'LARAVEL_LOAD_HOST' => '127.0.0.1',
                 'LARAVEL_LOAD_PORT' => '',
@@ -84,7 +85,7 @@ class DatabasePostgresSchemaStateTest extends TestCase
                 'host' => '127.0.0.1',
                 'database' => 'forge',
                 'password' => 'secret',
-                'bin' => '/Users/Shared/DBngin/postgresql/15.1/bin',
+                'bin' => Str::replace('/', DIRECTORY_SEPARATOR,'/Users/Shared/DBngin/postgresql/15.1/bin'),
             ],
         ];
     }

--- a/tests/Database/DatabasePostgresSchemaStateTest.php
+++ b/tests/Database/DatabasePostgresSchemaStateTest.php
@@ -72,8 +72,8 @@ class DatabasePostgresSchemaStateTest extends TestCase
         ];
 
         yield 'default_bin_path' => [
-	        Str::replace('/', DIRECTORY_SEPARATOR,'/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"'),
-	        Str::replace('/', DIRECTORY_SEPARATOR,'/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"'),
+            Str::replace('/', DIRECTORY_SEPARATOR, '/Users/Shared/DBngin/postgresql/15.1/bin/pg_dump --no-owner --no-acl --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}"'),
+            Str::replace('/', DIRECTORY_SEPARATOR, '/Users/Shared/DBngin/postgresql/15.1/bin/pg_restore --no-owner --no-acl --clean --if-exists --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --username="${:LARAVEL_LOAD_USER}" --dbname="${:LARAVEL_LOAD_DATABASE}" "${:LARAVEL_LOAD_PATH}"'),
             [
                 'LARAVEL_LOAD_HOST' => '127.0.0.1',
                 'LARAVEL_LOAD_PORT' => '',
@@ -85,7 +85,7 @@ class DatabasePostgresSchemaStateTest extends TestCase
                 'host' => '127.0.0.1',
                 'database' => 'forge',
                 'password' => 'secret',
-                'bin' => Str::replace('/', DIRECTORY_SEPARATOR,'/Users/Shared/DBngin/postgresql/15.1/bin'),
+                'bin' => Str::replace('/', DIRECTORY_SEPARATOR, '/Users/Shared/DBngin/postgresql/15.1/bin'),
             ],
         ];
     }

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -46,7 +46,15 @@ class DatabaseSqliteSchemaStateTest extends TestCase
 
     public function testLoadSchemaToDatabaseWithBinPath(): void
     {
-        $config = ['driver' => 'sqlite', 'database' => 'database/database.sqlite', 'prefix' => '', 'foreign_key_constraints' => true, 'name' => 'sqlite', 'bin' => '/usr/bin'];
+        $config = [
+			'driver' => 'sqlite',
+			'database' => 'database/database.sqlite',
+			'prefix' => '',
+			'foreign_key_constraints' => true,
+			'name' => 'sqlite',
+			'bin' => Str::replace('/', DIRECTORY_SEPARATOR,'/usr/bin'),
+        ];
+		
         $connection = m::mock(SQLiteConnection::class);
         $connection->shouldReceive('getConfig')->andReturn($config);
         $connection->shouldReceive('getDatabaseName')->andReturn($config['database']);

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -10,6 +10,7 @@ use Mockery as m;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
+
 use const DIRECTORY_SEPARATOR;
 
 class DatabaseSqliteSchemaStateTest extends TestCase
@@ -59,7 +60,7 @@ class DatabaseSqliteSchemaStateTest extends TestCase
         $schemaState->load('database/schema/sqlite-schema.dump');
 
         $processFactory->shouldHaveBeenCalled()->with(
-			Str::replace('/', DIRECTORY_SEPARATOR, '/usr/bin/sqlite3 "${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"')
+            Str::replace('/', DIRECTORY_SEPARATOR, '/usr/bin/sqlite3 "${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"')
         );
 
         $process->shouldHaveReceived('mustRun')->with(null, [

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -1,3 +1,4 @@
+
 <?php
 
 namespace Illuminate\Tests\Database;

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -5,10 +5,12 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Schema\SqliteSchemaState;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use Mockery as m;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
+use const DIRECTORY_SEPARATOR;
 
 class DatabaseSqliteSchemaStateTest extends TestCase
 {
@@ -56,7 +58,9 @@ class DatabaseSqliteSchemaStateTest extends TestCase
         $schemaState = new SqliteSchemaState($connection, null, $processFactory);
         $schemaState->load('database/schema/sqlite-schema.dump');
 
-        $processFactory->shouldHaveBeenCalled()->with('/usr/bin/sqlite3 "${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"');
+        $processFactory->shouldHaveBeenCalled()->with(
+			Str::replace('/', DIRECTORY_SEPARATOR, '/usr/bin/sqlite3 "${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"')
+        );
 
         $process->shouldHaveReceived('mustRun')->with(null, [
             'LARAVEL_LOAD_DATABASE' => 'database/database.sqlite',

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -47,14 +47,14 @@ class DatabaseSqliteSchemaStateTest extends TestCase
     public function testLoadSchemaToDatabaseWithBinPath(): void
     {
         $config = [
-			'driver' => 'sqlite',
-			'database' => 'database/database.sqlite',
-			'prefix' => '',
-			'foreign_key_constraints' => true,
-			'name' => 'sqlite',
-			'bin' => Str::replace('/', DIRECTORY_SEPARATOR,'/usr/bin'),
+            'driver' => 'sqlite',
+            'database' => 'database/database.sqlite',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+            'name' => 'sqlite',
+            'bin' => Str::replace('/', DIRECTORY_SEPARATOR, '/usr/bin'),
         ];
-		
+
         $connection = m::mock(SQLiteConnection::class);
         $connection->shouldReceive('getConfig')->andReturn($config);
         $connection->shouldReceive('getDatabaseName')->andReturn($config['database']);


### PR DESCRIPTION
In short: this PR allows developers to set a custom path for the database binaries using a `bin` option in the database connection config, in situations where developers have the `mysql`, `mysqldump` `pg_dump`, `pg_restore` or `sqlite3` commands not automatically in their $PATH, like when using DBngin.

## Background

I'm using DBngin to create and manage databases like MySQL and Postgres. Since DBngin manages its installation completely by itself and separate from the "normal" mysql bin in the system (if you have it).

I don't have `mysql` installed on my system in a general bin directory, since I've been always using DBngin and never had a reason for it.
However, this poses a problem when running `artisan schema:dump` or when importing the dump:

```
The command "mysql  --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"" failed.

Exit Code: 127(Command not found)

Working directory: /Users/ralphjsmit/Documents/Code/Sites/cj

Output:
================


Error Output:
================
sh: mysql: command not found
```

In order to solve this problem, DBngin offers a special button to export the environment variables to the terminal. This will open a terminal and paste in the following code:

```
export PATH=/Users/Shared/DBngin/mysql/8.0.19/bin:$PATH
```

If you then run the `artisan schema:dump` command directly after the export, it will work, because we now gave an explicit pointer to the location of the `mysql` command.

However, if you have tests that are running on MySQL as well, this won't work. Because when running tests (also e.g. via PhpStorm) it won't have the `export ...` command before the test command.

## Summary

This PR aims to solve this problem by providing developers with a way to register a custom location of the `mysql`, `mysqldump` `pg_dump`, `pg_restore` or `sqlite3` command using a `'bin'` option in the `config/database.php`.
I have provided a PR https://github.com/laravel/laravel/pull/6268 to keep the skeleton up-to-date as well.

The PR also adds a full new test for the Postgres schema state, which wasn't tested before.

Thanks!