### PR TITLE
[10.x] Fix tests failure on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, gmp
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, gmp, intl
           tools: composer:v2
           coverage: none
 


### PR DESCRIPTION
Tests are failing on Windows after 8ab218449481f6f7d71f47e7ec4a3e4cf2ddc05f. This PR fixes that by adding `intl` PHP extension on Windows.