### PR TITLE
[10.x] PHP 8.1 Support - Refactored Content Handling with `match` Expressions in `Illuminate\Http\Response`

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -82,11 +82,14 @@ class Response extends SymfonyResponse
      */
     protected function shouldBeJson($content)
     {
-        return $content instanceof Arrayable ||
-               $content instanceof Jsonable ||
-               $content instanceof ArrayObject ||
-               $content instanceof JsonSerializable ||
-               is_array($content);
+        return match (true) {
+            $content instanceof Arrayable,
+            $content instanceof Jsonable,
+            $content instanceof ArrayObject,
+            $content instanceof JsonSerializable,
+            is_array($content) => true,
+            default => false,
+        };
     }
 
     /**
@@ -97,12 +100,10 @@ class Response extends SymfonyResponse
      */
     protected function morphToJson($content)
     {
-        if ($content instanceof Jsonable) {
-            return $content->toJson();
-        } elseif ($content instanceof Arrayable) {
-            return json_encode($content->toArray());
-        }
-
-        return json_encode($content);
+        return match (true) {
+            $content instanceof Jsonable => $content->toJson(),
+            $content instanceof Arrayable => json_encode($content->toArray()),
+            default => json_encode($content),
+        };
     }
 }


### PR DESCRIPTION
This pull request introduces PHP 8.1 support by refactoring content handling methods within the codebase. The changes utilize the new `match` expression, improving readability and leveraging PHP 8.1's capabilities for better maintenance and future compatibility.

Changes:
- Updated `shouldBeJson` method to use `match` for clarity and brevity.
- Restructured `morphToJson` method to use `match` for better code organization and readability.

This enhancement provides a more concise and maintainable approach for content handling, ensuring compatibility with the PHP 8.1 version while maintaining Laravel's high coding standards.

