### PR TITLE
[10.x] Update MemcachedStore To Handle TTL Correctly

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -103,7 +103,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     public function put($key, $value, $seconds)
     {
         return $this->memcached->set(
-            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
+            $this->prefix.$key, $value, $seconds
         );
     }
 
@@ -123,7 +123,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
         }
 
         return $this->memcached->setMulti(
-            $prefixedValues, $this->calculateExpiration($seconds)
+            $prefixedValues, $seconds
         );
     }
 
@@ -138,7 +138,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     public function add($key, $value, $seconds)
     {
         return $this->memcached->add(
-            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
+            $this->prefix.$key, $value, $seconds
         );
     }
 


### PR DESCRIPTION
This PR was closed, but please note that the timestamp is treated as seconds which causes the TTL to not expire at the expected time. This causes huge issues when using memcached as the cache driver. Please check again

I fixed the issue by passing the expected arg (in seconds) to memcached