### PR TITLE
Ability to test chained job via closure

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -421,6 +421,18 @@ class BusFake implements Fake, QueueingDispatcher
                             ! $chain[$index]($chainedBatch->toPendingBatch())) {
                             return false;
                         }
+                    } elseif ($chain[$index] instanceof Closure) {
+                        [$expectedType, $callback] = [$this->firstClosureParameterType($chain[$index]), $chain[$index]];
+
+                        $chainedJob = unserialize($serializedChainedJob);
+
+                        if (! $chainedJob instanceof $expectedType) {
+                            throw new RuntimeException('The chained job was expected to be of type '.$expectedType.', '.$chainedJob::class.' chained.');
+                        }
+
+                        if (! $callback($chainedJob)) {
+                            return false;
+                        }
                     } elseif (is_string($chain[$index])) {
                         if ($chain[$index] != get_class(unserialize($serializedChainedJob))) {
                             return false;

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -534,6 +534,16 @@ class SupportTestingBusFakeTest extends TestCase
             ChainedJobStub::class,
         ]);
 
+        $this->fake->chain([
+            new ChainedJobStub(123),
+            new ChainedJobStub(456),
+        ])->dispatch();
+
+        $this->fake->assertChained([
+            fn (ChainedJobStub $job) => $job->id === 123,
+            fn (ChainedJobStub $job) => $job->id === 456,
+        ]);
+
         Container::setInstance(null);
     }
 
@@ -777,6 +787,13 @@ class BusJobStub
 class ChainedJobStub
 {
     use Queueable;
+
+    public $id;
+
+    public function __construct($id = null)
+    {
+        $this->id = $id;
+    }
 }
 
 class OtherBusJobStub


### PR DESCRIPTION
This PR adds the ability to test chained jobs via closures.

```php
Bus::assertChained([
    fn (ShipOrder $job) => $job->order->is($order),
    RecordShipment::class,
    fn (UpdateInventory $job) => $job->queue === 'internal',
]);
```

While not documented, you can already test the first chained job via a closure. However, subsequent jobs will throw an exception: Serialization of 'Closure' is not allowed

Allowing subsequent chained jobs to be tested via closures not only aligns with how jobs are tested in other assertions, but lets you strengthen your tests.

**Note:** the job type hint is required. This is a common requirement within the `BusFake` and helps yield a better failure message when job order/type mismatch.