### PR TITLE
[slim-skeleton-11.x] Fix MariaDB Tests with changed query

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
         "nyholm/psr7": "^1.2",
-        "orchestra/testbench-core": "^9.0",
+        "orchestra/testbench-core": "dev-next/slim-skeleton",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^10.1",

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -132,9 +132,10 @@ class SchemaBuilderTest extends DatabaseTestCase
 
             $uppercase = strtoupper($type);
 
-            $expected = ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL"];
-
-            $this->assertEquals($expected, $queries);
+            $this->assertContains($queries, [
+                ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL"], // MySQL
+                ["ALTER TABLE test CHANGE test_column test_column $uppercase NOT NULL COLLATE `utf8mb4_uca1400_ai_ci`"], // MariaDB
+            ]);
         }
     }
 }


### PR DESCRIPTION
In Response to the failing MariaDB tests in https://github.com/laravel/framework/pull/49111

(MySQL 5.7 failing tests are because of the new collation, which is not available in MySQL 5.7)

@crynobone 