### PR TITLE
[10.x] Add a new `Numberable` helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -18,6 +18,17 @@ class Number
     protected static $locale = 'en';
 
     /**
+     * Get a new numberable object from the given number.
+     *
+     * @param  int|float  $number
+     * @return \Illuminate\Support\Numberable
+     */
+    public static function of($number)
+    {
+        return new Numberable($number);
+    }
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -111,6 +111,68 @@ class Numberable
     }
 
     /**
+     * Format the current value according to the current locale.
+     *
+     * @param  int|null  $precision
+     * @param  int|null  $maxPrecision
+     * @param  ?string  $locale
+     * @return string|false
+     */
+    public function format(?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
+    {
+        return Number::format($this->value, $precision, $maxPrecision, $locale);
+    }
+
+    /**
+     * Convert the current value to its percentage equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @param  ?string  $locale
+     * @return string|false
+     */
+    public function percentage(int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
+    {
+        return Number::percentage($this->value, $precision, $maxPrecision, $locale);
+    }
+
+    /**
+     * Convert the current value to its currency equivalent.
+     *
+     * @param  string  $in
+     * @param  ?string  $locale
+     * @return string|false
+     */
+    public function currency(string $in = 'USD', ?string $locale = null)
+    {
+        return Number::currency($this->value, $in, $locale);
+    }
+
+    /**
+     * Convert the current value to its file size equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return string
+     */
+    public function fileSize(int $precision = 0, ?int $maxPrecision = null)
+    {
+        return Number::fileSize($this->value, $precision, $maxPrecision);
+    }
+
+    /**
+     * Convert the current value to its human readable equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return string
+     */
+    public function forHumans(int $precision = 0, ?int $maxPrecision = null)
+    {
+        return Number::forHumans($this->value, $precision, $maxPrecision);
+    }
+
+    /**
      * Proxy dynamic properties onto methods.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -124,6 +124,28 @@ class Numberable
     }
 
     /**
+     * Spell out the current value in the given locale.
+     *
+     * @param  ?string  $locale
+     * @return string
+     */
+    public function spell(?string $locale = null)
+    {
+        return Number::spell($this->value, $locale);
+    }
+
+    /**
+     * Convert the current value to ordinal form.
+     *
+     * @param  ?string  $locale
+     * @return string
+     */
+    public function ordinal(?string $locale = null)
+    {
+        return Number::ordinal($this->value, $locale);
+    }
+
+    /**
      * Convert the current value to its percentage equivalent.
      *
      * @param  int  $precision

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -184,7 +184,7 @@ class Numberable
     }
 
     /**
-     * Get the raw string value.
+     * Convert the current value to its string equivalent.
      *
      * @return string
      */

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -39,6 +39,78 @@ class Numberable
     }
 
     /**
+     * Add the given value to the current value.
+     *
+     * @param  int|float  $value
+     */
+    public function add($value): static
+    {
+        $this->value += $value;
+
+        return $this;
+    }
+
+    /**
+     * Subtract the given value from the current value.
+     *
+     * @param  int|float  $value
+     */
+    public function subtract($value): static
+    {
+        $this->value -= $value;
+
+        return $this;
+    }
+
+    /**
+     * Multiply the given value with the current value.
+     *
+     * @param  int|float  $value
+     */
+    public function multiply($value): static
+    {
+        $this->value *= $value;
+
+        return $this;
+    }
+
+    /**
+     * Divide the given value with the current value.
+     *
+     * @param  int|float  $value
+     */
+    public function divide($value): static
+    {
+        $this->value /= $value;
+
+        return $this;
+    }
+
+    /**
+     * Modulo the given value with the current value.
+     *
+     * @param  int|float  $value
+     */
+    public function modulo($value): static
+    {
+        $this->value %= $value;
+
+        return $this;
+    }
+
+    /**
+     * Raise the current value to the given exponent.
+     *
+     * @param  int|float  $value
+     */
+    public function pow($value): static
+    {
+        $this->value **= $value;
+
+        return $this;
+    }
+
+    /**
      * Proxy dynamic properties onto methods.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
+
+class Numberable
+{
+    use Conditionable, Macroable, Tappable;
+
+    /**
+     * The underlying numeric value.
+     *
+     * @var int|float
+     */
+    protected $value;
+
+    /**
+     * Create a new instance of the class.
+     *
+     * @param  int|float  $value
+     * @return void
+     */
+    public function __construct($value = 0)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Get the raw numeric value.
+     *
+     * @return int|float
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Proxy dynamic properties onto methods.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->{$key}();
+    }
+
+    /**
+     * Get the raw string value.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -4,11 +4,10 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Support\Traits\Tappable;
 
 class Numberable
 {
-    use Conditionable, Macroable, Tappable;
+    use Conditionable, Macroable;
 
     /**
      * The underlying numeric value.
@@ -45,9 +44,7 @@ class Numberable
      */
     public function add($value): static
     {
-        $this->value += $value;
-
-        return $this;
+        return new static($this->value + $value);
     }
 
     /**
@@ -57,9 +54,7 @@ class Numberable
      */
     public function subtract($value): static
     {
-        $this->value -= $value;
-
-        return $this;
+        return new static($this->value - $value);
     }
 
     /**
@@ -69,9 +64,7 @@ class Numberable
      */
     public function multiply($value): static
     {
-        $this->value *= $value;
-
-        return $this;
+        return new static($this->value * $value);
     }
 
     /**
@@ -81,9 +74,7 @@ class Numberable
      */
     public function divide($value): static
     {
-        $this->value /= $value;
-
-        return $this;
+        return new static($this->value / $value);
     }
 
     /**
@@ -93,9 +84,7 @@ class Numberable
      */
     public function modulo($value): static
     {
-        $this->value %= $value;
-
-        return $this;
+        return new static($this->value % $value);
     }
 
     /**
@@ -105,9 +94,7 @@ class Numberable
      */
     public function pow($value): static
     {
-        $this->value **= $value;
-
-        return $this;
+        return new static($this->value ** $value);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -5,6 +5,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Number;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -287,6 +288,19 @@ if (! function_exists('str')) {
         }
 
         return Str::of($string);
+    }
+}
+
+if (! function_exists('number')) {
+    /**
+     * Get a new numberable object from the given number.
+     *
+     * @param  int|float  $number
+     * @return \Illuminate\Support\Numberable|mixed
+     */
+    function number($number)
+    {
+        return Number::of($number);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,6 +7,8 @@ use ArrayIterator;
 use Countable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
+use Illuminate\Support\Number;
+use Illuminate\Support\Numberable;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Stringable;
@@ -591,6 +593,16 @@ class SupportHelpersTest extends TestCase
         $strAccessor = str();
         $this->assertTrue((new ReflectionClass($strAccessor))->isAnonymous());
         $this->assertSame((string) $strAccessor, '');
+    }
+
+    public function testNumber()
+    {
+        $numberable = number(10);
+
+        $this->assertInstanceOf(Numberable::class, $numberable);
+        $this->assertSame(10, $numberable->value());
+
+        $this->assertEquals(Number::of(10), number(10));
     }
 
     public function testTap()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,10 +3,16 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use Illuminate\Support\Numberable;
 use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
+    public function testOf()
+    {
+        $this->assertEquals(new Numberable(10), Number::of(10));
+    }
+
     public function testFormat()
     {
         $this->needsIntlExtension();

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -122,6 +122,18 @@ class SupportNumberableTest extends TestCase
         $this->assertSame($this->numberable(10000)->format(locale: 'de'), Number::format(10000, locale: 'de'));
     }
 
+    public function testSpell()
+    {
+        $this->assertSame($this->numberable(100)->spell(), Number::spell(100));
+        $this->assertSame($this->numberable(25)->spell(locale: 'de'), Number::spell(25, locale: 'de'));
+    }
+
+    public function testOrdinal()
+    {
+        $this->assertSame($this->numberable(1)->ordinal(), Number::ordinal(1));
+        $this->assertSame($this->numberable(2)->ordinal(locale: 'de'), Number::ordinal(2, locale: 'de'));
+    }
+
     public function testPercentage()
     {
         $this->assertSame($this->numberable(10)->percentage(), Number::percentage(10));

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -36,4 +36,80 @@ class SupportNumberableTest extends TestCase
         $this->assertSame('1', (string) $this->numberable(1));
         $this->assertSame('1.1', (string) $this->numberable(1.1));
     }
+
+    public function testAdd()
+    {
+        $number = $this->numberable();
+
+        $this->assertSame(1, $number->add(1)->value());
+        $this->assertSame(2, $number->add(1)->value());
+        $this->assertSame(-3, $number->add(-5)->value());
+    }
+
+    public function testSubtract()
+    {
+        $number = $this->numberable();
+
+        $this->assertSame(-1, $number->subtract(1)->value());
+        $this->assertSame(-2, $number->subtract(1)->value());
+        $this->assertSame(3, $number->subtract(-5)->value());
+    }
+
+    public function testMultiply()
+    {
+        $number = $this->numberable(2);
+
+        $this->assertSame(4, $number->multiply(2)->value());
+        $this->assertSame(8, $number->multiply(2)->value());
+        $this->assertSame(16, $number->multiply(2)->value());
+
+        $number = $this->numberable(2.5);
+
+        $this->assertSame(5.0, $number->multiply(2)->value());
+        $this->assertSame(7.5, $number->multiply(1.5)->value());
+        $this->assertSame(-1.875, $number->multiply(-0.25)->value());
+    }
+
+    public function testDivide()
+    {
+        $number = $this->numberable(2);
+
+        $this->assertSame(1, $number->divide(2)->value());
+        $this->assertSame(0.5, $number->divide(2)->value());
+        $this->assertSame(0.25, $number->divide(2)->value());
+
+        $number = $this->numberable(3);
+
+        $this->assertSame(1.5, $number->divide(2)->value());
+        $this->assertSame(0.5, $number->divide(3)->value());
+        $this->assertSame(-2.0, $number->divide(-0.25)->value());
+    }
+
+    public function testModulo()
+    {
+        $this->assertSame(0, $this->numberable(10)->modulo(2)->value());
+        $this->assertSame(1, $this->numberable(10)->modulo(3)->value());
+        $this->assertSame(2, $this->numberable(10)->modulo(4)->value());
+
+        // Floats are cast to int before modulo operation
+        $this->assertSame(0, $this->numberable(10)->modulo(1.5)->value());
+        $this->assertSame(0, $this->numberable(10)->modulo(1.75)->value());
+        $this->assertSame(0, $this->numberable(10)->modulo(1.25)->value());
+    }
+
+    public function testPow()
+    {
+        $this->assertSame(1, $this->numberable(10)->pow(0)->value());
+        $this->assertSame(10, $this->numberable(10)->pow(1)->value());
+        $this->assertSame(100, $this->numberable(10)->pow(2)->value());
+        $this->assertSame(1000, $this->numberable(10)->pow(3)->value());
+        $this->assertSame(10000, $this->numberable(10)->pow(4)->value());
+
+        $this->assertSame(1.0, $this->numberable(10)->pow(0.0)->value());
+        $this->assertSame(10.0, $this->numberable(10)->pow(1.0)->value());
+        $this->assertSame(100.0, $this->numberable(10)->pow(2.0)->value());
+
+        $this->assertSame(0.1, $this->numberable(10)->pow(-1)->value());
+        $this->assertSame(0.01, $this->numberable(10)->pow(-2)->value());
+    }
 }

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -43,8 +43,7 @@ class SupportNumberableTest extends TestCase
         $number = $this->numberable();
 
         $this->assertSame(1, $number->add(1)->value());
-        $this->assertSame(2, $number->add(1)->value());
-        $this->assertSame(-3, $number->add(-5)->value());
+        $this->assertSame(-5, $number->add(-5)->value());
     }
 
     public function testSubtract()
@@ -52,8 +51,7 @@ class SupportNumberableTest extends TestCase
         $number = $this->numberable();
 
         $this->assertSame(-1, $number->subtract(1)->value());
-        $this->assertSame(-2, $number->subtract(1)->value());
-        $this->assertSame(3, $number->subtract(-5)->value());
+        $this->assertSame(5, $number->subtract(-5)->value());
     }
 
     public function testMultiply()
@@ -61,14 +59,14 @@ class SupportNumberableTest extends TestCase
         $number = $this->numberable(2);
 
         $this->assertSame(4, $number->multiply(2)->value());
-        $this->assertSame(8, $number->multiply(2)->value());
-        $this->assertSame(16, $number->multiply(2)->value());
+        $this->assertSame(8, $number->multiply(4)->value());
+        $this->assertSame(16, $number->multiply(8)->value());
 
         $number = $this->numberable(2.5);
 
         $this->assertSame(5.0, $number->multiply(2)->value());
-        $this->assertSame(7.5, $number->multiply(1.5)->value());
-        $this->assertSame(-1.875, $number->multiply(-0.25)->value());
+        $this->assertSame(3.75, $number->multiply(1.5)->value());
+        $this->assertSame(-0.625, $number->multiply(-0.25)->value());
     }
 
     public function testDivide()
@@ -76,14 +74,14 @@ class SupportNumberableTest extends TestCase
         $number = $this->numberable(2);
 
         $this->assertSame(1, $number->divide(2)->value());
-        $this->assertSame(0.5, $number->divide(2)->value());
-        $this->assertSame(0.25, $number->divide(2)->value());
+        $this->assertSame(0.5, $number->divide(4)->value());
+        $this->assertSame(0.25, $number->divide(8)->value());
 
         $number = $this->numberable(3);
 
         $this->assertSame(1.5, $number->divide(2)->value());
-        $this->assertSame(0.5, $number->divide(3)->value());
-        $this->assertSame(-2.0, $number->divide(-0.25)->value());
+        $this->assertSame(1, $number->divide(3)->value());
+        $this->assertSame(-12.0, $number->divide(-0.25)->value());
     }
 
     public function testModulo()
@@ -165,13 +163,6 @@ class SupportNumberableTest extends TestCase
         $this->assertSame($this->numberable(10000)->forHumans(), Number::forHumans(10000));
     }
 
-    public function testTap()
-    {
-        $this->assertSame(15, $this->numberable(10)->tap(function (Numberable $number) {
-            $number->add(5);
-        })->value);
-    }
-
     public function testMacro()
     {
         Numberable::macro('addFive', function () {
@@ -227,18 +218,18 @@ class SupportNumberableTest extends TestCase
         })->value);
     }
 
-    public function testFluentOperations()
+    public function testImmutableOperations()
     {
         $number = $this->numberable(10);
 
         $this->assertSame(10, (int) (string) $number);
         $this->assertSame(15, (int) (string) $number->add(5));
-        $this->assertSame(5, (int) (string) $number->subtract(10));
-        $this->assertSame(50, (int) (string) $number->multiply(10));
-        $this->assertSame(25, (int) (string) $number->divide(2));
-        $this->assertSame(5, (int) (string) $number->modulo(20));
-        $this->assertSame(25, (int) (string) $number->pow(2));
+        $this->assertSame(0, (int) (string) $number->subtract(10));
+        $this->assertSame(100, (int) (string) $number->multiply(10));
+        $this->assertSame(5, (int) (string) $number->divide(2));
+        $this->assertSame(10, (int) (string) $number->modulo(20));
+        $this->assertSame(100, (int) (string) $number->pow(2));
 
-        $this->assertSame('21 trillion', $number->subtract(17)->multiply(10)->pow(7)->forHumans());
+        $this->assertSame('21 trillion', $number->subtract(5)->multiply(9.25)->pow(8)->forHumans());
     }
 }

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -145,8 +145,7 @@ class SupportNumberableTest extends TestCase
     public function testCurrency()
     {
         $this->assertSame($this->numberable(10)->currency(), Number::currency(10));
-        $this->assertSame($this->numberable(1.234)->currency(2), Number::currency(1.234, 2));
-        $this->assertSame($this->numberable(1.234)->currency(2, 1), Number::currency(1.234, 2, 1));
+        $this->assertSame($this->numberable(1.234)->currency(in: 'EUR'), Number::currency(1.234, in: 'EUR'));
         $this->assertSame($this->numberable(10000)->currency(locale: 'de'), Number::currency(10000, locale: 'de'));
     }
 

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Numberable;
+use PHPUnit\Framework\TestCase;
+
+class SupportNumberableTest extends TestCase
+{
+    /**
+     * @param  int|float  $number
+     * @return \Illuminate\Support\Numberable
+     */
+    protected function numberable($number = 0)
+    {
+        return new Numberable($number);
+    }
+
+    public function testNumberable()
+    {
+        $this->assertSame(0, $this->numberable()->value());
+        $this->assertSame(1, $this->numberable(1)->value());
+        $this->assertSame(1.1, $this->numberable(1.1)->value());
+    }
+
+    public function testMagicGet()
+    {
+        $this->assertSame(0, $this->numberable()->value);
+        $this->assertSame(1, $this->numberable(1)->value);
+        $this->assertSame(1.1, $this->numberable(1.1)->value);
+    }
+
+    public function testStringCast()
+    {
+        $this->assertSame('0', (string) $this->numberable());
+        $this->assertSame('1', (string) $this->numberable(1));
+        $this->assertSame('1.1', (string) $this->numberable(1.1));
+    }
+}

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -153,4 +153,81 @@ class SupportNumberableTest extends TestCase
         $this->assertSame($this->numberable(1.234)->forHumans(2, 1), Number::forHumans(1.234, 2, 1));
         $this->assertSame($this->numberable(10000)->forHumans(), Number::forHumans(10000));
     }
+
+    public function testTap()
+    {
+        $this->assertSame(15, $this->numberable(10)->tap(function (Numberable $number) {
+            $number->add(5);
+        })->value);
+    }
+
+    public function testMacro()
+    {
+        Numberable::macro('addFive', function () {
+            return $this->add(5);
+        });
+
+        $this->assertSame(15, $this->numberable(10)->addFive()->value);
+    }
+
+    public function testWhen()
+    {
+        $this->assertSame(15, $this->numberable(10)->when(true, function (Numberable $number) {
+            return $number->add(5);
+        })->value);
+
+        $this->assertSame(10, $this->numberable(10)->when(false, function (Numberable $number) {
+            return $number->add(5);
+        })->value);
+
+        $this->assertSame(15, $this->numberable(10)->when(true, function (Numberable $number) {
+            return $number->add(5);
+        }, function (Numberable $number) {
+            return $number->add(10);
+        })->value);
+
+        $this->assertSame(20, $this->numberable(10)->when(false, function (Numberable $number) {
+            return $number->add(5);
+        }, function (Numberable $number) {
+            return $number->add(10);
+        })->value);
+    }
+
+    public function testUnless()
+    {
+        $this->assertSame(15, $this->numberable(10)->unless(false, function (Numberable $number) {
+            return $number->add(5);
+        })->value);
+
+        $this->assertSame(10, $this->numberable(10)->unless(true, function (Numberable $number) {
+            return $number->add(5);
+        })->value);
+
+        $this->assertSame(15, $this->numberable(10)->unless(false, function (Numberable $number) {
+            return $number->add(5);
+        }, function (Numberable $number) {
+            return $number->add(10);
+        })->value);
+
+        $this->assertSame(20, $this->numberable(10)->unless(true, function (Numberable $number) {
+            return $number->add(5);
+        }, function (Numberable $number) {
+            return $number->add(10);
+        })->value);
+    }
+
+    public function testFluentOperations()
+    {
+        $number = $this->numberable(10);
+
+        $this->assertSame(10, (int) (string) $number);
+        $this->assertSame(15, (int) (string) $number->add(5));
+        $this->assertSame(5, (int) (string) $number->subtract(10));
+        $this->assertSame(50, (int) (string) $number->multiply(10));
+        $this->assertSame(25, (int) (string) $number->divide(2));
+        $this->assertSame(5, (int) (string) $number->modulo(20));
+        $this->assertSame(25, (int) (string) $number->pow(2));
+
+        $this->assertSame('21 trillion', $number->subtract(17)->multiply(10)->pow(7)->forHumans());
+    }
 }

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Number;
 use Illuminate\Support\Numberable;
 use PHPUnit\Framework\TestCase;
 
@@ -111,5 +112,45 @@ class SupportNumberableTest extends TestCase
 
         $this->assertSame(0.1, $this->numberable(10)->pow(-1)->value());
         $this->assertSame(0.01, $this->numberable(10)->pow(-2)->value());
+    }
+
+    public function testFormat()
+    {
+        $this->assertSame($this->numberable(10)->format(), Number::format(10));
+        $this->assertSame($this->numberable(1.234)->format(2), Number::format(1.234, 2));
+        $this->assertSame($this->numberable(1.234)->format(2, 1), Number::format(1.234, 2, 1));
+        $this->assertSame($this->numberable(10000)->format(locale: 'de'), Number::format(10000, locale: 'de'));
+    }
+
+    public function testPercentage()
+    {
+        $this->assertSame($this->numberable(10)->percentage(), Number::percentage(10));
+        $this->assertSame($this->numberable(1.234)->percentage(2), Number::percentage(1.234, 2));
+        $this->assertSame($this->numberable(1.234)->percentage(2, 1), Number::percentage(1.234, 2, 1));
+        $this->assertSame($this->numberable(10000)->percentage(locale: 'de'), Number::percentage(10000, locale: 'de'));
+    }
+
+    public function testCurrency()
+    {
+        $this->assertSame($this->numberable(10)->currency(), Number::currency(10));
+        $this->assertSame($this->numberable(1.234)->currency(2), Number::currency(1.234, 2));
+        $this->assertSame($this->numberable(1.234)->currency(2, 1), Number::currency(1.234, 2, 1));
+        $this->assertSame($this->numberable(10000)->currency(locale: 'de'), Number::currency(10000, locale: 'de'));
+    }
+
+    public function testFileSize()
+    {
+        $this->assertSame($this->numberable(10)->fileSize(), Number::fileSize(10));
+        $this->assertSame($this->numberable(1.234)->fileSize(2), Number::fileSize(1.234, 2));
+        $this->assertSame($this->numberable(1.234)->fileSize(2, 1), Number::fileSize(1.234, 2, 1));
+        $this->assertSame($this->numberable(10000)->fileSize(), Number::fileSize(10000));
+    }
+
+    public function testForHumans()
+    {
+        $this->assertSame($this->numberable(10)->forHumans(), Number::forHumans(10));
+        $this->assertSame($this->numberable(1.234)->forHumans(2), Number::forHumans(1.234, 2));
+        $this->assertSame($this->numberable(1.234)->forHumans(2, 1), Number::forHumans(1.234, 2, 1));
+        $this->assertSame($this->numberable(10000)->forHumans(), Number::forHumans(10000));
     }
 }


### PR DESCRIPTION
## Abstract

Building on https://github.com/laravel/framework/pull/48845, this class will work similarly to the `Stringable` class, but for numbers.

This was requested on the Discord and by several people on Twitter, and mentioned in https://github.com/laravel/framework/pull/48849

### Development

Feedback and contributions are much appreciated! I can be reached here, or in the `#internals` Discord.

- [x] Add accessors for the `Number` class
- [x] Add methods to interact with the value
- [x] Add `Number::of()` and `number()` shorthands
- [ ] See if we can find a better name for this helper? (Numerable has been suggested)
