### PR TITLE
[10.x] Add max_exclusive and min_exclusive validation rules

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -97,6 +97,12 @@ return [
         'string' => 'The :attribute field must not be greater than :max characters.',
     ],
     'max_digits' => 'The :attribute field must not have more than :max digits.',
+    'max_exclusive' => [
+        'array' => 'The :attribute field must be less than :max items.',
+        'file' => 'The :attribute field must be less than :max kilobytes.',
+        'numeric' => 'The :attribute field must be less than :max.',
+        'string' => 'The :attribute field must be less than :max characters.',
+    ],
     'mimes' => 'The :attribute field must be a file of type: :values.',
     'mimetypes' => 'The :attribute field must be a file of type: :values.',
     'min' => [
@@ -106,6 +112,12 @@ return [
         'string' => 'The :attribute field must be at least :min characters.',
     ],
     'min_digits' => 'The :attribute field must have at least :min digits.',
+    'min_exclusive' => [
+        'array' => 'The :attribute field must have more than :min items.',
+        'file' => 'The :attribute field must be more than :min kilobytes.',
+        'numeric' => 'The :attribute field must be more than :min.',
+        'string' => 'The :attribute field must be more than :min characters.',
+    ],
     'missing' => 'The :attribute field must be missing.',
     'missing_if' => 'The :attribute field must be missing when :other is :value.',
     'missing_unless' => 'The :attribute field must be missing unless :other is :value.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1444,7 +1444,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate the size of an attribute is less than a maximum value.
+     * Validate the size of an attribute is less than or equal to a maximum value.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -1477,6 +1477,25 @@ trait ValidatesAttributes
         $length = strlen((string) $value);
 
         return ! preg_match('/[^0-9]/', $value) && $length <= $parameters[0];
+    }
+
+    /**
+     * Validate the size of an attribute is less than but not equal to a maximum value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMaxExclusive($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max_exclusive');
+
+        if ($value instanceof UploadedFile && ! $value->isValid()) {
+            return false;
+        }
+
+        return BigNumber::of($this->getSize($attribute, $value))->isLessThan($this->trim($parameters[0]));
     }
 
     /**
@@ -1550,7 +1569,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate the size of an attribute is greater than a minimum value.
+     * Validate the size of an attribute is greater than or equal to a minimum value.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -1579,6 +1598,21 @@ trait ValidatesAttributes
         $length = strlen((string) $value);
 
         return ! preg_match('/[^0-9]/', $value) && $length >= $parameters[0];
+    }
+
+    /**
+     * Validate the size of an attribute is greater than but not equal to a minimum value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMinExclusive($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min_exclusive');
+
+        return BigNumber::of($this->getSize($attribute, $value))->isGreaterThan($this->trim($parameters[0]));
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3319,6 +3319,88 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateMinExclusive()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '0'], ['foo' => 'numeric|min_exclusive:0']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.00001'], ['foo' => 'numeric|min_exclusive:0']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'uhgfr'], ['foo' => 'min_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal length does NOT qualify.
+        $v = new Validator($trans, ['foo' => 'ugur'], ['foo' => 'min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'ugr'], ['foo' => 'min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // '5' is a string of length 1 in absence of the 'Numeric' rule.
+        $v = new Validator($trans, ['foo' => '5'], ['foo' => 'min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // '5' is considered as a numeric value when the "Numeric" rule exists.
+        $v = new Validator($trans, ['foo' => '5'], ['foo' => 'numeric|min_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal value does NOT qualify.
+        $v = new Validator($trans, ['foo' => '4'], ['foo' => 'numeric|min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '3'], ['foo' => 'numeric|min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // '4.1' is a string of length 3 in absence of the 'Numeric' rule.
+        $v = new Validator($trans, ['foo' => '4.1'], ['foo' => 'min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // '4.1' is considered as a float when the 'Numeric' rule exists.
+        $v = new Validator($trans, ['foo' => '4.1'], ['foo' => 'numeric|min_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal value does NOT qualify.
+        $v = new Validator($trans, ['foo' => '4.0'], ['foo' => 'numeric|min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '3.99999'], ['foo' => 'numeric|min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4, 5]], ['foo' => 'array|min_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal value does NOT qualify.
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'array|min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'array|min_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'min_exclusive:2']);
+        $this->assertTrue($v->passes());
+
+        // An equal value does NOT qualify.
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'min_exclusive:3']);
+        $this->assertFalse($v->passes());
+
+        // An equal value does NOT qualify.
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3073); // = 3.0009765625
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'min_exclusive:3']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'min_exclusive:10']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateMax()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -3379,6 +3461,88 @@ class ValidationValidatorTest extends TestCase
         $file->expects($this->any())->method('isValid')->willReturn(false);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:10']);
         $this->assertFalse($v->passes());
+    }
+
+    public function testValidateMaxExclusive()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'numeric|max_exclusive:1']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.99999'], ['foo' => 'numeric|max_exclusive:1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'ugr'], ['foo' => 'max_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal length does NOT qualify.
+        $v = new Validator($trans, ['foo' => 'ugur'], ['foo' => 'max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'uhgfr'], ['foo' => 'max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // '346' is a string of length 3 in absence of the 'Numeric' rule.
+        $v = new Validator($trans, ['foo' => '346'], ['foo' => 'max_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // '346' is considered as a numeric value when the "Numeric" rule exists.
+        $v = new Validator($trans, ['foo' => '346'], ['foo' => 'numeric|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // An equal value does NOT qualify.
+        $v = new Validator($trans, ['foo' => '4'], ['foo' => 'numeric|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '5'], ['foo' => 'numeric|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        // '1.1' is a string of length 3 in absence of the 'Numeric' rule.
+        $v = new Validator($trans, ['foo' => '1.1'], ['foo' => 'max_exclusive:2']);
+        $this->assertFalse($v->passes());
+
+        // '1.1' is considered as a float when the 'Numeric' rule exists.
+        $v = new Validator($trans, ['foo' => '1.1'], ['foo' => 'numeric|max_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal value does NOT qualify.
+        $v = new Validator($trans, ['foo' => '4.0'], ['foo' => 'numeric|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '4.00001'], ['foo' => 'numeric|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'array|max_exclusive:4']);
+        $this->assertTrue($v->passes());
+
+        // An equal value does NOT qualify.
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'array|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4, 5]], ['foo' => 'array|max_exclusive:4']);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'max_exclusive:2']);
+        $this->assertFalse($v->passes());
+
+        // An equal value does NOT qualify.
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'max_exclusive:3']);
+        $this->assertFalse($v->passes());
+
+        // An equal value does NOT qualify.
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3073); // = 3.0009765625
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'max_exclusive:3']);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file->expects($this->any())->method('getSize')->willReturn(3071); // = 2.9990234375
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'max_exclusive:3']);
+        $this->assertTrue($v->passes());
     }
 
     /**


### PR DESCRIPTION
Currently, the min/max rule works as inclusive (closed) meaning that boundaries are included during validation.

This PR adds an exclusive (open) min/max validation rule to check if an attribute is greater/less than but not equal to the value.

This is often useful for exchange rates where the value must be greater than zero but not zero itself. Ex: 1 USD = 0.91565829 EUR

Same principle applies to the `between` rule, but it can be done in another PR.

Also, I implemented two separate rules but it can be done with existing rules by providing a second `exclusivity` parameter (ex: `'max:5,true'`, `'min:4,true'`) and assuming the default as `false`. However, I reckon that it may cause confusions as what the `true/false` represents and  other rules are separated as well.