### PR TITLE
[10.x] Add routeRoute method to test request

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -297,7 +297,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Set the referer header and previous URL session value in order to simulate a previous request.
+     * Set the referer header and previous URL session value from a given URL in order to simulate a previous request.
      *
      * @param  string  $url
      * @return $this
@@ -307,6 +307,17 @@ trait MakesHttpRequests
         $this->app['session']->setPreviousUrl($url);
 
         return $this->withHeader('referer', $url);
+    }
+
+    /**
+     * Set the referer header and previous URL session value from a given route in order to simulate a previous request.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function fromRoute(string $name, mixed $parameters = [])
+    {
+        return $this->from($this->app['url']->route($name, $parameters));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -313,9 +313,10 @@ trait MakesHttpRequests
      * Set the referer header and previous URL session value from a given route in order to simulate a previous request.
      *
      * @param  string  $name
+     * @param  mixed  $parameters
      * @return $this
      */
-    public function fromRoute(string $name, mixed $parameters = [])
+    public function fromRoute(string $name, $parameters = [])
     {
         return $this->from($this->app['url']->route($name, $parameters));
     }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -18,6 +18,18 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('previous/url', $this->app['session']->previousUrl());
     }
 
+    public function testFromRouteSetsHeaderAndSession()
+    {
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('previous/url', fn () => 'ok')->name('previous-url');
+
+        $this->fromRoute('previous-url');
+
+        $this->assertSame('http://localhost/previous/url', $this->defaultHeaders['referer']);
+        $this->assertSame('http://localhost/previous/url', $this->app['session']->previousUrl());
+    }
+
     public function testWithTokenSetsAuthorizationHeader()
     {
         $this->withToken('foobar');


### PR DESCRIPTION
Hey 🤝 

In our test code base, we frequently call `->from(route('name'))` to assert the redirect response. Similar to the
`->assertRedirectToRoute(...)` helper, I've added `->fromRoute(...)` method.

Before:
```php
$this->from(route('index'))
    ->get(route('language', ['language' => 'de']))
    ->assertRedirectToRoute('index')
```

After:
```php
$this->fromRoute('index') // changed
    ->get(route('language', ['language' => 'de']))
    ->assertRedirectToRoute('index')
```