### PR TITLE
[11.x] Adds `update_date_on_publish` to configuration file

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -121,7 +121,10 @@ return [
     |
     */
 
-    'migrations' => 'migrations',
+    'migrations' => [
+        'table' => 'migrations',
+        'update_date_on_publish' => true,
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -69,8 +69,12 @@ class DumpCommand extends Command
      */
     protected function schemaState(Connection $connection)
     {
+        $migrations = Config::get('database.migrations', 'migrations');
+
+        $migrationTable = is_array($migrations) ? ($migrations['table'] ?? 'migrations') : $migrations;
+
         return $connection->getSchemaState()
-                ->withMigrationTable($connection->getTablePrefix().Config::get('database.migrations', 'migrations'))
+                ->withMigrationTable($connection->getTablePrefix().$migrationTable)
                 ->handleOutputUsing(function ($type, $buffer) {
                     $this->output->write($buffer);
                 });

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -59,7 +59,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     protected function registerRepository()
     {
         $this->app->singleton('migration.repository', function ($app) {
-            $table = $app['config']['database.migrations'];
+            $migrations = $app['config']['database.migrations'];
+
+            $table = is_array($migrations) ? ($migrations['table'] ?? null) : $migrations;
 
             return new DatabaseMigrationRepository($app['db'], $table);
         });

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -130,9 +130,11 @@ trait DatabaseTruncation
      */
     protected function exceptTables(?string $connectionName): array
     {
-        if (property_exists($this, 'exceptTables')) {
-            $migrationsTable = $this->app['config']->get('database.migrations');
+        $migrations = $this->app['config']->get('database.migrations');
 
+        $migrationsTable = is_array($migrations) ? ($migrations['table'] ?? null) : $migrations;
+
+        if (property_exists($this, 'exceptTables')) {
             if (array_is_list($this->exceptTables ?? [])) {
                 return array_merge(
                     $this->exceptTables ?? [],
@@ -146,7 +148,7 @@ trait DatabaseTruncation
             );
         }
 
-        return [$this->app['config']->get('database.migrations')];
+        return [$migrationsTable];
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -285,7 +285,9 @@ abstract class ServiceProvider
     {
         $this->publishes($paths, $groups);
 
-        static::$publishableMigrationPaths = array_unique(array_merge(static::$publishableMigrationPaths, array_keys($paths)));
+        if ($this->app->config->get('database.migrations.update_date_on_publish', false)) {
+            static::$publishableMigrationPaths = array_unique(array_merge(static::$publishableMigrationPaths, array_keys($paths)));
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request adds `update_date_on_publish` to the configuration file.

This new configuration option allows users to specify that the "vendor:publish" command should publish migrations with an up-to-date date in the migration file. By default, this new setting is disabled for older applications because they still have `config/database.php` with the older format. However, for new applications starting with Laravel 11, their `database.php` configuration file won't be published, so this setting will be enabled.

The code that accesses the `database.migrations` got updated, so it supports both formats.