### PR TITLE
Allow "missing" method to be used on route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -20,6 +20,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
+ * @method \Illuminate\Routing\RouteRegistrar missing(\Closure $missing)
  * @method \Illuminate\Routing\RouteRegistrar name(string $value)
  * @method \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string $prefix)
@@ -65,6 +66,7 @@ class RouteRegistrar
         'controller',
         'domain',
         'middleware',
+        'missing',
         'name',
         'namespace',
         'prefix',

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -498,9 +498,9 @@ class RouteRegistrarTest extends TestCase
     public function testRegisteringNonApprovedAttributesThrows()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\Routing\RouteRegistrar::missing does not exist.');
+        $this->expectExceptionMessage('Method Illuminate\Routing\RouteRegistrar::unsupportedMethod does not exist.');
 
-        $this->router->domain('foo')->missing('bar')->group(function ($router) {
+        $this->router->domain('foo')->unsupportedMethod('bar')->group(function ($router) {
             //
         });
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1883,6 +1883,29 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
+    public function testImplicitBindingsWithMissingModelHandledByMissingOnGroupLevel()
+    {
+        $router = $this->getRouter();
+        $router->as('foo.')
+            ->missing(fn() => new RedirectResponse('/', 302))
+            ->group(function () use ($router) {
+                $router->get('foo/{bar}', [
+                    'middleware' => SubstituteBindings::class,
+                    'uses' => function (RouteModelBindingNullStub $bar = null) {
+                        $this->assertInstanceOf(RouteModelBindingNullStub::class, $bar);
+
+                        return $bar->first();
+                    },
+                ]);
+            });
+
+        $request = Request::create('foo/taylor', 'GET');
+
+        $response = $router->dispatch($request);
+        $this->assertTrue($response->isRedirect('/'));
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
     public function testImplicitBindingsWithOptionalParameterWithNoKeyInUri()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1887,7 +1887,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->as('foo.')
-            ->missing(fn() => new RedirectResponse('/', 302))
+            ->missing(fn () => new RedirectResponse('/', 302))
             ->group(function () use ($router) {
                 $router->get('foo/{bar}', [
                     'middleware' => SubstituteBindings::class,


### PR DESCRIPTION
Imagine a route group where you want to return a specific "missing" response for the routes in that group.

```php
Route::prefix('locations')
    ->group(function() {
        Route::get('{location}', [LocationsController::class, 'show'])
            ->missing(fn() => ['success' => false, 'message' => 'The requested location does not exist']);
        Route::put('{location}', [LocationsController::class, 'update'])
            ->missing(fn() => ['success' => false, 'message' => 'The requested location does not exist']);
        Route::delete('{location}', [LocationsController::class, 'destroy'])
            ->missing(fn() => ['success' => false, 'message' => 'The requested location does not exist']);
    })
```


This PR makes it possible to write this in an easier way:

```php
Route::prefix('locations')
    ->missing(fn() => ['success' => false, 'message' => 'The requested location does not exist'])
    ->group(function() {
        Route::get('{location}', [LocationsController::class, 'show']);
        Route::put('{location}', [LocationsController::class, 'update']);
        Route::delete('{location}', [LocationsController::class, 'destroy']);
    })
```
