### PR TITLE
[10.x] Update InteractsWithDictionary.php to use base InvalidArgumentException

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use BackedEnum;
-use Doctrine\Instantiator\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use UnitEnum;
 
 trait InteractsWithDictionary
@@ -14,7 +14,7 @@ trait InteractsWithDictionary
      * @param  mixed  $attribute
      * @return mixed
      *
-     * @throws \Doctrine\Instantiator\Exception\InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function getDictionaryKey($attribute)
     {


### PR DESCRIPTION
Use base InvalidArgumentException instead of \Doctrine\Instantiator\Exception\InvalidArgumentException.

This was probably an IDE autocorrect mistake.. Not sure if this needs a test.
