### PR TITLE
Improve performance of `Arr::dot([])`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -111,13 +111,15 @@ class Arr
     {
         $results = [];
 
-        array_walk($array, function ($value, $key) use (&$results, $prepend) {
+        foreach ($array as $key => $value) {
             if (is_array($value) && !empty($value)) {
-              $results += static::dot($value, $prepend . $key . ".");
+                // the key of an array is always unique, so we can use array union operator (+)
+                // which is faster than array_merge() function.
+                $results += static::dot($value, $prepend . $key . ".");
             } else {
-              $results[$prepend . $key] = $value;
+                $results[$prepend . $key] = $value;
             }
-        });
+        };
 
         return $results;
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -111,13 +111,13 @@ class Arr
     {
         $results = [];
 
-        foreach ($array as $key => $value) {
-            if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+        array_walk($array, function ($value, $key) use (&$results, $prepend) {
+            if (is_array($value) && !empty($value)) {
+              $results += static::dot($value, $prepend . $key . ".");
             } else {
-                $results[$prepend.$key] = $value;
+              $results[$prepend . $key] = $value;
             }
-        }
+        });
 
         return $results;
     }


### PR DESCRIPTION
This PR improves the speed of `Arr::dot()` by using the array union operator instead of the slower `array_merge`

The reason why we can use the union operator here is, that an array always has unique keys.

> the + operator will only add the elements of the right side operand, if their key doesn't exist in the leftside operand, while array_merge will override existing keys.

see https://stitcher.io/blog/array-merge-vs+

But this is not a problem here, because, as I already noticed, the keys in an array are unique.

I've attached some benchmarks running the current Arr::dot() implementation agains my new implementation. As you can see, the new implementation solves a significant runtime issue.

```
Items: 100
old Arr::dot: 0.0003 seconds / 20.00 memory
new Arr::dot: 0.0001 seconds / 20.00 memory


Items: 1000
old Arr::dot: 0.0218 seconds / 22.00 memory
new Arr::dot: 0.0010 seconds / 24.00 memory


Items: 10000
old Arr::dot: 3.5038 seconds / 46.00 memory
new Arr::dot: 0.0129 seconds / 48.50 memory


Items: 15000
old Arr::dot: 10.4789 seconds / 64.00 memory
new Arr::dot: 0.0155 seconds / 68.50 memory
```

for futher information about the union operator see: https://www.php.net/manual/en/language.operators.array.php


