### PR TITLE
Add clone method to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1758,4 +1758,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Shallow clone the collection.
+     *
+     * @return static
+     */
+    public function clone()
+    {
+        return clone $this;
+    }
 }


### PR DESCRIPTION
Add clone method to the collection so that both Eloquent builder and Collection have the clone methods


### Why

it can be often beneficial to both allow a query builder and a collection, to avoid N+1 Query scenarios.

Currently the query builder is mutating when you add methods but collections are not, this creates a different expectation, and cloning is needed. consider the following scenario:
```php
public function GetUsers(Builder|Collection $source): User {
   return $source->where('first_name,'=', 'AName')->first()
     ??    $source->where('last_name,'=', 'AName')->first()
}
```

This would make the second query run with both firstname and lastname in the where statement but a collection could find a user base on "AName".


Now this would be possible, creating the same behaviour:

```php
public function GetUsers(Builder|Collection $source): User {
   return $source->clone()->where('first_name,'=', 'AName')->first()
     ??    $source->clone()->where('last_name,'=', 'AName')->first()
}
```


### Considerations

Adding it to the Enumerable interface, although im not sure with cloning an interable or generator would look like (in the Async collection).
