### PR TITLE
[10.x] Custom messages for `Password` validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -326,6 +326,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             'threshold' => $this->compromisedThreshold,
         ])) {
             $validator->addFailure($attribute, 'password.uncompromised');
+
             return $this->fail($validator->messages()->all());
         }
 

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -269,7 +269,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Specify additional validation rules that should be merged with the default rules during validation.
      *
-     * @param  string|array  $rules
+     * @param  string|array|\Closure  $rules
      * @return $this
      */
     public function rules($rules)

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -269,7 +269,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Specify additional validation rules that should be merged with the default rules during validation.
      *
-     * @param  string|array|\Closure  $rules
+     * @param  \Closure|string|array  $rules
      * @return $this
      */
     public function rules($rules)
@@ -333,6 +333,11 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         return true;
     }
 
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
     public function message()
     {
         return $this->messages;

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -290,7 +290,7 @@ class ValidationPasswordRuleTest extends TestCase
         $this->assertFalse($v->passes());
 
         $this->assertSame(
-            [ 'my_password' => array_values($messages) ],
+            ['my_password' => array_values($messages)],
             $v->messages()->toArray()
         );
     }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -50,7 +50,7 @@ class ValidationPasswordRuleTest extends TestCase
         });
 
         $this->fails($rule, ['aaaaaaaa', '11111111'], [
-            'The my password must contain at least one symbol.',
+            'validation.password.symbols',
         ]);
 
         $is_privileged_user = false;
@@ -64,7 +64,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testMixedCase()
     {
         $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM'], [
-            'The my password must contain at least one uppercase and one lowercase letter.',
+            'validation.password.mixed',
         ]);
 
         $this->passes(Password::min(2)->mixedCase(), ['Nn', 'Mn', 'âA']);
@@ -73,7 +73,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testLetters()
     {
         $this->fails(Password::min(2)->letters(), ['11', '22', '^^', '``', '**'], [
-            'The my password must contain at least one letter.',
+            'validation.password.letters',
         ]);
 
         $this->passes(Password::min(2)->letters(), ['1a', 'b2', 'â1', '1 京都府']);
@@ -82,7 +82,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testNumbers()
     {
         $this->fails(Password::min(2)->numbers(), ['aa', 'bb', '  a', '京都府'], [
-            'The my password must contain at least one number.',
+            'validation.password.numbers',
         ]);
 
         $this->passes(Password::min(2)->numbers(), ['1a', 'b2', '00', '京都府 1']);
@@ -99,7 +99,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testSymbols()
     {
         $this->fails(Password::min(2)->symbols(), ['ab', '1v'], [
-            'The my password must contain at least one symbol.',
+            'validation.password.symbols',
         ]);
 
         $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè$', '金廿土弓竹中；']);
@@ -116,7 +116,7 @@ class ValidationPasswordRuleTest extends TestCase
             '12345678',
             'nuno',
         ], [
-            'The given my password has appeared in a data leak. Please choose a different my password.',
+            'validation.password.uncompromised',
         ]);
 
         $this->passes(Password::min(2)->uncompromised(9999999), [
@@ -146,22 +146,22 @@ class ValidationPasswordRuleTest extends TestCase
 
         $this->fails($makeRules(), ['foo', 'azdazd'], [
             'validation.min.string',
-            'The my password must contain at least one uppercase and one lowercase letter.',
-            'The my password must contain at least one number.',
+            'validation.password.mixed',
+            'validation.password.numbers',
         ]);
 
         $this->fails($makeRules(), ['1231231'], [
             'validation.min.string',
-            'The my password must contain at least one uppercase and one lowercase letter.',
+            'validation.password.mixed',
         ]);
 
         $this->fails($makeRules(), ['4564654564564'], [
-            'The my password must contain at least one uppercase and one lowercase letter.',
+            'validation.password.mixed',
         ]);
 
         $this->fails($makeRules(), ['aaaaaaaaa', 'TJQSJQSIUQHS'], [
-            'The my password must contain at least one uppercase and one lowercase letter.',
-            'The my password must contain at least one number.',
+            'validation.password.mixed',
+            'validation.password.numbers',
         ]);
 
         $this->passes($makeRules(), ['4564654564564Abc']);
@@ -174,26 +174,26 @@ class ValidationPasswordRuleTest extends TestCase
 
         $this->fails($makeRules(), ['foo', 'azdazd'], [
             'validation.min.string',
-            'The my password must contain at least one symbol.',
+            'validation.password.symbols',
         ]);
 
         $this->fails($makeRules(), ['1231231'], [
             'validation.min.string',
-            'The my password must contain at least one letter.',
-            'The my password must contain at least one symbol.',
+            'validation.password.letters',
+            'validation.password.symbols',
         ]);
 
         $this->fails($makeRules(), ['aaaaaaaaa', 'TJQSJQSIUQHS'], [
-            'The my password must contain at least one symbol.',
+            'validation.password.symbols',
         ]);
 
         $this->fails($makeRules(), ['4564654564564'], [
-            'The my password must contain at least one letter.',
-            'The my password must contain at least one symbol.',
+            'validation.password.letters',
+            'validation.password.symbols',
         ]);
 
         $this->fails($makeRules(), ['abcabcabc!'], [
-            'The given my password has appeared in a data leak. Please choose a different my password.',
+            'validation.password.uncompromised',
         ]);
 
         $v = new Validator(
@@ -267,6 +267,32 @@ class ValidationPasswordRuleTest extends TestCase
         );
 
         $this->assertTrue($v1->passes());
+    }
+
+    public function testCustomMessages()
+    {
+        $rules = [
+            'my_password' => Password::min(6)->letters(),
+        ];
+
+        $messages = [
+            'min' => 'Message for validating length',
+            'password.letters' => 'Message for validating letters',
+        ];
+
+        $v = new Validator(
+            resolve('translator'),
+            ['my_password' => '1234'],
+            $rules,
+            $messages,
+        );
+
+        $this->assertFalse($v->passes());
+
+        $this->assertSame(
+            [ 'my_password' => array_values($messages) ],
+            $v->messages()->toArray()
+        );
     }
 
     public function testPassesWithCustomRules()


### PR DESCRIPTION
As described in #48866 `Password` validation rule did not support custom messages provided through the validator and had validation messages in code.