### PR TITLE
[10.x] Allow to search using `LIKE` operator if the given field is a string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
@@ -2129,6 +2130,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
+        $columnType = Schema::getColumnType($this->getTable(), $field ?? $this->getRouteKeyName());
+
+        if (in_array($columnType, ['varchar', 'text'])) {
+            return $query->where($field ?? $this->getRouteKeyName(), 'LIKE', "%{$value}%");
+        }
+
         return $query->where($field ?? $this->getRouteKeyName(), $value);
     }
 


### PR DESCRIPTION
This pull request fixes [49133](https://github.com/laravel/framework/discussions/49133)

As I explained before in that discussion I want to add an elegant feature when we customize the key with a string column.

> [!IMPORTANT]
> The idea behind adding this feature is that we can search similarly with the given string because will not remember the full and exact string.

Let's assume that we have an **Excepturi nemo.** title post and this post is related to the first user, then we want to use the [Custom Keys & Scoping](https://laravel.com/docs/10.x/routing#implicit-model-binding-scoping) feature, so when we replace the `id` column with the `title` column and provide part of a title such **Exceptu** the `NOT FOUND` exception will be thrown, so I updated this functionality to search using `LIKE` operator as I'll explain in the next figures.

## BEFORE this pull request is being merged

![before-pr-is-being-merged](https://github.com/laravel/framework/assets/48416569/cdb4945c-35c6-4aff-98be-6b08f0950968)

![before-pr-is-being-merged-not-found-exception](https://github.com/laravel/framework/assets/48416569/8049e817-d1aa-4761-bc10-566f29597b7e)

## AFTER this pull request is being merged

![after-pr-is-being-merged](https://github.com/laravel/framework/assets/48416569/6058ffb2-2c56-4273-b19b-13717729cce5)


Boom! I have got the value 🎉
