### PR TITLE
[11.x] Adds `ServiceProvider::publishesMigrations()` method

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -360,7 +360,7 @@ class VendorPublishCommand extends Command
             $path = realpath($path);
 
             if ($from === $path && preg_match('/\d{4}_(\d{2})_(\d{2})_(\d{6})_/', $to)) {
-                $to = preg_replace('/\d{4}_(\d{2})_(\d{2})_(\d{6})_/', date('Y_m_d_His_'), $to);
+                return preg_replace('/\d{4}_(\d{2})_(\d{2})_(\d{6})_/', date('Y_m_d_His_'), $to);
             }
         }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -347,7 +347,7 @@ class VendorPublishCommand extends Command
     }
 
     /**
-     * Ensure the migrations have current dates on their names.
+     * Ensure the given migration name is up-to-date.
      *
      * @param  string  $from
      * @param  string  $to

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -43,6 +43,13 @@ class VendorPublishCommand extends Command
     protected $tags = [];
 
     /**
+     * The time the command started.
+     *
+     * @var \Illuminate\Support\Carbon|null
+     */
+    protected $publishedAt;
+
+    /**
      * The console command signature.
      *
      * @var string
@@ -81,6 +88,8 @@ class VendorPublishCommand extends Command
      */
     public function handle()
     {
+        $this->publishedAt = now();
+
         $this->determineWhatShouldBePublished();
 
         foreach ($this->tags ?: [null] as $tag) {
@@ -360,7 +369,13 @@ class VendorPublishCommand extends Command
             $path = realpath($path);
 
             if ($from === $path && preg_match('/\d{4}_(\d{2})_(\d{2})_(\d{6})_/', $to)) {
-                return preg_replace('/\d{4}_(\d{2})_(\d{2})_(\d{6})_/', date('Y_m_d_His_'), $to);
+                $this->publishedAt->addSecond();
+
+                return preg_replace(
+                    '/\d{4}_(\d{2})_(\d{2})_(\d{6})_/',
+                    $this->publishedAt->format('Y_m_d_His').'_',
+                    $to,
+                );
             }
         }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -243,7 +243,6 @@ class VendorPublishCommand extends Command
     {
         if ((! $this->option('existing') && (! $this->files->exists($to) || $this->option('force')))
             || ($this->option('existing') && $this->files->exists($to))) {
-
             $to = $this->ensureUpToDateMigrationNames($from, $to);
 
             $this->createParentDirectory(dirname($to));

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -41,6 +41,13 @@ abstract class ServiceProvider
     public static $publishes = [];
 
     /**
+     * The migration paths that should be published.
+     *
+     * @var array
+     */
+    public static $migrationPublishes = [];
+
+    /**
      * The paths that should be published by group.
      *
      * @var array
@@ -286,6 +293,22 @@ abstract class ServiceProvider
     }
 
     /**
+     * Register migration paths to be published by the publish command.
+     *
+     * @param  array  $paths
+     * @param  mixed  $groups
+     * @return void
+     */
+    protected function migrationPublishes(array $paths, $groups = null)
+    {
+        $this->publishes($paths, $groups);
+
+        $this->ensureMigrationPublishArrayInitialized($class = static::class);
+
+        static::$migrationPublishes[$class] = array_merge(static::$migrationPublishes[$class], $paths);
+    }
+
+    /**
      * Ensure the publish array for the service provider is initialized.
      *
      * @param  string  $class
@@ -295,6 +318,19 @@ abstract class ServiceProvider
     {
         if (! array_key_exists($class, static::$publishes)) {
             static::$publishes[$class] = [];
+        }
+    }
+
+    /**
+     * Ensure the migration publish array for the service provider is initialized.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    protected function ensureMigrationPublishArrayInitialized($class)
+    {
+        if (! array_key_exists($class, static::$migrationPublishes)) {
+            static::$migrationPublishes[$class] = [];
         }
     }
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -34,18 +34,18 @@ abstract class ServiceProvider
     protected $bootedCallbacks = [];
 
     /**
+     * The migration paths available for publishing.
+     *
+     * @var array
+     */
+    protected static $publishableMigrationPaths = [];
+
+    /**
      * The paths that should be published.
      *
      * @var array
      */
     public static $publishes = [];
-
-    /**
-     * The migration paths that should be published.
-     *
-     * @var array
-     */
-    public static $migrationPublishes = [];
 
     /**
      * The paths that should be published by group.
@@ -299,13 +299,11 @@ abstract class ServiceProvider
      * @param  mixed  $groups
      * @return void
      */
-    protected function migrationPublishes(array $paths, $groups = null)
+    protected function publishesMigrations(array $paths, $groups = null)
     {
         $this->publishes($paths, $groups);
 
-        $this->ensureMigrationPublishArrayInitialized($class = static::class);
-
-        static::$migrationPublishes[$class] = array_merge(static::$migrationPublishes[$class], $paths);
+        static::$publishableMigrationPaths = array_merge(static::$publishableMigrationPaths, array_keys($paths));
     }
 
     /**
@@ -318,19 +316,6 @@ abstract class ServiceProvider
     {
         if (! array_key_exists($class, static::$publishes)) {
             static::$publishes[$class] = [];
-        }
-    }
-
-    /**
-     * Ensure the migration publish array for the service provider is initialized.
-     *
-     * @param  string  $class
-     * @return void
-     */
-    protected function ensureMigrationPublishArrayInitialized($class)
-    {
-        if (! array_key_exists($class, static::$migrationPublishes)) {
-            static::$migrationPublishes[$class] = [];
         }
     }
 
@@ -414,6 +399,16 @@ abstract class ServiceProvider
     public static function publishableProviders()
     {
         return array_keys(static::$publishes);
+    }
+
+    /**
+     * Get the migration paths available for publishing.
+     *
+     * @return array
+     */
+    public static function publishableMigrationPaths()
+    {
+        return static::$publishableMigrationPaths;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -303,7 +303,7 @@ abstract class ServiceProvider
     {
         $this->publishes($paths, $groups);
 
-        static::$publishableMigrationPaths = array_merge(static::$publishableMigrationPaths, array_keys($paths));
+        static::$publishableMigrationPaths = array_unique(array_merge(static::$publishableMigrationPaths, array_keys($paths)));
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -34,13 +34,6 @@ abstract class ServiceProvider
     protected $bootedCallbacks = [];
 
     /**
-     * The migration paths available for publishing.
-     *
-     * @var array
-     */
-    protected static $publishableMigrationPaths = [];
-
-    /**
      * The paths that should be published.
      *
      * @var array
@@ -53,6 +46,13 @@ abstract class ServiceProvider
      * @var array
      */
     public static $publishGroups = [];
+
+    /**
+     * The migration paths available for publishing.
+     *
+     * @var array
+     */
+    protected static $publishableMigrationPaths = [];
 
     /**
      * Create a new service provider instance.
@@ -275,6 +275,20 @@ abstract class ServiceProvider
     }
 
     /**
+     * Register migration paths to be published by the publish command.
+     *
+     * @param  array  $paths
+     * @param  mixed  $groups
+     * @return void
+     */
+    protected function publishesMigrations(array $paths, $groups = null)
+    {
+        $this->publishes($paths, $groups);
+
+        static::$publishableMigrationPaths = array_unique(array_merge(static::$publishableMigrationPaths, array_keys($paths)));
+    }
+
+    /**
      * Register paths to be published by the publish command.
      *
      * @param  array  $paths
@@ -290,20 +304,6 @@ abstract class ServiceProvider
         foreach ((array) $groups as $group) {
             $this->addPublishGroup($group, $paths);
         }
-    }
-
-    /**
-     * Register migration paths to be published by the publish command.
-     *
-     * @param  array  $paths
-     * @param  mixed  $groups
-     * @return void
-     */
-    protected function publishesMigrations(array $paths, $groups = null)
-    {
-        $this->publishes($paths, $groups);
-
-        static::$publishableMigrationPaths = array_unique(array_merge(static::$publishableMigrationPaths, array_keys($paths)));
     }
 
     /**

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -134,9 +134,9 @@ class ServiceProviderForTestingOne extends ServiceProvider
         $this->publishes(['source/tagged/one' => 'destination/tagged/one'], 'some_tag');
         $this->publishes(['source/tagged/multiple' => 'destination/tagged/multiple'], ['tag_one', 'tag_two']);
 
-        $this->migrationPublishes(['source/unmarked/two' => 'destination/unmarked/two']);
-        $this->migrationPublishes(['source/tagged/three' => 'destination/tagged/three'], 'tag_three');
-        $this->migrationPublishes(['source/tagged/multiple_two' => 'destination/tagged/multiple_two'], ['tag_four', 'tag_five']);
+        $this->publishesMigrations(['source/unmarked/two' => 'destination/unmarked/two']);
+        $this->publishesMigrations(['source/tagged/three' => 'destination/tagged/three'], 'tag_three');
+        $this->publishesMigrations(['source/tagged/multiple_two' => 'destination/tagged/multiple_two'], ['tag_four', 'tag_five']);
     }
 }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -39,7 +39,14 @@ class SupportServiceProviderTest extends TestCase
     public function testPublishableGroups()
     {
         $toPublish = ServiceProvider::publishableGroups();
-        $this->assertEquals(['some_tag', 'tag_one', 'tag_two'], $toPublish, 'Publishable groups do not return expected set of groups.');
+        $this->assertEquals([
+            'some_tag',
+            'tag_one',
+            'tag_two',
+            'tag_three',
+            'tag_four',
+            'tag_five',
+        ], $toPublish, 'Publishable groups do not return expected set of groups.');
     }
 
     public function testSimpleAssetsArePublishedCorrectly()
@@ -47,7 +54,14 @@ class SupportServiceProviderTest extends TestCase
         $toPublish = ServiceProvider::pathsToPublish(ServiceProviderForTestingOne::class);
         $this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected published path key.');
-        $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one', 'source/tagged/multiple' => 'destination/tagged/multiple'], $toPublish, 'Service provider does not return expected set of published paths.');
+        $this->assertEquals([
+            'source/unmarked/one' => 'destination/unmarked/one',
+            'source/tagged/one' => 'destination/tagged/one',
+            'source/tagged/multiple' => 'destination/tagged/multiple',
+            'source/unmarked/two' => 'destination/unmarked/two',
+            'source/tagged/three' => 'destination/tagged/three',
+            'source/tagged/multiple_two' => 'destination/tagged/multiple_two',
+        ], $toPublish, 'Service provider does not return expected set of published paths.');
     }
 
     public function testMultipleAssetsArePublishedCorrectly()
@@ -119,6 +133,10 @@ class ServiceProviderForTestingOne extends ServiceProvider
         $this->publishes(['source/unmarked/one' => 'destination/unmarked/one']);
         $this->publishes(['source/tagged/one' => 'destination/tagged/one'], 'some_tag');
         $this->publishes(['source/tagged/multiple' => 'destination/tagged/multiple'], ['tag_one', 'tag_two']);
+
+        $this->migrationPublishes(['source/unmarked/two' => 'destination/unmarked/two']);
+        $this->migrationPublishes(['source/tagged/three' => 'destination/tagged/three'], 'tag_three');
+        $this->migrationPublishes(['source/tagged/multiple_two' => 'destination/tagged/multiple_two'], ['tag_four', 'tag_five']);
     }
 }
 


### PR DESCRIPTION
This minimal pull request proposes the addition of a `ServiceProvider::publishesMigrations()` method, which can be used in favor of `ServiceProvider::publishes()` for migrations. It will ensure that any published migration has an "up-to-date" date in its name.

To get started, packages may opt in to this new method simply by replacing `publishes` with `publishesMigrations`:

```diff
        $this->publishes([
            __DIR__.'/../config/pennant.php' => config_path('pennant.php'),
        ], 'pennant-config');

-       $this->publishes([
+       $this->publishesMigrations([
            __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
        ], 'pennant-migrations');
```

If a package wants to support multiple Laravel versions, you may use the `method_exists` function like so:
```php
$migrations = [
    __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
];

method_exists($this, 'publishesMigrations')
    ? $this->publishesMigrations($migrations, 'pennant-migrations')
    ? $this->publishes($migrations, 'pennant-migrations')
```

The result will be that, instead of publishing a migration with an old date, Laravel will use a new date instead:

```diff
-2015_11_01_000001_create_features_table.php
+2023_12_05_132339_create_features_table.php
```

Note, when a package contains multiple migrations, for example like Jetstream with `create_user` and `create_team_user`, the package developer needs to add a number after the date. Here is an example, before and after:

```diff
-2015_11_01_000001_create_features_table.php
+2023_12_05_132339_create_features_table.php
```

At the moment, and intentionally, because I wanted to ensure we discuss it before coding it, this pull request does not detect if the migration already exists. So, if you run the command `php artisan vendor:publish --provider="Laravel\Pennant\PennantServiceProvider"` twice, you will end up with two similar migrations in your database/migrations directory:

```diff
+2023_12_05_132339_create_features_table.php
+2023_12_05_132400_create_features_table.php // duplicated here...
```