### PR TITLE
[10.x] Fixes retrying failed jobs causes PHP memory exhaustion errors when dealing with thousands of failed jobs

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -70,7 +70,11 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            return Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+            $failer = $this->laravel['queue.failer'];
+
+            return method_exists($failer, 'keys')
+                ? $failer->keys()
+                : Arr::pluck($failer->all(), 'id');
         }
 
         if ($queue = $this->option('queue')) {
@@ -92,10 +96,14 @@ class RetryCommand extends Command
      */
     protected function getJobIdsByQueue($queue)
     {
-        $ids = collect($this->laravel['queue.failer']->all())
-                        ->where('queue', $queue)
-                        ->pluck('id')
-                        ->toArray();
+        $failer = $this->laravel['queue.failer'];
+
+        $ids = method_exists($failer, 'keys')
+            ? $failer->keys($queue)
+            : collect($failer->all())
+                ->where('queue', $queue)
+                ->pluck('id')
+                ->toArray();
 
         if (count($ids) === 0) {
             $this->components->error("Unable to find failed jobs for queue [{$queue}].");

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -72,8 +72,8 @@ class RetryCommand extends Command
         if (count($ids) === 1 && $ids[0] === 'all') {
             $failer = $this->laravel['queue.failer'];
 
-            return method_exists($failer, 'keys')
-                ? $failer->keys()
+            return method_exists($failer, 'ids')
+                ? $failer->ids()
                 : Arr::pluck($failer->all(), 'id');
         }
 
@@ -98,8 +98,8 @@ class RetryCommand extends Command
     {
         $failer = $this->laravel['queue.failer'];
 
-        $ids = method_exists($failer, 'keys')
-            ? $failer->keys($queue)
+        $ids = method_exists($failer, 'ids')
+            ? $failer->ids($queue)
             : collect($failer->all())
                 ->where('queue', $queue)
                 ->pluck('id')

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -65,6 +65,21 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     }
 
     /**
+     * Get a list of all of IDs the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function keys($queue = null)
+    {
+        return $this->getTable()
+            ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))
+            ->orderBy('id', 'desc')
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
      * Get a list of all of the failed jobs.
      *
      * @return array

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -65,12 +65,12 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     }
 
     /**
-     * Get a list of all of IDs the failed jobs.
+     * Get the IDs of all of the failed jobs.
      *
      * @param  string|null  $queue
      * @return array
      */
-    public function keys($queue = null)
+    public function ids($queue = null)
     {
         return $this->getTable()
             ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -68,12 +68,12 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     }
 
     /**
-     * Get a list of all of IDs the failed jobs.
+     * Get the IDs of all of the failed jobs.
      *
      * @param  string|null  $queue
      * @return array
      */
-    public function keys($queue = null)
+    public function ids($queue = null)
     {
         return $this->getTable()
             ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -67,7 +67,6 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
         return $uuid;
     }
 
-
     /**
      * Get a list of all of IDs the failed jobs.
      *

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -67,6 +67,22 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
         return $uuid;
     }
 
+
+    /**
+     * Get a list of all of IDs the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function keys($queue = null)
+    {
+        return $this->getTable()
+            ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))
+            ->orderBy('id', 'desc')
+            ->pluck('uuid')
+            ->all();
+    }
+
     /**
      * Get a list of all of the failed jobs.
      *

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -79,12 +79,12 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     }
 
     /**
-     * Get a list of all of IDs the failed jobs.
+     * Get the IDs of all of the failed jobs.
      *
      * @param  string|null  $queue
      * @return array
      */
-    public function keys($queue = null)
+    public function ids($queue = null)
     {
         return collect($this->all())
             ->when(! is_null($queue), fn ($collect) => $collect->where('queue', $queue))

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -79,6 +79,20 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     }
 
     /**
+     * Get a list of all of IDs the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function keys($queue = null)
+    {
+        return collect($this->all())
+            ->when(! is_null($queue), fn ($collect) => $collect->where('queue', $queue))
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
      * Get a list of all of the failed jobs.
      *
      * @return array

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Queue\Failed;
 
+/**
+ * @method array keys(string $queue = null)
+ */
 interface FailedJobProviderInterface
 {
     /**

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue\Failed;
 
 /**
- * @method array keys(string $queue = null)
+ * @method array ids(string $queue = null)
  */
 interface FailedJobProviderInterface
 {

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -79,12 +79,12 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     }
 
     /**
-     * Get a list of all of IDs the failed jobs.
+     * Get the IDs of all of the failed jobs.
      *
      * @param  string|null  $queue
      * @return array
      */
-    public function keys($queue = null)
+    public function ids($queue = null)
     {
         return collect($this->all())
             ->when(! is_null($queue), fn ($collect) => $collect->where('queue', $queue))

--- a/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/FileFailedJobProvider.php
@@ -79,6 +79,20 @@ class FileFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     }
 
     /**
+     * Get a list of all of IDs the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function keys($queue = null)
+    {
+        return collect($this->all())
+            ->when(! is_null($queue), fn ($collect) => $collect->where('queue', $queue))
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
      * Get a list of all of the failed jobs.
      *
      * @return array

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -19,6 +19,17 @@ class NullFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     }
 
     /**
+     * Get a list of all of IDs the failed jobs.
+     *
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function keys($queue = null)
+    {
+        return [];
+    }
+
+    /**
      * Get a list of all of the failed jobs.
      *
      * @return array

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -19,12 +19,12 @@ class NullFailedJobProvider implements CountableFailedJobProvider, FailedJobProv
     }
 
     /**
-     * Get a list of all of IDs the failed jobs.
+     * Get the IDs of all of the failed jobs.
      *
      * @param  string|null  $queue
      * @return array
      */
-    public function keys($queue = null)
+    public function ids($queue = null)
     {
         return [];
     }


### PR DESCRIPTION
fixes laravel/framework#49185

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
