### PR TITLE
[10.x] Get foreign keys of a table

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -63,4 +63,27 @@ class MySqlProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of a foreign keys query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processForeignKeys($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'columns' => explode(',', $result->columns),
+                'foreign_schema' => $result->foreign_schema,
+                'foreign_table' => $result->foreign_table,
+                'foreign_columns' => explode(',', $result->foreign_columns),
+                'on_update' => strtolower($result->on_update),
+                'on_delete' => strtolower($result->on_delete),
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -91,4 +91,41 @@ class PostgresProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of a foreign keys query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processForeignKeys($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'columns' => explode(',', $result->columns),
+                'foreign_schema' => $result->foreign_schema,
+                'foreign_table' => $result->foreign_table,
+                'foreign_columns' => explode(',', $result->foreign_columns),
+                'on_update' => match (strtolower($result->on_update)) {
+                    'a' => 'no action',
+                    'r' => 'restrict',
+                    'c' => 'cascade',
+                    'n' => 'set null',
+                    'd' => 'set default',
+                    default => null,
+                },
+                'on_delete' => match (strtolower($result->on_delete)) {
+                    'a' => 'no action',
+                    'r' => 'restrict',
+                    'c' => 'cascade',
+                    'n' => 'set null',
+                    'd' => 'set default',
+                    default => null,
+                },
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -100,6 +100,17 @@ class Processor
     }
 
     /**
+     * Process the results of a foreign keys query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processForeignKeys($results)
+    {
+        return $results;
+    }
+
+    /**
      * Process the results of a column listing query.
      *
      * @deprecated Will be removed in a future Laravel version.

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -79,4 +79,27 @@ class SQLiteProcessor extends Processor
 
         return $indexes;
     }
+
+    /**
+     * Process the results of a foreign keys query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processForeignKeys($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => null,
+                'columns' => explode(',', $result->columns),
+                'foreign_schema' => null,
+                'foreign_table' => $result->foreign_table,
+                'foreign_columns' => explode(',', $result->foreign_columns),
+                'on_update' => strtolower($result->on_update),
+                'on_delete' => strtolower($result->on_delete),
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -121,4 +121,27 @@ class SqlServerProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of a foreign keys query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processForeignKeys($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'columns' => explode(',', $result->columns),
+                'foreign_schema' => $result->foreign_schema,
+                'foreign_table' => $result->foreign_table,
+                'foreign_columns' => explode(',', $result->foreign_columns),
+                'on_update' => strtolower(str_replace('_', ' ', $result->on_update)),
+                'on_delete' => strtolower(str_replace('_', ' ', $result->on_delete)),
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -358,6 +358,21 @@ class Builder
     }
 
     /**
+     * Get the foreign keys for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getForeignKeys($table)
+    {
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processForeignKeys(
+            $this->connection->selectFromWriteConnection($this->grammar->compileForeignKeys($table))
+        );
+    }
+
+    /**
      * Modify a table on the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -196,7 +196,7 @@ class MySqlGrammar extends Grammar
     {
         return sprintf(
             'select kc.constraint_name as `name`, '
-            .'group_concat(kc.column_name order by kc.ordinal_position) as `columns `, '
+            .'group_concat(kc.column_name order by kc.ordinal_position) as `columns`, '
             .'kc.referenced_table_schema as `foreign_schema`, '
             .'kc.referenced_table_name as `foreign_table`, '
             .'group_concat(kc.referenced_column_name order by kc.ordinal_position) as `foreign_columns`, '

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -186,6 +186,32 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the foreign keys.
+     *
+     * @param  string  $database
+     * @param  string  $table
+     * @return string
+     */
+    public function compileForeignKeys($database, $table)
+    {
+        return sprintf(
+            'select kc.constraint_name as `name`, '
+            .'group_concat(kc.column_name order by kc.ordinal_position) as `columns `, '
+            .'kc.referenced_table_schema as `foreign_schema`, '
+            .'kc.referenced_table_name as `foreign_table`, '
+            .'group_concat(kc.referenced_column_name order by kc.ordinal_position) as `foreign_columns`, '
+            .'rc.update_rule as `on_update`, '
+            .'rc.delete_rule as `on_delete` '
+            .'from information_schema.key_column_usage kc join information_schema.referential_constraints rc '
+            .'on kc.constraint_schema = rc.constraint_schema and kc.constraint_name = rc.constraint_name '
+            .'where kc.table_schema = %s and kc.table_name = %s and kc.referenced_table_name is not null '
+            .'group by kc.constraint_name, kc.referenced_table_schema, kc.referenced_table_name, rc.update_rule, rc.delete_rule',
+            $this->quoteString($database),
+            $this->quoteString($table)
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -190,6 +190,37 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the foreign keys.
+     *
+     * @param  string  $schema
+     * @param  string  $table
+     * @return string
+     */
+    public function compileForeignKeys($schema, $table)
+    {
+        return sprintf(
+            'select c.conname as name, '
+            ."string_agg(la.attname, ',' order by conseq.ord) as columns, "
+            .'fn.nspname as foreign_schema, fc.relname as foreign_table, '
+            ."string_agg(fa.attname, ',' order by confseq.ord) as foreign_columns, "
+            .'c.confupdtype as on_update, c.confdeltype as on_delete '
+            .'from pg_constraint c '
+            .'join pg_class tc on c.conrelid = tc.oid '
+            .'join pg_namespace tn on tn.oid = tc.relnamespace '
+            .'join pg_class fc on c.confrelid = fc.oid '
+            .'join pg_namespace fn on fn.oid = fc.relnamespace '
+            .'join lateral unnest(c.conkey) with ordinality as conseq(num, ord) on true '
+            .'join pg_attribute la on la.attrelid = c.conrelid and la.attnum = conseq.num '
+            .'join lateral unnest(c.confkey) with ordinality as confseq(num, ord) on true '
+            .'join pg_attribute fa on fa.attrelid = c.confrelid and fa.attnum = confseq.num '
+            ."where c.contype = 'f' and tn.nspname = %s and tc.relname = %s "
+            .'group by c.conname, fn.nspname, fc.relname, c.confupdtype, c.confdeltype',
+            $this->quoteString($table),
+            $this->quoteString($schema)
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -213,7 +213,7 @@ class PostgresGrammar extends Grammar
             .'join pg_attribute la on la.attrelid = c.conrelid and la.attnum = conseq.num '
             .'join lateral unnest(c.confkey) with ordinality as confseq(num, ord) on true '
             .'join pg_attribute fa on fa.attrelid = c.confrelid and fa.attnum = confseq.num '
-            ."where c.contype = 'f' and tn.nspname = %s and tc.relname = %s "
+            ."where c.contype = 'f' and tc.relname = %s and tn.nspname = %s "
             .'group by c.conname, fn.nspname, fc.relname, c.confupdtype, c.confdeltype',
             $this->quoteString($table),
             $this->quoteString($schema)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -202,7 +202,7 @@ class PostgresGrammar extends Grammar
             'select c.conname as name, '
             ."string_agg(la.attname, ',' order by conseq.ord) as columns, "
             .'fn.nspname as foreign_schema, fc.relname as foreign_table, '
-            ."string_agg(fa.attname, ',' order by confseq.ord) as foreign_columns, "
+            ."string_agg(fa.attname, ',' order by conseq.ord) as foreign_columns, "
             .'c.confupdtype as on_update, c.confdeltype as on_delete '
             .'from pg_constraint c '
             .'join pg_class tc on c.conrelid = tc.oid '
@@ -211,8 +211,7 @@ class PostgresGrammar extends Grammar
             .'join pg_namespace fn on fn.oid = fc.relnamespace '
             .'join lateral unnest(c.conkey) with ordinality as conseq(num, ord) on true '
             .'join pg_attribute la on la.attrelid = c.conrelid and la.attnum = conseq.num '
-            .'join lateral unnest(c.confkey) with ordinality as confseq(num, ord) on true '
-            .'join pg_attribute fa on fa.attrelid = c.confrelid and fa.attnum = confseq.num '
+            .'join pg_attribute fa on fa.attrelid = c.confrelid and fa.attnum = c.confkey[conseq.ord] '
             ."where c.contype = 'f' and tc.relname = %s and tn.nspname = %s "
             .'group by c.conname, fn.nspname, fc.relname, c.confupdtype, c.confdeltype',
             $this->quoteString($table),

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -147,6 +147,23 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the foreign keys.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function compileForeignKeys($table)
+    {
+        return sprintf(
+            'select group_concat("from") as columns, "table" as foreign_table, '
+            .'group_concat("to") as foreign_columns, on_update, on_delete '
+            .'from (select * from pragma_foreign_key_list(%s) order by id desc, seq) '
+            .'group by id, "table", on_update, on_delete',
+            $this->wrap(str_replace('.', '__', $table))
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -203,7 +203,7 @@ class SqlServerGrammar extends Grammar
             .'fs.name as foreign_schema, ft.name as foreign_table, '
             ."string_agg(fc.name, ',') within group (order by fkc.constraint_column_id) as foreign_columns, "
             .'fk.update_referential_action_desc as on_update, '
-            .'fk.delete_referential_action_desc as on_delete, '
+            .'fk.delete_referential_action_desc as on_delete '
             .'from sys.foreign_keys as fk '
             .'join sys.foreign_key_columns as fkc on fkc.constraint_object_id = fk.object_id '
             .'join sys.tables as lt on lt.object_id = fk.parent_object_id '

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -190,6 +190,35 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the foreign keys.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function compileForeignKeys($table)
+    {
+        return sprintf(
+            'select fk.name as name, '
+            ."string_agg(lc.name, ',') within group (order by fkc.constraint_column_id) as columns, "
+            .'fs.name as foreign_schema, ft.name as foreign_table, '
+            ."string_agg(fc.name, ',') within group (order by fkc.constraint_column_id) as foreign_columns, "
+            .'fk.update_referential_action_desc as on_update, '
+            .'fk.delete_referential_action_desc as on_delete, '
+            .'from sys.foreign_keys as fk '
+            .'join sys.foreign_key_columns as fkc on fkc.constraint_object_id = fk.object_id '
+            .'join sys.tables as lt on lt.object_id = fk.parent_object_id '
+            .'join sys.schemas as ls on lt.schema_id = ls.schema_id '
+            .'join sys.columns as lc on fkc.parent_object_id = lc.object_id and fkc.parent_column_id = lc.column_id '
+            .'join sys.tables as ft on ft.object_id = fk.referenced_object_id '
+            .'join sys.schemas as fs on ft.schema_id = fs.schema_id '
+            .'join sys.columns as fc on fkc.referenced_object_id = fc.object_id and fkc.referenced_column_id = fc.column_id '
+            .'where lt.name = %s and ls.name = SCHEMA_NAME() '
+            .'group by fk.name, fs.name, ft.name, fk.update_referential_action_desc, fk.delete_referential_action_desc',
+            $this->quoteString($table)
+        );
+    }
+
+    /**
      * Compile a create table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -121,6 +121,23 @@ class MySqlBuilder extends Builder
     }
 
     /**
+     * Get the foreign keys for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getForeignKeys($table)
+    {
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processForeignKeys(
+            $this->connection->selectFromWriteConnection(
+                $this->grammar->compileForeignKeys($this->connection->getDatabaseName(), $table)
+            )
+        );
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -221,6 +221,23 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * Get the foreign keys for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getForeignKeys($table)
+    {
+        [, $schema, $table] = $this->parseSchemaAndTable($table);
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processForeignKeys(
+            $this->connection->selectFromWriteConnection($this->grammar->compileForeignKeys($schema, $table))
+        );
+    }
+
+    /**
      * Get the schemas for the connection.
      *
      * @return array

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -22,6 +22,7 @@ namespace Illuminate\Support\Facades;
  * @method static array getColumnListing(string $table)
  * @method static array getColumns(string $table)
  * @method static array getIndexes(string $table)
+ * @method static array getForeignKeys(string $table)
  * @method static void table(string $table, \Closure $callback)
  * @method static void create(string $table, \Closure $callback)
  * @method static void drop(string $table)

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -261,4 +261,49 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertTrue(collect($indexes)->contains(fn ($index) => $index['columns'] === ['id'] && $index['primary']));
         $this->assertTrue(collect($indexes)->contains('name', 'articles_body_title_fulltext'));
     }
+
+    public function testGetForeignKeys()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->foreignId('user_id')->constrained()->cascadeOnUpdate()->nullOnDelete();
+        });
+
+        $foreignKeys = Schema::getForeignKeys('posts');
+
+        $this->assertCount(1, $foreignKeys);
+        $this->assertTrue(collect($foreignKeys)->contains(
+            fn ($foreign) => $foreign['columns'] === ['user_id']
+                && $foreign['foreign_table'] === 'users' && $foreign['foreign_columns'] === ['id']
+                && $foreign['on_update'] === 'cascade' && $foreign['on_delete'] === 'set null'
+        ));
+    }
+
+    public function testGetCompoundForeignKeys()
+    {
+        Schema::create('parent', function (Blueprint $table) {
+            $table->id();
+            $table->integer('a');
+            $table->integer('b');
+        });
+
+        Schema::create('child', function (Blueprint $table) {
+            $table->integer('c');
+            $table->integer('d');
+
+            $table->foreign(['d', 'c'], 'test_fk')->references(['b', 'a'])->on('parent');
+        });
+
+        $foreignKeys = Schema::getForeignKeys('child');
+
+        $this->assertCount(1, $foreignKeys);
+        $this->assertTrue(collect($foreignKeys)->contains(
+            fn ($foreign) => $foreign['columns'] === ['d', 'c']
+                && $foreign['foreign_table'] === 'parent'
+                && $foreign['foreign_columns'] === ['b', 'a']
+        ));
+    }
 }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -269,7 +269,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         });
 
         Schema::create('posts', function (Blueprint $table) {
-            $table->foreignId('user_id')->constrained()->cascadeOnUpdate()->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnUpdate()->nullOnDelete();
         });
 
         $foreignKeys = Schema::getForeignKeys('posts');
@@ -288,6 +288,8 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->id();
             $table->integer('a');
             $table->integer('b');
+
+            $table->unique(['b', 'a']);
         });
 
         Schema::create('child', function (Blueprint $table) {


### PR DESCRIPTION
This PR adds `Schema::getForeignKeys()` method to get foreign keys' info of the given table. 

## Usage
Just like `Schema::getColumns()` added on #48357 and `Schema::getIndexes()` added on #49204, the new `Schema::getForeignKeys()`method is to inspect the tables' foreign keys.

### `Schema::getForeignKeys()`
* `name` (`?string`): Name of the constraint (`null` on SQLite)
* `columns` (`string[]`): Array of local columns' names
* `foreign_schema` (`?string`):
  * SQLite: `null`
  * MySQL: Database name of the foreign table
  * PostgreSQL and SQL Server: Schema name of the foreign table
* `foreign_table` (`string`): Foreign table's name
* `foreign_columns` (`string[]`): Array of foreign columns' names
* `on_update` (`string`): Action rule on update (`cascade`, `set null`, `set default`, `restrict` (except SQL Server), `no action`)
* `on_delete` (`string`): Action rule on delete (`cascade`, `set null`, `set default`, `restrict` (except SQL Server), `no action`
