### PR TITLE
[10.x] Get user-defined types on PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -46,6 +46,54 @@ class PostgresProcessor extends Processor
     }
 
     /**
+     * Process the results of a types query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processTypes($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'schema' => $result->schema,
+                'implicit' => (bool) $result->implicit,
+                'type' => match (strtolower($result->type)) {
+                    'b' => 'base',
+                    'c' => 'composite',
+                    'd' => 'domain',
+                    'e' => 'enum',
+                    'p' => 'pseudo',
+                    'r' => 'range',
+                    'm' => 'multirange',
+                    default => null,
+                },
+                'category' => match (strtolower($result->category)) {
+                    'a' => 'array',
+                    'b' => 'boolean',
+                    'c' => 'composite',
+                    'd' => 'date_time',
+                    'e' => 'enum',
+                    'g' => 'geometric',
+                    'i' => 'network_address',
+                    'n' => 'numeric',
+                    'p' => 'pseudo',
+                    'r' => 'range',
+                    's' => 'string',
+                    't' => 'timespan',
+                    'u' => 'user_defined',
+                    'v' => 'bit_string',
+                    'x' => 'unknown',
+                    'z' => 'internal_use',
+                    default => null,
+                },
+            ];
+        }, $results);
+    }
+
+    /**
      * Process the results of a columns query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -78,6 +78,17 @@ class Processor
     }
 
     /**
+     * Process the results of a types query.
+     *
+     * @param  array  $results
+     * @return array
+     */
+    public function processTypes($results)
+    {
+        return $results;
+    }
+
+    /**
      * Process the results of a columns query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -212,6 +212,16 @@ class Builder
     }
 
     /**
+     * Get the user-defined types that belong to the database.
+     *
+     * @return array
+     */
+    public function getTypes()
+    {
+        throw new LogicException('This database driver does not support user-defined types.');
+    }
+
+    /**
      * Get all of the table names for the database.
      *
      * @deprecated Will be removed in a future Laravel version.

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -112,7 +112,10 @@ class PostgresGrammar extends Grammar
             ."((t.typinput = 'array_in'::regproc and t.typoutput = 'array_out'::regproc) or t.typtype = 'm') as implicit "
             .'from pg_type t join pg_namespace n on n.oid = t.typnamespace '
             .'left join pg_class c on c.oid = t.typrelid '
-            ."where (t.typrelid = 0 or c.relkind = 'c') and n.nspname not in ('pg_catalog', 'information_schema')";
+            .'left join pg_type el on el.oid = t.typelem '
+            .'left join pg_class ce on ce.oid = el.typrelid '
+            ."where ((t.typrelid = 0 and (ce.relkind = 'c' or ce.relkind is null)) or c.relkind = 'c') "
+            ."and n.nspname not in ('pg_catalog', 'information_schema')";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -102,6 +102,20 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the user-defined types.
+     *
+     * @return string
+     */
+    public function compileTypes()
+    {
+        return 'select t.typname as name, n.nspname as schema, t.typtype as type, t.typcategory as category, '
+            ."((t.typinput = 'array_in'::regproc and t.typoutput = 'array_out'::regproc) or t.typtype = 'm') as implicit "
+            .'from pg_type t join pg_namespace n on n.oid = t.typnamespace '
+            .'left join pg_class c on c.oid = t.typrelid '
+            ."where (t.typrelid = 0 or c.relkind = 'c') and n.nspname not in ('pg_catalog', 'information_schema')";
+    }
+
+    /**
      * Compile the SQL needed to retrieve all table names.
      *
      * @deprecated Will be removed in a future Laravel version.
@@ -474,7 +488,20 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to drop all domains.
+     *
+     * @param  array  $domains
+     * @return string
+     */
+    public function compileDropAllDomains($domains)
+    {
+        return 'drop domain '.implode(',', $this->escapeNames($domains)).' cascade';
+    }
+
+    /**
      * Compile the SQL needed to retrieve all type names.
+     *
+     * @deprecated Will be removed in a future Laravel version.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -54,6 +54,18 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * Get the user-defined types that belong to the database.
+     *
+     * @return array
+     */
+    public function getTypes()
+    {
+        return $this->connection->getPostProcessor()->processTypes(
+            $this->connection->selectFromWriteConnection($this->grammar->compileTypes())
+        );
+    }
+
+    /**
      * Get all of the table names for the database.
      *
      * @deprecated Will be removed in a future Laravel version.
@@ -151,6 +163,8 @@ class PostgresBuilder extends Builder
     /**
      * Get all of the type names for the database.
      *
+     * @deprecated Will be removed in a future Laravel version.
+     *
      * @return array
      */
     public function getAllTypes()
@@ -168,20 +182,27 @@ class PostgresBuilder extends Builder
     public function dropAllTypes()
     {
         $types = [];
+        $domains = [];
 
-        foreach ($this->getAllTypes() as $row) {
-            $row = (array) $row;
+        $schemas = $this->grammar->escapeNames($this->getSchemas());
 
-            $types[] = reset($row);
+        foreach ($this->getTypes() as $type) {
+            if (! $type['implicit'] && in_array($this->grammar->escapeNames([$type['schema']])[0], $schemas)) {
+                if ($type['type'] === 'domain') {
+                    $domains[] = $type['schema'].'.'.$type['name'];
+                } else {
+                    $type[] = $type['schema'].'.'.$type['name'];
+                }
+            }
         }
 
-        if (empty($types)) {
-            return;
+        if (! empty($types)) {
+            $this->connection->statement($this->grammar->compileDropAllTypes($types));
         }
 
-        $this->connection->statement(
-            $this->grammar->compileDropAllTypes($types)
-        );
+        if (! empty($domains)) {
+            $this->connection->statement($this->grammar->compileDropAllDomains($domains));
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -191,7 +191,7 @@ class PostgresBuilder extends Builder
                 if ($type['type'] === 'domain') {
                     $domains[] = $type['schema'].'.'.$type['name'];
                 } else {
-                    $type[] = $type['schema'].'.'.$type['name'];
+                    $types[] = $type['schema'].'.'.$type['name'];
                 }
             }
         }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -14,6 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasView(string $view)
  * @method static array getTables()
  * @method static array getViews()
+ * @method static array getTypes()
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
  * @method static void whenTableHasColumn(string $table, string $column, \Closure $callback)

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -206,8 +206,6 @@ class SchemaBuilderTest extends DatabaseTestCase
         Schema::dropAllTypes();
         $types = Schema::getTypes();
 
-        var_dump($types);
-
         $this->assertEmpty($types);
     }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -196,20 +196,12 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $types = Schema::getTypes();
 
-        var_dump($types);
-
-        $this->assertCount(11, $types);
+        $this->assertCount(5, collect($types)->reject(fn ($type) => $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'pseudo_foo' && $type['type'] === 'pseudo' && ! $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'comp_foo' && $type['type'] === 'composite' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_comp_foo' && $type['type'] === 'base' && $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'enum_foo' && $type['type'] === 'enum' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_enum_foo' && $type['type'] === 'base' && $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'range_foo' && $type['type'] === 'range' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'multirange_foo' && $type['type'] === 'multirange' && $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_range_foo' && $type['type'] === 'base' && $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_multirange_foo' && $type['type'] === 'base' && $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'domain_foo' && $type['type'] === 'domain' && ! $type['implicit']));
-        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_domain_foo' && $type['type'] === 'base' && $type['implicit']));
 
         Schema::dropAllTypes();
         $types = Schema::getTypes();

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -206,6 +206,8 @@ class SchemaBuilderTest extends DatabaseTestCase
         Schema::dropAllTypes();
         $types = Schema::getTypes();
 
+        var_dump($types);
+
         $this->assertEmpty($types);
     }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -196,6 +196,8 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $types = Schema::getTypes();
 
+        var_dump($types);
+
         $this->assertCount(11, $types);
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'pseudo_foo' && $type['type'] === 'pseudo' && ! $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'comp_foo' && $type['type'] === 'composite' && ! $type['implicit']));

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -196,7 +196,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $types = Schema::getTypes();
 
-        $this->assertCount(5, collect($types)->reject(fn ($type) => $type['implicit']));
+        $this->assertCount(11, $types);
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'pseudo_foo' && $type['type'] === 'pseudo' && ! $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'comp_foo' && $type['type'] === 'composite' && ! $type['implicit']));
         $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'enum_foo' && $type['type'] === 'enum' && ! $type['implicit']));

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -182,6 +182,39 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertEmpty(array_diff(['foo', 'bar', 'baz'], array_column($views, 'name')));
     }
 
+    public function testGetAndDropTypes()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a PostgreSQL connection.');
+        }
+
+        DB::statement('create type pseudo_foo');
+        DB::statement('create type comp_foo as (f1 int, f2 text)');
+        DB::statement("create type enum_foo as enum ('new', 'open', 'closed')");
+        DB::statement('create type range_foo as range (subtype = float8)');
+        DB::statement('create domain domain_foo as text');
+
+        $types = Schema::getTypes();
+
+        $this->assertCount(11, $types);
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'pseudo_foo' && $type['type'] === 'pseudo' && ! $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'comp_foo' && $type['type'] === 'composite' && ! $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_comp_foo' && $type['type'] === 'base' && $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'enum_foo' && $type['type'] === 'enum' && ! $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_enum_foo' && $type['type'] === 'base' && $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'range_foo' && $type['type'] === 'range' && ! $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'multirange_foo' && $type['type'] === 'multirange' && $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_range_foo' && $type['type'] === 'base' && $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_multirange_foo' && $type['type'] === 'base' && $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === 'domain_foo' && $type['type'] === 'domain' && ! $type['implicit']));
+        $this->assertTrue(collect($types)->contains(fn ($type) => $type['name'] === '_domain_foo' && $type['type'] === 'base' && $type['implicit']));
+
+        Schema::dropAllTypes();
+        $types = Schema::getTypes();
+
+        $this->assertEmpty($types);
+    }
+
     public function testGetIndexes()
     {
         Schema::create('foo', function (Blueprint $table) {


### PR DESCRIPTION
Fixes #49195

This PR adds `Schema::getTypes()` on PostgreSQL to retrieve all user-defined types and their info and makes `Schema::dropAllTypes()` to use it. This also deprecates `Schema::getAllTypes()`.

## Usage
Like `Schema::getTables()` added on #49020, the new `Schema::getTypes()` lists user-defined types (defined by `create type` and `create domain`).

### `Schema::getTypes()` 
* `name` (`string`): Name of the user-defined type
* `schema` (`string`): Schema name
* `schema_qualified_name` (`string`): Schema-qualified name of the type in `schema_name.type_name` format. (added on Laravel 12.x via #54274)
* `implicit` (`boolean`): Whenever a user-defined type is created, PostgreSQL automatically creates an associated **array type**, also whenever a user-defined range type is created, PostgreSQL automatically creates an associated **multirange type**. The value of `implicit` would be `true` for any implicitly-created types.
* `type` (`string`): Type of the user-defined type: `base`, `composite`, `domain`, `enum`, `pseudo`, `range`, and `multirange`.
* `category` (`string`): Category of the user-defined type: `array`, `boolean`, `composite`, `date_time`, `enum`, `geometric`, `network_address`, `numeric`, `pseudo`, `range`, `string`, `timespan`, `user_defined`, `bit_string`, `unknown`, `internal_use`.

## Changes
| Feature  | Before | After |
| ------------- | ------------- | ------------- |
| `Schema::getTypes()`  | _N/A_  | Added. Uses `PostgresProcessor::processTypes()` and `PostgresGrammar::compileTypes()`  |
| `Schema::dropAllTypes()`  | Uses `PostgresGrammar::getAllTypes()` | Uses newly added `Schema::getTypes()` and drops all types and domains |

## Deprecations
* `\Illuminate\Database\Schema\PostgresBuilder::getAllTypes()`
* `\Illuminate\Database\Schema\Grammars\PostgresGrammar::compileGetAllTypes()`