### PR TITLE
[11.x] Handle missing translation strings improvements

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,4 +39,14 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
+
+    /**
+     * Determine if a translation exists.
+     *
+     * @param  string  $key
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return bool
+     */
+    public function has($key, $locale = null, $fallback = true);
 }

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Contracts\Translation;
 
+/**
+ * @method bool has(string, string|null, bool)
+ */
 interface Translator
 {
     /**
@@ -13,6 +16,16 @@ interface Translator
      * @return mixed
      */
     public function get($key, array $replace = [], $locale = null);
+
+    /**
+     * Determine if a translation exists.
+     *
+     * @param  string  $key
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return bool
+     */
+    public function has($key, $locale = null, $fallback = true);
 
     /**
      * Get a translation according to an integer value.
@@ -39,14 +52,4 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
-
-    /**
-     * Determine if a translation exists.
-     *
-     * @param  string  $key
-     * @param  string|null  $locale
-     * @param  bool  $fallback
-     * @return bool
-     */
-    public function has($key, $locale = null, $fallback = true);
 }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -129,16 +129,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
-        $line = $this->translate($key, $replace, $locale, $fallback);
-
-        // Handle missing translation strings
-        if (is_null($line)) {
-            $line = $this->handleMissingTranslationKey(
+        return $this->translate($key, $replace, $locale, $fallback) ??
+            $this->handleMissingTranslationKey(
                 $key, $replace, $locale, $fallback
-            );
-        }
-
-        return $line;
+            ) ??
+            $key;
     }
 
     /**
@@ -347,7 +342,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         if (! $this->handleMissingTranslationKeys ||
             ! isset($this->missingTranslationKeyCallback)) {
-            return $key;
+            return null;
         }
 
         // Prevent infinite loops...

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -129,18 +129,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
-        $result = $this->translate($key, $replace, $locale, $fallback);
-        if (! is_null($result)) {
-            return $result;
+        $line = $this->translate($key, $replace, $locale, $fallback);
+
+        // Handle missing translation strings
+        if (is_null($line)) {
+            $line = $this->handleMissingTranslationKey(
+                $key, $replace, $locale, $fallback
+            );
         }
 
-        $line = $this->handleMissingTranslationKey(
-            $key, $replace, $locale, $fallback
-        );
-
-        // If the line doesn't exist, we will return back the key which was requested as
-        // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
         return $this->makeReplacements($line, $replace);
     }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -137,6 +137,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 $key, $replace, $locale, $fallback
             );
         }
+
+        return $line;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -260,6 +260,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         if (empty($replace)) {
             return $line;
         }
+        if (is_array($line)) {
+            return $line;
+        }
 
         $shouldReplace = [];
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -131,13 +131,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locale = $locale ?: $this->locale;
 
-        $line = $this->translate($key, $replace, $locale, $fallback);
-
-        if (is_null($line)) {
-            $line = $this->handleMissingTranslationKey(
+        $line = $this->translate($key, $replace, $locale, $fallback)
+            ?? $this->handleMissingTranslationKey(
                 $key, $replace, $locale, $fallback
-            ) ?? $key;
-        }
+            )
+            ?? $key;
 
         return $this->makeReplacements($line, $replace);
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -183,6 +183,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 }
             }
         }
+
         return $line;
     }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -115,18 +115,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function has($key, $locale = null, $fallback = true)
     {
-        $locale = $locale ?: $this->locale;
-
-        $line = $this->get($key, [], $locale, $fallback);
-
-        // For JSON translations, the loaded files will contain the correct line.
-        // Otherwise, we must assume we are handling typical translation file
-        // and check if the returned line is not the same as the given key.
-        if (! is_null($this->loaded['*']['*'][$locale][$key] ?? null)) {
-            return true;
-        }
-
-        return $line !== $key;
+        return $this->translate($key, [], $locale, $fallback) !== null;
     }
 
     /**
@@ -139,6 +128,23 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @return string|array
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
+    {
+        return $this->translate($key, $replace, $locale, $fallback) ??
+            $this->handleMissingTranslationKey(
+                $key, $replace, $locale, $fallback
+            );
+    }
+
+    /**
+     * Get the translation for a given key.  If not key exists, return null.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return null|string|array
+     */
+    protected function translate($key, array $replace = [], $locale = null, $fallback = true)
     {
         $locale = $locale ?: $this->locale;
 
@@ -168,9 +174,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 }
             }
 
-            $key = $this->handleMissingTranslationKey(
-                $key, $replace, $locale, $fallback
-            );
+            return null;
         }
 
         // If the line doesn't exist, we will return back the key which was requested as

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -137,8 +137,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 $key, $replace, $locale, $fallback
             );
         }
-
-        return $this->makeReplacements($line, $replace);
     }
 
     /**
@@ -181,7 +179,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             }
         }
 
-        return $line;
+        // If the line doesn't exist, we will return back the key which was requested as
+        // that will be quick to spot in the UI if language keys are wrong or missing
+        // from the application's language files. Otherwise we can return the line.
+        return $this->makeReplacements($line ?: $key, $replace);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -129,6 +129,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
+        $locale = $locale ?: $this->locale;
+
         $line = $this->translate($key, $replace, $locale, $fallback);
 
         if (is_null($line)) {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -130,7 +130,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
         $result = $this->translate($key, $replace, $locale, $fallback);
-        if (!is_null($result)) {
+        if (! is_null($result)) {
             return $result;
         }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -181,6 +181,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 }
             }
         }
+
+        return $line;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -129,11 +129,15 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
-        return $this->translate($key, $replace, $locale, $fallback) ??
-            $this->handleMissingTranslationKey(
+        $line = $this->translate($key, $replace, $locale, $fallback);
+
+        if (is_null($line)) {
+            $line = $this->handleMissingTranslationKey(
                 $key, $replace, $locale, $fallback
-            ) ??
-            $key;
+            ) ?? $key;
+        }
+
+        return $this->makeReplacements($line, $replace);
     }
 
     /**
@@ -175,11 +179,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 }
             }
         }
-
-        // If the line doesn't exist, we will return back the key which was requested as
-        // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -129,10 +129,19 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
-        return $this->translate($key, $replace, $locale, $fallback) ??
-            $this->handleMissingTranslationKey(
-                $key, $replace, $locale, $fallback
-            );
+        $result = $this->translate($key, $replace, $locale, $fallback);
+        if (!is_null($result)) {
+            return $result;
+        }
+
+        $line = $this->handleMissingTranslationKey(
+            $key, $replace, $locale, $fallback
+        );
+
+        // If the line doesn't exist, we will return back the key which was requested as
+        // that will be quick to spot in the UI if language keys are wrong or missing
+        // from the application's language files. Otherwise we can return the line.
+        return $this->makeReplacements($line, $replace);
     }
 
     /**
@@ -173,14 +182,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                     return $line;
                 }
             }
-
-            return null;
         }
-
-        // If the line doesn't exist, we will return back the key which was requested as
-        // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
+        return $line;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -62,8 +62,8 @@ trait FormatsMessages
         // messages out of the translator service for this validation rule.
         $key = "validation.{$lowerRule}";
 
-        if ($key !== ($value = $this->translator->get($key))) {
-            return $value;
+        if ($this->translator->has($key)) {
+            return $this->translator->get($key);
         }
 
         return $this->getFromLocalArray(
@@ -144,8 +144,8 @@ trait FormatsMessages
     protected function getCustomMessageFromTranslator($keys)
     {
         foreach (Arr::wrap($keys) as $key) {
-            if (($message = $this->translator->get($key)) !== $key) {
-                return $message;
+            if ($this->translator->has($key)) {
+                return $this->traslator->get($key);
             }
 
             // If an exact match was not found for the key, we will collapse all of these
@@ -448,8 +448,8 @@ trait FormatsMessages
 
         $key = "validation.values.{$attribute}.{$value}";
 
-        if (($line = $this->translator->get($key)) !== $key) {
-            return $line;
+        if ($this->translator->has($key)) {
+            return $this->translator->get($key);
         }
 
         if (is_bool($value)) {

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -145,7 +145,7 @@ trait FormatsMessages
     {
         foreach (Arr::wrap($keys) as $key) {
             if ($this->translator->has($key)) {
-                return $this->traslator->get($key);
+                return $this->translator->get($key);
             }
 
             // If an exact match was not found for the key, we will collapse all of these

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -267,8 +267,8 @@ class FoundationFormRequestTest extends TestCase
      */
     protected function createValidationFactory($container)
     {
-        $translator = m::mock(Translator::class)->shouldReceive('get')
-                       ->zeroOrMoreTimes()->andReturn('error')->getMock();
+        $translator = m::mock(Translator::class)->shouldReceive('has')
+                       ->zeroOrMoreTimes()->andReturn(false)->getMock();
 
         return new ValidationFactory($translator, $container);
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -267,8 +267,10 @@ class FoundationFormRequestTest extends TestCase
      */
     protected function createValidationFactory($container)
     {
-        $translator = m::mock(Translator::class)->shouldReceive('has')
-                       ->zeroOrMoreTimes()->andReturn(false)->getMock();
+        $translator = m::mock(Translator::class)
+            ->shouldReceive('has')->zeroOrMoreTimes()->andReturn(false)
+            ->shouldReceive('get')->zeroOrMoreTimes()->andReturn('error')
+            ->getMock();
 
         return new ValidationFactory($translator, $container);
     }

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -56,4 +56,18 @@ class TranslatorTest extends TestCase
 
         $this->app['translator']->handleMissingKeysUsing(null);
     }
+
+    public function testItCanHandleMissingKeysUsingCallbackWithoutReturn()
+    {
+        $this->app['translator']->handleMissingKeysUsing(function ($key) {
+            $_SERVER['__missing_translation_key'] = $key;
+        });
+
+        $key = $this->app['translator']->get('some missing key');
+
+        $this->assertSame('some missing key', $key);
+        $this->assertSame('some missing key', $_SERVER['__missing_translation_key']);
+
+        $this->app['translator']->handleMissingKeysUsing(null);
+    }
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -157,7 +157,7 @@ class TranslationTranslatorTest extends TestCase
     public function testGetJsonReplaces()
     {
         $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('translate')->once()->with('foo :i:c :u', 'en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+        $t->getLoader()->shouldReceive('load')->once()->with('foo :i:c :u', 'en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
         $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -19,19 +19,19 @@ class TranslationTranslatorTest extends TestCase
 
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
         $this->assertFalse($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
         $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
         $this->assertTrue($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
-        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -20,7 +20,7 @@ class TranslationTranslatorTest extends TestCase
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
+        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn(null);
         $this->assertFalse($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
@@ -32,7 +32,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['translate'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
+        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn(null);
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
         $t = new Translator($this->getLoader(), 'en');
@@ -157,7 +157,7 @@ class TranslationTranslatorTest extends TestCase
     public function testGetJsonReplaces()
     {
         $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+        $t->getLoader()->shouldReceive('translate')->once()->with('foo :i:c :u', 'en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
         $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -20,19 +20,19 @@ class TranslationTranslatorTest extends TestCase
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
+        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
         $this->assertFalse($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
+        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
         $this->assertTrue($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
+        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
+        $t->expects($this->once())->method('translate')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
         $t = new Translator($this->getLoader(), 'en');

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -157,7 +157,7 @@ class TranslationTranslatorTest extends TestCase
     public function testGetJsonReplaces()
     {
         $t = new Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('foo :i:c :u', 'en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
         $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -974,7 +974,7 @@ class ValidationValidatorTest extends TestCase
         $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
-        $trans->shouldReceive('get')->andReturnArg(0);
+        $trans->shouldReceive('has')->andReturn(false);
 
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'current_password']);
         $v->setContainer($container);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -975,6 +975,7 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getTranslator();
         $trans->shouldReceive('has')->andReturn(false);
+        $trans->shouldReceive('get')->andReturnArg(0);
 
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'current_password']);
         $v->setContainer($container);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -999,6 +999,7 @@ class ValidationValidatorTest extends TestCase
         $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
+        $trans->shouldReceive('has')->andReturn(false);
         $trans->shouldReceive('get')->andReturnArg(0);
 
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'current_password']);
@@ -1023,6 +1024,7 @@ class ValidationValidatorTest extends TestCase
         $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
+        $trans->shouldReceive('has')->andReturn(false);
         $trans->shouldReceive('get')->andReturnArg(0);
 
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'current_password']);
@@ -1047,6 +1049,7 @@ class ValidationValidatorTest extends TestCase
         $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
+        $trans->shouldReceive('has')->andReturn(false);
         $trans->shouldReceive('get')->andReturnArg(0);
 
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'current_password:custom']);


### PR DESCRIPTION
Following on from https://github.com/laravel/framework/pull/49040

This PR aims to:
1. Fix false positives occurring in handle missing translation functionality.
2. Gracefully handle erroneous user-defined handlers.

After our first usage of the above PR, we have noticed false positives being detected as missing translations. As a result, we have decided to submit a PR with the following suggested improvements:

1. Ensures that if users forget to include a `return` statement in their missing translation handler callback, the default behaviour of `__()` returning the translation key occurs.
3. Ensures that calling the `has()` method of the `Translator` class does not result in the missing translation string handler being called. Previously the `has()` method called the `get()` method directly, which included the handle missing translation keys functionality. Since `has()` is expected to receive missing translation keys under normal operation, this is not ideal.
4. Ensures that in other places in the framework, translation strings are checked properly for their existence using `has()` before retrieval. Previously the code relied on the returned value of the `get()` method being equal to the `$key` parameter indicating that a translation key is missing, however this is now not always the case following the above PR.