### PR TITLE
[10.x] `ensure`: Resolve `$itemType` outside the closure

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -328,10 +328,10 @@ trait EnumeratesValues
      */
     public function ensure($type)
     {
-        return $this->each(function ($item) use ($type) {
-            $itemType = get_debug_type($item);
+        $allowedTypes = is_array($type) ? $type : [$type];
 
-            $allowedTypes = is_array($type) ? $type : [$type];
+        return $this->each(function ($item) use ($allowedTypes) {
+            $itemType = get_debug_type($item);
 
             foreach ($allowedTypes as $allowedType) {
                 if ($itemType === $allowedType || $item instanceof $allowedType) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR updates `\Illuminate\Support\Traits\EnumeratesValues::ensure` so that `$itemType` is resolved only once for each item in the collection.
cc. @ash-jc-allen 
