### PR TITLE
[10.x] Support custom cdn for Vite directive

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -115,7 +115,7 @@ trait InteractsWithContainer
 
         $this->swap(Vite::class, new class extends Vite
         {
-            public function __invoke($entrypoints, $buildDirectory = null)
+            public function __invoke($entrypoints, $buildDirectory = null, $assetsUrl = null)
             {
                 return new HtmlString('');
             }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -120,7 +120,7 @@ class Vite implements Htmlable
     /**
      * Generate or set a Content Security Policy nonce to apply to all generated tags.
      *
-     * @param string|null $nonce
+     * @param  string|null  $nonce
      * @return string
      */
     public function useCspNonce($nonce = null)
@@ -131,7 +131,7 @@ class Vite implements Htmlable
     /**
      * Use the given key to detect integrity hashes in the manifest.
      *
-     * @param string|false $key
+     * @param  string|false  $key
      * @return $this
      */
     public function useIntegrityKey($key)
@@ -144,7 +144,7 @@ class Vite implements Htmlable
     /**
      * Set the Vite entry points.
      *
-     * @param array $entryPoints
+     * @param  array  $entryPoints
      * @return $this
      */
     public function withEntryPoints($entryPoints)
@@ -157,7 +157,7 @@ class Vite implements Htmlable
     /**
      * Set the filename for the manifest file.
      *
-     * @param string $filename
+     * @param  string  $filename
      * @return $this
      */
     public function useManifestFilename($filename)
@@ -180,7 +180,7 @@ class Vite implements Htmlable
     /**
      * Set the Vite "hot" file path.
      *
-     * @param string $path
+     * @param  string  $path
      * @return $this
      */
     public function useHotFile($path)
@@ -193,7 +193,7 @@ class Vite implements Htmlable
     /**
      * Set the Vite build directory.
      *
-     * @param string $path
+     * @param  string  $path
      * @return $this
      */
     public function useBuildDirectory($path)
@@ -206,13 +206,13 @@ class Vite implements Htmlable
     /**
      * Use the given callback to resolve attributes for script tags.
      *
-     * @param (callable(string, string, ?array, ?array): array)|array $attributes
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
      * @return $this
      */
     public function useScriptTagAttributes($attributes)
     {
         if (! is_callable($attributes)) {
-            $attributes = fn() => $attributes;
+            $attributes = fn () => $attributes;
         }
 
         $this->scriptTagAttributesResolvers[] = $attributes;
@@ -223,13 +223,13 @@ class Vite implements Htmlable
     /**
      * Use the given callback to resolve attributes for style tags.
      *
-     * @param (callable(string, string, ?array, ?array): array)|array $attributes
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
      * @return $this
      */
     public function useStyleTagAttributes($attributes)
     {
         if (! is_callable($attributes)) {
-            $attributes = fn() => $attributes;
+            $attributes = fn () => $attributes;
         }
 
         $this->styleTagAttributesResolvers[] = $attributes;
@@ -240,13 +240,13 @@ class Vite implements Htmlable
     /**
      * Use the given callback to resolve attributes for preload tags.
      *
-     * @param (callable(string, string, ?array, ?array): (array|false))|array|false $attributes
+     * @param  (callable(string, string, ?array, ?array): (array|false))|array|false  $attributes
      * @return $this
      */
     public function usePreloadTagAttributes($attributes)
     {
         if (! is_callable($attributes)) {
-            $attributes = fn() => $attributes;
+            $attributes = fn () => $attributes;
         }
 
         $this->preloadTagAttributesResolvers[] = $attributes;
@@ -257,8 +257,8 @@ class Vite implements Htmlable
     /**
      * Generate Vite tags for an entrypoint.
      *
-     * @param string|string[] $entrypoints
-     * @param string|null $buildDirectory
+     * @param  string|string[]  $entrypoints
+     * @param  string|null  $buildDirectory
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception
@@ -273,7 +273,7 @@ class Vite implements Htmlable
             return new HtmlString(
                 $entrypoints
                     ->prepend('@vite/client')
-                    ->map(fn($entrypoint) => $this->makeTagForChunk($entrypoint, $this->hotAsset($entrypoint), null, null))
+                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, $this->hotAsset($entrypoint), null, null))
                     ->join('')
             );
         }
@@ -346,22 +346,22 @@ class Vite implements Htmlable
             }
         }
 
-        [$stylesheets, $scripts] = $tags->unique()->partition(fn($tag) => str_starts_with($tag, '<link'));
+        [$stylesheets, $scripts] = $tags->unique()->partition(fn ($tag) => str_starts_with($tag, '<link'));
 
         $preloads = $preloads->unique()
-            ->sortByDesc(fn($args) => $this->isCssPath($args[1]))
-            ->map(fn($args) => $this->makePreloadTagForChunk(...$args));
+            ->sortByDesc(fn ($args) => $this->isCssPath($args[1]))
+            ->map(fn ($args) => $this->makePreloadTagForChunk(...$args));
 
-        return new HtmlString($preloads->join('') . $stylesheets->join('') . $scripts->join(''));
+        return new HtmlString($preloads->join('').$stylesheets->join('').$scripts->join(''));
     }
 
     /**
      * Make tag for the given chunk.
      *
-     * @param string $src
-     * @param string $url
-     * @param array|null $chunk
-     * @param array|null $manifest
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array|null  $chunk
+     * @param  array|null  $manifest
      * @return string
      */
     protected function makeTagForChunk($src, $url, $chunk, $manifest)
@@ -391,10 +391,10 @@ class Vite implements Htmlable
     /**
      * Make a preload tag for the given chunk.
      *
-     * @param string $src
-     * @param string $url
-     * @param array $chunk
-     * @param array $manifest
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array  $chunk
+     * @param  array  $manifest
      * @return string
      */
     protected function makePreloadTagForChunk($src, $url, $chunk, $manifest)
@@ -409,16 +409,16 @@ class Vite implements Htmlable
             Collection::make($attributes)->forget('href')->all()
         );
 
-        return '<link ' . implode(' ', $this->parseAttributes($attributes)) . ' />';
+        return '<link '.implode(' ', $this->parseAttributes($attributes)).' />';
     }
 
     /**
      * Resolve the attributes for the chunks generated script tag.
      *
-     * @param string $src
-     * @param string $url
-     * @param array|null $chunk
-     * @param array|null $manifest
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array|null  $chunk
+     * @param  array|null  $manifest
      * @return array
      */
     protected function resolveScriptTagAttributes($src, $url, $chunk, $manifest)
@@ -437,10 +437,10 @@ class Vite implements Htmlable
     /**
      * Resolve the attributes for the chunks generated stylesheet tag.
      *
-     * @param string $src
-     * @param string $url
-     * @param array|null $chunk
-     * @param array|null $manifest
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array|null  $chunk
+     * @param  array|null  $manifest
      * @return array
      */
     protected function resolveStylesheetTagAttributes($src, $url, $chunk, $manifest)
@@ -459,10 +459,10 @@ class Vite implements Htmlable
     /**
      * Resolve the attributes for the chunks generated preload tag.
      *
-     * @param string $src
-     * @param string $url
-     * @param array $chunk
-     * @param array $manifest
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array  $chunk
+     * @param  array  $manifest
      * @return array|false
      */
     protected function resolvePreloadTagAttributes($src, $url, $chunk, $manifest)
@@ -498,10 +498,10 @@ class Vite implements Htmlable
     /**
      * Generate an appropriate tag for the given URL in HMR mode.
      *
-     * @param string $url
-     * @return string
      * @deprecated Will be removed in a future Laravel version.
      *
+     * @param  string  $url
+     * @return string
      */
     protected function makeTag($url)
     {
@@ -515,10 +515,10 @@ class Vite implements Htmlable
     /**
      * Generate a script tag for the given URL.
      *
-     * @param string $url
-     * @return string
      * @deprecated Will be removed in a future Laravel version.
      *
+     * @param  string  $url
+     * @return string
      */
     protected function makeScriptTag($url)
     {
@@ -528,10 +528,10 @@ class Vite implements Htmlable
     /**
      * Generate a stylesheet tag for the given URL in HMR mode.
      *
-     * @param string $url
-     * @return string
      * @deprecated Will be removed in a future Laravel version.
      *
+     * @param  string  $url
+     * @return string
      */
     protected function makeStylesheetTag($url)
     {
@@ -541,8 +541,8 @@ class Vite implements Htmlable
     /**
      * Generate a script tag with attributes for the given URL.
      *
-     * @param string $url
-     * @param array $attributes
+     * @param  string  $url
+     * @param  array  $attributes
      * @return string
      */
     protected function makeScriptTagWithAttributes($url, $attributes)
@@ -553,14 +553,14 @@ class Vite implements Htmlable
             'nonce' => $this->nonce ?? false,
         ], $attributes));
 
-        return '<script ' . implode(' ', $attributes) . '></script>';
+        return '<script '.implode(' ', $attributes).'></script>';
     }
 
     /**
      * Generate a link tag with attributes for the given URL.
      *
-     * @param string $url
-     * @param array $attributes
+     * @param  string  $url
+     * @param  array  $attributes
      * @return string
      */
     protected function makeStylesheetTagWithAttributes($url, $attributes)
@@ -571,13 +571,13 @@ class Vite implements Htmlable
             'nonce' => $this->nonce ?? false,
         ], $attributes));
 
-        return '<link ' . implode(' ', $attributes) . ' />';
+        return '<link '.implode(' ', $attributes).' />';
     }
 
     /**
      * Determine whether the given path is a CSS file.
      *
-     * @param string $path
+     * @param  string  $path
      * @return bool
      */
     protected function isCssPath($path)
@@ -588,15 +588,15 @@ class Vite implements Htmlable
     /**
      * Parse the attributes into key="value" strings.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return array
      */
     protected function parseAttributes($attributes)
     {
         return Collection::make($attributes)
-            ->reject(fn($value, $key) => in_array($value, [false, null], true))
-            ->flatMap(fn($value, $key) => $value === true ? [$key] : [$key => $value])
-            ->map(fn($value, $key) => is_int($key) ? $value : $key . '="' . $value . '"')
+            ->reject(fn ($value, $key) => in_array($value, [false, null], true))
+            ->flatMap(fn ($value, $key) => $value === true ? [$key] : [$key => $value])
+            ->map(fn ($value, $key) => is_int($key) ? $value : $key.'="'.$value.'"')
             ->values()
             ->all();
     }
@@ -640,14 +640,14 @@ class Vite implements Htmlable
      */
     protected function hotAsset($asset)
     {
-        return rtrim(file_get_contents($this->hotFile())) . '/' . $asset;
+        return rtrim(file_get_contents($this->hotFile())).'/'.$asset;
     }
 
     /**
      * Get the URL for an asset.
      *
-     * @param string $asset
-     * @param string|null $buildDirectory
+     * @param  string  $asset
+     * @param  string|null  $buildDirectory
      * @return string
      */
     public function asset($asset, $buildDirectory = null)
@@ -660,14 +660,14 @@ class Vite implements Htmlable
 
         $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
 
-        return $this->assetPath($buildDirectory . '/' . $chunk['file']);
+        return $this->assetPath($buildDirectory.'/'.$chunk['file']);
     }
 
     /**
      * Get the content of a given asset.
      *
-     * @param string $asset
-     * @param string|null $buildDirectory
+     * @param  string  $asset
+     * @param  string|null  $buildDirectory
      * @return string
      *
      * @throws \Exception
@@ -678,7 +678,7 @@ class Vite implements Htmlable
 
         $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
 
-        $path = public_path($buildDirectory . '/' . $chunk['file']);
+        $path = public_path($buildDirectory.'/'.$chunk['file']);
 
         if (! is_file($path) || ! file_exists($path)) {
             throw new Exception("Unable to locate file from Vite manifest: {$path}.");
@@ -690,8 +690,8 @@ class Vite implements Htmlable
     /**
      * Generate an asset path for the application.
      *
-     * @param string $path
-     * @param bool|null $secure
+     * @param  string  $path
+     * @param  bool|null  $secure
      * @return string
      */
     protected function assetPath($path, $secure = null)
@@ -706,7 +706,7 @@ class Vite implements Htmlable
     /**
      * Get the the manifest file for the given build directory.
      *
-     * @param string $buildDirectory
+     * @param  string  $buildDirectory
      * @return array
      *
      * @throws \Illuminate\Foundation\ViteManifestNotFoundException
@@ -729,18 +729,18 @@ class Vite implements Htmlable
     /**
      * Get the path to the manifest file for the given build directory.
      *
-     * @param string $buildDirectory
+     * @param  string  $buildDirectory
      * @return string
      */
     protected function manifestPath($buildDirectory)
     {
-        return public_path($buildDirectory . '/' . $this->manifestFilename);
+        return public_path($buildDirectory.'/'.$this->manifestFilename);
     }
 
     /**
      * Get a unique hash representing the current manifest, or null if there is no manifest.
      *
-     * @param string|null $buildDirectory
+     * @param  string|null  $buildDirectory
      * @return string|null
      */
     public function manifestHash($buildDirectory = null)
@@ -761,8 +761,8 @@ class Vite implements Htmlable
     /**
      * Get the chunk for the given entry point / asset.
      *
-     * @param array $manifest
-     * @param string $file
+     * @param  array  $manifest
+     * @param  string  $file
      * @return array
      *
      * @throws \Exception


### PR DESCRIPTION
assetsUrl added to be able to pass custom cdn.
```blade
@vite('resources/sass/app.scss', assetsUrl: 'https://cdn.domain/assets')
```
to have output like this:
```html
<link rel="preload" as="style" href="https://cdn.domain/assets/app.c3369b22.css" />
<link rel="stylesheet" href="https://cdn.domain/assets/app.c3369b22.css" />
```