### PR TITLE
[11.x] data_get helper first/last directives support for ArrayAccess&Iterable

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -77,9 +77,9 @@ if (! function_exists('data_get')) {
             $segment = match ($segment) {
                 '\*' => '*',
                 '\{first}' => '{first}',
-                '{first}' => array_key_first(iterator_to_array($target)),
+                '{first}' => array_key_first(is_array($target) ? $target : collect($target)->all()),
                 '\{last}' => '{last}',
-                '{last}' => array_key_last(iterator_to_array($target)),
+                '{last}' => array_key_last(is_array($target) ? $target : collect($target)->all()),
                 default => $segment,
             };
 

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -77,9 +77,9 @@ if (! function_exists('data_get')) {
             $segment = match ($segment) {
                 '\*' => '*',
                 '\{first}' => '{first}',
-                '{first}' => array_key_first($target),
+                '{first}' => array_key_first(iterator_to_array($target)),
                 '\{last}' => '{last}',
-                '{last}' => array_key_last($target),
+                '{last}' => array_key_last(iterator_to_array($target)),
                 default => $segment,
             };
 


### PR DESCRIPTION
This PR allows usage of `ArrayAccess` classes with `{first}`/`{last}` directives (#49175). Classes implementing `ArrayAccess` must also be `iterable` (i.e. implementing `Iterator` or `IteratorAggregate`). `ArrayObject` and `Collection` both meet those requirements.
