### PR TITLE
[10.x] `Collection::scope` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -768,7 +768,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the key's values.
      *
      * @param  string|int  $key
-     * @param  string|null $default
+     * @param  string|null  $default
      * @return static<array-key, mixed>
      */
     public function scope($key, $default = null)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -765,18 +765,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get the key's values.
-     *
-     * @param  string|int  $key
-     * @param  string|null  $default
-     * @return static<array-key, mixed>
-     */
-    public function scope($key, $default = null)
-    {
-        return new static(Arr::get($this->items, $key, $default));
-    }
-
-    /**
      * Run a map over each of the items.
      *
      * @template TMapValue
@@ -1083,6 +1071,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function reverse()
     {
         return new static(array_reverse($this->items, true));
+    }
+
+    /**
+     * Get the value of the given key as a new collection instance.
+     *
+     * @param  string|int  $key
+     * @param  string|null  $default
+     * @return static<array-key, mixed>
+     */
+    public function scope($key, $default = null)
+    {
+        return new static(Arr::get($this->items, $key, $default));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -765,6 +765,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the key's values.
+     *
+     * @param  string|int  $key
+     * @param  string|null $default
+     * @return static<array-key, mixed>
+     */
+    public function scope($key, $default = null)
+    {
+        return new static(Arr::get($this->items, $key, $default));
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @template TMapValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -776,7 +776,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the key's values.
+     * Get the value of the given key as a new collection instance.
      *
      * @template TScopeDefault
      *
@@ -788,7 +788,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         return new static(function () use ($key, $default) {
             foreach ($this as $itemKey => $itemValue) {
-                $value = data_get([$itemKey => $itemValue], $key, $marker = new stdClass());
+                $value = data_get([$itemKey => $itemValue], $key, $marker = new stdClass);
 
                 if ($value !== $marker) {
                     return $value;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -780,8 +780,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @template TScopeDefault
      *
-     * @param TKey $key
-     * @param TScopeDefault|(\Closure(): TScopeDefault)  $default
+     * @param  TKey  $key
+     * @param  TScopeDefault|(\Closure(): TScopeDefault)  $default
      * @return static<TKey, mixed>
      */
     public function scope($key, $default = null)

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -776,6 +776,30 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the key's values.
+     *
+     * @template TScopeDefault
+     *
+     * @param TKey $key
+     * @param TScopeDefault|(\Closure(): TScopeDefault)  $default
+     * @return static<TKey, mixed>
+     */
+    public function scope($key, $default = null)
+    {
+        return new static(function () use ($key, $default) {
+            foreach ($this as $itemKey => $itemValue) {
+                $value = data_get([$itemKey => $itemValue], $key, $marker = new stdClass());
+
+                if ($value !== $marker) {
+                    return $value;
+                }
+            }
+
+            return value($default);
+        });
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @template TMapValue

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -643,7 +643,6 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get an array with the key's values.
      *
-     * @param  string|array<array-key, string>  $value
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -641,7 +641,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get an array with the key's values.
+     * Get the value of the given key as a new collection instance.
      *
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection<array-key, mixed>

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -641,6 +641,18 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get an array with the key's values.
+     *
+     * @param  string|array<array-key, string>  $value
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection<array-key, mixed>
+     */
+    public function scope($key, $default = null)
+    {
+        return $this->toBase()->scope($key, $default);
+    }
+
+    /**
      * Zip the collection together with one or more arrays.
      *
      * @template TZipValue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2346,6 +2346,27 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testScope($collection)
+    {
+        $data = new $collection([1 => 'php', 2 => 'asp', 3 => 'java']);
+        $this->assertEquals(['php'], $data->scope(1)->all());
+        $this->assertEquals(['asp'], $data->scope(2)->all());
+
+        $data = new $collection(['user' => ['name' => 'taylor']]);
+        $this->assertEquals(['taylor'], $data->scope('user.name')->all());
+        $this->assertEquals(['dayle'], $data->scope('user.age', 'dayle')->all());
+
+        $data = new $collection(['products' => ['forge', 'vapour', 'spark']]);
+        $this->assertEquals(['forge', 'vapour', 'spark'], $data->scope('products')->all());
+        $this->assertEquals(['foo', 'bar'], $data->scope('missing', ['foo', 'bar'])->all());
+
+        $data = new $collection(['authors' => ['taylor' => ['products' => ['forge', 'vapour', 'spark']]]]);
+        $this->assertEquals(['forge', 'vapour', 'spark'], $data->scope('authors.taylor.products')->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testHas($collection)
     {
         $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);


### PR DESCRIPTION
## Description

This pull request introduces the `scope` method to Laravel's `Collection` classes. The `scope` method provides an easy way to `collect` associative data at a given key. It returns a new instance of the collection containing the value found at the specified key or the given default value.

This method is in contrast to the `pluck` method, where `pluck` is meant for pulling values from nested arrays of data, `scope` is meant for pulling values from associative arrays of data.

It's a `$collection->get()`, but supports dot-notation and returns the value as a new collection.

## Usage

**Accessing Nested Values**:

```php
$collection = new Collection(['user' => ['name' => 'Taylor']]);

$collection->scope('user')->all(); // Returns ['name' => 'Taylor']

$collection->scope('user.name')->all(); // Returns ['Taylor']

$collection->scope('user.title', 'Artisan')->all(); // Returns ['Artisan']
```

**Accessing Nested Arrays**:
```php
$collection = new Collection([
    'authors' => [
        'taylor' => [
            'products' => ['forge', 'vapour', 'spark']
        ],
        '...' => ['...'],
    ],
]);

$collection->scope('authors.taylor.products')->all(); // Returns ['forge', 'vapour', 'spark']
```

---

Let me know your thoughts, and if you'd also like me to push updates to the documentation (if you are interested in this PR).

Thanks for your time! No hard feelings on closure ❤️ 