### PR TITLE
[10.x] Add "noActionOnUpdate" method in Illuminate/Database/Schema/ForeignKeyDefinition

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -35,6 +35,16 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
+     * Indicate that updates should have "no action".
+     *
+     * @return $this
+     */
+    public function noActionOnUpdate()
+    {
+        return $this->onUpdate('no action');
+    }
+
+    /**
      * Indicate that deletes should cascade.
      *
      * @return $this


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

An easier way to define `->onUpdate('no action')` when creating foreign keys in migrations
