### PR TITLE
[10.x] Use arrow function in `raw` method in `Illuminate/Auth/Access/Gate` class

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -448,9 +448,7 @@ class Gate implements GateContract
         // if that is required for this application. Then we'll return the result.
         return tap($this->callAfterCallbacks(
             $user, $ability, $arguments, $result
-        ), function ($result) use ($user, $ability, $arguments) {
-            $this->dispatchGateEvaluatedEvent($user, $ability, $arguments, $result);
-        });
+        ), fn ($result) => $this->dispatchGateEvaluatedEvent($user, $ability, $arguments, $result));
     }
 
     /**


### PR DESCRIPTION
In this pull request, I have replaced the anonymous function with an arrow function. This change is primarily a stylistic adjustment aimed at improving code readability and reducing verbosity while preserving the existing functionality.