### PR TITLE
[10.x] Extract dirty getter for `performUpdate`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2039,6 +2039,16 @@ trait HasAttributes
     }
 
     /**
+     * Get the attributes that have been changed since the last sync for an update operation.
+     *
+     * @return array
+     */
+    protected function getDirtyForUpdate()
+    {
+        return $this->getDirty();
+    }
+
+    /**
      * Get the attributes that were changed when the model was last saved.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1207,7 +1207,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // Once we have run the update operation, we will fire the "updated" event for
         // this model instance. This will allow developers to hook into these after
         // models are updated, giving them a chance to do any special processing.
-        $dirty = $this->getDirty();
+        $dirty = $this->getDirtyForUpdate();
 
         if (count($dirty) > 0) {
             $this->setKeysForSaveQuery($query)->update($dirty);


### PR DESCRIPTION
Back in 8.x [this](https://github.com/laravel/framework/pull/36963) PR was merged so that attributes could be easily altered before being inserted. This is similar to that PR except this time it is for updating. 

For context, we use a database driver for a database called [spanner](https://github.com/colopl/laravel-spanner) which require values for column types like `DECIMAL` to be wrapped in a special class `Google\Cloud\Spanner\Numeric`. Adding this will allow us to do the conversion without having to override the entire `performUpdate` method. 