### PR TITLE
[10.x] Implement feature to resolve route from path

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -163,6 +163,34 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Find the first route matching a given path.
+     *
+     * @param string $uri
+     * @return Route|null
+     */
+    public function getRouteFromPath(string $uri): ?Route
+    {
+        // Get all available routes.
+        $routes = $this->getRoutes();
+        // Create a fresh request from the given path.
+        $request = Request::create($uri);
+
+        // Find a route based on the fresh request instance.
+        $route = $this->matchAgainstRoutes($routes, $request);
+
+        // If the route is found, we return a clone so that any changes made to it does not affect any potential
+        // current request route.
+        if ($route instanceof Route) {
+            $clone = clone $route;
+            // Bind the created request so we can get parameters from the route.
+            $clone->bind($request);
+            return $clone;
+        }
+
+        return null;
+    }
+
+    /**
      * Get routes from the collection by method.
      *
      * @param  string|null  $method

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -184,6 +184,7 @@ class RouteCollection extends AbstractRouteCollection
             $clone = clone $route;
             // Bind the created request so we can get parameters from the route.
             $clone->bind($request);
+
             return $clone;
         }
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -165,7 +165,7 @@ class RouteCollection extends AbstractRouteCollection
     /**
      * Find the first route matching a given path.
      *
-     * @param string $uri
+     * @param  string  $uri
      * @return Route|null
      */
     public function getRouteFromPath(string $uri): ?Route


### PR DESCRIPTION
Based on #47800, this PR solves #47795. 

This PR adds a new method to the `Illuminate\Routing\RouteCollection` that allows you to resolve a (unknown) URI / URL path to a `Illuminate\Routing\Route` object if it exists in your routes. In comparison to the given suggestion (described in the mentioned issue), it will _not_ affect the current request. 