### PR TITLE
[10.x] Feature: Enhanced Request Pooling with Concurrency Limit Control

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -857,13 +857,12 @@ class PendingRequest
         $pool = tap(new Pool($this->factory), $callback)->getRequests();
 
         $promises = array_map(function ($request) {
-            // Convert the PendingRequest into a Guzzle Promise
             return $request instanceof static ? $request->getPromise() : $request;
         }, $pool);
 
         Each::ofLimit(
             $promises,
-            $concurrencyLimit ?: count($pool), // Fallback to the count of requests if no limit is defined
+            $concurrencyLimit ?: count($pool),
             function ($response, $index) use (&$results) {
                 // Handle a successful response
                 $results[$index] = $response instanceof \GuzzleHttp\Psr7\Response
@@ -871,7 +870,6 @@ class PendingRequest
                     : $response;
             },
             function ($reason, $index) use (&$results) {
-                // Handle exceptions, might need to wrap this in a Laravel HTTP Client response?
                 $results[$index] = $reason;
             }
         )->wait();

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -864,7 +864,6 @@ class PendingRequest
             $promises,
             $concurrencyLimit ?: count($pool),
             function ($response, $index) use (&$results) {
-                // Handle a successful response
                 $results[$index] = $response instanceof \GuzzleHttp\Psr7\Response
                     ? new \Illuminate\Http\Client\Response($response)
                     : $response;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -435,7 +435,8 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable {
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable
+        {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -456,7 +457,8 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable, Arrayable {
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable, Arrayable
+        {
             public function jsonSerialize(): mixed
             {
                 return [

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2720,7 +2720,8 @@ class CustomFactory extends Factory
 {
     protected function newPendingRequest()
     {
-        return new class extends PendingRequest {
+        return new class extends PendingRequest
+        {
             protected function newResponse($response)
             {
                 return new TestResponse($response);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,37 +3,37 @@
 namespace Illuminate\Tests\Http;
 
 use Exception;
-use GuzzleHttp\Middleware;
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Response as Psr7Response;
-use GuzzleHttp\TransferStats;
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Http\Client\Events\RequestSending;
-use Illuminate\Http\Client\Events\ResponseReceived;
-use Illuminate\Http\Client\Factory;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Http\Client\Pool;
-use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
-use Illuminate\Http\Client\Response;
-use Illuminate\Http\Client\ResponseSequence;
-use Illuminate\Http\Response as HttpResponse;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Fluent;
-use Illuminate\Support\Sleep;
-use Illuminate\Support\Str;
-use JsonSerializable;
 use Mockery as m;
+use JsonSerializable;
+use RuntimeException;
 use OutOfBoundsException;
-use PHPUnit\Framework\AssertionFailedError;
+use GuzzleHttp\Middleware;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use GuzzleHttp\TransferStats;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Fluent;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Support\Collection;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\PendingRequest;
 use Symfony\Component\VarDumper\VarDumper;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Support\Arrayable;
+use PHPUnit\Framework\AssertionFailedError;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\ResponseSequence;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Response as HttpResponse;
+use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Http\Client\Events\ResponseReceived;
 
 class HttpClientTest extends TestCase
 {
@@ -46,7 +46,7 @@ class HttpClientTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory = new Factory;
+        $this->factory = new Factory();
     }
 
     protected function tearDown(): void
@@ -435,8 +435,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable
-        {
+        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -457,8 +456,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable, Arrayable
-        {
+        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable, Arrayable {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -780,7 +778,8 @@ class HttpClientTest extends TestCase
         $this->factory->fakeSequence()->pushStatus(200);
 
         $response = $this->factory->withCookies(
-            ['foo' => 'bar'], 'https://laravel.com'
+            ['foo' => 'bar'],
+            'https://laravel.com'
         )->get('https://laravel.com');
 
         $this->assertCount(1, $response->cookies()->toArray());
@@ -934,8 +933,8 @@ class HttpClientTest extends TestCase
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
-                && ! isset($request['foo'])
-                && ! isset($request['bar'])
+                && !isset($request['foo'])
+                && !isset($request['bar'])
                 && $request['page'] === '1';
         });
     }
@@ -1538,6 +1537,56 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $responses['test200']->status());
         $this->assertSame(400, $responses['test400']->status());
         $this->assertSame(500, $responses['test500']->status());
+    }
+
+    public function testRequestConcurrencyLimitInPoolIsRespected()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('', 200),
+        ]);
+
+        (array) $requests = [
+            'test1' => 'test1.com',
+            'test2' => 'test2.com',
+            'test3' => 'test3.com',
+            'test4' => 'test4.com',
+            'test5' => 'test5.com',
+        ];
+        (array) $requestTimes = [];
+
+        $responses = $this->factory->pool(function (Pool $pool) use ($requests, &$requestTimes) {
+            foreach ($requests as $name => $url) {
+                $requestTimes[$name]['start'] = microtime(true);
+                $pool->as($name)->async()->get($url)->then(function () use ($name, &$requestTimes) {
+                    $requestTimes[$name]['end'] = microtime(true);
+                });
+            }
+        }, $concurrencyLimit = 2);
+
+        // Flatten and sort all timestamps
+        $timestamps = [];
+        foreach ($requestTimes as $key => $times) {
+            $timestamps[] = ['time' => $times['start'], 'type' => 'start'];
+            $timestamps[] = ['time' => $times['end'], 'type' => 'end'];
+        }
+
+        usort($timestamps, function ($a, $b) {
+            return $a['time'] <=> $b['time'];
+        });
+
+        // Analyze concurrency
+        $currentConcurrency = 0;
+        $maxConcurrency = 0;
+        foreach ($timestamps as $timestamp) {
+            if ($timestamp['type'] === 'start') {
+                $currentConcurrency++;
+                $maxConcurrency = max($maxConcurrency, $concurrencyLimit);
+            } else {
+                $currentConcurrency--;
+            }
+        }
+
+        $this->assertEquals($concurrencyLimit, $maxConcurrency);
     }
 
     public function testMiddlewareRunsInPool()
@@ -2648,7 +2697,7 @@ class HttpClientTest extends TestCase
 
     public function testItCanReturnCustomResponseClass(): void
     {
-        $factory = new CustomFactory;
+        $factory = new CustomFactory();
 
         $factory->fake([
             '*' => $factory::response('expected content'),
@@ -2665,8 +2714,7 @@ class CustomFactory extends Factory
 {
     protected function newPendingRequest()
     {
-        return new class extends PendingRequest
-        {
+        return new class () extends PendingRequest {
             protected function newResponse($response)
             {
                 return new TestResponse($response);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,37 +3,37 @@
 namespace Illuminate\Tests\Http;
 
 use Exception;
-use Mockery as m;
-use JsonSerializable;
-use RuntimeException;
-use OutOfBoundsException;
 use GuzzleHttp\Middleware;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use GuzzleHttp\TransferStats;
-use Illuminate\Support\Sleep;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Fluent;
-use PHPUnit\Framework\TestCase;
-use Illuminate\Http\Client\Pool;
-use Illuminate\Support\Collection;
-use Illuminate\Http\Client\Factory;
-use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\Response;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Promise\PromiseInterface;
-use Illuminate\Http\Client\PendingRequest;
-use Symfony\Component\VarDumper\VarDumper;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
-use PHPUnit\Framework\AssertionFailedError;
-use Illuminate\Http\Client\RequestException;
-use Illuminate\Http\Client\ResponseSequence;
-use GuzzleHttp\Psr7\Response as Psr7Response;
-use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Client\ResponseSequence;
+use Illuminate\Http\Response as HttpResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Str;
+use JsonSerializable;
+use Mockery as m;
+use OutOfBoundsException;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+use Symfony\Component\VarDumper\VarDumper;
 
 class HttpClientTest extends TestCase
 {
@@ -46,7 +46,7 @@ class HttpClientTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory = new Factory();
+        $this->factory = new Factory;
     }
 
     protected function tearDown(): void
@@ -435,7 +435,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable {
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -456,7 +456,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asJson()->post('http://foo.com/form', new class () implements JsonSerializable, Arrayable {
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable, Arrayable {
             public function jsonSerialize(): mixed
             {
                 return [
@@ -778,8 +778,7 @@ class HttpClientTest extends TestCase
         $this->factory->fakeSequence()->pushStatus(200);
 
         $response = $this->factory->withCookies(
-            ['foo' => 'bar'],
-            'https://laravel.com'
+            ['foo' => 'bar'], 'https://laravel.com'
         )->get('https://laravel.com');
 
         $this->assertCount(1, $response->cookies()->toArray());
@@ -933,8 +932,8 @@ class HttpClientTest extends TestCase
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
-                && !isset($request['foo'])
-                && !isset($request['bar'])
+                && ! isset($request['foo'])
+                && ! isset($request['bar'])
                 && $request['page'] === '1';
         });
     }
@@ -1556,15 +1555,15 @@ class HttpClientTest extends TestCase
 
         $responses = $this->factory->pool(function (Pool $pool) use ($requests, &$requestTimes) {
             foreach ($requests as $name => $url) {
-                $requestTimes[$name]['start'] = microtime(true);
+                (float) $requestTimes[$name]['start'] = microtime(true);
                 $pool->as($name)->async()->get($url)->then(function () use ($name, &$requestTimes) {
-                    $requestTimes[$name]['end'] = microtime(true);
+                    (float) $requestTimes[$name]['end'] = microtime(true);
                 });
             }
         }, $concurrencyLimit = 2);
 
         // Flatten and sort all timestamps
-        $timestamps = [];
+        (array) $timestamps = [];
         foreach ($requestTimes as $key => $times) {
             $timestamps[] = ['time' => $times['start'], 'type' => 'start'];
             $timestamps[] = ['time' => $times['end'], 'type' => 'end'];
@@ -1575,8 +1574,8 @@ class HttpClientTest extends TestCase
         });
 
         // Analyze concurrency
-        $currentConcurrency = 0;
-        $maxConcurrency = 0;
+        (int) $currentConcurrency = 0;
+        (int) $maxConcurrency = 0;
         foreach ($timestamps as $timestamp) {
             if ($timestamp['type'] === 'start') {
                 $currentConcurrency++;
@@ -1586,7 +1585,12 @@ class HttpClientTest extends TestCase
             }
         }
 
+        // Ensure the max concurrency was equal to the limit set on the pool
         $this->assertEquals($concurrencyLimit, $maxConcurrency);
+        // Check for same number of requests vs responses
+        $this->assertEquals(count($requests), count($responses));
+        // Check to make sure the named request array keys match the named response array keys
+        $this->assertEquals(array_keys($requests), array_keys($responses));
     }
 
     public function testMiddlewareRunsInPool()
@@ -2697,7 +2701,7 @@ class HttpClientTest extends TestCase
 
     public function testItCanReturnCustomResponseClass(): void
     {
-        $factory = new CustomFactory();
+        $factory = new CustomFactory;
 
         $factory->fake([
             '*' => $factory::response('expected content'),
@@ -2714,7 +2718,7 @@ class CustomFactory extends Factory
 {
     protected function newPendingRequest()
     {
-        return new class () extends PendingRequest {
+        return new class extends PendingRequest {
             protected function newResponse($response)
             {
                 return new TestResponse($response);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1555,7 +1555,7 @@ class HttpClientTest extends TestCase
         };
 
         // Test with different concurrency limits, the higher the number the faster it should be
-        $concurrencyLimits = [1, 5, 10];
+        $concurrencyLimits = [2, 10];
         $previousDuration = PHP_INT_MAX;
 
         foreach ($concurrencyLimits as $limit) {
@@ -1570,12 +1570,9 @@ class HttpClientTest extends TestCase
             $this->assertCount(10, $results);
 
             // Assert that the higher the concurrency limit, the less time it takes
-            $this->assertLessThanOrEqual(
-                $previousDuration,
-                $duration,
-                "The duration with concurrency limit {$limit} should be less or equal than duration of previous limit."
-            );
+            $this->assertLessThanOrEqual($previousDuration, $duration);
 
+            // Set previous duration for the next pool test
             $previousDuration = $duration;
         }
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1554,7 +1554,6 @@ class HttpClientTest extends TestCase
             }
         };
 
-        // Test with different concurrency limits, the higher the number the faster it should be
         $concurrencyLimits = [2, 10];
         $previousDuration = PHP_INT_MAX;
 
@@ -1566,13 +1565,9 @@ class HttpClientTest extends TestCase
             $endTime = microtime(true);
             $duration = $endTime - $startTime;
 
-            // Check if the results are as expected
             $this->assertCount(10, $results);
-
-            // Assert that the higher the concurrency limit, the less time it takes
             $this->assertLessThanOrEqual($previousDuration, $duration);
 
-            // Set previous duration for the next pool test
             $previousDuration = $duration;
         }
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1554,7 +1554,7 @@ class HttpClientTest extends TestCase
             }
         };
 
-        // Test with different concurrency limits, the higher the number (or null) the faster it should be
+        // Test with different concurrency limits, the higher the number the faster it should be
         $concurrencyLimits = [1, 5, 10];
         $previousDuration = PHP_INT_MAX;
 


### PR DESCRIPTION
This PR introduces a significant enhancement to the `PendingRequest` class, allowing for more efficient handling of multiple HTTP client requests by integrating concurrency limits on request pools. The core change involves using Guzzle's `\GuzzleHttp\Promises\Each::ofEach()` method to manage simultaneous requests.

The main addition is the ability to specify a concurrency limit through an optional integer (`$concurrencyLimit`) on the `pool()` method. If unspecified, it'll default to sending all requests in the pool simultaneously (determined by the count of requests in the pool array).

### Testing

The unit testing for this feature posed a few challenges and I spent a long time trying to work around it, in case anyone is wondering why I wrote the tests the way that they are - I'm open to suggestions if someone has a better way. I was unable to find a reliable method to test the active requests and compute them into a max requests, and time comparisons were not accurate due to the `->wait()` on the `ofLimit()`

- Attempts to create and use a custom handler stack class for tracking requests was a no-go, responses were registering sequentially rather than concurrently
- Overriding the `send()` method was not feasible, that method was not even triggered during testing
- Did not want to tap into Guzzle's mechanics too much, maintaining the "Laravel nativeness"
- Adding logic to record timestamps using the `beforeSending()` hook and one for the `then()` resolve were not working, and I believe it has something to do with the `->wait()` chained to the `Each::ofLimit()` in the pool method. The beginning and end timestamps were never always overlapping, causing the max to always be the total number of requests

I changed strategy to instead compare times of two different concurrency limits, 2 and 10, then compare them to the last duration it took to finish the pool execution for the assertions.

### Documentation

This could probably be mentioned in the docs under the [Concurrent Requests](https://laravel.com/docs/10.x/http-client#concurrent-requests) section. The usage is super simple:

```php
use Illuminate\Http\Client\Pool;
use Illuminate\Support\Facades\Http;
 
$responses = Http::pool(fn (Pool $pool) => [
    $pool->as('first')->get('http://localhost/first'),
    $pool->as('second')->get('http://localhost/second'),
    $pool->as('third')->get('http://localhost/third'),
], 2);
 
return $responses['first']->ok();
```

I've run into a lot of cases in API/app development where I have a lot of urls to hit and the default concurrency runs them all in parallel, so the server ends up crashing or my local environment gets hung up. Hopefully this helps enhance the efficiency, control and flexibility of handling large request pools 👍 

Edit: fixing test, this isn't sustainable