### PR TITLE
[10.x] Handle missing translation strings using callback

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -360,7 +360,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  callable|null  $callback
      * @return static
      */
-    public function handleMissingTranslationKeysUsing(?callable $callback)
+    public function handleMissingKeysUsing(?callable $callback)
     {
         $this->missingTranslationKeyCallback = $callback;
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -345,7 +345,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // Prevent infinite loops...
         $this->handleMissingTranslationKeys = false;
 
-        $key = call_user_func($this->missingTranslationKeyCallback,
+        $key = call_user_func(
+            $this->missingTranslationKeyCallback,
             $key, $replace, $locale, $fallback
         );
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -70,7 +70,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      *
      * @var callable|null
      */
-    protected static $missingTranslationKeyCallback;
+    protected $missingTranslationKeyCallback;
 
     /**
      * Indicates whether missing translation keys should be handled.

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -360,7 +360,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  callable|null  $callback
      * @return static
      */
-    public function handleMissingTranslationKeyUsing(?callable $callback)
+    public function handleMissingTranslationKeysUsing(?callable $callback)
     {
         $this->missingTranslationKeyCallback = $callback;
 

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -43,7 +43,7 @@ class TranslatorTest extends TestCase
 
     public function testItCanHandleMissingKeysUsingCallback()
     {
-        $this->app['translator']->handleMissingTranslationKeysUsing(function ($key) {
+        $this->app['translator']->handleMissingKeysUsing(function ($key) {
             $_SERVER['__missing_translation_key'] = $key;
             return 'callback key';
         });
@@ -53,6 +53,6 @@ class TranslatorTest extends TestCase
         $this->assertSame('callback key', $key);
         $this->assertSame('some missing key', $_SERVER['__missing_translation_key']);
 
-        $this->app['translator']->handleMissingTranslationKeysUsing(null);
+        $this->app['translator']->handleMissingKeysUsing(null);
     }
 }

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -40,4 +40,19 @@ class TranslatorTest extends TestCase
         $this->assertFalse($this->app['translator']->hasForLocale('1 Day'));
         $this->assertTrue($this->app['translator']->hasForLocale('30 Days'));
     }
+
+    public function testItCanHandleMissingKeysUsingCallback()
+    {
+        $this->app['translator']->handleMissingTranslationKeysUsing(function ($key) {
+            $_SERVER['__missing_translation_key'] = $key;
+            return 'callback key';
+        });
+
+        $key = $this->app['translator']->get('some missing key');
+
+        $this->assertSame('callback key', $key);
+        $this->assertSame('some missing key', $_SERVER['__missing_translation_key']);
+
+        $this->app['translator']->handleMissingTranslationKeysUsing(null);
+    }
 }


### PR DESCRIPTION
This change adds the ability to customise the behaviour of how missing translations are handled. The current behaviour is to return the key unchanged. For example `{{ __('user.name') }}` will render as `user.name` if the corresponding translation key doesn't exist in language files. This change allows a callback to define the missing translation behaviour increasing customisability. The callback can return a string which will then be returned by the `get` method.

An example of a use case for this is: I would like to add the ability to trigger a log message if a translation key is missed in production to detect when cryptic text such as user.name are being displayed to users in production.

There are packages to solve this problem using static analysis such as https://github.com/LarsWiegers/laravel-translations-checker, however static analysis is limited and can not pick up run-time generated keys, e.g. `__("user.$field")`. This change would make it possible to detect translation misses in run-time.

Example of usage in any service provider:

```php
use Illuminate\Translation\Translator;
use Log;
// Edit: the syntax has changed since this feature was originally proposed.
// Please see docs at https://laravel.com/docs/10.x/localization#handling-missing-translation-strings
Translator::handleMissingTranslationKeyUsing(function ($key) {
    Log::error("Missing translation key [$key] detected.");
});
```

These changes also include functionality to prevent infinite loops where the user defined callback itself contains a missing translation.

This idea was originally proposed at: https://github.com/laravel/framework/discussions/48862