### PR TITLE
[10.x] Adds `possessive` helper to `Str`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1525,7 +1525,7 @@ class Str
     public static function possessive($subject)
     {
         return static::endsWith(static::lower($subject), 's')
-            ?"{$subject}'"
+            ? "{$subject}'"
             : "{$subject}'s";
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1517,6 +1517,19 @@ class Str
     }
 
     /**
+     * Add the possessive apostraphe to the given noun.
+     *
+     * @param  string  $subject
+     * @return string
+     */
+    public static function possessive($subject)
+    {
+        return static::endsWith(static::lower($subject), 's')
+            ?"{$subject}'"
+            : "{$subject}'s";
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1319,6 +1319,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Add the possessive apostraphe to the given noun.
+     *
+     * @return string
+     */
+    public function possessive()
+    {
+        return Str::possessive($this->value);
+    }
+
+    /**
      * Convert the object to a string when JSON encoded.
      *
      * @return string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1324,6 +1324,16 @@ class SupportStrTest extends TestCase
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }
+
+    public function testItCanGenerateThePossessiveFormOfWords()
+    {
+        $this->assertSame('John\'s', Str::possessive('John'));
+        $this->assertSame('JOHN\'s', Str::possessive('JOHN'));
+        $this->assertSame('Jess\'', Str::possessive('Jess'));
+        $this->assertSame('JESS\'', Str::possessive('JESS'));
+        $this->assertSame('The car is John\'s', Str::possessive('The car is John'));
+        $this->assertSame('The car is Jess\'', Str::possessive('The car is Jess'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1295,4 +1295,14 @@ class SupportStringableTest extends TestCase
         $this->assertTrue(isset($str[2]));
         $this->assertFalse(isset($str[10]));
     }
+
+    public function testPossessiveFormOfWords()
+    {
+        $this->assertSame('John\'s', $this->stringable('John')->possessive());
+        $this->assertSame('JOHN\'s', $this->stringable('JOHN')->possessive());
+        $this->assertSame('Jess\'', $this->stringable('Jess')->possessive());
+        $this->assertSame('JESS\'', $this->stringable('JESS')->possessive());
+        $this->assertSame('The car is John\'s', $this->stringable('The car is John')->possessive());
+        $this->assertSame('The car is Jess\'', $this->stringable('The car is Jess')->possessive());
+    }
 }


### PR DESCRIPTION
This PR adds a new `Str::possessive` helper. It is very simple, but is intended to simplify the use case where you have a user, company or other noun and want to correctly generate the possessive form.

That is to say that if the word ends in an 's', the apostrophe is simply appended, whereas if the word ends in any other letter, the method also adds the 's'.

```blade
You are now viewing {{ Str::possessive($user->name) }} profile!
```

In the above example, if the user is called "John", then the result is "You are now viewing John's profile!" If the user is "Jess", it would instead render "You are now viewing Jess' profile!"

I've also added a `Stringable` method: `str("John")->possessive(); // John's`

## Caveats

There are some additional rules that I've played with adding, but it becomes difficult to do so without having a neural engine with complete knowledge of the English language and sentence structure. For example, "me" would be "my", not "me's", but can also be "mine" depending on where it is placed. Other examples include "you", "we", "them" and "who". 

As such, I've kept this simple with the intended use case being proper nouns.

As always, thanks so much for all your hard work.

Regards,
Luke

