### PR TITLE
[10.x] Added alias for eloquent model attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1883,7 +1883,11 @@ trait HasAttributes
         $results = [];
 
         foreach (is_array($attributes) ? $attributes : func_get_args() as $attribute) {
-            $results[$attribute] = $this->getAttribute($attribute);
+            [$field, $alias] = str_contains($attribute, ' as ')
+                ? explode(' as ', $attribute, 2)
+                : [$attribute, $attribute];
+
+            $results[$alias] = $this->getAttribute($field);
         }
 
         return $results;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2062,6 +2062,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
     }
 
+    public function testGetOnlyAttributes()
+    {
+        $model = new EloquentModelStub;
+        $model->foo = 'foo';
+        $model->bar = 'bar';
+
+        $this->assertEquals(['foo' => 'foo'], $model->only('foo'));
+
+        $this->assertEquals(['value' => 'foo'], $model->only('foo as value'));
+
+        $this->assertEquals(['value' => 'foo', 'bar' => 'bar'], $model->only('foo as value', 'bar'));
+    }
+
     public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
With this PR you can now specify alias for attributes of a model instance when retrieving them via `only` method.

Current approach:
```php
$post = Post::query()->first();

return [
    'value' => $post->id,
    'title' => $post->title,
];
```

New approach:
```php
$post = Post::query()->first();

return $post->only([
    'id as value',
    'title',
]);
```