### PR TITLE
[10.x] Change `newPendingRequest()` method from protected to public

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -398,7 +398,7 @@ class Factory
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */
-    protected function newPendingRequest()
+    public function newPendingRequest()
     {
         return new PendingRequest($this, $this->globalMiddleware);
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -87,6 +87,7 @@ use Illuminate\Http\Client\Factory;
  * @method static array getOptions()
  * @method static \Illuminate\Http\Client\PendingRequest|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Http\Client\PendingRequest|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static \Illuminate\Http\Client\PendingRequest newPendingRequest()
  *
  * @see \Illuminate\Http\Client\Factory
  */

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2656,7 +2656,7 @@ class HttpClientTest extends TestCase
 
 class CustomFactory extends Factory
 {
-    protected function newPendingRequest()
+    public function newPendingRequest()
     {
         return new class extends PendingRequest
         {


### PR DESCRIPTION
This PR makes the `newPendingRequest()` method on the HTTP Client Factory publicly accessible. This way, you can instantiate a new `PendingRequest` class with the Global Middleware applied, as there's no other way to get the Global Middleware from outside of the factory.

The `PendingRequest` class is used by [Saloon's Laravel Plugin](https://docs.saloon.dev/plugins/laravel-integration), but it currently lacks support for Global Middleware because it can't access the `$globalMiddleware` array. See also https://github.com/saloonphp/laravel-http-sender/pull/15.

If this change is not desired, I could also submit an alternative PR that simply adds a `getGlobalMiddleware()` method to the HTTP Client Factory.