### PR TITLE
[10.x] Add @throws in doc-blocks

### DIFF
--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -172,6 +172,8 @@ class FakeProcessResult implements ProcessResultContract
      *
      * @param  callable|null  $callback
      * @return $this
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessFailedException
      */
     public function throw(callable $callback = null)
     {
@@ -194,6 +196,8 @@ class FakeProcessResult implements ProcessResultContract
      * @param  bool  $condition
      * @param  callable|null  $callback
      * @return $this
+     *
+     * @throws \Throwable
      */
     public function throwIf(bool $condition, callable $callback = null)
     {

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -105,6 +105,8 @@ class InvokedProcess implements InvokedProcessContract
      *
      * @param  callable|null  $output
      * @return \Illuminate\Process\ProcessResult
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
      */
     public function wait(callable $output = null)
     {

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -237,6 +237,9 @@ class PendingProcess
      * @param  array<array-key, string>|string|null  $command
      * @param  callable|null  $output
      * @return \Illuminate\Contracts\Process\ProcessResult
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessTimedOutException
+     * @throws \RuntimeException
      */
     public function run(array|string $command = null, callable $output = null)
     {

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -113,6 +113,8 @@ class ProcessResult implements ProcessResultContract
      *
      * @param  callable|null  $callback
      * @return $this
+     *
+     * @throws \Illuminate\Process\Exceptions\ProcessFailedException
      */
     public function throw(callable $callback = null)
     {
@@ -135,6 +137,8 @@ class ProcessResult implements ProcessResultContract
      * @param  bool  $condition
      * @param  callable|null  $callback
      * @return $this
+     *
+     * @throws \Throwable
      */
     public function throwIf(bool $condition, callable $callback = null)
     {


### PR DESCRIPTION
These methods throw exceptions but do not have any `@throws` in their doc-blocks.