### PR TITLE
[10.x] Add `engine` method to `Blueprint`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -288,6 +288,17 @@ class Blueprint
     }
 
     /**
+     * Set the engine that should be used on the table.
+     *
+     * @param  string  $engine
+     * @return void
+     */
+    public function engine($engine)
+    {
+        $this->engine = $engine;
+    }
+
+    /**
      * Indicate that the table needs to be temporary.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -288,7 +288,7 @@ class Blueprint
     }
 
     /**
-     * Set the engine that should be used on the table.
+     * Specify the storage engine that should be used for the table.
      *
      * @param  string  $engine
      * @return void
@@ -296,6 +296,17 @@ class Blueprint
     public function engine($engine)
     {
         $this->engine = $engine;
+    }
+
+    /**
+     * Specify that the InnoDB storage engine should be used for the table (MySQL only).
+     *
+     * @param  string  $engine
+     * @return void
+     */
+    public function innoDb()
+    {
+        return $this->engine('InnoDB');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -306,7 +306,7 @@ class Blueprint
      */
     public function innoDb()
     {
-        return $this->engine('InnoDB');
+        $this->engine('InnoDB');
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -86,7 +86,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $blueprint->engine = 'InnoDB';
+        $blueprint->engine('InnoDB');
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');


### PR DESCRIPTION
This DX sucks:

```php
Schema::table('foo', function (Blueprint $table) {
    $table->engine = 'InnoDB';

    // ...
});
```

This is nicer:

```php
Schema::table('foo', function (Blueprint $table) {
    $table->engine('InnoDB');

    // ...
});
```

I didn't want to provide engine-specific methods such as `MyISAM` or `InnoDB` as these are MySQL specific and we'd provide methods that wouldn't necessarily work for other databases.