### PR TITLE
[10.x] Support asserting against chained batches

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -72,7 +72,7 @@ class ChainedBatch implements ShouldQueue
      */
     public function handle()
     {
-        $batch = new PendingBatch(Container::getInstance(), $this->jobs);
+        $batch = Container::getInstance()->make(Dispatcher::class)->batch($this->jobs);
 
         $batch->name = $this->name;
         $batch->options = $this->options;

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -72,6 +72,18 @@ class ChainedBatch implements ShouldQueue
      */
     public function handle()
     {
+        $this->attachRemainderOfChainToEndOfBatch(
+            $this->toPendingBatch()
+        )->dispatch();
+    }
+
+    /**
+     * Convert the chained batch instance into a pending batch.
+     *
+     * @return \Illuminate\Bus\PendingBatch
+     */
+    public function toPendingBatch()
+    {
         $batch = Container::getInstance()->make(Dispatcher::class)->batch($this->jobs);
 
         $batch->name = $this->name;
@@ -85,8 +97,6 @@ class ChainedBatch implements ShouldQueue
             $batch->onConnection($this->connection);
         }
 
-        $this->dispatchRemainderOfChainAfterBatch($batch);
-
         foreach ($this->chainCatchCallbacks ?? [] as $callback) {
             $batch->catch(function (Batch $batch, ?Throwable $exception) use ($callback) {
                 if (! $batch->allowsFailures()) {
@@ -95,16 +105,16 @@ class ChainedBatch implements ShouldQueue
             });
         }
 
-        $batch->dispatch();
+        return $batch;
     }
 
     /**
      * Move the remainder of the chain to a "finally" batch callback.
      *
      * @param  \Illuminate\Bus\PendingBatch  $batch
-     * @return
+     * @return \Illuminate\Bus\PendingBatch
      */
-    protected function dispatchRemainderOfChainAfterBatch(PendingBatch $batch)
+    protected function attachRemainderOfChainToEndOfBatch(PendingBatch $batch)
     {
         if (! empty($this->chained)) {
             $next = unserialize(array_shift($this->chained));
@@ -126,5 +136,7 @@ class ChainedBatch implements ShouldQueue
 
             $this->chained = [];
         }
+
+        return $batch;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -452,7 +452,7 @@ class BusFake implements Fake, QueueingDispatcher
         $chain = $expectedChain;
 
         $matching = $this->dispatched($command, $callback)->filter(function ($job) use ($chain) {
-            if (count($expectedChain) !== count($job->chained)) {
+            if (count($chain) !== count($job->chained)) {
                 return false;
             }
 
@@ -464,7 +464,7 @@ class BusFake implements Fake, QueueingDispatcher
                         ! $chain[$index]($chainedBatch->toPendingBatch())) {
                         return false;
                     }
-                } elseif ($chain[$index] != $serializedChainedJob) {
+                } elseif ($chain[$index] != get_class(unserialize($serializedChainedJob))) {
                     return false;
                 }
             }
@@ -472,13 +472,13 @@ class BusFake implements Fake, QueueingDispatcher
             return true;
         });
 
-        $matching = $this->dispatched($command, $callback)->map->chained->map(function ($chain) {
-            return collect($chain)->map(
-                fn ($job) => get_class(unserialize($job))
-            );
-        })->filter(
-            fn ($chain) => $chain->all() === $expectedChain
-        );
+        // $matching = $this->dispatched($command, $callback)->map->chained->map(function ($chain) {
+        //     return collect($chain)->map(
+        //         fn ($job) => get_class(unserialize($job))
+        //     );
+        // })->filter(
+        //     fn ($chain) => $chain->all() === $expectedChain
+        // );
 
         PHPUnit::assertTrue(
             $matching->isNotEmpty(), 'The expected chain was not dispatched.'

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ReflectsClosures;
-use LogicException;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class BusFake implements Fake, QueueingDispatcher

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -674,6 +674,8 @@ class BusFake implements Fake, QueueingDispatcher
         $jobs = Collection::wrap($jobs);
         $jobs = ChainedBatch::prepareNestedBatches($jobs);
 
+        $jobs->whereInstanceOf(ChainedBatch::class)->each->handle();
+
         return new PendingChainFake($this, $jobs->shift(), $jobs->toArray());
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -472,14 +472,6 @@ class BusFake implements Fake, QueueingDispatcher
             return true;
         });
 
-        // $matching = $this->dispatched($command, $callback)->map->chained->map(function ($chain) {
-        //     return collect($chain)->map(
-        //         fn ($job) => get_class(unserialize($job))
-        //     );
-        // })->filter(
-        //     fn ($chain) => $chain->all() === $expectedChain
-        // );
-
         PHPUnit::assertTrue(
             $matching->isNotEmpty(), 'The expected chain was not dispatched.'
         );
@@ -741,8 +733,6 @@ class BusFake implements Fake, QueueingDispatcher
     {
         $jobs = Collection::wrap($jobs);
         $jobs = ChainedBatch::prepareNestedBatches($jobs);
-
-        $jobs->whereInstanceOf(ChainedBatch::class)->each->handle();
 
         return new PendingChainFake($this, $jobs->shift(), $jobs->toArray());
     }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -339,9 +339,7 @@ class BusFake implements Fake, QueueingDispatcher
 
             $command = ChainedBatch::class;
 
-            $callback = function ($job) use ($instance) {
-                return $instance($job->toPendingBatch());
-            };
+            $callback = fn ($job) => $instance($job->toPendingBatch());
         } elseif (! is_string($command)) {
             $instance = $command;
 

--- a/src/Illuminate/Support/Testing/Fakes/ChainedBatchTruthTest.php
+++ b/src/Illuminate/Support/Testing/Fakes/ChainedBatchTruthTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Closure;
+
+class ChainedBatchTruthTest
+{
+    /**
+     * The underlying truth test.
+     *
+     * @var \Closure
+     */
+    protected $callback;
+
+    /**
+     * Create a new truth test instance.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function __construct(Closure $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * Invoke the truth test with the given pending batch.
+     *
+     * @param  \Illuminate\Bus\PendingBatch
+     * @return bool
+     */
+    public function __invoke($pendingBatch)
+    {
+        return call_user_func($this->callback, $pendingBatch);
+    }
+}

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Testing\Fakes\BatchRepositoryFake;
 use Illuminate\Support\Testing\Fakes\BusFake;
@@ -468,6 +470,10 @@ class SupportTestingBusFakeTest extends TestCase
 
     public function testAssertChained()
     {
+        Container::setInstance($container = new Container);
+
+        $container->instance(Dispatcher::class, $this->fake);
+
         $this->fake->chain([
             new ChainedJobStub,
         ])->dispatch();
@@ -485,6 +491,33 @@ class SupportTestingBusFakeTest extends TestCase
             ChainedJobStub::class,
             OtherBusJobStub::class,
         ]);
+
+        $this->fake->chain([
+            new ChainedJobStub,
+            $this->fake->batch([
+                new OtherBusJobStub,
+                new OtherBusJobStub,
+            ]),
+            new ChainedJobStub,
+        ])->dispatch();
+
+        $this->fake->assertChained([
+            ChainedJobStub::class,
+            $this->fake->chainedBatch(function ($pendingBatch) {
+                return $pendingBatch->jobs->count() === 2;
+            }),
+            ChainedJobStub::class,
+        ]);
+
+        $this->fake->assertChained([
+            new ChainedJobStub,
+            $this->fake->chainedBatch(function ($pendingBatch) {
+                return $pendingBatch->jobs->count() === 2;
+            }),
+            new ChainedJobStub,
+        ]);
+
+        Container::setInstance(null);
     }
 
     public function testAssertDispatchedWithIgnoreClass()

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -517,6 +517,23 @@ class SupportTestingBusFakeTest extends TestCase
             new ChainedJobStub,
         ]);
 
+        $this->fake->chain([
+            $this->fake->batch([
+                new OtherBusJobStub,
+                new OtherBusJobStub,
+            ]),
+            new ChainedJobStub,
+            new ChainedJobStub,
+        ])->dispatch();
+
+        $this->fake->assertChained([
+            $this->fake->chainedBatch(function ($pendingBatch) {
+                return $pendingBatch->jobs->count() === 2;
+            }),
+            ChainedJobStub::class,
+            ChainedJobStub::class,
+        ]);
+
         Container::setInstance(null);
     }
 


### PR DESCRIPTION
This improves the testability of batches that exist within chains via a new `Bus::chainedBatch` testing helper which allows you to generate a truth test for a batch within a chain.

Given this route:

```php
Route::get('/batch', function () {
    Bus::chain([
        new TestJob,
        Bus::batch([
            new TestJob,
        ]),
        new TestJob,
    ])->dispatch();
});
```

A test could now be written like so:

```php
public function test_the_application_returns_a_successful_response(): void
{
    Bus::fake();

    $response = $this->get('/batch');

    $response->assertSuccessful();

    Bus::assertChained([
        new TestJob,
        Bus::chainedBatch(function ($batch) {
            return $batch->jobs->count() === 1;
        }),
        new TestJob,
    ]);
}
```