### PR TITLE
[10.x] Add `@elsePushIf` and `@elsePush`

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -379,7 +379,7 @@ trait CompilesConditionals
      * @param  string  $expression
      * @return string
      */
-    protected function compilePushElseIf($expression)
+    protected function compileElsePushIf($expression)
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
 
@@ -392,7 +392,7 @@ trait CompilesConditionals
      * @param  string  $expression
      * @return string
      */
-    protected function compilePushElse($expression)
+    protected function compileElsePush($expression)
     {
         return "<?php \$__env->stopPush(); else: \$__env->startPush{$expression}; ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -383,7 +383,7 @@ trait CompilesConditionals
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        return "<?php elseif({$parts[0]}): \$__env->startPush({$parts[1]}); ?>";
+        return "<?php \$__env->stopPush(); elseif({$parts[0]}): \$__env->startPush({$parts[1]}); ?>";
     }
 
     /**
@@ -394,7 +394,7 @@ trait CompilesConditionals
      */
     protected function compilePushElse($expression)
     {
-        return "<?php else: \$__env->startPush{$expression}; ?>";
+        return "<?php \$__env->stopPush(); else: \$__env->startPush{$expression}; ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -374,6 +374,30 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the else-if push statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePushElseIf($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression), 2);
+
+        return "<?php elseif({$parts[0]}): \$__env->startPush({$parts[1]}); ?>";
+    }
+
+    /**
+     * Compile the else push statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePushElse($expression)
+    {
+        return "<?php else: \$__env->startPush{$expression}; ?>";
+    }
+
+    /**
      * Compile the end-push statements into valid PHP.
      *
      * @return string

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -69,4 +69,24 @@ test
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testPushIfElseIsCompiled()
+    {
+        $string = '@pushIf(true, \'stack\')
+if
+@pushElseIf(false, \'stack\')
+elseif
+@pushElse(\'stack\')
+else
+@endPushIf';
+        $expected = '<?php if(true): $__env->startPush( \'stack\'); ?>
+if
+<?php elseif(false): $__env->startPush( \'stack\'); ?>
+elseif
+<?php else: $__env->startPush(\'stack\'); ?>
+else
+<?php $__env->stopPush(); endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -74,9 +74,9 @@ test
     {
         $string = '@pushIf(true, \'stack\')
 if
-@pushElseIf(false, \'stack\')
+@elsePushIf(false, \'stack\')
 elseif
-@pushElse(\'stack\')
+@elsePush(\'stack\')
 else
 @endPushIf';
         $expected = '<?php if(true): $__env->startPush( \'stack\'); ?>

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -81,9 +81,9 @@ else
 @endPushIf';
         $expected = '<?php if(true): $__env->startPush( \'stack\'); ?>
 if
-<?php elseif(false): $__env->startPush( \'stack\'); ?>
+<?php $__env->stopPush(); elseif(false): $__env->startPush( \'stack\'); ?>
 elseif
-<?php else: $__env->startPush(\'stack\'); ?>
+<?php $__env->stopPush(); else: $__env->startPush(\'stack\'); ?>
 else
 <?php $__env->stopPush(); endif; ?>';
 


### PR DESCRIPTION
When I reached for the `@pushIf` Blade Directive Laravel already had it. However, I then reached for `@pushElseIf` thinking _why not_ and, well, Laravel didn't have it.

This PR adds those missing directives which completes the full set of conditionals for `@pushIf`, allowing you to write something such as:

```blade
@pushIf($type == 'tailwind', 'css')
  <link href="public/css/tailwind.css" media="all" rel="stylesheet">
@elsePushIf($type == 'boostrap', 'css')
  <link href="public/css/bootstrap.css" media="all" rel="stylesheet">
@elsePush('css')
  <link href="public/css/app.css" media="all" rel="stylesheet">
@pushEndIf
```