### PR TITLE
[10.x] Add function to validate if a lock is owned by the current owner.

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -153,6 +153,17 @@ abstract class Lock implements LockContract
         return $this->getCurrentOwner() === $this->owner;
     }
 
+
+    /**
+     * Determine if this lock is owned  by the current owner.
+     * 
+     * @return bool
+     */
+    public function isOwner()
+    {
+        return $this->isOwnedByCurrentProcess();
+    }
+
     /**
      * Specify the number of milliseconds to sleep in between blocked lock acquisition attempts.
      *

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -36,6 +36,13 @@ interface Lock
     public function owner();
 
     /**
+     * Determine if this lock is owned  by the current owner.
+     *
+     * @return bool
+     */
+    public function isOwner();
+
+    /**
      * Releases this lock in disregard of ownership.
      *
      * @return void


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pr adds a public function `isOwner` to the Cache/Lock.php class. This can be used to determine if a restored lock is owned by the current owner. Currently it is not possible to determine if a restoredLock is owned by the given owner, except when releasing it.

We ran into a problem when we wanted to validate on the queue if we still had the lock on a specific key. We pass the `$owner` to the job, and can currently release the lock using `restoreLock($key, $owner)->release()`, but we have no way of validating whether the lock is still viable (without releasing it).

This is backwards-compatible because it only adds a function to the api, not changing any existing functions.
