### PR TITLE
[10.x] Allow currency formatting with control over precision

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -103,13 +103,18 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  ?string  $locale
+     * @param  bool  $withCents
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null)
+    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null, bool $withCents = true)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
+
+        if (!$withCents) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+        }
 
         return $formatter->formatCurrency($number, $in);
     }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -103,17 +103,17 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  ?string  $locale
-     * @param  bool  $withCents
+     * @param  ?int  $precision
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null, bool $withCents = true)
+    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null, ?int $precision = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
 
-        if (!$withCents) {
-            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+        if (isset($precision)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
 
         return $formatter->formatCurrency($number, $in);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -123,21 +123,16 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$5.32', Number::currency(5.325));
     }
 
-    public function testToCurrencyWithoutCents()
+    public function testToCurrencyWithPrecision()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('$0', Number::currency(0, withCents: false));
-        $this->assertSame('$1', Number::currency(1, withCents: false));
-        $this->assertSame('$10', Number::currency(10, withCents: false));
+        $this->assertSame('$0', Number::currency(0, precision: 0));
+        $this->assertSame('$2', Number::currency(1.50, precision: 0));
 
-        $this->assertSame('€0', Number::currency(0, 'EUR', withCents: false));
-        $this->assertSame('€1', Number::currency(1, 'EUR', withCents: false));
-        $this->assertSame('€10', Number::currency(10, 'EUR', withCents: false));
-
-        $this->assertSame('-$5', Number::currency(-5, withCents: false));
-        $this->assertSame('$5', Number::currency(5.00, withCents: false));
-        $this->assertSame('$5', Number::currency(5.325, withCents: false));
+        $this->assertSame('-$2', Number::currency(-1.75, precision: 0));
+        $this->assertSame('$5', Number::currency(5.00, precision: 0));
+        $this->assertSame('$5', Number::currency(5.325, precision: 0));
     }
 
     public function testToCurrencyWithDifferentLocale()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -123,6 +123,23 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$5.32', Number::currency(5.325));
     }
 
+    public function testToCurrencyWithoutCents()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('$0', Number::currency(0, withCents: false));
+        $this->assertSame('$1', Number::currency(1, withCents: false));
+        $this->assertSame('$10', Number::currency(10, withCents: false));
+
+        $this->assertSame('€0', Number::currency(0, 'EUR', withCents: false));
+        $this->assertSame('€1', Number::currency(1, 'EUR', withCents: false));
+        $this->assertSame('€10', Number::currency(10, 'EUR', withCents: false));
+
+        $this->assertSame('-$5', Number::currency(-5, withCents: false));
+        $this->assertSame('$5', Number::currency(5.00, withCents: false));
+        $this->assertSame('$5', Number::currency(5.325, withCents: false));
+    }
+
     public function testToCurrencyWithDifferentLocale()
     {
         $this->needsIntlExtension();


### PR DESCRIPTION
This may be a little specific to my use-cases, but I often find myself formatting whole amounts without cents. 

This exposes an optional `precision` argument (matching the `precision` argument on plain-old `Number::format()` as well.

I wasn't sure whether to move `$precision` ahead of `$locale` like the other methods in case it was breaking. But as it's brand new it may not be too bad?