### PR TITLE
[10.x] Add check if the string is hex color

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -442,6 +442,17 @@ class Str
     }
 
     /**
+     * Determine if a given string is valid HEX color.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isHexColor($value)
+    {
+        return preg_match('/^#(?:[0-9a-fA-F]{3}){1,2}$/', $value) === 1;
+    }
+
+    /**
      * Determine if a given value is valid JSON.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -325,6 +325,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Determine if a given string is valid HEX color.
+     *
+     * @return bool
+     */
+    public function isHexColor()
+    {
+        return Str::isHexColor($this->value);
+    }
+
+    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1279,7 +1279,7 @@ trait ValidatesAttributes
      */
     public function validateHexColor($attribute, $value)
     {
-        return preg_match('/^#(?:[0-9a-fA-F]{3}){1,2}$/', $value) === 1;
+        return Str::isHexColor($value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -924,6 +924,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::slug(null));
     }
 
+    public function testIsHexColor()
+    {
+        $this->assertTrue(Str::isHexColor('#FFFFFF'));
+        $this->assertFalse(Str::isHexColor('#GGGGGGG'));
+    }
+
     public function testPadBoth()
     {
         $this->assertSame('__Alien___', Str::padBoth('Alien', 10, '_'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -33,6 +33,12 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('ù')->isAscii());
     }
 
+    public function testIsHexColor()
+    {
+        $this->assertTrue($this->stringable('#FFFFFF')->isHexColor());
+        $this->assertFalse($this->stringable('#GGGGGGG')->isHexColor());
+    }
+
     public function testIsUrl()
     {
         $this->assertTrue($this->stringable('https://laravel.com')->isUrl());


### PR DESCRIPTION
This PR adds a to check if the string is a hex color

```php
$isHexColor = Str::isHexColor('#FFFFFF');

// Or

$isHexColor = str('#FFFFFF')->isHexColor();
```