### PR TITLE
[10.x] Allow setting the associative flag when getting json files decoded from storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -267,7 +267,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  int  $flags
-     * @param  bool $associative
+     * @param  bool  $associative
      * @return array|null
      */
     public function json($path, $flags = 0, $associative = true)

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -267,13 +267,14 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  int  $flags
+     * @param  bool $associative
      * @return array|null
      */
-    public function json($path, $flags = 0)
+    public function json($path, $flags = 0, $associative = true)
     {
         $content = $this->get($path);
 
-        return is_null($content) ? null : json_decode($content, true, 512, $flags);
+        return is_null($content) ? null : json_decode($content, $associative, 512, $flags);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -191,11 +191,14 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $filesystemAdapter->json('file.json'));
     }
 
-    public function testJsonReturnsDecodedUnassociativeJsonData()
+    public function testJsonReturnsDecodedObjectJsonData()
     {
         $this->filesystem->write('file.json', '[{"foo": "bar"}, {"bar": "foo"}]');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
-        $this->assertSame([['foo' => 'bar'], ['bar' => 'foo']], $filesystemAdapter->json('file.json'));
+        $this->assertEquals(
+            [(object) ['foo' => 'bar'], (object) ['bar' => 'foo']],
+            $filesystemAdapter->json('file.json', associative: false)
+        );
     }
 
     public function testJsonReturnsNullIfJsonDataIsInvalid()

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -191,6 +191,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $filesystemAdapter->json('file.json'));
     }
 
+    public function testJsonReturnsDecodedUnassociativeJsonData()
+    {
+        $this->filesystem->write('file.json', '[{"foo": "bar"}, {"bar": "foo"}]');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $this->assertSame([['foo' => 'bar'], ['bar' => 'foo']], $filesystemAdapter->json('file.json'));
+    }
+
     public function testJsonReturnsNullIfJsonDataIsInvalid()
     {
         $this->filesystem->write('file.json', '{"foo":');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When getting json files with the Storage facade from a disk you didn't have an option to change the associative flag on the json_decode method.

It may be a certain use-case for whoever prefers fetch objects instead of arrays, but this small change allows to use it directly through the json method.

So instead of 

```
$json = Storage::disk('any')->get('path/to/file.json');

// associative flag is false by default on json decode
json_decode($json)
```

we can do 

```
$json = Storage::disk('any')->json('path/to/file.json', associative: false);
```
