### PR TITLE
[11.x] Update Testbench to `^9.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
         "nyholm/psr7": "^1.2",
-        "orchestra/testbench-core": "dev-next/slim-skeleton",
+        "orchestra/testbench-core": "^9.0",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^10.1",

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -35,7 +35,7 @@ class AboutCommandTest extends TestCase
                 'database' => 'testing',
                 'logs' => ['single'],
                 'mail' => 'smtp',
-                'queue' => 'sync',
+                'queue' => 'database',
                 'session' => 'file',
             ], $output['drivers']);
         });

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Orchestra\Testbench\Attributes\WithMigration;
 
+#[WithMigration]
 #[WithMigration('queue')]
 class JobEncryptionTest extends DatabaseTestCase
 {

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\TestCase;
 
+#[WithMigration]
 #[WithMigration('queue')]
 class UniqueJobTest extends TestCase
 {

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -11,6 +11,7 @@ use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\TestCase;
 use Queue;
 
+#[WithMigration]
 #[WithMigration('queue')]
 class WorkCommandTest extends TestCase
 {


### PR DESCRIPTION
* Use `^9.0` version constraint 
* Add `#[WithMigration]` to run default Laravel skeleton migrations (which now includes `jobs` table).