### PR TITLE
[slim-skeleton-11.x] Test Improvements

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           DB_CONNECTION: mysql
           DB_USERNAME: root
-          DB_COLLATION: utf8mb4_unicode_ci
+          MYSQL_COLLATION: utf8mb4_unicode_ci
 
   mysql_8:
     runs-on: ubuntu-22.04

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           DB_CONNECTION: mysql
           DB_USERNAME: root
+          DB_COLLATION: utf8mb4_unicode_ci
 
   mysql_8:
     runs-on: ubuntu-22.04

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
         "nyholm/psr7": "^1.2",
-        "orchestra/testbench-core": "^9.0",
+        "orchestra/testbench-core": "dev-next/slim-skeleton",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^10.1",

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -132,9 +132,10 @@ class SchemaBuilderTest extends DatabaseTestCase
 
             $uppercase = strtoupper($type);
 
-            $expected = ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL"];
-
-            $this->assertEquals($expected, $queries);
+            $this->assertContains($queries, [
+                ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL"], // MySQL
+                ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`"], // MariaDB
+            ]);
         }
     }
 }

--- a/tests/Integration/Generators/CacheTableCommandTest.php
+++ b/tests/Integration/Generators/CacheTableCommandTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Cache\Console\CacheTableCommand;
+
 class CacheTableCommandTest extends TestCase
 {
     public function testCreateMakesMigration()
     {
-        $this->artisan('cache:table')->assertExitCode(0);
+        $this->artisan(CacheTableCommand::class)->assertExitCode(0);
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',

--- a/tests/Integration/Generators/NotificationTableCommandTest.php
+++ b/tests/Integration/Generators/NotificationTableCommandTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Notifications\Console\NotificationTableCommand;
+
 class NotificationTableCommandTest extends TestCase
 {
     public function testCreateMakesMigration()
     {
-        $this->artisan('notifications:table')->assertExitCode(0);
+        $this->artisan(NotificationTableCommand::class)->assertExitCode(0);
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',

--- a/tests/Integration/Generators/QueueBatchesTableCommandTest.php
+++ b/tests/Integration/Generators/QueueBatchesTableCommandTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Queue\Console\BatchesTableCommand;
+
 class QueueBatchesTableCommandTest extends TestCase
 {
     public function testCreateMakesMigration()
     {
-        $this->artisan('queue:batches-table')->assertExitCode(0);
+        $this->artisan(BatchesTableCommand::class)->assertExitCode(0);
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',

--- a/tests/Integration/Generators/QueueFailedTableCommandTest.php
+++ b/tests/Integration/Generators/QueueFailedTableCommandTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Queue\Console\FailedTableCommand;
+
 class QueueFailedTableCommandTest extends TestCase
 {
     public function testCreateMakesMigration()
     {
-        $this->artisan('queue:failed-table')->assertExitCode(0);
+        $this->artisan(FailedTableCommand::class)->assertExitCode(0);
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',

--- a/tests/Integration/Generators/QueueTableCommandTest.php
+++ b/tests/Integration/Generators/QueueTableCommandTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Queue\Console\TableCommand;
+
 class QueueTableCommandTest extends TestCase
 {
     public function testCreateMakesMigration()
     {
-        $this->artisan('queue:table')->assertExitCode(0);
+        $this->artisan(TableCommand::class)->assertExitCode(0);
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',

--- a/tests/Integration/Generators/SessionTableCommandTest.php
+++ b/tests/Integration/Generators/SessionTableCommandTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Session\Console\SessionTableCommand;
+
 class SessionTableCommandTest extends TestCase
 {
     public function testCreateMakesMigration()
     {
-        $this->artisan('session:table')->assertExitCode(0);
+        $this->artisan(SessionTableCommand::class)->assertExitCode(0);
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',


### PR DESCRIPTION
Using `$this->artisan()` with `Command::$aliases` doesn't work properly at the moment. I believe this is due to how Symfony registers commands vs how Laravel resolves it with `$signature`.
