### PR TITLE
[11.x] Update universal date format to work with all installations of MS SQLServer

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -473,7 +473,7 @@ class SqlServerGrammar extends Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s.v';
+        return 'Ymd H:i:s.v';
     }
 
     /**


### PR DESCRIPTION
This is a very simple fix for Issue 

- #49074 

The date format `YYYY-MM-DD` (`Y-m-d`) despite being based on an ISO standard is actually country and language dependent.

The date format `YYYYMMDD` (`Ymd`) is guaranteed to be correct in all installations.

This pull request updates the default date format returned by `getDateFormat()`  in the SQLServer Grammar

## Overview

Laravel uses the [ISO standard](https://www.iso.org/iso-8601-date-and-time-format.html) international date format (`YYYY-MM-DD`)

>  'Y-m-d H:i:s.v';

https://github.com/laravel/framework/blob/3a46fa307c73c8371ea6c72129f7c23a2f52c7f3/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php#L506-L509

This is supposed to be standard and in most instances it is, however when using MSSQL SERVER it is not universal and is country and language dependent.

In SQL Server

> 2023-04-01 12:00:00

may be interpreted as the 4th of January or the 1st of April depending on your machine language and country settings.

This is discussed in several places online

- https://sqlblog.org/2009/10/16/bad-habits-to-kick-mis-handling-date-range-queries
- https://stackoverflow.com/questions/19565320/why-is-sql-server-misinterpreting-this-iso-8601-format-date

There seem to be 1 real alternative that is guarantied to always be interpreted correctly.

- Ymd H:i:s.v 

This format is accepted by SQL Server as an ISO standard format (https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16)

Changing the default format in the getDateFormat() method in the SQLServer Grammar solves this problem without side effects.




