### PR TITLE
Add dateTimesTz methods for migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -486,6 +486,26 @@ class Blueprint
     }
 
     /**
+     * Indicate that the datetimes columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropDatetimes()
+    {
+        $this->dropTimestamps();
+    }
+
+    /**
+     * Indicate that the datetimesTz columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropDatetimesTz()
+    {
+        $this->dropTimestamps();
+    }
+
+    /**
      * Indicate that the soft delete column should be dropped.
      *
      * @param  string  $column
@@ -1228,6 +1248,19 @@ class Blueprint
     }
 
     /**
+     * Add creation and update dateTimeTz columns to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function datetimesTz($precision = 0)
+    {
+        $this->dateTimeTz('created_at', $precision)->nullable();
+
+        $this->dateTimeTz('updated_at', $precision)->nullable();
+    }
+
+    /**
      * Add a "deleted at" timestamp for the table.
      *
      * @param  string  $column
@@ -1263,6 +1296,18 @@ class Blueprint
         return $this->datetime($column, $precision)->nullable();
     }
 
+    /**
+     * Add a "deleted at" dateTimeTz column to the table.
+     *
+     * @param  string  $column
+     * @param  int|null  $precision
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function softDeletesDatetimeTz($column = 'deleted_at', $precision = 0)
+    {
+        return $this->dateTimeTz($column, $precision)->nullable();
+    }
+    
     /**
      * Create a new year column on the table.
      *


### PR DESCRIPTION
Added missing methods for the create `datetimesTz`, `softDeletesDatetimeTz`, `dropDatetimes`, `dropDatetimesTz`

`dropDatetimes`, `dropDatetimesTz` are not very necessary

It is still a current topic
Timestamp ends `2038-01-19` and for that you need to prepare all the necessary methods. https://en.wikipedia.org/wiki/Year_2038_problem

https://github.com/laravel/framework/pull/3957#issuecomment-38355678 
https://github.com/laravel/framework/pull/28372#issuecomment-487948734

