### PR TITLE
[10.x] Make Validator::getValue() public

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1104,7 +1104,7 @@ class Validator implements ValidatorContract
      * @param  string  $attribute
      * @return mixed
      */
-    protected function getValue($attribute)
+    public function getValue($attribute)
     {
         return Arr::get($this->data, $attribute);
     }


### PR DESCRIPTION
Hi guys.

I would like to propose a pull request to make the getValue() method public in the Validator class.

My pull request would simply change the access modifier of getValue() from protected to public to match setValue(). This would allow retrieving values from Validator when needed from outside.

```diff
BEFORE:
- $validator->attributes()['title'] ?? null

AFTER:
+ $validator->getValue('title')
```

Currently, setValue() is public while getValue() is protected. Having the getter be more restricted than the setter is unconventional and limits the usefulness of Validator instances.

The getValue() method does not seem to require protected access given that setValue() is already public. I think this change would improve the overall consistency and usability of the Validator class.

Please consider merging this pull request to make getValue() public. Let me know if you would like me to make any other changes to the PR.

There may be a related discussion:  #49006

Thanks!
