### PR TITLE
[10.x] Feature Helper TryOr

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -416,6 +416,29 @@ if (! function_exists('windows_os')) {
     }
 }
 
+if (! function_exists('try_or')) {
+    /**
+     * Execute the given closure, logging any exceptions and returning a default value if an exception occurs.
+     *
+     * @param  \Closure  $callback  The closure to execute.
+     * @param  mixed  $default  The default value to return in case of an exception.
+     * @return mixed The result of the closure or the default value.
+     */
+    function try_or(\Closure $callback, $default = null)
+    {
+        try {
+            return $callback();
+        } catch (\Throwable $th) {
+            \Illuminate\Support\Facades\Log::error(
+                "Error in {$th->getFile()}, line {$th->getLine()}: {$th->getMessage()}",
+                ['context' => 'try_or']
+            );
+
+            return $default;
+        }
+    }
+}
+
 if (! function_exists('with')) {
     /**
      * Return the given value, optionally passed through the given callback.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -626,18 +626,11 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('Success', $result);
     }
 
-    /**
-     * Test the try_or helper with a failing closure.
-     *
-     * @return void
-     */
-    public function testTryOrWithFailingClosure()
+    public function testThrowDefaultException()
     {
-        $result = try_or(function () {
-            return 10 / 0;
-        }, 'Default Value');
+        $this->expectException(RuntimeException::class);
 
-        $this->assertEquals('Default Value', $result);
+        throw_if(true);
     }
 
     public function testThrowExceptionWithMessage()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -640,13 +640,6 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('Default Value', $result);
     }
 
-    public function testThrowDefaultException()
-    {
-        $this->expectException(RuntimeException::class);
-
-        throw_if(true);
-    }
-
     public function testThrowExceptionWithMessage()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -633,13 +633,12 @@ class SupportHelpersTest extends TestCase
      */
     public function testTryOrWithFailingClosure()
     {
-        $result = try_or(function (){
+        $result = try_or(function () {
             return 10 / 0;
         }, 'Default Value');
 
         $this->assertEquals('Default Value', $result);
     }
-
 
     public function testThrowDefaultException()
     {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -612,6 +612,35 @@ class SupportHelpersTest extends TestCase
         throw_if(true, new LogicException);
     }
 
+    /**
+     * Test the try_or helper with a successful closure.
+     *
+     * @return void
+     */
+    public function testTryOrWithSuccessfulClosure()
+    {
+        $result = try_or(function () {
+            return 'Success';
+        }, 'Default Value');
+
+        $this->assertEquals('Success', $result);
+    }
+
+    /**
+     * Test the try_or helper with a failing closure.
+     *
+     * @return void
+     */
+    public function testTryOrWithFailingClosure()
+    {
+        $result = try_or(function (){
+            return 10 / 0;
+        }, 'Default Value');
+
+        $this->assertEquals('Default Value', $result);
+    }
+
+
     public function testThrowDefaultException()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
# try_or Helper

The `try_or` helper in Laravel provides a concise way to execute a closure, log any exceptions, and return a default value if an exception occurs. This README provides examples and guidelines on how to use the helper.

### Examples

#### 1. Accessing Data from an API

```php
use Illuminate\Support\Facades\Http;

$result = try_or(function () {
    return Http::get('https://api.example.com/data');
}, []);
```

#### 2. Example: Division by Zero

```php
$result = try_or(function () {
    return 10 / 0; // This will throw a DivisionByZeroError
}, 'Default Value');

echo "Result: $result";
```

#### 3. Reading Files

```php
$content = try_or(function () {
    return file_get_contents('path/to/file.txt');
}, 'Default Content');
```

#### 4. Custom

You can also customize the behavior of the `try_or` helper by providing additional options and context:

```php
$result = try_or(function () {
    // Your code here
}, $defaultValue);
```
