### PR TITLE
[10.x] Add Conditionable to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Support\ViewErrorBag;
@@ -32,7 +33,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class TestResponse implements ArrayAccess
 {
-    use Concerns\AssertsStatusCodes, Tappable, Macroable {
+    use Concerns\AssertsStatusCodes, Conditionable, Tappable, Macroable {
         __call as macroCall;
     }
 


### PR DESCRIPTION
This PR adds the Conditionable trait to the TestResponse class, which can make your test code a little cleaner.
I think this would work well with the Data Provider feature.

Below is a small example using Pest.
```php
test('name', function ($attributes) {
    $user = User::factory()->create($attributes);

    $response = $this
        ->actingAs($user)
        ->get('/');

    $response
        ->assertOk()
        ->when($attributes['gender'] === 1, fn () => $response->assertSee('Hello boys!'))
        ->when($attributes['gender'] === 2, fn () => $response->assertSee('Hello girls!'));
})->with([
    'boy' => [
        [
            'name' => 'Michael',
            'gender' => 1,
        ],
    ],
    'girl' => [
        [
            'name' => 'Susan',
            'gender' => 2,
        ],
    ],
]);
```