### PR TITLE
[10.x] Determine if the given view exists.

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -169,6 +169,25 @@ class Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        $view = $this->connection->getTablePrefix().$view;
+
+        foreach ($this->getViews() as $value) {
+            if (strtolower($view) === strtolower($value['name'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get the tables that belong to the database.
      *
      * @return array

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -31,6 +31,19 @@ class SqlServerBuilder extends Builder
     }
 
     /**
+     * Determine if the given table exists.
+     *
+     * @deprecated Will be removed in a future Laravel version.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function hasTable($table)
+    {
+        return parent::hasTable($table) || $this->hasView($table);
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -31,19 +31,6 @@ class SqlServerBuilder extends Builder
     }
 
     /**
-     * Determine if the given table exists.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  string  $table
-     * @return bool
-     */
-    public function hasTable($table)
-    {
-        return parent::hasTable($table) || $this->hasView($table);
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool createDatabase(string $name)
  * @method static bool dropDatabaseIfExists(string $name)
  * @method static bool hasTable(string $table)
+ * @method static bool hasView(string $view)
  * @method static array getTables()
  * @method static array getViews()
  * @method static bool hasColumn(string $table, string $column)

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -164,6 +164,13 @@ class SchemaBuilderTest extends DatabaseTestCase
         }
     }
 
+    public function testHasView()
+    {
+        DB::statement('create view foo (id) as select 1');
+
+        $this->assertTrue(Schema::hasView('foo'));
+    }
+
     public function testGetViews()
     {
         DB::statement('create view foo (id) as select 1');


### PR DESCRIPTION
Fixes #49227. The `Schema::hasTable()` on SQL Server, was using a wrong query before 10.34 that was causing this function to also return `true` for views, but this is not the case on the other database drivers.

This PR does:
* Add `Schema::hasView()` to check for existence of a view
* ~~Override `SqlServerBuilder::hasTable()` on SQL Server to also check for views, however, as this is not the intend of this function, I marked this overridden function as `deprecated` to be removed on 11.x that makes `Schema::hasTable()` to work as expected (not checking views on SQL Server) on all databases.~~