### PR TITLE
Allow Trusting Multiple Proxy Layers With Wildcards

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -15,7 +15,7 @@ class TrustProxies
     protected $proxies;
 
     /**
-     * The number of proxy layers to trust
+     * The number of proxy layers to trust.
      *
      * @var int
      */
@@ -93,7 +93,7 @@ class TrustProxies
     }
 
     /**
-     * Trust the most recent $layers number of proxies
+     * Trust the most recent $layers number of proxies.
      *
      * @param  Request  $request
      * @param  int  $layers
@@ -147,7 +147,7 @@ class TrustProxies
     }
 
     /**
-     * Get the number of proxy layers to trust
+     * Get the number of proxy layers to trust.
      *
      * @return int
      */

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -97,7 +97,7 @@ class TrustProxies
      *
      * @param  Request  $request
      * @param  int  $layers
-     * @return  void
+     * @return void
      */
     protected function setTrustedProxyIpAddressesToLayers(Request $request, int $layers): void
     {

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -80,7 +80,7 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
-     * Test that TrustedProxies will apply a wildcard up to two layers of proxies deep
+     * Test that TrustedProxies will apply a wildcard up to two layers of proxies deep.
      */
     public function test_trusted_proxy_sets_trusted_proxies_for_2_layers()
     {
@@ -102,7 +102,7 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
-     * Test that TrustedProxies will apply a wildcard up to n layers of proxies deep
+     * Test that TrustedProxies will apply a wildcard up to n layers of proxies deep.
      */
     public function test_trusted_proxy_sets_trusted_proxies_for_n_layers()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Some Laravel applications are hosted behind multiple layers of proxies that you control. For example, a request may travel through `Cloudflare WAF > AWS Load Balancer > Web Server`. Currently Laravel allows setting `$proxies = '*'` to trust all proxies in the `TrustProxies` middleware: https://laravel.com/docs/10.x/requests#trusting-all-proxies. This only trusts the previous proxy (The AWS Load Balancer in this example), which is probably good default behavior, since trusting more than that would open the application up to IP spoofing.

However, if there are multiple proxies in the chain, this results in the IP of the second-to-last proxy being returned from calls to `request()->ip()` rather than the client's real IP. You would have ```X-Forwarded-For: '<Client IP>, <Cloudflare IP>'``` in your request, and the `<Cloudflare IP>` would be returned

There *used* to be a `**` option in the fideloper/TrustedProxy package v3, but it was removed in v4 (see https://github.com/fideloper/TrustedProxy/issues/115#issuecomment-469459016 and https://github.com/wintercms/storm/commit/411695b3e7c7c3b32f702a625d6612319cc4052d) and was not reintroduced when the package was integrated into the Laravel framework. Presumably, this was removed as it completely removes the point of the trusted proxy system, and allows the user to send whatever they'd like in `X-Forwarded-For` to spoof their IP, which is no good

This PR allows the wildcard `$proxies = '*'` to apply to a specified number of proxies, where the default is `$layers = 1` (the current default behavior). Using the example, if `$layers = 2`, both the Load Balancer IP and the Cloudflare IP would be included in the trusted proxies array, allowing `request()->ip()` to return the true Client IP. This is secure, since you are limiting the trusting to the two proxies which you (presumably) control. I've included tests to verify this behavior

The advantage this provides is allowing applications to be hosted behind multiple proxies *without* having to use less secure workarounds like `$proxies = ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']` to correctly track IPs

This change is backwards compatible as it does not change the default behavior of `$proxies = '*'` trusting only the first proxy. It does, however, remove usages of `setTrustedProxyIpAddressesToTheCallingIp`. I've left the method in as it's protected, and may be used/called in child classes