### PR TITLE
[10.x] Get indexes of a table

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -42,4 +42,25 @@ class MySqlProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of an indexes query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processIndexes($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $name = strtolower($result->name),
+                'columns' => explode(',', $result->columns),
+                'type' => strtolower($result->type),
+                'unique' => (bool) $result->unique,
+                'primary' => $name === 'primary',
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -70,4 +70,25 @@ class PostgresProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of an indexes query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processIndexes($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => strtolower($result->name),
+                'columns' => explode(',', $result->columns),
+                'type' => strtolower($result->type),
+                'unique' => (bool) $result->unique,
+                'primary' => (bool) $result->primary,
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -89,6 +89,17 @@ class Processor
     }
 
     /**
+     * Process the results of an indexes query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processIndexes($results)
+    {
+        return $results;
+    }
+
+    /**
      * Process the results of a column listing query.
      *
      * @deprecated Will be removed in a future Laravel version.

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -46,4 +46,37 @@ class SQLiteProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of an indexes query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processIndexes($results)
+    {
+        $primaryCount = 0;
+
+        $indexes = array_map(function ($result) use (&$primaryCount) {
+            $result = (object) $result;
+
+            if ($isPrimary = (bool) $result->primary) {
+                $primaryCount += 1;
+            }
+
+            return [
+                'name' => strtolower($result->name),
+                'columns' => explode(',', $result->columns),
+                'type' => null,
+                'unique' => (bool) $result->unique,
+                'primary' => $isPrimary,
+            ];
+        }, $results);
+
+        if ($primaryCount > 1) {
+            $indexes = array_filter($indexes, fn ($index) => $index['name'] !== 'primary');
+        }
+
+        return $indexes;
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -100,4 +100,25 @@ class SqlServerProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of an indexes query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processIndexes($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => strtolower($result->name),
+                'columns' => explode(',', $result->columns),
+                'type' => strtolower($result->type),
+                'unique' => (bool) $result->unique,
+                'primary' => (bool) $result->primary,
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -324,6 +324,21 @@ class Builder
     }
 
     /**
+     * Get the indexes for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getIndexes($table)
+    {
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processIndexes(
+            $this->connection->selectFromWriteConnection($this->grammar->compileIndexes($table))
+        );
+    }
+
+    /**
      * Modify a table on the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -167,6 +167,25 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the indexes.
+     *
+     * @param  string  $database
+     * @param  string  $table
+     * @return string
+     */
+    public function compileIndexes($database, $table)
+    {
+        return sprintf(
+            'select index_name as `name`, group_concat(column_name order by seq_in_index) as `columns`, '
+            .'index_type as `type`, not non_unique as `unique` '
+            .'from information_schema.statistics where table_schema = %s and table_name = %s '
+            .'group by index_name, index_type, non_unique',
+            $this->quoteString($database),
+            $this->quoteString($table)
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -180,7 +180,7 @@ class PostgresGrammar extends Grammar
             .'join pg_namespace tn on tn.oid = tc.relnamespace '
             .'join pg_class ic on ic.oid = i.indexrelid '
             .'join pg_am am on am.oid = ic.relam '
-            .'join unnest(i.indkey) with ordinality as indseq(num, ord) on true '
+            .'join lateral unnest(i.indkey) with ordinality as indseq(num, ord) on true '
             .'left join pg_attribute a on a.attrelid = i.indrelid and a.attnum = indseq.num '
             .'where tc.relname = %s and tn.nspname = %s '
             .'group by ic.relname, am.amname, i.indisunique, i.indisprimary',

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -164,6 +164,32 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the indexes.
+     *
+     * @param  string  $schema
+     * @param  string  $table
+     * @return string
+     */
+    public function compileIndexes($schema, $table)
+    {
+        return sprintf(
+            "select ic.relname as name, string_agg(a.attname, ',' order by indseq.ord) as columns, "
+            .'am.amname as "type", i.indisunique as "unique", i.indisprimary as "primary" '
+            .'from pg_index i '
+            .'join pg_class tc on tc.oid = i.indrelid '
+            .'join pg_namespace tn on tn.oid = tc.relnamespace '
+            .'join pg_class ic on ic.oid = i.indexrelid '
+            .'join pg_am am on am.oid = ic.relam '
+            .'join unnest(i.indkey) with ordinality as indseq(num, ord) on true '
+            .'left join pg_attribute a on a.attrelid = i.indrelid and a.attnum = indseq.num '
+            .'where tc.relname = % and tn.nspname = %s '
+            .'group by ic.relname, am.amname, i.indisunique, i.indisprimary',
+            $this->quoteString($table),
+            $this->quoteString($schema)
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -182,7 +182,7 @@ class PostgresGrammar extends Grammar
             .'join pg_am am on am.oid = ic.relam '
             .'join unnest(i.indkey) with ordinality as indseq(num, ord) on true '
             .'left join pg_attribute a on a.attrelid = i.indrelid and a.attnum = indseq.num '
-            .'where tc.relname = % and tn.nspname = %s '
+            .'where tc.relname = %s and tn.nspname = %s '
             .'group by ic.relname, am.amname, i.indisunique, i.indisprimary',
             $this->quoteString($table),
             $this->quoteString($schema)

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -136,11 +136,11 @@ class SQLiteGrammar extends Grammar
     public function compileIndexes($table)
     {
         return sprintf(
-            'select -1 as seq, "primary" as name, group_concat(col) as columns, 1 as "unique", 1 as "primary" '
-            .'from (select name as col from pragma_table_info(%s) where pk > 0 order by pk, cid) group by seq '
-            .'union select seq, name, group_concat(col) as columns, "unique", origin = "pk" as "primary" '
+            'select "primary" as name, group_concat(col) as columns, 1 as "unique", 1 as "primary" '
+            .'from (select name as col from pragma_table_info(%s) where pk > 0 order by pk, cid) group by name '
+            .'union select name, group_concat(col) as columns, "unique", origin = "pk" as "primary" '
             .'from (select il.*, ii.name as col from pragma_index_list(%s) il, pragma_index_info(il.name) ii order by il.seq, ii.seqno) '
-            .'group by name order by seq',
+            .'group by name, "unique", "primary"',
             $table = $this->wrap(str_replace('.', '__', $table)),
             $table
         );

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -128,6 +128,25 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the indexes.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function compileIndexes($table)
+    {
+        return sprintf(
+            'select -1 as seq, "primary" as name, group_concat(col) as columns, 1 as "unique", 1 as "primary" '
+            .'from (select name as col from pragma_table_info(%s) where pk > 0 order by pk, cid) group by seq '
+            .'union select seq, name, group_concat(col) as columns, "unique", origin = "pk" as "primary" '
+            .'from (select il.*, ii.name as col from pragma_index_list(%s) il, pragma_index_info(il.name) ii order by il.seq, ii.seqno) '
+            .'group by name order by seq',
+            $table = $this->wrap(str_replace('.', '__', $table)),
+            $table
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -168,6 +168,28 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the indexes.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function compileIndexes($table)
+    {
+        return sprintf(
+            "select idx.name as name, STRING_AGG(col.name, ',') within group (order by idxcol.key_ordinal) as columns, "
+            .'idx.type_desc as [type], idx.is_unique as [unique], idx.is_primary_key as [primary] '
+            .'from sys.indexes as idx '
+            .'join sys.tables as tbl on idx.object_id = tbl.object_id '
+            .'join sys.schemas as scm on tbl.schema_id = scm.schema_id '
+            .'join sys.index_columns as idxcol on idx.object_id = idxcol.object_id and idx.index_id = idxcol.index_id '
+            .'join sys.columns as col on idxcol.object_id = col.object_id and idxcol.column_id = col.column_id '
+            .'where tbl.name = %s and scm.name = SCHEMA_NAME() '
+            .'group by idx.name, idx.type_desc, idx.is_unique, idx.is_primary_key',
+            $this->quoteString($table),
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -176,7 +176,7 @@ class SqlServerGrammar extends Grammar
     public function compileIndexes($table)
     {
         return sprintf(
-            "select idx.name as name, STRING_AGG(col.name, ',') within group (order by idxcol.key_ordinal) as columns, "
+            "select idx.name as name, string_agg(col.name, ',') within group (order by idxcol.key_ordinal) as columns, "
             .'idx.type_desc as [type], idx.is_unique as [unique], idx.is_primary_key as [primary] '
             .'from sys.indexes as idx '
             .'join sys.tables as tbl on idx.object_id = tbl.object_id '

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -104,6 +104,23 @@ class MySqlBuilder extends Builder
     }
 
     /**
+     * Get the indexes for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getIndexes($table)
+    {
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processIndexes(
+            $this->connection->selectFromWriteConnection(
+                $this->grammar->compileIndexes($this->connection->getDatabaseName(), $table)
+            )
+        );
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -204,6 +204,23 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * Get the indexes for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getIndexes($table)
+    {
+        [, $schema, $table] = $this->parseSchemaAndTable($table);
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processIndexes(
+            $this->connection->selectFromWriteConnection($this->grammar->compileIndexes($schema, $table))
+        );
+    }
+
+    /**
      * Get the schemas for the connection.
      *
      * @return array

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -20,6 +20,7 @@ namespace Illuminate\Support\Facades;
  * @method static string getColumnType(string $table, string $column, bool $fullDefinition = false)
  * @method static array getColumnListing(string $table)
  * @method static array getColumns(string $table)
+ * @method static array getIndexes(string $table)
  * @method static void table(string $table, \Closure $callback)
  * @method static void create(string $table, \Closure $callback)
  * @method static void drop(string $table)

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -164,20 +164,21 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
             $table->index(['name', 'email'], 'index1');
         });
 
-        $manager = $db->getConnection()->getDoctrineSchemaManager();
-        $details = $manager->listTableDetails('prefix_users');
-        $this->assertTrue($details->hasIndex('index1'));
-        $this->assertFalse($details->hasIndex('index2'));
+        $indexes = array_column($schema->getIndexes('users'), 'name');
+
+        $this->assertContains('index1', $indexes);
+        $this->assertNotContains('index2', $indexes);
 
         $schema->table('users', function (Blueprint $table) {
             $table->renameIndex('index1', 'index2');
         });
 
-        $details = $manager->listTableDetails('prefix_users');
-        $this->assertFalse($details->hasIndex('index1'));
-        $this->assertTrue($details->hasIndex('index2'));
+        $indexes = $schema->getIndexes('users');
 
-        $this->assertEquals(['name', 'email'], $details->getIndex('index2')->getUnquotedColumns());
+        $this->assertNotContains('index1', array_column($indexes, 'name'));
+        $this->assertTrue(collect($indexes)->contains(
+            fn ($index) => $index['name'] === 'index2' && $index['columns'] === ['name', 'email']
+        ));
     }
 
     public function testAddingPrimaryKey()

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -87,7 +87,10 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->string('name')->index();
         });
 
-        $this->assertArrayHasKey('table1_name_index', $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1'));
+        $this->assertContains(
+            'table1_name_index',
+            array_column($this->db->connection()->getSchemaBuilder()->getIndexes('table1'), 'name')
+        );
     }
 
     public function testHasColumnAndIndexWithPrefixIndexEnabled()
@@ -104,7 +107,10 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->string('name')->index();
         });
 
-        $this->assertArrayHasKey('example_table1_name_index', $this->db->connection()->getDoctrineSchemaManager()->listTableIndexes('example_table1'));
+        $this->assertContains(
+            'example_table1_name_index',
+            array_column($this->db->connection()->getSchemaBuilder()->getIndexes('table1'), 'name')
+        );
     }
 
     public function testDropColumnWithTablePrefix()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -174,4 +174,84 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $this->assertEmpty(array_diff(['foo', 'bar', 'baz'], array_column($views, 'name')));
     }
+
+    public function testGetIndexes()
+    {
+        Schema::create('foo', function (Blueprint $table) {
+            $table->string('bar')->index('my_index');
+        });
+
+        $indexes = Schema::getIndexes('foo');
+
+        $this->assertCount(1, $indexes);
+        $this->assertTrue(
+            $indexes[0]['name'] === 'my_index'
+            && $indexes[0]['columns'] === ['bar']
+            && ! $indexes[0]['unique']
+            && ! $indexes[0]['primary']
+        );
+    }
+
+    public function testGetUniqueIndexes()
+    {
+        Schema::create('foo', function (Blueprint $table) {
+            $table->id();
+            $table->string('bar');
+            $table->integer('baz');
+
+            $table->unique(['baz', 'bar']);
+        });
+
+        $indexes = Schema::getIndexes('foo');
+
+        $this->assertCount(2, $indexes);
+        $this->assertTrue(collect($indexes)->contains(
+            fn ($index) => $index['columns'] === ['id'] && $index['primary']
+        ));
+        $this->assertTrue(collect($indexes)->contains(
+            fn ($index) => $index['name'] === 'foo_baz_bar_unique' && $index['columns'] === ['baz', 'bar'] && $index['unique']
+        ));
+    }
+
+    public function testGetIndexesWithCompositeKeys()
+    {
+        Schema::create('foo', function (Blueprint $table) {
+            $table->unsignedBigInteger('key');
+            $table->string('bar')->unique();
+            $table->integer('baz');
+
+            $table->primary(['baz', 'key']);
+        });
+
+        $indexes = Schema::getIndexes('foo');
+
+        $this->assertCount(2, $indexes);
+        $this->assertTrue(collect($indexes)->contains(
+            fn ($index) => $index['columns'] === ['baz', 'key'] && $index['primary']
+        ));
+        $this->assertTrue(collect($indexes)->contains(
+            fn ($index) => $index['name'] === 'foo_bar_unique' && $index['columns'] === ['bar'] && $index['unique']
+        ));
+    }
+
+    public function testGetFullTextIndexes()
+    {
+        if (! in_array($this->driver, ['pgsql', 'mysql'])) {
+            $this->markTestSkipped('Test requires a MySQL or a PostgreSQL connection.');
+        }
+
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->string('title', 200);
+            $table->text('body');
+
+            $table->fulltext(['body', 'title']);
+        });
+
+        $indexes = Schema::getIndexes('foo');
+
+        $this->assertCount(2, $indexes);
+        $this->assertTrue(collect($indexes)->contains(fn ($index) => $index['columns'] === ['id'] && $index['primary']));
+        $this->assertTrue(collect($indexes)->contains('name', 'articles_body_title_fulltext'));
+    }
 }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -248,7 +248,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->fulltext(['body', 'title']);
         });
 
-        $indexes = Schema::getIndexes('foo');
+        $indexes = Schema::getIndexes('articles');
 
         $this->assertCount(2, $indexes);
         $this->assertTrue(collect($indexes)->contains(fn ($index) => $index['columns'] === ['id'] && $index['primary']));


### PR DESCRIPTION
This PR adds `Schema::getIndexes()` method to get indexes' info of the given table. 

## Usage
Just like `Schema::getColumns()` added on #48357, the new `Schema::getIndexes()`method is to inspect the tables' indexes.

### `Schema::getIndexes()` 
* `name` (`string`): Name of the index
* `columns` (`string[]`): Array of indexed columns
* `type` (`?string`): Index type.
  * SQLite: `null`
  * MySQL: `btree`, `fulltext`, `hash`, `rtree`, `spatial`
  * PostgreSQL: `btree`, `hash`, `gist`, `spgist`, `gin`, `brin`
  * SQL Server: `heap`, `clustered`, `nonclustered`, `xml`, `spatial`, `clustered columnstore`, `nonclustered columnstore`, `nonclustered hash`
* `unique` (`boolean`): Is unique index?
* `primary` (`boolean`): Is primary index?
