### PR TITLE
fix hidden crsf token input not accepting autocomplete

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -323,7 +323,7 @@ if (! function_exists('csrf_field')) {
      */
     function csrf_field()
     {
-        return new HtmlString('<input type="hidden" name="_token" value="'.csrf_token().'" autocomplete="off">');
+        return new HtmlString('<input type="text" style="display:none" name="_token" value="'.csrf_token().'">');
     }
 }
 


### PR DESCRIPTION
This PR addresses the following issue when validating HTML code: "An `input` element with a `type` attribute whose value is `hidden` must not have an `autocomplete` attribute whose value is `on` or `off`."

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
