### PR TITLE
[10.x] Avoid using `rescue()` in standalone `illuminate/database` component.

### DIFF
--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\File;
 
 class SQLiteBuilder extends Builder
@@ -37,7 +38,13 @@ class SQLiteBuilder extends Builder
      */
     public function getTables()
     {
-        $withSize = rescue(fn () => $this->connection->scalar($this->grammar->compileDbstatExists()), false, false);
+        $withSize = false;
+
+        try {
+            $withSize = $this->connection->scalar($this->grammar->compileDbstatExists());
+        } catch (QueryException $e) {
+            //
+        }
 
         return $this->connection->getPostProcessor()->processTables(
             $this->connection->selectFromWriteConnection($this->grammar->compileTables($withSize))


### PR DESCRIPTION
fixes laravel/framework#49354

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
