### PR TITLE
[10.x] Update import & typo

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
+use RuntimeException;
 
 class BusFake implements Fake, QueueingDispatcher
 {

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -63,7 +63,7 @@ class UniqueJobTest extends QueueTestCase
         $this->expectException(Exception::class);
 
         try {
-            dispatchSync($job = new UniqueTestFailJob);
+            dispatch_sync($job = new UniqueTestFailJob);
         } finally {
             $this->assertTrue($job::$handled);
             $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockKey($job), 10)->get());


### PR DESCRIPTION
Fix missing `use RuntimeException` and `dispatchSync()` call