### PR TITLE
[x10] Number::ordinal() Values Adjustment

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -11,7 +11,7 @@ class Number
     use Macroable;
 
     /**
-     * Constants Ordinal Text
+     * Constants Ordinal Text.
      */
     public const ORDINAL_DEFAULT = '%spellout-ordinal';
     public const ORDINAL_MALE = '%spellout-ordinal-masculine';
@@ -44,7 +44,7 @@ class Number
         } elseif (! is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
-
+        
         return $formatter->format($number);
     }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -44,7 +44,7 @@ class Number
         } elseif (! is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
-        
+
         return $formatter->format($number);
     }
 
@@ -82,7 +82,7 @@ class Number
             $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
             $formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, $mode);
         }
-        
+
         return $formatter->format($number);
     }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -11,6 +11,13 @@ class Number
     use Macroable;
 
     /**
+     * Constants Ordinal Text
+     */
+    public const ORDINAL_DEFAULT = '%spellout-ordinal';
+    public const ORDINAL_MALE = '%spellout-ordinal-masculine';
+    public const ORDINAL_FEMALE = '%spellout-ordinal-feminine';
+
+    /**
      * The current default locale.
      *
      * @var string
@@ -61,15 +68,21 @@ class Number
      * Convert the given number to ordinal form.
      *
      * @param  int|float  $number
+     * @param  ?string  $mode
      * @param  ?string  $locale
      * @return string
      */
-    public static function ordinal(int|float $number, ?string $locale = null)
+    public static function ordinal(int|float $number, ?string $mode = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
-        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::ORDINAL);
-
+        if (empty($mode)) {
+            $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::ORDINAL);
+        } else {
+            $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
+            $formatter->setTextAttribute(NumberFormatter::DEFAULT_RULESET, $mode);
+        }
+        
         return $formatter->format($number);
     }
 


### PR DESCRIPTION
After seeing this new implementation I found that we could improve some things, based on the fact that I have a package that is intended to convert number values into letters.

Adjust the ordinal method as follows, since not all languages handle the single English standard and the output type must be defined.

```php
Number::ordinal(2);
// "2nd"

Number::ordinal(2, Number::ORDINAL_DEFAULT);
// "Second"

Number::ordinal(2, Number::ORDINAL_MALE, "es");
// "Segundo"

Number::ordinal(2, Number::ORDINAL_FEMALE, "es");
// "Segunda"
```

See related documentation: https://rmunate.github.io/SpellNumber/usage/numbers-to-ordinal.html
