### PR TITLE
[11.x] Allow to specify nested key when calling Fluent::collect()

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -103,7 +103,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the fluent instance to a Collection.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */
     public function collect($key = null)

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -103,7 +103,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the fluent instance to a Collection.
      *
-     * @param  TKey  $key
+     * @param  string  $key
      * @return \Illuminate\Support\Collection
      */
     public function collect($key = null)

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -103,11 +103,12 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the fluent instance to a Collection.
      *
+     * @param  TKey  $key
      * @return \Illuminate\Support\Collection
      */
-    public function collect()
+    public function collect($key = null)
     {
-        return new Collection($this->attributes);
+        return new Collection($this->get($key));
     }
 
     /**

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -129,6 +129,9 @@ class SupportFluentTest extends TestCase
     {
         $fluent = new Fluent(['forge', 'vapour', 'spark']);
         $this->assertEquals(['forge', 'vapour', 'spark'], $fluent->collect()->all());
+
+        $fluent = new Fluent(['authors' => ['taylor' => ['products' => ['forge', 'vapour', 'spark']]]]);
+        $this->assertEquals(['forge', 'vapour', 'spark'], $fluent->collect('authors.taylor.products')->all());
     }
 }
 


### PR DESCRIPTION
Similar to `Http\Client\Response`, allow `Fluent::collect()` to accept key to retrieve the nested attribute before converting to collection

https://github.com/laravel/framework/blob/0c574d42e9c7d82a0bd304a5cb2ce031a914bfa6/src/Illuminate/Http/Client/Response.php#L101-L104