### PR TITLE
[10.x] Add Str::transliterate to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -89,6 +89,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Transliterate a string to its closest ASCII representation.
+     *
+     * @param  string|null  $unknown
+     * @param  bool|null  $strict
+     * @return static
+     */
+    public function transliterate($unknown = '?', $strict = false)
+    {
+        return new static(Str::transliterate($this->value, $unknown, $strict));
+    }
+
+    /**
      * Get the trailing name component of the path.
      *
      * @param  string  $suffix

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -89,18 +89,6 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Transliterate a string to its closest ASCII representation.
-     *
-     * @param  string|null  $unknown
-     * @param  bool|null  $strict
-     * @return static
-     */
-    public function transliterate($unknown = '?', $strict = false)
-    {
-        return new static(Str::transliterate($this->value, $unknown, $strict));
-    }
-
-    /**
      * Get the trailing name component of the path.
      *
      * @param  string  $suffix
@@ -807,6 +795,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function title()
     {
         return new static(Str::title($this->value));
+    }
+
+    /**
+     * Transliterate a string to its closest ASCII representation.
+     *
+     * @param  string|null  $unknown
+     * @param  bool|null  $strict
+     * @return static
+     */
+    public function transliterate($unknown = '?', $strict = false)
+    {
+        return new static(Str::transliterate($this->value, $unknown, $strict));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -527,6 +527,12 @@ class SupportStringableTest extends TestCase
         $this->assertSame('u', (string) $this->stringable('ü')->ascii());
     }
 
+    public function testTransliterate()
+    {
+        $this->assertSame('HHH', (string) $this->stringable('🎂🚧🏆')->transliterate('H'));
+        $this->assertSame('Hello', (string) $this->stringable('🎂')->transliterate('Hello'));
+    }
+
     public function testNewLine()
     {
         $this->assertSame('Laravel'.PHP_EOL, (string) $this->stringable('Laravel')->newLine());


### PR DESCRIPTION
I tried looking up the PR history, I'm not entirely sure what the sentiment is towards adding missing `Str` helpers to `Stringable`.

I went to use `Str::of($content)->transliterate()` today and it didn't work, which threw me off for a bit before I realised it was only available as `Str::transliterate()`.