### PR TITLE
[10.x] Added `getGlobalMiddleware` method to HTTP Client Factory

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -85,16 +85,6 @@ class Factory
     }
 
     /**
-     * Get the array of global middleware.
-     *
-     * @return array
-     */
-    public function getGlobalMiddleware()
-    {
-        return $this->globalMiddleware;
-    }
-
-    /**
      * Add middleware to apply to every request.
      *
      * @param  callable  $middleware
@@ -421,6 +411,16 @@ class Factory
     public function getDispatcher()
     {
         return $this->dispatcher;
+    }
+
+    /**
+     * Get the array of global middleware.
+     *
+     * @return array
+     */
+    public function getGlobalMiddleware()
+    {
+        return $this->globalMiddleware;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -83,7 +83,7 @@ class Factory
 
         $this->stubCallbacks = collect();
     }
-    
+
     /**
      * Get the array of global middleware.
      *

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -83,6 +83,16 @@ class Factory
 
         $this->stubCallbacks = collect();
     }
+    
+    /**
+     * Get the array of global middleware.
+     *
+     * @return array
+     */
+    public function getGlobalMiddleware()
+    {
+        return $this->globalMiddleware;
+    }
 
     /**
      * Add middleware to apply to every request.

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Factory globalMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalRequestMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalResponseMiddleware(callable $middleware)
+ * @method static array getGlobalMiddleware()
  * @method static \GuzzleHttp\Promise\PromiseInterface response(array|string|null $body = null, int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\Client\ResponseSequence sequence(array $responses = [])
  * @method static \Illuminate\Http\Client\Factory allowStrayRequests()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2593,6 +2593,13 @@ class HttpClientTest extends TestCase
         $this->assertSame('Bar', $responses[1]->header('X-Foo'));
     }
 
+    public function testItCanGetTheGlobalMiddleware()
+    {
+        $this->factory->globalMiddleware($middleware = fn () => null);
+
+        $this->assertEquals([$middleware], $this->factory->getGlobalMiddleware());
+    }
+
     public function testItCanAddRequestMiddleware()
     {
         $requests = [];


### PR DESCRIPTION
This PR adds a `getGlobalMiddleware()` method to the HTTP Client Factory.

The `PendingRequest` class is used by [Saloon's Laravel Plugin](https://docs.saloon.dev/plugins/laravel-integration), but it currently lacks support for Global Middleware because it can't access the $globalMiddleware array. See also https://github.com/saloonphp/laravel-http-sender/pull/15.