### PR TITLE
[10.x] Tiny `Support\Collection` test fix - Unused data provider parameter

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2333,7 +2333,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testPluckDuplicateKeysExist($collection)
     {
-        $data = new collection([
+        $data = new $collection([
             ['brand' => 'Tesla', 'color' => 'red'],
             ['brand' => 'Pagani', 'color' => 'white'],
             ['brand' => 'Tesla', 'color' => 'black'],


### PR DESCRIPTION
This PR pushes a tiny fix for an unused data provider parameter I noticed while browsing the `Support\Collection` tests.