### PR TITLE
[10.x] Use 'none' as key when Configuring the MultiSearch and MultiSelectPrompt prompts

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -63,8 +63,8 @@ trait ConfiguresPrompts
             }
 
             return $this->promptUntilValid(
-                fn () => collect($this->components->choice($prompt->label, ['' => 'None', ...$prompt->options], 'None', multiple: true))
-                    ->reject('')
+                fn () => collect($this->components->choice($prompt->label, ['none' => 'None', ...$prompt->options], 'none', multiple: true))
+                    ->reject('none')
                     ->all(),
                 $prompt->required,
                 $prompt->validate

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -103,8 +103,8 @@ trait ConfiguresPrompts
                             ->all();
                     }
 
-                    return collect($this->components->choice($prompt->label, ['' => 'None', ...$options], '', multiple: true))
-                        ->reject('')
+                    return collect($this->components->choice($prompt->label, ['none' => 'None', ...$options], 'none', multiple: true))
+                        ->reject('none')
                         ->values()
                         ->all();
                 }


### PR DESCRIPTION
Without this change, the Symfony Console [ChoiceQuestion gives an InvalidArgumentException](https://github.com/symfony/console/blob/6.4/Question/ChoiceQuestion.php#L123). A value of "" is invalid and that is what None is using without this PR. 

I found this when [adding Prompts to Drush](https://github.com/drush-ops/drush/pull/5823/files), but I think it applies to Laravel Framework as well. Here is our test failure that showed this bug https://app.circleci.com/pipelines/github/drush-ops/drush/6234/workflows/d0ec5398-d4dd-4b85-8bf8-5a7d31c8c377/jobs/36497/tests#failed-test-0

I looked into adding a test for this but I'm new here and could use guidance.  The bug wont show up if we mock the ChoiceQuestion, as existing tests do. 

In case anyone is unclear - the bug is in this repo, not in the Prompts repo.
