### PR TITLE
[10.x] Refactor increment method by eliminating tap function in  `Illuminate\Cache\ArrayStore`

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -95,14 +95,12 @@ class ArrayStore extends TaggableStore implements LockProvider
     public function increment($key, $value = 1)
     {
         if (! is_null($existing = $this->get($key))) {
-            return tap(((int) $existing) + $value, function ($incremented) use ($key) {
-                $value = $this->serializesValues ? serialize($incremented) : $incremented;
-
-                $this->storage[$key]['value'] = $value;
-            });
+            $incremented = (int) $existing + $value;
+            $value = $this->serializesValues ? serialize($incremented) : $incremented;
+            $this->storage[$key]['value'] = $value;
+        } else {
+            $this->forever($key, $value);
         }
-
-        $this->forever($key, $value);
 
         return $value;
     }


### PR DESCRIPTION
This pull request eliminates the usage of the tap function in the `increment` method of the storage class. The changes directly handle the logic of incrementing values and updating storage without the need for tap, simplifying the code while maintaining the same functionality. This update aims to improve readability and maintainability by using a more direct approach.
