### PR TITLE
updated padLeft introduced an unexpected behaviour

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -774,7 +774,7 @@ class Str
     public static function padLeft($value, $length, $pad = ' ')
     {
         if (function_exists('mb_str_pad')) {
-            return mb_str_pad($value, $length, $pad, STR_PAD_LEFT);
+            return mb_str_pad((string)$value, $length, $pad, STR_PAD_LEFT);
         }
 
         $short = max(0, $length - mb_strlen($value));


### PR DESCRIPTION
In the previous release the method Str::padLeft deals with null values but the way it was implemented to use mb_str_pad it does not allows the value to be null. 

Now it casts to a string the value to prevent this error.

e.g:

in the previous release:

```PHP
$value = null;
Str::padLeft($value, 4, '0') // returns 0000
```

in the current release (v10.34.0)
```PHP
$value = null;
Str::padLeft($value, 4, '0') 
// throws exception mb_str_pad(): Argument #1 ($string) must be of type string, null given, called in /var/www/vendor/laravel/framework/src/Illuminate/Support/Str.php on line 777
```
