### PR TITLE
[10.x] Support new path for Vite 5 manifest.json

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -722,7 +722,10 @@ class Vite implements Htmlable
      */
     protected function manifestPath($buildDirectory)
     {
-        return public_path($buildDirectory.'/'.$this->manifestFilename);
+        $vitePath = public_path($buildDirectory.'/.vite/'.$this->manifestFilename);
+        $mainPath = public_path($buildDirectory.'/'.$this->manifestFilename);
+
+        return (is_file($vitePath) || ! is_file($mainPath)) ? $vitePath : $mainPath;
     }
 
     /**


### PR DESCRIPTION
In Vite v5 [manifest files are now generated in .vite directory by default](https://vitejs.dev/guide/migration.html#manifest-files-are-now-generated-in-vite-directory-by-default).

This PR is adding support for the new path and provides fallback for the old one.
It ensures that that the new expected path is returned when the manifest file is not found.