### PR TITLE
[10.x] remove `url()` call wrapping `route()` call

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -94,10 +94,10 @@ class ResetPassword extends Notification
             return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
         }
 
-        return url(route('password.reset', [
+        return route('password.reset', [
             'token' => $this->token,
             'email' => $notifiable->getEmailForPasswordReset(),
-        ], false));
+        ]);
     }
 
     /**


### PR DESCRIPTION
we can use `route()` to generate an absolute URL by itself. we can remove the wrapping `url()` function, and remove the `false` override of the `absolute` parameter.

this change was introduced in https://github.com/laravel/framework/commit/5608c22e28f71cd3484af08d0ebf315bb95e9445

I believe `url()` was needed originally to add the query parameters to the URL, since we were manually concatenating the "app.url" with the relative route.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
