### PR TITLE
[10.x] Add `progress` option to `PendingBatch`

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -241,6 +241,14 @@ class Batch implements Arrayable, JsonSerializable
     {
         $counts = $this->decrementPendingJobs($jobId);
 
+        if ($this->hasProgressCallbacks()) {
+            $batch = $this->fresh();
+
+            collect($this->options['progress'])->each(function ($handler) use ($batch) {
+                $this->invokeHandlerCallback($handler, $batch);
+            });
+        }
+
         if ($counts->pendingJobs === 0) {
             $this->repository->markAsFinished($this->id);
         }
@@ -281,6 +289,16 @@ class Batch implements Arrayable, JsonSerializable
     public function finished()
     {
         return ! is_null($this->finishedAt);
+    }
+
+    /**
+     * Determine if the batch has "progress" callbacks.
+     *
+     * @return bool
+     */
+    public function hasProgressCallbacks()
+    {
+        return isset($this->options['progress']) && ! empty($this->options['progress']);
     }
 
     /**

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -72,6 +72,31 @@ class PendingBatch
     }
 
     /**
+     * Add a callback to be executed after a job in the batch have executed successfully.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function progress($callback)
+    {
+        $this->options['progress'][] = $callback instanceof Closure
+            ? new SerializableClosure($callback)
+            : $callback;
+
+        return $this;
+    }
+
+    /**
+     * Get the "progress" callbacks that have been registered with the pending batch.
+     *
+     * @return array
+     */
+    public function progressCallbacks()
+    {
+        return $this->options['progress'] ?? [];
+    }
+
+    /**
      * Add a callback to be executed after all jobs in the batch have executed successfully.
      *
      * @param  callable  $callback

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -40,6 +40,7 @@ class BusBatchTest extends TestCase
         $this->createSchema();
 
         $_SERVER['__finally.count'] = 0;
+        $_SERVER['__progress.count'] = 0;
         $_SERVER['__then.count'] = 0;
         $_SERVER['__catch.count'] = 0;
     }
@@ -72,7 +73,7 @@ class BusBatchTest extends TestCase
      */
     protected function tearDown(): void
     {
-        unset($_SERVER['__finally.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
+        unset($_SERVER['__finally.batch'], $_SERVER['__progress.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
 
         $this->schema()->drop('job_batches');
 
@@ -201,12 +202,14 @@ class BusBatchTest extends TestCase
         $batch->recordSuccessfulJob('test-id');
 
         $this->assertInstanceOf(Batch::class, $_SERVER['__finally.batch']);
+        $this->assertInstanceOf(Batch::class, $_SERVER['__progress.batch']);
         $this->assertInstanceOf(Batch::class, $_SERVER['__then.batch']);
 
         $batch = $batch->fresh();
         $this->assertEquals(0, $batch->pendingJobs);
         $this->assertTrue($batch->finished());
         $this->assertEquals(1, $_SERVER['__finally.count']);
+        $this->assertEquals(2, $_SERVER['__progress.count']);
         $this->assertEquals(1, $_SERVER['__then.count']);
     }
 
@@ -326,6 +329,11 @@ class BusBatchTest extends TestCase
         $this->assertFalse($batch->finished());
         $batch->finishedAt = now();
         $this->assertTrue($batch->finished());
+
+        $batch->options['progress'] = [];
+        $this->assertFalse($batch->hasProgressCallbacks());
+        $batch->options['progress'] = [1];
+        $this->assertTrue($batch->hasProgressCallbacks());
 
         $batch->options['then'] = [];
         $this->assertFalse($batch->hasThenCallbacks());
@@ -463,6 +471,10 @@ class BusBatchTest extends TestCase
         $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
 
         $pendingBatch = (new PendingBatch(new Container, collect()))
+                            ->progress(function (Batch $batch) {
+                                $_SERVER['__progress.batch'] = $batch;
+                                $_SERVER['__progress.count']++;
+                            })
                             ->then(function (Batch $batch) {
                                 $_SERVER['__then.batch'] = $batch;
                                 $_SERVER['__then.count']++;

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -37,7 +37,9 @@ class BusPendingBatchTest extends TestCase
 
         $pendingBatch = new PendingBatch($container, new Collection([$job]));
 
-        $pendingBatch = $pendingBatch->then(function () {
+        $pendingBatch = $pendingBatch->progress(function () {
+            //
+        })->then(function () {
             //
         })->catch(function () {
             //
@@ -45,6 +47,7 @@ class BusPendingBatchTest extends TestCase
 
         $this->assertSame('test-connection', $pendingBatch->connection());
         $this->assertSame('test-queue', $pendingBatch->queue());
+        $this->assertCount(1, $pendingBatch->progressCallbacks());
         $this->assertCount(1, $pendingBatch->thenCallbacks());
         $this->assertCount(1, $pendingBatch->catchCallbacks());
         $this->assertArrayHasKey('extra-option', $pendingBatch->options);


### PR DESCRIPTION
The goal is to invoke a callback every time a job in batch successfully executes. Useful when we want to fire an event on progress, which will send a broadcast message to the user with a real progress percentage using `\Illuminate\Bus\Batch` `progress` value.

I named the new option `progress`, I believe it makes sense because a callback will be called only when the batch progresses. But feel free to rename it, or request rename.