### PR TITLE
[10.x] Accept the length of the secret key 🔐

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -24,7 +24,7 @@ class DownCommand extends Command
                                  {--retry= : The number of seconds after which the request may be retried}
                                  {--refresh= : The number of seconds after which the browser may refresh}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
-                                 {--with-secret : Generate a random secret phrase that may be used to bypass maintenance mode}
+                                 {--with-secret= : Generate a random secret phrase that may be used to bypass maintenance mode}
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
@@ -155,7 +155,7 @@ class DownCommand extends Command
     {
         return match (true) {
             ! is_null($this->option('secret')) => $this->option('secret'),
-            $this->option('with-secret') => Str::random(),
+            ! is_null($this->option('with-secret')) => Str::random($this->option('with-secret')),
             default => null,
         };
     }


### PR DESCRIPTION
This PR adds more flexibility and difficulty to the merged #49171 PR where we can pass the length of the secret key that we wish to generate via the next artisan command

```ARTISAN
php artisan down --with-secret=32
```

This command should generate the next output

> [!NOTE]
> Application is now in maintenance mode.
>  You may bypass maintenance mode via [http://localhost/OSv41HY6bYiN8TkbuiKL09G3lMlOTBmw]