### PR TITLE
[slim-skeleton-11.x] Removes unused `?: new ArgvInput`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -24,7 +24,6 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -1162,7 +1161,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $kernel = $this->make(ConsoleKernelContract::class);
 
         $status = $kernel->handle(
-            $input ?: new ArgvInput,
+            $input,
             new ConsoleOutput
         );
 


### PR DESCRIPTION
This pull request removes unused `?: new ArgvInput` because the given `$input` to the method handleCommand can't actually be `null`.