### PR TITLE
[10.x] Show default `false` values in `db:table` command

### DIFF
--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -212,7 +212,7 @@ class TableCommand extends DatabaseInspectionCommand
             $columns->each(function ($column) {
                 $this->components->twoColumnDetail(
                     $column['column'].' <fg=gray>'.$column['attributes']->implode(', ').'</>',
-                    ($column['default'] ? '<fg=gray>'.$column['default'].'</> ' : '').''.$column['type'].''
+                    (! is_null($column['default']) ? '<fg=gray>'.$column['default'].'</> ' : '').''.$column['type'].''
                 );
             });
 


### PR DESCRIPTION
Using this in a migration:
![afbeelding](https://github.com/laravel/framework/assets/11609290/1412cf17-a06e-4e8c-82f6-1f1c8c2b70e0)

Before using the `db:table` command:
![afbeelding](https://github.com/laravel/framework/assets/11609290/0304e83a-4fc8-4c44-ba11-8a64221d54fe)

After using using the `db:table` command:
![afbeelding](https://github.com/laravel/framework/assets/11609290/d5eb3855-b732-4f8e-9843-9404bb8b623b)
