### PR TITLE
[10.x] Fix `MorphTo::associate()` PHPDoc parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -226,7 +226,7 @@ class MorphTo extends BelongsTo
     /**
      * Associate the model instance to the given parent.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function associate($model)


### PR DESCRIPTION
Similar to `BelongsTo::associate()` the `MorphTo::associate()` method also accepts `null`. The implementation accounts for this, but the PHPDoc parameter does not. There's a test case that covers this scenario:

https://github.com/laravel/framework/blob/10.x/tests/Database/DatabaseEloquentMorphToTest.php#L173-L185