### PR TITLE
[11.x] Improves `RedirectIfAuthenticated` middleware default redirect

### DIFF
--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -58,7 +58,7 @@ class RedirectIfAuthenticated
             }
 
             if (isset($routes[$uri])) {
-                return '/' . $uri;
+                return '/'.$uri;
             }
         }
 

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -56,7 +56,9 @@ class RedirectIfAuthenticated
             if (Route::has($uri)) {
                 return route($uri);
             }
+        }
 
+        foreach (['dashboard', 'home'] as $uri) {
             if (isset($routes[$uri])) {
                 return '/' . $uri;
             }

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\Response;
 
 class RedirectIfAuthenticated
@@ -12,7 +13,7 @@ class RedirectIfAuthenticated
     /**
      * The callback that should be used to generate the authentication redirect path.
      *
-     * @var callable
+     * @var callable|null
      */
     protected static $redirectToCallback;
 
@@ -41,7 +42,27 @@ class RedirectIfAuthenticated
     {
         return static::$redirectToCallback
             ? call_user_func(static::$redirectToCallback, $request)
-            : '/dashboard';
+            : $this->defaultRedirectTo();
+    }
+
+    /**
+     * Get the default URI the user should be redirected to when they are authenticated.
+     */
+    protected function defaultRedirectTo()
+    {
+        $routes = Route::getRoutes()->get('GET');
+
+        foreach (['dashboard', 'home'] as $uri) {
+            if (Route::has($uri)) {
+                return route($uri);
+            }
+
+            if (isset($routes[$uri])) {
+                return '/' . $uri;
+            }
+        }
+
+        return '/';
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -42,13 +42,13 @@ class RedirectIfAuthenticated
     {
         return static::$redirectToCallback
             ? call_user_func(static::$redirectToCallback, $request)
-            : $this->defaultRedirectTo();
+            : $this->defaultRedirectUri();
     }
 
     /**
      * Get the default URI the user should be redirected to when they are authenticated.
      */
-    protected function defaultRedirectTo()
+    protected function defaultRedirectUri(): string
     {
         foreach (['dashboard', 'home'] as $uri) {
             if (Route::has($uri)) {

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -50,13 +50,13 @@ class RedirectIfAuthenticated
      */
     protected function defaultRedirectTo()
     {
-        $routes = Route::getRoutes()->get('GET');
-
         foreach (['dashboard', 'home'] as $uri) {
             if (Route::has($uri)) {
                 return route($uri);
             }
         }
+
+        $routes = Route::getRoutes()->get('GET');
 
         foreach (['dashboard', 'home'] as $uri) {
             if (isset($routes[$uri])) {

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -191,8 +191,7 @@ class ApplicationBuilder
     {
         $this->app->afterResolving(HttpKernel::class, function ($kernel) use ($callback) {
             $middleware = (new Middleware)
-                ->auth(redirectTo: fn () => route('login'))
-                ->guest(redirectTo: fn () => route('dashboard'));
+                ->auth(redirectTo: fn () => route('login'));
 
             $callback($middleware);
 

--- a/tests/Integration/Auth/Middleware/RedirectIfAuthenticatedTest.php
+++ b/tests/Integration/Auth/Middleware/RedirectIfAuthenticatedTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Middleware;
+
+use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Support\Str;
+use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
+use Orchestra\Testbench\Factories\UserFactory;
+use Orchestra\Testbench\TestCase;
+
+class RedirectIfAuthenticatedTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutExceptionHandling();
+
+        /** @var \Illuminate\Contracts\Routing\Registrar $router */
+        $this->router = $this->app->make(Registrar::class);
+
+        $this->router->get('/login', function () {
+            return response('Login Form');
+        })->middleware(RedirectIfAuthenticated::class);
+
+        UserFactory::new()->create();
+
+        $user = AuthenticationTestUser::first();
+        $this->router->get('/login', function () {
+            return response('Login Form');
+        })->middleware(RedirectIfAuthenticated::class);
+
+        UserFactory::new()->create();
+
+        $this->user = AuthenticationTestUser::first();
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('app.key', Str::random(32));
+        $app['config']->set('auth.providers.users.model', AuthenticationTestUser::class);
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadLaravelMigrations();
+    }
+
+    public function testWhenDashboardNamedRouteIsAvailable()
+    {
+        $this->router->get('/named-dashboard', function () {
+            return response('Named Dashboard');
+        })->name('dashboard');
+
+        $response = $this->actingAs($this->user)->get('/login');
+
+        $response->assertRedirect('/named-dashboard');
+    }
+
+    public function testWhenHomeNamedRouteIsAvailable()
+    {
+        $this->router->get('/named-home', function () {
+            return response('Named Home');
+        })->name('home');
+
+        $response = $this->actingAs($this->user)->get('/login');
+
+        $response->assertRedirect('/named-home');
+    }
+
+    public function testWhenDashboardSlugIsAvailable()
+    {
+        $this->router->get('/dashboard', function () {
+            return response('My Dashboard');
+        });
+
+        $response = $this->actingAs($this->user)->get('/login');
+
+        $response->assertRedirect('/dashboard');
+    }
+
+    public function testWhenHomeSlugIsAvailable()
+    {
+        $this->router->get('/home', function () {
+            return response('My Home');
+        })->name('home');
+
+        $response = $this->actingAs($this->user)->get('/login');
+
+        $response->assertRedirect('/home');
+    }
+
+    public function testWhenHomeOrDashboardAreNotAvailable()
+    {
+        $response = $this->actingAs($this->user)->get('/login');
+
+        $response->assertRedirect('/');
+    }
+
+    public function testWhenGuest()
+    {
+        $response = $this->get('/login');
+
+        $response->assertOk();
+        $response->assertSee('Login Form');
+    }
+}


### PR DESCRIPTION
This pull request improves the `RedirectIfAuthenticated` middleware's default redirect by checking if the redirect exists before actually making the redirect. The following checks are made in this order:

1. "dashboard" named route.
2. "home" named route.
3. "dashboard" slug route.
4. "home" slug route.
5. "/".