### PR TITLE
[10.x] Allow deprecation of model attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/DeprecatesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/DeprecatesAttributes.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait DeprecatesAttributes
+{
+    /**
+     * The attributes that are deprecated.
+     *
+     * @var array<string>
+     */
+    protected $deprecated = [];
+
+    /**
+     * Get the deprecated attributes for the model.
+     *
+     * @return array<string>
+     */
+    public function getDeprecated()
+    {
+        return $this->deprecated;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -33,6 +33,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasUniqueIds,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
+        Concerns\DeprecatesAttributes,
         ForwardsCalls;
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a new `DeprecatesAttributes` trait to the `Model` class, that allows a user to specify deprecated attributes within their models. 

Currently this does not do anything more, I considered triggering a deprecation but I did not want to spam the log with the messages and I could not figure out how to show the proper code location when triggering the deprecation within the `getAttribute` method.

I still think that this might be helpful as this could potentially enable tools like `larastan` to inform users that they are using deprecated attributes and even still just looking at a model a user can see the deprecated attributes declared. 
