### PR TITLE
[11.x] Apply `#[\Override]` attribute on methods extended from Symfony

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -208,6 +208,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  \Symfony\Component\Console\Command\Command  $command
      * @return \Symfony\Component\Console\Command\Command|null
      */
+    #[\Override]
     public function add(SymfonyCommand $command): ?SymfonyCommand
     {
         if ($command instanceof Command) {
@@ -285,6 +286,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      *
      * @return \Symfony\Component\Console\Input\InputDefinition
      */
+    #[\Override]
     protected function getDefaultInputDefinition(): InputDefinition
     {
         return tap(parent::getDefaultInputDefinition(), function ($definition) {

--- a/src/Illuminate/Console/BufferedConsoleOutput.php
+++ b/src/Illuminate/Console/BufferedConsoleOutput.php
@@ -28,6 +28,7 @@ class BufferedConsoleOutput extends ConsoleOutput
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     protected function doWrite(string $message, bool $newline): void
     {
         $this->buffer .= $message;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -166,6 +166,7 @@ class Command extends SymfonyCommand
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return int
      */
+    #[\Override]
     public function run(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output instanceof OutputStyle ? $output : $this->laravel->make(
@@ -191,6 +192,7 @@ class Command extends SymfonyCommand
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($this instanceof Isolatable && $this->option('isolated') !== false &&
@@ -257,6 +259,7 @@ class Command extends SymfonyCommand
      *
      * @return bool
      */
+    #[\Override]
     public function isHidden(): bool
     {
         return $this->hidden;
@@ -265,6 +268,7 @@ class Command extends SymfonyCommand
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setHidden(bool $hidden = true): static
     {
         parent::setHidden($this->hidden = $hidden);

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -52,6 +52,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function askQuestion(Question $question): mixed
     {
         try {
@@ -64,6 +65,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function write(string|iterable $messages, bool $newline = false, int $options = 0): void
     {
         $this->newLinesWritten = $this->trailingNewLineCount($messages) + (int) $newline;
@@ -75,6 +77,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function writeln(string|iterable $messages, int $type = self::OUTPUT_NORMAL): void
     {
         $this->newLinesWritten = $this->trailingNewLineCount($messages) + 1;
@@ -86,6 +89,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function newLine(int $count = 1): void
     {
         $this->newLinesWritten += $count;

--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -17,6 +17,7 @@ class QuestionHelper extends SymfonyQuestionHelper
      *
      * @return void
      */
+    #[\Override]
     protected function writePrompt(OutputInterface $output, Question $question): void
     {
         $text = OutputFormatter::escapeTrailingBackslash($question->getQuestion());

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -37,6 +37,7 @@ class JsonResponse extends BaseJsonResponse
      *
      * @return static
      */
+    #[\Override]
     public static function fromJsonString(?string $data = null, int $status = 200, array $headers = []): static
     {
         return new static($data, $status, $headers, 0, true);
@@ -70,6 +71,7 @@ class JsonResponse extends BaseJsonResponse
      *
      * @return static
      */
+    #[\Override]
     public function setData($data = []): static
     {
         $this->original = $data;
@@ -116,6 +118,7 @@ class JsonResponse extends BaseJsonResponse
      *
      * @return static
      */
+    #[\Override]
     public function setEncodingOptions($options): static
     {
         $this->encodingOptions = (int) $options;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -389,6 +389,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  mixed  $default
      * @return mixed
      */
+    #[\Override]
     public function get(string $key, mixed $default = null): mixed
     {
         return parent::get($key, $default);
@@ -499,6 +500,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @return static
      */
+    #[\Override]
     public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null): static
     {
         return parent::duplicate($query, $request, $attributes, $cookies, $this->filterFiles($files), $server);
@@ -532,6 +534,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function hasSession(bool $skipIfUninitialized = false): bool
     {
         return $this->session instanceof SymfonySessionDecorator;
@@ -540,6 +543,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getSession(): SessionInterface
     {
         return $this->hasSession()

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -45,6 +45,7 @@ class Response extends SymfonyResponse
      *
      * @throws \InvalidArgumentException
      */
+    #[\Override]
     public function setContent(mixed $content): static
     {
         $this->original = $content;


### PR DESCRIPTION
With the new `Override` attribute available from PHP8.3, we can make use of PHP to detect if any breaking changes occurs on those methods in case our tests doesn't cover it.