### PR TITLE
[10.x] Accounting for timezone when calculating lastDayOfTheMonth

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -563,7 +563,7 @@ trait ManagesFrequencies
     {
         $this->dailyAt($time);
 
-        return $this->spliceIntoPosition(3, Carbon::now()->endOfMonth()->day);
+        return $this->spliceIntoPosition(3, Carbon::now($this->timezone)->endOfMonth()->day);
     }
 
     /**
@@ -644,7 +644,7 @@ trait ManagesFrequencies
      */
     public function timezone($timezone)
     {
-        $this->timezone = $timezone;
+	    $this->timezone = $timezone;
 
         return $this;
     }


### PR DESCRIPTION
This is a hotfix for #49211 

This is a draft as a Test needs to be written in `tests/Console/Scheduling/FrequencyTest.php`.
