### PR TITLE
[10.x] Use HtmlString in Vite fake

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -117,7 +117,7 @@ trait InteractsWithContainer
         {
             public function __invoke($entrypoints, $buildDirectory = null)
             {
-                return '';
+                return new HtmlString('');
             }
 
             public function __call($method, $parameters)

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -13,7 +13,7 @@ class InteractsWithContainerTest extends TestCase
     {
         $instance = $this->withoutVite();
 
-        $this->assertSame('', app(Vite::class)(['resources/js/app.js']));
+        $this->assertSame('', app(Vite::class)(['resources/js/app.js'])->toHtml());
         $this->assertSame($this, $instance);
     }
 


### PR DESCRIPTION
The change in #49150 has started to break our test suite.

Since that PR, the faked Vite instance now implements `Htmlable`, so we're now seeing a lot of `Call to member function toHtml() on string` from this line:

https://github.com/laravel/framework/blob/1e03a4a9029513c359b44fd6150d7ef2b772da49/src/Illuminate/Foundation/Vite.php#L784

Since `toHtml()` is expecting `__invoke` to return an `HtmlString`, that's what this PR is doing.

We don't use the `@vite` directive (the error doesn't happen if you do). We use the facade essentially like this:

```blade
{{ Vite::withEntryPoints(['path/to/file.css']) }}
```

For the test I just slapped on `->toHtml()` the same way you do that in https://github.com/laravel/framework/blob/10.x/tests/Foundation/FoundationViteTest.php