### PR TITLE
[10.x] Use container to resolve email validator class

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -840,7 +840,7 @@ trait ValidatesAttributes
             ->values()
             ->all() ?: [new RFCValidation];
 
-        return (new EmailValidator)->isValid($value, new MultipleValidationWithAnd($validations));
+        return $this->container->make(EmailValidator::class)->isValid($value, new MultipleValidationWithAnd($validations));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -15,6 +15,7 @@ use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use Exception;
+use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Exceptions\MathException;
@@ -840,7 +841,9 @@ trait ValidatesAttributes
             ->values()
             ->all() ?: [new RFCValidation];
 
-        return $this->container->make(EmailValidator::class)->isValid($value, new MultipleValidationWithAnd($validations));
+        $emailValidator = Container::getInstance()->make(EmailValidator::class);
+
+        return $emailValidator->isValid($value, new MultipleValidationWithAnd($validations));
     }
 
     /**


### PR DESCRIPTION
This PR updates the `email` validation rule to use the container to resolve `\Egulias\EmailValidator\EmailValidator`.
The benefit of this change is being able to mock/configure/replace the class on certain conditions. The best use-case for this is test coverage. When using the email validation rule with `email:dns` it always does a check against DNS records even in a test environment.
Resolving the service from the container would allow us to mock or replace it with a fake service where we can prevent it from checking against DNS and slowing down the test runner unnecessarily.
