### PR TITLE
[10.x] Handle casting for assertDatabaseHas checks

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -27,11 +27,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
         if ($table instanceof Model) {
-            foreach ($data as $key => $value) {
-                $table->setAttribute($key, $value);
-            }
-
-            $data = $table->getAttributes();
+            $data = (new $table)->forceFill($data)->getAttributes();
         }
 
         $this->assertThat(

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -27,7 +27,13 @@ trait InteractsWithDatabase
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
         if ($table instanceof Model) {
-            $data = (new $table)->forceFill($data)->getAttributes();
+            $table = (new $table);
+
+            foreach ($data as $key => $value) {
+                $table->setAttribute($key, $value);
+            }
+
+            $data = $table->getAttributes();
         }
 
         $this->assertThat(

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -26,6 +26,14 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            foreach ($data as $key => $value) {
+                $table->setAttribute($key, $value);
+            }
+
+            $data = $table->getAttributes();
+        }
+
         $this->assertThat(
             $this->getTable($table), new HasInDatabase($this->getConnection($connection, $table), $data)
         );

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -127,7 +127,7 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testJsonArrayCasting() {
+    public function testNonAssocArrayToArrayCasting() {
         Schema::create('test_model3', function (Blueprint $table) {
             $table->id();
             $table->json('settings');
@@ -137,8 +137,83 @@ class EloquentModelTest extends DatabaseTestCase
             'settings' => ['example'],
         ]);
 
-        $this->assertDatabaseHas('test_model3', [
+        $this->assertDatabaseHas($model, [
             'settings' => ['example'],
+        ]);
+    }
+
+    public function testAssocArrayToArrayCasting() {
+        Schema::create('test_model3', function (Blueprint $table) {
+            $table->id();
+            $table->json('settings');
+        });
+
+        $model = TestModel3::create([
+            'settings' => ['label' => 'example'],
+        ]);
+
+        $this->assertDatabaseHas($model, [
+            'settings' => ['label' => 'example'],
+        ]);
+    }
+
+    public function testNonAssocArrayToJsonCasting() {
+        Schema::create('test_model4', function (Blueprint $table) {
+            $table->id();
+            $table->json('settings');
+        });
+
+        $model = TestModel4::create([
+            'settings' => ['example'],
+        ]);
+
+        $this->assertDatabaseHas($model, [
+            'settings' => ['example'],
+        ]);
+    }
+
+    public function testAssocArrayToJsonCasting() {
+        Schema::create('test_model4', function (Blueprint $table) {
+            $table->id();
+            $table->json('settings');
+        });
+
+        $model = TestModel4::create([
+            'settings' => ['label' => 'example'],
+        ]);
+
+        $this->assertDatabaseHas($model, [
+            'settings' => ['label' => 'example'],
+        ]);
+    }
+
+    public function testNonAssocArrayToObjectCasting() {
+        Schema::create('test_model5', function (Blueprint $table) {
+            $table->id();
+            $table->json('settings');
+        });
+
+        $model = TestModel5::create([
+            'settings' => ['example'],
+        ]);
+
+        $this->assertDatabaseHas($model, [
+            'settings' => ['example'],
+        ]);
+    }
+
+    public function testAssocArrayToObjectCasting() {
+        Schema::create('test_model5', function (Blueprint $table) {
+            $table->id();
+            $table->json('settings');
+        });
+
+        $model = TestModel5::create([
+            'settings' => ['label' => 'example'],
+        ]);
+
+        $this->assertDatabaseHas($model, [
+            'settings' => ['label' => 'example'],
         ]);
     }
 }
@@ -164,4 +239,20 @@ class TestModel3 extends Model
     public $timestamps = false;
     protected $guarded = [];
     protected $casts = ['settings' => 'array'];
+}
+
+class TestModel4 extends Model
+{
+    public $table = 'test_model4';
+    public $timestamps = false;
+    protected $guarded = [];
+    protected $casts = ['settings' => 'json'];
+}
+
+class TestModel5 extends Model
+{
+    public $table = 'test_model5';
+    public $timestamps = false;
+    protected $guarded = [];
+    protected $casts = ['settings' => 'object'];
 }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -127,7 +127,8 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testNonAssocArrayToArrayCasting() {
+    public function testNonAssocArrayToArrayCasting()
+    {
         Schema::create('test_model3', function (Blueprint $table) {
             $table->id();
             $table->json('settings');
@@ -142,7 +143,8 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testAssocArrayToArrayCasting() {
+    public function testAssocArrayToArrayCasting()
+    {
         Schema::create('test_model3', function (Blueprint $table) {
             $table->id();
             $table->json('settings');
@@ -157,7 +159,8 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testNonAssocArrayToJsonCasting() {
+    public function testNonAssocArrayToJsonCasting()
+    {
         Schema::create('test_model4', function (Blueprint $table) {
             $table->id();
             $table->json('settings');
@@ -172,7 +175,8 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testAssocArrayToJsonCasting() {
+    public function testAssocArrayToJsonCasting()
+    {
         Schema::create('test_model4', function (Blueprint $table) {
             $table->id();
             $table->json('settings');
@@ -187,7 +191,8 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testNonAssocArrayToObjectCasting() {
+    public function testNonAssocArrayToObjectCasting()
+    {
         Schema::create('test_model5', function (Blueprint $table) {
             $table->id();
             $table->json('settings');
@@ -202,7 +207,8 @@ class EloquentModelTest extends DatabaseTestCase
         ]);
     }
 
-    public function testAssocArrayToObjectCasting() {
+    public function testAssocArrayToObjectCasting()
+    {
         Schema::create('test_model5', function (Blueprint $table) {
             $table->id();
             $table->json('settings');

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -126,6 +126,21 @@ class EloquentModelTest extends DatabaseTestCase
             'analyze' => true,
         ]);
     }
+
+    public function testJsonArrayCasting() {
+        Schema::create('test_model3', function (Blueprint $table) {
+            $table->id();
+            $table->json('settings');
+        });
+
+        $model = TestModel3::create([
+            'settings' => ['example'],
+        ]);
+
+        $this->assertDatabaseHas('test_model3', [
+            'settings' => ['example'],
+        ]);
+    }
 }
 
 class TestModel1 extends Model
@@ -141,4 +156,12 @@ class TestModel2 extends Model
     public $table = 'test_model2';
     public $timestamps = false;
     protected $guarded = [];
+}
+
+class TestModel3 extends Model
+{
+    public $table = 'test_model3';
+    public $timestamps = false;
+    protected $guarded = [];
+    protected $casts = ['settings' => 'array'];
 }


### PR DESCRIPTION
assertDatabaseHas currently does not follow the casting that has been defined, this now matches the way that the attributes are defined by the user. This only works if the test is defined against the model, rather than the table name directly.