### PR TITLE
request.stub update. So, PHP Storm will not show any warnings!

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -2,6 +2,7 @@
 
 namespace {{ namespace }};
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class {{ class }} extends FormRequest
@@ -17,7 +18,7 @@ class {{ class }} extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array|string>
      */
     public function rules(): array
     {


### PR DESCRIPTION
The old annotation causes PHP storm to show warnings. With this update, it won't show any warnings anymore.
