### PR TITLE
[slim-skeleton-11.x] Adds `app.frontend_url` to `config/app.php`

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -57,6 +57,8 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    'frontend_url' => env('FRONTEND_URL', 'http://localhost:3000'),
+
     'asset_url' => env('ASSET_URL'),
 
     /*


### PR DESCRIPTION
This pull request adds `app.frontend_url` to `config/app.php`, and the goal is try to avoid publishing the `config/app.php` on the Breeze's API stack simply to add this configuration value.

Related to https://github.com/laravel/breeze/pull/331.