### PR TITLE
[10.x] Generate a unique hash for anonymous components

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Compilers\Concerns;
 
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Str;
+use Illuminate\View\AnonymousComponent;
 use Illuminate\View\ComponentAttributeBag;
 
 trait CompilesComponents
@@ -29,7 +30,9 @@ trait CompilesComponents
 
         $component = trim($component, '\'"');
 
-        $hash = static::newComponentHash($component);
+        $hash = static::newComponentHash(
+            $component === AnonymousComponent::class ? $component.':'.trim($alias, '\'"') : $component
+        );
 
         if (Str::contains($component, ['::class', '\\'])) {
             return static::compileClassComponentOpening($component, $alias, $data, $hash);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently, the same hash is generated for anonymous components. This causes issues with scoped slots when nesting two or more anonymous components. For example:

```
<x-menu>
  <x-menu-item>
    <x-button>Hello World</x-button>
  </x-menu-item>
  @dd($component)
</x-menu>
```

Given the above example, `$component` should be scoped to the `x-menu` component, but because of this issue, it's scoped to the `x-menu-item` component.

This happens because of what's returned by the `Illuminate\View\Compilers\Concerns\CompilesComponents::compileClassComponentOpening` method, which creates a copy of the containing component and assigns it to a variable using the hash of the current component:

```
<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>
```

When another anonymous component is nested, the previous is overwritten. Here's an example of the compiled view which shows the issue:

```
<?php if (isset($component)) { $__componentOriginal71c6471fa76ce19017edc287b6f4508c = $component; } ?>
<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'components.menu','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? (array) $attributes->getIterator() : [])); ?>
<?php $component->withName('menu'); ?>

<?php if (isset($component)) { $__componentOriginal71c6471fa76ce19017edc287b6f4508c = $component; } ?>
<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'components.menu-item','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? (array) $attributes->getIterator() : [])); ?>
<?php $component->withName('menu-item'); ?>

<?php if (isset($component)) { $__componentOriginal71c6471fa76ce19017edc287b6f4508c = $component; } ?>
<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'components.button','data' => []] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? (array) $attributes->getIterator() : [])); ?>
<?php $component->withName('button'); ?>

<?php $component->withAttributes([]); ?>Hello World! <?php echo $__env->renderComponent(); ?>

<?php if (isset($__componentOriginal71c6471fa76ce19017edc287b6f4508c)): ?>
<?php $component = $__componentOriginal71c6471fa76ce19017edc287b6f4508c; ?>
<?php unset($__componentOriginal71c6471fa76ce19017edc287b6f4508c); ?>
<?php endif; ?>

<?php echo $__env->renderComponent(); ?>

<?php if (isset($__componentOriginal71c6471fa76ce19017edc287b6f4508c)): ?>
<?php $component = $__componentOriginal71c6471fa76ce19017edc287b6f4508c; ?>
<?php unset($__componentOriginal71c6471fa76ce19017edc287b6f4508c); ?>
<?php endif; ?>

<?php dd($component); ?>
<?php echo $__env->renderComponent(); ?>

<?php if (isset($__componentOriginal71c6471fa76ce19017edc287b6f4508c)): ?>
<?php $component = $__componentOriginal71c6471fa76ce19017edc287b6f4508c; ?>
<?php unset($__componentOriginal71c6471fa76ce19017edc287b6f4508c); ?>
<?php endif; ?>
```



