### PR TITLE
[10.x] Add permutations method to arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -901,13 +901,14 @@ class Arr
 	 * Generate all possible combinations from an array (permutations) array elements included.
 	 *
 	 * @param array $array
+	 * @param bool  $includeOriginalArray
 	 *
 	 * @return array
 	 */
-	public static function permutations(array $array = [])
+	public static function permutations(array $array = [], bool $includeOriginalArray = false)
 	{
 
-		$permutations = $array;
+		$permutations = $includeOriginalArray ? $array : [];
 		$size = count($array);
 
 		$indices = [];
@@ -921,6 +922,7 @@ class Arr
 			for ($index = 0; $index < $size; $index++) {
 				$res[] = $array[$index][$indices[$index]];
 			}
+
 			$permutations[] = $res;
 			$next = $size - 1;
 			while ($next >= 0 &&

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -911,10 +911,7 @@ class Arr
 		$permutations = $includeOriginalArray ? $array : [];
 		$size = count($array);
 
-		$indices = [];
-		for ($index = 0; $index < $size; $index++) {
-			$indices[$index] = 0;
-		}
+		$indices = array_fill(0, $size, 0);
 
 		while (1) {
 
@@ -926,13 +923,16 @@ class Arr
 			$permutations[] = $res;
 			$next = $size - 1;
 			while ($next >= 0 &&
-				   ($indices[$next] + 1 >= count($array[$next]))) {
+				   (($indices[$next] + 1) >= count($array[$next]))) {
 				$next--;
 			}
+
 			if ($next < 0) {
 				return $permutations;
 			}
+
 			$indices[$next]++;
+
 			for ($index = $next + 1; $index < $size; $index++) {
 				$indices[$index] = 0;
 			}

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -896,4 +896,47 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+	/**
+	 * Generate all possible combinations from an array (permutations) array elements included.
+	 *
+	 * @param array $array
+	 *
+	 * @return array
+	 */
+	public static function permutations(array $array = [])
+	{
+
+		$permutations = $array;
+		$size = count($array);
+
+		$indices = [];
+		for ($index = 0; $index < $size; $index++) {
+			$indices[$index] = 0;
+		}
+
+		while (1) {
+
+			$res = [];
+			for ($index = 0; $index < $size; $index++) {
+				$res[] = $array[$index][$indices[$index]];
+			}
+			$permutations[] = $res;
+			$next = $size - 1;
+			while ($next >= 0 &&
+				   ($indices[$next] + 1 >= count($array[$next]))) {
+				$next--;
+			}
+			if ($next < 0) {
+				return $permutations;
+			}
+			$indices[$next]++;
+			for ($index = $next + 1; $index < $size; $index++) {
+				$indices[$index] = 0;
+			}
+
+		}
+
+	}
+
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1263,11 +1263,5 @@ class SupportArrTest extends TestCase
 		$permutationsElements = Arr::permutations([$array7, $array8]);
 		$this->assertEquals($permutationsExpected, $permutationsElements);
 
-		$colors = ['Black', 'White'];
-		$storageCapacities = ['64GB', '128GB'];
-
-		// Generating variations using Arr::permutations
-		$actualVariations = Arr::permutations([$colors, $storageCapacities], false);
-		print_r($actualVariations);
 	}
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1231,4 +1231,21 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+	public function testPermutations()
+	{
+
+		$array = [1, 2];
+		$array2 = [3, 4];
+		$permutations = [ [1, 2], [3, 4], [1, 3], [1, 4], [2, 3], [2, 4]];
+		$permutationsResult = Arr::permutations([$array, $array2]);
+		$this->assertEquals($permutations, $permutationsResult);
+
+		$array3 = ['AB', 'CD'];
+		$array4 = ['EF', 'GH'];
+		$permutationsExpected = [ ['AB', 'CD'], ['EF', 'GH'], ['AB', 'EF'], ['AB', 'GH'], ['CD', 'EF'], ['CD', 'GH']];
+		$permutationsElements = Arr::permutations([$array3, $array4]);
+		$this->assertEquals($permutationsExpected, $permutationsElements);
+
+	}
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1235,17 +1235,39 @@ class SupportArrTest extends TestCase
 	public function testPermutations()
 	{
 
+		$includeOriginalArray = true;
 		$array = [1, 2];
 		$array2 = [3, 4];
 		$permutations = [ [1, 2], [3, 4], [1, 3], [1, 4], [2, 3], [2, 4]];
-		$permutationsResult = Arr::permutations([$array, $array2]);
+		$permutationsResult = Arr::permutations([$array, $array2], $includeOriginalArray);
 		$this->assertEquals($permutations, $permutationsResult);
 
-		$array3 = ['AB', 'CD'];
-		$array4 = ['EF', 'GH'];
+		// print_r($permutations);
+		// print_r($permutationsResult);
+		// exit();
+		$array3 = [1, 2];
+		$array4 = [3, 4];
+		$permutations = [ [1, 3], [1, 4], [2, 3], [2, 4]];
+		$permutationsResult = Arr::permutations([$array3, $array4]);
+		$this->assertEquals($permutations, $permutationsResult);
+
+		$array5 = ['AB', 'CD'];
+		$array6 = ['EF', 'GH'];
 		$permutationsExpected = [ ['AB', 'CD'], ['EF', 'GH'], ['AB', 'EF'], ['AB', 'GH'], ['CD', 'EF'], ['CD', 'GH']];
-		$permutationsElements = Arr::permutations([$array3, $array4]);
+		$permutationsElements = Arr::permutations([$array5, $array6], $includeOriginalArray);
 		$this->assertEquals($permutationsExpected, $permutationsElements);
 
+		$array7 = ['AB', 'CD'];
+		$array8 = ['EF', 'GH', 'IJ'];
+		$permutationsExpected = [ ['AB', 'EF'], ['AB', 'GH'], ['AB', 'IJ'], ['CD', 'EF'], ['CD', 'GH'], ['CD', 'IJ']];
+		$permutationsElements = Arr::permutations([$array7, $array8]);
+		$this->assertEquals($permutationsExpected, $permutationsElements);
+
+		$colors = ['Black', 'White'];
+		$storageCapacities = ['64GB', '128GB'];
+
+		// Generating variations using Arr::permutations
+		$actualVariations = Arr::permutations([$colors, $storageCapacities], false);
+		print_r($actualVariations);
 	}
 }


### PR DESCRIPTION

This pull request introduces a new permutations method to the Arr class, along with comprehensive tests to ensure its functionality. The purpose of this enhancement is to provide Laravel developers with a convenient way to generate permutations of arrays, enhancing the versatility of the Arr class.

Ex. 
```php
    // Customizable features for a smartphone
    $colors = ['Black', 'White'];
    $storageCapacities = ['64GB', '128GB'];

    // Generating variations using Arr::permutations
    $actualVariations = Arr::permutations([$colors, $storageCapacities]);
```
Result
```php
Array
(
    [0] => Array
        (
            [0] => Black
            [1] => 64GB
        )

    [1] => Array
        (
            [0] => Black
            [1] => 128GB
        )

    [2] => Array
        (
            [0] => White
            [1] => 64GB
        )

    [3] => Array
        (
            [0] => White
            [1] => 128GB
        )

)
```


Your feedback is greatly appreciated, and I am open to any suggestions for improvement. Thank you for considering this enhancement to the Laravel framework.