### PR TITLE
[10.x] Support ordering index

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -77,6 +77,15 @@ abstract class Grammar
             return $this->wrapJsonSelector($value);
         }
 
+        // If the given value suffix has an ordering direction, we will separate
+        // it to wrap the field and ordering direction SQL independently.
+        // Afterward, we will join them back together, ensuring that the clause
+        // is processed correctly by the database.
+        if (preg_match('/\s+desc|\s+asc/i', $value)) {
+            [$column, $order] = explode(' ', $value);
+            return $this->wrap($column).' '.strtoupper($order);
+        }
+
         return $this->wrapSegments(explode('.', $value));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1681,7 +1681,7 @@ class Blueprint
     {
         $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
-        return str_replace(['-', '.'], '_', $index);
+        return str_replace(['-', '.', ' '], '_', $index);
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -245,7 +245,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
     }
 
-    public function testDropIndex()
+    public function testDropIndex(): void
     {
         $blueprint = new Blueprint('users');
         $blueprint->dropIndex('foo');
@@ -254,6 +254,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
     }
+
+    public function testDropIndexWithAscendingAndDescending(): void
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIndex(['foo desc', 'bar ASC', 'baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop index `users_foo_desc_bar_asc_baz_index`', $statements[0]);
+    }
+
 
     public function testDropSpatialIndex()
     {
@@ -364,6 +375,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
+    }
+
+    public function testAddingIndexWithAscendingAndDescending(): void
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo desc', 'bar ASC', 'baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `users_foo_desc_bar_asc_baz_index`(`foo` DESC, `bar` ASC, `baz`)', $statements[0]);
     }
 
     public function testAddingIndexWithAlgorithm()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -168,6 +168,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('drop index "foo"', $statements[0]);
     }
 
+    public function testDropIndexWithAscendingAndDescending(): void
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIndex(['foo desc', 'bar ASC', 'baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop index "users_foo_desc_bar_asc_baz_index"', $statements[0]);
+    }
+
     public function testDropSpatialIndex()
     {
         $blueprint = new Blueprint('geo');
@@ -267,6 +277,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexWithAscendingAndDescending(): void
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo desc', 'bar ASC', 'baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_foo_desc_bar_asc_baz_index" on "users" ("foo" DESC, "bar" ASC, "baz")', $statements[0]);
     }
 
     public function testAddingIndexWithAlgorithm()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -44,6 +44,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $commands = $blueprint->getCommands();
         $this->assertSame('users_foo_index', $commands[0]->index);
 
+        $blueprint = new Blueprint('users');
+        $blueprint->index('foo desc');
+        $commands = $blueprint->getCommands();
+        $this->assertSame('users_foo_desc_index', $commands[0]->index);
+
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
         $commands = $blueprint->getCommands();
@@ -61,6 +66,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->index('foo');
         $commands = $blueprint->getCommands();
         $this->assertSame('prefix_users_foo_index', $commands[0]->index);
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->index('foo desc');
+        $commands = $blueprint->getCommands();
+        $this->assertSame('prefix_users_foo_desc_index', $commands[0]->index);
 
         $blueprint = new Blueprint('geo', null, 'prefix_');
         $blueprint->spatialIndex('coordinates');
@@ -80,6 +90,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $commands = $blueprint->getCommands();
         $this->assertSame('users_foo_index', $commands[0]->index);
 
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIndex(['foo DESC']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('users_foo_desc_index', $commands[0]->index);
+
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
         $commands = $blueprint->getCommands();
@@ -97,6 +112,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->dropIndex(['foo']);
         $commands = $blueprint->getCommands();
         $this->assertSame('prefix_users_foo_index', $commands[0]->index);
+
+        $blueprint = new Blueprint('users', null, 'prefix_');
+        $blueprint->dropIndex(['foo DESC']);
+        $commands = $blueprint->getCommands();
+        $this->assertSame('prefix_users_foo_desc_index', $commands[0]->index);
 
         $blueprint = new Blueprint('geo', null, 'prefix_');
         $blueprint->dropSpatialIndex(['coordinates']);

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -157,6 +157,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('drop index "foo" on "users"', $statements[0]);
     }
 
+    public function testDropIndexWithAscendingAndDescending()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIndex('foo DESC');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('drop index "foo_desc" on "users"', $statements[0]);
+    }
+
     public function testDropSpatialIndex()
     {
         $blueprint = new Blueprint('geo');
@@ -267,6 +277,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexWithAscendingAndDescending(): void
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo desc', 'bar ASC', 'baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_foo_desc_bar_asc_baz_index" on "users" ("foo" DESC, "bar" ASC, "baz")', $statements[0]);
     }
 
     public function testAddingSpatialIndex()


### PR DESCRIPTION
Support ordering index DB:
- [MySQL 8.0](https://dev.mysql.com/doc/refman/8.0/en/descending-indexes.html)
- [SQLite](https://www.sqlite.org/lang_createindex.html#:~:text=1.3.%20Descending%20Indexes)
- [PostgreSQL 12](https://www.postgresql.org/docs/current/indexes-ordering.html)
- [MariaDB 10.11](https://mariadb.com/kb/en/descending-indexes/)
- [MSSQL](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver16)

---
How to use
- create index
```php
// in migration file
Schema::table('demos', function (Blueprint $table) {
// alter table `demos` add index `demos_name_asc_sort_desc_is_active_index`(`name` ASC, `sort` DESC, `is_active`)
    $this->index([
        'name ASC',
        'sort DESC',
        'is_active'
    ]);
// or specify index name
    $this->index([
        'name ASC',
        'sort DESC',
        'is_active'
    ], 'index_1');
});
```
- drop index
```php
// in migration file
Schema::table('demos', function (Blueprint $table) {
// alter table `demos` drop index `demos_name_asc_sort_desc_is_active_index`
    $this->dropIndex([
        'name ASC',
        'sort DESC',
        'is_active'
    ]);
});
```