### PR TITLE
Refactor forget method for better efficiency shorter syntax in `Cache\ArrayStore`

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -139,13 +139,9 @@ class ArrayStore extends TaggableStore implements LockProvider
      */
     public function forget($key)
     {
-        if (array_key_exists($key, $this->storage)) {
-            unset($this->storage[$key]);
-
-            return true;
-        }
-
-        return false;
+        $exists = array_key_exists($key, $this->storage);
+        unset($this->storage[$key]);
+        return $exists;
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the 'forget' method by refactoring the code structure for improved efficiency and clarity. The changes separate the existence check and the removal process, ensuring a more streamlined and effective operation.

Changes:
- Refactored 'forget' method to separate existence check and key removal for clearer logic.
- Ensured the removal of the key from the storage array while returning pre-checked existence status.
