### PR TITLE
[10.x] Fixing number helper for floating 0.0

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -193,7 +193,7 @@ class Number
         }
 
         switch (true) {
-            case $number === 0:
+            case (int) $number === 0:
                 return '0';
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -194,7 +194,7 @@ class Number
 
         switch (true) {
             case floatval($number) === 0.0:
-                return '0';
+                return $precision > 0 ? static::format(0, $precision, $maxPrecision) : '0';
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));
             case $number >= 1e15:

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -193,7 +193,7 @@ class Number
         }
 
         switch (true) {
-            case (int) $number === 0:
+            case floatval($number) === 0.0:
                 return '0';
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -195,6 +195,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 thousand quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000000));
 
         $this->assertSame('0', Number::forHumans(0));
+        $this->assertSame('0.00', Number::forHumans(0,2));
+        $this->assertSame('0', Number::forHumans(0.0));
+        $this->assertSame('0.00', Number::forHumans(0.0,2));
         $this->assertSame('-1', Number::forHumans(-1));
         $this->assertSame('-1.00', Number::forHumans(-1, precision: 2));
         $this->assertSame('-10', Number::forHumans(-10));
@@ -212,6 +215,10 @@ class SupportNumberTest extends TestCase
 
     public function testSummarize()
     {
+        $this->assertSame('0', Number::abbreviate(0));
+        $this->assertSame('0.00', Number::abbreviate(0,2));
+        $this->assertSame('0.00', Number::abbreviate(0.0,2));
+        $this->assertSame('0', Number::abbreviate(0.0));
         $this->assertSame('1', Number::abbreviate(1));
         $this->assertSame('1.00', Number::abbreviate(1, precision: 2));
         $this->assertSame('10', Number::abbreviate(10));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -195,8 +195,8 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 thousand quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000000));
 
         $this->assertSame('0', Number::forHumans(0));
-        $this->assertSame('0.00', Number::forHumans(0, 2));
         $this->assertSame('0', Number::forHumans(0.0));
+        $this->assertSame('0.00', Number::forHumans(0, 2));
         $this->assertSame('0.00', Number::forHumans(0.0, 2));
         $this->assertSame('-1', Number::forHumans(-1));
         $this->assertSame('-1.00', Number::forHumans(-1, precision: 2));
@@ -215,10 +215,6 @@ class SupportNumberTest extends TestCase
 
     public function testSummarize()
     {
-        $this->assertSame('0', Number::abbreviate(0));
-        $this->assertSame('0.00', Number::abbreviate(0, 2));
-        $this->assertSame('0.00', Number::abbreviate(0.0, 2));
-        $this->assertSame('0', Number::abbreviate(0.0));
         $this->assertSame('1', Number::abbreviate(1));
         $this->assertSame('1.00', Number::abbreviate(1, precision: 2));
         $this->assertSame('10', Number::abbreviate(10));
@@ -255,6 +251,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1KQQ', Number::abbreviate(1000000000000000000000000000000000));
 
         $this->assertSame('0', Number::abbreviate(0));
+        $this->assertSame('0', Number::abbreviate(0.0));
+        $this->assertSame('0.00', Number::abbreviate(0, 2));
+        $this->assertSame('0.00', Number::abbreviate(0.0, 2));
         $this->assertSame('-1', Number::abbreviate(-1));
         $this->assertSame('-1.00', Number::abbreviate(-1, precision: 2));
         $this->assertSame('-10', Number::abbreviate(-10));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -195,9 +195,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 thousand quadrillion quadrillion', Number::forHumans(1000000000000000000000000000000000));
 
         $this->assertSame('0', Number::forHumans(0));
-        $this->assertSame('0.00', Number::forHumans(0,2));
+        $this->assertSame('0.00', Number::forHumans(0, 2));
         $this->assertSame('0', Number::forHumans(0.0));
-        $this->assertSame('0.00', Number::forHumans(0.0,2));
+        $this->assertSame('0.00', Number::forHumans(0.0, 2));
         $this->assertSame('-1', Number::forHumans(-1));
         $this->assertSame('-1.00', Number::forHumans(-1, precision: 2));
         $this->assertSame('-10', Number::forHumans(-10));
@@ -216,8 +216,8 @@ class SupportNumberTest extends TestCase
     public function testSummarize()
     {
         $this->assertSame('0', Number::abbreviate(0));
-        $this->assertSame('0.00', Number::abbreviate(0,2));
-        $this->assertSame('0.00', Number::abbreviate(0.0,2));
+        $this->assertSame('0.00', Number::abbreviate(0, 2));
+        $this->assertSame('0.00', Number::abbreviate(0.0, 2));
         $this->assertSame('0', Number::abbreviate(0.0));
         $this->assertSame('1', Number::abbreviate(1));
         $this->assertSame('1.00', Number::abbreviate(1, precision: 2));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -12,6 +12,8 @@ class SupportNumberTest extends TestCase
         $this->needsIntlExtension();
 
         $this->assertSame('0', Number::format(0));
+        $this->assertSame('0', Number::format(0.0));
+        $this->assertSame('0', Number::format(0.00));
         $this->assertSame('1', Number::format(1));
         $this->assertSame('10', Number::format(10));
         $this->assertSame('25', Number::format(25));


### PR DESCRIPTION
Resolving a Critical `Bug` in `Number Helper`: This pull request addresses a significant issue in the Laravel Framework's `Number Helper`, where adding a floating value of 0 (e.g., `0.0` or `0.00`) triggers a `Division by zero` exception. 

Test cases were failing...
```php
$this->assertSame('0.00', Number::abbreviate(0.0, 2));
$this->assertSame('0', Number::abbreviate(0.0));
```
The fix involves enhancing the validation logic to account for these scenarios, accompanied by the addition of two comprehensive test cases to ensure the robustness of the solution. 

Furthermore, the bug is effectively resolved by implementing the necessary type casting, ~~specifically converting the number to an integer during the check for 0~~ added `floatvat($number) === 0.0` to check if the value is 0 or not...

it supports values between 0 and 1 unlike casting to int, Special thanks to @eusonlito for bringing this to my attention.

This enhancement guarantees a seamless experience and prevents potential runtime errors related to `division by zero`.
