### PR TITLE
[10.x] Add `--with-secret` option to Artisan `down` command.

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -86,7 +86,7 @@ class DownCommand extends Command
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
-            'secret' => $this->getSecretPhrase(),
+            'secret' => $this->getSecret(),
             'status' => (int) $this->option('status', 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];
@@ -151,7 +151,7 @@ class DownCommand extends Command
      *
      * @return string|null
      */
-    protected function getSecretPhrase()
+    protected function getSecret()
     {
         if ($this->option('secret') !== null) {
             return $this->option('secret');

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -7,9 +7,9 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
-use Illuminate\Support\Str;
 
 #[AsCommand(name: 'down')]
 class DownCommand extends Command

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
+use Illuminate\Support\Str;
 
 #[AsCommand(name: 'down')]
 class DownCommand extends Command
@@ -23,6 +24,7 @@ class DownCommand extends Command
                                  {--retry= : The number of seconds after which the request may be retried}
                                  {--refresh= : The number of seconds after which the browser may refresh}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
+                                 {--generate-secret : Generate a random secret phrase that may be used to bypass maintenance mode}
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
@@ -46,7 +48,9 @@ class DownCommand extends Command
                 return 0;
             }
 
-            $this->laravel->maintenanceMode()->activate($this->getDownFilePayload());
+            $downFilePayload = $this->getDownFilePayload();
+
+            $this->laravel->maintenanceMode()->activate($downFilePayload);
 
             file_put_contents(
                 storage_path('framework/maintenance.php'),
@@ -56,6 +60,10 @@ class DownCommand extends Command
             $this->laravel->get('events')->dispatch(new MaintenanceModeEnabled());
 
             $this->components->info('Application is now in maintenance mode.');
+
+            if ($downFilePayload['secret'] !== null) {
+                $this->components->info("You may bypass the application's maintenace mode by acessing the following URL [" . config('app.url') . "/{$downFilePayload['secret']}].");
+            }
         } catch (Exception $e) {
             $this->components->error(sprintf(
                 'Failed to enter maintenance mode: %s.',
@@ -78,7 +86,7 @@ class DownCommand extends Command
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
-            'secret' => $this->option('secret'),
+            'secret' => $this->getSecretPhrase(),
             'status' => (int) $this->option('status', 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];
@@ -136,5 +144,23 @@ class DownCommand extends Command
         $retry = $this->option('retry');
 
         return is_numeric($retry) && $retry > 0 ? (int) $retry : null;
+    }
+
+    /**
+     * Get the secret phrase that may be used to bypass maintenance mode.
+     *
+     * @return string|null
+     */
+    protected function getSecretPhrase()
+    {
+        if ($this->option('secret') !== null) {
+            return $this->option('secret');
+        }
+
+        if ($this->option('generate-secret')) {
+            return (string) Str::uuid();
+        }
+
+        return null;
     }
 }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -62,7 +62,7 @@ class DownCommand extends Command
             $this->components->info('Application is now in maintenance mode.');
 
             if ($downFilePayload['secret'] !== null) {
-                $this->components->info("You may bypass the application's maintenace mode by acessing the following URL [" . config('app.url') . "/{$downFilePayload['secret']}].");
+                $this->components->info("You may bypass the application's maintenace mode by going to [" . config('app.url') . "/{$downFilePayload['secret']}].");
             }
         } catch (Exception $e) {
             $this->components->error(sprintf(

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -24,7 +24,7 @@ class DownCommand extends Command
                                  {--retry= : The number of seconds after which the request may be retried}
                                  {--refresh= : The number of seconds after which the browser may refresh}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
-                                 {--generate-secret : Generate a random secret phrase that may be used to bypass maintenance mode}
+                                 {--with-secret : Generate a random secret phrase that may be used to bypass maintenance mode}
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
@@ -62,7 +62,7 @@ class DownCommand extends Command
             $this->components->info('Application is now in maintenance mode.');
 
             if ($downFilePayload['secret'] !== null) {
-                $this->components->info("You may bypass the application's maintenance mode by going to [" . config('app.url') . "/{$downFilePayload['secret']}].");
+                $this->components->info("You may bypass maintenance mode via [".config('app.url')."/{$downFilePayload['secret']}].");
             }
         } catch (Exception $e) {
             $this->components->error(sprintf(
@@ -153,14 +153,10 @@ class DownCommand extends Command
      */
     protected function getSecret()
     {
-        if ($this->option('secret') !== null) {
-            return $this->option('secret');
-        }
-
-        if ($this->option('generate-secret')) {
-            return Str::random();
-        }
-
-        return null;
+        return match (true) {
+            ! is_null($this->option('secret')) => $this->option('secret'),
+            $this->option('with-secret') => Str::random(),
+            default => null,
+        };
     }
 }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -62,7 +62,7 @@ class DownCommand extends Command
             $this->components->info('Application is now in maintenance mode.');
 
             if ($downFilePayload['secret'] !== null) {
-                $this->components->info("You may bypass the application's maintenace mode by going to [" . config('app.url') . "/{$downFilePayload['secret']}].");
+                $this->components->info("You may bypass the application's maintenance mode by going to [" . config('app.url') . "/{$downFilePayload['secret']}].");
             }
         } catch (Exception $e) {
             $this->components->error(sprintf(

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -158,7 +158,7 @@ class DownCommand extends Command
         }
 
         if ($this->option('generate-secret')) {
-            return (string) Str::uuid();
+            return Str::random();
         }
 
         return null;


### PR DESCRIPTION
This PR adds a `--with-secret` option to the Artisan `down` command which will generate a secret phrase that can be used to bypass maintenance mode so that the user doesn't have to define one themself, saving time.

The random secret is generated using `Str::random()` which should be fine for this purpose.

Along with this change, if the user defines a secret (either via the existing `--secret` option or the added `--with-secret` option), the app's URL appended with the secret will be printed to the terminal:

![image](https://github.com/laravel/framework/assets/48543796/149c9ce1-c710-4a9c-818f-cdb7cfe74df7)

As an extra note, if a user were to use the existing `--secret` option and the `--with-secret` option together, the secret defined by the user would take precedence as it is checked first (see the added `getSecret()` method).