### PR TITLE
[11.x] Makes `name` argument required on `config:publish`

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Finder\Finder;
-use Illuminate\Contracts\Console\PromptsForMissingInput;
 
 use function Laravel\Prompts\select;
 

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -5,9 +5,12 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+
+use function Laravel\Prompts\select;
 
 #[AsCommand(name: 'config:publish')]
-class ConfigPublishCommand extends Command
+class ConfigPublishCommand extends Command implements PromptsForMissingInput
 {
     /**
      * The name and signature of the console command.
@@ -80,5 +83,22 @@ class ConfigPublishCommand extends Command
         }
 
         return collect($config)->sortKeys()->all();
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingArgumentsUsing()
+    {
+        return [
+            'name' => fn () => select(
+                label: 'Which configuration file would you like to publish?',
+                options: collect($this->getBaseConfigurationFiles())->map(function (string $path) {
+                    return basename($path, '.php');
+                }),
+            ),
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -15,7 +15,7 @@ class ConfigPublishCommand extends Command
      * @var string
      */
     protected $signature = 'config:publish
-                    {name? : The name of the configuration file to publish}
+                    {name : The name of the configuration file to publish}
                     {--force : Overwrite any existing configuration files}';
 
     /**
@@ -34,19 +34,15 @@ class ConfigPublishCommand extends Command
     {
         $config = $this->getBaseConfigurationFiles();
 
-        $name = $this->argument('name');
+        $name = (string) $this->argument('name');
 
-        if (! is_null($name) && ! isset($config[$name])) {
+        if (! isset($config[$name])) {
             $this->components->error('Unrecognized configuration file.');
 
             return 1;
         }
 
-        foreach ($config as $key => $file) {
-            if ($key === $name || is_null($name)) {
-                $this->publish($key, $file, $this->laravel->configPath().'/'.$key.'.php');
-            }
-        }
+        $this->publish($name, $config[$name], $this->laravel->configPath().'/'.$name.'.php');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use function Laravel\Prompts\select;
 use Symfony\Component\Console\Attribute\AsCommand;
-
 use Symfony\Component\Finder\Finder;
+
+use function Laravel\Prompts\select;
 
 #[AsCommand(name: 'config:publish')]
 class ConfigPublishCommand extends Command


### PR DESCRIPTION
This pull request makes the  `name` argument required on the new `config:publish` command, so we don't end up with all configurations published when no arguments provided.