### PR TITLE
[10.x] Fixes `AboutCommand::format()` docblock

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -273,8 +273,8 @@ class AboutCommand extends Command
      * Materialize a function that formats a given value for CLI or JSON output.
      *
      * @param  mixed  $value
-     * @param  (\Closure():(mixed))|null  $console
-     * @param  (\Closure():(mixed))|null  $json
+     * @param  (\Closure(mixed):(mixed))|null  $console
+     * @param  (\Closure(mixed):(mixed))|null  $json
      * @return \Closure(bool):mixed
      */
     public static function format($value, Closure $console = null, Closure $json = null)

--- a/types/Foundation/AboutCommand.php
+++ b/types/Foundation/AboutCommand.php
@@ -1,6 +1,5 @@
 <?php
 
-use Closure;
 use Illuminate\Foundation\Console\AboutCommand;
 
 use function PHPStan\Testing\assertType;

--- a/types/Foundation/AboutCommand.php
+++ b/types/Foundation/AboutCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+use Closure;
+use Illuminate\Foundation\Console\AboutCommand;
+
+use function PHPStan\Testing\assertType;
+
+$format = AboutCommand::format(true, console: fn ($value) => $value ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF');
+
+assertType('Closure(bool): mixed', $format);
+assertType('mixed', $format(false));
+assertType('mixed', $format(true));


### PR DESCRIPTION
fixes https://github.com/laravel/pulse/pull/156/files#r1418654745