### PR TITLE
[10.x] Add `classFromFile` method to Filesystem

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelPruningFinished;
 use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
 use InvalidArgumentException;
 use Symfony\Component\Finder\Finder;
 
@@ -126,15 +126,8 @@ class PruneCommand extends Command
         }
 
         return collect((new Finder)->in($this->getDefaultPath())->files()->name('*.php'))
-            ->map(function ($model) {
-                $namespace = $this->laravel->getNamespace();
-
-                return $namespace.str_replace(
-                    ['/', '.php'],
-                    ['\\', ''],
-                    Str::after($model->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
-                );
-            })->when(! empty($except), function ($models) use ($except) {
+            ->map(fn ($model) => File::classFromFile($model->getRealPath()))
+            ->when(! empty($except), function ($models) use ($except) {
                 return $models->reject(function ($model) use ($except) {
                     return in_array($model, $except);
                 });

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -6,6 +6,7 @@ use ErrorException;
 use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
@@ -599,6 +600,25 @@ class Filesystem
         return iterator_to_array(
             Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->sortByName(),
             false
+        );
+    }
+
+    /**
+     * Get the PSR-4 class name for a file.
+     *
+     * @return ($files is string ? class-string : array<int, class-string>)
+     */
+    public function classFromFile(array|string $files, ?string $basePath = null): string|array
+    {
+        $namespaces = app('composer')->getNamespaces();
+        $realBasePath = Str::of(realpath($basePath ?? base_path()))
+            ->finish(DIRECTORY_SEPARATOR)
+            ->toString();
+
+        return str_replace(
+            search: [$realBasePath, ...array_values($namespaces), DIRECTORY_SEPARATOR, '.php'],
+            replace: ['', ...array_keys($namespaces), '\\', ''],
+            subject: $files,
         );
     }
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -17,8 +17,8 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\InteractsWithTime;
-use Illuminate\Support\Str;
 use ReflectionClass;
 use SplFileInfo;
 use Symfony\Component\Console\ConsoleEvents;
@@ -357,15 +357,11 @@ class Kernel implements KernelContract
      *
      * @param  \SplFileInfo  $file
      * @param  string  $namespace
-     * @return string
+     * @return class-string
      */
     protected function commandClassFromFile(SplFileInfo $file, string $namespace): string
     {
-        return $namespace.str_replace(
-            ['/', '.php'],
-            ['\\', ''],
-            Str::after($file->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
-        );
+        return File::classFromFile($file->getRealPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Events;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -90,7 +91,7 @@ class DiscoverEvents
      *
      * @param  \SplFileInfo  $file
      * @param  string  $basePath
-     * @return string
+     * @return class-string
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
@@ -98,13 +99,7 @@ class DiscoverEvents
             return call_user_func(static::$guessClassNamesUsingCallback, $file, $basePath);
         }
 
-        $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
-
-        return str_replace(
-            [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'],
-            ['\\', app()->getNamespace()],
-            ucfirst(Str::replaceLast('.php', '', $class))
-        );
+        return File::classFromFile($file->getRealPath(), $basePath);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -41,6 +41,7 @@ namespace Illuminate\Support\Facades;
  * @method static array glob(string $pattern, int $flags = 0)
  * @method static \Symfony\Component\Finder\SplFileInfo[] files(string $directory, bool $hidden = false)
  * @method static \Symfony\Component\Finder\SplFileInfo[] allFiles(string $directory, bool $hidden = false)
+ * @method static string|array<int, class-string> classFromFile(string|array $file, ?string $basePath = null)
  * @method static array directories(string $directory)
  * @method static void ensureDirectoryExists(string $path, int $mode = 0755, bool $recursive = true)
  * @method static bool makeDirectory(string $path, int $mode = 0755, bool $recursive = false, bool $force = false)


### PR DESCRIPTION
Hello!

This PR adds a `classFromFile` method to the `Filesystem` class / `File` facade0 (although this might could also be placed on the Composer class instead) which returns the PSR-4 qualified class from a file.

There are several places in the codebase that repeat similar logic to convert a filename to the class name. I also needed this same logic in user-land so I duplicated this in my app.

This:
- moves the 'class from file' logic to a single location
- uses the namespaces defined in `composer.json` to work for any namespace (not just `App`)
- falls back to the defined app namespace if a project is not deploy to production with a `composer.json` (could happen I suppose, but can remove if there's no concern with it)

Thanks!