### PR TITLE
[10.x] Add `nullOnUpdate` method in ForeignKeyDefinition

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -35,6 +35,16 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
+     * Indicate that updates should set the foreign key value to null.
+     *
+     * @return $this
+     */
+    public function nullOnUpdate()
+    {
+        return $this->onUpdate('set null');
+    }
+
+    /**
      * Indicate that updates should have "no action".
      *
      * @return $this


### PR DESCRIPTION
This PR adds a new method for writing easier null on update action, also This PR completes the methods of `ForeignKeyDefinition`.