### PR TITLE
Add `exists` and `doesntExist` methods to model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1751,6 +1751,26 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Determine if the model exists.
+     *
+     * @var bool
+     */
+    public function exists()
+    {
+        return $this->exists;
+    }
+
+    /**
+     * Determine if the model does not exist.
+     *
+     * @var bool
+     */
+    public function doesntExist()
+    {
+        return ! $this->exists;
+    }
+
+    /**
      * Determine if two models have the same ID and belong to the same table.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $model

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -499,6 +499,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('test', $newInstance->getTable());
     }
 
+    public function testExists()
+    {
+        $model = new EloquentModelStub;
+        $model->exists = true;
+
+        $this->assertTrue($model->exists());
+        $this->assertFalse($model->doesntExist());
+    }
+
     public function testNewInstanceReturnsNewInstanceWithMergedCasts()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
It's common to write logic checks like this in views and policies:

```php
if ($user->is($post->author))
 
@if($user->posts->isNotEmpty())
```

As a fan of the Null Object pattern, my views and policies also contain a lot of logic checks like this:

```php
if (! $post->author->exists)

@if($author->profile->exists)
```

This PR adds `exists()` and `doesntExist()` methods to models so that existence checks are visually symmetric with other common comparison and empty checks. The examples above could be refactored to:

```php
if ($post->author->doesntExist())

@if($author->profile->exists())
```

The `doesntExist()` method is easier to understand without needing the `!` in front, and both methods mirror the `exists()` and `doesntExist()` methods on the Query Builder. 