### PR TITLE
[10.x] Round milliseconds in database seeder console output runtime

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -61,7 +61,7 @@ abstract class Seeder
             $seeder->__invoke($parameters);
 
             if ($silent === false && isset($this->command)) {
-                $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
+                $runTime = number_format((microtime(true) - $startTime) * 1000);
 
                 with(new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/43400 the runtime of console commands is rounded to the nearest millisecond. I noticed today that seeders still show their runtime with two decimals.

Before this PR:

![before 2](https://github.com/laravel/framework/assets/7202674/e8bdffb5-57c6-4215-80d9-d1eeda067e82)

After this PR:

![after](https://github.com/laravel/framework/assets/7202674/57b3a0e9-82fb-4fca-9c9d-0c10e3df22c1)
