### PR TITLE
[10.x] add assertResourceStructure method

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1440,6 +1440,13 @@ class TestResponse implements ArrayAccess
         return $this;
     }
 
+    public function assertResourceStructure(array $keys, JsonResource $resource, $escape = true)
+    {
+        PHPUnit::assertEquals($keys, array_keys($resource->resolve()));
+
+        return $this;
+    }
+
     /**
      * Get the current session store.
      *


### PR DESCRIPTION
This pull request allows comparing the array keys with the ```JsonStructure``` keys to ensure the testing response matching those keys.