### PR TITLE
Replace return type of ValidationRule with bool (previously void)

### DIFF
--- a/src/Illuminate/Contracts/Validation/ValidationRule.php
+++ b/src/Illuminate/Contracts/Validation/ValidationRule.php
@@ -12,7 +12,7 @@ interface ValidationRule
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
-     * @return void
+     * @return bool
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void;
+    public function validate(string $attribute, mixed $value, Closure $fail): bool;
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The return-type of `ValidationRule->validate()` is currently `void`, however its return-value is used on Line 654 within `Validator->validateAttribute()` as part of a `bool` comparison. 
Currently the return value `null` will be negated and therefore is always true. This will add a failure to the validator no matter whether it passed or not.
