### PR TITLE
Added function to get size of files in the given directory

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -188,4 +188,15 @@ interface Filesystem
      * @return bool
      */
     public function deleteDirectory($directory);
+
+    /**
+     * Get and calculate size of files in the given directory
+     * returns size with kilobytes
+     * 
+     * @param  string  $path
+     * @param  bool  $hidden
+     * @return int|bool 
+     */
+
+     public function sizeFilesInDirectore($path , $hidden = false);
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -790,4 +790,31 @@ class Filesystem
     {
         return $this->deleteDirectory($directory, true);
     }
+
+
+    /**
+     * Get and calculate size of files in the given directory
+     * returns size with kilobytes
+     * 
+     * @param  string  $path
+     * @param  bool  $hidden
+     * @return int|bool 
+     */
+
+    public function sizeFilesInDirectore($path , $hidden = false) 
+    {
+        $size = 0;
+
+        if($this->isFile($path)) return false;
+
+        if(!$this->isDirectory($path)) return false;
+
+        foreach($this->files($path , $hidden) as $file)
+        {
+            $size += $this->size($file->getPath());
+        }
+
+        return $size;
+
+    }
 }


### PR DESCRIPTION
I needed a function in my project that get size of a directory path in my project to do some sort of actions.

So i have added a function named sizeFilesInDirectore() that get size of files include in directory.

I think because of this behavior is need to be on right place i did it .. i know everyone can add this function on own project but it's some duplication code and violation of SOLID.

I sent my pull request on filesys-func branch.

Thanks