### PR TITLE
Fix directory separator CMD display

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -171,7 +171,7 @@ class MigrationCreator
      */
     protected function getPath($name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        return $path . DIRECTORY_SEPARATOR . $this->getDatePrefix() . '_' . $name . '.php';
     }
 
     /**


### PR DESCRIPTION
The directory separator is not consistent when running the artisan make:migration commands as below:

![bad-charecter](https://github.com/laravel/framework/assets/8941145/193cdbaa-a867-4832-a783-e1bbcc6a018e)

but now:
![good-charecter](https://github.com/laravel/framework/assets/8941145/6a2752eb-9f91-4057-a5a6-10f5e5221c4b)


