### PR TITLE
[10.x] Implemented html entity transcoding for stringable instance

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -306,6 +306,33 @@ class Str
     }
 
     /**
+     * Convert all applicable characters to HTML entities.
+     *
+     * @param  string  $string
+     * @param  int  $flags
+     * @param  string|null  $encoding
+     * @param  bool  $doubleEncode
+     * @return string
+     */
+    public static function encodeHtml(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, ?string $encoding = null, bool $doubleEncode = true): string
+    {
+        return htmlentities($string, $flags, $encoding, $doubleEncode);
+    }
+
+    /**
+     * Convert HTML entities to their corresponding characters.
+     *
+     * @param  string  $string
+     * @param  int  $flags
+     * @param  string|null  $encoding
+     * @return string
+     */
+    public static function decodeHtml(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, ?string $encoding = null): string
+    {
+        return html_entity_decode($string, $flags, $encoding);
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -224,6 +224,31 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Convert all applicable characters to HTML entities.
+     *
+     * @param  int  $flags
+     * @param  string|null  $encoding
+     * @param  bool  $doubleEncode
+     * @return static
+     */
+    public function encodeHtml(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, ?string $encoding = null, bool $doubleEncode = true): static
+    {
+        return new static(Str::encodeHtml($this->value, $flags, $encoding, $doubleEncode));
+    }
+
+    /**
+     * Convert HTML entities to their corresponding characters.
+     *
+     * @param  int  $flags
+     * @param  string|null  $encoding
+     * @return static
+     */
+    public function decodeHtml(int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, ?string $encoding = null): static
+    {
+        return new static(Str::decodeHtml($this->value, $flags, $encoding));
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string|iterable<string>  $needles

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -303,6 +303,34 @@ class SupportStrTest extends TestCase
         $this->assertEquals($expected, Str::containsAll($haystack, $needles, $ignoreCase));
     }
 
+    public function testStrEncodeHtml()
+    {
+        $strings = [
+            'Hello "World"',
+            'Hello <World>',
+            'Hello & World',
+            'سلام‌دنیا',
+        ];
+
+        foreach ($strings as $string) {
+            $this->assertEquals(htmlentities($string), Str::encodeHtml($string));
+        }
+    }
+
+    public function testStrDecodeHtml()
+    {
+        $strings = [
+            'Hello &quot;World&quot;',
+            'Hello &lt;World&gt;',
+            'Hello &amp; World',
+            'سلام&zwnj;دنیا',
+        ];
+
+        foreach ($strings as $string) {
+            $this->assertEquals(html_entity_decode($string), Str::decodeHtml($string));
+        }
+    }
+
     public function testConvertCase()
     {
         // Upper Case Conversion


### PR DESCRIPTION
This PR implements html string transcoding for `Stringable` instances. 

Usage:

```php
use Illuminate\Support\Str;

Str::of($html)->encodeHtml();

Str::of($html)->decodeHtml();
``` 