### PR TITLE
[10.x] feat: new isEmail method for Str class

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -287,10 +287,10 @@ class ServeCommand extends Command
             } elseif (str($line)->contains(['Closed without sending a request'])) {
                 // ...
             } elseif (! empty($line)) {
-                $position = strpos($line,'] ');
+                $position = strpos($line, '] ');
 
                 if ($position !== false) {
-                    $line = substr($line, $position+1);
+                    $line = substr($line, $position + 1);
                 }
                 $this->components->warn($line);
             }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -292,6 +292,7 @@ class ServeCommand extends Command
                 if ($position !== false) {
                     $line = substr($line, $position + 1);
                 }
+
                 $this->components->warn($line);
             }
         });

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -287,8 +287,12 @@ class ServeCommand extends Command
             } elseif (str($line)->contains(['Closed without sending a request'])) {
                 // ...
             } elseif (! empty($line)) {
-                $warning = explode('] ', $line);
-                $this->components->warn(count($warning) > 1 ? $warning[1] : $warning[0]);
+                $position = strpos($line,'] ');
+
+                if ($position !== false) {
+                    $line = substr($line, $position+1);
+                }
+                $this->components->warn($line);
             }
         });
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1727,4 +1727,16 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public static function isEmail($value): bool
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1729,14 +1729,15 @@ class Str
     }
 
     /**
-     * @param mixed $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isEmail($value): bool
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
+
         return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
     }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1340,22 +1340,23 @@ class SupportStrTest extends TestCase
     {
         $this->assertFalse(Str::isEmail($email));
     }
+
     public static function validEmailAddressProvider(): array
     {
         return [
-            ["taylor@email.com"],
-            ["maria@email.com"],
-            ["niko@email.com"]
+            ['taylor@email.com'],
+            ['maria@email.com'],
+            ['niko@email.com'],
         ];
     }
 
     public static function inValidEmailAddressProvider(): array
     {
         return [
-            ["tayloremail.com"],
-            ["maria@emailcom"],
-            ["niko.email.com"],
-            ["12345"]
+            ['tayloremail.com'],
+            ['maria@emailcom'],
+            ['niko.email.com'],
+            ['12345'],
         ];
     }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1324,6 +1324,40 @@ class SupportStrTest extends TestCase
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }
+
+    /**
+     * @dataProvider validEmailAddressProvider
+     */
+    public function testIsEmailIsValid($email)
+    {
+        $this->assertTrue(Str::isEmail($email));
+    }
+
+    /**
+     * @dataProvider inValidEmailAddressProvider
+     */
+    public function testIsEmailIsInvalid($email)
+    {
+        $this->assertFalse(Str::isEmail($email));
+    }
+    public static function validEmailAddressProvider(): array
+    {
+        return [
+            ["taylor@email.com"],
+            ["maria@email.com"],
+            ["niko@email.com"]
+        ];
+    }
+
+    public static function inValidEmailAddressProvider(): array
+    {
+        return [
+            ["tayloremail.com"],
+            ["maria@emailcom"],
+            ["niko.email.com"],
+            ["12345"]
+        ];
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
The method checks if the given string is a valid email or not.

https://github.com/laravel/framework/blob/9fec9e1952fdf11c78ce9447bde8402d9f87d444/src/Illuminate/Support/Str.php#L1735-L1742

Tests
https://github.com/nikopeikrishvili/laravel-framework/blob/0a6215db4fb2dbafe1cc285c61a4f0f52df12ca3/tests/Support/SupportStrTest.php#L1328-L1342