### PR TITLE
[10.x] Only stage committed transactions

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -47,7 +47,7 @@ trait ManagesTransactions
                     $this->getPdo()->commit();
                 }
 
-                $this->transactionsManager?->stageTransactions($this->getName());
+                $this->transactionsManager?->stageTransactions($this->getName(), $this->transactions);
 
                 $this->transactions = max(0, $this->transactions - 1);
 
@@ -196,7 +196,7 @@ trait ManagesTransactions
             $this->getPdo()->commit();
         }
 
-        $this->transactionsManager?->stageTransactions($this->getName());
+        $this->transactionsManager?->stageTransactions($this->getName(), $this->transactions);
 
         $this->transactions = max(0, $this->transactions - 1);
 

--- a/src/Illuminate/Database/DatabaseTransactionRecord.php
+++ b/src/Illuminate/Database/DatabaseTransactionRecord.php
@@ -19,6 +19,13 @@ class DatabaseTransactionRecord
     public $level;
 
     /**
+     * The parent instance of this transaction.
+     *
+     * @var \Illuminate\Database\DatabaseTransactionRecord
+     */
+    public $parent;
+
+    /**
      * The callbacks that should be executed after committing.
      *
      * @var array
@@ -30,12 +37,14 @@ class DatabaseTransactionRecord
      *
      * @param  string  $connection
      * @param  int  $level
+     * @param  \Illuminate\Database\DatabaseTransactionRecord|null  $parent
      * @return void
      */
-    public function __construct($connection, $level)
+    public function __construct($connection, $level, ?DatabaseTransactionRecord $parent = null)
     {
         $this->connection = $connection;
         $this->level = $level;
+        $this->parent = $parent;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -170,7 +170,9 @@ class DatabaseTransactionsManager
                                $committed->parent === $transaction
         );
 
-
+        // There may be multiple deeply nested transactions that have already committed that we
+        // also need to remove. We will recurse down the children of all removed transaction
+        // instances until there are no more deeply nested child transactions for removal.
         $removedTransactions->each(
             fn ($transaction) => $this->removeCommittedTransactionsThatAreChildrenOf($transaction)
         );

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -136,6 +136,7 @@ class DatabaseTransactionsManager
     protected function removeCommittedTransactionsThatAreChildrenOf(DatabaseTransactionRecord $transaction)
     {
         $this->committedTransactions = $this->committedTransactions->reject(fn ($committed) =>
+            $committed->connection == $transaction->connection &&
             $committed->parent === $transaction
         );
     }

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -70,7 +70,7 @@ class DatabaseTransactionsManager
                                  $transaction->level >= $levelBeingCommitted
         );
 
-        $this->currentTransaction = $this->currentTransaction->parent;
+        $this->currentTransaction = $this->currentTransaction?->parent;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -165,10 +165,15 @@ class DatabaseTransactionsManager
      */
     protected function removeCommittedTransactionsThatAreChildrenOf(DatabaseTransactionRecord $transaction)
     {
-        $this->committedTransactions = $this->committedTransactions->reject(
+        [$removedTransactions, $this->committedTransactions] = $this->committedTransactions->partition(
             fn ($committed) => $committed->connection == $transaction->connection &&
                                $committed->parent === $transaction
-        )->values();
+        );
+
+
+        $removedTransactions->each(
+            fn ($transaction) => $this->removeCommittedTransactionsThatAreChildrenOf($transaction)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -92,19 +92,21 @@ class DatabaseTransactionsManager
     }
 
     /**
-     * Move all the pending transactions to a committed state.
+     * Move relevant pending transactions to a committed state.
      *
      * @param  string  $connection
      * @return void
      */
-    public function stageTransactions($connection)
+    public function stageTransactions($connection, $level)
     {
         $this->committedTransactions = $this->committedTransactions->merge(
-            $this->pendingTransactions->filter(fn ($transaction) => $transaction->connection === $connection)
+            $this->pendingTransactions->filter(
+                fn ($transaction) => $transaction->connection === $connection && $transaction->level >= $level
+            )
         );
 
         $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection === $connection
+            fn ($transaction) => $transaction->connection === $connection && $transaction->level >= $level
         );
     }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -130,7 +130,10 @@ class DatabaseTransactionsManager
                     $this->removeCommittedTransactionsThatAreChildrenOf($this->currentTransaction[$connection]);
 
                     $this->currentTransaction[$connection] = $this->currentTransaction[$connection]->parent;
-                } while (isset($this->currentTransaction[$connection]) && $this->currentTransaction[$connection]->level > $newTransactionLevel);
+                } while (
+                    isset($this->currentTransaction[$connection]) &&
+                    $this->currentTransaction[$connection]->level > $newTransactionLevel
+                );
             }
         }
     }
@@ -162,9 +165,9 @@ class DatabaseTransactionsManager
      */
     protected function removeCommittedTransactionsThatAreChildrenOf(DatabaseTransactionRecord $transaction)
     {
-        $this->committedTransactions = $this->committedTransactions->reject(fn ($committed) =>
-            $committed->connection == $transaction->connection &&
-            $committed->parent === $transaction
+        $this->committedTransactions = $this->committedTransactions->reject(
+            fn ($committed) => $committed->connection == $transaction->connection &&
+                               $committed->parent === $transaction
         )->values();
     }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -118,8 +118,13 @@ class DatabaseTransactionsManager
     public function rollback($connection, $newTransactionLevel)
     {
         if ($newTransactionLevel === 0) {
-            $this->pendingTransactions = new Collection;
-            $this->committedTransactions = new Collection;
+            $this->pendingTransactions = $this->pendingTransactions->reject(
+                fn ($transaction) => $transaction->connection == $connection
+            );
+
+            $this->committedTransactions = $this->committedTransactions->reject(
+                fn ($transaction) => $transaction->connection == $connection
+            );
 
             $this->currentTransaction[$connection] = null;
         } else {

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -54,10 +54,15 @@ class DatabaseTransactionsManager
      */
     public function rollback($connection, $newTransactionLevel)
     {
-        $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection == $connection &&
-                                 $transaction->level > $newTransactionLevel
-        )->values();
+        if ($newTransactionLevel === 0) {
+            $this->pendingTransactions = new Collection;
+            $this->committedTransactions = new Collection;
+        } else {
+            $this->pendingTransactions = $this->pendingTransactions->reject(
+                fn ($transaction) => $transaction->connection == $connection &&
+                                     $transaction->level > $newTransactionLevel
+            )->values();
+        }
     }
 
     /**

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -64,7 +64,7 @@ class DatabaseTransactionsTest extends TestCase
     {
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default');
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
         $transactionManager->shouldReceive('commit')->once()->with('default');
 
         $this->connection()->setTransactionManager($transactionManager);
@@ -84,7 +84,7 @@ class DatabaseTransactionsTest extends TestCase
     {
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default');
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
         $transactionManager->shouldReceive('commit')->once()->with('default');
 
         $this->connection()->setTransactionManager($transactionManager);
@@ -105,7 +105,8 @@ class DatabaseTransactionsTest extends TestCase
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
         $transactionManager->shouldReceive('begin')->once()->with('default', 2);
-        $transactionManager->shouldReceive('stageTransactions')->twice()->with('default');
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 2);
         $transactionManager->shouldReceive('commit')->once()->with('default');
 
         $this->connection()->setTransactionManager($transactionManager);
@@ -133,8 +134,9 @@ class DatabaseTransactionsTest extends TestCase
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
         $transactionManager->shouldReceive('begin')->once()->with('second_connection', 1);
         $transactionManager->shouldReceive('begin')->once()->with('second_connection', 2);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default');
-        $transactionManager->shouldReceive('stageTransactions')->twice()->with('second_connection');
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('second_connection', 1);
+        $transactionManager->shouldReceive('stageTransactions')->once()->with('second_connection', 2);
         $transactionManager->shouldReceive('commit')->once()->with('default');
         $transactionManager->shouldReceive('commit')->once()->with('second_connection');
 

--- a/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
+++ b/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
@@ -42,7 +42,7 @@ class DatabaseTransactionsManagerTest extends TestCase
 
         $this->assertFalse($testObject->ran);
 
-        $manager->stageTransactions('foo');
+        $manager->stageTransactions('foo', 1);
         $manager->commit('foo');
         $this->assertTrue($testObject->ran);
         $this->assertEquals(1, $testObject->runs);

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -171,7 +171,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
         $this->assertFalse(ShouldDispatchAfterCommitTestEvent::$ran);
     }
 
-public function testItHandlesNestedTransactionsWhereTheSecondOneFails()
+    public function testItHandlesNestedTransactionsWhereTheSecondOneFails()
     {
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
         Event::listen(AnotherShouldDispatchAfterCommitTestEvent::class, AnotherShouldDispatchAfterCommitListener::class);
@@ -199,19 +199,19 @@ public function testItHandlesNestedTransactionsWhereTheSecondOneFails()
     {
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
 
-            DB::transaction(function () {
-                try {
+        DB::transaction(function () {
+            try {
+                DB::transaction(function () {
                     DB::transaction(function () {
-                        DB::transaction(function () {
-                            Event::dispatch(new ShouldDispatchAfterCommitTestEvent());
-                        });
-
-                        throw new \Exception;
+                        Event::dispatch(new ShouldDispatchAfterCommitTestEvent());
                     });
-                } catch (\Exception $e) {
-                    //
-                }
-            });
+
+                    throw new \Exception;
+                });
+            } catch (\Exception $e) {
+                //
+            }
+        });
 
         $this->assertFalse(ShouldDispatchAfterCommitTestEvent::$ran);
     }

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -216,7 +216,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
         $this->assertFalse(ShouldDispatchAfterCommitTestEvent::$ran);
     }
 
-    public function testComplexTransactionCommittingAndFailures()
+    public function testItHandlesFailuresWithTransactionsTwoLevelsHigher()
     {
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
         Event::listen(AnotherShouldDispatchAfterCommitTestEvent::class, AnotherShouldDispatchAfterCommitListener::class);

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -195,7 +195,7 @@ public function testItHandlesNestedTransactionsWhereTheSecondOneFails()
         $this->assertFalse(AnotherShouldDispatchAfterCommitTestEvent::$ran);
     }
 
-    public function testItHandlesDeeplyNestedTransactions()
+    public function testChildCallbacksShouldNotBeDispatchedIfTheirParentFails()
     {
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
 

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -130,6 +130,21 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
         $this->assertTrue(ShouldDispatchAfterCommitTestEvent::$ran);
         $this->assertTrue(AnotherShouldDispatchAfterCommitTestEvent::$ran);
     }
+
+    public function testItDoesNotDispatchAfterCommitEventsImmediatelyIfASiblingTransactionIsCommittedFirst()
+    {
+        Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
+
+        DB::transaction(function () {
+            DB::transaction(function () {});
+
+            Event::dispatch(new ShouldDispatchAfterCommitTestEvent);
+
+            $this->assertFalse(ShouldDispatchAfterCommitTestEvent::$ran);
+        });
+
+        $this->assertTrue(ShouldDispatchAfterCommitTestEvent::$ran);
+    }
 }
 
 class TransactionUnawareTestEvent

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -136,7 +136,8 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
 
         DB::transaction(function () {
-            DB::transaction(function () {});
+            DB::transaction(function () {
+            });
 
             Event::dispatch(new ShouldDispatchAfterCommitTestEvent);
 

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -216,7 +216,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
         $this->assertFalse(ShouldDispatchAfterCommitTestEvent::$ran);
     }
 
-    public function testItHandlesNestedTransactionsWhereTheSecondOneFails2()
+    public function testComplexTransactionCommittingAndFailures()
     {
         Event::listen(ShouldDispatchAfterCommitTestEvent::class, ShouldDispatchAfterCommitListener::class);
         Event::listen(AnotherShouldDispatchAfterCommitTestEvent::class, AnotherShouldDispatchAfterCommitListener::class);


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/49057.

Updates the TransactionManager's stageTransactions method to accept a $level parameter, allowing it to only stage the transactions that will actually be committed. The previous implementation staged all existing transactions, which caused the manager's pendingTransactions and committedTransactions properties to be incorrect, leading to unexpected behaviour after a child transaction was committed but before the parent transaction had been committed.


