### PR TITLE
[10.x] Improved updateOrCreate Method with Selective Fields for Insert and Update

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -587,17 +587,26 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Create or update a record matching the attributes, and fill it with values.
+     * Create or update a record matching the attributes, and fill it with updateValues or insertValues.
      *
-     * @param  array  $attributes
-     * @param  array  $values
+     * If the record exists, it will be updated with the provided $updateValues.
+     * If the record doesn't exist, a new record will be created with merged $attributes and $insertValues.
+     *
+     * @param array $attributes
+     * @param array $updateValues
+     * @param array $insertValues
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, array $updateValues = [], array $insertValues = [])
     {
-        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+        // If $insertValues is not provided, use $updateValues as $insertValues
+        if (empty($insertValues)) {
+            $insertValues = $updateValues;
+        }
+
+        return tap($this->firstOrCreate($attributes, $insertValues), function ($instance) use ($updateValues) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values)->save();
+                $instance->fill($updateValues)->save();
             }
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -662,19 +662,28 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Create or update a related record matching the attributes, and fill it with values.
+     * Create or update a related record matching the attributes, and fill it with updateValues or insertValues.
+     *
+     * If the record exists, it will be updated with the provided $updateValues.
+     * If the record doesn't exist, a new record will be created with merged $attributes and $insertValues.
      *
      * @param  array  $attributes
-     * @param  array  $values
+     * @param  array $updateValues
      * @param  array  $joining
      * @param  bool  $touch
+     * @param  array $insertValues
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
+    public function updateOrCreate(array $attributes, array $updateValues = [], array $joining = [], bool $touch = true, array $insertValues = [])
     {
-        return tap($this->firstOrCreate($attributes, $values, $joining, $touch), function ($instance) use ($values) {
+        // If $insertValues is not provided, use $updateValues as $insertValues
+        if (empty($insertValues)) {
+            $insertValues = $updateValues;
+        }
+
+        return tap($this->firstOrCreate($attributes, $insertValues, $joining, $touch), function ($instance) use ($updateValues) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values);
+                $instance->fill($updateValues);
 
                 $instance->save(['touch' => false]);
             }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -297,7 +297,7 @@ class HasManyThrough extends Relation
     }
 
     /**
-     * Create or update a record matching the attributes, and fill it with updateValues or insertValues.
+     * Create or update a related record matching the attributes, and fill it with updateValues or insertValues.
      *
      * If the record exists, it will be updated with the provided $updateValues.
      * If the record doesn't exist, a new record will be created with merged $attributes and $insertValues.

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -297,17 +297,26 @@ class HasManyThrough extends Relation
     }
 
     /**
-     * Create or update a related record matching the attributes, and fill it with values.
+     * Create or update a record matching the attributes, and fill it with updateValues or insertValues.
      *
-     * @param  array  $attributes
-     * @param  array  $values
+     * If the record exists, it will be updated with the provided $updateValues.
+     * If the record doesn't exist, a new record will be created with merged $attributes and $insertValues.
+     *
+     * @param array $attributes
+     * @param array $updateValues
+     * @param array $insertValues
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, array $updateValues = [], array $insertValues = [])
     {
-        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+        // If $insertValues is not provided, use $updateValues as $insertValues
+        if (empty($insertValues)) {
+            $insertValues = $updateValues;
+        }
+
+        return tap($this->firstOrCreate($attributes, $insertValues), function ($instance) use ($updateValues) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values)->save();
+                $instance->fill($updateValues)->save();
             }
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -259,17 +259,26 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Create or update a related record matching the attributes, and fill it with values.
+     * Create or update a record matching the attributes, and fill it with updateValues or insertValues.
      *
-     * @param  array  $attributes
-     * @param  array  $values
+     * If the record exists, it will be updated with the provided $updateValues.
+     * If the record doesn't exist, a new record will be created with merged $attributes and $insertValues.
+     *
+     * @param array $attributes
+     * @param array $updateValues
+     * @param array $insertValues
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, array $updateValues = [], array $insertValues = [])
     {
-        return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
+        // If $insertValues is not provided, use $updateValues as $insertValues
+        if (empty($insertValues)) {
+            $insertValues = $updateValues;
+        }
+
+        return tap($this->firstOrCreate($attributes, $insertValues), function ($instance) use ($updateValues) {
             if (! $instance->wasRecentlyCreated) {
-                $instance->fill($values)->save();
+                $instance->fill($updateValues)->save();
             }
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -259,7 +259,7 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Create or update a record matching the attributes, and fill it with updateValues or insertValues.
+     * Create or update a related record matching the attributes, and fill it with updateValues or insertValues.
      *
      * If the record exists, it will be updated with the provided $updateValues.
      * If the record doesn't exist, a new record will be created with merged $attributes and $insertValues.

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -390,6 +390,48 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
         ], $result->toArray());
     }
 
+    public function testUpdateOrCreateMethodCreatesNewRelatedWithSeparateInsertUpdateFields(): void
+    {
+        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        {
+            protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
+            {
+                $relation = Mockery::mock(BelongsToMany::class)->makePartial();
+                $relation->__construct(...func_get_args());
+                $instance = new BelongsToManyCreateOrFirstTestRelatedModel([
+                    'id' => 456,
+                    'attr' => 'foo',
+                    'val' => 'inserted',
+                    'created_at' => '2023-01-01T00:00:00.000000Z',
+                    'updated_at' => '2023-01-01T00:00:00.000000Z',
+                ]);
+                $instance->exists = true;
+                $instance->wasRecentlyCreated = true;
+                $instance->syncOriginal();
+                $relation
+                    ->expects('firstOrCreate')
+                    ->with(['attr' => 'foo'], ['val' => 'inserted'], [], true)
+                    ->andReturn($instance);
+
+                return $relation;
+            }
+        };
+        $source->id = 123;
+        $this->mockConnectionForModels(
+            [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
+            'SQLite',
+        );
+
+        $result = $source->related()->updateOrCreate(['attr' => 'foo'], ['val' => 'updated'], [],true, ['val' => 'inserted']);
+        $this->assertEquals([
+            'id' => 456,
+            'attr' => 'foo',
+            'val' => 'inserted',
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
     public function testUpdateOrCreateMethodUpdatesExistingRelated(): void
     {
         $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
@@ -437,6 +479,58 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             'id' => 456,
             'attr' => 'foo',
             'val' => 'baz',
+            'created_at' => '2023-01-01T00:00:00.000000Z',
+            'updated_at' => '2023-01-01T00:00:00.000000Z',
+        ], $result->toArray());
+    }
+
+    public function testUpdateOrCreateMethodUpdatesExistingRelatedWithSeparateInsertUpdateFields(): void
+    {
+        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        {
+            protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
+            {
+                $relation = Mockery::mock(BelongsToMany::class)->makePartial();
+                $relation->__construct(...func_get_args());
+                $instance = new BelongsToManyCreateOrFirstTestRelatedModel([
+                    'id' => 456,
+                    'attr' => 'foo',
+                    'val' => 'bar',
+                    'created_at' => '2023-01-01T00:00:00.000000Z',
+                    'updated_at' => '2023-01-01T00:00:00.000000Z',
+                ]);
+                $instance->exists = true;
+                $instance->wasRecentlyCreated = false;
+                $instance->syncOriginal();
+                $relation
+                    ->expects('firstOrCreate')
+                    ->with(['attr' => 'foo'], ['val' => 'inserted'], [], true)
+                    ->andReturn($instance);
+
+                return $relation;
+            }
+        };
+        $source->id = 123;
+        $this->mockConnectionForModels(
+            [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
+            'SQLite',
+        );
+        $source->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
+        $source->getConnection()->shouldReceive('getName')->andReturn('sqlite');
+
+        $source->getConnection()
+            ->expects('update')
+            ->with(
+                'update "related_table" set "val" = ?, "updated_at" = ? where "id" = ?',
+                ['updated', '2023-01-01 00:00:00', 456],
+            )
+            ->andReturn(1);
+
+        $result = $source->related()->updateOrCreate(['attr' => 'foo'], ['val' => 'updated'], [], true, ['val' => 'inserted']);
+        $this->assertEquals([
+            'id' => 456,
+            'attr' => 'foo',
+            'val' => 'updated',
             'created_at' => '2023-01-01T00:00:00.000000Z',
             'updated_at' => '2023-01-01T00:00:00.000000Z',
         ], $result->toArray());

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -86,6 +86,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $table->string('name')->nullable();
                 $table->string('email');
                 $table->timestamp('birthday', 6)->nullable();
+                $table->string('status')->nullable();
                 $table->timestamps();
             });
 
@@ -611,6 +612,32 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertSame('Mohamed Said', $user3->name);
+        $this->assertEquals(2, EloquentTestUser::count());
+    }
+
+    public function testUpdateOrCreateWithSeparateUpdateAndInsertFields()
+    {
+        $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com','status' => 'inactive']);
+
+        $user2 = EloquentTestUser::updateOrCreate(
+            ['email' => 'taylorotwell@gmail.com'],
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Taylor Otwell' , 'status' => 'active']
+        );
+
+        $this->assertEquals($user1->id, $user2->id);
+        $this->assertSame('taylorotwell@gmail.com', $user2->email);
+        $this->assertSame('Taylor Otwell', $user2->name);
+        $this->assertSame('inactive', $user2->status);
+
+        $user3 = EloquentTestUser::updateOrCreate(
+            ['email' => 'test@gmail.com'],
+            ['name' => 'behnam'],
+            ['name' => 'behnam' , 'status' => 'active']
+        );
+
+        $this->assertSame('behnam', $user3->name);
+        $this->assertSame('active', $user3->status);
         $this->assertEquals(2, EloquentTestUser::count());
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -86,7 +86,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $table->string('name')->nullable();
                 $table->string('email');
                 $table->timestamp('birthday', 6)->nullable();
-                $table->string('status')->nullable();
                 $table->timestamps();
             });
 
@@ -617,27 +616,29 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testUpdateOrCreateWithSeparateUpdateAndInsertFields()
     {
-        $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com','status' => 'inactive']);
+        $birthday = '1998-12-01 09:25:00';
+        $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com', 'birthday' => $birthday]);
 
         $user2 = EloquentTestUser::updateOrCreate(
             ['email' => 'taylorotwell@gmail.com'],
             ['name' => 'Taylor Otwell'],
-            ['name' => 'Taylor Otwell' , 'status' => 'active']
+            ['name' => 'Taylor Otwell' , 'birthday' => '2000-05-10 16:00:00']
         );
 
         $this->assertEquals($user1->id, $user2->id);
         $this->assertSame('taylorotwell@gmail.com', $user2->email);
         $this->assertSame('Taylor Otwell', $user2->name);
-        $this->assertSame('inactive', $user2->status);
+        $this->assertSame($birthday, (string) $user2->birthday);
 
+        $birthday = '1996-05-10 16:00:00';
         $user3 = EloquentTestUser::updateOrCreate(
             ['email' => 'test@gmail.com'],
             ['name' => 'behnam'],
-            ['name' => 'behnam' , 'status' => 'active']
+            ['name' => 'behnam' , 'birthday' => $birthday]
         );
 
         $this->assertSame('behnam', $user3->name);
-        $this->assertSame('active', $user3->status);
+        $this->assertSame($birthday, (string) $user3->birthday);
         $this->assertEquals(2, EloquentTestUser::count());
     }
 


### PR DESCRIPTION
The current implementation of the updateOrCreate method in Laravel database functionality lacks efficiency in certain scenarios. One notable limitation is encountered when there is a need to update only specific database fields or to provide distinct field values for inserts and updates.

Consider the following example: a Product model with fields like name, price, and status. In the process of synchronizing products from a designated API, one may encounter situations where only certain fields need updating or where unique values should be assigned during creation or updates.

```
Product::query()->updateOrCreate(
    ['slug' => $data['slug']],
    ['status' => 'active', 'price' => $data['price']]
);
```

In the code snippet above, an issue arises as the 'status' field is updated to 'active' both during the creation and updating of a product. This behavior is not desirable in scenarios where the status field should remain unchanged during updates.


Another problematic scenario is the inability to set specific values exclusively for insertion or updating purposes.

To address these limitations, I propose an enhancement to the updateOrCreate method by introducing additional parameters that handle the aforementioned issues.

With the enhanced implementation, developers can now provide extra parameters for selective field updates during insertion:


```
Product::query()->updateOrCreate(
    ['slug' => $data['slug']],
    ['price' => $data['price']],
    ['status' => 'active', 'price' => $data['price']]
);
```


In this example, the 'status' field is updated to 'active' only when creating a new product, preserving the status during updates.

Additionally, users can now customize values for both update and create modes:

```
Product::query()->updateOrCreate(
    ['slug' => $data['slug']],
    ['status' => 'updated'],
    ['status' => 'created']
);
```

The introduced extra parameters are optional, ensuring backward compatibility with the existing usage of the updateOrCreate method. Users can choose to utilize the new functionality without affecting their previous codebase. This enhancement aims to provide more flexibility and control in managing database updates and inserts.