### PR TITLE
[10.x] Pass the property $validator as a parameter to the $callback Closure

### DIFF
--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -64,7 +64,7 @@ class ClosureValidationRule implements RuleContract, ValidatorAwareRule
             $this->failed = true;
 
             return $this->pendingPotentiallyTranslatedString($attribute, $message);
-        });
+        }, $this->validator);
 
         return ! $this->failed;
     }


### PR DESCRIPTION
Hi everyone.

This PR passes the property $validator as a parameter to the $callback Closure, so that we could take advantage of the existing $validator property in the class ClosureValidationRule.

Doing this allows callback closures to access the $validator, making the validation using Closure to be more flexible than it currently is.

For example:

```diff
use Closure;
use Illuminate\Support\Facades\Validator;
use Illuminate\Support\LazyCollection;
+ use Illuminate\Validation\Validator as ValidationValidator;

$rules = [
    'price' => [
-       function (string $attribute, mixed $value, Closure $fail) {
+       function (string $attribute, mixed $value, Closure $fail, ValidationValidator $validator) {
-           if ($value === 'foo') {
+           if (!price_logic($value, $validator->attributes()['payment_country'] ?? null)) {
                $fail("The {$attribute} is invalid.");
            }
        },
    ],
];

/** @var LazyCollection $csv_rows */
$csv_rows = next_row_from_csv();

foreach ($csv_rows as $row) {
    if (Validator::make($row, $rules)->failed()) {
        throw new \LogicException;
    }
}
```

Related discussion: #49006

Merging this in would enable cleaner validation rule declarations by removing the need to re-declare new ValidationRule that implements [ValidatorAwareRule](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Contracts/Validation/ValidatorAwareRule.php) interface. It's a small change but makes the syntax less redundant.

Please let me know if you need any other details about this change! I'm happy to explain or amend the PR if any improvements are needed.

Thank you!