### PR TITLE
[10.x] Add Support for Specifying Columns in Eloquent `fresh()` Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -370,7 +370,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * @param  array<array-key, string>|string  $with
      * @return static
      */
-    public function fresh($with = [])
+    public function fresh($with = [], $columns = ['*'])
     {
         if ($this->isEmpty()) {
             return new static;
@@ -381,7 +381,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $freshModels = $model->newQueryWithoutScopes()
             ->with(is_string($with) ? func_get_args() : $with)
             ->whereIn($model->getKeyName(), $this->modelKeys())
-            ->get()
+            ->get($columns)
             ->getDictionary();
 
         return $this->filter(fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1671,7 +1671,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array|string  $with
      * @return static|null
      */
-    public function fresh($with = [])
+    public function fresh($with = [], $columns = ['*'])
     {
         if (! $this->exists) {
             return;
@@ -1680,7 +1680,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         return $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
             ->useWritePdo()
             ->with(is_string($with) ? func_get_args() : $with)
-            ->first();
+            ->first($columns);
     }
 
     /**


### PR DESCRIPTION

**Overview**:
This pull request enhances the Eloquent fresh method to allow specifying columns.

**Changes**:
Added support for specifying columns in the fresh method to selectively load only the required data.

**Example Usage**:
```
$user = User::create([
    'id' => 1,
    'email' => 'taylorotwell@gmail.com',
    'name' => null,
]);

$user->update([
    'name' => 'Mathieu TUDISCO',
]);

// Before
// ['id' => 1, 'email' => 'taylorotwell@gmail.com', 'name' => 'Mathieu TUDISCO']
$freshUser = $user->fresh()->toArray();

// After
// ['id' => 1, 'name' => 'Mathieu TUDISCO']
$freshUser = $user->fresh(columns: [
    'id',
    'name',
])->toArray();

```
