### PR TITLE
[10.x] Allow multiple types in Collection's `ensure` method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -340,7 +340,7 @@ trait EnumeratesValues
             }
 
             throw new UnexpectedValueException(
-                sprintf("Collection should only include [%s] items, but '%s' found.", implode(', ', $types), $itemType)
+                sprintf("Collection should only include [%s] items, but '%s' found.", implode(', ', $allowedTypes), $itemType)
             );
         });
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -321,7 +321,7 @@ trait EnumeratesValues
      *
      * @template TEnsureOfType
      *
-     * @param  class-string<TEnsureOfType>|class-string<TEnsureOfType>[]  $type
+     * @param  class-string<TEnsureOfType>|array<array-key, class-string<TEnsureOfType>>  $type
      * @return static<TKey, TEnsureOfType>
      *
      * @throws \UnexpectedValueException

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -321,7 +321,7 @@ trait EnumeratesValues
      *
      * @template TEnsureOfType
      *
-     * @param  class-string<TEnsureOfType>  $type
+     * @param  class-string<TEnsureOfType>|class-string<TEnsureOfType>[]  $type
      * @return static<TKey, TEnsureOfType>
      *
      * @throws \UnexpectedValueException
@@ -331,11 +331,17 @@ trait EnumeratesValues
         return $this->each(function ($item) use ($type) {
             $itemType = get_debug_type($item);
 
-            if ($itemType !== $type && ! $item instanceof $type) {
-                throw new UnexpectedValueException(
-                    sprintf("Collection should only include '%s' items, but '%s' found.", $type, $itemType)
-                );
+            $allowedTypes = is_array($type) ? $type : [$type];
+
+            foreach ($allowedTypes as $allowedType) {
+                if ($itemType === $allowedType || $item instanceof $allowedType) {
+                    return true;
+                }
             }
+
+            throw new UnexpectedValueException(
+                sprintf("Collection should only include [%s] items, but '%s' found.", implode(', ', $types), $itemType)
+            );
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5650,6 +5650,19 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testEnsureForMultipleTypes($collection)
+    {
+        $data = $collection::make([new \Error, 123]);
+        $data->ensure([\Throwable::class, 'int']);
+
+        $data = $collection::make([new \Error, new \Error, new $collection]);
+        $this->expectException(UnexpectedValueException::class);
+        $data->ensure([\Throwable::class, 'int']);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testPercentageWithFlatCollection($collection)
     {
         $collection = new $collection([1, 1, 2, 2, 2, 3]);


### PR DESCRIPTION
Hey! This PR proposes a small update to the `ensure` method for Collections so you can pass multiple types rather than a single type.

I have a use case where I'm building up a Collection from two different types of classes. For extra reassurance, I just want to check that every item in the Collection is correct before I work on it. At the moment, it looks like the `ensure` method only supports specifying a single type, so my update would allow me to check for both of these types.

As a basic example:

```php
collect([new User(), new Contact(), new Contact()])
    ->ensure([User::class, Contact::class]);
```

In the example above, every item in the Collection would need to be an instance of my `User` or `Contact` classes. If they aren't one of the two, then an exception will be thrown.

I hope I've added this correctly (without breaking anything!) and updated the docblock properly too. The method should still work exactly as it does now, so single types (not passed as an array) should still work 🙂

If you think this is something that could be useful to other devs, please let me know if there's anything you'd like me to change 😄