### PR TITLE
[slim-skeleton-11.x] Removes `bootstrap/providers.php`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -432,16 +432,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
-     * Get the path to the service provider list in the bootstrap directory.
-     *
-     * @return string
-     */
-    public function getBootstrapProvidersPath()
-    {
-        return $this->bootstrapPath('providers.php');
-    }
-
-    /**
      * Set the bootstrap file directory.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
@@ -14,13 +14,6 @@ class RegisterProviders
     protected static $merge = [];
 
     /**
-     * The path to the bootstrap provider configuration file.
-     *
-     * @var string|null
-     */
-    protected static $bootstrapProviderPath;
-
-    /**
      * Bootstrap the given application.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -43,23 +36,11 @@ class RegisterProviders
      */
     protected function mergeAdditionalProviders(Application $app)
     {
-        if (static::$bootstrapProviderPath &&
-            file_exists(static::$bootstrapProviderPath)) {
-            $packageProviders = require static::$bootstrapProviderPath;
-
-            foreach ($packageProviders as $index => $provider) {
-                if (! class_exists($provider)) {
-                    unset($packageProviders[$index]);
-                }
-            }
-        }
-
         $app->make('config')->set(
             'app.providers',
             array_merge(
                 $app->make('config')->get('app.providers'),
                 static::$merge,
-                array_values($packageProviders ?? []),
             ),
         );
     }
@@ -68,13 +49,10 @@ class RegisterProviders
      * Merge the given providers into the provider configuration before registration.
      *
      * @param  array  $providers
-     * @param  string|null  $bootstrapProviderPath
      * @return void
      */
-    public static function merge(array $providers, ?string $bootstrapProviderPath = null)
+    public static function merge(array $providers)
     {
-        static::$bootstrapProviderPath = $bootstrapProviderPath;
-
         static::$merge = array_values(array_filter(array_unique(
             array_merge(static::$merge, $providers)
         )));

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -53,16 +53,12 @@ class ApplicationBuilder
      * Register additional service providers.
      *
      * @param  array  $providers
-     * @param  bool  $withBootstrapProviders
      * @return $this
      */
-    public function withProviders(array $providers = [], bool $withBootstrapProviders = true)
+    public function withProviders(array $providers = [])
     {
         RegisterProviders::merge(
             $providers,
-            $withBootstrapProviders
-                ? $this->app->getBootstrapProvidersPath()
-                : null
         );
 
         return $this;


### PR DESCRIPTION
This pull request removes `bootstrap/providers.php` as it appears redundant, given the `withProviders` method already available in `bootstrap/app.php`. If this pull request is merged, I will adjust the skeleton PR.