### PR TITLE
[10.x] Add Static Method for Polymorphic Class Name Retrieval

### DIFF
--- a/src/Illuminate/Database/ClassMorphViolationException.php
+++ b/src/Illuminate/Database/ClassMorphViolationException.php
@@ -16,11 +16,11 @@ class ClassMorphViolationException extends RuntimeException
     /**
      * Create a new exception instance.
      *
-     * @param  object  $model
+     * @param  object|string  $model
      */
     public function __construct($model)
     {
-        $class = get_class($model);
+        $class = is_object($model) ? get_class($model) : $model;
 
         parent::__construct("No morph map defined for model [{$class}].");
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -769,7 +769,7 @@ trait HasRelationships
     {
         $morphMap = Relation::morphMap();
 
-        if (!empty($morphMap) && in_array($classname, $morphMap)) {
+        if (! empty($morphMap) && in_array($classname, $morphMap)) {
             return array_search($classname, $morphMap, true);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -761,25 +761,47 @@ trait HasRelationships
     /**
      * Get the class name for polymorphic relations.
      *
+     * @param  string  $alias
+     * @param  string  $name
+     * @return string
+     */
+    private static function resolveMorphClass(string $classname, $instance = null)
+    {
+        $morphMap = Relation::morphMap();
+
+        if (!empty($morphMap) && in_array($classname, $morphMap)) {
+            return array_search($classname, $morphMap, true);
+        }
+
+        if ($classname === Pivot::class) {
+            return $classname;
+        }
+
+        if (Relation::requiresMorphMap()) {
+            throw new ClassMorphViolationException($instance ?: $classname);
+        }
+
+        return $classname;
+    }
+
+    /**
+     * Get the class name for polymorphic relations staticly.
+     *
+     * @return string
+     */
+    public static function getMorphClassStatic()
+    {
+        return static::resolveMorphClass(static::class);
+    }
+
+    /**
+     * Get the class name for polymorphic relations.
+     *
      * @return string
      */
     public function getMorphClass()
     {
-        $morphMap = Relation::morphMap();
-
-        if (! empty($morphMap) && in_array(static::class, $morphMap)) {
-            return array_search(static::class, $morphMap, true);
-        }
-
-        if (static::class === Pivot::class) {
-            return static::class;
-        }
-
-        if (Relation::requiresMorphMap()) {
-            throw new ClassMorphViolationException($this);
-        }
-
-        return static::class;
+        return static::resolveMorphClass(static::class, $this);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -68,6 +68,52 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
         $pivotModel->getMorphClass();
     }
 
+    public function testStaticMethodForMorphClassRetrieval()
+    {
+        // Test without a morph map
+        Relation::requireMorphMap(true);
+        $this->expectException(ClassMorphViolationException::class);
+        TestModel::getMorphClassStatic();
+
+        Relation::requireMorphMap(false);
+
+        Relation::morphMap([
+            'test' => TestModel::class,
+        ]);
+
+        $morphName = TestModel::getMorphClassStatic();
+        $this->assertSame('test', $morphName);
+
+        $pivotMorphName = TestPivotModel::getMorphClassStatic();
+        $this->assertSame(TestPivotModel::class, $pivotMorphName);
+    }
+
+    public function testStaticMethodWithEmptyMorphMap()
+    {
+        Relation::morphMap([]);
+
+        $this->expectException(ClassMorphViolationException::class);
+        TestModel::getMorphClassStatic();
+    }
+
+    public function testStaticMethodWithNonExistingClassInMorphMap()
+    {
+        Relation::morphMap([
+            'test' => SomeOtherModel::class,
+        ]);
+
+        $this->expectException(ClassMorphViolationException::class);
+        TestModel::getMorphClassStatic();
+    }
+
+    public function testStaticMethodExceptionForRequiredMorphMap()
+    {
+        Relation::requireMorphMap(true);
+
+        $this->expectException(ClassMorphViolationException::class);
+        TestModel::getMorphClassStatic();
+    }
+
     protected function tearDown(): void
     {
         parent::tearDown();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
**Description**
This PR introduces a new static method, `getMorphClassStatic`, to Laravel's Eloquent models. This method allows users to retrieve the class name for polymorphic relations in a static context. The addition provides a more flexible and efficient way to access class names, especially in scenarios where creating an instance of the model is not ideal or possible.

**Motivation and Context**
In certain situations, developers need to access the class name for polymorphic relations without having to instantiate the model. The current implementation of `getMorphClass` requires an instance of the model to function. This new static method overcomes this limitation, enabling developers to retrieve the class name statically, thus offering better performance and cleaner code, particularly in complex applications with extensive use of polymorphic relations.

**Implementation Details**
The method `getMorphClassStatic` has been added to the `Model` class.
Refactoring was done to ensure minimal code duplication and maintainability. Shared logic between `getMorphClass` and the new static method is extracted into a private static method.
Thorough unit tests have been added to ensure the new functionality works as expected and does not interfere with existing features.

**Benefits to End Users**
- Flexibility: Developers can now retrieve polymorphic class names in both instance and static contexts, providing greater flexibility in different coding scenarios.
- Performance: Reduces overhead in scenarios where the full model instance is not required, thus improving performance.
- Readability and Maintainability: Simplifies the codebase by providing a straightforward approach to retrieving class names, leading to cleaner and more maintainable code.

**Compatibility and Testing**
The addition is backward compatible and does not break any existing features of Laravel.
New unit tests have been written to cover the static method and ensure it behaves as expected under various scenarios.