### PR TITLE
[11.x] Test Improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,6 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
-        if: matrix.php >= 8.2
 
       - name: Install dependencies
         uses: nick-fields/retry@v2
@@ -131,7 +130,6 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require guzzlehttp/psr7:~2.4 --no-interaction --no-update
-        if: matrix.php >= 8.2
 
       - name: Install dependencies
         uses: nick-fields/retry@v2

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 class ThrottleRequestsTest extends TestCase
@@ -127,7 +128,7 @@ class ThrottleRequestsTest extends TestCase
         ];
     }
 
-    /** @dataProvider perMinuteThrottlingDataSet */
+    #[DataProvider('perMinuteThrottlingDataSet')]
     public function testItCanThrottlePerMinute(string $middleware)
     {
         $rateLimiter = Container::getInstance()->make(RateLimiter::class);


### PR DESCRIPTION
* Laravel 11 already using PHP 8.2 as minimum, doesn't need `if: matrix.php >= 8.2`
* Use PHPUnit Attribute instead of Annotation.