### PR TITLE
[10.x] Fix notifications being counted as sent without a "shouldSend" method

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -307,9 +307,10 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                     fn ($channel) => $notification->shouldSend($notifiable, $channel) !== false
                 );
 
-                if (empty($notifiableChannels)) {
-                    continue;
-                }
+            }
+
+            if (empty($notifiableChannels)) {
+                continue;
             }
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -306,7 +306,6 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                     $notifiableChannels,
                     fn ($channel) => $notification->shouldSend($notifiable, $channel) !== false
                 );
-
             }
 
             if (empty($notifiableChannels)) {


### PR DESCRIPTION
This PR fixes an issue with unit testing where a custom abstract notification class returning an empty array from the `via` function is still counted as sent if the class does not have a `shouldSend()` method.

Real world testing proves this works fine, an empty via means there is no channel to send the notification on, so it is never sent.

The `NotificationFake` class skips this channel check if the `shouldSend()` method does not exist on the class. This PR moves it out of that check, so will now work in both cases.

NB: Tests should be updated to have a failing test for this, but not sure how to re-architect them at this stage.

The interesting thing is, all `NotificationSenderTests` pass no matter what you change:

![CleanShot 2023-11-17 at 9  57 30@2x](https://github.com/laravel/framework/assets/3906839/8340b332-c8a5-4b6c-84f6-8746a5ec5e2e)

I can change this to `bus->shouldReceive` and have this test still pass. I also believe the function name may be wrong for this test, but not 100% sure.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
