### PR TITLE
[10.x] Add Blade `@session` Directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -30,6 +30,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesLayouts,
         Concerns\CompilesLoops,
         Concerns\CompilesRawPhp,
+        Concerns\CompilesSessions,
         Concerns\CompilesStacks,
         Concerns\CompilesStyles,
         Concerns\CompilesTranslations,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
@@ -16,7 +16,7 @@ trait CompilesSessions
 
         return '<?php $__sessionArgs = ['.$expression.'];
 if (session()->has($__sessionArgs[0])) :
-if (isset($session)) { $__sessionOriginal = $session; }
+if (isset($session)) { $__sessionPrevious[] = $session; }
 $session = session()->get($__sessionArgs[0]); ?>';
     }
 
@@ -29,7 +29,7 @@ $session = session()->get($__sessionArgs[0]); ?>';
     protected function compileEndsession($expression)
     {
         return '<?php unset($session);
-if (isset($__sessionOriginal)) { $session = $__sessionOriginal; }
+if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $session = array_pop($__sessionPrevious); }
 endif;
 unset($__sessionArgs); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
@@ -30,6 +30,7 @@ $session = session()->get($__sessionArgs[0]); ?>';
     {
         return '<?php unset($session);
 if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $session = array_pop($__sessionPrevious); }
+if (isset($__sessionPrevious) && empty($__sessionPrevious)) { unset($__sessionPrevious); }
 endif;
 unset($__sessionArgs); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesSessions
+{
+    /**
+     * Compile the session statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSession($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return '<?php $__sessionArgs = ['.$expression.'];
+if (session()->has($__sessionArgs[0])) :
+if (isset($session)) { $__sessionOriginal = $session; }
+$session = session()->get($__sessionArgs[0]); ?>';
+    }
+
+    /**
+     * Compile the endsession statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndsession($expression)
+    {
+        return '<?php unset($session);
+if (isset($__sessionOriginal)) { $session = $__sessionOriginal; }
+endif;
+unset($__sessionArgs); ?>';
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesSessions.php
@@ -16,8 +16,8 @@ trait CompilesSessions
 
         return '<?php $__sessionArgs = ['.$expression.'];
 if (session()->has($__sessionArgs[0])) :
-if (isset($session)) { $__sessionPrevious[] = $session; }
-$session = session()->get($__sessionArgs[0]); ?>';
+if (isset($value)) { $__sessionPrevious[] = $value; }
+$value = session()->get($__sessionArgs[0]); ?>';
     }
 
     /**
@@ -28,8 +28,8 @@ $session = session()->get($__sessionArgs[0]); ?>';
      */
     protected function compileEndsession($expression)
     {
-        return '<?php unset($session);
-if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $session = array_pop($__sessionPrevious); }
+        return '<?php unset($value);
+if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $value = array_pop($__sessionPrevious); }
 if (isset($__sessionPrevious) && empty($__sessionPrevious)) { unset($__sessionPrevious); }
 endif;
 unset($__sessionArgs); ?>';

--- a/tests/View/Blade/BladeSessionTest.php
+++ b/tests/View/Blade/BladeSessionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeSessionTest extends AbstractBladeTestCase
+{
+    public function testSessionsAreCompiled()
+    {
+        $string = '
+@session(\'status\')
+    <span>{{ $session }}</span>
+@endsession';
+        $expected = '
+<?php $__sessionArgs = [\'status\'];
+if (session()->has($__sessionArgs[0])) :
+if (isset($session)) { $__sessionOriginal = $session; }
+$session = session()->get($__errorArgs[0]); ?>
+    <span><?php echo e($session); ?></span>
+<?php unset($session);
+if (isset($__sessionOriginal)) { $session = $__sessionOriginal; }
+endif;
+unset($__sessionArgs); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeSessionTest.php
+++ b/tests/View/Blade/BladeSessionTest.php
@@ -18,6 +18,7 @@ $session = session()->get($__sessionArgs[0]); ?>
     <span><?php echo e($session); ?></span>
 <?php unset($session);
 if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $session = array_pop($__sessionPrevious); }
+if (isset($__sessionPrevious) && empty($__sessionPrevious)) { unset($__sessionPrevious); }
 endif;
 unset($__sessionArgs); ?>';
 

--- a/tests/View/Blade/BladeSessionTest.php
+++ b/tests/View/Blade/BladeSessionTest.php
@@ -8,16 +8,16 @@ class BladeSessionTest extends AbstractBladeTestCase
     {
         $string = '
 @session(\'status\')
-    <span>{{ $session }}</span>
+    <span>{{ $value }}</span>
 @endsession';
         $expected = '
 <?php $__sessionArgs = [\'status\'];
 if (session()->has($__sessionArgs[0])) :
-if (isset($session)) { $__sessionPrevious[] = $session; }
-$session = session()->get($__sessionArgs[0]); ?>
-    <span><?php echo e($session); ?></span>
-<?php unset($session);
-if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $session = array_pop($__sessionPrevious); }
+if (isset($value)) { $__sessionPrevious[] = $value; }
+$value = session()->get($__sessionArgs[0]); ?>
+    <span><?php echo e($value); ?></span>
+<?php unset($value);
+if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $value = array_pop($__sessionPrevious); }
 if (isset($__sessionPrevious) && empty($__sessionPrevious)) { unset($__sessionPrevious); }
 endif;
 unset($__sessionArgs); ?>';

--- a/tests/View/Blade/BladeSessionTest.php
+++ b/tests/View/Blade/BladeSessionTest.php
@@ -14,7 +14,7 @@ class BladeSessionTest extends AbstractBladeTestCase
 <?php $__sessionArgs = [\'status\'];
 if (session()->has($__sessionArgs[0])) :
 if (isset($session)) { $__sessionOriginal = $session; }
-$session = session()->get($__errorArgs[0]); ?>
+$session = session()->get($__sessionArgs[0]); ?>
     <span><?php echo e($session); ?></span>
 <?php unset($session);
 if (isset($__sessionOriginal)) { $session = $__sessionOriginal; }

--- a/tests/View/Blade/BladeSessionTest.php
+++ b/tests/View/Blade/BladeSessionTest.php
@@ -13,11 +13,11 @@ class BladeSessionTest extends AbstractBladeTestCase
         $expected = '
 <?php $__sessionArgs = [\'status\'];
 if (session()->has($__sessionArgs[0])) :
-if (isset($session)) { $__sessionOriginal = $session; }
+if (isset($session)) { $__sessionPrevious[] = $session; }
 $session = session()->get($__sessionArgs[0]); ?>
     <span><?php echo e($session); ?></span>
 <?php unset($session);
-if (isset($__sessionOriginal)) { $session = $__sessionOriginal; }
+if (isset($__sessionPrevious) && !empty($__sessionPrevious)) { $session = array_pop($__sessionPrevious); }
 endif;
 unset($__sessionArgs); ?>';
 


### PR DESCRIPTION
This PR adds a `@session` Blade directive.

Instead of implementing the basic idea as discussed on https://github.com/laravel/framework/discussions/45786, I implemented it like the `@error` Blade directive to also have a usable variable within the directive.

## Benefits
* Cleaner code within Blade views.
* Access to a `$session` template variable within the directive.

## Breaking Changes
* Only if someone is using a custom `@session` directive already.

## Usage
Before:
```php
@if(session('status'))
<div class="alert alert-success" role="alert">
    {{ session('status') }}
</div>
@endif
```

After:
(Updated example to reflect the final [commit](https://github.com/laravel/framework/pull/49339#issuecomment-1858039799))
```php
@session('status')
<div class="alert alert-success" role="alert">
    {{ $value }}
</div>
@endsession
```

## Caveats
It makes use of the global `session()` helper, as I wasn't sure if I should call the session Facade directly to call the `set` and `get` methods. However, that can be swapped to the Facade if that approach is preferred.