### PR TITLE
[10.x] Add `Conditionable` trait to `AssertableJson`

### DIFF
--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -5,6 +5,7 @@ namespace Illuminate\Testing\Fluent;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\AssertableJsonString;
@@ -16,6 +17,7 @@ class AssertableJson implements Arrayable
         Concerns\Matching,
         Concerns\Debugging,
         Concerns\Interaction,
+        Conditionable,
         Macroable,
         Tappable;
 


### PR DESCRIPTION
This PR adds `Conditionable` trait to `AssertableJson` class.

Sometimes, it's necessary to assert based on a conditionan.
In that case we should break the chain.
e.g.:
```php
$response->assertJson(function (AssertableJson $json) use ($condition) {
    $json->has('data');

    if ($condition) {
        $json->has('meta');
    }

   $json->etc();
});
```

This PR provides a syntax sugar to keep the chain and use arrow function:
```php
$response->assertJson(fn (AssertableJson $json) => $json
    ->has('data')
    ->when($condition, fn (AssertableJson $json) => $json->has('meta'))
    ->etc(),
);
```
