### PR TITLE
[10.x] Allow model->push() to persist all necessary records

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -998,6 +998,10 @@ trait HasAttributes
             $value = $this->castAttributeAsHashedString($key, $value);
         }
 
+        if ($this->isRelation($key)) {
+            return $this->setRelation($key, $value);
+        }
+
         $this->attributes[$key] = $value;
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionObject;
 
 trait HasRelationships
 {
@@ -929,40 +930,46 @@ trait HasRelationships
     }
 
     /**
-     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> $type
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> ...$types
      * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Relations\Relation>
      */
-    public function getRelationsOfType($type)
+    public function getRelationsOfType(...$types)
     {
-        return collect($this->getRelations())->filter(function ($models, $relation) use ($type) {
-            return $this->isRelationshipOfType($relation, $type);
+        return collect($this->getRelations())->filter(function ($models, $relation) use ($types) {
+            return $this->isRelationshipOfType($relation, $types);
         });
     }
 
     /**
-     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> $type
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> ...$types
      * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Relations\Relation>
      */
-    public function getRelationsExceptOfType($type)
+    public function getRelationsExceptOfType(...$types)
     {
-        return collect($this->getRelations())->reject(function ($models, $relation) use ($type) {
-            return $this->isRelationshipOfType($relation, $type);
+        return collect($this->getRelations())->reject(function ($models, $relation) use ($types) {
+            return $this->isRelationshipOfType($relation, $types);
         });
     }
 
     /**
      * @param  string  $relation
-     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation>  $type
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation>[]  $types
      * @return bool
      */
-    public function isRelationshipOfType($relation, $type)
+    public function isRelationshipOfType($relation, $types)
     {
         $relationObject = $this->$relation();
 
         if (! $relationObject) {
-            return null;
+            return false;
         }
 
-        return $relationObject instanceof $type;
+        foreach ($types as $type) {
+            if ($relationObject instanceof $type) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -22,8 +22,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use ReflectionClass;
-use ReflectionObject;
 
 trait HasRelationships
 {
@@ -930,7 +928,7 @@ trait HasRelationships
     }
 
     /**
-     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> ...$types
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation>  ...$types
      * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Relations\Relation>
      */
     public function getRelationsOfType(...$types)
@@ -941,7 +939,7 @@ trait HasRelationships
     }
 
     /**
-     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> ...$types
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation>  ...$types
      * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Relations\Relation>
      */
     public function getRelationsExceptOfType(...$types)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use ReflectionClass;
 
 trait HasRelationships
 {
@@ -925,5 +926,43 @@ trait HasRelationships
         $this->touches = $touches;
 
         return $this;
+    }
+
+    /**
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> $type
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Relations\Relation>
+     */
+    public function getRelationsOfType($type)
+    {
+        return collect($this->getRelations())->filter(function ($models, $relation) use ($type) {
+            return $this->isRelationshipOfType($relation, $type);
+        });
+    }
+
+    /**
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation> $type
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Eloquent\Relations\Relation>
+     */
+    public function getRelationsExceptOfType($type)
+    {
+        return collect($this->getRelations())->reject(function ($models, $relation) use ($type) {
+            return $this->isRelationshipOfType($relation, $type);
+        });
+    }
+
+    /**
+     * @param  string  $relation
+     * @param  class-string<\Illuminate\Database\Eloquent\Relations\Relation>  $type
+     * @return bool
+     */
+    public function isRelationshipOfType($relation, $type)
+    {
+        $relationObject = $this->$relation();
+
+        if (! $relationObject) {
+            return null;
+        }
+
+        return $relationObject instanceof $type;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1081,14 +1081,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // the relationships and save each model via this "push" method, which allows
         // us to recurse into all of these nested relations for the model instance.
         if (! $this->pushRelations(
-            $this->getRelationsOfType(MorphOneOrMany::class)->all(),
-            MorphOneOrMany::class)) {
+            $this->getRelationsOfType(MorphOneOrMany::class)->all()
+        )) {
             return false;
         }
 
         if (! $this->pushRelations(
-            $this->getRelationsOfType(HasOneOrMany::class)->all(),
-            HasOneOrMany::class)) {
+            $this->getRelationsOfType(HasOneOrMany::class)->all()
+        )) {
             return false;
         }
 
@@ -1105,7 +1105,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         return static::withoutEvents(fn () => $this->push());
     }
 
-    protected function pushRelations($relations, $relationType)
+    protected function pushRelations($relations)
     {
         foreach ($relations as $relation => $models) {
              $models = $models instanceof Collection
@@ -1114,23 +1114,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             foreach (array_filter($models) as $model) {
                 $relation = $this->{$relation}();
 
-
-
-                if ($relationType === MorphOneOrMany::class && ! $model->exists) {
+                if ($relation instanceof MorphOneOrMany) {
                     $model->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
                     $model->setAttribute($relation->getMorphType(), $relation->getMorphClass());
+                } elseif ($relation instanceof HasOneOrMany) {
+                    $model->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
                 }
-
-                if ($relationType === HasOneOrMany::class && ! $model->exists) {
-                    $model = $model->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
-                }
-
 
                 if (! $model->push()) {
                     return false;
                 }
 
-                if ($relationType === BelongsTo::class) {
+                if ($relation instanceof BelongsTo) {
                     $relation->associate($model);
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1114,13 +1114,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             foreach (array_filter($models) as $model) {
                 $relation = $this->{$relation}();
 
+
+
                 if ($relationType === MorphOneOrMany::class && ! $model->exists) {
                     $model->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
                     $model->setAttribute($relation->getMorphType(), $relation->getMorphClass());
                 }
 
                 if ($relationType === HasOneOrMany::class && ! $model->exists) {
-                    $relation = $this->{$relation}();
                     $model = $model->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
                 }
 
@@ -1130,7 +1131,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 }
 
                 if ($relationType === BelongsTo::class) {
-                    $this->{$relation}()->associate($model);
+                    $relation->associate($model);
                 }
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -1101,8 +1100,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected function pushRelations($relations)
     {
         foreach ($relations as $relationName => $models) {
-             $models = $models instanceof Collection
-                ? $models->all() : [$models];
+            $models = $models instanceof Collection
+               ? $models->all() : [$models];
 
             foreach (array_filter($models) as $model) {
                 $relation = $this->{$relationName}();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1092,6 +1092,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
+        if (! $this->pushRelations(
+            $this->getRelationsOfType(BelongsToMany::class)->all()
+        )) {
+            return false;
+        }
+
         return true;
     }
 
@@ -1127,6 +1133,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
                 if ($relation instanceof BelongsTo) {
                     $relation->associate($model);
+                } elseif ($relation instanceof BelongsToMany) {
+                    $relation->attach($model);
                 }
             }
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2435,8 +2435,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($model->delete);
 
         $model = m::mock(EloquentModelStub::class.'[delete]');
+        $model->shouldNotReceive('delete');
         $model->delete = 123;
         $this->assertEquals(123, $model->delete);
+    }
+
+    public function testItDoesNotCallANonRelationMethodWhenSettingAnAttribute()
+    {
+        $model = m::mock(EloquentModelStub::class.'[delete,getRelationValue]');
+        $model->shouldNotReceive('delete');
+        $model->shouldNotReceive('nonRelationMethod');
+
+        $model->nonRelationMethod = 'foo';
+        $this->assertSame('foo', $model->nonRelationMethod);
     }
 
     public function testIntKeyTypePreserved()
@@ -2940,6 +2951,11 @@ class EloquentModelStub extends Model
     public function scopeDate(Builder $builder, Carbon $date)
     {
         $this->scopesCalled['date'] = $date;
+    }
+
+    public function nonRelationMethod($args)
+    {
+        return false;
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -972,7 +972,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $related1 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
-        $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
+        $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1', 'foo' => 1], 'id')->andReturn(2);
         $query->shouldReceive('getConnection')->once();
         $related1->expects($this->once())->method('newModelQuery')->willReturn($query);
         $related1->expects($this->once())->method('updateTimestamps');
@@ -1022,7 +1022,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $related1 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
-        $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
+        $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1', 'foo' => 1], 'id')->andReturn(2);
         $query->shouldReceive('getConnection')->once();
         $related1->expects($this->once())->method('newModelQuery')->willReturn($query);
         $related1->expects($this->once())->method('updateTimestamps');
@@ -1031,7 +1031,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $related2 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
-        $query->shouldReceive('insertGetId')->once()->with(['name' => 'related2'], 'id')->andReturn(3);
+        $query->shouldReceive('insertGetId')->once()->with(['name' => 'related2', 'foo' => 1], 'id')->andReturn(3);
         $query->shouldReceive('getConnection')->once();
         $related2->expects($this->once())->method('newModelQuery')->willReturn($query);
         $related2->expects($this->once())->method('updateTimestamps');
@@ -1048,7 +1048,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model->name = 'taylor';
         $model->exists = false;
         $model->setRelation('relationMany', new Collection([$related1, $related2]));
-
         $this->assertTrue($model->push());
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
@@ -2896,6 +2895,16 @@ class EloquentModelStub extends Model
     public function belongsToExplicitKeyStub()
     {
         return $this->belongsTo(EloquentModelSaveStub::class, 'foo');
+    }
+
+    public function relationMany()
+    {
+        return $this->hasMany(EloquentModelSaveStub::class, 'foo');
+    }
+
+    public function relationOne()
+    {
+        return $this->hasOne(EloquentModelSaveStub::class, 'foo');
     }
 
     public function incorrectRelationStub()

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Mockery;
@@ -225,7 +224,7 @@ class PostX extends Model
 
     public function comment()
     {
-        return $this->morphOne(CommentX::Class, 'commentable');
+        return $this->morphOne(CommentX::class, 'commentable');
     }
 
     public function comments()

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -51,6 +51,18 @@ class EloquentPushTest extends DatabaseTestCase
         $this->assertSame(1, CommentX::count());
         $this->assertSame('Test comment 1', CommentX::firstOrFail()->comment);
     }
+
+    public function testPushSavesABelongsToRelationship()
+    {
+        $post = PostX::make(['title' => 'Test title']);
+        $post->user()->associate($user = UserX::make(['name' => 'Test']));
+
+        $post->push();
+
+        $this->assertEquals(1, $user->id);
+        $this->assertEquals(1, $post->id);
+        $this->assertTrue($post->fresh()->user->is($user));
+    }
 }
 
 class UserX extends Model
@@ -74,6 +86,11 @@ class PostX extends Model
     public function comments()
     {
         return $this->hasMany(CommentX::class, 'post_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(UserX::class, 'user_id');
     }
 }
 


### PR DESCRIPTION
So... I started working on this because of [this tweet](https://twitter.com/cviniciussdias/status/1720488869307511139) thinking it was a bug with a `BelongsTo` relationship, since the first thing `push()` does is persist the base model, and on `BelongsTo` case the relationship would need to be persisted first (and associated).  

I realized this looks less like a bug and more like a design choice — `push()` kinda supposes all the related models have been persisted already. I think it would be a nice addition to have it persist every relationship. 
For example, this doesn't work:
```php
$user = UserX::make(['name' => 'Test']);
$post = PostX::make(['title' => 'Test title']);
$user->posts->push($post);

$user->push();
```

Because the models have not been persisted yet. If `$user` had been persisted, it'd still not work because `$post` would be missing the `user_id` reference.  

In other frameworks it's common to build everything in memory and then persist all of the objects at once. I think this would be a powerful addition to Eloquent. We'd be able do this:

```php
$user = User::make([..];
$post = Post::make(...];
$post->tags->push(Tag::make([]);
$user->posts->push($post);

$user->push():
```

This is just a PoC and isn't ready by any means, but I have some ideas on how to refactor it and handle all the relationship scenarios.

Since this is a relatively big behavior change I wonder (assuming you think this is a good feature) if it could be a separate method or aimed at 11.x, although with `push()` I just expect the framework to persist everything it needs.

- [x] Handle `BelongsTo`
- [x] Handle `BelongsToMany`
- [x] Handle `HasOneOrMany`
- [x] Handle `MorphOneOrMany`
- [x] Refactor code

