### PR TITLE
[10.x] Fix Cache DatabaseStore::add() error occur on Postgres within transaction

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -168,6 +168,7 @@ class DatabaseStore implements LockProvider, Store
         } catch (QueryException) {
             // ignore if duplicate
         }
+
         return false;
     }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Cache\Store;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 
@@ -153,17 +154,21 @@ class DatabaseStore implements LockProvider, Store
         $value = $this->serialize($value);
         $expiration = $this->getTime() + $seconds;
 
+        if ($this->get($key) !== null) {
+            return false;
+        }
+
+        $notSupportInsertOrIgnoreConnections = [SqlServerConnection::class];
+        if (! in_array(get_class($this->getConnection()), $notSupportInsertOrIgnoreConnections)) {
+            return $this->table()->insertOrIgnore(compact('key', 'value', 'expiration')) > 0;
+        }
+
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (QueryException) {
-            return $this->table()
-                ->where('key', $key)
-                ->where('expiration', '<=', $this->getTime())
-                ->update([
-                    'value' => $value,
-                    'expiration' => $expiration,
-                ]) >= 1;
+            // ignore if duplicate
         }
+        return false;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -154,19 +154,20 @@ class DatabaseStore implements LockProvider, Store
         $value = $this->serialize($value);
         $expiration = $this->getTime() + $seconds;
 
-        if ($this->get($key) !== null) {
+        if (! is_null($this->get($key))) {
             return false;
         }
 
-        $notSupportInsertOrIgnoreConnections = [SqlServerConnection::class];
-        if (! in_array(get_class($this->getConnection()), $notSupportInsertOrIgnoreConnections)) {
+        $doesntSupportInsertOrIgnore = [SqlServerConnection::class];
+
+        if (! in_array(get_class($this->getConnection()), $doesntSupportInsertOrIgnore)) {
             return $this->table()->insertOrIgnore(compact('key', 'value', 'expiration')) > 0;
         }
 
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (QueryException) {
-            // ignore if duplicate
+            // ...
         }
 
         return false;

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -41,6 +41,66 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertSame('new-bar', $store->get('foo'));
     }
 
+    public function testAddOperationCanStoreNewCache()
+    {
+        $store = $this->getStore();
+
+        $result = $store->add('foo', 'bar', 60);
+
+        $this->assertTrue($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotUpdateExistCache()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 60);
+        $result = $store->add('foo', 'new-bar', 60);
+
+        $this->assertFalse($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotUpdateExistCacheInTransaction()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 60);
+
+        DB::beginTransaction();
+        $result = $store->add('foo', 'new-bar', 60);
+        DB::commit();
+
+        $this->assertFalse($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationCanUpdateIfCacheExpired()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 0);
+        $result = $store->add('foo', 'new-bar', 60);
+
+        $this->assertTrue($result);
+        $this->assertSame('new-bar', $store->get('foo'));
+    }
+
+    public function testAddOperationCanUpdateIfCacheExpiredInTransaction()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 0);
+
+        DB::beginTransaction();
+        $result = $store->add('foo', 'new-bar', 60);
+        DB::commit();
+
+        $this->assertTrue($result);
+        $this->assertSame('new-bar', $store->get('foo'));
+    }
+
     protected function getStore()
     {
         return Cache::store('database');


### PR DESCRIPTION
## Problem
similar to the previous [PR](https://github.com/laravel/framework/pull/48968), when using Postgres as the Cache database store,
an error occurs when performing `Cache::add()` operation on an already existing cache key within transaction.

PS.  i make a integration test to prove this bug [here](https://github.com/xdevor/framework/pull/5)

## Steps To Reproduce
- Step 1: after setup postgres and .env file put the following code to laravel `routes/console.php`
```php
use Illuminate\Support\Facades\Cache;
use Illuminate\Support\Facades\DB;

Artisan::command('test', function () {
    $store = Cache::store('database');

    $store->add('test-key', 'test-value', 60);
    
    DB::beginTransaction();
    $store->add('test-key', 'new-test-value', 60);
    DB::commit();

});
```
- Step 2:  run `php artisan test` and the error will show

## Solution
- call `get()` before `insert()` not only check cache exist but also `get()` will delete expired record in DB, therefor no need to update expired record in error handle statement which the root cause of PG error

## Versions
- Postgres: v12 and v16
- PHP: 8.2
- Laravel: 10