### PR TITLE
'when' helper method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -197,6 +197,27 @@ if (! function_exists('optional')) {
     }
 }
 
+if (! function_exists('when')) {
+    /**
+     * When the given value is truthy, return the truthy value / callback
+     * otherwise return the falsy value / callback.
+     *
+     * @param  mixed  $value
+     * @param  callable|mixed  $whenTruthy
+     * @param  callable|mixed  $whenFalsy
+     * @param  bool  $strict
+     * @return mixed
+     */
+    function when(mixed $value, mixed $whenTruthy = true, mixed $whenFalsy = false, bool $strict = false): mixed
+    {
+        if ($strict && $value === true || ! $strict && $value) {
+            return is_callable($whenTruthy) ? $whenTruthy($value) : $whenTruthy;
+        }
+
+        return is_callable($whenFalsy) ? $whenFalsy($value) : $whenFalsy;
+    }
+}
+
 if (! function_exists('preg_replace_array')) {
     /**
      * Replace a given pattern with each value in the array in sequentially.


### PR DESCRIPTION
With Laravel's convenience methods and the rapid development it offers, it makes  traditional if/else statements often feel lengthy and bloated.

The `when` helper accepts an input, a truthy, and a falsy output (outputs can be closures that will be evaluated when needed). It also takes a strict parameter, to determine if the value should be strictly checked as true.

A very crude example of where this helper would come in handy would be something like the below:

```php
$createUser = (bool)$request->input('create');

if ($createUser) {
  $user = User::create();
} else {
  $user = User::make();
}
```

With the `when` helper, this can be refactored to:
```php
$user = when($request->input('create'), fn() => User::create(), fn() => User::make());
```

The value provided is also passed into each callback and mixed values are accepted for both the truthy & falsy response making the possible outputs flexible.

There's many cases for this method being very useful. I've had this helper in my projects for some time now and thought it'd be useful to PR it as I often find myself reaching for it and I feel like other users of Laravel will too.

I'd be happy to write up some tests for this if it's something you'd consider merging in.

Thanks!