### PR TITLE
[10.x] Add support for `Number::summarize`

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -98,7 +98,7 @@ class Number
     }
 
     /**
-     * Convert the given number to its currency equivalent.for
+     * Convert the given number to its currency equivalent.
      *
      * @param  int|float  $number
      * @param  string  $in
@@ -168,7 +168,7 @@ class Number
     }
 
     /**
-     * Convert the number to its human readable equivalent.
+     * Summarizes the number.
      *
      * @param  int  $number
      * @param  int  $precision

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -141,9 +141,15 @@ class Number
      * @param  int|null  $maxPrecision
      * @return string
      */
-    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
     {
-        return static::summarize($number, $precision, $maxPrecision, [
+        return static::summarize($number, $precision, $maxPrecision, $abbreviate ? [
+            3 => 'K',
+            6 => 'M',
+            9 => 'B',
+            12 => 'T',
+            15 => 'Q',
+        ] : [
             3 => ' thousand',
             6 => ' million',
             9 => ' billion',
@@ -153,14 +159,15 @@ class Number
     }
 
     /**
-     * Summarizes the number.
+     * Convert the number to its human readable equivalent.
      *
      * @param  int  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
+     * @param  array  $units
      * @return string
      */
-    public static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])
+    protected static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])
     {
         if (empty($units)) {
             $units = [

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -141,6 +141,19 @@ class Number
      * @param  int|null  $maxPrecision
      * @return string
      */
+    public static function abbreviate(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    {
+        return static::forHumans($number, $precision, $maxPrecision, abbreviate: true);
+    }
+
+    /**
+     * Convert the number to its human readable equivalent.
+     *
+     * @param  int  $number
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return string
+     */
     public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
     {
         return static::summarize($number, $precision, $maxPrecision, $abbreviate ? [

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -183,7 +183,7 @@ class Number
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision));
             case $number >= 1e15:
-                return sprintf('%sQ', static::summarize($number / 1e15, $precision, $maxPrecision));
+                return sprintf('%s' . end($units), static::summarize($number / 1e15, $precision, $maxPrecision));
         }
 
         $numberExponent = floor(log10($number));

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -143,18 +143,13 @@ class Number
      */
     public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null)
     {
-        return static::summarize(
-            number: $number,
-            precision: $precision,
-            maxPrecision: $maxPrecision,
-            units: [
-                3 => ' thousand',
-                6 => ' million',
-                9 => ' billion',
-                12 => ' trillion',
-                15 => ' quadrillion',
-            ],
-        );
+        return static::summarize($number, $precision, $maxPrecision, [
+            3 => ' thousand',
+            6 => ' million',
+            9 => ' billion',
+            12 => ' trillion',
+            15 => ' quadrillion',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -143,28 +143,18 @@ class Number
      */
     public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null)
     {
-        $units = [
-            3 => 'thousand',
-            6 => 'million',
-            9 => 'billion',
-            12 => 'trillion',
-            15 => 'quadrillion',
-        ];
-
-        switch (true) {
-            case $number === 0:
-                return '0';
-            case $number < 0:
-                return sprintf('-%s', static::forHumans(abs($number), $precision, $maxPrecision));
-            case $number >= 1e15:
-                return sprintf('%s quadrillion', static::forHumans($number / 1e15, $precision, $maxPrecision));
-        }
-
-        $numberExponent = floor(log10($number));
-        $displayExponent = $numberExponent - ($numberExponent % 3);
-        $number /= pow(10, $displayExponent);
-
-        return trim(sprintf('%s %s', static::format($number, $precision, $maxPrecision), $units[$displayExponent] ?? ''));
+        return static::summarize(
+            number: $number,
+            precision: $precision,
+            maxPrecision: $maxPrecision,
+            units: [
+                3 => ' thousand',
+                6 => ' million',
+                9 => ' billion',
+                12 => ' trillion',
+                15 => ' quadrillion',
+            ],
+        );
     }
 
     /**
@@ -175,23 +165,25 @@ class Number
      * @param  int|null  $maxPrecision
      * @return string
      */
-    public static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null, array $units = [])
     {
-        $units = [
-            3 => 'K',
-            6 => 'M',
-            9 => 'B',
-            12 => 'T',
-            15 => 'Q',
-        ];
+        if (empty($units)) {
+            $units = [
+                3 => 'K',
+                6 => 'M',
+                9 => 'B',
+                12 => 'T',
+                15 => 'Q',
+            ];
+        }
 
         switch (true) {
             case $number === 0:
                 return '0';
             case $number < 0:
-                return sprintf('-%s', static::forHumans(abs($number), $precision, $maxPrecision));
+                return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision));
             case $number >= 1e15:
-                return sprintf('%sQ', static::forHumans($number / 1e15, $precision, $maxPrecision));
+                return sprintf('%sQ', static::summarize($number / 1e15, $precision, $maxPrecision));
         }
 
         $numberExponent = floor(log10($number));

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -98,7 +98,7 @@ class Number
     }
 
     /**
-     * Convert the given number to its currency equivalent.
+     * Convert the given number to its currency equivalent.for
      *
      * @param  int|float  $number
      * @param  string  $in
@@ -165,6 +165,40 @@ class Number
         $number /= pow(10, $displayExponent);
 
         return trim(sprintf('%s %s', static::format($number, $precision, $maxPrecision), $units[$displayExponent] ?? ''));
+    }
+
+    /**
+     * Convert the number to its human readable equivalent.
+     *
+     * @param  int  $number
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return string
+     */
+    public static function summarize(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    {
+        $units = [
+            3 => 'K',
+            6 => 'M',
+            9 => 'B',
+            12 => 'T',
+            15 => 'Q',
+        ];
+
+        switch (true) {
+            case $number === 0:
+                return '0';
+            case $number < 0:
+                return sprintf('-%s', static::forHumans(abs($number), $precision, $maxPrecision));
+            case $number >= 1e15:
+                return sprintf('%sQ', static::forHumans($number / 1e15, $precision, $maxPrecision));
+        }
+
+        $numberExponent = floor(log10($number));
+        $displayExponent = $numberExponent - ($numberExponent % 3);
+        $number /= pow(10, $displayExponent);
+
+        return trim(sprintf('%s%s', static::format($number, $precision, $maxPrecision), $units[$displayExponent] ?? ''));
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -178,7 +178,7 @@ class Number
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision));
             case $number >= 1e15:
-                return sprintf('%s' . end($units), static::summarize($number / 1e15, $precision, $maxPrecision));
+                return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision));
         }
 
         $numberExponent = floor(log10($number));

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -176,9 +176,9 @@ class Number
             case $number === 0:
                 return '0';
             case $number < 0:
-                return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision));
+                return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));
             case $number >= 1e15:
-                return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision));
+                return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision, $units));
         }
 
         $numberExponent = floor(log10($number));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -208,6 +208,59 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
     }
 
+    public function testSummarize()
+    {
+        $this->assertSame('1', Number::forHumans(1));
+        $this->assertSame('1.00', Number::forHumans(1, precision: 2));
+        $this->assertSame('10', Number::forHumans(10));
+        $this->assertSame('100', Number::forHumans(100));
+        $this->assertSame('1K', Number::forHumans(1000));
+        $this->assertSame('1.00K', Number::forHumans(1000, precision: 2));
+        $this->assertSame('1K', Number::forHumans(1000, maxPrecision: 2));
+        $this->assertSame('1K', Number::forHumans(1230));
+        $this->assertSame('1.2K', Number::forHumans(1230, maxPrecision: 1));
+        $this->assertSame('1M', Number::forHumans(1000000));
+        $this->assertSame('1B', Number::forHumans(1000000000));
+        $this->assertSame('1T', Number::forHumans(1000000000000));
+        $this->assertSame('1Q', Number::forHumans(1000000000000000));
+        $this->assertSame('1KQ', Number::forHumans(1000000000000000000));
+
+        $this->assertSame('123', Number::forHumans(123));
+        $this->assertSame('1K', Number::forHumans(1234));
+        $this->assertSame('1.23K', Number::forHumans(1234, precision: 2));
+        $this->assertSame('12K', Number::forHumans(12345));
+        $this->assertSame('1M', Number::forHumans(1234567));
+        $this->assertSame('1B', Number::forHumans(1234567890));
+        $this->assertSame('1T', Number::forHumans(1234567890123));
+        $this->assertSame('1.23T', Number::forHumans(1234567890123, precision: 2));
+        $this->assertSame('1Q', Number::forHumans(1234567890123456));
+        $this->assertSame('1.23KQ', Number::forHumans(1234567890123456789, precision: 2));
+        $this->assertSame('490K', Number::forHumans(489939));
+        $this->assertSame('489.9390K', Number::forHumans(489939, precision: 4));
+        $this->assertSame('500.00000M', Number::forHumans(500000000, precision: 5));
+
+        $this->assertSame('1MQ', Number::forHumans(1000000000000000000000));
+        $this->assertSame('1BQ', Number::forHumans(1000000000000000000000000));
+        $this->assertSame('1TQ', Number::forHumans(1000000000000000000000000000));
+        $this->assertSame('1Q', Number::forHumans(1000000000000000000000000000000));
+        $this->assertSame('1KQ', Number::forHumans(1000000000000000000000000000000000));
+
+        $this->assertSame('0', Number::forHumans(0));
+        $this->assertSame('-1', Number::forHumans(-1));
+        $this->assertSame('-1.00', Number::forHumans(-1, precision: 2));
+        $this->assertSame('-10', Number::forHumans(-10));
+        $this->assertSame('-100', Number::forHumans(-100));
+        $this->assertSame('-1K', Number::forHumans(-1000));
+        $this->assertSame('-1.23K', Number::forHumans(-1234, precision: 2));
+        $this->assertSame('-1.2K', Number::forHumans(-1234, maxPrecision: 1));
+        $this->assertSame('-1M', Number::forHumans(-1000000));
+        $this->assertSame('-1B', Number::forHumans(-1000000000));
+        $this->assertSame('-1T', Number::forHumans(-1000000000000));
+        $this->assertSame('-1.1T', Number::forHumans(-1100000000000, maxPrecision: 1));
+        $this->assertSame('-1Q', Number::forHumans(-1000000000000000));
+        $this->assertSame('-1KQ', Number::forHumans(-1000000000000000000));
+    }
+
     protected function needsIntlExtension()
     {
         if (! extension_loaded('intl')) {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -210,55 +210,55 @@ class SupportNumberTest extends TestCase
 
     public function testSummarize()
     {
-        $this->assertSame('1', Number::forHumans(1));
-        $this->assertSame('1.00', Number::forHumans(1, precision: 2));
-        $this->assertSame('10', Number::forHumans(10));
-        $this->assertSame('100', Number::forHumans(100));
-        $this->assertSame('1K', Number::forHumans(1000));
-        $this->assertSame('1.00K', Number::forHumans(1000, precision: 2));
-        $this->assertSame('1K', Number::forHumans(1000, maxPrecision: 2));
-        $this->assertSame('1K', Number::forHumans(1230));
-        $this->assertSame('1.2K', Number::forHumans(1230, maxPrecision: 1));
-        $this->assertSame('1M', Number::forHumans(1000000));
-        $this->assertSame('1B', Number::forHumans(1000000000));
-        $this->assertSame('1T', Number::forHumans(1000000000000));
-        $this->assertSame('1Q', Number::forHumans(1000000000000000));
-        $this->assertSame('1KQ', Number::forHumans(1000000000000000000));
+        $this->assertSame('1', Number::summarize(1));
+        $this->assertSame('1.00', Number::summarize(1, precision: 2));
+        $this->assertSame('10', Number::summarize(10));
+        $this->assertSame('100', Number::summarize(100));
+        $this->assertSame('1K', Number::summarize(1000));
+        $this->assertSame('1.00K', Number::summarize(1000, precision: 2));
+        $this->assertSame('1K', Number::summarize(1000, maxPrecision: 2));
+        $this->assertSame('1K', Number::summarize(1230));
+        $this->assertSame('1.2K', Number::summarize(1230, maxPrecision: 1));
+        $this->assertSame('1M', Number::summarize(1000000));
+        $this->assertSame('1B', Number::summarize(1000000000));
+        $this->assertSame('1T', Number::summarize(1000000000000));
+        $this->assertSame('1Q', Number::summarize(1000000000000000));
+        $this->assertSame('1KQ', Number::summarize(1000000000000000000));
 
-        $this->assertSame('123', Number::forHumans(123));
-        $this->assertSame('1K', Number::forHumans(1234));
-        $this->assertSame('1.23K', Number::forHumans(1234, precision: 2));
-        $this->assertSame('12K', Number::forHumans(12345));
-        $this->assertSame('1M', Number::forHumans(1234567));
-        $this->assertSame('1B', Number::forHumans(1234567890));
-        $this->assertSame('1T', Number::forHumans(1234567890123));
-        $this->assertSame('1.23T', Number::forHumans(1234567890123, precision: 2));
-        $this->assertSame('1Q', Number::forHumans(1234567890123456));
-        $this->assertSame('1.23KQ', Number::forHumans(1234567890123456789, precision: 2));
-        $this->assertSame('490K', Number::forHumans(489939));
-        $this->assertSame('489.9390K', Number::forHumans(489939, precision: 4));
-        $this->assertSame('500.00000M', Number::forHumans(500000000, precision: 5));
+        $this->assertSame('123', Number::summarize(123));
+        $this->assertSame('1K', Number::summarize(1234));
+        $this->assertSame('1.23K', Number::summarize(1234, precision: 2));
+        $this->assertSame('12K', Number::summarize(12345));
+        $this->assertSame('1M', Number::summarize(1234567));
+        $this->assertSame('1B', Number::summarize(1234567890));
+        $this->assertSame('1T', Number::summarize(1234567890123));
+        $this->assertSame('1.23T', Number::summarize(1234567890123, precision: 2));
+        $this->assertSame('1Q', Number::summarize(1234567890123456));
+        $this->assertSame('1.23KQ', Number::summarize(1234567890123456789, precision: 2));
+        $this->assertSame('490K', Number::summarize(489939));
+        $this->assertSame('489.9390K', Number::summarize(489939, precision: 4));
+        $this->assertSame('500.00000M', Number::summarize(500000000, precision: 5));
 
-        $this->assertSame('1MQ', Number::forHumans(1000000000000000000000));
-        $this->assertSame('1BQ', Number::forHumans(1000000000000000000000000));
-        $this->assertSame('1TQ', Number::forHumans(1000000000000000000000000000));
-        $this->assertSame('1Q', Number::forHumans(1000000000000000000000000000000));
-        $this->assertSame('1KQ', Number::forHumans(1000000000000000000000000000000000));
+        $this->assertSame('1MQ', Number::summarize(1000000000000000000000));
+        $this->assertSame('1BQ', Number::summarize(1000000000000000000000000));
+        $this->assertSame('1TQ', Number::summarize(1000000000000000000000000000));
+        $this->assertSame('1Q', Number::summarize(1000000000000000000000000000000));
+        $this->assertSame('1KQ', Number::summarize(1000000000000000000000000000000000));
 
-        $this->assertSame('0', Number::forHumans(0));
-        $this->assertSame('-1', Number::forHumans(-1));
-        $this->assertSame('-1.00', Number::forHumans(-1, precision: 2));
-        $this->assertSame('-10', Number::forHumans(-10));
-        $this->assertSame('-100', Number::forHumans(-100));
-        $this->assertSame('-1K', Number::forHumans(-1000));
-        $this->assertSame('-1.23K', Number::forHumans(-1234, precision: 2));
-        $this->assertSame('-1.2K', Number::forHumans(-1234, maxPrecision: 1));
-        $this->assertSame('-1M', Number::forHumans(-1000000));
-        $this->assertSame('-1B', Number::forHumans(-1000000000));
-        $this->assertSame('-1T', Number::forHumans(-1000000000000));
-        $this->assertSame('-1.1T', Number::forHumans(-1100000000000, maxPrecision: 1));
-        $this->assertSame('-1Q', Number::forHumans(-1000000000000000));
-        $this->assertSame('-1KQ', Number::forHumans(-1000000000000000000));
+        $this->assertSame('0', Number::summarize(0));
+        $this->assertSame('-1', Number::summarize(-1));
+        $this->assertSame('-1.00', Number::summarize(-1, precision: 2));
+        $this->assertSame('-10', Number::summarize(-10));
+        $this->assertSame('-100', Number::summarize(-100));
+        $this->assertSame('-1K', Number::summarize(-1000));
+        $this->assertSame('-1.23K', Number::summarize(-1234, precision: 2));
+        $this->assertSame('-1.2K', Number::summarize(-1234, maxPrecision: 1));
+        $this->assertSame('-1M', Number::summarize(-1000000));
+        $this->assertSame('-1B', Number::summarize(-1000000000));
+        $this->assertSame('-1T', Number::summarize(-1000000000000));
+        $this->assertSame('-1.1T', Number::summarize(-1100000000000, maxPrecision: 1));
+        $this->assertSame('-1Q', Number::summarize(-1000000000000000));
+        $this->assertSame('-1KQ', Number::summarize(-1000000000000000000));
     }
 
     protected function needsIntlExtension()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -210,55 +210,55 @@ class SupportNumberTest extends TestCase
 
     public function testSummarize()
     {
-        $this->assertSame('1', Number::forHumans(abbreviate: true, number: 1));
-        $this->assertSame('1.00', Number::forHumans(abbreviate: true, number: 1, precision: 2));
-        $this->assertSame('10', Number::forHumans(abbreviate: true, number: 10));
-        $this->assertSame('100', Number::forHumans(abbreviate: true, number: 100));
-        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1000));
-        $this->assertSame('1.00K', Number::forHumans(abbreviate: true, number: 1000, precision: 2));
-        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1000, maxPrecision: 2));
-        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1230));
-        $this->assertSame('1.2K', Number::forHumans(abbreviate: true, number: 1230, maxPrecision: 1));
-        $this->assertSame('1M', Number::forHumans(abbreviate: true, number: 1000000));
-        $this->assertSame('1B', Number::forHumans(abbreviate: true, number: 1000000000));
-        $this->assertSame('1T', Number::forHumans(abbreviate: true, number: 1000000000000));
-        $this->assertSame('1Q', Number::forHumans(abbreviate: true, number: 1000000000000000));
-        $this->assertSame('1KQ', Number::forHumans(abbreviate: true, number: 1000000000000000000));
+        $this->assertSame('1', Number::abbreviate(1));
+        $this->assertSame('1.00', Number::abbreviate(1, precision: 2));
+        $this->assertSame('10', Number::abbreviate(10));
+        $this->assertSame('100', Number::abbreviate(100));
+        $this->assertSame('1K', Number::abbreviate(1000));
+        $this->assertSame('1.00K', Number::abbreviate(1000, precision: 2));
+        $this->assertSame('1K', Number::abbreviate(1000, maxPrecision: 2));
+        $this->assertSame('1K', Number::abbreviate(1230));
+        $this->assertSame('1.2K', Number::abbreviate(1230, maxPrecision: 1));
+        $this->assertSame('1M', Number::abbreviate(1000000));
+        $this->assertSame('1B', Number::abbreviate(1000000000));
+        $this->assertSame('1T', Number::abbreviate(1000000000000));
+        $this->assertSame('1Q', Number::abbreviate(1000000000000000));
+        $this->assertSame('1KQ', Number::abbreviate(1000000000000000000));
 
-        $this->assertSame('123', Number::forHumans(abbreviate: true, number: 123));
-        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1234));
-        $this->assertSame('1.23K', Number::forHumans(abbreviate: true, number: 1234, precision: 2));
-        $this->assertSame('12K', Number::forHumans(abbreviate: true, number: 12345));
-        $this->assertSame('1M', Number::forHumans(abbreviate: true, number: 1234567));
-        $this->assertSame('1B', Number::forHumans(abbreviate: true, number: 1234567890));
-        $this->assertSame('1T', Number::forHumans(abbreviate: true, number: 1234567890123));
-        $this->assertSame('1.23T', Number::forHumans(abbreviate: true, number: 1234567890123, precision: 2));
-        $this->assertSame('1Q', Number::forHumans(abbreviate: true, number: 1234567890123456));
-        $this->assertSame('1.23KQ', Number::forHumans(abbreviate: true, number: 1234567890123456789, precision: 2));
-        $this->assertSame('490K', Number::forHumans(abbreviate: true, number: 489939));
-        $this->assertSame('489.9390K', Number::forHumans(abbreviate: true, number: 489939, precision: 4));
-        $this->assertSame('500.00000M', Number::forHumans(abbreviate: true, number: 500000000, precision: 5));
+        $this->assertSame('123', Number::abbreviate(123));
+        $this->assertSame('1K', Number::abbreviate(1234));
+        $this->assertSame('1.23K', Number::abbreviate(1234, precision: 2));
+        $this->assertSame('12K', Number::abbreviate(12345));
+        $this->assertSame('1M', Number::abbreviate(1234567));
+        $this->assertSame('1B', Number::abbreviate(1234567890));
+        $this->assertSame('1T', Number::abbreviate(1234567890123));
+        $this->assertSame('1.23T', Number::abbreviate(1234567890123, precision: 2));
+        $this->assertSame('1Q', Number::abbreviate(1234567890123456));
+        $this->assertSame('1.23KQ', Number::abbreviate(1234567890123456789, precision: 2));
+        $this->assertSame('490K', Number::abbreviate(489939));
+        $this->assertSame('489.9390K', Number::abbreviate(489939, precision: 4));
+        $this->assertSame('500.00000M', Number::abbreviate(500000000, precision: 5));
 
-        $this->assertSame('1MQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000));
-        $this->assertSame('1BQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000));
-        $this->assertSame('1TQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000000));
-        $this->assertSame('1QQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000000000));
-        $this->assertSame('1KQQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000000000000));
+        $this->assertSame('1MQ', Number::abbreviate(1000000000000000000000));
+        $this->assertSame('1BQ', Number::abbreviate(1000000000000000000000000));
+        $this->assertSame('1TQ', Number::abbreviate(1000000000000000000000000000));
+        $this->assertSame('1QQ', Number::abbreviate(1000000000000000000000000000000));
+        $this->assertSame('1KQQ', Number::abbreviate(1000000000000000000000000000000000));
 
-        $this->assertSame('0', Number::forHumans(abbreviate: true, number: 0));
-        $this->assertSame('-1', Number::forHumans(abbreviate: true, number: -1));
-        $this->assertSame('-1.00', Number::forHumans(abbreviate: true, number: -1, precision: 2));
-        $this->assertSame('-10', Number::forHumans(abbreviate: true, number: -10));
-        $this->assertSame('-100', Number::forHumans(abbreviate: true, number: -100));
-        $this->assertSame('-1K', Number::forHumans(abbreviate: true, number: -1000));
-        $this->assertSame('-1.23K', Number::forHumans(abbreviate: true, number: -1234, precision: 2));
-        $this->assertSame('-1.2K', Number::forHumans(abbreviate: true, number: -1234, maxPrecision: 1));
-        $this->assertSame('-1M', Number::forHumans(abbreviate: true, number: -1000000));
-        $this->assertSame('-1B', Number::forHumans(abbreviate: true, number: -1000000000));
-        $this->assertSame('-1T', Number::forHumans(abbreviate: true, number: -1000000000000));
-        $this->assertSame('-1.1T', Number::forHumans(abbreviate: true, number: -1100000000000, maxPrecision: 1));
-        $this->assertSame('-1Q', Number::forHumans(abbreviate: true, number: -1000000000000000));
-        $this->assertSame('-1KQ', Number::forHumans(abbreviate: true, number: -1000000000000000000));
+        $this->assertSame('0', Number::abbreviate(0));
+        $this->assertSame('-1', Number::abbreviate(-1));
+        $this->assertSame('-1.00', Number::abbreviate(-1, precision: 2));
+        $this->assertSame('-10', Number::abbreviate(-10));
+        $this->assertSame('-100', Number::abbreviate(-100));
+        $this->assertSame('-1K', Number::abbreviate(-1000));
+        $this->assertSame('-1.23K', Number::abbreviate(-1234, precision: 2));
+        $this->assertSame('-1.2K', Number::abbreviate(-1234, maxPrecision: 1));
+        $this->assertSame('-1M', Number::abbreviate(-1000000));
+        $this->assertSame('-1B', Number::abbreviate(-1000000000));
+        $this->assertSame('-1T', Number::abbreviate(-1000000000000));
+        $this->assertSame('-1.1T', Number::abbreviate(-1100000000000, maxPrecision: 1));
+        $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
+        $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
     }
 
     protected function needsIntlExtension()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -242,8 +242,8 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1MQ', Number::summarize(1000000000000000000000));
         $this->assertSame('1BQ', Number::summarize(1000000000000000000000000));
         $this->assertSame('1TQ', Number::summarize(1000000000000000000000000000));
-        $this->assertSame('1Q', Number::summarize(1000000000000000000000000000000));
-        $this->assertSame('1KQ', Number::summarize(1000000000000000000000000000000000));
+        $this->assertSame('1QQ', Number::summarize(1000000000000000000000000000000));
+        $this->assertSame('1KQQ', Number::summarize(1000000000000000000000000000000000));
 
         $this->assertSame('0', Number::summarize(0));
         $this->assertSame('-1', Number::summarize(-1));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -210,55 +210,55 @@ class SupportNumberTest extends TestCase
 
     public function testSummarize()
     {
-        $this->assertSame('1', Number::summarize(1));
-        $this->assertSame('1.00', Number::summarize(1, precision: 2));
-        $this->assertSame('10', Number::summarize(10));
-        $this->assertSame('100', Number::summarize(100));
-        $this->assertSame('1K', Number::summarize(1000));
-        $this->assertSame('1.00K', Number::summarize(1000, precision: 2));
-        $this->assertSame('1K', Number::summarize(1000, maxPrecision: 2));
-        $this->assertSame('1K', Number::summarize(1230));
-        $this->assertSame('1.2K', Number::summarize(1230, maxPrecision: 1));
-        $this->assertSame('1M', Number::summarize(1000000));
-        $this->assertSame('1B', Number::summarize(1000000000));
-        $this->assertSame('1T', Number::summarize(1000000000000));
-        $this->assertSame('1Q', Number::summarize(1000000000000000));
-        $this->assertSame('1KQ', Number::summarize(1000000000000000000));
+        $this->assertSame('1', Number::forHumans(abbreviate: true, number: 1));
+        $this->assertSame('1.00', Number::forHumans(abbreviate: true, number: 1, precision: 2));
+        $this->assertSame('10', Number::forHumans(abbreviate: true, number: 10));
+        $this->assertSame('100', Number::forHumans(abbreviate: true, number: 100));
+        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1000));
+        $this->assertSame('1.00K', Number::forHumans(abbreviate: true, number: 1000, precision: 2));
+        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1000, maxPrecision: 2));
+        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1230));
+        $this->assertSame('1.2K', Number::forHumans(abbreviate: true, number: 1230, maxPrecision: 1));
+        $this->assertSame('1M', Number::forHumans(abbreviate: true, number: 1000000));
+        $this->assertSame('1B', Number::forHumans(abbreviate: true, number: 1000000000));
+        $this->assertSame('1T', Number::forHumans(abbreviate: true, number: 1000000000000));
+        $this->assertSame('1Q', Number::forHumans(abbreviate: true, number: 1000000000000000));
+        $this->assertSame('1KQ', Number::forHumans(abbreviate: true, number: 1000000000000000000));
 
-        $this->assertSame('123', Number::summarize(123));
-        $this->assertSame('1K', Number::summarize(1234));
-        $this->assertSame('1.23K', Number::summarize(1234, precision: 2));
-        $this->assertSame('12K', Number::summarize(12345));
-        $this->assertSame('1M', Number::summarize(1234567));
-        $this->assertSame('1B', Number::summarize(1234567890));
-        $this->assertSame('1T', Number::summarize(1234567890123));
-        $this->assertSame('1.23T', Number::summarize(1234567890123, precision: 2));
-        $this->assertSame('1Q', Number::summarize(1234567890123456));
-        $this->assertSame('1.23KQ', Number::summarize(1234567890123456789, precision: 2));
-        $this->assertSame('490K', Number::summarize(489939));
-        $this->assertSame('489.9390K', Number::summarize(489939, precision: 4));
-        $this->assertSame('500.00000M', Number::summarize(500000000, precision: 5));
+        $this->assertSame('123', Number::forHumans(abbreviate: true, number: 123));
+        $this->assertSame('1K', Number::forHumans(abbreviate: true, number: 1234));
+        $this->assertSame('1.23K', Number::forHumans(abbreviate: true, number: 1234, precision: 2));
+        $this->assertSame('12K', Number::forHumans(abbreviate: true, number: 12345));
+        $this->assertSame('1M', Number::forHumans(abbreviate: true, number: 1234567));
+        $this->assertSame('1B', Number::forHumans(abbreviate: true, number: 1234567890));
+        $this->assertSame('1T', Number::forHumans(abbreviate: true, number: 1234567890123));
+        $this->assertSame('1.23T', Number::forHumans(abbreviate: true, number: 1234567890123, precision: 2));
+        $this->assertSame('1Q', Number::forHumans(abbreviate: true, number: 1234567890123456));
+        $this->assertSame('1.23KQ', Number::forHumans(abbreviate: true, number: 1234567890123456789, precision: 2));
+        $this->assertSame('490K', Number::forHumans(abbreviate: true, number: 489939));
+        $this->assertSame('489.9390K', Number::forHumans(abbreviate: true, number: 489939, precision: 4));
+        $this->assertSame('500.00000M', Number::forHumans(abbreviate: true, number: 500000000, precision: 5));
 
-        $this->assertSame('1MQ', Number::summarize(1000000000000000000000));
-        $this->assertSame('1BQ', Number::summarize(1000000000000000000000000));
-        $this->assertSame('1TQ', Number::summarize(1000000000000000000000000000));
-        $this->assertSame('1QQ', Number::summarize(1000000000000000000000000000000));
-        $this->assertSame('1KQQ', Number::summarize(1000000000000000000000000000000000));
+        $this->assertSame('1MQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000));
+        $this->assertSame('1BQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000));
+        $this->assertSame('1TQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000000));
+        $this->assertSame('1QQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000000000));
+        $this->assertSame('1KQQ', Number::forHumans(abbreviate: true, number: 1000000000000000000000000000000000));
 
-        $this->assertSame('0', Number::summarize(0));
-        $this->assertSame('-1', Number::summarize(-1));
-        $this->assertSame('-1.00', Number::summarize(-1, precision: 2));
-        $this->assertSame('-10', Number::summarize(-10));
-        $this->assertSame('-100', Number::summarize(-100));
-        $this->assertSame('-1K', Number::summarize(-1000));
-        $this->assertSame('-1.23K', Number::summarize(-1234, precision: 2));
-        $this->assertSame('-1.2K', Number::summarize(-1234, maxPrecision: 1));
-        $this->assertSame('-1M', Number::summarize(-1000000));
-        $this->assertSame('-1B', Number::summarize(-1000000000));
-        $this->assertSame('-1T', Number::summarize(-1000000000000));
-        $this->assertSame('-1.1T', Number::summarize(-1100000000000, maxPrecision: 1));
-        $this->assertSame('-1Q', Number::summarize(-1000000000000000));
-        $this->assertSame('-1KQ', Number::summarize(-1000000000000000000));
+        $this->assertSame('0', Number::forHumans(abbreviate: true, number: 0));
+        $this->assertSame('-1', Number::forHumans(abbreviate: true, number: -1));
+        $this->assertSame('-1.00', Number::forHumans(abbreviate: true, number: -1, precision: 2));
+        $this->assertSame('-10', Number::forHumans(abbreviate: true, number: -10));
+        $this->assertSame('-100', Number::forHumans(abbreviate: true, number: -100));
+        $this->assertSame('-1K', Number::forHumans(abbreviate: true, number: -1000));
+        $this->assertSame('-1.23K', Number::forHumans(abbreviate: true, number: -1234, precision: 2));
+        $this->assertSame('-1.2K', Number::forHumans(abbreviate: true, number: -1234, maxPrecision: 1));
+        $this->assertSame('-1M', Number::forHumans(abbreviate: true, number: -1000000));
+        $this->assertSame('-1B', Number::forHumans(abbreviate: true, number: -1000000000));
+        $this->assertSame('-1T', Number::forHumans(abbreviate: true, number: -1000000000000));
+        $this->assertSame('-1.1T', Number::forHumans(abbreviate: true, number: -1100000000000, maxPrecision: 1));
+        $this->assertSame('-1Q', Number::forHumans(abbreviate: true, number: -1000000000000000));
+        $this->assertSame('-1KQ', Number::forHumans(abbreviate: true, number: -1000000000000000000));
     }
 
     protected function needsIntlExtension()


### PR DESCRIPTION
Summarizing numbers is a common need, especially when creating dashboards.

Here are some screenshots of it being done in packages throughout the Laravel ecosystem:

**Vapor**:
![image](https://github.com/laravel/framework/assets/5937317/cbfdafad-5216-4dca-8231-3e76236960c1)

**Nova**:
![image](https://github.com/laravel/framework/assets/5937317/8486a670-be17-4db1-aba7-96a0d6a6ec75)

Additionally, other dashboards like Horizon and Pulse can benefit from it (Horizon doesn't summarize currently) :
![image](https://github.com/laravel/framework/assets/5937317/e34de02c-c800-48ff-9a0a-54fd57115ffe)

This pull request creates a `Number::summarize` method that allows Laravel to unify all of its dashboard number summarization code, as well as allowing anyone planning to make dashboards using Laravel, e.g. with Pulse, easier and faster.

This PR also makes the units configurable, which is useful for localizing or if user has unique needs for their project.