### PR TITLE
[10.x] Add `progress` option to `PendingBatch`

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -241,6 +241,14 @@ class Batch implements Arrayable, JsonSerializable
     {
         $counts = $this->decrementPendingJobs($jobId);
 
+        if ($this->hasProgressCallbacks()) {
+            $batch = $this->fresh();
+
+            collect($this->options['progress'])->each(function ($handler) use ($batch) {
+                $this->invokeHandlerCallback($handler, $batch);
+            });
+        }
+
         if ($counts->pendingJobs === 0) {
             $this->repository->markAsFinished($this->id);
         }
@@ -281,6 +289,16 @@ class Batch implements Arrayable, JsonSerializable
     public function finished()
     {
         return ! is_null($this->finishedAt);
+    }
+
+    /**
+     * Determine if the batch has "progress" callbacks.
+     *
+     * @return bool
+     */
+    public function hasProgressCallbacks()
+    {
+        return isset($this->options['progress']) && ! empty($this->options['progress']);
     }
 
     /**

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -346,6 +346,14 @@ class Batch implements Arrayable, JsonSerializable
             $this->cancel();
         }
 
+        if ($this->hasProgressCallbacks() && $this->allowsFailures()) {
+            $batch = $this->fresh();
+
+            collect($this->options['progress'])->each(function ($handler) use ($batch, $e) {
+                $this->invokeHandlerCallback($handler, $batch, $e);
+            });
+        }
+
         if ($counts->failedJobs === 1 && $this->hasCatchCallbacks()) {
             $batch = $this->fresh();
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -72,6 +72,31 @@ class PendingBatch
     }
 
     /**
+     * Add a callback to be executed after a job in the batch have executed successfully.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function progress($callback)
+    {
+        $this->options['progress'][] = $callback instanceof Closure
+            ? new SerializableClosure($callback)
+            : $callback;
+
+        return $this;
+    }
+
+    /**
+     * Get the "progress" callbacks that have been registered with the pending batch.
+     *
+     * @return array
+     */
+    public function progressCallbacks()
+    {
+        return $this->options['progress'] ?? [];
+    }
+
+    /**
      * Add a callback to be executed after all jobs in the batch have executed successfully.
      *
      * @param  callable  $callback

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -40,6 +40,7 @@ class BusBatchTest extends TestCase
         $this->createSchema();
 
         $_SERVER['__finally.count'] = 0;
+        $_SERVER['__progress.count'] = 0;
         $_SERVER['__then.count'] = 0;
         $_SERVER['__catch.count'] = 0;
     }
@@ -72,7 +73,7 @@ class BusBatchTest extends TestCase
      */
     protected function tearDown(): void
     {
-        unset($_SERVER['__finally.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
+        unset($_SERVER['__finally.batch'], $_SERVER['__progress.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
 
         $this->schema()->drop('job_batches');
 
@@ -201,12 +202,14 @@ class BusBatchTest extends TestCase
         $batch->recordSuccessfulJob('test-id');
 
         $this->assertInstanceOf(Batch::class, $_SERVER['__finally.batch']);
+        $this->assertInstanceOf(Batch::class, $_SERVER['__progress.batch']);
         $this->assertInstanceOf(Batch::class, $_SERVER['__then.batch']);
 
         $batch = $batch->fresh();
         $this->assertEquals(0, $batch->pendingJobs);
         $this->assertTrue($batch->finished());
         $this->assertEquals(1, $_SERVER['__finally.count']);
+        $this->assertEquals(2, $_SERVER['__progress.count']);
         $this->assertEquals(1, $_SERVER['__then.count']);
     }
 
@@ -326,6 +329,11 @@ class BusBatchTest extends TestCase
         $this->assertFalse($batch->finished());
         $batch->finishedAt = now();
         $this->assertTrue($batch->finished());
+
+        $batch->options['progress'] = [];
+        $this->assertFalse($batch->hasProgressCallbacks());
+        $batch->options['progress'] = [1];
+        $this->assertTrue($batch->hasProgressCallbacks());
 
         $batch->options['then'] = [];
         $this->assertFalse($batch->hasThenCallbacks());
@@ -463,6 +471,10 @@ class BusBatchTest extends TestCase
         $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
 
         $pendingBatch = (new PendingBatch(new Container, collect()))
+                            ->progress(function (Batch $batch) {
+                                $_SERVER['__progress.batch'] = $batch;
+                                $_SERVER['__progress.count']++;
+                            })
                             ->then(function (Batch $batch) {
                                 $_SERVER['__then.batch'] = $batch;
                                 $_SERVER['__then.count']++;

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -250,6 +250,7 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->finished());
         $this->assertTrue($batch->cancelled());
         $this->assertEquals(1, $_SERVER['__finally.count']);
+        $this->assertEquals(0, $_SERVER['__progress.count']);
         $this->assertEquals(1, $_SERVER['__catch.count']);
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
@@ -291,6 +292,7 @@ class BusBatchTest extends TestCase
         $this->assertFalse($batch->finished());
         $this->assertFalse($batch->cancelled());
         $this->assertEquals(1, $_SERVER['__catch.count']);
+        $this->assertEquals(2, $_SERVER['__progress.count']);
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -37,7 +37,9 @@ class BusPendingBatchTest extends TestCase
 
         $pendingBatch = new PendingBatch($container, new Collection([$job]));
 
-        $pendingBatch = $pendingBatch->then(function () {
+        $pendingBatch = $pendingBatch->progress(function () {
+            //
+        })->then(function () {
             //
         })->catch(function () {
             //
@@ -45,6 +47,7 @@ class BusPendingBatchTest extends TestCase
 
         $this->assertSame('test-connection', $pendingBatch->connection());
         $this->assertSame('test-queue', $pendingBatch->queue());
+        $this->assertCount(1, $pendingBatch->progressCallbacks());
         $this->assertCount(1, $pendingBatch->thenCallbacks());
         $this->assertCount(1, $pendingBatch->catchCallbacks());
         $this->assertArrayHasKey('extra-option', $pendingBatch->options);


### PR DESCRIPTION
My take number 2 for this feature request... https://github.com/laravel/framework/pull/49099

Implementing this feature on the application level is not easy and requires a lot of overriding...

- Create a new Batch class, extend from `\Illuminate\Bus\Batch`. Add `hasProgressCallbacks()` to check against progress callback availability. Override `recordSuccessfulJob()` and `recordFailedJob()` methods, invoke progress callbacks

```php
class ModifiedBatch extends \Illuminate\Bus\Batch
{
    public function recordSuccessfulJob(string $jobId): void
    {
        ...
    }

    public function recordFailedJob(string $jobId, $e): void
    {
        ...
    }

    public function hasProgressCallbacks(): bool
    {
        return isset($this->options['progress']) && ! empty($this->options['progress']);
    }
}
```

- Create a new BatchFactory class, extend from `\Illuminate\Bus\BatchFactory`. Override the `make()` method and return the modified `Batch` class

```php
class ModifiedBatchFactory extends \Illuminate\Bus\BatchFactory
{
    public function make(
        BatchRepository $repository,
        string $id,
        string $name,
        int $totalJobs,
        int $pendingJobs,
        int $failedJobs,
        array $failedJobIds,
        array $options,
        CarbonImmutable $createdAt,
        ?CarbonImmutable $cancelledAt,
        ?CarbonImmutable $finishedAt
    ): Batch {
        return new ModifiedBatch($this->queue, $repository, $id, $name, $totalJobs, $pendingJobs, $failedJobs, $failedJobIds, $options, $createdAt, $cancelledAt, $finishedAt);
    }
}
```

- Create a new PendingBatch class, extend from `\Illuminate\Bus\PendingBatch`. Add a `progress()` method which can accept callbacks to execute on progress

```php
class ModifiedPendingBatch extends \\Illuminate\Bus\PendingBatch
{
    public function progress(mixed $callback): self
    {
        $this->options['progress'][] = $callback instanceof Closure
            ? new SerializableClosure($callback)
            : $callback;

        return $this;
    }
}
```

- Create a new Dispatcher class, extend from `\Illuminate\Bus\Dispatcher`. Override the `batch()` method and return the modified `PendingBatch` class

```php
class ModifiedDispatcher extends \Illuminate\Bus\Dispatcher
{
    public function batch($jobs): PendingBatch
    {
        return new ModifiedPendingBatch($this->container, Collection::wrap($jobs));
    }
}
```

- Bind `ModifiedBatchFactory` class when container requests for `\Illuminate\Bus\BatchFactory`
```php
$this->app->bind(\Illuminate\Bus\BatchFactory::class, ModifiedBatchFactory::class);
```

- The `\Illuminate\Bus\Dispatcher` service is defined as a singleton, not possible to replace, instruct container to extend it instead, initiate and assign modified `Dispatcher` class
```php
$this->app->extend(
    \Illuminate\Bus\Dispatcher::class,
    fn () => new ModifiedDispatcher(
        $this->app,
        fn ($connection = null) => $this->app->make(\Illuminate\Contracts\Queue\Factory::class)->connection($connection)
    )
);
```

I hope you also agree that these are a lot of overrides for a simple, optional callback on batch job execution.

### Changes compared to https://github.com/laravel/framework/pull/49099

Compared to the previous PR, on this one, I also invoke `progress` callbacks on job failure if the batch allows failures. This way, progress can still be tracked on failed jobs.