### PR TITLE
[10.x] Add missing parameter `references()` in `ColumnDefinition`

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Fluent;
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary() Add a primary index
  * @method $this fulltext(string $indexName = null) Add a fulltext index
+ * @method $this references(string $column) Add a reference for a column
  * @method $this spatialIndex(string $indexName = null) Add a spatial index
  * @method $this startingValue(int $startingValue) Set the starting value of an auto-incrementing field (MySQL/PostgreSQL)
  * @method $this storedAs(string $expression) Create a stored generated column (MySQL/PostgreSQL/SQLite)


### PR DESCRIPTION
Good Day. I noticed this one when it was reported by larastan (phpstan) when our codebase got checked with this specific error below

```
Call to an undefined method Illuminate\Database\Schema\ColumnDefinition::references().  
```

in this line

```
$table->bigInteger('category_id')->references('id')->on('categories')->onDelete('cascade');
```

BTW, we are using Laravel v10.x, I checked the repo codebase and found out it was missing so I added it. Please check.