### PR TITLE
[10.x] Fix loss of attributes after calling child component

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -67,6 +67,7 @@ trait CompilesComponents
     {
         return implode("\n", [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
+            '<?php if (isset($attributes)) { $__attributesOriginal'.$hash.' = $attributes; } ?>',
             '<?php $component = '.$component.'::resolve('.($data ?: '[]').' + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? (array) $attributes->getIterator() : [])); ?>',
             '<?php $component->withName('.$alias.'); ?>',
             '<?php if ($component->shouldRender()): ?>',
@@ -94,6 +95,10 @@ trait CompilesComponents
         $hash = array_pop(static::$componentHashStack);
 
         return $this->compileEndComponent()."\n".implode("\n", [
+            '<?php endif; ?>',
+            '<?php if (isset($__attributesOriginal'.$hash.')): ?>',
+            '<?php $attributes = $__attributesOriginal'.$hash.'; ?>',
+            '<?php unset($__attributesOriginal'.$hash.'); ?>',
             '<?php endif; ?>',
             '<?php if (isset($__componentOriginal'.$hash.')): ?>',
             '<?php $component = $__componentOriginal'.$hash.'; ?>',

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -758,7 +758,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $profileComponent->shouldReceive('shouldRender')->once()->andReturn(true);
         $profileComponent->shouldReceive('resolveView')->once()->andReturn('');
         $profileComponent->shouldReceive('data')->once()->andReturn([]);
-        $profileComponent->shouldReceive('withAttributes')->once();
+        $profileComponent->shouldReceive('withAttributes')->with(['attributes' => new ComponentAttributeBag(['other' => 'ok'])])->once();
 
         Component::resolveComponentsUsing(fn ($component) => match ($component) {
             TestContainerComponent::class => $containerComponent,

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -779,7 +779,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         eval(" ?> $template <?php ");
         ob_get_clean();
 
-        $this->assertNotNull($attributes->get('userId'), 'bar');
+        $this->assertSame($attributes->get('userId'), 'bar');
         $this->assertSame($attributes->get('other'), 'ok');
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -715,7 +715,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $component->shouldReceive('shouldRender')->once()->andReturn(true);
         $component->shouldReceive('resolveView')->once()->andReturn('');
         $component->shouldReceive('data')->once()->andReturn([]);
-        $component->shouldReceive('withAttributes')->once();
+        $component->shouldReceive('withAttributes')->with(['attributes' => new ComponentAttributeBag(['other' => 'ok'])])->once();
 
         Component::resolveComponentsUsing(fn () => $component);
 
@@ -730,7 +730,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         eval(" ?> $template <?php ");
         ob_get_clean();
 
-        $this->assertNull($attributes->get('userId'));
+        $this->assertSame($attributes->get('other'), 'ok');
     }
 
     public function testOriginalAttributesAreRestoredAfterRenderingChildComponentWithProps()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -730,6 +730,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         eval(" ?> $template <?php ");
         ob_get_clean();
 
+        $this->assertSame($attributes->get('userId'), 'bar');
         $this->assertSame($attributes->get('other'), 'ok');
     }
 

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -17,6 +17,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
     public function testClassComponentsAreCompiled()
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal2dda3d2f2f9b76bd400bf03f0b84e87f = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal2dda3d2f2f9b76bd400bf03f0b84e87f = $attributes; } ?>
 <?php $component = Illuminate\Tests\View\Blade\ComponentStub::class::resolve(["foo" => "bar"] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? (array) $attributes->getIterator() : [])); ?>
 <?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
@@ -35,6 +36,10 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $this->compiler->newComponentHash('foo');
 
         $this->assertSame('<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal79aef92e83454121ab6e5f64077e7d8a)): ?>
+<?php $attributes = $__attributesOriginal79aef92e83454121ab6e5f64077e7d8a; ?>
+<?php unset($__attributesOriginal79aef92e83454121ab6e5f64077e7d8a); ?>
 <?php endif; ?>
 <?php if (isset($__componentOriginal79aef92e83454121ab6e5f64077e7d8a)): ?>
 <?php $component = $__componentOriginal79aef92e83454121ab6e5f64077e7d8a; ?>


### PR DESCRIPTION
This fixes the issue as described in #49206 by storing and restoring the original attributes after rendering a component. This is the same solution that is used for components.
