### PR TITLE
[10.x] Use translator from validator in `Can` and `Enum` rules

### DIFF
--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -23,7 +23,7 @@ class Can implements Rule, ValidatorAwareRule
     protected $arguments;
 
     /**
-     * The validator performing the validation.
+     * The current validator instance.
      *
      * @var \Illuminate\Validation\Validator
      */
@@ -72,7 +72,7 @@ class Can implements Rule, ValidatorAwareRule
     }
 
     /**
-     * Set the performing validator.
+     * Set the current validator.
      *
      * @param  \Illuminate\Validation\Validator  $validator
      * @return $this

--- a/src/Illuminate/Validation/Rules/Can.php
+++ b/src/Illuminate/Validation/Rules/Can.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Facades\Gate;
 
-class Can implements Rule
+class Can implements Rule, ValidatorAwareRule
 {
     /**
      * The ability to check.
@@ -20,6 +21,13 @@ class Can implements Rule
      * @var array
      */
     protected $arguments;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
 
     /**
      * Constructor.
@@ -56,10 +64,23 @@ class Can implements Rule
      */
     public function message()
     {
-        $message = trans('validation.can');
+        $message = $this->validator->getTranslator()->get('validation.can');
 
         return $message === 'validation.can'
             ? ['The :attribute field contains an unauthorized value.']
             : $message;
+    }
+
+    /**
+     * Set the performing validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -16,7 +16,7 @@ class Enum implements Rule, ValidatorAwareRule
     protected $type;
 
     /**
-     * The validator performing the validation.
+     * The current validator instance.
      *
      * @var \Illuminate\Validation\Validator
      */
@@ -72,7 +72,7 @@ class Enum implements Rule, ValidatorAwareRule
     }
 
     /**
-     * Set the performing validator.
+     * Set the current validator.
      *
      * @param  \Illuminate\Validation\Validator  $validator
      * @return $this

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use TypeError;
 
-class Enum implements Rule
+class Enum implements Rule, ValidatorAwareRule
 {
     /**
      * The type of the enum.
@@ -13,6 +14,13 @@ class Enum implements Rule
      * @var string
      */
     protected $type;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
 
     /**
      * Create a new rule instance.
@@ -56,10 +64,23 @@ class Enum implements Rule
      */
     public function message()
     {
-        $message = trans('validation.enum');
+        $message = $this->validator->getTranslator()->get('validation.enum');
 
         return $message === 'validation.enum'
             ? ['The selected :attribute is invalid.']
             : $message;
+    }
+
+    /**
+     * Set the performing validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
     }
 }


### PR DESCRIPTION
* Using `trans()` prevents the code from using the right translator that was passed to `Validator::__construct()` or that was changed with `Validator::setTranslator()`.