### PR TITLE
[10.x] Handling NULL and NOT_NULL in DB validation rules

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -235,7 +235,13 @@ trait DatabaseRule
     protected function formatWheres()
     {
         return collect($this->wheres)->map(function ($where) {
-            return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
+            if ($where['value'] === 'NULL') {
+                return $where['column'].',NULL';
+            } elseif ($where['value'] === 'NOT_NULL') {
+                return $where['column'].',NOT_NULL';
+            } else {
+                return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
+            }
         })->implode(',');
     }
 }


### PR DESCRIPTION
When creating database validation rules (e.g., unique) NULL and NOT_NULL values are incorrectly wrapped in quotes as "NULL" and "NOT_NULL" respectively which fails to match NULL database values.

Example:

```php
use Illuminate/Validation/Rules;

$unique = Rule::unique('users', 'email')->withoutTrashed();

echo (string) $unique; // unique:users,email,NULL,id,deleted_at,"NULL"
```

This incorrectly wraps NULL in quotes to "NULL", it should be:

```php
echo (string) $unique; // unique:users,email,NULL,id,deleted_at,NULL
```

Here's another example using the "whereNull" and "whereNotNull" methods:

```php
use Illuminate/Validation/Rules;

$unique = Rule::unique('users', 'email')->whereNull('column1')->whereNotNull('column2');

echo (string) $unique; // unique:users,email,NULL,id,column1,"NULL",column2,"NOT_NULL"
```

This should be:

```php
echo (string) $unique; // unique:users,email,NULL,id,column1,NULL,column2,NOT_NULL
```

The fix is to check for NULL and NOT_NULL values in "formatWheres" method before handling everything else in the `Illuminate\Rules\DatabaseRule` file.

```php
/**
 * Format the where clauses.
 *
 * @return string
 */
protected function formatWheres()
{
    return collect($this->wheres)->map(function ($where) {
        if ($where['value'] === 'NULL') {
            return $where['column'].',NULL';
        } elseif ($where['value'] === 'NOT_NULL') {
            return $where['column'].',NOT_NULL';
        } else {
            return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
        }
    })->implode(',');
}
```

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Validation/Rules/DatabaseRule.php#L235