### PR TITLE
fixes issue with stderr when there was "]" character.

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -287,10 +287,10 @@ class ServeCommand extends Command
             } elseif (str($line)->contains(['Closed without sending a request'])) {
                 // ...
             } elseif (! empty($line)) {
-                $position = strpos($line,'] ');
+                $position = strpos($line, '] ');
 
                 if ($position !== false) {
-                    $line = substr($line, $position+1);
+                    $line = substr($line, $position + 1);
                 }
                 $this->components->warn($line);
             }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -292,6 +292,7 @@ class ServeCommand extends Command
                 if ($position !== false) {
                     $line = substr($line, $position + 1);
                 }
+
                 $this->components->warn($line);
             }
         });

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -287,8 +287,12 @@ class ServeCommand extends Command
             } elseif (str($line)->contains(['Closed without sending a request'])) {
                 // ...
             } elseif (! empty($line)) {
-                $warning = explode('] ', $line);
-                $this->components->warn(count($warning) > 1 ? $warning[1] : $warning[0]);
+                $position = strpos($line,'] ');
+
+                if ($position !== false) {
+                    $line = substr($line, $position+1);
+                }
+                $this->components->warn($line);
             }
         });
     }


### PR DESCRIPTION
Fix log message handling for messages with ']' character (Issue #48924)

This commit resolves the issue where log messages containing the ']' character were incorrectly processed due to the explode function splitting the log string on this character. This issue was traced to the explode function in ServeCommand.php, which removes the DateTime from the actual log message.
https://github.com/laravel/framework/blob/20085feef61119b58fef540cba79595b4a85a89a/src/Illuminate/Foundation/Console/ServeCommand.php#L290

Previously, a log message like `[2023-11-11 10:08:06] local.ERROR: [Test] This is a test error log entry` 
**P.S. The framework prepends  DateTime. It's not part of user input**
 That was split into an array, with only the second element being printed, leading to the loss of part of the log message.
```php
// Result after  explode('] ', $line);

Array
(
    [0] => [2023-11-11 10:08:06
    [1] => local.ERROR: [Test
    [2] => This is a test error log entry
)
```
https://github.com/laravel/framework/blob/20085feef61119b58fef540cba79595b4a85a89a/src/Illuminate/Foundation/Console/ServeCommand.php#L291
The fix involves replacing the explode logic to handle log messages with  ']' characters, ensuring complete and accurate logging. The updated code now processes log messages correctly, preserving the full content.

