### PR TITLE
[10.x] Add support for multiple use statements in single `@use` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -12,11 +12,32 @@ trait CompilesUseStatements
      */
     protected function compileUse($expression)
     {
+        if (preg_match('/\(\s*\[\s*(.*)\s*\]\s*\)/', $expression)) {
+            return $this->compileMultipleUseStatements(preg_replace('/\(\s*\[\s*(.*)\s*\]\s*\)/', '$1', $expression));
+        }
+
         $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
         $use = trim($segments[0], " '\"");
         $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';
 
         return "<?php use \\{$use}{$as}; ?>";
+    }
+
+    /**
+     * Compile multiple use statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileMultipleUseStatements($expression)
+    {
+        return collect(explode(',', $expression))
+            ->map(function ($use) {
+                $use = str_replace('=>', ',', $use);
+
+                return $this->compileUse($use);
+            })
+            ->implode("\n");
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -33,6 +33,7 @@ trait CompilesUseStatements
     protected function compileMultipleUseStatements($expression)
     {
         return collect(explode(',', $expression))
+            ->filter(fn ($value) => trim($value))
             ->map(function ($use) {
                 $use = str_replace('=>', ',', $use);
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -12,14 +12,14 @@ trait CompilesUseStatements
      */
     protected function compileUse($expression)
     {
-        if (preg_match('/\(\s*\[\s*(.*)\s*\]\s*\)/', $expression)) {
-            return $this->compileMultipleUseStatements(preg_replace('/\(\s*\[\s*(.*)\s*\]\s*\)/', '$1', $expression));
+        if (preg_match('/\(\s*\[\s*(.*)\s*\]\s*\)/s', $expression)) {
+            return $this->compileMultipleUseStatements(preg_replace('/\(\s*\[\s*(.*)\s*\]\s*\)/s', '$1', $expression));
         }
 
         $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
-        $use = trim($segments[0], " '\"");
-        $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';
+        $use = trim($segments[0], " '\"\n\r\t\v\0");
+        $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"\n\r\t\v\0") : '';
 
         return "<?php use \\{$use}{$as}; ?>";
     }

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -37,7 +37,7 @@ class BladeUseTest extends AbstractBladeTestCase
         $string = <<<EOF
             @use([
                 'SomeNamespace\SomeClass' => 'Foo',
-                'AnotherNamespace\AnotherClass'
+                'AnotherNamespace\AnotherClass',
             ])
             EOF;
 

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -31,4 +31,17 @@ class BladeUseTest extends AbstractBladeTestCase
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?>\n<?php use \AnotherNamespace\AnotherClass as Bar; ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithMultipleValuesOnNewLinesAreCompiled()
+    {
+        $string = <<<EOF
+            @use([
+                'SomeNamespace\SomeClass' => 'Foo',
+                'AnotherNamespace\AnotherClass'
+            ])
+            EOF;
+
+        $expected = "<?php use \SomeNamespace\SomeClass as Foo; ?>\n<?php use \AnotherNamespace\AnotherClass; ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -17,4 +17,18 @@ class BladeUseTest extends AbstractBladeTestCase
         $expected = "Foo <?php use \SomeNamespace\SomeClass; ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithMultipleValuesAreCompiled()
+    {
+        $string = "Foo @use(['SomeNamespace\SomeClass', 'AnotherNamespace\AnotherClass']) bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass; ?>\n<?php use \AnotherNamespace\AnotherClass; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithMultipleValuesWithAsAreCompiled()
+    {
+        $string = "Foo @use(['SomeNamespace\SomeClass' => 'Foo', 'AnotherNamespace\AnotherClass' => 'Bar']) bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?>\n<?php use \AnotherNamespace\AnotherClass as Bar; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR adds support for multiple use statements in single `@use` directive by using an array as its parameter:

```blade
@use([
    'SomeNamespace\SomeClass',
    'AnotherNamespace\AnotherClass',
])
```

you can also use aliases by using the key as the class and the value as the alias:

```blade
@use([
    'SomeNamespace\SomeClass' => 'Foo',
    'AnotherNamespace\AnotherClass',
])
```