### PR TITLE
Adds the ability to pass an array as an argument to the flash() function

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -425,8 +425,8 @@ class Store implements Session
     /**
      * Manages the storage of a flash key-value pair in the session.
      *
-     * @param string $key
-     * @param mixed $item
+     * @param  string  $key
+     * @param  mixed  $item
      * @return void
      */
     protected function handleFlashKey($key, $item)
@@ -439,8 +439,8 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session.
      *
-     * @param string|array $key
-     * @param mixed $value
+     * @param  string|array  $key
+     * @param  mixed  $value
      * @return void
      */
     public function flash(string|array $key, $value = true)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -439,8 +439,8 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session.
      *
-     * @param  string|array  $key
-     * @param  mixed  $value
+     * @param string|array $key
+     * @param mixed $value
      * @return void
      */
     public function flash(string|array $key, $value = true)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -423,19 +423,37 @@ class Store implements Session
     }
 
     /**
+     * Manages the storage of a flash key-value pair in the session.
+     *
+     * @param string $key
+     * @param mixed $item
+     * @return void
+     */
+    protected function handleFlashKey($key, $item)
+    {
+        $this->put($key, $item);
+
+        $this->push('_flash.new', $key);
+    }
+
+    /**
      * Flash a key / value pair to the session.
      *
-     * @param  string  $key
+     * @param  string|array  $key
      * @param  mixed  $value
      * @return void
      */
-    public function flash(string $key, $value = true)
+    public function flash(string|array $key, $value = true)
     {
-        $this->put($key, $value);
+        if ($isKeyAnArray = is_array($key)) {
+            collect($key)->each(function ($item, $key) use ($value) {
+                $this->handleFlashKey($key, $item ?? $value);
+            });
+        } else {
+            $this->handleFlashKey($key, $value);
+        }
 
-        $this->push('_flash.new', $key);
-
-        $this->removeFromOldFlashData([$key]);
+        $this->removeFromOldFlashData($isKeyAnArray ? $key : [$key]);
     }
 
     /**


### PR DESCRIPTION
I don't know if I've missed a method or a way of doing things, but I couldn't find a way of passing an array as an argument to the flash function.

Here's an example:

Old
```php
$request->session()->flash('status', 'Example');
```

New
```php
$request->session()->flash([
    'status' => 'success',
    'message' => 'Example
]);
```

I know there's a way of writing it like this:

```php
$request->session()->flash('message', ['status' => 'success', 'text' => 'Example']);
```

But if the two flash messages have nothing in common, this poses the problem of code duplication (again, if I haven't missed a way of doing things differently).