### PR TITLE
Adds a shortForm parameter to forHumans method of Number helper to output 1 M instead of 1 million

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -141,7 +141,7 @@ class Number
      * @param  int|null  $maxPrecision
      * @return string
      */
-    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, $shortForm = false)
     {
         $units = [
             3 => 'thousand',
@@ -150,6 +150,16 @@ class Number
             12 => 'trillion',
             15 => 'quadrillion',
         ];
+
+        if ($shortForm) {
+            $units = [
+                3 => 'K',
+                6 => 'M',
+                9 => 'B',
+                12 => 'T',
+                15 => 'Q',
+            ];
+        }
 
         switch (true) {
             case $number === 0:


### PR DESCRIPTION
Adds a optional parameter to the `forHumans` method of `Illuminate\Support\Number` class. When this parameter 
Currently it formats the bug number as 1 thousand, 1 million , 1 Billion . This PR adds a optional parameter `shortForm`, when set to true, this method will format the number as 1 M, 1 B , 1 T and so on. 
This does not break current implementation because , current value is provided as default. 😊