### PR TITLE
[10.x] Change array_key_exists with null coalescing assignment operator in FilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -289,13 +289,8 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         $response = new StreamedResponse;
 
-        if (! array_key_exists('Content-Type', $headers)) {
-            $headers['Content-Type'] = $this->mimeType($path);
-        }
-
-        if (! array_key_exists('Content-Length', $headers)) {
-            $headers['Content-Length'] = $this->size($path);
-        }
+        $headers['Content-Type'] ??= $this->mimeType($path);
+        $headers['Content-Length'] ??= $this->size($path);
 
         if (! array_key_exists('Content-Disposition', $headers)) {
             $filename = $name ?? basename($path);


### PR DESCRIPTION
I’ve used the null coalescing assignment operator (??=) to simplify the assignment of Content-Type and Content-Length headers. This makes the code more concise and easier to read.