### PR TITLE
[10.x] Add `hasIndex` and `hasIndexes` methods to Schema Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -290,6 +290,40 @@ class Builder
     }
 
     /**
+     * Determine if the given table has a given column.
+     *
+     * @param  string  $table
+     * @param  string  $index
+     * @return bool
+     */
+    public function hasIndex($table, $index)
+    {
+        return in_array(
+            strtolower($index), array_map('strtolower', $this->getIndexes($table))
+        );
+    }
+
+    /**
+     * Determine if the given table has given columns.
+     *
+     * @param  string  $table
+     * @param  array  $indexes
+     * @return bool
+     */
+    public function hasIndexes($table, array $indexes)
+    {
+        $tableIndexes = array_map('strtolower', $this->getIndexes($table));
+
+        foreach ($tableIndexes as $tableIndex) {
+            if (! in_array(strtolower($tableIndex), $indexes)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get the data type for the given column name.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -299,7 +299,7 @@ class Builder
     public function hasIndex($table, $index)
     {
         return in_array(
-            strtolower($index), array_map('strtolower', $this->getIndexes($table))
+            strtolower($index), array_map('strtolower', $this->getIndexListing($table))
         );
     }
 
@@ -312,10 +312,10 @@ class Builder
      */
     public function hasIndexes($table, array $indexes)
     {
-        $tableIndexes = array_map('strtolower', $this->getIndexes($table));
+        $tableIndexes = array_map('strtolower', $this->getIndexListing($table));
 
-        foreach ($tableIndexes as $tableIndex) {
-            if (! in_array(strtolower($tableIndex), $indexes)) {
+        foreach ($indexes as $index) {
+            if (! in_array(strtolower($index), $tableIndexes)) {
                 return false;
             }
         }
@@ -359,6 +359,17 @@ class Builder
     public function getColumnListing($table)
     {
         return array_column($this->getColumns($table), 'name');
+    }
+
+    /**
+     * Get the index listing for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getIndexListing($table)
+    {
+        return array_column($this->getIndexes($table), 'name');
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -16,6 +16,8 @@ namespace Illuminate\Support\Facades;
  * @method static array getViews()
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
+ * @method static bool hasIndex(string $table, string $column)
+ * @method static bool hasIndexes(string $table, array $columns)
  * @method static void whenTableHasColumn(string $table, string $column, \Closure $callback)
  * @method static void whenTableDoesntHaveColumn(string $table, string $column, \Closure $callback)
  * @method static string getColumnType(string $table, string $column, bool $fullDefinition = false)

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -76,8 +76,8 @@ class DatabaseSchemaBuilderTest extends TestCase
         $connection = m::mock(Connection::class);
         $grammar = m::mock(stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $builder = m::mock(Builder::class.'[getIndexes]', [$connection]);
-        $builder->shouldReceive('getIndexes')->with('users')->times(3)->andReturn(['id', 'firstname']);
+        $builder = m::mock(Builder::class.'[getIndexListing]', [$connection]);
+        $builder->shouldReceive('getIndexListing')->with('users')->times(3)->andReturn(['id', 'firstname']);
 
         $this->assertTrue($builder->hasIndex('users', 'id'));
         $this->assertTrue($builder->hasIndex('users', 'firstname'));
@@ -89,8 +89,8 @@ class DatabaseSchemaBuilderTest extends TestCase
         $connection = m::mock(Connection::class);
         $grammar = m::mock(stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        $builder = m::mock(Builder::class.'[getIndexes]', [$connection]);
-        $builder->shouldReceive('getIndexes')->with('users')->twice()->andReturn(['id', 'firstname']);
+        $builder = m::mock(Builder::class.'[getIndexListing]', [$connection]);
+        $builder->shouldReceive('getIndexListing')->with('users')->twice()->andReturn(['id', 'firstname']);
 
         $this->assertTrue($builder->hasIndexes('users', ['id', 'firstname']));
         $this->assertFalse($builder->hasIndexes('users', ['id', 'address']));

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -77,9 +77,10 @@ class DatabaseSchemaBuilderTest extends TestCase
         $grammar = m::mock(stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = m::mock(Builder::class.'[getIndexes]', [$connection]);
-        $builder->shouldReceive('getIndexes')->with('users')->twice()->andReturn(['id', 'firstname']);
+        $builder->shouldReceive('getIndexes')->with('users')->times(3)->andReturn(['id', 'firstname']);
 
         $this->assertTrue($builder->hasIndex('users', 'id'));
+        $this->assertTrue($builder->hasIndex('users', 'firstname'));
         $this->assertFalse($builder->hasIndex('users', 'address'));
     }
 

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -71,6 +71,30 @@ class DatabaseSchemaBuilderTest extends TestCase
         $this->assertFalse($builder->hasColumns('users', ['id', 'address']));
     }
 
+    public function testTableHasIndex()
+    {
+        $connection = m::mock(Connection::class);
+        $grammar = m::mock(stdClass::class);
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $builder = m::mock(Builder::class.'[getIndexes]', [$connection]);
+        $builder->shouldReceive('getIndexes')->with('users')->twice()->andReturn(['id', 'firstname']);
+
+        $this->assertTrue($builder->hasIndex('users', 'id'));
+        $this->assertFalse($builder->hasIndex('users', 'address'));
+    }
+
+    public function testTableHasIndexes()
+    {
+        $connection = m::mock(Connection::class);
+        $grammar = m::mock(stdClass::class);
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $builder = m::mock(Builder::class.'[getIndexes]', [$connection]);
+        $builder->shouldReceive('getIndexes')->with('users')->twice()->andReturn(['id', 'firstname']);
+
+        $this->assertTrue($builder->hasIndexes('users', ['id', 'firstname']));
+        $this->assertFalse($builder->hasIndexes('users', ['id', 'address']));
+    }
+
     public function testGetColumnTypeAddsPrefix()
     {
         $connection = m::mock(Connection::class);


### PR DESCRIPTION
This PR introduces two new methods to the Schema builder: `Schema::hasIndex($table, $index)` and `Schema::hasIndexes($table, $indexes)`. These methods align with the existing `hasColumn` and `hasColumns`  methods as discussed on https://github.com/laravel/framework/pull/49204#issuecomment-1836199514

## Usage

`Schema::hasIndex('user', 'email');`

`Schema::hasIndexes('user', ['email', 'name']);`

## Testing

Added unit tests, but also tested manually to ensure it actually works with real database

<img width="421" alt="image" src="https://github.com/laravel/framework/assets/2040842/4d1f8904-88b3-4a17-b014-b1b2fed0b7ae">
