### PR TITLE
[10.x] Add localization support to the `Number::forHumans` helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -141,30 +141,30 @@ class Number
      * @param  int|null  $maxPrecision
      * @return string
      */
-    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
     {
         $units = [
-            3 => 'thousand',
-            6 => 'million',
-            9 => 'billion',
-            12 => 'trillion',
-            15 => 'quadrillion',
+            3 => __('thousand', locale: $locale ?? static::$locale),
+            6 => __('million', locale: $locale ?? static::$locale),
+            9 => __('billion', locale: $locale ?? static::$locale),
+            12 => __('trillion', locale: $locale ?? static::$locale),
+            15 => __('quadrillion', locale: $locale ?? static::$locale),
         ];
 
         switch (true) {
             case $number === 0:
                 return '0';
             case $number < 0:
-                return sprintf('-%s', static::forHumans(abs($number), $precision, $maxPrecision));
+                return sprintf('-%s', static::forHumans(abs($number), $precision, $maxPrecision, $locale));
             case $number >= 1e15:
-                return sprintf('%s quadrillion', static::forHumans($number / 1e15, $precision, $maxPrecision));
+                return sprintf('%s %s', static::forHumans($number / 1e15, $precision, $maxPrecision, $locale), __('quadrillion', locale: $locale ?? static::$locale));
         }
 
         $numberExponent = floor(log10($number));
         $displayExponent = $numberExponent - ($numberExponent % 3);
         $number /= pow(10, $displayExponent);
 
-        return trim(sprintf('%s %s', static::format($number, $precision, $maxPrecision), $units[$displayExponent] ?? ''));
+        return trim(sprintf('%s %s', static::format($number, $precision, $maxPrecision, $locale), $units[$displayExponent] ?? ''));
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -143,26 +143,26 @@ class Number
      */
     public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
     {
-        $units = [
-            3 => __('thousand', locale: $locale ?? static::$locale),
-            6 => __('million', locale: $locale ?? static::$locale),
-            9 => __('billion', locale: $locale ?? static::$locale),
-            12 => __('trillion', locale: $locale ?? static::$locale),
-            15 => __('quadrillion', locale: $locale ?? static::$locale),
-        ];
-
         switch (true) {
             case $number === 0:
                 return '0';
             case $number < 0:
                 return sprintf('-%s', static::forHumans(abs($number), $precision, $maxPrecision, $locale));
             case $number >= 1e15:
-                return sprintf('%s %s', static::forHumans($number / 1e15, $precision, $maxPrecision, $locale), __('quadrillion', locale: $locale ?? static::$locale));
+                return sprintf('%s %s', static::forHumans($number = $number / 1e15, $precision, $maxPrecision, $locale), trans_choice('quadrillion', $number, locale: $locale ?? static::$locale));
         }
 
         $numberExponent = floor(log10($number));
         $displayExponent = $numberExponent - ($numberExponent % 3);
         $number /= pow(10, $displayExponent);
+
+        $units = [
+            3 => trans_choice('thousand', $number, locale: $locale ?? static::$locale),
+            6 => trans_choice('million', $number, locale: $locale ?? static::$locale),
+            9 => trans_choice('billion', $number, locale: $locale ?? static::$locale),
+            12 => trans_choice('trillion', $number, locale: $locale ?? static::$locale),
+            15 => trans_choice('quadrillion', $number, locale: $locale ?? static::$locale),
+        ];
 
         return trim(sprintf('%s %s', static::format($number, $precision, $maxPrecision, $locale), $units[$displayExponent] ?? ''));
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -247,6 +247,39 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,23 miljon', Number::forHumans(1234567, locale: 'sv', precision: 2));
     }
 
+    public function testToHumansWithPluralizedLocalization()
+    {
+        $this->mockTranslator();
+
+        app('translator')->setLoaded([
+            '*' => [
+                '*' => [
+                    'sv' => [
+                        'thousand' => 'tusen',
+                        'million' => 'miljon|miljoner',
+                        'billion' => 'miljard|miljarder',
+                        'trillion' => 'biljon|biljoner',
+                        'quadrillion' => 'biljard|biljarder',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('1 tusen', Number::forHumans(1000, locale: 'sv'));
+        $this->assertSame('10 tusen', Number::forHumans(10000, locale: 'sv'));
+        $this->assertSame('1 miljon', Number::forHumans(1000000, locale: 'sv'));
+        $this->assertSame('1 miljard', Number::forHumans(1000000000, locale: 'sv'));
+        $this->assertSame('1 biljon', Number::forHumans(1000000000000, locale: 'sv'));
+        $this->assertSame('1 biljard', Number::forHumans(1000000000000000, locale: 'sv'));
+
+        $this->assertSame('1,23 miljoner', Number::forHumans(1234567, locale: 'sv', precision: 2));
+        $this->assertSame('10 miljoner', Number::forHumans(10000000, locale: 'sv'));
+        $this->assertSame('10 miljarder', Number::forHumans(10000000000, locale: 'sv'));
+        $this->assertSame('10 biljoner', Number::forHumans(10000000000000, locale: 'sv'));
+        $this->assertSame('1 tusen biljarder', Number::forHumans(1000000000000000000, locale: 'sv'));
+        $this->assertSame('10 tusen biljarder', Number::forHumans(10000000000000000000, locale: 'sv'));
+    }
+
     protected function mockTranslator(): void
     {
         app()->singleton('translator', fn () => new Translator(new ArrayLoader(), 'en'));


### PR DESCRIPTION
## Abstract

Many people have requested a way to add localization to the `forHumans` helper added in https://github.com/laravel/framework/pull/48845. Here's my attempt at implementing localization support for this method using translation helpers.

## Example

```php
// Example language setup

'sv' => [
    'thousand' => 'tusen',
    'million' => 'miljon',
    'billion' => 'miljard',
    'trillion' => 'biljon',
    'quadrillion' => 'biljard',
],

// Usage

Number::forHumans(1000, locale: 'sv'); // 1 tusen
Number::forHumans(10000, locale: 'sv'); // 10 tusen
Number::forHumans(1000000, locale: 'sv'); // 1 miljon
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
