### PR TITLE
[10.x] Fix RateLimiter as it does not reset after the time limit has passed

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -94,11 +94,11 @@ class RateLimiter
     public function tooManyAttempts($key, $maxAttempts)
     {
         if ($this->attempts($key) >= $maxAttempts) {
-            if ($this->cache->has($this->cleanRateLimiterKey($key).':timer')) {
+            if ($this->availableIn($key) > 0) {
                 return true;
             }
 
-            $this->resetAttempts($key);
+            $this->clear($key);
         }
 
         return false;


### PR DESCRIPTION
RateLimiter does not clear after the time set for expiration has passed

In the current code, the code never resets after the expiration time has passed:

```
   public function tooManyAttempts($key, $maxAttempts)
    {
        if ($this->attempts($key) >= $maxAttempts) {
            if ($this->cache->has($this->cleanRateLimiterKey($key).':timer')) {
                return true;
            }

            $this->resetAttempts($key);
        }

        return false;
    }
```
I am editing the code, so that after the ttl has passed, the key is reset as expected

```
public function tooManyAttempts($key, $maxAttempts)
{
    if ($this->attempts($key) >= $maxAttempts) {
        if ($this->availableIn($key) > 0) {
            return true;
        }

        $this->clear($key);
    }

    return false;
}
```