### PR TITLE
[10.x] Fallback to default values instead of null

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -202,19 +202,19 @@ class NotificationSender
                 $connection = $notification->connection;
 
                 if (method_exists($notification, 'viaConnections')) {
-                    $connection = $notification->viaConnections()[$channel] ?? null;
+                    $connection = $notification->viaConnections()[$channel] ?? $connection;
                 }
 
                 $queue = $notification->queue;
 
                 if (method_exists($notification, 'viaQueues')) {
-                    $queue = $notification->viaQueues()[$channel] ?? null;
+                    $queue = $notification->viaQueues()[$channel] ?? $queue;
                 }
 
                 $delay = $notification->delay;
 
                 if (method_exists($notification, 'withDelay')) {
-                    $delay = $notification->withDelay($notifiable, $channel) ?? null;
+                    $delay = $notification->withDelay($notifiable, $channel) ?? $delay;
                 }
 
                 $middleware = $notification->middleware ?? [];


### PR DESCRIPTION
If you want to set up a custom queue for a channel, you are forced to use the default value for all other channels. The same applies to the `viaConnections` and `withDelay` methods. Here it would be easier to fallback to the respective default values instead of `null`. Then you could only change the values for the channels you want to adjust:

Before:

<img width="518" alt="Bildschirmfoto 2023-12-04 um 10 27 52" src="https://github.com/laravel/framework/assets/5833477/efb1e6b1-1558-46ee-aba3-e7d0b7302ecd">

After:

<img width="515" alt="Bildschirmfoto 2023-12-04 um 10 35 07" src="https://github.com/laravel/framework/assets/5833477/aa834582-7da9-4e5e-b7fc-cb7f6f00be2e">

