### PR TITLE
[10.x] Prevent passing null to base64_decode in Encrypter

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -207,7 +207,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     {
         // If the payload is not a string we can bail out early
         // to avoid triggering deprecation warnings.
-        if(!is_string($payload)) {
+        if (! is_string($payload)) {
             throw new DecryptException('The payload is invalid.');
         }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -205,6 +205,12 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function getJsonPayload($payload)
     {
+        // If the payload is not a string we can bail out early
+        // to avoid triggering deprecation warnings.
+        if(!is_string($payload)) {
+            throw new DecryptException('The payload is invalid.');
+        }
+
         $payload = json_decode(base64_decode($payload), true);
 
         // If the payload is not valid JSON or does not have the proper keys set we will

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -205,8 +205,6 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function getJsonPayload($payload)
     {
-        // If the payload is not a string we can bail out early
-        // to avoid triggering deprecation warnings.
         if (! is_string($payload)) {
             throw new DecryptException('The payload is invalid.');
         }


### PR DESCRIPTION
Since updating to PHP8.1 last year, our logs have been littered with deprecation warnings like this:

```
ErrorException: base64_decode(): Passing null to parameter #1 ($string) of type string is deprecated in /home/forge/my-laravel-site.com/vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php:208
```

This PR aims to solve this by instead throwing a `DecryptException` immediately if the `$payload` is not a string.

A `DecryptException` can be handled as the developer sees fit in their application `Handler`.