### PR TITLE
[10.x] Include partitioned tables on PostgreSQL when retrieving tables

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -87,7 +87,7 @@ class PostgresGrammar extends Grammar
     {
         return 'select c.relname as name, n.nspname as schema, pg_total_relation_size(c.oid) as size, '
             ."obj_description(c.oid, 'pg_class') as comment from pg_class c, pg_namespace n "
-            ."where c.relkind = 'r' and n.oid = c.relnamespace and n.nspname not in ('pg_catalog', 'information_schema')"
+            ."where c.relkind in ('r', 'p') and n.oid = c.relnamespace and n.nspname not in ('pg_catalog', 'information_schema')"
             .'order by c.relname';
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -87,7 +87,7 @@ class PostgresGrammar extends Grammar
     {
         return 'select c.relname as name, n.nspname as schema, pg_total_relation_size(c.oid) as size, '
             ."obj_description(c.oid, 'pg_class') as comment from pg_class c, pg_namespace n "
-            ."where c.relkind = 'r' and n.oid = c.relnamespace "
+            ."where c.relkind = 'r' and n.oid = c.relnamespace and n.nspname not in ('pg_catalog', 'information_schema')"
             .'order by c.relname';
     }
 
@@ -98,7 +98,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileViews()
     {
-        return 'select viewname as name, schemaname as schema, definition from pg_views order by viewname';
+        return "select viewname as name, schemaname as schema, definition from pg_views where schemaname not in ('pg_catalog', 'information_schema') order by viewname";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -37,7 +37,7 @@ class SQLiteBuilder extends Builder
      */
     public function getTables()
     {
-        $withSize = $this->connection->scalar($this->grammar->compileDbstatExists());
+        $withSize = rescue($this->connection->scalar($this->grammar->compileDbstatExists()), false, false);
 
         return $this->connection->getPostProcessor()->processTables(
             $this->connection->selectFromWriteConnection($this->grammar->compileTables($withSize))

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -37,7 +37,7 @@ class SQLiteBuilder extends Builder
      */
     public function getTables()
     {
-        $withSize = rescue($this->connection->scalar($this->grammar->compileDbstatExists()), false, false);
+        $withSize = rescue(fn () => $this->connection->scalar($this->grammar->compileDbstatExists()), false, false);
 
         return $this->connection->getPostProcessor()->processTables(
             $this->connection->selectFromWriteConnection($this->grammar->compileTables($withSize))

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -167,28 +167,11 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
 
     public function testDropPartitionedTables()
     {
-        DB::unprepared(<<<'SQL'
-            CREATE TABLE groups (
-                id BIGSERIAL,
-                tenant_id BIGINT,
-                name VARCHAR,
-                PRIMARY KEY (id, tenant_id)
-            ) PARTITION BY HASH (tenant_id);
+        DB::statement('create table groups (id bigserial, tenant_id bigint, name varchar, primary key (id, tenant_id)) partition by hash (tenant_id)');
+        DB::statement('create table groups_1 partition of groups for values with (modulus 2, remainder 0)');
+        DB::statement('create table groups_2 partition of groups for values with (modulus 2, remainder 1)');
 
-            CREATE TABLE groups_1
-            PARTITION OF groups
-            FOR VALUES WITH (MODULUS 2, REMAINDER 0);
-
-            CREATE TABLE groups_2
-            PARTITION OF groups
-            FOR VALUES WITH (MODULUS 2, REMAINDER 1);
-        SQL);
-
-        $tables = Schema::getTables();
-
-        var_dump($tables);
-
-        $tables = array_column($tables, 'name');
+        $tables = array_column(Schema::getTables(), 'name');
 
         $this->assertContains('groups', $tables);
         $this->assertContains('groups_1', $tables);
@@ -197,23 +180,6 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
         Schema::dropAllTables();
 
         $this->assertEmpty(Schema::getTables());
-
-        DB::unprepared(<<<'SQL'
-            CREATE TABLE groups (
-                id BIGSERIAL,
-                tenant_id BIGINT,
-                name VARCHAR,
-                PRIMARY KEY (id, tenant_id)
-            ) PARTITION BY HASH (tenant_id);
-
-            CREATE TABLE groups_1
-            PARTITION OF groups
-            FOR VALUES WITH (MODULUS 2, REMAINDER 0);
-
-            CREATE TABLE groups_2
-            PARTITION OF groups
-            FOR VALUES WITH (MODULUS 2, REMAINDER 1);
-        SQL);
     }
 
     protected function hasView($schema, $table)

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -181,6 +181,8 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
 
         $this->artisan('migrate:install');
 
+        $tables = array_column(Schema::getTables(), 'name');
+
         $this->assertNotContains('groups', $tables);
         $this->assertNotContains('groups_1', $tables);
         $this->assertNotContains('groups_2', $tables);

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -179,7 +179,11 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
 
         Schema::dropAllTables();
 
-        $this->assertEmpty(Schema::getTables());
+        $this->artisan('migrate:install');
+
+        $this->assertNotContains('groups', $tables);
+        $this->assertNotContains('groups_1', $tables);
+        $this->assertNotContains('groups_2', $tables);
     }
 
     protected function hasView($schema, $table)


### PR DESCRIPTION
Fixes #49321 by including partitioned tables on `Schema::getTables()`.

Fixes orchestral/testbench#388 by simply rescue compiling the query as some legacy SQLite versions doesn't support `pragma_compile_options`.