### PR TITLE
[10.x] Add support to class properties

### DIFF
--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View;
 
 use Illuminate\View\ComponentAttributeBag;
 use PHPUnit\Framework\TestCase;
+use function value;
 
 class ViewComponentAttributeBagTest extends TestCase
 {
@@ -127,5 +128,38 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertFalse((bool) $bag->has(['name', 'class']));
         $this->assertFalse((bool) $bag->has('name', 'class'));
         $this->assertTrue((bool) $bag->missing('class'));
+    }
+
+    public function testClassPropsProperties()
+    {
+        $config = fn(ComponentAttributeBag $component) => $component->classProps([
+            'xs' => fn($c) => value($c->get('outline')) ? 'button-xs-outline' : 'button-xs',
+            'md' => 'button-md',
+        ], 'md'
+        )->classProps([
+            'outline' => 'bg-transparent'
+        ])
+        ->classProps([
+            'white'=>'text-white',
+            'black'=>'text-black',
+        ],'white','color');
+        $bag = (new ComponentAttributeBag());
+        $bag = $config($bag);
+        $this->assertSame('class="text-white button-md"', (string)$bag);
+        $bag->setAttributes(['xs' => true]);
+        $bag = $config($bag);
+        $this->assertSame('class="text-white button-xs"', (string)$bag);
+        $bag->setAttributes(['xs' => true,'outline' => false,'color'=>'black']);
+        $bag = $config($bag);
+        $this->assertSame('class="text-black button-xs"', (string)$bag);
+        $bag->setAttributes(['xs' => true,'outline' => true,'color'=>'black']);
+        $bag = $config($bag);
+        $this->assertSame('class="text-black bg-transparent button-xs-outline"', (string)$bag);
+        $bag->setAttributes(['xs' => true,'outline' => true,'color'=>'black']);
+        $bag = $config($bag);
+        $this->assertSame('class="text-black bg-transparent button-xs-outline"', (string)$bag);
+        $bag->setAttributes(['xs' => true,'outline' => true,'black'=>true]);
+        $bag = $config($bag);
+        $this->assertSame('class="text-black bg-transparent button-xs-outline"', (string)$bag);
     }
 }


### PR DESCRIPTION
With this feature you can set properties to modify component classes easy.
Example:
```php
// resources/view/components/button.blade.php
<button {{$attributes
    ->classProps([
        'xs'=>fn(ComponentAttributeBag $c)=>$c->has('outline')?'button-xs-outline':'button-xs',
        'md'=>'button-md',
    ],'md','size')
}}>
    {{$slot}}
</button>
```
first parameter is cases for check properties
second parameter is the default property
in the third parameter you can pass property name to set current class property. eg: `size="xs"`

#Is possible combine many class props
```php
// resources/view/components/button.blade.php
<button {{$attributes
    ->classProps([
        'xs'=>fn($c)=>$c->has('outline')?'text-primary-500':'bg-primary-500 text-white',
        'md'=>'button-md',
        'lg'=>'button-lg'
    ],'md','size')
    ->classProps([
        'outline'=>'bg-transparent'
    ])
}}>
    {{$slot}}
</button>
```
usage:
```php
<x-button lg>Test</x-button> //class="button-lg"
<x-button :lg="fn():bool=>true">Test</x-button> //class="button-lg"
<x-button xs outline>Test</x-button> //class="bg-transparent text-primary-500"
<x-button size="md" outline>Test</x-button> //class="bg-transparent button-md"
```