### PR TITLE
Revert "[10.x] `league/flysystem` 3.22.0 now prefer inclusive mime-type instead of `null`."

### DIFF
--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Filesystem;
 
 use Carbon\Carbon;
-use Composer\InstalledVersions;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\FilesystemManager;
@@ -199,19 +198,9 @@ class FilesystemAdapterTest extends TestCase
         $this->assertNull($filesystemAdapter->json('file.json'));
     }
 
-    public function testMimeTypeDetectedPreferInclusiveMimeTypeOverNullAsEmpty()
-    {
-        if (version_compare(InstalledVersions::getPrettyVersion('league/flysystem'), '3.22.0', '<')) {
-            $this->markTestSkipped('Require league/flysystem 3.22.0');
-        }
-
-        $this->filesystem->write('unknown.mime-type', '');
-        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
-        $this->assertSame('application/x-empty', $filesystemAdapter->mimeType('unknown.mime-type'));
-    }
-
     public function testMimeTypeNotDetected()
     {
+        $this->filesystem->write('unknown.mime-type', '');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertFalse($filesystemAdapter->mimeType('unknown.mime-type'));
     }
@@ -542,6 +531,8 @@ class FilesystemAdapterTest extends TestCase
 
     public function testThrowExceptionsForMimeType()
     {
+        $this->filesystem->write('unknown.mime-type', '');
+
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {


### PR DESCRIPTION
Reverts laravel/framework#49229