### PR TITLE
[10.x] Add time unit conversion helpers

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -168,6 +168,100 @@ class Number
     }
 
     /**
+     * Convert the given time units to microseconds.
+     *
+     * @param  int|float  $milliseconds
+     * @param  int|float  $seconds
+     * @param  int|float  $minutes
+     * @param  int|float  $hours
+     * @param  int|float  $days
+     * @param  int|float  $weeks
+     * @param  int|float  $years
+     * @return float|int
+     */
+    public static function microseconds(
+        int|float $milliseconds = 0,
+        int|float $seconds = 0,
+        int|float $minutes = 0,
+        int|float $hours = 0,
+        int|float $days = 0,
+        int|float $weeks = 0,
+        int|float $years = 0
+    ) {
+        $milliseconds += static::milliseconds($seconds, $minutes, $hours, $days, $weeks, $years);
+
+        return $milliseconds * 1000;
+    }
+
+    /**
+     * Convert the given time units to milliseconds.
+     *
+     * @param  int|float  $seconds
+     * @param  int|float  $minutes
+     * @param  int|float  $hours
+     * @param  int|float  $days
+     * @param  int|float  $weeks
+     * @param  int|float  $years
+     * @return float|int
+     */
+    public static function milliseconds(
+        int|float $seconds = 0,
+        int|float $minutes = 0,
+        int|float $hours = 0,
+        int|float $days = 0,
+        int|float $weeks = 0,
+        int|float $years = 0
+    ) {
+        $seconds += static::seconds($minutes, $hours, $days, $weeks, $years);
+
+        return $seconds * 1000;
+    }
+
+    /**
+     * Convert the given time units to seconds.
+     *
+     * @param  int|float  $minutes
+     * @param  int|float  $hours
+     * @param  int|float  $days
+     * @param  int|float  $weeks
+     * @param  int|float  $years
+     * @return float|int
+     */
+    public static function seconds(
+        int|float $minutes = 0,
+        int|float $hours = 0,
+        int|float $days = 0,
+        int|float $weeks = 0,
+        int|float $years = 0
+    ) {
+        $minutes += static::minutes($hours, $days, $weeks, $years);
+
+        return $minutes * 60;
+    }
+
+    /**
+     * Convert the given time units to minutes.
+     *
+     * @param  int|float  $hours
+     * @param  int|float  $days
+     * @param  int|float  $weeks
+     * @param  int|float  $years
+     * @return float|int
+     */
+    public static function minutes(
+        int|float $hours = 0,
+        int|float $days = 0,
+        int|float $weeks = 0,
+        int|float $years = 0
+    ) {
+        $days += $years * 365;
+        $days += $weeks * 7;
+        $hours += $days * 24;
+
+        return $hours * 60;
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -208,6 +208,52 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
     }
 
+    public function testMicroseconds()
+    {
+        $this->assertSame(0, Number::microseconds());
+        $this->assertSame(1000, Number::microseconds(milliseconds: 1));
+        $this->assertSame(1000000, Number::microseconds(seconds: 1));
+        $this->assertSame(60000000, Number::microseconds(minutes: 1));
+        $this->assertSame(3600000000, Number::microseconds(hours: 1));
+        $this->assertSame(86400000000, Number::microseconds(days: 1));
+        $this->assertSame(604800000000, Number::microseconds(weeks: 1));
+        $this->assertSame(31536000000000, Number::microseconds(years: 1));
+        $this->assertSame(32230861001000, Number::microseconds(milliseconds: 1, seconds: 1, minutes: 1, hours: 1, days: 1, weeks: 1, years: 1));
+    }
+
+    public function testMilliseconds()
+    {
+        $this->assertSame(0, Number::milliseconds());
+        $this->assertSame(1000, Number::milliseconds(seconds: 1));
+        $this->assertSame(60000, Number::milliseconds(minutes: 1));
+        $this->assertSame(3600000, Number::milliseconds(hours: 1));
+        $this->assertSame(86400000, Number::milliseconds(days: 1));
+        $this->assertSame(604800000, Number::milliseconds(weeks: 1));
+        $this->assertSame(31536000000, Number::milliseconds(years: 1));
+        $this->assertSame(32230861000, Number::milliseconds(seconds: 1, minutes: 1, hours: 1, days: 1, weeks: 1, years: 1));
+    }
+
+    public function testSeconds()
+    {
+        $this->assertSame(0, Number::seconds());
+        $this->assertSame(60, Number::seconds(minutes: 1));
+        $this->assertSame(3600, Number::seconds(hours: 1));
+        $this->assertSame(86400, Number::seconds(days: 1));
+        $this->assertSame(604800, Number::seconds(weeks: 1));
+        $this->assertSame(31536000, Number::seconds(years: 1));
+        $this->assertSame(32230860, Number::seconds(minutes: 1, hours: 1, days: 1, weeks: 1, years: 1));
+    }
+
+    public function testMinutes()
+    {
+        $this->assertSame(0, Number::minutes());
+        $this->assertSame(60, Number::minutes(hours: 1));
+        $this->assertSame(1440, Number::minutes(days: 1));
+        $this->assertSame(10080, Number::minutes(weeks: 1));
+        $this->assertSame(525600, Number::minutes(years: 1));
+        $this->assertSame(537180, Number::minutes(hours: 1, days: 1, weeks: 1, years: 1));
+    }
+
     protected function needsIntlExtension()
     {
         if (! extension_loaded('intl')) {


### PR DESCRIPTION
There are many functions in PHP and Laravel that expect microseconds/seconds/minutes as a parameter, whenever I use these functions I have to multiply higher units to get the value in seconds etc.

This PR adds helper functions that will convert higher units to lower units. For example `Number::minutes(hours: 1)` will return `60`. This will make the code more readable and easier to understand.

Before:
```php
Cookie::queue('name', 'value', 60 * 24 * 365);
``` 

After:
```php
Cookie::queue('name', 'value', Number::minutes(years: 1));
```
