### PR TITLE
Updated Str.php limit() function to optionally preserv the last word.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -563,20 +563,28 @@ class Str
     }
 
     /**
-     * Limit the number of characters in a string.
+     * Limit the number of characters in a string, optionally preserving the integrity of the last word.
      *
      * @param  string  $value
-     * @param  int  $limit
+     * @param  int     $limit
      * @param  string  $end
+     * @param  bool    $onWord
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...')
+    public static function limit($value, $limit = 100, $end = '...', $onWord = false)
     {
         if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
         }
-
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+    
+        $limitedString = mb_strimwidth($value, 0, $limit, '', 'UTF-8');
+    
+        if ($onWord && mb_strpos($value, ' ', $limit) != false) {
+            $lastSpace = mb_strrpos($limitedString, ' ', 0, 'UTF-8');
+            $limitedString = mb_substr($limitedString, 0, $lastSpace);
+        }
+    
+        return rtrim($limitedString).$end;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -566,9 +566,9 @@ class Str
      * Limit the number of characters in a string, optionally preserving the integrity of the last word.
      *
      * @param  string  $value
-     * @param  int     $limit
+     * @param  int  $limit
      * @param  string  $end
-     * @param  bool    $onWord
+     * @param  bool  $onWord
      * @return string
      */
     public static function limit($value, $limit = 100, $end = '...', $onWord = false)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -576,14 +576,14 @@ class Str
         if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
         }
-    
+
         $limitedString = mb_strimwidth($value, 0, $limit, '', 'UTF-8');
-    
+
         if ($onWord && mb_strpos($value, ' ', $limit) != false) {
             $lastSpace = mb_strrpos($limitedString, ' ', 0, 'UTF-8');
             $limitedString = mb_substr($limitedString, 0, $lastSpace);
         }
-    
+
         return rtrim($limitedString).$end;
     }
 


### PR DESCRIPTION
Description:
Updated 'limit()' function to limit the number of characters in a string, and optionally preserving the integrity of the last word.

The benefit to end users:
Just added one additional, optional argument to a limit() function. That argument is 'false' by default and function works as before. However if you will enable this argument - set it to true - function will not cut the string in the middle of the last word, and will preserve it, while still not exceeding the max length.

It certainly makes building web applications easier, by not requiring to write extra code for limiting the string length while preserving the readability of the shortened text.
