### PR TITLE
[10.x] $model->refresh() not forcing use of writer DB instance for the loaded relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1701,15 +1701,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 ->attributes
         );
 
-        $relations = collect($this->relations)
+
+        $this->load(
+            collect($this->relations)
                 ->reject(function ($relation) {
                     return $relation instanceof Pivot
                         || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true));
                 })
-                ->keys();
-
-        $this->load(
-            $relations->keys()
+                ->keys()
                 ->mapWithKeys(function ($relation) {
                     return [
                         $relation => fn ($query) => $query->useWritePdo(),

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1712,7 +1712,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $relations->keys()
                 ->mapWithKeys(function ($relation) {
                     return [
-                        $relation => fn ($query) => $query->useWritePdo()
+                        $relation => fn ($query) => $query->useWritePdo(),
                     ];
                 })->all()
         );

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1701,7 +1701,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 ->attributes
         );
 
-
         $this->load(
             collect($this->relations)
                 ->reject(function ($relation) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Found an issue when working on a project that has a Writer instance and multiple readers when using `$model->refresh()`, I was expecting the refreshed model an relationships to be the latest modifications, but turns out that although the model itself was being loaded from the writer, the relationships where being loaded from readers which in some cases have not been replicated too yet.

Only users that have both reader and writer db instances would benefit from this changes, apps with only readers would notice no change in behavior