### PR TITLE
[10.x] Add "substituteImplicitBindingsUsing" method to router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -120,6 +120,13 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $groupStack = [];
 
     /**
+     * All of the registered implicit binding callbacks.
+     *
+     * @var array
+     */
+    protected $implicitBindingCallbacks = [];
+
+    /**
      * All of the verbs supported by the router.
      *
      * @var string[]
@@ -950,6 +957,21 @@ class Router implements BindingRegistrar, RegistrarContract
     public function substituteImplicitBindings($route)
     {
         ImplicitRouteBinding::resolveForRoute($this->container, $route);
+
+        foreach ($this->implicitBindingCallbacks as $callback) {
+            call_user_func($callback, $route);
+        }
+    }
+
+    /**
+     * Register a callback to to run after implicit bindings are substituted.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public function substituteImplicitBindingsUsing($callback)
+    {
+        $this->implicitBindingCallbacks[] = $callback;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -958,11 +958,10 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $default = fn () => ImplicitRouteBinding::resolveForRoute($this->container, $route);
 
-        if ($this->implicitBindingCallback) {
-            return call_user_func($this->implicitBindingCallback, $this->container, $route, $default);
-        }
+        return call_user_func(
+            $this->implicitBindingCallback ?? $default, $this->container, $route, $default
+        );
 
-        return $default();
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -120,11 +120,11 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $groupStack = [];
 
     /**
-     * All of the registered implicit binding callbacks.
+     * The registered custom implicit binding callback.
      *
      * @var array
      */
-    protected $implicitBindingCallbacks = [];
+    protected $implicitBindingCallback;
 
     /**
      * All of the verbs supported by the router.
@@ -956,22 +956,26 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function substituteImplicitBindings($route)
     {
-        ImplicitRouteBinding::resolveForRoute($this->container, $route);
+        $default = fn () => ImplicitRouteBinding::resolveForRoute($this->container, $route);
 
-        foreach ($this->implicitBindingCallbacks as $callback) {
-            call_user_func($callback, $route);
+        if ($this->implicitBindingCallback) {
+            return call_user_func($this->implicitBindingCallback, $this->container, $route, $default);
         }
+
+        return $default();
     }
 
     /**
      * Register a callback to to run after implicit bindings are substituted.
      *
      * @param  callable  $callback
-     * @return void
+     * @return $this
      */
     public function substituteImplicitBindingsUsing($callback)
     {
-        $this->implicitBindingCallbacks[] = $callback;
+        $this->implicitBindingCallback = $callback;
+
+        return $this;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1760,7 +1760,9 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $router->substituteImplicitBindingsUsing(function ($route) {
+        $router->substituteImplicitBindingsUsing(function ($container, $route, $default) {
+            $default = $default();
+
             $model = $route->parameter('bar');
             $model->value = 'otwell';
         });

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -982,18 +982,6 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testRouteBindingWithBindingClosure()
-    {
-        $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
-            return $name;
-        }]);
-        $router->bind('bar', function ($value) {
-            return strtoupper($value);
-        });
-        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
-    }
-
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -982,6 +982,18 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testRouteBindingWithBindingClosure()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->bind('bar', function ($value) {
+            return strtoupper($value);
+        });
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();
@@ -1754,6 +1766,25 @@ class RoutingRouteTest extends TestCase
         ]);
 
         $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testImplicitBindingsWithClosure()
+    {
+        $router = $this->getRouter();
+
+        $router->substituteImplicitBindingsUsing(function ($route) {
+            $model = $route->parameter('bar');
+            $model->value = 'otwell';
+        });
+
+        $router->get('foo/{bar}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RoutingTestUserModel $bar) {
+                return $bar->value;
+            },
+        ]);
+
+        $this->assertSame('otwell', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testImplicitBindingsWhereScopedBindingsArePrevented()


### PR DESCRIPTION
## Usage
This PR adds the following public method to Laravel's router that can be used from a service provider like so:

```php
app('router')->substituteImplicitBindingsUsing(function ($route) {
    $route->setParameter('foo', 'bar');
});
```

## Behavior
* After Laravel runs `substituteImplicitBindings()` internally to implicitly transform plain route parameters into Eloquent models and such
* The callbacks provided to `substituteImplicitBindingsUsing()` will be run, allowing packages and apps to inject additional behavior

## Reasoning
The following code currently doesn't work when using Livewire:

**Route definition**
```php
Route::get('/post/{post}', App\Livewire\UpdatePost::class)
    ->middleware('can:update,post');
```

**Post Policy**
```php
class PostPolicy
{
    public function update(?User $user, Post $post): bool
    {
        return $user?->id === $post->user_id;
    }
}
```

**Livewire Component**
```php
class UpdatePost extends Component
{
    public Post $post;
    
    // ...
}
```

As you can see, a Livewire component is different than a standard controller action in that it declares type-hinted route dependencies as properties of the component (`public Post $post`), rather than as parameters of a controller method or closure.

The reason the component works as a route action at all is that the base `Component` class has an internal `__invoke()` method to allow them to be used as single-action controllers:

```php
class Component
{
    public function __invoke()
    // ...
}
```

However, because no parameters are defined on `__invoke()`, middleware like `can:update,post` aren't be able to resolve the `{post}` binding and will result in an error.

Using this new method (`substituteImplicitBindingsUsing`), Livewire's core will be able to solve this using code like the following:

```php
app('router')->substituteImplicitBindingsUsing(function ($route) {
    [$class, $method] = explode('@', $route->action['uses']);

    if (is_subclass_of($class, \Livewire\Component::class)) {
        foreach (Livewire::resolveComponentBindings($class) as $key => $value) {
            $route->setParameter($key, $value);
        }
    }
});
```

(The above code is pseudo-code. I'm aware it doesn't account for different types of route actions.)

## Alternatives
In this PR, I run the provided callbacks AFTER Laravel has already done all of its implicit bindings.

This way, the provided callbacks have full control over the resulting bindings as they can override Laravel's internal bindings.

If that's not ideal for some reason, these callbacks can easily be run BEFORE instead without changing my ability to use this method inside Livewire.

## Documentation
I'm figuring this is a more internal API, so I didn't document it. If anyone thinks it's helpful/desired, I'm happy to add documentation!

Thanks for your time!