### PR TITLE
[10.x] Add support for Sec-Purpose header

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -297,7 +297,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function prefetch()
     {
         return strcasecmp($this->server->get('HTTP_X_MOZ') ?? '', 'prefetch') === 0 ||
-               strcasecmp($this->headers->get('Purpose') ?? '', 'prefetch') === 0;
+               strcasecmp($this->headers->get('Purpose') ?? '', 'prefetch') === 0 ||
+               strcasecmp($this->headers->get('Sec-Purpose') ?? '', 'prefetch') === 0;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -254,6 +254,15 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->prefetch());
         $request->headers->set('Purpose', 'Prefetch');
         $this->assertTrue($request->prefetch());
+
+        $request->headers->remove('Purpose');
+
+        $request->headers->set('Sec-Purpose', '');
+        $this->assertFalse($request->prefetch());
+        $request->headers->set('Sec-Purpose', 'prefetch');
+        $this->assertTrue($request->prefetch());
+        $request->headers->set('Sec-Purpose', 'Prefetch');
+        $this->assertTrue($request->prefetch());
     }
 
     public function testPjaxMethod()


### PR DESCRIPTION
## Problem

The current implementation of `\Illuminate\Http\Request::prefetch()` returns false if the [`Sec-Purpose: prefetch`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Purpose#) header is set in the request.

Whilst most User Agents set `Purpose: prefetch` in prefetch requests, Firefox uses `Sec-Purpose: prefetch` in the latest version, as described in the above MDN article. This means that calling the `->prefetch()` method on the request will return `false` for requests sent via the Firefox browser, regardless of prefetch status.

## Benefit to the end user

The end user can rely on `\Illuminate\Http\Request::prefetch()` returning the correct result for all major browsers.

## Backwards compatibility

This PR implements checking for Firefox' `Sec-Purpose` header without affecting anything else.

## Notes

This replaces #48923 where I had made a mistake with the test.