### PR TITLE
[11.x] Refactor `Number` Class Functions for Simplicity and Code

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -27,8 +27,8 @@ class Number
     /**
      * Creates a new instance of the class and sets the number and locale properties.
      *
-     * @param  int|float $number
-     * @param  string $locale
+     * @param  int|float  $number
+     * @param  string  $locale
      * @return self
      */
     public static function create(int|float $number, string $locale = 'en')
@@ -55,9 +55,9 @@ class Number
 
         $formatter = new NumberFormatter($this->locale, NumberFormatter::DECIMAL);
 
-        if (!is_null($maxPrecision)) {
+        if (! is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
-        } elseif (!is_null($precision)) {
+        } elseif (! is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -22,7 +22,7 @@ class Number
      *
      * @var string
      */
-    protected $locale;
+    protected static $locale = 'en';
 
     /**
      * Creates a new instance of the class and sets the number and locale properties.
@@ -31,13 +31,13 @@ class Number
      * @param  string  $locale
      * @return self
      */
-    public static function create(int|float $number, string $locale = 'en')
+    public static function create(int|float $number, ?string $locale = null)
     {
         $instants = new static;
 
         $instants->number = $number;
 
-        $instants->locale = $locale;
+        $instants->locale = $locale ?? static::$locale;
 
         return $instants;
     }
@@ -142,16 +142,16 @@ class Number
     /**
      * Convert the given number to its currency equivalent.
      *
-     * @param  string  $in
+     * @param  string  $currency
      * @return string|false
      */
-    public function toCurrency(string $in = 'USD')
+    public function toCurrency(string $currency = 'USD')
     {
         $this->ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($this->locale, NumberFormatter::CURRENCY);
 
-        return $formatter->formatCurrency($this->number, $in);
+        return $formatter->formatCurrency($this->number, $currency);
     }
 
     /**
@@ -191,6 +191,17 @@ class Number
             $number >= 1e15 => sprintf('%s quadrillion', static::create($number / 1e15, $this->locale)->toHumans($precision, $maxPrecision)),
             default => $this->formatWithUnit($precision, $maxPrecision),
         };
+    }
+
+    /**
+     * Set the default locale.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    public static function useLocale(string $locale)
+    {
+        static::$locale = $locale;
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -18,7 +18,7 @@ class Number
     protected $number;
 
     /**
-     * The current default locale.
+     * The current locale.
      *
      * @var string
      */
@@ -200,7 +200,7 @@ class Number
      */
     protected function ensureIntlExtensionIsInstalled()
     {
-        if (!extension_loaded('intl')) {
+        if (! extension_loaded('intl')) {
             throw new RuntimeException('The "intl" PHP extension is required to use this method.');
         }
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -11,207 +11,207 @@ class SupportNumberTest extends TestCase
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('0', Number::format(0));
-        $this->assertSame('1', Number::format(1));
-        $this->assertSame('10', Number::format(10));
-        $this->assertSame('25', Number::format(25));
-        $this->assertSame('100', Number::format(100));
-        $this->assertSame('100,000', Number::format(100000));
-        $this->assertSame('100,000.00', Number::format(100000, precision: 2));
-        $this->assertSame('100,000.12', Number::format(100000.123, precision: 2));
-        $this->assertSame('100,000.123', Number::format(100000.1234, maxPrecision: 3));
-        $this->assertSame('100,000.124', Number::format(100000.1236, maxPrecision: 3));
-        $this->assertSame('123,456,789', Number::format(123456789));
+        $this->assertSame('0', Number::create(0)->format());
+        $this->assertSame('1', Number::create(1)->format());
+        $this->assertSame('10', Number::create(10)->format());
+        $this->assertSame('25', Number::create(25)->format());
+        $this->assertSame('100', Number::create(100)->format());
+        $this->assertSame('100,000', Number::create(100000)->format());
+        $this->assertSame('100,000.00', Number::create(100000)->format(precision: 2));
+        $this->assertSame('100,000.12', Number::create(100000.123)->format(precision: 2));
+        $this->assertSame('100,000.123', Number::create(100000.1234)->format(maxPrecision: 3));
+        $this->assertSame('100,000.124', Number::create(100000.1236)->format(maxPrecision: 3));
+        $this->assertSame('123,456,789', Number::create(123456789)->format());
 
-        $this->assertSame('-1', Number::format(-1));
-        $this->assertSame('-10', Number::format(-10));
-        $this->assertSame('-25', Number::format(-25));
+        $this->assertSame('-1', Number::create(-1)->format());
+        $this->assertSame('-10', Number::create(-10)->format());
+        $this->assertSame('-25', Number::create(-25)->format());
 
-        $this->assertSame('0.2', Number::format(0.2));
-        $this->assertSame('0.20', Number::format(0.2, precision: 2));
-        $this->assertSame('0.123', Number::format(0.1234, maxPrecision: 3));
-        $this->assertSame('1.23', Number::format(1.23));
-        $this->assertSame('-1.23', Number::format(-1.23));
-        $this->assertSame('123.456', Number::format(123.456));
+        $this->assertSame('0.2', Number::create(0.2)->format());
+        $this->assertSame('0.20', Number::create(0.2)->format(precision: 2));
+        $this->assertSame('0.123', Number::create(0.1234)->format(maxPrecision: 3));
+        $this->assertSame('1.23', Number::create(1.23)->format());
+        $this->assertSame('-1.23', Number::create(-1.23)->format());
+        $this->assertSame('123.456', Number::create(123.456)->format());
 
-        $this->assertSame('∞', Number::format(INF));
-        $this->assertSame('NaN', Number::format(NAN));
+        $this->assertSame('∞', Number::create(INF)->format());
+        $this->assertSame('NaN', Number::create(NAN)->format());
     }
 
     public function testFormatWithDifferentLocale()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('123,456,789', Number::format(123456789, locale: 'en'));
-        $this->assertSame('123.456.789', Number::format(123456789, locale: 'de'));
-        $this->assertSame('123 456 789', Number::format(123456789, locale: 'fr'));
-        $this->assertSame('123 456 789', Number::format(123456789, locale: 'ru'));
-        $this->assertSame('123 456 789', Number::format(123456789, locale: 'sv'));
+        $this->assertSame('123,456,789', Number::create(123456789, 'en')->format());
+        $this->assertSame('123.456.789', Number::create(123456789, 'de')->format());
+        $this->assertSame('123 456 789', Number::create(123456789, 'fr')->format());
+        $this->assertSame('123 456 789', Number::create(123456789, 'ru')->format());
+        $this->assertSame('123 456 789', Number::create(123456789, 'sv')->format());
     }
 
     public function testFormatWithAppLocale()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('123,456,789', Number::format(123456789));
+        $this->assertSame('123,456,789', Number::create(123456789)->format());
 
         Number::useLocale('de');
 
-        $this->assertSame('123.456.789', Number::format(123456789));
+        $this->assertSame('123.456.789', Number::create(123456789)->format());
 
         Number::useLocale('en');
     }
 
     public function testSpellout()
     {
-        $this->assertSame('ten', Number::spell(10));
-        $this->assertSame('one point two', Number::spell(1.2));
+        $this->assertSame('ten', Number::create(10)->toSpell());
+        $this->assertSame('one point two', Number::create(1.2)->toSpell());
     }
 
     public function testSpelloutWithLocale()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('trois', Number::spell(3, 'fr'));
+        $this->assertSame('trois', Number::create(3, 'fr')->toSpell());
     }
 
     public function testOrdinal()
     {
-        $this->assertSame('1st', Number::ordinal(1));
-        $this->assertSame('2nd', Number::ordinal(2));
-        $this->assertSame('3rd', Number::ordinal(3));
+        $this->assertSame('1st', Number::create(1)->toOrdinal());
+        $this->assertSame('2nd', Number::create(2)->toOrdinal());
+        $this->assertSame('3rd', Number::create(3)->toOrdinal());
     }
 
     public function testToPercent()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('0%', Number::percentage(0, precision: 0));
-        $this->assertSame('0%', Number::percentage(0));
-        $this->assertSame('1%', Number::percentage(1));
-        $this->assertSame('10.00%', Number::percentage(10, precision: 2));
-        $this->assertSame('100%', Number::percentage(100));
-        $this->assertSame('100.00%', Number::percentage(100, precision: 2));
-        $this->assertSame('100.123%', Number::percentage(100.1234, maxPrecision: 3));
+        $this->assertSame('0%', Number::create(0)->toPercentage(precision: 0));
+        $this->assertSame('0%', Number::create(0)->toPercentage());
+        $this->assertSame('1%', Number::create(1)->toPercentage());
+        $this->assertSame('10.00%', Number::create(10)->toPercentage(precision: 2));
+        $this->assertSame('100%', Number::create(100)->toPercentage());
+        $this->assertSame('100.00%', Number::create(100)->toPercentage(precision: 2));
+        $this->assertSame('100.123%', Number::create(100.1234)->toPercentage(maxPrecision: 3));
 
-        $this->assertSame('300%', Number::percentage(300));
-        $this->assertSame('1,000%', Number::percentage(1000));
+        $this->assertSame('300%', Number::create(300)->toPercentage());
+        $this->assertSame('1,000%', Number::create(1000)->toPercentage());
 
-        $this->assertSame('2%', Number::percentage(1.75));
-        $this->assertSame('1.75%', Number::percentage(1.75, precision: 2));
-        $this->assertSame('1.750%', Number::percentage(1.75, precision: 3));
-        $this->assertSame('0%', Number::percentage(0.12345));
-        $this->assertSame('0.00%', Number::percentage(0, precision: 2));
-        $this->assertSame('0.12%', Number::percentage(0.12345, precision: 2));
-        $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4));
+        $this->assertSame('2%', Number::create(1.75)->toPercentage());
+        $this->assertSame('1.75%', Number::create(1.75)->toPercentage(precision: 2));
+        $this->assertSame('1.750%', Number::create(1.75)->toPercentage(precision: 3));
+        $this->assertSame('0%', Number::create(0.12345)->toPercentage());
+        $this->assertSame('0.00%', Number::create(0)->toPercentage(precision: 2));
+        $this->assertSame('0.12%', Number::create(0.12345)->toPercentage(precision: 2));
+        $this->assertSame('0.1235%', Number::create(0.12345)->toPercentage(precision: 4));
     }
 
     public function testToCurrency()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('$0.00', Number::currency(0));
-        $this->assertSame('$1.00', Number::currency(1));
-        $this->assertSame('$10.00', Number::currency(10));
+        $this->assertSame('$0.00', Number::create(0)->toCurrency());
+        $this->assertSame('$1.00', Number::create(1)->toCurrency());
+        $this->assertSame('$10.00', Number::create(10)->toCurrency());
 
-        $this->assertSame('€0.00', Number::currency(0, 'EUR'));
-        $this->assertSame('€1.00', Number::currency(1, 'EUR'));
-        $this->assertSame('€10.00', Number::currency(10, 'EUR'));
+        $this->assertSame('€0.00', Number::create(0)->toCurrency('EUR'));
+        $this->assertSame('€1.00', Number::create(1)->toCurrency('EUR'));
+        $this->assertSame('€10.00', Number::create(10)->toCurrency('EUR'));
 
-        $this->assertSame('-$5.00', Number::currency(-5));
-        $this->assertSame('$5.00', Number::currency(5.00));
-        $this->assertSame('$5.32', Number::currency(5.325));
+        $this->assertSame('-$5.00', Number::create(-5)->toCurrency());
+        $this->assertSame('$5.00', Number::create(5.00)->toCurrency());
+        $this->assertSame('$5.32', Number::create(5.325)->toCurrency());
     }
 
     public function testToCurrencyWithDifferentLocale()
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('1,00 €', Number::currency(1, 'EUR', 'de'));
-        $this->assertSame('1,00 $', Number::currency(1, 'USD', 'de'));
-        $this->assertSame('1,00 £', Number::currency(1, 'GBP', 'de'));
+        $this->assertSame('1,00 €', Number::create(1, 'de')->toCurrency('EUR'));
+        $this->assertSame('1,00 $', Number::create(1, 'de')->toCurrency('USD'));
+        $this->assertSame('1,00 £', Number::create(1, 'de')->toCurrency('GBP'));
 
-        $this->assertSame('123.456.789,12 $', Number::currency(123456789.12345, 'USD', 'de'));
-        $this->assertSame('123.456.789,12 €', Number::currency(123456789.12345, 'EUR', 'de'));
-        $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
+        $this->assertSame('123.456.789,12 $', Number::create(123456789.12345, 'de')->toCurrency('USD'));
+        $this->assertSame('123.456.789,12 €', Number::create(123456789.12345, 'de')->toCurrency('EUR'));
+        $this->assertSame('1 234,56 $US', Number::create(1234.56, 'fr')->toCurrency('USD'));
     }
 
     public function testBytesToHuman()
     {
-        $this->assertSame('0 B', Number::fileSize(0));
-        $this->assertSame('0.00 B', Number::fileSize(0, precision: 2));
-        $this->assertSame('1 B', Number::fileSize(1));
-        $this->assertSame('1 KB', Number::fileSize(1024));
-        $this->assertSame('2 KB', Number::fileSize(2048));
-        $this->assertSame('2.00 KB', Number::fileSize(2048, precision: 2));
-        $this->assertSame('1.23 KB', Number::fileSize(1264, precision: 2));
-        $this->assertSame('1.234 KB', Number::fileSize(1264.12345, maxPrecision: 3));
-        $this->assertSame('1.234 KB', Number::fileSize(1264, 3));
-        $this->assertSame('5 GB', Number::fileSize(1024 * 1024 * 1024 * 5));
-        $this->assertSame('10 TB', Number::fileSize((1024 ** 4) * 10));
-        $this->assertSame('10 PB', Number::fileSize((1024 ** 5) * 10));
-        $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
-        $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
-        $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+        $this->assertSame('0 B', Number::create(0)->toFileSize());
+        $this->assertSame('0.00 B', Number::create(0)->toFileSize(precision: 2));
+        $this->assertSame('1 B', Number::create(1)->toFileSize());
+        $this->assertSame('1 KB', Number::create(1024)->toFileSize());
+        $this->assertSame('2 KB', Number::create(2048)->toFileSize());
+        $this->assertSame('2.00 KB', Number::create(2048)->toFileSize(precision: 2));
+        $this->assertSame('1.23 KB', Number::create(1264)->toFileSize(precision: 2));
+        $this->assertSame('1.234 KB', Number::create(1264.12345)->toFileSize(maxPrecision: 3));
+        $this->assertSame('1.234 KB', Number::create(1264, 3)->toFileSize());
+        $this->assertSame('5 GB', Number::create(1024 * 1024 * 1024 * 5)->toFileSize());
+        $this->assertSame('10 TB', Number::create((1024 ** 4) * 10)->toFileSize());
+        $this->assertSame('10 PB', Number::create((1024 ** 5) * 10)->toFileSize());
+        $this->assertSame('1 ZB', Number::create(1024 ** 7)->toFileSize());
+        $this->assertSame('1 YB', Number::create(1024 ** 8)->toFileSize());
+        $this->assertSame('1,024 YB', Number::create(1024 ** 9)->toFileSize());
     }
 
     public function testToHuman()
     {
-        $this->assertSame('1', Number::forHumans(1));
-        $this->assertSame('1.00', Number::forHumans(1, precision: 2));
-        $this->assertSame('10', Number::forHumans(10));
-        $this->assertSame('100', Number::forHumans(100));
-        $this->assertSame('1 thousand', Number::forHumans(1000));
-        $this->assertSame('1.00 thousand', Number::forHumans(1000, precision: 2));
-        $this->assertSame('1 thousand', Number::forHumans(1000, maxPrecision: 2));
-        $this->assertSame('1 thousand', Number::forHumans(1230));
-        $this->assertSame('1.2 thousand', Number::forHumans(1230, maxPrecision: 1));
-        $this->assertSame('1 million', Number::forHumans(1000000));
-        $this->assertSame('1 billion', Number::forHumans(1000000000));
-        $this->assertSame('1 trillion', Number::forHumans(1000000000000));
-        $this->assertSame('1 quadrillion', Number::forHumans(1000000000000000));
-        $this->assertSame('1 thousand quadrillion', Number::forHumans(1000000000000000000));
+        $this->assertSame('1', Number::create(1)->toHumans());
+        $this->assertSame('1.00', Number::create(1)->toHumans(precision: 2));
+        $this->assertSame('10', Number::create(10)->toHumans());
+        $this->assertSame('100', Number::create(100)->toHumans());
+        $this->assertSame('1 thousand', Number::create(1000)->toHumans());
+        $this->assertSame('1.00 thousand', Number::create(1000)->toHumans(precision: 2));
+        $this->assertSame('1 thousand', Number::create(1000)->toHumans(maxPrecision: 2));
+        $this->assertSame('1 thousand', Number::create(1230)->toHumans());
+        $this->assertSame('1.2 thousand', Number::create(1230)->toHumans(maxPrecision: 1));
+        $this->assertSame('1 million', Number::create(1000000)->toHumans());
+        $this->assertSame('1 billion', Number::create(1000000000)->toHumans());
+        $this->assertSame('1 trillion', Number::create(1000000000000)->toHumans());
+        $this->assertSame('1 quadrillion', Number::create(1000000000000000)->toHumans());
+        $this->assertSame('1 thousand quadrillion', Number::create(1000000000000000000)->toHumans());
 
-        $this->assertSame('123', Number::forHumans(123));
-        $this->assertSame('1 thousand', Number::forHumans(1234));
-        $this->assertSame('1.23 thousand', Number::forHumans(1234, precision: 2));
-        $this->assertSame('12 thousand', Number::forHumans(12345));
-        $this->assertSame('1 million', Number::forHumans(1234567));
-        $this->assertSame('1 billion', Number::forHumans(1234567890));
-        $this->assertSame('1 trillion', Number::forHumans(1234567890123));
-        $this->assertSame('1.23 trillion', Number::forHumans(1234567890123, precision: 2));
-        $this->assertSame('1 quadrillion', Number::forHumans(1234567890123456));
-        $this->assertSame('1.23 thousand quadrillion', Number::forHumans(1234567890123456789, precision: 2));
-        $this->assertSame('490 thousand', Number::forHumans(489939));
-        $this->assertSame('489.9390 thousand', Number::forHumans(489939, precision: 4));
-        $this->assertSame('500.00000 million', Number::forHumans(500000000, precision: 5));
+        $this->assertSame('123', Number::create(123)->toHumans());
+        $this->assertSame('1 thousand', Number::create(1234)->toHumans());
+        $this->assertSame('1.23 thousand', Number::create(1234)->toHumans(precision: 2));
+        $this->assertSame('12 thousand', Number::create(12345)->toHumans());
+        $this->assertSame('1 million', Number::create(1234567)->toHumans());
+        $this->assertSame('1 billion', Number::create(1234567890)->toHumans());
+        $this->assertSame('1 trillion', Number::create(1234567890123)->toHumans());
+        $this->assertSame('1.23 trillion', Number::create(1234567890123)->toHumans(precision: 2));
+        $this->assertSame('1 quadrillion', Number::create(1234567890123456)->toHumans());
+        $this->assertSame('1.23 thousand quadrillion', Number::create(1234567890123456789)->toHumans(precision: 2));
+        $this->assertSame('490 thousand', Number::create(489939)->toHumans());
+        $this->assertSame('489.9390 thousand', Number::create(489939)->toHumans(precision: 4));
+        $this->assertSame('500.00000 million', Number::create(500000000)->toHumans(precision: 5));
 
-        $this->assertSame('1 million quadrillion', Number::forHumans(1000000000000000000000));
-        $this->assertSame('1 billion quadrillion', Number::forHumans(1000000000000000000000000));
-        $this->assertSame('1 trillion quadrillion', Number::forHumans(1000000000000000000000000000));
-        $this->assertSame('1 quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000));
-        $this->assertSame('1 thousand quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000000));
+        $this->assertSame('1 million quadrillion', Number::create(1000000000000000000000)->toHumans());
+        $this->assertSame('1 billion quadrillion', Number::create(1000000000000000000000000)->toHumans());
+        $this->assertSame('1 trillion quadrillion', Number::create(1000000000000000000000000000)->toHumans());
+        $this->assertSame('1 quadrillion quadrillion', Number::create(1000000000000000000000000000000)->toHumans());
+        $this->assertSame('1 thousand quadrillion quadrillion', Number::create(1000000000000000000000000000000000)->toHumans());
 
-        $this->assertSame('0', Number::forHumans(0));
-        $this->assertSame('-1', Number::forHumans(-1));
-        $this->assertSame('-1.00', Number::forHumans(-1, precision: 2));
-        $this->assertSame('-10', Number::forHumans(-10));
-        $this->assertSame('-100', Number::forHumans(-100));
-        $this->assertSame('-1 thousand', Number::forHumans(-1000));
-        $this->assertSame('-1.23 thousand', Number::forHumans(-1234, precision: 2));
-        $this->assertSame('-1.2 thousand', Number::forHumans(-1234, maxPrecision: 1));
-        $this->assertSame('-1 million', Number::forHumans(-1000000));
-        $this->assertSame('-1 billion', Number::forHumans(-1000000000));
-        $this->assertSame('-1 trillion', Number::forHumans(-1000000000000));
-        $this->assertSame('-1.1 trillion', Number::forHumans(-1100000000000, maxPrecision: 1));
-        $this->assertSame('-1 quadrillion', Number::forHumans(-1000000000000000));
-        $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
+        $this->assertSame('0', Number::create(0)->toHumans());
+        $this->assertSame('-1', Number::create(-1)->toHumans());
+        $this->assertSame('-1.00', Number::create(-1)->toHumans(precision: 2));
+        $this->assertSame('-10', Number::create(-10)->toHumans());
+        $this->assertSame('-100', Number::create(-100)->toHumans());
+        $this->assertSame('-1 thousand', Number::create(-1000)->toHumans());
+        $this->assertSame('-1.23 thousand', Number::create(-1234)->toHumans(precision: 2));
+        $this->assertSame('-1.2 thousand', Number::create(-1234)->toHumans(maxPrecision: 1));
+        $this->assertSame('-1 million', Number::create(-1000000)->toHumans());
+        $this->assertSame('-1 billion', Number::create(-1000000000)->toHumans());
+        $this->assertSame('-1 trillion', Number::create(-1000000000000)->toHumans());
+        $this->assertSame('-1.1 trillion', Number::create(-1100000000000)->toHumans(maxPrecision: 1));
+        $this->assertSame('-1 quadrillion', Number::create(-1000000000000000)->toHumans());
+        $this->assertSame('-1 thousand quadrillion', Number::create(-1000000000000000000)->toHumans());
     }
 
     protected function needsIntlExtension()
     {
-        if (! extension_loaded('intl')) {
-            $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable '.__CLASS__);
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable ' . __CLASS__);
         }
     }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -210,7 +210,7 @@ class SupportNumberTest extends TestCase
 
     protected function needsIntlExtension()
     {
-        if (!extension_loaded('intl')) {
+        if (! extension_loaded('intl')) {
             $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable ' . __CLASS__);
         }
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -146,7 +146,7 @@ class SupportNumberTest extends TestCase
         $this->assertSame('2.00 KB', Number::create(2048)->toFileSize(precision: 2));
         $this->assertSame('1.23 KB', Number::create(1264)->toFileSize(precision: 2));
         $this->assertSame('1.234 KB', Number::create(1264.12345)->toFileSize(maxPrecision: 3));
-        $this->assertSame('1.234 KB', Number::create(1264, 3)->toFileSize());
+        $this->assertSame('1.234 KB', Number::create(1264)->toFileSize(3));
         $this->assertSame('5 GB', Number::create(1024 * 1024 * 1024 * 5)->toFileSize());
         $this->assertSame('10 TB', Number::create((1024 ** 4) * 10)->toFileSize());
         $this->assertSame('10 PB', Number::create((1024 ** 5) * 10)->toFileSize());


### PR DESCRIPTION
This PR streamlines the `Number` class by removing duplicate parameters (`number` and `locale`) from various functions. Instead, it introduces `Number::create` to instantiate objects with predefined `number` and `locale` values, eliminating the need to pass these parameters to each function explicitly. This not only enhances code readability but also simplifies function calls.

Additionally, the PR includes a set of function renaming to improve clarity and maintain consistency throughout the `Number` class. These changes aim to make the codebase more cohesive and easier to understand. The refactor ensures a more streamlined and efficient usage of the `Number` class across the codebase.

This enhancement contributes to a cleaner and more maintainable codebase while preserving the functionality and purpose of the `Number` class.

## Usage Example

Before:
```php
$numberInstance = Number::format(42, locale: 'ar');
```

After:
```php
$result = Number::create(42, 'ar')->format();
```

## List of Renamed Functions

1. `spell` → `toSpell`
2. `ordinal` → `toOrdinal`
3. `percentage` → `toPercentage`
4. `fileSize` → `toFileSize`
5. `forHumans` → `toHumans`

## Removed Functions

1. `withLocale`
2. `useLocale`