### PR TITLE
[10.x] Add "--deferred" option to ProviderMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -37,6 +37,10 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('deferred')) {
+            return $this->resolveStubPath('/stubs/provider-deferred.stub');
+        }
+
         return $this->resolveStubPath('/stubs/provider.stub');
     }
 
@@ -50,7 +54,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.$stub;
+            : __DIR__ . $stub;
     }
 
     /**
@@ -61,7 +65,7 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\Providers';
+        return $rootNamespace . '\Providers';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -77,7 +77,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the provider already exists'],
-            ['deferred', null, InputOption::VALUE_NONE, "Indicates the provider should be deferred"]
+            ['deferred', null, InputOption::VALUE_NONE, "Indicates the provider should be deferred"],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -77,7 +77,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the provider already exists'],
-            ['deferred', null, InputOption::VALUE_NONE, "Indicates the provider should be deferred"],
+            ['deferred', null, InputOption::VALUE_NONE, 'Indicates the provider should be deferred'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -77,6 +77,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the provider already exists'],
+            ['deferred', null, InputOption::VALUE_NONE, "Indicates the provider should be deferred"]
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -54,7 +54,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__ . $stub;
+            : __DIR__.$stub;
     }
 
     /**
@@ -65,7 +65,7 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\Providers';
+        return $rootNamespace.'\Providers';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/provider-deferred.stub
+++ b/src/Illuminate/Foundation/Console/stubs/provider-deferred.stub
@@ -1,0 +1,27 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
+
+class {{ class }} extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array<int, string>
+     */
+    public function provides(): array
+    {
+        // 
+    }
+}

--- a/tests/Integration/Generators/ProviderMakeCommandTest.php
+++ b/tests/Integration/Generators/ProviderMakeCommandTest.php
@@ -24,7 +24,7 @@ class ProviderMakeCommandTest extends TestCase
 
     public function testItCanGenerateDeferredServiceProviderFile()
     {
-        $this->artisan('make:provider', ['name' => 'FooServiceProvider'])
+        $this->artisan('make:provider', ['name' => 'FooServiceProvider', '--deferred' => true])
             ->assertExitCode(0);
 
         $this->assertFileContains([

--- a/tests/Integration/Generators/ProviderMakeCommandTest.php
+++ b/tests/Integration/Generators/ProviderMakeCommandTest.php
@@ -21,4 +21,18 @@ class ProviderMakeCommandTest extends TestCase
             'public function boot()',
         ], 'app/Providers/FooServiceProvider.php');
     }
+
+    public function testItCanGenerateDeferredServiceProviderFile()
+    {
+        $this->artisan('make:provider', ['name' => 'FooServiceProvider'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Providers;',
+            'use Illuminate\Support\ServiceProvider;',
+            'class FooServiceProvider extends ServiceProvider implements DeferrableProvider',
+            'public function register()',
+            'public function provides()',
+        ], 'app/Providers/FooServiceProvider.php');
+    }
 }


### PR DESCRIPTION
## Usage
Now you can add the `--deferred` option to the ProviderMakeCommand like so
```
php artisan make:provider FooServiceProvider --deferred
```
## Behaviour
It will generate boilerplate code from "provider-deferred.stub" which implements the `DeferrableProvider` interface
```php
<?php
 
namespace App\Providers;

use Illuminate\Support\ServiceProvider;
use Illuminate\Contracts\Support\DeferrableProvider;

class FooServiceProvider extends ServiceProvider implements DeferrableProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        //
    }
 
    /**
     * Get the services provided by the provider.
     *
     * @return array<int, string>
     */
    public function provides(): array
    {
        //
    }
}
```
## The boot method
Would you prefer to have the `boot` method included in the stub as well? I decided to omit it since it isn't being shown in the docs. https://laravel.com/docs/10.x/providers#deferred-providers

## Documentation
I will make a PR to the documentation as well if this gets merged.