### PR TITLE
[10.x] Refactor set_error_handler callback to use arrow function in `InteractsWithDeprecationHandling`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
@@ -21,9 +21,7 @@ trait InteractsWithDeprecationHandling
     protected function withDeprecationHandling()
     {
         if ($this->originalDeprecationHandler) {
-            set_error_handler(tap($this->originalDeprecationHandler, function () {
-                $this->originalDeprecationHandler = null;
-            }));
+            set_error_handler(tap($this->originalDeprecationHandler, fn () => $this->originalDeprecationHandler = null));
         }
 
         return $this;


### PR DESCRIPTION
This pull request updates the error handling code in accordance with modern PHP practices. The original anonymous function used for `set_error_handler` has been replaced with the more concise arrow function syntax. This change improves code readability while preserving the existing functionality. No functional changes are introduced, and the codebase remains Laravel-compatible.
