### PR TITLE
[10.x] Fix docblock for wasRecentlyCreated

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -106,7 +106,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public $exists = false;
 
     /**
-     * Indicates if the model was inserted during the current request lifecycle.
+     * Indicates if the model was inserted during the object's lifecycle.
      *
      * @var bool
      */


### PR DESCRIPTION
"current request lifecycle" is misleading as there's no global state tracking what models were created during the current request. The property is only set to `true` during an insert by the model itself.

Feel free to propose alternative wording. I went with `object's lifecycle` to make it clear that it's referring to the model instance. Maybe using "model" instead of "object", or "lifetime" instead of "lifecycle" could work better.