### PR TITLE
[10.x] Blade: Add support for `@inject`-ing enums

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -18,6 +18,12 @@ trait CompilesInjections
 
         $service = trim($segments[1]);
 
+        $enum = trim($service, " '\"");
+
+        if (enum_exists($enum)) {
+            return "<?php class_alias(\\{$enum}::class, '{$variable}'); ?>";
+        }
+
         return "<?php \${$variable} = app({$service}); ?>";
     }
 }

--- a/tests/View/Blade/BladeInjectTest.php
+++ b/tests/View/Blade/BladeInjectTest.php
@@ -40,4 +40,5 @@ class BladeInjectTest extends AbstractBladeTestCase
     }
 }
 
-enum Test {}
+enum Test {
+}

--- a/tests/View/Blade/BladeInjectTest.php
+++ b/tests/View/Blade/BladeInjectTest.php
@@ -31,4 +31,13 @@ class BladeInjectTest extends AbstractBladeTestCase
         $expected = "Foo <?php \$baz = app(SomeNamespace\SomeClass::class); ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testEnumInjectionsAreCompiled()
+    {
+        $string = 'Foo @inject("baz", "Illuminate\Tests\View\Blade\Test") bar';
+        $expected = "Foo <?php class_alias(\Illuminate\Tests\View\Blade\Test::class, 'baz'); ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }
+
+enum Test {}

--- a/tests/View/Blade/BladeInjectTest.php
+++ b/tests/View/Blade/BladeInjectTest.php
@@ -40,5 +40,6 @@ class BladeInjectTest extends AbstractBladeTestCase
     }
 }
 
-enum Test {
+enum Test
+{
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Today I tried to `@inject` an enum to alias it in my Blade template, because my template looked kind of ugly having the full namespace written out, especially when the template needs to reference the same enum multiple times.

```blade
{{-- Before --}}

if ($model->status === \App\Enums\SomeReallyLongAndConvolutedEnumName::Foo) {
    ...
}

{{-- or --}}

\Some\Really\Deeply\Namespaced\Enum\In\A\Package\Somewhere::Bar

---

{{-- After --}}

@inject('LocalAlias', '\Some\Really\Deeply\Namespaced\Enum\In\A\Package\Somewhere')

if ($model->status === LocalAlias::Foo) {
    ...
}
```

### `@inject` vs ?
`@inject` seemed like a good candidate as it's already for similarly 'aliasing' services into a variable as it resolves them out of the container, however, I was also considering completely separating this into an `@alias` or `@use` directive or something. Thoughts?

### Native alternatives
You can, of course, simply use `class_alias` or the even cleaner `use X as Y` statement:

```php
use \App\Enums\SomeReallyLongAndConvolutedEnumName as Status; // This has great IDE support
// or
class_alias(\App\Enums\SomeReallyLongAndConvolutedEnumName::class, 'Status'); // IDE support can be patchy
```