### PR TITLE
[10.x] Fix test namespaces and remove unused import

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -4,7 +4,6 @@ namespace Illuminate\Redis\Connections;
 
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
-use Redis;
 use RedisException;
 
 /**

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Database\EloquentRelationshipsTest;
+namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;

--- a/tests/Foundation/Testing/TestCaseTest.php
+++ b/tests/Foundation/Testing/TestCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Foundation\Testing;
+namespace Illuminate\Tests\Foundation\Testing;
 
 use Exception;
 use Illuminate\Foundation\Testing\TestCase;

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Sleep;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Database/ConfigureCustomDoctrineTypeTest.php
+++ b/tests/Integration/Database/ConfigureCustomDoctrineTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\SchemaTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -8,7 +8,6 @@ use Illuminate\Database\Grammar;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class ConfigureCustomDoctrineTypeTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -11,7 +11,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentBelongsToTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Integration\Database;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentCollectionLoadCountTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentHasManyThroughTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -8,7 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentHasManyThroughTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentHasOneIsTest.php
+++ b/tests/Integration/Database/EloquentHasOneIsTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentHasOneIsTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentHasOneIsTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentHasOneOfManyTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentHasOneOfManyTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentLazyEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelCustomEventsTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelCustomEventsTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelDateCastingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelDecimalCastingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Brick\Math\Exception\NumberFormatException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelDecimalCastingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelImmutableDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelImmutableDateCastingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelImmutableDateCastingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use stdClass;
 
 class EloquentModelJsonCastingTest extends DatabaseTestCase
@@ -25,7 +24,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
 
     public function testStringsAreCastable()
     {
-        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $object */
+        /** @var \Illuminate\Tests\Integration\Database\JsonCast $object */
         $object = JsonCast::create([
             'basic_string_as_json_field' => 'this is a string',
             'json_string_as_json_field' => '{"key1":"value1"}',
@@ -37,7 +36,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
 
     public function testArraysAreCastable()
     {
-        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $object */
+        /** @var \Illuminate\Tests\Integration\Database\JsonCast $object */
         $object = JsonCast::create([
             'array_as_json_field' => ['key1' => 'value1'],
         ]);
@@ -50,7 +49,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
         $object = new stdClass;
         $object->key1 = 'value1';
 
-        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $user */
+        /** @var \Illuminate\Tests\Integration\Database\JsonCast $user */
         $user = JsonCast::create([
             'object_as_json_field' => $object,
         ]);
@@ -61,7 +60,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
 
     public function testCollectionsAreCastable()
     {
-        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $user */
+        /** @var \Illuminate\Tests\Integration\Database\JsonCast $user */
         $user = JsonCast::create([
             'collection_as_json_field' => new Collection(['key1' => 'value1']),
         ]);

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelLoadCountTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelLoadCountTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelLoadMissingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelLoadMissingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelRefreshTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphConstrainTest.php
+++ b/tests/Integration/Database/EloquentMorphConstrainTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphConstrainTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphConstrainTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphCountEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphCountLazyEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphCountLazyEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphLazyEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphLazyEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
@@ -8,7 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphManyTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphOneIsTest.php
+++ b/tests/Integration/Database/EloquentMorphOneIsTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphOneIsTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphOneIsTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphToGlobalScopesTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphToIsTest.php
+++ b/tests/Integration/Database/EloquentMorphToIsTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphToIsTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphToIsTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphToLazyEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphToSelectTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphToSelectTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMorphToTouchesTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMorphToTouchesTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentMultiDimensionalArrayEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMultiDimensionalArrayEagerLoadingTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentMultiDimensionalArrayEagerLoadingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentMultiDimensionalArrayEagerLoadingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentTouchParentWithGlobalScopeTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentWhereHasMorphTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentWhereHasMorphTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentWhereHasTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
@@ -8,7 +8,6 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentWhereHasTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentWithCountTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentWithCountTest extends DatabaseTestCase
 {


### PR DESCRIPTION
While browsing through the tests in the framework, I noticed there were some test case files with incorrect namespaces.

This PR just adjusts them to the correct namespace.