### PR TITLE
Add `--only-values` to env encrypt and decrypt commands

### DIFF
--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -284,4 +284,41 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->expectsOutputToContain('Invalid filename.')
             ->assertExitCode(1);
     }
+
+    public function testItDecryptsAnEncryptedEnvironmentWhereOnlyValuesAreEncrypted()
+    {
+        $contents = <<<'Text'
+        APP_NAME=Laravel
+        APP_ENV=local
+        APP_DEBUG=true
+        APP_URL=http://localhost
+        Text;
+
+        $encrypter = new Encrypter('abcdefghijklmnopabcdefghijklmnop', 'AES-256-CBC');
+
+        $encryptedContents = <<<TEXT
+        APP_NAME={$encrypter->encrypt('Laravel')}
+        APP_ENV={$encrypter->encrypt('local')}
+        APP_DEBUG={$encrypter->encrypt('true')}
+        APP_URL={$encrypter->encrypt('http://localhost')}
+        TEXT;
+
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn($encryptedContents);
+
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnopabcdefghijklmnop', '--filename' => '.env', '--path' => '/tmp', '--only-values' => true])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with('/tmp'.DIRECTORY_SEPARATOR.'.env', $contents);
+    }
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -4,7 +4,9 @@ namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
@@ -18,9 +20,9 @@ class EnvironmentEncryptCommandTest extends TestCase
 
         $this->filesystem = m::spy(Filesystem::class);
         $this->filesystem->shouldReceive('get')
-            ->andReturn(true)
+            ->andReturn(true)->byDefault()
             ->shouldReceive('put')
-            ->andReturn('APP_NAME=Laravel');
+            ->andReturn('APP_NAME=Laravel')->byDefault();
         File::swap($this->filesystem);
     }
 
@@ -153,6 +155,43 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->expectsOutputToContain('Environment successfully encrypted')
             ->expectsOutputToContain('base64:'.base64_encode($key))
             ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+    }
+
+    public function testItEncryptsTheValuesOfAnEnvironment()
+    {
+        $contents = <<<'Text'
+        APP_NAME=Laravel
+        APP_ENV=local
+        APP_DEBUG=true
+        APP_URL=http://localhost
+        Text;
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->andReturn($contents)
+            ->shouldReceive('put')
+            ->withArgs(function ($file, $contents) {
+                $encrypter = new Encrypter('abcdefghijklmnopabcdefghijklmnop', 'AES-256-CBC');
+
+                $this->assertStringContainsString('APP_NAME', $contents);
+                $this->assertStringContainsString('APP_ENV', $contents);
+                $this->assertStringContainsString('APP_DEBUG', $contents);
+                $this->assertStringContainsString('APP_URL', $contents);
+
+                $this->assertEquals('Laravel', $encrypter->decrypt(Str::betweenFirst($contents, '=', "\n")));
+
+                return true;
+            })
+            ->andReturn(true);
+
+        $this->artisan('env:encrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnopabcdefghijklmnop', '--only-values' => true])
+            ->expectsOutputToContain('Environment successfully encrypted.')
             ->assertExitCode(0);
     }
 }


### PR DESCRIPTION
### What
This PR adds a `--only-values` option to the `env:encrypt` and `env:decrypt` commands. If enabled while encrypting the command will generate this:

```text
APP_NAME=eyJpdiI6ImplT2xTaGRzV...
APP_ENV=eyJpdiI6ImplT2xTaGRzV...
APP_KEY=eyJpdiI6ImplT2xTaGRzV...
...
```

Instead of this:
```text
eyJpdiI6ImplT2xTaGRzV...
```

### Why
I wanted to add a full development environment (including secrets for development purposes) to our repositories and it would be nice to see the variables in there. For us this would mean we could drop the `.env.example` and the discipline that is necessary to maintain it.

### Non-breaking
I used the `--only-values` flag to make this feature completely optional.

### Future ideas
Merging both to (only re-encrypt values when they were changed) and from (instead of `--force` provide a dialog for each value that differs from the encrypted file) the encrypted environment file.

### Thoughts?
I am happy to hear anyone's thoughts and to make changes if necessary.