### PR TITLE
[10.x] Fix `hex_color` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1279,7 +1279,7 @@ trait ValidatesAttributes
      */
     public function validateHexColor($attribute, $value)
     {
-        return preg_match('/^#(?:[0-9a-fA-F]{3}){1,2}(?:[0-9a-fA-F]{2})?$|^#(?:[0-9a-fA-F]{4}){1,2}$/', $value) === 1;
+        return preg_match('/^#(?:(?:[0-9a-f]{3}){1,2}|(?:[0-9a-f]{4}){1,2})$/i', $value) === 1;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1944,6 +1944,8 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v = new Validator($trans, ['color'=> '#GGGG'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['color'=> '#123AB'], ['color'=>'hex_color']);
+        $this->assertFalse($v->passes());
         $v = new Validator($trans, ['color'=> '#GGGGGG'], ['color'=>'hex_color']);
         $this->assertFalse($v->passes());
         $v = new Validator($trans, ['color'=> '#GGGGGGG'], ['color'=>'hex_color']);


### PR DESCRIPTION
Currently, the `hex_color` rule will pass for input that has 5 digits value, even though the valid value are only 3, 4, 6 and 8 digits, according to [developer.mozilla.org/en-US/docs/Web/CSS/hex-color](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color). This PR will fix that.