### PR TITLE
[10.x] Handle missing translations: more robust handling of callback return value

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -348,7 +348,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $key = call_user_func(
             $this->missingTranslationKeyCallback,
             $key, $replace, $locale, $fallback
-        );
+        ) ?? $key;
 
         $this->handleMissingTranslationKeys = true;
 

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -56,4 +56,18 @@ class TranslatorTest extends TestCase
 
         $this->app['translator']->handleMissingKeysUsing(null);
     }
+
+    public function testItCanHandleMissingKeysNoReturn()
+    {
+        $this->app['translator']->handleMissingKeysUsing(function ($key) {
+            $_SERVER['__missing_translation_key'] = $key;
+        });
+
+        $key = $this->app['translator']->get('some missing key');
+
+        $this->assertSame('some missing key', $key);
+        $this->assertSame('some missing key', $_SERVER['__missing_translation_key']);
+
+        $this->app['translator']->handleMissingKeysUsing(null);
+    }
 }


### PR DESCRIPTION
**What's changed**

Currently, using the `Lang::handleMissingKeysUsing` method will cause `translator->get()` to return `null` for missing keys when the user supplied closure doesn't return a value. This PR ensures that if the user-defined callback is missing a return statement, or otherwise returns `null`, that the translation key (rather than `null`) is returned by `__()`, keeping with established behavior prior to https://github.com/laravel/framework/pull/49040

**Why this PR should be merged**

1. This PR represents a very small code change.
2. This PR handles an edge case which makes `Lang::handleMissingKeysUsing` less likely to break an application.
3. This PR allows users to only "do something" in their missing translation handler closure - without having to worry about returning a value.
4. Many pieces of code inside the framework and outside depend on the translator returning the translation key unchanged if the key is missing. Consider the code below. It is not immediately obvious that it would cause that expectation to be violated. Currently, this code causes `null` to be returned by the translator for missing keys.

```php
Lang::handleMissingKeysUsing(function (string $key) {
    $message = "Missing translation key [$key] detected.";

    // Handle differently depending upon config.
    match (config('base.missing_translation_behaviour')) {
        'exception' => throw new \Exception($message),
        'log_error' => Log::error($message),
        'log_warning' => Log::warning($message),
        'log_warning' => info($message),
        default => null,
    };
});
```

This PR is following on from https://github.com/laravel/framework/pull/49040