### PR TITLE
[10.x] Allow setting retain_visibility config option on Flysystem filesystems

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -319,6 +319,7 @@ class FilesystemManager implements FactoryContract
         return new Flysystem($adapter, Arr::only($config, [
             'directory_visibility',
             'disable_asserts',
+            'retain_visibility',
             'temporary_url',
             'url',
             'visibility',


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This config option was introduced in version 3.19.0; see also https://github.com/thephpleague/flysystem/blob/3.19.0/CHANGELOG.md#3190---2023-11-07 and https://github.com/thephpleague/flysystem/pull/1721.