### PR TITLE
Harmonic Mean Calculation in Number Class

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -236,6 +236,30 @@ class Number
     }
 
     /**
+     * Calculate the harmonic mean of a set of numbers.
+     *
+     * @param int|float ...$numbers An indefinite number of numeric arguments
+     * @return float Harmonic mean of the numbers
+     * @throws InvalidArgumentException If the arguments are empty, non-numeric, or contain zero values.
+     */
+    public static function harmonize(int|float ...$numbers): float 
+    {
+        if (empty($numbers)) {
+            throw new InvalidArgumentException("Arguments cannot be empty");
+        }
+
+        $sumOfReciprocals = 0;
+        foreach ($numbers as $number) {
+            if (!is_numeric($number) || $number <= 0) {
+                throw new InvalidArgumentException("All elements must be positive numbers");
+            }
+            $sumOfReciprocals += 1 / $number;
+        }
+
+        return count($numbers) / $sumOfReciprocals;
+    }
+
+    /**
      * Ensure the "intl" PHP exntension is installed.
      *
      * @return void


### PR DESCRIPTION
This PR introduces a new feature to the Number class - the `harmonize` method. This method calculates the harmonic mean of a given set of numbers.

- The `harmonize` method accepts an indefinite number of numeric arguments.
- It throws an InvalidArgumentException if any argument is non-numeric or less than or equal to zero.
- This method is particularly useful in scenarios where the average rates or ratios are required, like in financial applications, performance monitoring, or data analysis.

### Example
```php
// Example usage of the harmonize method
$averageSpeed = Number::harmonize(60, 40); // Average speed for two different speeds
echo "The harmonic mean of the speeds 60 and 40 is: " . $averageSpeed . " km/h"; // 48 km/h

// Another example with more numbers
$dataRates = Number::harmonize(5, 10, 15); // Harmonic mean of data transfer rates
echo "The harmonic mean of the data rates 5, 10, 15 is: " . $dataRates . " Mbps"; // 6.666666666666667 Mbps
```

### Impact
- This enhancement broadens the utility of the Number class, making it a more versatile tool for various mathematical and statistical calculations on Laravel applications.