### PR TITLE
[10.x][Cache] Fix handling of `false` values in apc

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -41,11 +41,7 @@ class ApcStore extends TaggableStore
      */
     public function get($key)
     {
-        $value = $this->apc->get($this->prefix.$key);
-
-        if ($value !== false) {
-            return $value;
-        }
+        return $this->apc->get($this->prefix.$key);
     }
 
     /**

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -29,7 +29,9 @@ class ApcWrapper
      */
     public function get($key)
     {
-        return $this->apcu ? apcu_fetch($key) : apc_fetch($key);
+        $fetchedValue = $this->apcu ? apcu_fetch($key, $success) : apc_fetch($key, $success);
+
+        return $success ? $fetchedValue : null;
     }
 
     /**

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -25,6 +25,14 @@ class CacheApcStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
+    public function testAPCFalseValueIsReturned()
+    {
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
+        $apc->expects($this->once())->method('get')->willReturn(false);
+        $store = new ApcStore($apc);
+        $this->assertFalse($store->get('foo'));
+    }
+
     public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();


### PR DESCRIPTION
This commit addresses an issue in the `ApcWrapper` and `ApcStore` components of the caching system, particularly when dealing with a cached value of `false`. Previously, the `ApcWrapper`'s default behavior was to simply retrieve and return values from the APC cache store. However, in `ApcStore::get()`, there was a check to determine if the returned value was not `false`. If it wasn't, the value would be returned. This posed a problem where a `false` value is legitimately stored in the cache, but the existing check led to unnecessary cache misses and repeated `get` & `store` operations.

To resolve this, we have modified the implementation. Now, we leverage the second parameter of `apc_fetch`, which indicates whether the fetch operation was successful. This allows `ApcStore` to accurately differentiate between a successful fetch of a `false` value and a failed fetch operation.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
