### PR TITLE
[10.x] Fix 'queue' property set in payload of all job types

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -63,6 +63,7 @@ class BroadcastEvent implements ShouldQueue
         $this->backoff = property_exists($event, 'backoff') ? $event->backoff : null;
         $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
         $this->maxExceptions = property_exists($event, 'maxExceptions') ? $event->maxExceptions : null;
+        $this->queue = method_exists($event, 'broadcastQueue') ? $event->broadcastQueue() : (property_exists($event, 'queue') ? $event->queue : null);
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -671,6 +671,7 @@ class Dispatcher implements DispatcherContract
 
             $job->backoff = method_exists($listener, 'backoff') ? $listener->backoff(...$data) : ($listener->backoff ?? null);
             $job->maxExceptions = $listener->maxExceptions ?? null;
+            $job->queue = method_exists($listener, 'viaQueue') ? $listener->viaQueue() : ($listener->queue ?? null);
             $job->retryUntil = method_exists($listener, 'retryUntil') ? $listener->retryUntil(...$data) : null;
             $job->shouldBeEncrypted = $listener instanceof ShouldBeEncrypted;
             $job->timeout = $listener->timeout ?? null;

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -339,9 +339,9 @@ class TestDispatcherGetQueueDynamically implements ShouldQueue
         //
     }
 
-    public function viaQueue($event)
+    public function viaQueue($event = null)
     {
-        if ($event['useHighPriorityQueue']) {
+        if ($event != null && $event['useHighPriorityQueue']) {
             return 'p0';
         }
 


### PR DESCRIPTION
Fixed the $queue property in the job payload to represent the actual queue for all job types. The $queue property on jobs will be serialized into the payload of the job. For normal jobs the property always represents the actual queue, however for some other job types it didn't, because it wasn't set, which can cause confusion and relying on the $queue property was thus illegitimate.

This is currently causing issues with the https://github.com/stackkit/laravel-google-cloud-tasks-queue package. Cause it is relying on the $queue property to fetch the job form Google Cloud Tasks after it has been pushed to Laravel by Google Cloud Tasks. If this isn't properly set, this breaks as the package does not know from which queue to fetch the job.

For end users this change serves as a fix that restores a logical consistency that is currently broken.

See the report I created for the various cases:

- [x] JOB: class constructor ->onQueue() function (already worked)
- [x] JOB: manual ->queue() function (already worked)
- [x] EVENT LISTENER: class defined $queue property (fixed)
- [x] EVENT SUBSCRIBER: class defined $queue property (fixed)
- [x] EVENT BROADCAST: class defined $queue property (fixed)
- [x] EVENT BROADCAST: class defined broadcastQueue() function (fixed)
- [x] NOTIFICATION: class defined viaQueue() function (already worked)
- [x] NOTIFICATION BROADCAST: class defined ->onQueue() in toBroadcast() function (already worked). Only works when notification itself doesn't implement ShouldQueue, in that case queue can be specified using the viaQueue() function

This should not break any existing features as all code using the $queue property on the job payload should expect it to represent the actual queue. The queue property is also already present, but null, on all job payloads, even if no $queue has been set on the job.