### PR TITLE
[10.x] Added File Validation `extensions`

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -52,6 +52,7 @@ return [
     'ends_with' => 'The :attribute field must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
     'exists' => 'The selected :attribute is invalid.',
+    'extensions' => 'The :attribute field must be a file with extension: :values.',
     'file' => 'The :attribute field must be a file.',
     'filled' => 'The :attribute field must have a value.',
     'gt' => [

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -52,7 +52,7 @@ return [
     'ends_with' => 'The :attribute field must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
     'exists' => 'The selected :attribute is invalid.',
-    'extensions' => 'The :attribute field must be a file with extension: :values.',
+    'extensions' => 'The :attribute field must have one of the following extensions: :values.',
     'file' => 'The :attribute field must be a file.',
     'filled' => 'The :attribute field must have a value.',
     'gt' => [

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -358,6 +358,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the extensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceExtensions($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the present_if rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -133,6 +133,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the extensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceExtensions($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the min rule.
      *
      * @param  string  $message
@@ -353,20 +367,6 @@ trait ReplacesAttributes
      * @return string
      */
     protected function replaceMimes($message, $attribute, $rule, $parameters)
-    {
-        return str_replace(':values', implode(', ', $parameters), $message);
-    }
-
-    /**
-     * Replace all place-holders for the extensions rule.
-     *
-     * @param  string  $message
-     * @param  string  $attribute
-     * @param  string  $rule
-     * @param  array<int,string>  $parameters
-     * @return string
-     */
-    protected function replaceExtensions($message, $attribute, $rule, $parameters)
     {
         return str_replace(':values', implode(', ', $parameters), $message);
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1507,6 +1507,27 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the extension of a file upload attribute is in a set of defined extensions.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateExtensions($attribute, $value, $parameters)
+    {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
+        return in_array(strtolower($value->getClientOriginalExtension()), $parameters);
+    }
+
+    /**
      * Check if PHP uploads are explicitly allowed.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1077,6 +1077,27 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the extension of a file upload attribute is in a set of defined extensions.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateExtensions($attribute, $value, $parameters)
+    {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
+        return in_array(strtolower($value->getClientOriginalExtension()), $parameters);
+    }
+
+    /**
      * Validate the given value is a valid file.
      *
      * @param  string  $attribute
@@ -1504,27 +1525,6 @@ trait ValidatesAttributes
         return $value->getPath() !== '' &&
                 (in_array($value->getMimeType(), $parameters) ||
                  in_array(explode('/', $value->getMimeType())[0].'/*', $parameters));
-    }
-
-    /**
-     * Validate the extension of a file upload attribute is in a set of defined extensions.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
-     * @return bool
-     */
-    public function validateExtensions($attribute, $value, $parameters)
-    {
-        if (! $this->isValidFileInstance($value)) {
-            return false;
-        }
-
-        if ($this->shouldBlockPhpUpload($value, $parameters)) {
-            return false;
-        }
-
-        return in_array(strtolower($value->getClientOriginalExtension()), $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -136,15 +136,18 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
         return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
     }
 
+
     /**
      * Limit the uploaded file to the given file extensions.
      *
      * @param  string|array<int, string>  $extensions
-     * @return static
+     * @return $this
      */
-    public static function extensions($extensions)
+    public function extensions($extensions)
     {
-        return tap(new static(), fn ($file) => $file->allowedExtensions = (array) $extensions);
+        $this->allowedExtensions = (array) $extensions;
+
+        return $this;
     }
 
     /**
@@ -274,7 +277,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
 
         $rules = array_merge($rules, $this->buildMimetypes());
 
-        if ($this->allowedExtensions) {
+        if (! empty($this->allowedExtensions)) {
             $rules[] = 'extensions:'.implode(',', array_map('strtolower', $this->allowedExtensions));
         }
 

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -25,7 +25,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     protected $allowedMimetypes = [];
 
     /**
-     * The extensions types that the given file should match.
+     * The extensions that the given file should match.
      *
      * @var array
      */

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -25,6 +25,13 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     protected $allowedMimetypes = [];
 
     /**
+     * The extensions types that the given file should match.
+     *
+     * @var array
+     */
+    protected $allowedExtensions = [];
+
+    /**
      * The minimum size in kilobytes that the file can be.
      *
      * @var null|int
@@ -127,6 +134,17 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     public static function types($mimetypes)
     {
         return tap(new static(), fn ($file) => $file->allowedMimetypes = (array) $mimetypes);
+    }
+
+    /**
+     * Limit the uploaded file to the given file extensions.
+     *
+     * @param  string|array<int, string>  $extensions
+     * @return static
+     */
+    public static function extensions($extensions)
+    {
+        return tap(new static(), fn ($file) => $file->allowedExtensions = (array) $extensions);
     }
 
     /**
@@ -255,6 +273,10 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
         $rules = ['file'];
 
         $rules = array_merge($rules, $this->buildMimetypes());
+
+        if ($this->allowedExtensions) {
+            $rules[] = 'extensions:'.implode(',', array_map('strtolower', $this->allowedExtensions));
+        }
 
         $rules[] = match (true) {
             is_null($this->minimumFileSize) && is_null($this->maximumFileSize) => null,

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -187,12 +187,12 @@ class Validator implements ValidatorContract
     protected $fileRules = [
         'Between',
         'Dimensions',
+        'Extensions',
         'File',
         'Image',
         'Max',
         'Mimes',
         'Mimetypes',
-        'Extensions',
         'Min',
         'Size',
     ];

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -192,6 +192,7 @@ class Validator implements ValidatorContract
         'Max',
         'Mimes',
         'Mimetypes',
+        'Extensions',
         'Min',
         'Size',
     ];

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -134,6 +134,34 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testSingleExtension()
+    {
+        $this->fails(
+            File::extensions('png'),
+            UploadedFile::fake()->createWithContent('foo', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->passes(
+            File::extensions('png'),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testMultipleExtensions()
+    {
+        $this->fails(
+            File::extensions(['png', 'jpeg', 'jpg']),
+            UploadedFile::fake()->createWithContent('foo', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->passes(
+            File::extensions(['png', 'jpeg', 'jpg']),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
     public function testImage()
     {
         $this->fails(

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -137,25 +137,25 @@ class ValidationFileRuleTest extends TestCase
     public function testSingleExtension()
     {
         $this->fails(
-            File::extensions('png'),
+            File::default()->extensions('png'),
             UploadedFile::fake()->createWithContent('foo', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.extensions']
         );
 
         $this->fails(
-            File::extensions('png'),
+            File::default()->extensions('png'),
             UploadedFile::fake()->createWithContent('foo.jpg', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.extensions']
         );
 
         $this->fails(
-            File::extensions('jpeg'),
+            File::default()->extensions('jpeg'),
             UploadedFile::fake()->createWithContent('foo.jpg', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.extensions']
         );
 
         $this->passes(
-            File::extensions('png'),
+            File::default()->extensions('png'),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
         );
     }
@@ -163,19 +163,19 @@ class ValidationFileRuleTest extends TestCase
     public function testMultipleExtensions()
     {
         $this->fails(
-            File::extensions(['png', 'jpeg', 'jpg']),
+            File::default()->extensions(['png', 'jpeg', 'jpg']),
             UploadedFile::fake()->createWithContent('foo', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.extensions']
         );
 
         $this->fails(
-            File::extensions(['png', 'jpeg']),
+            File::default()->extensions(['png', 'jpeg']),
             UploadedFile::fake()->createWithContent('foo.jpg', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.extensions']
         );
 
         $this->passes(
-            File::extensions(['png', 'jpeg', 'jpg']),
+            File::default()->extensions(['png', 'jpeg', 'jpg']),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
         );
     }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -142,6 +142,18 @@ class ValidationFileRuleTest extends TestCase
             ['validation.extensions']
         );
 
+        $this->fails(
+            File::extensions('png'),
+            UploadedFile::fake()->createWithContent('foo.jpg', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->fails(
+            File::extensions('jpeg'),
+            UploadedFile::fake()->createWithContent('foo.jpg', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
         $this->passes(
             File::extensions('png'),
             UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
@@ -153,6 +165,12 @@ class ValidationFileRuleTest extends TestCase
         $this->fails(
             File::extensions(['png', 'jpeg', 'jpg']),
             UploadedFile::fake()->createWithContent('foo', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.extensions']
+        );
+
+        $this->fails(
+            File::extensions(['png', 'jpeg']),
+            UploadedFile::fake()->createWithContent('foo.jpg', file_get_contents(__DIR__.'/fixtures/image.png')),
             ['validation.extensions']
         );
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4697,6 +4697,38 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateExtension()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $uploadedFile = [__FILE__, '', null, null, true];
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('pdf');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:pdf']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpg']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg,jpg']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'extensions:jpeg']);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpg|extensions:jpg']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateMimeEnforcesPhpCheck()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Currently Laravel has the `mimes` validator that validates a file by both its extension and its mimetype. The issue is that any file with a correct mimetype will be valid, regardless of its extension, and right now it is not possible to force the file to also have a valid extension (or just an extension).

For example, for this validation rule:

```
['file', 'mimes:jpg,jpeg,png']
```

The validator currently allows to upload a valid image regardless of its extension, for example a valid image with name `image.txt` would be accepted by the validator, or even an image without extension.

https://laravel.com/docs/10.x/validation#basic-usage-of-mime-rule

> Even though you only need to specify the extensions, this rule actually validates the MIME type of the file by reading the file's contents and guessing its MIME type.

This PR adds an additional validator `extensions` that explicitly validates the file extension, and that can be combined with `mimes` or any other file related validator, for example:

```
['file', 'mimes:jpg,jpeg,png', 'extensions:jpg,png']
```