### PR TITLE
[10.x] Adding --create-database option in migrate command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -170,6 +170,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     {
         if ($this->option('force') || $this->option('create-database')) {
             $this->components->info("Creating SQLite database '{$path}'.");
+
             return touch($path);
         }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -193,7 +193,7 @@ class Number
         }
 
         switch (true) {
-            case $number === 0:
+            case (int) $number === 0:
                 return '0';
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -12,6 +12,8 @@ class SupportNumberTest extends TestCase
         $this->needsIntlExtension();
 
         $this->assertSame('0', Number::format(0));
+        $this->assertSame('0', Number::format(0.0));
+        $this->assertSame('0', Number::format(0.00));
         $this->assertSame('1', Number::format(1));
         $this->assertSame('10', Number::format(10));
         $this->assertSame('25', Number::format(25));


### PR DESCRIPTION
## Overview:
This pull request introduces a new option, `--create-database`, to the Laravel migrate command. The purpose of this option is to automate the database creation process if the specified database does not exist, eliminating the need for manual intervention.

## Motivation:
In certain scenarios, developers may find it cumbersome to create databases separately before running migrations. The `--create-database` option streamlines the workflow by allowing the migrate command to automatically create the database if it doesn't already exist. This enhancement promotes a more seamless and efficient development experience.

## Usage:
To use the new option, simply include --create-database when executing the migrate command:
```bash
php artisan migrate --create-database
```
If the specified database does not exist, Laravel will now create it before proceeding with the migrations.

added support for `MySql` and `Sqlite` both.