### PR TITLE
[10.x] Add Conditionable to Batched and Chained jobs

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -8,11 +8,14 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
 use Throwable;
 
 class PendingBatch
 {
+    use Conditionable;
+
     /**
      * The IoC container instance.
      *

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -5,10 +5,13 @@ namespace Illuminate\Foundation\Bus;
 use Closure;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
 
 class PendingChain
 {
+    use Conditionable;
+
     /**
      * The class name of the job being dispatched.
      *

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -440,8 +440,8 @@ class JobChainingTestFirstJob implements ShouldQueue
 
     public function handle()
     {
-        static::$ran            = true;
-        static::$usedQueue      = $this->queue;
+        static::$ran = true;
+        static::$usedQueue = $this->queue;
         static::$usedConnection = $this->connection;
     }
 }
@@ -458,8 +458,8 @@ class JobChainingTestSecondJob implements ShouldQueue
 
     public function handle()
     {
-        static::$ran            = true;
-        static::$usedQueue      = $this->queue;
+        static::$ran = true;
+        static::$usedQueue = $this->queue;
         static::$usedConnection = $this->connection;
     }
 }
@@ -476,8 +476,8 @@ class JobChainingTestThirdJob implements ShouldQueue
 
     public function handle()
     {
-        static::$ran            = true;
-        static::$usedQueue      = $this->queue;
+        static::$ran = true;
+        static::$usedQueue = $this->queue;
         static::$usedConnection = $this->connection;
     }
 }
@@ -600,7 +600,7 @@ class JobChainingTestBatchedJob implements ShouldQueue
 
     public function __construct(string $id, int $times = 0)
     {
-        $this->id    = $id;
+        $this->id = $id;
         $this->times = $times;
     }
 
@@ -643,7 +643,7 @@ class JobRunRecorder
 
     public static function reset()
     {
-        self::$results  = [];
+        self::$results = [];
         self::$failures = [];
     }
 }

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -607,7 +607,7 @@ class JobChainingTestBatchedJob implements ShouldQueue
     public function handle()
     {
         for ($i = 0; $i < $this->times; $i++) {
-            $this->batch()->add(new JobChainingTestBatchedJob($this->id . '-' . $i));
+            $this->batch()->add(new JobChainingTestBatchedJob($this->id.'-'.$i));
         }
         JobRunRecorder::record($this->id);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I recently needed to alter the connection on a batch/chain based on a flag, i went to use `when()` and it wasn't available. 

Adding it in with tests
