### PR TITLE
[11.x] Add first/last directives to data_get helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -74,6 +74,13 @@ if (! function_exists('data_get')) {
                 return in_array('*', $key) ? Arr::collapse($result) : $result;
             }
 
+            $segment = match ($segment) {
+                '\*' => '*',
+                '\^' => '^', '^' => array_key_first($target),
+                '\$' => '$', '$' => array_key_last($target),
+                default => $segment,
+            };
+
             if (Arr::accessible($target) && Arr::exists($target, $segment)) {
                 $target = $target[$segment];
             } elseif (is_object($target) && isset($target->{$segment})) {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -76,8 +76,10 @@ if (! function_exists('data_get')) {
 
             $segment = match ($segment) {
                 '\*' => '*',
-                '\^' => '^', '^' => array_key_first($target),
-                '\$' => '$', '$' => array_key_last($target),
+                '\{first}' => '{first}',
+                '{first}' => array_key_first($target),
+                '\{last}' => '{last}',
+                '{last}' => array_key_last($target),
                 default => $segment,
             };
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -252,6 +252,58 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
     }
 
+    public function testDataGetFirstLastDirectives()
+    {
+        $array = [
+            'flights' => [
+                [
+                    'segments' => [
+                        ['from' => 'LHR', 'departure' => '9:00', 'to' => 'IST', 'arrival' => '15:00'],
+                        ['from' => 'IST', 'departure' => '16:00', 'to' => 'PKX', 'arrival' => '20:00'],
+                    ],
+                ],
+                [
+                    'segments' => [
+                        ['from' => 'LGW', 'departure' => '8:00', 'to' => 'SAW', 'arrival' => '14:00'],
+                        ['from' => 'SAW', 'departure' => '15:00', 'to' => 'PEK', 'arrival' => '19:00'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals('LHR', data_get($array, 'flights.0.segments.^.from'));
+        $this->assertEquals('PKX', data_get($array, 'flights.0.segments.$.to'));
+
+        $this->assertEquals('LHR', data_get($array, 'flights.^.segments.^.from'));
+        $this->assertEquals('PEK', data_get($array, 'flights.$.segments.$.to'));
+        $this->assertEquals('PKX', data_get($array, 'flights.^.segments.$.to'));
+        $this->assertEquals('LGW', data_get($array, 'flights.$.segments.^.from'));
+
+        $this->assertEquals(['LHR', 'IST'], data_get($array, 'flights.^.segments.*.from'));
+        $this->assertEquals(['SAW', 'PEK'], data_get($array, 'flights.$.segments.*.to'));
+
+        $this->assertEquals(['LHR', 'LGW'], data_get($array, 'flights.*.segments.^.from'));
+        $this->assertEquals(['PKX', 'PEK'], data_get($array, 'flights.*.segments.$.to'));
+    }
+
+    public function testDataGetEscapedKeys()
+    {
+        $array = [
+            'symbols' => [
+                '$' => ['description' => 'dollar'],
+                '*' => ['description' => 'asterisk'],
+                '^' => ['description' => 'caret'],
+            ],
+        ];
+
+        $this->assertEquals('caret', data_get($array, 'symbols.\^.description'));
+        $this->assertEquals('dollar', data_get($array, 'symbols.^.description'));
+        $this->assertEquals('asterisk', data_get($array, 'symbols.\*.description'));
+        $this->assertEquals(['dollar', 'asterisk', 'caret'], data_get($array, 'symbols.*.description'));
+        $this->assertEquals('dollar', data_get($array, 'symbols.\$.description'));
+        $this->assertEquals('caret', data_get($array, 'symbols.$.description'));
+    }
+
     public function testDataFill()
     {
         $data = ['foo' => 'bar'];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -286,7 +286,29 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(['PKX', 'PEK'], data_get($array, 'flights.*.segments.$.to'));
     }
 
-    public function testDataGetEscapedKeys()
+    public function testDataGetFirstLastDirectivesOnKeyedArrays()
+    {
+        $array = [
+            'numericKeys' => [
+                2 => 'first',
+                0 => 'second',
+                1 => 'last',
+            ],
+            'stringKeys' => [
+                'one' => 'first',
+                'two' => 'second',
+                'three' => 'last',
+            ],
+        ];
+
+        $this->assertEquals('second', data_get($array, 'numericKeys.0'));
+        $this->assertEquals('first', data_get($array, 'numericKeys.^'));
+        $this->assertEquals('last', data_get($array, 'numericKeys.$'));
+        $this->assertEquals('first', data_get($array, 'stringKeys.^'));
+        $this->assertEquals('last', data_get($array, 'stringKeys.$'));
+    }
+
+    public function testDataGetEscapedSegmentKeys()
     {
         $array = [
             'symbols' => [

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -271,19 +271,19 @@ class SupportHelpersTest extends TestCase
             ],
         ];
 
-        $this->assertEquals('LHR', data_get($array, 'flights.0.segments.^.from'));
-        $this->assertEquals('PKX', data_get($array, 'flights.0.segments.$.to'));
+        $this->assertEquals('LHR', data_get($array, 'flights.0.segments.{first}.from'));
+        $this->assertEquals('PKX', data_get($array, 'flights.0.segments.{last}.to'));
 
-        $this->assertEquals('LHR', data_get($array, 'flights.^.segments.^.from'));
-        $this->assertEquals('PEK', data_get($array, 'flights.$.segments.$.to'));
-        $this->assertEquals('PKX', data_get($array, 'flights.^.segments.$.to'));
-        $this->assertEquals('LGW', data_get($array, 'flights.$.segments.^.from'));
+        $this->assertEquals('LHR', data_get($array, 'flights.{first}.segments.{first}.from'));
+        $this->assertEquals('PEK', data_get($array, 'flights.{last}.segments.{last}.to'));
+        $this->assertEquals('PKX', data_get($array, 'flights.{first}.segments.{last}.to'));
+        $this->assertEquals('LGW', data_get($array, 'flights.{last}.segments.{first}.from'));
 
-        $this->assertEquals(['LHR', 'IST'], data_get($array, 'flights.^.segments.*.from'));
-        $this->assertEquals(['SAW', 'PEK'], data_get($array, 'flights.$.segments.*.to'));
+        $this->assertEquals(['LHR', 'IST'], data_get($array, 'flights.{first}.segments.*.from'));
+        $this->assertEquals(['SAW', 'PEK'], data_get($array, 'flights.{last}.segments.*.to'));
 
-        $this->assertEquals(['LHR', 'LGW'], data_get($array, 'flights.*.segments.^.from'));
-        $this->assertEquals(['PKX', 'PEK'], data_get($array, 'flights.*.segments.$.to'));
+        $this->assertEquals(['LHR', 'LGW'], data_get($array, 'flights.*.segments.{first}.from'));
+        $this->assertEquals(['PKX', 'PEK'], data_get($array, 'flights.*.segments.{last}.to'));
     }
 
     public function testDataGetFirstLastDirectivesOnKeyedArrays()
@@ -302,28 +302,28 @@ class SupportHelpersTest extends TestCase
         ];
 
         $this->assertEquals('second', data_get($array, 'numericKeys.0'));
-        $this->assertEquals('first', data_get($array, 'numericKeys.^'));
-        $this->assertEquals('last', data_get($array, 'numericKeys.$'));
-        $this->assertEquals('first', data_get($array, 'stringKeys.^'));
-        $this->assertEquals('last', data_get($array, 'stringKeys.$'));
+        $this->assertEquals('first', data_get($array, 'numericKeys.{first}'));
+        $this->assertEquals('last', data_get($array, 'numericKeys.{last}'));
+        $this->assertEquals('first', data_get($array, 'stringKeys.{first}'));
+        $this->assertEquals('last', data_get($array, 'stringKeys.{last}'));
     }
 
     public function testDataGetEscapedSegmentKeys()
     {
         $array = [
             'symbols' => [
-                '$' => ['description' => 'dollar'],
+                '{last}' => ['description' => 'dollar'],
                 '*' => ['description' => 'asterisk'],
-                '^' => ['description' => 'caret'],
+                '{first}' => ['description' => 'caret'],
             ],
         ];
 
-        $this->assertEquals('caret', data_get($array, 'symbols.\^.description'));
-        $this->assertEquals('dollar', data_get($array, 'symbols.^.description'));
+        $this->assertEquals('caret', data_get($array, 'symbols.\{first}.description'));
+        $this->assertEquals('dollar', data_get($array, 'symbols.{first}.description'));
         $this->assertEquals('asterisk', data_get($array, 'symbols.\*.description'));
         $this->assertEquals(['dollar', 'asterisk', 'caret'], data_get($array, 'symbols.*.description'));
-        $this->assertEquals('dollar', data_get($array, 'symbols.\$.description'));
-        $this->assertEquals('caret', data_get($array, 'symbols.$.description'));
+        $this->assertEquals('dollar', data_get($array, 'symbols.\{last}.description'));
+        $this->assertEquals('caret', data_get($array, 'symbols.{last}.description'));
     }
 
     public function testDataFill()


### PR DESCRIPTION
This PR adds special directives `^` (fetch first element) and `$` (fetch last element) into `data_get` helper. These symbols were chosen as they mimic regexp anchors with similar meaning.

### Reasoning

It is not unusual to use `0` to access first element; but there's no easy way to access last. Why do we even need that?
Here is the example:
```php
<?php

$flight = [
    'segments' => [
        ['from' => 'LHR', 'departure' => '9:00', 'to' => 'IST', 'arrival' => '15:00'],
        ['from' => 'IST', 'departure' => '16:00', 'to' => 'PKX', 'arrival' => '20:00'],
    ],
];

// Departure airport of first flight segment - arrival airport of last flight segment
echo 'Route: '.data_get($flight, 'segments.^.from').' - '.data_get($flight, 'segments.$.to');
// Route: LHR - PKX

// Departure time of first flight segment - arrival time of last flight segment
echo 'Timespan: '.data_get($flight, 'segments.^.departure').' - '.data_get($flight, 'segments.$.arrival');
// Timespan: 9:00 - 20:00
```

### Backwards compatibility

This feature breaks BC as when someone have arrays with `^`/`$` keys, they now need to be escaped during fetching:
```php
<?php

$array = [
    'symbols' => [
        '$' => ['description' => 'dollar'],
        '*' => ['description' => 'asterisk'],
        '^' => ['description' => 'caret'],
    ],
];

echo data_get($array, 'symbols.\^.description');
// "caret"

// We can now also escape asterisk the same way: `\*`.
echo data_get($array, 'symbols.\*.description');
// "asterisk"
```

### Implementation details

`^`/`$` directives implemented using `array_key_first`/`array_key_last` functions respectively. So in most cases with numeric keys `^` is the same as `0`. Anyway, I think we need to keep `^` directive for completeness.