### PR TITLE
[10.x] Make test error messages more multi-byte readable

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1663,7 +1663,7 @@ class TestResponse implements ArrayAccess
     protected function appendErrorsToException($errors, $exception, $json = false)
     {
         $errors = $json
-            ? json_encode($errors, JSON_PRETTY_PRINT)
+            ? json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
             : implode(PHP_EOL, Arr::flatten($errors));
 
         // JSON error messages may already contain the errors, so we shouldn't duplicate them...


### PR DESCRIPTION
During testing, if you use `postJson` and you get the unexpected status code because of validation errors, Laravel will kindly display the validation error messages.
But unfortunately, with multibyte characters, it is difficult to understand what is being written.

This pull request solves that problem.

## Before
![image](https://github.com/laravel/framework/assets/14008307/adc0cf92-9f1a-4ff5-bf57-c7af06a3a71b)

## After
![image](https://github.com/laravel/framework/assets/14008307/8d8a55cf-e8dd-42f4-b74f-242d72650919)
(Also, slashes are not escaped.)


Below is the code for confirmation.

web.php
```php
Route::post('', function (Request $request) {
    $request->validate([
        'name' => 'required|string|max:255',
        'url' => 'required|string|max:255',
    ], [
        'name.required' => '名前は必須です',
        'url.required' => '/ is a slash symbol.',
    ]);

    return response()->json(['foo' => 'bar'], 201);
});
```

test code
```php
    public function test_name()
    {
        $this->postJson('', [])
            ->assertStatus(201)
            ->assertJson(['foo' => 'bar']);
    }
```
