### PR TITLE
[10.x] Allow checking if lock succesfully restored

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -148,20 +148,9 @@ abstract class Lock implements LockContract
      *
      * @return bool
      */
-    protected function isOwnedByCurrentProcess()
+    public function isOwnedByCurrentProcess()
     {
         return $this->getCurrentOwner() === $this->owner;
-    }
-
-
-    /**
-     * Determine if this lock is owned  by the current owner.
-     * 
-     * @return bool
-     */
-    public function isOwner()
-    {
-        return $this->isOwnedByCurrentProcess();
     }
 
     /**

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -153,6 +153,17 @@ abstract class Lock implements LockContract
         return $this->getCurrentOwner() === $this->owner;
     }
 
+
+    /**
+     * Determine if this lock is owned  by the current owner.
+     * 
+     * @return bool
+     */
+    public function isOwner()
+    {
+        return $this->isOwnedByCurrentProcess();
+    }
+
     /**
      * Specify the number of milliseconds to sleep in between blocked lock acquisition attempts.
      *

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -36,13 +36,6 @@ interface Lock
     public function owner();
 
     /**
-     * Determine if this lock is owned  by the current owner.
-     *
-     * @return bool
-     */
-    public function isOwner();
-
-    /**
      * Releases this lock in disregard of ownership.
      *
      * @return void

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -36,6 +36,13 @@ interface Lock
     public function owner();
 
     /**
+     * Determine if this lock is owned  by the current owner.
+     *
+     * @return bool
+     */
+    public function isOwner();
+
+    /**
      * Releases this lock in disregard of ownership.
      *
      * @return void

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -117,6 +117,5 @@ class FileCacheLockTest extends TestCase
 
         $secondLock = Cache::store('file')->restoreLock('foo', 'other_owner');
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
- 
-   }
+    }
 }

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -95,4 +95,28 @@ class FileCacheLockTest extends TestCase
 
         $this->assertTrue(Cache::lock('foo')->get());
     }
+
+    public function testOwnerStatusCanBeCheckedAfterRestoringLock()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+        $owner = $firstLock->owner();
+
+        $secondLock = Cache::store('file')->restoreLock('foo', $owner);
+        $this->assertTrue($secondLock->isOwnedByCurrentProcess());
+    }
+
+    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+
+        $secondLock = Cache::store('file')->restoreLock('foo', 'other_owner');
+        $this->assertFalse($secondLock->isOwnedByCurrentProcess());
+ 
+   }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

See: https://github.com/laravel/framework/pull/49249

This change makes the isOwnedByCurrentProcess function public.