### PR TITLE
[11.x] Add function to validate if a lock is owned by the current owner.

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -148,19 +148,9 @@ abstract class Lock implements LockContract
      *
      * @return bool
      */
-    protected function isOwnedByCurrentProcess()
+    public function isOwnedByCurrentProcess()
     {
         return $this->getCurrentOwner() === $this->owner;
-    }
-
-    /**
-     * Determine if this lock is owned  by the current owner.
-     *
-     * @return bool
-     */
-    public function isOwner()
-    {
-        return $this->isOwnedByCurrentProcess();
     }
 
     /**

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -154,6 +154,16 @@ abstract class Lock implements LockContract
     }
 
     /**
+     * Determine if this lock is owned  by the current owner.
+     *
+     * @return bool
+     */
+    public function isOwner()
+    {
+        return $this->isOwnedByCurrentProcess();
+    }
+
+    /**
      * Specify the number of milliseconds to sleep in between blocked lock acquisition attempts.
      *
      * @param  int  $milliseconds

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -36,13 +36,6 @@ interface Lock
     public function owner();
 
     /**
-     * Determine if this lock is owned  by the current owner.
-     *
-     * @return bool
-     */
-    public function isOwner();
-
-    /**
      * Releases this lock in disregard of ownership.
      *
      * @return void

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -36,6 +36,13 @@ interface Lock
     public function owner();
 
     /**
+     * Determine if this lock is owned  by the current owner.
+     *
+     * @return bool
+     */
+    public function isOwner();
+
+    /**
      * Releases this lock in disregard of ownership.
      *
      * @return void

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -95,4 +95,27 @@ class FileCacheLockTest extends TestCase
 
         $this->assertTrue(Cache::lock('foo')->get());
     }
+
+    public function testOwnerStatusCanBeCheckedAfterRestoringLock()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+        $owner = $firstLock->owner();
+
+        $secondLock = Cache::store('file')->restoreLock('foo', $owner);
+        $this->assertTrue($secondLock->isOwner());
+    }
+
+    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+
+        $secondLock = Cache::store('file')->restoreLock('foo', 'other_owner');
+        $this->assertFalse($secondLock->isOwner());
+    }
 }

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -105,7 +105,7 @@ class FileCacheLockTest extends TestCase
         $owner = $firstLock->owner();
 
         $secondLock = Cache::store('file')->restoreLock('foo', $owner);
-        $this->assertTrue($secondLock->isOwner());
+        $this->assertTrue($secondLock->isOwnedByCurrentProcess());
     }
 
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
@@ -116,6 +116,6 @@ class FileCacheLockTest extends TestCase
         $this->assertTrue($firstLock->get());
 
         $secondLock = Cache::store('file')->restoreLock('foo', 'other_owner');
-        $this->assertFalse($secondLock->isOwner());
+        $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -80,7 +80,6 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
         $this->assertTrue(Cache::store('memcached')->lock('foo')->get());
     }
 
-    
     public function testOwnerStatusCanBeCheckedAfterRestoringLock()
     {
         Cache::store('memcached')->lock('foo')->forceRelease();

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -79,4 +79,28 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
 
         $this->assertTrue(Cache::store('memcached')->lock('foo')->get());
     }
+
+    
+    public function testOwnerStatusCanBeCheckedAfterRestoringLock()
+    {
+        Cache::store('memcached')->lock('foo')->forceRelease();
+
+        $firstLock = Cache::store('memcached')->lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+        $owner = $firstLock->owner();
+
+        $secondLock = Cache::store('memcached')->restoreLock('foo', $owner);
+        $this->assertTrue($secondLock->isOwner());
+    }
+
+    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    {
+        Cache::store('memcached')->lock('foo')->forceRelease();
+
+        $firstLock = Cache::store('memcached')->lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+
+        $secondLock = Cache::store('memcached')->restoreLock('foo', 'other_owner');
+        $this->assertFalse($secondLock->isOwner());
+    }
 }

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -89,7 +89,7 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
         $owner = $firstLock->owner();
 
         $secondLock = Cache::store('memcached')->restoreLock('foo', $owner);
-        $this->assertTrue($secondLock->isOwner());
+        $this->assertTrue($secondLock->isOwnedByCurrentProcess());
     }
 
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
@@ -100,6 +100,6 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
         $this->assertTrue($firstLock->get());
 
         $secondLock = Cache::store('memcached')->restoreLock('foo', 'other_owner');
-        $this->assertFalse($secondLock->isOwner());
+        $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -108,4 +108,28 @@ class RedisCacheLockTest extends TestCase
 
         $this->assertTrue(Cache::store('redis')->lock('foo')->get());
     }
+
+    
+    public function testOwnerStatusCanBeCheckedAfterRestoringLock()
+    {
+        Cache::store('redis')->lock('foo')->forceRelease();
+
+        $firstLock = Cache::store('redis')->lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+        $owner = $firstLock->owner();
+
+        $secondLock = Cache::store('redis')->restoreLock('foo', $owner);
+        $this->assertTrue($secondLock->isOwner());
+    }
+
+    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    {
+        Cache::store('redis')->lock('foo')->forceRelease();
+
+        $firstLock = Cache::store('redis')->lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+
+        $secondLock = Cache::store('redis')->restoreLock('foo', 'other_owner');
+        $this->assertFalse($secondLock->isOwner());
+    }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -118,7 +118,7 @@ class RedisCacheLockTest extends TestCase
         $owner = $firstLock->owner();
 
         $secondLock = Cache::store('redis')->restoreLock('foo', $owner);
-        $this->assertTrue($secondLock->isOwner());
+        $this->assertTrue($secondLock->isOwnedByCurrentProcess());
     }
 
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
@@ -129,6 +129,6 @@ class RedisCacheLockTest extends TestCase
         $this->assertTrue($firstLock->get());
 
         $secondLock = Cache::store('redis')->restoreLock('foo', 'other_owner');
-        $this->assertFalse($secondLock->isOwner());
+        $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -109,7 +109,6 @@ class RedisCacheLockTest extends TestCase
         $this->assertTrue(Cache::store('redis')->lock('foo')->get());
     }
 
-    
     public function testOwnerStatusCanBeCheckedAfterRestoringLock()
     {
         Cache::store('redis')->lock('foo')->forceRelease();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pr adds a public function isOwner to the Cache/Lock.php class and the Contracts/Cache/Lock class. This can be used to determine if a restored lock is owned by the current owner. Currently it is not possible to determine if a restoredLock is owned by the given owner, except when releasing it.

We ran into a problem when we wanted to validate on the queue if we still had the lock on a specific key. We pass the $owner to the job, and can currently release the lock using restoreLock($key, $owner)->release(), but we have no way of validating whether the lock is still viable (without releasing it).
