### PR TITLE
[10.x] Add unless conditional on validation rules

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -34,7 +34,7 @@ class Rule
     }
 
     /**
-     * Apply the rules of the given "condition" is (or resolves to) truthy.
+     * Apply the given rules if the given condition is truthy.
      *
      * @param  callable|bool  $condition
      * @param  array|string|\Closure  $rules
@@ -47,7 +47,7 @@ class Rule
     }
 
     /**
-     * Apply the rules of the given "condition" is (or resolves to) falsy.
+     * Apply the given rules if the given condition is falsy.
      *
      * @param  callable|bool  $condition
      * @param  array|string|\Closure  $rules

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -34,7 +34,7 @@ class Rule
     }
 
     /**
-     * Create a new conditional rule set.
+     * Apply the rules of the given "condition" is (or resolves to) truthy.
      *
      * @param  callable|bool  $condition
      * @param  array|string|\Closure  $rules
@@ -44,6 +44,19 @@ class Rule
     public static function when($condition, $rules, $defaultRules = [])
     {
         return new ConditionalRules($condition, $rules, $defaultRules);
+    }
+
+    /**
+     * Apply the rules of the given "condition" is (or resolves to) falsy.
+     *
+     * @param  callable|bool  $condition
+     * @param  array|string|\Closure  $rules
+     * @param  array|string|\Closure  $defaultRules
+     * @return \Illuminate\Validation\ConditionalRules
+     */
+    public static function unless($condition, $rules, $defaultRules = [])
+    {
+        return new ConditionalRules(! $condition, $rules, $defaultRules);
     }
 
     /**

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -11,19 +11,21 @@ class ValidationRuleParserTest extends TestCase
 {
     public function testConditionalRulesAreProperlyExpandedAndFiltered()
     {
+        $isAdmin = true;
+
         $rules = ValidationRuleParser::filterConditionalRules([
-            'name' => Rule::when(true, ['required', 'min:2']),
-            'email' => Rule::when(false, ['required', 'min:2']),
-            'password' => Rule::when(true, 'required|min:2'),
-            'username' => ['required', Rule::when(true, ['min:2'])],
-            'address' => ['required', Rule::when(false, ['min:2'])],
+            'name' => Rule::when($isAdmin, ['required', 'min:2']),
+            'email' => Rule::unless($isAdmin, ['required', 'min:2']),
+            'password' => Rule::when($isAdmin, 'required|min:2'),
+            'username' => ['required', Rule::when($isAdmin, ['min:2'])],
+            'address' => ['required', Rule::unless($isAdmin, ['min:2'])],
             'city' => ['required', Rule::when(function (Fluent $input) {
                 return true;
             }, ['min:2'])],
-            'state' => ['required', Rule::when(true, function (Fluent $input) {
+            'state' => ['required', Rule::when($isAdmin, function (Fluent $input) {
                 return 'min:2';
             })],
-            'zip' => ['required', Rule::when(false, [], function (Fluent $input) {
+            'zip' => ['required', Rule::when($isAdmin, function (Fluent $input) {
                 return ['min:2'];
             })],
         ]);
@@ -42,16 +44,20 @@ class ValidationRuleParserTest extends TestCase
 
     public function testEmptyRulesArePreserved()
     {
+        $isAdmin = true;
+
         $rules = ValidationRuleParser::filterConditionalRules([
             'name' => [],
             'email' => '',
-            'password' => Rule::when(true, 'required|min:2'),
+            'password' => Rule::when($isAdmin, 'required|min:2'),
+            'gender' => Rule::unless($isAdmin, 'required'),
         ]);
 
         $this->assertEquals([
             'name' => [],
             'email' => '',
             'password' => ['required', 'min:2'],
+            'gender' => [],
         ], $rules);
     }
 
@@ -64,12 +70,14 @@ class ValidationRuleParserTest extends TestCase
 
     public function testConditionalRulesWithDefault()
     {
+        $isAdmin = true;
+
         $rules = ValidationRuleParser::filterConditionalRules([
-            'name' => Rule::when(true, ['required', 'min:2'], ['string', 'max:10']),
-            'email' => Rule::when(false, ['required', 'min:2'], ['string', 'max:10']),
-            'password' => Rule::when(false, 'required|min:2', 'string|max:10'),
-            'username' => ['required', Rule::when(true, ['min:2'], ['string', 'max:10'])],
-            'address' => ['required', Rule::when(false, ['min:2'], ['string', 'max:10'])],
+            'name' => Rule::when($isAdmin, ['required', 'min:2'], ['string', 'max:10']),
+            'email' => Rule::unless($isAdmin,  ['required', 'min:2'], ['string', 'max:10']),
+            'password' => Rule::unless($isAdmin,  'required|min:2', 'string|max:10'),
+            'username' => ['required', Rule::when($isAdmin, ['min:2'], ['string', 'max:10'])],
+            'address' => ['required', Rule::unless($isAdmin, ['min:2'], ['string', 'max:10'])],
         ]);
 
         $this->assertEquals([
@@ -83,10 +91,12 @@ class ValidationRuleParserTest extends TestCase
 
     public function testEmptyConditionalRulesArePreserved()
     {
+        $isAdmin = true;
+
         $rules = ValidationRuleParser::filterConditionalRules([
-            'name' => Rule::when(true, '', ['string', 'max:10']),
-            'email' => Rule::when(false, ['required', 'min:2'], []),
-            'password' => Rule::when(false, 'required|min:2', 'string|max:10'),
+            'name' => Rule::when($isAdmin, '', ['string', 'max:10']),
+            'email' => Rule::unless($isAdmin, ['required', 'min:2']),
+            'password' => Rule::unless($isAdmin, 'required|min:2', 'string|max:10'),
         ]);
 
         $this->assertEquals([

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -74,8 +74,8 @@ class ValidationRuleParserTest extends TestCase
 
         $rules = ValidationRuleParser::filterConditionalRules([
             'name' => Rule::when($isAdmin, ['required', 'min:2'], ['string', 'max:10']),
-            'email' => Rule::unless($isAdmin,  ['required', 'min:2'], ['string', 'max:10']),
-            'password' => Rule::unless($isAdmin,  'required|min:2', 'string|max:10'),
+            'email' => Rule::unless($isAdmin, ['required', 'min:2'], ['string', 'max:10']),
+            'password' => Rule::unless($isAdmin, 'required|min:2', 'string|max:10'),
             'username' => ['required', Rule::when($isAdmin, ['min:2'], ['string', 'max:10'])],
             'address' => ['required', Rule::unless($isAdmin, ['min:2'], ['string', 'max:10'])],
         ]);


### PR DESCRIPTION
This PR a new feature added `unless` conditional on validation rules

```php
request()->validate([
    'name' => ['required', 'string', 'min:6'],
    'password' => ['required', 'string', Rule::unless(false, ['min:5', 'confirmed'])],
]);
```
