### PR TITLE
[10.x] ReflectiveConstants

### DIFF
--- a/src/Illuminate/Support/Traits/ReflectiveConstants.php
+++ b/src/Illuminate/Support/Traits/ReflectiveConstants.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait ReflectiveConstants
+{
+    /**
+     * Access a constant of the class using the trait.
+     *
+     * @param  string  $name  The name of the constant to access.
+     * @return mixed The value of the constant.
+     *
+     * @throws \ReflectionException If the constant does not exist or is not accessible.
+     */
+    public static function constant(string $name)
+    {
+        $class = static::class;
+
+        if (!defined("$class::$name")) {
+            throw new \ReflectionException("Constant $class::$name does not exist.");
+        }
+
+        return constant("$class::$name");
+    }
+
+    /**
+     * Access a constant of the class using the trait or return null if not exists.
+     *
+     * @param  string  $name  The name of the constant to access.
+     * @return mixed|null The value of the constant or null if it does not exist.
+     */
+    public static function constantOrNull(string $name)
+    {
+        $class = static::class;
+
+        return defined("$class::$name") ? constant("$class::$name") : null;
+    }
+
+    /**
+     * Access a constant of the class using the trait or throw an exception if not exists.
+     *
+     * @param  string  $name  The name of the constant to access.
+     * @return mixed The value of the constant.
+     *
+     * @throws \ReflectionException If the constant does not exist or is not accessible.
+     */
+    public static function constantOrFail(string $name)
+    {
+        $class = static::class;
+
+        if (!defined("$class::$name")) {
+            throw new \ReflectionException("Constant $class::$name does not exist.");
+        }
+
+        return constant("$class::$name");
+    }
+
+    /**
+     * Access a constant of the class using the trait or return a default value if not exists.
+     *
+     * @param  string  $name  The name of the constant to access.
+     * @param  mixed  $default  The default value to return if the constant does not exist.
+     * @return mixed The value of the constant or the default value.
+     */
+    public static function constantOr(string $name, $default = null)
+    {
+        $class = static::class;
+
+        return defined("$class::$name") ? constant("$class::$name") : $default;
+    }
+
+    /**
+     * Get all constants of the class using the trait.
+     *
+     * @return array Associative array with constant names as keys and their values.
+     */
+    public static function getAllConstants()
+    {
+        $class = static::class;
+        $reflection = new \ReflectionClass($class);
+
+        return $reflection->getConstants();
+    }
+
+    /**
+     * Check if a constant exists in the class using the trait.
+     *
+     * @param  string  $name  The name of the constant to check.
+     * @return bool True if the constant exists, false otherwise.
+     */
+    public static function hasConstant(string $name)
+    {
+        $class = static::class;
+
+        return defined("$class::$name");
+    }
+}

--- a/src/Illuminate/Support/Traits/ReflectiveConstants.php
+++ b/src/Illuminate/Support/Traits/ReflectiveConstants.php
@@ -16,7 +16,7 @@ trait ReflectiveConstants
     {
         $class = static::class;
 
-        if (!defined("$class::$name")) {
+        if (! defined("$class::$name")) {
             throw new \ReflectionException("Constant $class::$name does not exist.");
         }
 
@@ -48,7 +48,7 @@ trait ReflectiveConstants
     {
         $class = static::class;
 
-        if (!defined("$class::$name")) {
+        if (! defined("$class::$name")) {
             throw new \ReflectionException("Constant $class::$name does not exist.");
         }
 
@@ -72,14 +72,14 @@ trait ReflectiveConstants
     /**
      * Get all constants of the class using the trait.
      *
-     * @return array Associative array with constant names as keys and their values.
+     * @return \stdClass An object with constant names as properties and their values.
      */
     public static function getAllConstants()
     {
         $class = static::class;
         $reflection = new \ReflectionClass($class);
 
-        return $reflection->getConstants();
+        return (object) $reflection->getConstants();
     }
 
     /**


### PR DESCRIPTION
This trait represents a refined embodiment of the original concept presented in PR #49368.

Why is this necessary?
Well, the use of class constants for various purposes is quite common, but dynamic and easy reading from external classes can become cumbersome. So, what is proposed here are implementations that exist as helper classes, traits, or similar in some systems.

I believe incorporating this into the Laravel core would be extremely beneficial. It definitely adds a super clean and concise syntax for working with constants of any class (Models, Controllers, Services, Enums, etc.).

**Example in action:**

```php
<?php

// Example class
class MyClass
{
     use Illuminate\Support\Traits\ReflectiveConstants;

     const STATUS_ACTIVE = 'active';
     const STATUS_INACTIVE = 'inactive';
     const MAX_ATTEMPTS = 5;
}
```

## Empower your codebase from external classes:

```php
// Access the 'STATUS_ACTIVE' constant 🚀
$value = MyClass::constant('STATUS_ACTIVE');

// Access the 'MAX_ATTEMPTS' constant or gracefully handle its absence 🎯
$valueOrNull = MyClass::constantOrNull('MAX_ATTEMPTS');

// Unleash the power of 'UNKNOWN_CONSTANT' or elegantly handle its absence with style 🌈
$valueOrFail = MyClass::constantOrFail('UNKNOWN_CONSTANT');

// Access 'UNKNOWN_CONSTANT' smoothly or fallback to a default value with style 🌟
$valueOrDefault = MyClass::constantOr('UNKNOWN_CONSTANT', 'default_value');

// Get all constants of the class encapsulated in an elegant \stdClass object 🎁
$allConstants = MyClass::getAllConstants();

// Validate the existence of a specific constant with a single call 🧐
$hasConstant = MyClass::hasConstant('STATUS_ACTIVE');
```

Please consider the new benefits and facilities of the framework. I apologize for insisting on the purpose of this trait, but it is much cleaner than creating methods that often lack a standard for working with constants. 🚀✨"

```php
// Dynamic usage of ConstantAccessor in a loop

$constantsToRetrieve = ['PI', 'EULER_NUMBER', 'GOLDEN_RATIO', 'SQUARE_ROOT_2'];

foreach ($constantsToRetrieve as $constantName) {
    $constantValue = MathConstants::constant($constantName);
    echo "$constantName: $constantValue\n";
}
```

Before
```php
$class = new ReflectionClass(ClassName::class);
$constantValue = constant("$class->getShortName()::$constantName");
```
Now
```php
$constantValue =  ClassName::constant($constantName);
```