### PR TITLE
[11.x] Improve stateful guard return types

### DIFF
--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -35,7 +35,7 @@ interface StatefulGuard extends Guard
      *
      * @param  mixed  $id
      * @param  bool  $remember
-     * @return \Illuminate\Contracts\Auth\Authenticatable|bool
+     * @return \Illuminate\Contracts\Auth\Authenticatable|false
      */
     public function loginUsingId($id, $remember = false);
 
@@ -43,7 +43,7 @@ interface StatefulGuard extends Guard
      * Log the given user ID into the application without sessions or cookies.
      *
      * @param  mixed  $id
-     * @return \Illuminate\Contracts\Auth\Authenticatable|bool
+     * @return \Illuminate\Contracts\Auth\Authenticatable|false
      */
     public function onceUsingId($id);
 


### PR DESCRIPTION
Narrows some return types of `StatefulGuard`, bringing it in line with its implementation `SessionGuard`. PR to master because this is technically a breaking change (although its probably not very likely that someone has a custom guard that returns true here).

https://github.com/laravel/framework/blob/0c574d42e9c7d82a0bd304a5cb2ce031a914bfa6/src/Illuminate/Contracts/Auth/StatefulGuard.php#L33-L39

https://github.com/laravel/framework/blob/0c574d42e9c7d82a0bd304a5cb2ce031a914bfa6/src/Illuminate/Contracts/Auth/StatefulGuard.php#L42-L47

https://github.com/laravel/framework/blob/0c574d42e9c7d82a0bd304a5cb2ce031a914bfa6/src/Illuminate/Auth/SessionGuard.php#L468-L474

https://github.com/laravel/framework/blob/0c574d42e9c7d82a0bd304a5cb2ce031a914bfa6/src/Illuminate/Auth/SessionGuard.php#L254-L259