### PR TITLE
[10.x] Allow error list per field

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1208,21 +1208,23 @@ class TestResponse implements ArrayAccess
                 "Failed to find a validation error in session for key: '{$value}'".PHP_EOL.PHP_EOL.$errorMessage
             );
 
-            if (! is_int($key)) {
-                $hasError = false;
+            foreach (Arr::wrap($value) as $message) {
+                if (! is_int($key)) {
+                    $hasError = false;
 
-                foreach (Arr::wrap($sessionErrors[$key]) as $sessionErrorMessage) {
-                    if (Str::contains($sessionErrorMessage, $value)) {
-                        $hasError = true;
+                    foreach (Arr::wrap($sessionErrors[$key]) as $sessionErrorMessage) {
+                        if (Str::contains($sessionErrorMessage, $message)) {
+                            $hasError = true;
 
-                        break;
+                            break;
+                        }
                     }
-                }
 
-                if (! $hasError) {
-                    PHPUnit::fail(
-                        "Failed to find a validation error for key and message: '$key' => '$value'".PHP_EOL.PHP_EOL.$errorMessage
-                    );
+                    if (! $hasError) {
+                        PHPUnit::fail(
+                            "Failed to find a validation error for key and message: '$key' => '$message'".PHP_EOL.PHP_EOL.$errorMessage
+                        );
+                    }
                 }
             }
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1203,9 +1203,9 @@ class TestResponse implements ArrayAccess
 
         foreach (Arr::wrap($errors) as $key => $value) {
             PHPUnit::assertArrayHasKey(
-                (is_int($key)) ? $value : $key,
+                $resolvedKey = (is_int($key)) ? $value : $key,
                 $sessionErrors,
-                "Failed to find a validation error in session for key: '{$value}'".PHP_EOL.PHP_EOL.$errorMessage
+                "Failed to find a validation error in session for key: '{$resolvedKey}'".PHP_EOL.PHP_EOL.$errorMessage
             );
 
             foreach (Arr::wrap($value) as $message) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1500,6 +1500,27 @@ class TestResponseTest extends TestCase
         $testResponse->assertValid();
     }
 
+    public function testAssertingKeyIsInvalidErrorMessage()
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+        $store->put('errors', $errorBag = new ViewErrorBag);
+        $testResponse = TestResponse::fromBaseResponse(new Response);
+
+        try {
+            $testResponse->assertInvalid(['input_name']);
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringStartsWith("Failed to find a validation error in session for key: 'input_name'", $e->getMessage());
+        }
+
+        try {
+            $testResponse->assertInvalid(['input_name' => 'Expected error message.']);
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringStartsWith("Failed to find a validation error in session for key: 'input_name'", $e->getMessage());
+        }
+    }
+
     public function testInvalidWithListOfErrors()
     {
         app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));


### PR DESCRIPTION
## Feature

It is not currently possible to make an assertion against a single input that is contains more than one error message.

The following pattern is required...

```php
$response->assertInvalid(['email' => 'The email field must be a string.']);
$response->assertInvalid(['email' => 'The email field must be at least 5 characters.']);
```

This PR allows the value of the array to be a list of messages...

```php
$response->assertInvalid([
    'email' => [
        'The email field must be a string.',
         'The email field must be at least 5 characters.',
    ],
]);
```

---

## Bug fix

While adding this I noticed a bug in the existing assertion. The bug occurs when:

1. The key does NOT have any errors.
2. The [key => value] structure is used.

```php
$response->assertInvalid([
    'email' => 'The email field must be a string.',
]);

// "Failed to find a validation error in session for key: 'The email field must be a string.'"
```

You can see that the expected error message is being used instead of the input `key`.