### PR TITLE
Fix byte formatting abbreviations to use established standards

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -124,10 +124,10 @@ class Number
      */
     public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
     {
-        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
-            $bytes /= 1024;
+        for ($i = 0; ($bytes / 1000) > 0.9 && ($i < count($units) - 1); $i++) {
+            $bytes /= 1000;
         }
 
         return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision), $units[$i]);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -141,18 +141,25 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0 B', Number::fileSize(0));
         $this->assertSame('0.00 B', Number::fileSize(0, precision: 2));
         $this->assertSame('1 B', Number::fileSize(1));
-        $this->assertSame('1 KB', Number::fileSize(1024));
-        $this->assertSame('2 KB', Number::fileSize(2048));
-        $this->assertSame('2.00 KB', Number::fileSize(2048, precision: 2));
-        $this->assertSame('1.23 KB', Number::fileSize(1264, precision: 2));
-        $this->assertSame('1.234 KB', Number::fileSize(1264.12345, maxPrecision: 3));
-        $this->assertSame('1.234 KB', Number::fileSize(1264, 3));
+        $this->assertSame('1 kB', Number::fileSize(1000));
+        $this->assertSame('1 kB', Number::fileSize(1024));
+        $this->assertSame('1.02 kB', Number::fileSize(1024, precision: 2));
+        $this->assertSame('2 kB', Number::fileSize(2000));
+        $this->assertSame('2.00 kB', Number::fileSize(2000, precision: 2));
+        $this->assertSame('2 kB', Number::fileSize(2048));
+        $this->assertSame('2.048 kB', Number::fileSize(2048, precision: 3));
+        $this->assertSame('1.26 kB', Number::fileSize(1264, precision: 2));
+        $this->assertSame('1.264 kB', Number::fileSize(1264.12345, maxPrecision: 3));
+        $this->assertSame('1.264 kB', Number::fileSize(1264, 3));
+        $this->assertSame('5 GB', Number::fileSize(1000 * 1000 * 1000 * 5));
+        $this->assertSame('5.37 GB', Number::fileSize(1024 * 1024 * 1024 * 5, precision: 2));
         $this->assertSame('5 GB', Number::fileSize(1024 * 1024 * 1024 * 5));
-        $this->assertSame('10 TB', Number::fileSize((1024 ** 4) * 10));
-        $this->assertSame('10 PB', Number::fileSize((1024 ** 5) * 10));
+        $this->assertSame('10 TB', Number::fileSize((1000 ** 4) * 10));
+        $this->assertSame('11 TB', Number::fileSize((1024 ** 4) * 10));
+        $this->assertSame('11 PB', Number::fileSize((1024 ** 5) * 10));
         $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
         $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
-        $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+        $this->assertSame('1,238 YB', Number::fileSize(1024 ** 9));
     }
 
     public function testToHuman()


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/48845, a `Number` class was added, following a request to add a file size formatting function to Laravel. After the ultimate merge, the byte formatting function `Number::fileSize()` uses a custom abbreviation scheme. I want to cite my two comments in the mentioned pull request:

[Oct 30](https://github.com/laravel/framework/pull/48845#issuecomment-1784984816)
> The use of prefixes in `bytesToHuman()` seems to follow a custom naming scheme instead of established standards.
> 
> I notice two things:
> 
> 1. The prefixes used seem to be [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix) (`k`, `M`, `G`, ...), calculating base-10, with the exception that an uppercase `K` is used instead of the official lowercase `k`
> 2. The calculations seem to be done using base-2, which would actually suggest [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) (`Ki`, `Mi`, `Gi`, ...) should be used
> 
> I propose to replace `bytesToHuman()` with two other methods:
> 
> 1. `bytesToMetric()`, using division by 1000 and using metric abbreviations `kB`, `MB`, `GB`, ...
> 2. `bytesToBinary()` (or some better name), using division by 1024 and using binary abbreviations `KiB`, `MiB`, `GiB`, ...
> 
> Other suggestions: `toMetricBytes`/`toBinaryBytes`, `formatMetricBytes`/`formatBinaryBytes`

[Oct 31](https://github.com/laravel/framework/pull/48845#issuecomment-1787576500)
> I want to stress that the code in the current state uses binary calculations in combination with decimal/metric abbreviations, a combination that would lead to technically confusing results. Do note however, that Windows (up to this date) also does exactly that: it reports filesizes in multiples of 1024 while using metric abbreviations. I would propose to not follow this false windows-path and stick to binary calculations with binary prefixes and/or metric calculations with metric prefixes.

To put the above comments into current context, Laravel 10.x since ships with a `Number::fileSize()` method that reports metric abbreviations, while it performs calculations using multiples of 1024. This leads to erroneous results when formatting relatively large numbers, e.g. an amount of `10^13` bytes is reported as `10 TB` while it surely should be `11 TB`, according to the definition of `T = 10^12`. A more detailed explanation of related errors can be found on [wikipedia](https://en.wikipedia.org/wiki/Binary_prefix).

Another way to put it: currently this method reports metric units, but calculates quantities in a non-metric fashion.

Reports of byte quantities using multiples of 1024 do have their place within computing, but these are primarily in technical details like amount of RAM, storage disk space or CPU caches, where the hardware is built in a binary fashion by nature. A file size is not binary by nature, as a file can be any number of bytes large, not limited to only being equal to multiples of 2. Hence, it is not necessary nor logical to use multiples of 1024 in file size reporting.

This leads me to the conclusion that the most enduser-friendly thing to do here, is to use multiples of 1000 instead of 1024 to calculate the (abbreviated) units:
1. There is no apparent reason to use multiples of 1024
2. Using multiples of 1000 ensures that the usage of the established units `MB`, `GB`, `TB`, ... is in line with the metric system
3. Divisions by 1000 are more user-friendly as the relation between numbers of bytes and numbers of (e.g.) terabytes is immediately apparent, not having to reason about why the formatted number of bytes reports something that seems to be just a little of compared to the raw number of bytes

In the rare circumstance one needs to report figures about hardware properties, I propose developers create their own method that reports byte quantities in binary units (kibi, mebi, ...), along with calculations using multiples of 1024.

To sum up, in this PR I propose the following 2 changes to fully comply with the metric system in order to use the metric prefixes:
1. Calculate using multiples of 1000 instead of 1024
2. Use the correct abbreviation `k` for kilo instead of `K`.

---

If this PR does not get merged, I would advise to update the [docs](https://laravel.com/docs/10.x/helpers#method-number-file-size) on this method to warn developers that the used abbreviations follow a custom naming scheme that does not follow an established standard.