### PR TITLE
[10.x] Generate Batch of notifications to deliver over direct Queue dispatch

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Notifications\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Notifications\Factory as FactoryContract;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
 
@@ -37,6 +39,20 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         (new NotificationSender(
             $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
         )->send($notifiables, $notification);
+    }
+
+    /**
+     * Send the given notification to the given notifiable entities.
+     *
+     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
+     * @param  mixed  $notification
+     * @return PendingBatch
+     */
+    public function batch($notifiables, $notification)
+    {
+        return (new NotificationSender(
+            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
+        )->batch($notifiables, $notification, new PendingBatch($this->container, new Collection()));
     }
 
     /**

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -42,7 +42,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     }
 
     /**
-     * Send the given notification to the given notifiable entities.
+     * Create a queue batch for all the notifiables to receive the notification.
      *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Notifications;
 
-use Illuminate\Bus\Batch;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -83,7 +82,7 @@ class NotificationSender
     }
 
     /**
-     * Apply jobs to a PendingBatch for queue delivery
+     * Apply jobs to a PendingBatch for queue delivery.
      * 
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification
@@ -244,7 +243,7 @@ class NotificationSender
                 if (method_exists($notification, 'middleware')) {
                     $middleware = array_merge(
                         $notification->middleware($notifiable, $channel),
-                        $middleware
+                        $middleware,
                     );
                 }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -83,7 +83,7 @@ class NotificationSender
 
     /**
      * Apply jobs to a PendingBatch for queue delivery.
-     * 
+     *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification
      * @param  PendingBatch  $pendingBatch
@@ -243,7 +243,7 @@ class NotificationSender
                 if (method_exists($notification, 'middleware')) {
                     $middleware = array_merge(
                         $notification->middleware($notifiable, $channel),
-                        $middleware,
+                        $middleware
                     );
                 }
 
@@ -309,7 +309,7 @@ class NotificationSender
                 if (method_exists($notification, 'middleware')) {
                     $middleware = [
                         ...$notification->middleware($notifiable, $channel),
-                        ...$middleware
+                        ...$middleware,
                     ];
                 }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -83,9 +83,11 @@ class NotificationSender
     }
 
     /**
-     * @param \Illuminate\Support\Collection|array|mixed $notifiables
-     * @param object $notification
-     * @param PendingBatch $pendingBatch
+     * Apply jobs to a PendingBatch for queue delivery
+     * 
+     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
+     * @param  mixed  $notification
+     * @param  PendingBatch  $pendingBatch
      * @return PendingBatch
      */
     public function batch($notifiables, $notification, $pendingBatch)
@@ -258,11 +260,11 @@ class NotificationSender
     }
 
     /**
-     * Queue the given notification instances.
+     * Add jobs to a PendingBatch.
      *
-     * @param mixed $notifiables
-     * @param \Illuminate\Notifications\Notification $notification
-     * @param PendingBatch $pendingBatch
+     * @param  mixed  $notifiables
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  PendingBatch  $pendingBatch
      * @return PendingBatch
      */
     protected function queueNotificationBatch($notifiables, $notification, $pendingBatch)

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
@@ -9,6 +10,7 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
 /**
  * @method static void send(\Illuminate\Support\Collection|array|mixed $notifiables, mixed $notification)
  * @method static void sendNow(\Illuminate\Support\Collection|array|mixed $notifiables, mixed $notification, array|null $channels = null)
+ * @method static PendingBatch batch(\Illuminate\Support\Collection|array|mixed $notifiables, mixed $notification)
  * @method static mixed channel(string|null $name = null)
  * @method static string getDefaultDriver()
  * @method static string deliversVia()


### PR DESCRIPTION
# What

This PR replicates the functionality of queuing a notification to multiple notifiables, but instead of dispatching directly to a queue, it will add them to a PendingBatch instance that can then be returned and dispatched with additional options.

Examples usage:

```php
$batch = Notification::batch($notiables, $notification)
    ->then(function (Batch $batch) {
        // do something upon completion
    })
    ->dispatch();
```

# Why

I noticed a little while ago that it was impossible to send Notifications as batches without implementing much of the job prep in a new class. I felt this implementation was simple enough that it was worth contributing to the framework so others might use it. The main aim was to be able to run additional code when a batch of notifications is delivered, something I was unable to do with just the `send` method.

# Notes

This change does create some duplicate code, but I felt it best to leave it as is. I'm happy to clean that up if required.