### PR TITLE
[10.x] Exclude extension types on PostgreSQL when retrieving types

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -115,7 +115,7 @@ class PostgresGrammar extends Grammar
             .'left join pg_type el on el.oid = t.typelem '
             .'left join pg_class ce on ce.oid = el.typrelid '
             ."where ((t.typrelid = 0 and (ce.relkind = 'c' or ce.relkind is null)) or c.relkind = 'c') "
-            ."and not exists (select 1 from pg_depend d where d.objid = t.oid and d.deptype = 'e') "
+            ."and not exists (select 1 from pg_depend d where d.objid in (t.oid, t.typelem) and d.deptype = 'e') "
             ."and n.nspname not in ('pg_catalog', 'information_schema')";
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -115,6 +115,7 @@ class PostgresGrammar extends Grammar
             .'left join pg_type el on el.oid = t.typelem '
             .'left join pg_class ce on ce.oid = el.typrelid '
             ."where ((t.typrelid = 0 and (ce.relkind = 'c' or ce.relkind is null)) or c.relkind = 'c') "
+            ."and not exists (select 1 from pg_depend d where d.objid = t.oid and d.deptype = 'e') "
             ."and n.nspname not in ('pg_catalog', 'information_schema')";
     }
 


### PR DESCRIPTION
Related to #49303

Fixes #49349 by excluding the types dependent to an extension.

There seems to be no way to write a test for this ATM, as there is no PostgreSQL extension installed.