### PR TITLE
[10.x] Cast to string $contents on Component.php to prevent render deprecation messages

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -147,7 +147,11 @@ abstract class Component
                 return $view;
             }
 
-            return $this->extractBladeViewFromString(strval($view));
+            if (! is_string($view)) {
+                return '';
+            }
+
+            return $this->extractBladeViewFromString($view);
         };
 
         return $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -133,7 +133,7 @@ abstract class Component
     public function resolveView()
     {
         $resolver = function ($view) {
-            if (($view instanceof ViewContract) || ($view instanceof Htmlable)) {
+            if ($view instanceof ViewContract || $view instanceof Htmlable) {
                 return $view;
             }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -132,32 +132,23 @@ abstract class Component
      */
     public function resolveView()
     {
-        $view = $this->render();
-
-        if ($view instanceof ViewContract) {
-            return $view;
-        }
-
-        if ($view instanceof Htmlable) {
-            return $view;
-        }
-
         $resolver = function ($view) {
-            if ($view instanceof ViewContract) {
+            if (($view instanceof ViewContract) || ($view instanceof Htmlable)) {
                 return $view;
             }
 
-            if (! is_string($view)) {
-                return '';
+            if (is_string($view)) {
+                return $this->extractBladeViewFromString($view);
             }
 
-            return $this->extractBladeViewFromString($view);
+            return '';
         };
 
-        return $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {
-            return $resolver($view($data));
-        }
-        : $resolver($view);
+        $view = $this->render();
+
+        return ($view instanceof Closure)
+            ? fn (array $data = []) => $resolver($view($data))
+            : $resolver($view);
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -147,7 +147,7 @@ abstract class Component
                 return $view;
             }
 
-            return $this->extractBladeViewFromString($view);
+            return $this->extractBladeViewFromString(strval($view));
         };
 
         return $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {


### PR DESCRIPTION
Returning `null` from the render method is a valid option when extending a component:

```php
public function render(): ?View
{
    if ($condition === false) {
        return null;
    }
    
    return view('components.map');
}
```

The above code is still valid; however, since this PR https://github.com/laravel/framework/pull/31271, there's a new method to check if a component should be rendered, called `shouldRender`. Nevertheless, there is code that uses the old way (and it still works).

The issue arises with the `Component.php` file, which is not designed to handle anything other than a `ViewContract` or a `string`.

```php
    /**
     * Create a Blade view with the raw component string content.
     *
     * @param  string  $contents
     * @return string
     */
    protected function extractBladeViewFromString($contents)
    {
```

If `null` is received, the deprecation log reports:

```
[2023-11-07T15:25:53+00:00] deprecations-daily.WARNING: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/app/vendor/laravel/framework/src/Illuminate/View/Component.php on line 173
[2023-11-07T15:25:53+00:00] deprecations-daily.WARNING: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/app/vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php on line 75
[2023-11-07T15:25:53+00:00] deprecations-daily.WARNING: hash(): Passing null to parameter #2 ($data) of type string is deprecated in /var/www/app/vendor/laravel/framework/src/Illuminate/View/Component.php on line 194
```

The solution involves casting the `$contents` variable in Component to a string to prevent these warnings.