### PR TITLE
[10.x] fixing number helper for floating 0

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -193,7 +193,7 @@ class Number
         }
 
         switch (true) {
-            case $number === 0:
+            case (int) $number === 0:
                 return '0';
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -12,6 +12,8 @@ class SupportNumberTest extends TestCase
         $this->needsIntlExtension();
 
         $this->assertSame('0', Number::format(0));
+        $this->assertSame('0', Number::format(0.0));
+        $this->assertSame('0', Number::format(0.00));
         $this->assertSame('1', Number::format(1));
         $this->assertSame('10', Number::format(10));
         $this->assertSame('25', Number::format(25));


### PR DESCRIPTION
Resolving a Critical `Bug` in `Number Helper`: This pull request addresses a significant issue in the Laravel Framework's `Number Helper`, where adding a floating value of 0 (e.g., `0.0` or `0.00`) triggers a `Division by zero` exception. 

The fix involves enhancing the validation logic to account for these scenarios, accompanied by the addition of two comprehensive test cases to ensure the robustness of the solution. 

Furthermore, the bug is effectively resolved by implementing the necessary type casting, specifically converting the number to an integer during the check for 0. 

This enhancement guarantees a seamless experience and prevents potential runtime errors related to `division by zero`.