### PR TITLE
Better transaction manager object design

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -201,7 +201,7 @@ trait ManagesTransactions
 
         [$levelBeingCommitted, $this->transactions] = [
             $this->transactions,
-            max(0, $this->transactions - 1)
+            max(0, $this->transactions - 1),
         ];
 
         $this->transactionsManager?->commit(

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -47,13 +47,16 @@ trait ManagesTransactions
                     $this->getPdo()->commit();
                 }
 
-                $this->transactionsManager?->stageTransactions($this->getName(), $this->transactions);
+                [$levelBeingCommitted, $this->transactions] = [
+                    $this->transactions,
+                    max(0, $this->transactions - 1),
+                ];
 
-                $this->transactions = max(0, $this->transactions - 1);
-
-                if ($this->afterCommitCallbacksShouldBeExecuted()) {
-                    $this->transactionsManager?->commit($this->getName());
-                }
+                $this->transactionsManager?->commit(
+                    $this->getName(),
+                    $levelBeingCommitted,
+                    $this->transactions
+                );
             } catch (Throwable $e) {
                 $this->handleCommitTransactionException(
                     $e, $currentAttempt, $attempts
@@ -196,25 +199,16 @@ trait ManagesTransactions
             $this->getPdo()->commit();
         }
 
-        $this->transactionsManager?->stageTransactions($this->getName(), $this->transactions);
+        [$levelBeingCommitted, $this->transactions] = [
+            $this->transactions,
+            max(0, $this->transactions - 1)
+        ];
 
-        $this->transactions = max(0, $this->transactions - 1);
-
-        if ($this->afterCommitCallbacksShouldBeExecuted()) {
-            $this->transactionsManager?->commit($this->getName());
-        }
+        $this->transactionsManager?->commit(
+            $this->getName(), $levelBeingCommitted, $this->transactions
+        );
 
         $this->fireConnectionEvent('committed');
-    }
-
-    /**
-     * Determine if after commit callbacks should be executed.
-     *
-     * @return bool
-     */
-    protected function afterCommitCallbacksShouldBeExecuted()
-    {
-        return $this->transactionsManager?->afterCommitCallbacksShouldBeExecuted($this->transactions) || $this->transactions == 0;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -74,7 +74,7 @@ class DatabaseTransactionsManager
             $this->currentTransaction[$connection] = $this->currentTransaction[$connection]->parent;
         }
 
-        if ($newTransactionLevel > 0) {
+        if (! $this->afterCommitCallbacksShouldBeExecuted($newTransactionLevel)) {
             return [];
         }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -74,8 +74,8 @@ class DatabaseTransactionsManager
             $this->currentTransaction[$connection] = $this->currentTransaction[$connection]->parent;
         }
 
-        if (! $this->afterCommitCallbacksShouldBeExecuted($newTransactionLevel) ||
-            $newTransactionLevel === 0) {
+        if (! $this->afterCommitCallbacksShouldBeExecuted($newTransactionLevel) &&
+            $newTransactionLevel !== 0) {
             return [];
         }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -74,7 +74,8 @@ class DatabaseTransactionsManager
             $this->currentTransaction[$connection] = $this->currentTransaction[$connection]->parent;
         }
 
-        if (! $this->afterCommitCallbacksShouldBeExecuted($newTransactionLevel)) {
+        if (! $this->afterCommitCallbacksShouldBeExecuted($newTransactionLevel) ||
+            $newTransactionLevel === 0) {
             return [];
         }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -59,6 +59,44 @@ class DatabaseTransactionsManager
     }
 
     /**
+     * Commit the root database transaction and execute callbacks.
+     *
+     * @param  string  $connection
+     * @param  int  $levelBeingCommitted
+     * @param  int  $newTransactionLevel
+     * @return array
+     */
+    public function commit($connection, $levelBeingCommitted, $newTransactionLevel)
+    {
+        $this->stageTransactions($connection, $levelBeingCommitted);
+
+        if (isset($this->currentTransaction[$connection])) {
+            $this->currentTransaction[$connection] = $this->currentTransaction[$connection]->parent;
+        }
+
+        if ($newTransactionLevel > 0) {
+            return [];
+        }
+
+        // This method is only called when the root database transaction is committed so there
+        // shouldn't be any pending transactions, but going to clear them here anyways just
+        // in case. This method could be refactored to receive a level in the future too.
+        $this->pendingTransactions = $this->pendingTransactions->reject(
+            fn ($transaction) => $transaction->connection === $connection
+        )->values();
+
+        [$forThisConnection, $forOtherConnections] = $this->committedTransactions->partition(
+            fn ($transaction) => $transaction->connection == $connection
+        );
+
+        $this->committedTransactions = $forOtherConnections->values();
+
+        $forThisConnection->map->executeCallbacks();
+
+        return $forThisConnection;
+    }
+
+    /**
      * Move relevant pending transactions to a committed state.
      *
      * @param  string  $connection
@@ -78,34 +116,6 @@ class DatabaseTransactionsManager
             fn ($transaction) => $transaction->connection === $connection &&
                                  $transaction->level >= $levelBeingCommitted
         );
-
-        if (isset($this->currentTransaction[$connection])) {
-            $this->currentTransaction[$connection] = $this->currentTransaction[$connection]->parent;
-        }
-    }
-
-    /**
-     * Commit the root database transaction and execute callbacks.
-     *
-     * @param  string  $connection
-     * @return void
-     */
-    public function commit($connection)
-    {
-        // This method is only called when the root database transaction is committed so there
-        // shouldn't be any pending transactions, but going to clear them here anyways just
-        // in case. This method could be refactored to receive a level in the future too.
-        $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection === $connection
-        )->values();
-
-        [$forThisConnection, $forOtherConnections] = $this->committedTransactions->partition(
-            fn ($transaction) => $transaction->connection == $connection
-        );
-
-        $this->committedTransactions = $forOtherConnections->values();
-
-        $forThisConnection->map->executeCallbacks();
     }
 
     /**

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -7,7 +7,6 @@ use ErrorException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
-use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -290,20 +290,6 @@ class DatabaseConnectionTest extends TestCase
         $connection->commit();
     }
 
-    public function testAfterCommitIsExecutedOnFinalCommit()
-    {
-        $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['beginTransaction', 'commit'])->getMock();
-        $transactionsManager = $this->getMockBuilder(DatabaseTransactionsManager::class)->onlyMethods(['afterCommitCallbacksShouldBeExecuted'])->getMock();
-        $transactionsManager->expects($this->once())->method('afterCommitCallbacksShouldBeExecuted')->with(0)->willReturn(true);
-
-        $connection = $this->getMockConnection([], $pdo);
-        $connection->setTransactionManager($transactionsManager);
-
-        $connection->transaction(function () {
-            // do nothing
-        });
-    }
-
     public function testRollBackedFiresEventsIfSet()
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -64,8 +64,7 @@ class DatabaseTransactionsTest extends TestCase
     {
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
-        $transactionManager->shouldReceive('commit')->once()->with('default');
+        $transactionManager->shouldReceive('commit')->once()->with('default', 1, 0);
 
         $this->connection()->setTransactionManager($transactionManager);
 
@@ -84,8 +83,7 @@ class DatabaseTransactionsTest extends TestCase
     {
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
-        $transactionManager->shouldReceive('commit')->once()->with('default');
+        $transactionManager->shouldReceive('commit')->once()->with('default', 1, 0);
 
         $this->connection()->setTransactionManager($transactionManager);
 
@@ -105,9 +103,8 @@ class DatabaseTransactionsTest extends TestCase
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
         $transactionManager->shouldReceive('begin')->once()->with('default', 2);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 2);
-        $transactionManager->shouldReceive('commit')->once()->with('default');
+        $transactionManager->shouldReceive('commit')->once()->with('default', 2, 1);
+        $transactionManager->shouldReceive('commit')->once()->with('default', 1, 0);
 
         $this->connection()->setTransactionManager($transactionManager);
 
@@ -134,11 +131,9 @@ class DatabaseTransactionsTest extends TestCase
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
         $transactionManager->shouldReceive('begin')->once()->with('second_connection', 1);
         $transactionManager->shouldReceive('begin')->once()->with('second_connection', 2);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('default', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('second_connection', 1);
-        $transactionManager->shouldReceive('stageTransactions')->once()->with('second_connection', 2);
-        $transactionManager->shouldReceive('commit')->once()->with('default');
-        $transactionManager->shouldReceive('commit')->once()->with('second_connection');
+        $transactionManager->shouldReceive('commit')->once()->with('default', 1, 0);
+        $transactionManager->shouldReceive('commit')->once()->with('second_connection', 2, 1);
+        $transactionManager->shouldReceive('commit')->once()->with('second_connection', 1, 0);
 
         $this->connection()->setTransactionManager($transactionManager);
         $this->connection('second_connection')->setTransactionManager($transactionManager);
@@ -196,7 +191,7 @@ class DatabaseTransactionsTest extends TestCase
         $transactionManager = m::mock(new DatabaseTransactionsManager);
         $transactionManager->shouldReceive('begin')->once()->with('default', 1);
         $transactionManager->shouldReceive('rollback')->once()->with('default', 0);
-        $transactionManager->shouldNotReceive('commit');
+        $transactionManager->shouldNotReceive('commit', 1, 0);
 
         $this->connection()->setTransactionManager($transactionManager);
 

--- a/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
+++ b/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
@@ -42,8 +42,8 @@ class DatabaseTransactionsManagerTest extends TestCase
 
         $this->assertFalse($testObject->ran);
 
-        $manager->stageTransactions('foo', 1);
-        $manager->commit('foo');
+        $manager->commit('foo', 2, 1);
+        $manager->commit('foo', 1, 0);
         $this->assertTrue($testObject->ran);
         $this->assertEquals(1, $testObject->runs);
     }


### PR DESCRIPTION
The connection doesn't need to be aware of `stageTransactions` at all or only call `commit` at level 0. It should just call `commit` every time and let the transaction manager decide what to do.