### PR TITLE
Add support for Sec-Purpose header

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -297,7 +297,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function prefetch()
     {
         return strcasecmp($this->server->get('HTTP_X_MOZ') ?? '', 'prefetch') === 0 ||
-               strcasecmp($this->headers->get('Purpose') ?? '', 'prefetch') === 0;
+               strcasecmp($this->headers->get('Purpose') ?? '', 'prefetch') === 0 ||
+               strcasecmp($this->headers->get('Sec-Purpose') ?? '', 'prefetch') === 0;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -254,6 +254,15 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->prefetch());
         $request->headers->set('Purpose', 'Prefetch');
         $this->assertTrue($request->prefetch());
+
+        $request->server->remove('Purpose');
+
+        $request->headers->set('Sec-Purpose', '');
+        $this->assertFalse($request->prefetch());
+        $request->headers->set('Sec-Purpose', 'prefetch');
+        $this->assertTrue($request->prefetch());
+        $request->headers->set('Sec-Purpose', 'Prefetch');
+        $this->assertTrue($request->prefetch());
     }
 
     public function testPjaxMethod()


### PR DESCRIPTION
The current implementation of `\Illuminate\Http\Request::prefetch()` returns false if the [`Sec-Purpose: prefetch`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Purpose#) header is set in the request.

This Pull request fixes this