### PR TITLE
[11.x] Disconnecting the database connection after testing 

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -33,7 +33,7 @@ trait DatabaseTransactions
                 $connection->unsetEventDispatcher();
                 $connection->rollBack();
                 $connection->setEventDispatcher($dispatcher);
-                $connection->disconnect();
+                $database->purge($name);
             }
         });
     }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -108,7 +108,7 @@ trait RefreshDatabase
                 $connection->unsetEventDispatcher();
                 $connection->rollBack();
                 $connection->setEventDispatcher($dispatcher);
-                $connection->disconnect();
+                $database->purge($name);
             }
         });
     }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -187,6 +187,12 @@ abstract class TestCase extends BaseTestCase
 
             ParallelTesting::callTearDownTestCaseCallbacks($this);
 
+            $database = $this->app['db'] ?? null;
+
+            foreach (array_keys($database?->getConnections() ?? []) as $name) {
+                $database->purge($name);
+            }
+
             $this->app->flush();
 
             $this->app = null;


### PR DESCRIPTION
fixes #49311

#49327 has been reverted as a breaking change.
I would like to propose the same fix as a major version update.

This fix prevents connections from leaking when testing with a database without having to write workaround code in each test.
