### PR TITLE
Add missing url() method to filesystem-contract

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -63,6 +63,16 @@ interface Filesystem
     public function writeStream($path, $resource, array $options = []);
 
     /**
+     * Get the URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function url($path);
+
+    /**
      * Get the visibility for the given path.
      *
      * @param  string  $path


### PR DESCRIPTION
The Filesystem contract misses the URL method.

`Storage::url(...)` exists and works. But `Storage::disk(...)->url(..)` does not because of the missing url method in the contract.

The storage-facade has this method, but the contract does not. I think this should work for all storage-backend (since the availability on the facade), but not 100% sure. I just think this is a bug and was missed somehow in the past.
