### PR TITLE
[10.x] `league/flysystem` 3.22.0 now prefer inclusive mime-type instead of `null`.

### DIFF
--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -198,9 +198,15 @@ class FilesystemAdapterTest extends TestCase
         $this->assertNull($filesystemAdapter->json('file.json'));
     }
 
-    public function testMimeTypeNotDetected()
+    public function testMimeTypeDetectedAsEmpty()
     {
         $this->filesystem->write('unknown.mime-type', '');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $this->assertSame('application/x-empty', $filesystemAdapter->mimeType('unknown.mime-type'));
+    }
+
+    public function testMimeTypeNotDetected()
+    {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertFalse($filesystemAdapter->mimeType('unknown.mime-type'));
     }
@@ -531,8 +537,6 @@ class FilesystemAdapterTest extends TestCase
 
     public function testThrowExceptionsForMimeType()
     {
-        $this->filesystem->write('unknown.mime-type', '');
-
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Filesystem;
 
 use Carbon\Carbon;
 use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\FilesystemManager;

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -202,7 +202,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testMimeTypeDetectedPreferInclusiveMimeTypeOverNullAsEmpty()
     {
-        if (version_compare(InstalledVersions::getPrettyVersion('league/flysystem'), '<', '3.22.0')) {
+        if (version_compare(InstalledVersions::getPrettyVersion('league/flysystem'), '3.22.0', '<')) {
             $this->markTestSkipped('Require league/flysystem 3.22.0');
         }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Filesystem;
 
 use Carbon\Carbon;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\FilesystemManager;
@@ -198,8 +200,12 @@ class FilesystemAdapterTest extends TestCase
         $this->assertNull($filesystemAdapter->json('file.json'));
     }
 
-    public function testMimeTypeDetectedAsEmpty()
+    public function testMimeTypeDetectedPreferInclusiveMimeTypeOverNullAsEmpty()
     {
+        if (version_compare(InstalledVersions::getPrettyVersion('league/flysystem'), '<', '3.22.0')) {
+            $this->markTestSkipped('Require league/flysystem 3.22.0');
+        }
+
         $this->filesystem->write('unknown.mime-type', '');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertSame('application/x-empty', $filesystemAdapter->mimeType('unknown.mime-type'));


### PR DESCRIPTION
See https://github.com/thephpleague/flysystem/pull/1710