### PR TITLE
[10.x] Fix middleware "SetCacheHeaders" with download responses

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SetCacheHeaders
 {
@@ -41,7 +42,7 @@ class SetCacheHeaders
     {
         $response = $next($request);
 
-        if (! $request->isMethodCacheable() || (! $response->getContent() && ! $response instanceof BinaryFileResponse)) {
+        if (! $request->isMethodCacheable() || (! $response->getContent() && ! $response instanceof BinaryFileResponse && ! $response instanceof StreamedResponse)) {
             return $response;
         }
 

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class CacheTest extends TestCase
 {
@@ -57,12 +58,24 @@ class CacheTest extends TestCase
         $this->assertNull($response->getEtag());
     }
 
-    public function testSetHeaderToFileEvenWithNoContent()
+    public function testSetHeaderToFileResponseEvenWithNoContent()
     {
         $response = (new Cache)->handle(new Request, function () {
             $filePath = __DIR__.'/../fixtures/test.txt';
 
             return new BinaryFileResponse($filePath);
+        }, 'max_age=120;s_maxage=60');
+
+        $this->assertNotNull($response->getMaxAge());
+    }
+
+    public function testSetHeaderToDownloadResponseEvenWithNoContent()
+    {
+        $response = (new Cache)->handle(new Request, function () {
+            return new StreamedResponse(function () {
+                $filePath = __DIR__.'/../fixtures/test.txt';
+                readfile($filePath);
+            });
         }, 'max_age=120;s_maxage=60');
 
         $this->assertNotNull($response->getMaxAge());


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where the `SetCacheHeaders` middleware was not functioning as expected when used in conjunction with `response->download()` in Laravel. This problem was previously identified and fixed for `response->file()` in [PR #44063](https://github.com/laravel/framework/pull/44063).

**Changes:**

The changes in this pull request extend the fix provided in [PR #44063](https://github.com/laravel/framework/pull/44063) to also cover scenarios involving `response->download()`. By addressing this inconsistency, the `SetCacheHeaders` middleware will now work seamlessly with both `response->file()` and `response->download()`.