### PR TITLE
Update PendingRequest.php

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -23,7 +23,6 @@ use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
-use OutOfBoundsException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use RuntimeException;
@@ -1008,7 +1007,7 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                 });
             })
-            ->otherwise(function (TransferException|OutOfBoundsException $e) {
+            ->otherwise(function ($e) {
                 if ($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
                 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
+use OutOfBoundsException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use RuntimeException;
@@ -1007,7 +1008,7 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                 });
             })
-            ->otherwise(function ($e) {
+            ->otherwise(function (OutOfBoundsException|TransferException $e) {
                 if ($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
                 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
+use OutOfBoundsException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use RuntimeException;
@@ -1007,7 +1008,7 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                 });
             })
-            ->otherwise(function (TransferException $e) {
+            ->otherwise(function (TransferException | OutOfBoundsException $e) {
                 if ($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
                 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1008,7 +1008,7 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                 });
             })
-            ->otherwise(function (TransferException | OutOfBoundsException $e) {
+            ->otherwise(function (TransferException|OutOfBoundsException $e) {
                 if ($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
                 }


### PR DESCRIPTION
As suggested by Dries, this PR fixes #48938 by altering the `otherwise` closure of the `makePromise` method on `Illuminate\Http\Client\PendingRequest` so that the exception parameter becomes a union type.

Currently, any exception sent to `otherwise()` had to be a `TransferException`, however when using concurrent requests (via the HTTP client's Pool method), you can also encounter an `OutOfBoundsException`.

This is particularly noticeable when trying to create a fake sequence within a test e.g.

```php
use Illuminate\Support\Facades\Http;

Http::fakeSequence()
    ->push(null, 401)
    ->push(null, 403) 
    ->push(null, 405);
```

Another option is to remove the type hint altogether, however this may have unintended consequences that I'm not aware of. 

P.S. Since this simply adds a secondary type hint, I haven't added a test. TBH, I'm not sure how you'd specifically check for it. 