### PR TITLE
[10.x] Removed deprecated and not used argument

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -110,7 +110,6 @@ class ModelMakeCommand extends GeneratorCommand
         $this->call('make:migration', [
             'name' => "create_{$table}_table",
             '--create' => $table,
-            '--fullpath' => true,
         ]);
     }
 


### PR DESCRIPTION
No usage found.

See: https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php#L22

In the `MigrateMakeCommand` I kept the argument to avoid errors if any packages use `--fullpath`.