### PR TITLE
authenticate method refactored to use null coalescing operator

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -33,11 +33,7 @@ trait GuardHelpers
      */
     public function authenticate()
     {
-        if (! is_null($user = $this->user())) {
-            return $user;
-        }
-
-        throw new AuthenticationException;
+        return $this->user() ?? throw new AuthenticationException;
     }
 
     /**


### PR DESCRIPTION
i refactored authenticate method in Auth/GuardHelpers with null coalescing operator to be more concise and readable.
