### PR TITLE
[v10.x] Add missing methods to newly extended fake `Vite` instance

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -160,12 +160,22 @@ trait InteractsWithContainer
                 return $this;
             }
 
+            public function usePreloadTagAttributes($attributes)
+            {
+                return $this;
+            }
+
             public function preloadedAssets()
             {
                 return [];
             }
 
             public function reactRefresh()
+            {
+                return '';
+            }
+
+            public function content($asset, $buildDirectory = null)
             {
                 return '';
             }


### PR DESCRIPTION
Similar to https://github.com/laravel/framework/pull/49163, the changes made in https://github.com/laravel/framework/pull/49150 to the fake `Vite` instance swapped out using `$this->withoutVite()` in our tests has broken our suite. If I roll back to a `v10.3X` version, the test passes normally.

This PR adds some remaining methods that are documented in the facade and on the laravel.com website.

---

Test:
```php
public function testItSavesAsPdf()
{
    $this->withoutVite();

    $invoice = Invoice::factory()->create();

    $media = $invoice->saveAsPdf();

    $this->assertEquals(now()->format('Y-m').'-invoice.pdf', $media->file_name);
}
```

Exception:
```
Illuminate\View\ViewException: Vite manifest not found at: /Users/stevebauman/Sites/project/public/build/manifest.json (View: /Users/stevebauman/Sites/project/resources/views/invoice/show.blade.php)
```

This is due to the following call in our `show.blade.php` method:

```blade
<style>{!! Vite::content('resources/scss/app.scss') !!}</style>
```

---

On another note, this anonymous class is getting pretty large. Should we swap this out with its own dedicated `ViteFake` class living in the `Illuminate\Support\Testing\Fakes` namespace that implements the `Fake` interface?