### PR TITLE
[10.x]: Add Blade @use directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -33,6 +33,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesStacks,
         Concerns\CompilesStyles,
         Concerns\CompilesTranslations,
+        Concerns\CompilesUseStatements,
         ReflectsClosures;
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesUseStatements
+{
+    /**
+     * Compile the inject statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileUse($expression)
+    {
+        $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
+
+        $use = trim($segments[0], " '\"");
+        $as = trim($segments[1], " '\"");
+
+        return "<?php use \\{$use} as {$as}; ?>";
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -15,8 +15,8 @@ trait CompilesUseStatements
         $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
         $use = trim($segments[0], " '\"");
-        $as = trim($segments[1], " '\"");
+        $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';
 
-        return "<?php use \\{$use} as {$as}; ?>";
+        return "<?php use \\{$use}{$as}; ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -5,7 +5,7 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesUseStatements
 {
     /**
-     * Compile the inject statements into valid PHP.
+     * Compile the use statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -10,4 +10,11 @@ class BladeUseTest extends AbstractBladeTestCase
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithoutAsAreCompiled()
+    {
+        $string = "Foo @use('SomeNamespace\SomeClass') bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeUseTest extends AbstractBladeTestCase
+{
+    public function testUseStatementsAreCompiled()
+    {
+        $string = "Foo @use('SomeNamespace\SomeClass', 'Foo') bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
This is a variation on #49177 as I talked myself into a slightly better approach.

This is only an addition, so shouldn't cause any trouble or disturbance - unless someone has create a custom Blade directive called `@use`.

A minor addition for convenience when trying to use classes/enums in your Blade templates.

### Benefits
- 1 line instead of 3 🔥
- Less code to type ⏱️
- Makes templates look cleaner 🧹
- Better than abusing `@inject` just for enums 😅

### Example
```blade
{{-- Before --}}
@php
use \App\Enums\WidgetStatusEnum as Status;
@endphp

{{-- After --}}
@use('App\Enums\WidgetStatusEnum', 'Status')

@use('App\Models\Bar')

{{ Status::Foo }}

{{ Bar::first() }}
```

### Caveats
IDE support won't be there initially for folks, so there will be squigglies.