### PR TITLE
[10.x] Allow for stricter lazy loading check

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -409,9 +409,8 @@ class Builder implements BuilderContract
         return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
             $model = $instance->newFromBuilder($item);
 
-            if (count($items) > 1) {
-                $model->preventsLazyLoading = Model::preventsLazyLoading();
-            }
+            $model->preventsLazyLoading = Model::preventsLazyLoading() === 'strict'
+                || Model::preventsLazyLoading() && count($items) > 1;
 
             return $model;
         }, $items));

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -164,7 +164,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Indicates whether lazy loading should be restricted on all models.
      *
-     * @var bool
+     * @var bool|string
      */
     protected static $modelsShouldPreventLazyLoading = false;
 
@@ -415,7 +415,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Prevent model relationships from being lazy loaded.
      *
-     * @param  bool  $value
+     * @param  bool|string  $value Can be set to 'strict' to prevent lazy loading even in non N+1 situations.
      * @return void
      */
     public static function preventLazyLoading($value = true)


### PR DESCRIPTION
### Overview

We just ran into an issue where a potential Eloquent lazy load violation was missed during local development, but once the release hit production it started logging violation errors.

The reason for this is a check in the `Builder` to only check for lazy loading violations if the model is part of a query that returned multiple models. See `Builder.hyrdate` [here](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Builder.php#L412) and PR #37503 for the original change to add the restriction.

I am proposing a new `strict` setting for `Model::preventLazyLoading` which removes this restriction.

If the application calls `Model::preventLazyLoading('strict')`, then we will no longer check that the model belongs to a set of more than one model. This will make lazy loading violations more common, so should be opt-in only, and the default will remain as is.

### Why?

The query that caused this issue in our application would return 1 model 90% of the time, but in more complex scenarios would return multiple models. We didn't pick up on this lazy loading violation locally because we mostly test in the single model case. Once the app hit production and saw more complex scenarios with multiple models the violation triggered.

We would prefer to catch *all* lazy loading violations in local testing so that this doesn't occur.

To add to the issue, another developer was doing a demo using their local system and hit the violation during the demo which we had never seen before (and locally it threw an actual exception, so the demo showed the app breaking).

### What's next

This is a quick draft of the change that I am proposing. I am happy to add a unit test to cover it if there is agreement for this change in principle.

As another commenter on the original PR mentioned - the best solution here would be to figure out not if more than one model was returned, but what the intention of the query was ie. was it a query for a single item, or a query that could return multiple models. If we could figure out a way to pass this down to `hydrate` then that would be ideal. It would be possible in some places, but in others it looks like it would be more difficult.