### PR TITLE
[10.x] Fix directory separator CMD display on windows

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -187,6 +187,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             }
         }
 
+        if (windows_os()) {
+            $path = str_replace('/', '\\', $path);
+        }
+
         $this->components->info(sprintf('%s [%s] created successfully.', $info, $path));
     }
 


### PR DESCRIPTION
The directory separators are not consistent when running the `artisan make:*` commands as below:

![image](https://github.com/laravel/framework/assets/6961695/91b74d76-4977-4507-aa9c-873f9239e4f6)

Since this is in the base class all the make commands family take benefit from it.

After:
![image](https://github.com/laravel/framework/assets/6961695/a7c34dc3-4198-4d3d-a915-27c1cb98e89b)
