### PR TITLE
[10.x] Filesystem : can lock file on append of content

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -268,7 +268,7 @@ class Filesystem
      *
      * @param  string  $path
      * @param  string  $data
-     * @param  bool    $lock
+     * @param  bool  $lock
      * @return int
      */
     public function append($path, $data, $lock = false)

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -268,11 +268,12 @@ class Filesystem
      *
      * @param  string  $path
      * @param  string  $data
+     * @param  bool    $lock
      * @return int
      */
-    public function append($path, $data)
+    public function append($path, $data, $lock = false)
     {
-        return file_put_contents($path, $data, FILE_APPEND);
+        return file_put_contents($path, $data, FILE_APPEND | ($lock ? LOCK_EX : 0));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -16,7 +16,7 @@ namespace Illuminate\Support\Facades;
  * @method static void replace(string $path, string $content, int|null $mode = null)
  * @method static void replaceInFile(array|string $search, array|string $replace, string $path)
  * @method static int prepend(string $path, string $data)
- * @method static int append(string $path, string $data)
+ * @method static int append(string $path, string $data, bool $lock = false)
  * @method static mixed chmod(string $path, int|null $mode = null)
  * @method static bool delete(string|array $paths)
  * @method static bool move(string $path, string $target)


### PR DESCRIPTION
When an application receives a large volume of competing data, and we want to add content to a file, the original content is overwritten.

The append method does not allow you to use the LOCK_EX flag as you can with the put method, which I added here.