### PR TITLE
Add Alpha Channel support to Hex validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1279,7 +1279,7 @@ trait ValidatesAttributes
      */
     public function validateHexColor($attribute, $value)
     {
-        return preg_match('/^#(?:[0-9a-fA-F]{3}){1,2}$/', $value) === 1;
+        return preg_match('/^#(?:[0-9a-fA-F]{3}){1,2}(?:[0-9a-fA-F]{2})?$|^#(?:[0-9a-fA-F]{4}){1,2}$/', $value) === 1;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1936,6 +1936,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
         $v = new Validator($trans, ['color'=> '#FF000080'], ['color'=>'hex_color']);
         $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['color'=> '#FF000080'], ['color'=>'hex_color']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['color'=> '#00FF0080'], ['color'=>'hex_color']);
+        $this->assertTrue($v->passes());
         $v = new Validator($trans, ['color'=> '#GGG'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());
         $v = new Validator($trans, ['color'=> '#GGGG'], ['color'=>'hex_color']);
@@ -1943,6 +1947,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['color'=> '#GGGGGG'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());
         $v = new Validator($trans, ['color'=> '#GGGGGGG'], ['color'=>'hex_color']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['color'=> '#FFGG00FF'], ['color'=>'hex_color']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['color'=> '#00FF008X'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1928,11 +1928,19 @@ class ValidationValidatorTest extends TestCase
     public function testValidateHexColor()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['color'=> '#FFFFFF'], ['color'=>'hex_color']);
-        $this->assertTrue($v->passes());
         $v = new Validator($trans, ['color'=> '#FFF'], ['color'=>'hex_color']);
         $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['color'=> '#FFFF'], ['color'=>'hex_color']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['color'=> '#FFFFFF'], ['color'=>'hex_color']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['color'=> '#FF000080'], ['color'=>'hex_color']);
+        $this->assertTrue($v->passes());
         $v = new Validator($trans, ['color'=> '#GGG'], ['color'=>'hex_color']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['color'=> '#GGGG'], ['color'=>'hex_color']);
+        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['color'=> '#GGGGGG'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());
         $v = new Validator($trans, ['color'=> '#GGGGGGG'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
This PR adds support for Hex colors on the [Alpha](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color) channel to the[ Hex validation rule](https://github.com/laravel/framework/pull/49056), where it's currently unsupported:

#FF000080
#00FF0080
#0000FFFF
#FFA500FF 