### PR TITLE
[10.x] Add resume method to batched jobs as an option

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -387,6 +387,16 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Resume the batch.
+     *
+     * @return void
+     */
+    public function resume()
+    {
+        $this->repository->resume($this->id);
+    }
+
+    /**
      * Determine if the batch has been cancelled.
      *
      * @return bool

--- a/src/Illuminate/Bus/BatchRepository.php
+++ b/src/Illuminate/Bus/BatchRepository.php
@@ -78,6 +78,14 @@ interface BatchRepository
     public function cancel(string $batchId);
 
     /**
+     * Resume the batch that has the given ID.
+     *
+     * @param  string  $batchId
+     * @return void
+     */
+    public function resume(string $batchId);
+
+    /**
      * Delete the batch that has the given ID.
      *
      * @param  string  $batchId

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -222,6 +222,20 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     }
 
     /**
+     * Resume the batch that has the given ID.
+     *
+     * @param  string  $batchId
+     * @return void
+     */
+    public function resume(string $batchId)
+    {
+        $this->connection->table($this->table)->where('id', $batchId)->update([
+            'cancelled_at' => null,
+            'finished_at' => null,
+        ]);
+    }
+
+    /**
      * Delete the batch that has the given ID.
      *
      * @param  string  $batchId

--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -47,7 +47,7 @@ class RetryBatchCommand extends Command implements Isolatable
 
         if ($this->option('resume')) {
             $this->components->info("Resuming job batch [$id].");
-
+            $batch->resume();
         }
 
         $this->components->info("Pushing failed queue jobs of the batch [$id] back onto the queue.");

--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -15,7 +15,9 @@ class RetryBatchCommand extends Command implements Isolatable
      *
      * @var string
      */
-    protected $signature = 'queue:retry-batch {id : The ID of the batch whose failed jobs should be retried}';
+    protected $signature = 'queue:retry-batch
+                            {id : The ID of the batch whose failed jobs should be retried}
+                            {--resume : If the batch was previously cancelled, this will un-cancel the batch}';
 
     /**
      * The console command description.
@@ -41,6 +43,11 @@ class RetryBatchCommand extends Command implements Isolatable
             $this->components->error('The given batch does not contain any failed jobs.');
 
             return 1;
+        }
+
+        if ($this->option('resume')) {
+            $this->components->info("Resuming job batch [$id].");
+
         }
 
         $this->components->info("Pushing failed queue jobs of the batch [$id] back onto the queue.");

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -130,6 +130,19 @@ class BatchRepositoryFake implements BatchRepository
     }
 
     /**
+     * Resume the batch that has the given ID.
+     *
+     * @param  string  $batchId
+     * @return void
+     */
+    public function resume(string $batchId)
+    {
+        if (isset($this->batches[$batchId])) {
+            $this->batches[$batchId]->resume();
+        }
+    }
+
+    /**
      * Delete the batch that has the given ID.
      *
      * @param  string  $batchId

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -304,6 +304,23 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->cancelled());
     }
 
+    public function test_batch_can_be_resumed()
+    {
+        $queue = m::mock(Factory::class);
+
+        $batch = $this->createTestBatch($queue);
+
+        $batch->cancel();
+
+        $batch = $batch->fresh();
+
+        $batch->resume();
+
+        $batch = $batch->fresh();
+
+        $this->assertFalse($batch->cancelled());
+    }
+
     public function test_batch_can_be_deleted()
     {
         $queue = m::mock(Factory::class);


### PR DESCRIPTION
With the new Job Chain/Batching feature (#48633), I am moving my custom implementation over to the "Laravel Way".

Currently, you can do the following with a Job Batch:
1) Cancel the batch and all remaining jobs get cancelled
2) Allow failures

Without being inside of a Chain, this was good enough for my use case because I would allow failures, but then only move to the next 'step' after all failed jobs were remediated. Now that I can take advantage of the Job Chain with Batches inside, I need to be able to cancel a Batch on failure....fix the issue, and restart the jobs in the batch that failed.

My Use Case:
Batch 1 has 100 jobs. All 100 jobs must be completed(not failed) before going to Batch 2.
Batch 2 has 30 jobs. All 30 jobs are dependent upon the data received in the Batch 1 jobs.

What I Am Currently Doing:
Batch 1 created a unique lock based on an ID. Once Batch 1 completed, an event was sent to remove the 'lock'
Batch 2 would check if that lock still existed. If so, return the job to the queue and try again.

I need to be able to have a job inside of Batch 1 fail and cancel the batch(Therefore, cancelling the Chain it is in). After I remedy the failure, I need to be able to run `queue:retry-batch {id}`.

The problem: Retrying the batch does not "un-cancel" the batch, meaning that inside of the job when checking if cancelled, it doesn't perform the actions.

```php
/**
 * Execute the job.
 */
public function handle(): void
{ 
    if ($this->batch()->cancelled()) {
        return;
    }

    // Business logic runs here...
}
```

The solution: Retrying the batch has an option to `--resume` which "un-cancels" the batch, allowing the business logic to be ran.

```php
queue:retry-batch {id} --resume
```

---

Scenario(End Goal):
```php
$batch1 = [
   new Job(1),
   new Job(2),
   new Job(3),
];

$batch2 = [
   new OtherJob(1),
   new OtherJob(2),
   new OtherJob(3),
];

Bus::chain([
    Bus::batch($batch1),
    Bus::batch($batch2),
])->dispatch();

```

`Job(1)` successfully runs.
`Job(2)` fails and cancels the batch.
// The chain has now stopped.
// Fix failure reason manually and run `queue:retry-batch {id} --resume`
`Job(2)` successfully runs now.
`Job(3)` successfully runs.
`$batch2` now runs
