### PR TITLE
[10.x] Allow to pass `Arrayable` or `Stringble` in rules `In` and `NotIn`

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use BackedEnum;
+use Illuminate\Contracts\Support\Arrayable;
 use UnitEnum;
 
 class In
@@ -24,12 +25,16 @@ class In
     /**
      * Create a new in rule instance.
      *
-     * @param  array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
      * @return void
      */
-    public function __construct(array $values)
+    public function __construct($values)
     {
-        $this->values = $values;
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->values = is_array($values) ? $values : func_get_args();
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use BackedEnum;
+use Illuminate\Contracts\Support\Arrayable;
 use UnitEnum;
 
 class NotIn
@@ -24,12 +25,16 @@ class NotIn
     /**
      * Create a new "not in" rule instance.
      *
-     * @param  array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
      * @return void
      */
-    public function __construct(array $values)
+    public function __construct($values)
     {
-        $this->values = $values;
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->values = is_array($values) ? $values : func_get_args();
     }
 
     /**

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -17,9 +17,21 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertSame('in:"Laravel","Framework","PHP"', (string) $rule);
 
+        $rule = new In(collect(['Taylor', 'Michael', 'Tim']));
+
+        $this->assertSame('in:"Taylor","Michael","Tim"', (string) $rule);
+
         $rule = new In(['Life, the Universe and Everything', 'this is a "quote"']);
 
         $this->assertSame('in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
+
+        $rule = Rule::in(collect([1, 2, 3, 4]));
+
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::in(collect([1, 2, 3, 4]));
+
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
         $rule = new In(["a,b\nc,d"]);
 
@@ -38,6 +50,10 @@ class ValidationInRuleTest extends TestCase
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::in('1', '2', '3', '4');
+
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
+
+        $rule = new In('1', '2', '3', '4');
 
         $this->assertSame('in:"1","2","3","4"', (string) $rule);
 

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Tests\Validation\fixtures\Values;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\NotIn;
 use PHPUnit\Framework\TestCase;
@@ -16,6 +17,18 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertSame('not_in:"Laravel","Framework","PHP"', (string) $rule);
 
+        $rule = new NotIn(collect(['Taylor', 'Michael', 'Tim']));
+
+        $this->assertSame('not_in:"Taylor","Michael","Tim"', (string) $rule);
+
+        $rule = Rule::notIn(collect([1, 2, 3, 4]));
+
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::notIn(collect([1, 2, 3, 4]));
+
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
         $rule = Rule::notIn([1, 2, 3, 4]);
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
@@ -24,7 +37,19 @@ class ValidationNotInRuleTest extends TestCase
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
+        $rule = Rule::notIn(new Values);
+
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
+        $rule = new NotIn(new Values);
+
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
         $rule = Rule::notIn('1', '2', '3', '4');
+
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
+
+        $rule = new NotIn('1', '2', '3', '4');
 
         $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 


### PR DESCRIPTION
This PR adds the ability to Allow to pass `Arrayable` or `Stringble` in rules `In` and `NotIn`


```php
request()->validate([
    'name' => ['required', 'string', 'min:6', In(collect(['Taylor', 'Michael', 'Tim']))],
    'password' => ['required', 'string', NotIn(collect(['12345', 'password']))],
]);
```