### PR TITLE
[10.x] Add `--clean` option to `vendor:publish` command

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -50,6 +50,7 @@ class VendorPublishCommand extends Command
     protected $signature = 'vendor:publish
                     {--existing : Publish and overwrite only the files that have already been published}
                     {--force : Overwrite any existing files}
+                    {--clean : Delete existing files in published directories}
                     {--all : Publish assets for all service providers without prompt}
                     {--provider= : The service provider that has assets you want to publish}
                     {--tag=* : One or many tags that have assets you want to publish}';
@@ -276,7 +277,11 @@ class VendorPublishCommand extends Command
 
         $this->moveManagedFiles(new MountManager([
             'from' => new Flysystem(new LocalAdapter($from)),
-            'to' => new Flysystem(new LocalAdapter($to, $visibility)),
+            'to' => tap(new Flysystem(new LocalAdapter($to, $visibility)), function ($files) {
+                if ($this->option('clean')) {
+                    $files->deleteDirectory('');
+                }
+            }),
         ]));
 
         $this->status($from, $to, 'directory');


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/48964.

I have a package that uses Vite to build assets. When the package is installed in a project, you run the `vendor:publish` command to publish those assets. You might end up with the following assets in your public folder:
<img width="189" alt="Screen Shot 2023-12-11 at 16 27 27" src="https://github.com/laravel/framework/assets/22586858/78068f1c-372d-4528-a615-5f7a6eb09646">

When the package's assets change, you have to run the `vendor:publish` command again to get the new assets in your project. When you do that, you get the following result:
<img width="199" alt="Screen Shot 2023-12-11 at 16 27 51" src="https://github.com/laravel/framework/assets/22586858/c2b38fcf-716d-48d0-a347-606957c5b7d6">
Because the asset filenames change, the existing old files are not deleted and the new files are just added to the existing directory. This is a problem, as the old files will start to accumulate in that folder.

This PR fixes that by introducing a `--clean` option to the `vendor:publish` command. When you use that command option, any existing files in a published directory will be deleted. That way, you end up with the correct and new files in your project:
<img width="205" alt="Screen Shot 2023-12-11 at 16 31 30" src="https://github.com/laravel/framework/assets/22586858/ed067596-6523-4ed6-8ecd-26ecda718ac5">