### PR TITLE
[10.x] Fix the replace() method in DefaultService class

### DIFF
--- a/src/Illuminate/Support/DefaultProviders.php
+++ b/src/Illuminate/Support/DefaultProviders.php
@@ -70,7 +70,7 @@ class DefaultProviders
         foreach ($replacements as $from => $to) {
             $key = $current->search($from);
 
-            $current = $key ? $current->replace([$key => $to]) : $current;
+            $current = is_int($key) ? $current->replace([$key => $to]) : $current;
         }
 
         return new static($current->values()->toArray());


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/49021: The replace() method in Illuminate\Support\DefaultProviders always omits the first item.