### PR TITLE
[10.x] Make fake instance inherit from `Vite` when using `withoutVite()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -164,6 +164,16 @@ trait InteractsWithContainer
             {
                 return [];
             }
+
+            public function reactRefresh()
+            {
+                return '';
+            }
+
+            public function asset($asset, $buildDirectory = null)
+            {
+                return '';
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -113,14 +113,14 @@ trait InteractsWithContainer
 
         Facade::clearResolvedInstance(Vite::class);
 
-        $this->swap(Vite::class, new class
+        $this->swap(Vite::class, new class extends Vite
         {
-            public function __invoke()
+            public function __invoke($entrypoints, $buildDirectory = null)
             {
                 return '';
             }
 
-            public function __call($name, $arguments)
+            public function __call($method, $parameters)
             {
                 return '';
             }
@@ -130,32 +130,32 @@ trait InteractsWithContainer
                 return '';
             }
 
-            public function useIntegrityKey()
+            public function useIntegrityKey($key)
             {
                 return $this;
             }
 
-            public function useBuildDirectory()
+            public function useBuildDirectory($path)
             {
                 return $this;
             }
 
-            public function useHotFile()
+            public function useHotFile($path)
             {
                 return $this;
             }
 
-            public function withEntryPoints()
+            public function withEntryPoints($entryPoints)
             {
                 return $this;
             }
 
-            public function useScriptTagAttributes()
+            public function useScriptTagAttributes($attributes)
             {
                 return $this;
             }
 
-            public function useStyleTagAttributes()
+            public function useStyleTagAttributes($attributes)
             {
                 return $this;
             }


### PR DESCRIPTION
This PR makes the fake anonymous class extend from `\Illuminate\Foundation\Vite` when calling the `withoutVite()` method.

The goal behind it is to make sure the swapped class is still compatible with the real one. This is important when type-hinting to inject `\Illuminate\Foundation\Vite` from the container. Currently, it is not possible when using `withoutVite()`.