### PR TITLE
[10.x] Improves output when using `php artisan about --json`

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -168,16 +168,16 @@ class AboutCommand extends Command
             'PHP Version' => phpversion(),
             'Composer Version' => $this->composer->getVersion() ?? '<fg=yellow;options=bold>-</>',
             'Environment' => $this->laravel->environment(),
-            'Debug Mode' => $isEnabled(config('app.debug')),
+            'Debug Mode' => static::format(config('app.debug'), console: $isEnabled),
             'URL' => Str::of(config('app.url'))->replace(['http://', 'https://'], ''),
-            'Maintenance Mode' => static::format($this->laravel->isDownForMaintenance(), cli: $isEnabled),
+            'Maintenance Mode' => static::format($this->laravel->isDownForMaintenance(), console: $isEnabled),
         ]);
 
         static::addToSection('Cache', fn () => [
-            'Config' => static::format($this->laravel->configurationIsCached(), cli: $isCached),
-            'Events' => static::format($this->laravel->eventsAreCached(), cli: $isCached),
-            'Routes' => static::format($this->laravel->routesAreCached(), cli: $isCached),
-            'Views' => static::format($this->hasPhpFiles($this->laravel->storagePath('framework/views')), cli: $isCached),
+            'Config' => static::format($this->laravel->configurationIsCached(), console: $isCached),
+            'Events' => static::format($this->laravel->eventsAreCached(), console: $isCached),
+            'Routes' => static::format($this->laravel->routesAreCached(), console: $isCached),
+            'Views' => static::format($this->hasPhpFiles($this->laravel->storagePath('framework/views')), console: $isCached),
         ]);
 
         static::addToSection('Drivers', fn () => array_filter([
@@ -192,7 +192,7 @@ class AboutCommand extends Command
 
                     return value(static::format(
                         value: $logChannel,
-                        cli: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
                         json: fn () => $secondary->all(),
                     ), $json);
                 } else {
@@ -239,18 +239,18 @@ class AboutCommand extends Command
      * Format the given value for CLI or JSON.
      *
      * @param  mixed  $value
-     * @param  (\Closure():(mixed))|null  $cli
+     * @param  (\Closure():(mixed))|null  $console
      * @param  (\Closure():(mixed))|null  $json
      * @return \Closure(bool):mixed
      */
-    public static function format($value, Closure $cli = null, Closure $json = null)
+    public static function format($value, Closure $console = null, Closure $json = null)
     {
-        return function ($isJson) use ($value, $cli, $json) {
+        return function ($isJson) use ($value, $console, $json) {
             /** @var bool $isJson */
             if ($isJson === true && $json instanceof Closure) {
                 return value($json, $value);
-            } elseif ($isJson === false && $cli instanceof Closure) {
-                return value($cli, $value);
+            } elseif ($isJson === false && $console instanceof Closure) {
+                return value($console, $value);
             }
 
             return value($value);

--- a/tests/Foundation/Console/AboutCommandTest.php
+++ b/tests/Foundation/Console/AboutCommandTest.php
@@ -20,8 +20,8 @@ class AboutCommandTest extends TestCase
 
     public static function cliDataProvider()
     {
-        yield [AboutCommand::format(true, cli: fn ($value) => $value === true ? 'YES' : 'NO'), 'YES'];
-        yield [AboutCommand::format(false, cli: fn ($value) => $value === true ? 'YES' : 'NO'), 'NO'];
+        yield [AboutCommand::format(true, console: fn ($value) => $value === true ? 'YES' : 'NO'), 'YES'];
+        yield [AboutCommand::format(false, console: fn ($value) => $value === true ? 'YES' : 'NO'), 'NO'];
     }
 
     /**

--- a/tests/Foundation/Console/AboutCommandTest.php
+++ b/tests/Foundation/Console/AboutCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Foundation\Console\AboutCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AboutCommandTest extends TestCase
+{
+    /**
+     * @param  \Closure(bool):mixed  $format
+     * @param  mixed  $expected
+     */
+    #[DataProvider('cliDataProvider')]
+    public function testItCanFormatForCliInterface($format, $expected)
+    {
+        $this->assertSame($expected, value($format, false));
+    }
+
+    public static function cliDataProvider()
+    {
+        yield [AboutCommand::format(true, cli: fn ($value) => $value === true ? 'YES' : 'NO'), 'YES'];
+        yield [AboutCommand::format(false, cli: fn ($value) => $value === true ? 'YES' : 'NO'), 'NO'];
+    }
+
+    /**
+     * @param  \Closure(bool):mixed  $format
+     * @param  mixed  $expected
+     */
+    #[DataProvider('jsonDataProvider')]
+    public function testItCanFormatForJsonInterface($format, $expected)
+    {
+        $this->assertSame($expected, value($format, true));
+    }
+
+    public static function jsonDataProvider()
+    {
+        yield [AboutCommand::format(true, json: fn ($value) => $value === true ? 'YES' : 'NO'), 'YES'];
+        yield [AboutCommand::format(false, json: fn ($value) => $value === true ? 'YES' : 'NO'), 'NO'];
+    }
+}

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -13,21 +13,23 @@ class AboutCommandTest extends TestCase
     {
         $process = remote('about --json')->mustRun();
 
-        Assert::assertArraySubset([
-            'environment' => [
+        tap(json_decode($process->getOutput(), true), function ($output) {
+            Assert::assertArraySubset([
                 'application_name' => 'Laravel',
                 'php_version' => PHP_VERSION,
                 'environment' => 'testing',
                 'debug_mode' => true,
                 'url' => 'localhost',
                 'maintenance_mode' => false,
-            ],
-            'cache' => [
+            ], $output['environment']);
+
+            Assert::assertArraySubset([
                 'config' => false,
                 'events' => false,
                 'routes' => false,
-            ],
-            'drivers' => [
+            ], $output['cache']);
+
+            Assert::assertArraySubset([
                 'broadcasting' => 'log',
                 'cache' => 'file',
                 'database' => 'testing',
@@ -35,7 +37,7 @@ class AboutCommandTest extends TestCase
                 'mail' => 'smtp',
                 'queue' => 'sync',
                 'session' => 'file',
-            ],
-        ], json_decode($process->getOutput(), true));
+            ], $output['drivers']);
+        });
     }
 }

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Testing\Assert;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Testing\Assert;
+use Orchestra\Testbench\TestCase;
+
+use function Orchestra\Testbench\remote;
+
+class AboutCommandTest extends TestCase
+{
+    public function testItCanDisplayAboutCommandAsJson()
+    {
+        $process = remote('about --json')->mustRun();
+
+        Assert::assertArraySubset([
+            'environment' => [
+                'application_name' => 'Laravel',
+                'php_version' => PHP_VERSION,
+                'environment' => 'testing',
+                'debug_mode' => true,
+                'url' => 'localhost',
+                'maintenance_mode' => false,
+            ],
+            'cache' => [
+                'config' => false,
+                'events' => false,
+                'routes' => false,
+            ],
+            'drivers' => [
+                'broadcasting' => 'log',
+                'cache' => 'file',
+                'database' => 'testing',
+                'logs' => ['single'],
+                'mail' => 'smtp',
+                'queue' => 'sync',
+                'session' => 'file',
+            ],
+        ], json_decode($process->getOutput(), true));
+    }
+}


### PR DESCRIPTION
Fixes #49147 

Introduce new `AboutCommand::format()` helper method to make it possible to apply a different format for JSON and CLI.