### PR TITLE
[10.x] Improve `Arr::dot` performance

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -115,7 +115,7 @@ class Arr
             if (is_array($value) && ! empty($value)) {
                 $results[] = static::dot($value, $prepend.$key.'.');
             } else {
-                $results[0][$prepend.$key] = $value;
+                $results[][$prepend.$key] = $value;
             }
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -113,7 +113,7 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results += static::dot($value, $prepend.$key.'.');
             } else {
                 $results[$prepend.$key] = $value;
             }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -109,17 +109,17 @@ class Arr
      */
     public static function dot($array, $prepend = '')
     {
-        $results = [];
+        $results = [[]];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results += static::dot($value, $prepend.$key.'.');
+                $results[] = static::dot($value, $prepend.$key.'.');
             } else {
-                $results[$prepend.$key] = $value;
+                $results[0][$prepend.$key] = $value;
             }
         }
 
-        return $results;
+        return array_merge(...$results);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -115,7 +115,7 @@ class Arr
             if (is_array($value) && ! empty($value)) {
                 $results[] = static::dot($value, $prepend.$key.'.');
             } else {
-                $results[][$prepend.$key] = $value;
+                $results[] = [$prepend.$key => $value];
             }
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayObject;
+use Illuminate\Foundation\Console\ConfigShowCommand;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -100,22 +101,22 @@ class SupportArrTest extends TestCase
     public function testDot()
     {
         $array = Arr::dot(['foo' => ['bar' => 'baz']]);
-        $this->assertEquals(['foo.bar' => 'baz'], $array);
+        $this->assertSame(['foo.bar' => 'baz'], $array);
 
         $array = Arr::dot([]);
-        $this->assertEquals([], $array);
+        $this->assertSame([], $array);
 
         $array = Arr::dot(['foo' => []]);
-        $this->assertEquals(['foo' => []], $array);
+        $this->assertSame(['foo' => []], $array);
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
-        $this->assertEquals(['foo.bar' => []], $array);
+        $this->assertSame(['foo.bar' => []], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
-        $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
+        $this->assertSame(['name' => 'taylor', 'languages.php' => true], $array);
 
         $array = Arr::dot(['user' => ['name' => 'Taylor', 'age' => 25, 'languages' => ['PHP', 'C#']]]);
-        $this->assertEquals([
+        $this->assertSame([
             'user.name' => 'Taylor',
             'user.age' => 25,
             'user.languages.0' =>'PHP',
@@ -123,10 +124,18 @@ class SupportArrTest extends TestCase
         ], $array);
 
         $array = Arr::dot(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]]);
-        $this->assertEquals([
+        $this->assertSame([
             'foo',
             'foo.bar' => 'baz',
             'foo.baz.a' => 'b',
+        ], $array);
+
+        $array = Arr::dot(['foo' => 'bar', 'empty_array' => [], 'user' => ['name' => 'Taylor'], 'key' => 'value']);
+        $this->assertSame([
+            'foo' => 'bar',
+            'empty_array' => [],
+            'user.name' => 'Taylor',
+            'key' => 'value',
         ], $array);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -119,14 +119,14 @@ class SupportArrTest extends TestCase
             'user.name' => 'Taylor',
             'user.age' => 25,
             'user.languages.0' =>'PHP',
-            'user.languages.1' => 'C#'
+            'user.languages.1' => 'C#',
         ], $array);
 
         $array = Arr::dot(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]]);
         $this->assertEquals([
             'foo',
             'foo.bar' => 'baz',
-            'foo.baz.a' => 'b'
+            'foo.baz.a' => 'b',
         ], $array);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -113,6 +113,21 @@ class SupportArrTest extends TestCase
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
+
+        $array = Arr::dot(['user' => ['name' => 'Taylor', 'age' => 25, 'languages' => ['PHP', 'C#']]]);
+        $this->assertEquals([
+            'user.name' => 'Taylor',
+            'user.age' => 25,
+            'user.languages.0' =>'PHP',
+            'user.languages.1' => 'C#'
+        ], $array);
+
+        $array = Arr::dot(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]]);
+        $this->assertEquals([
+            'foo',
+            'foo.bar' => 'baz',
+            'foo.baz.a' => 'b'
+        ], $array);
     }
 
     public function testUndot()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayObject;
-use Illuminate\Foundation\Console\ConfigShowCommand;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;


### PR DESCRIPTION
Re submission of #49380 by @comes 

Original description : 

> This PR improves the speed of `Arr::dot()` by using the array union operator instead of the slower `array_merge`
> 
> The reason why we can use the union operator here is, that an array always has unique keys.
> 
> > the + operator will only add the elements of the right side operand, if their key doesn't exist in the leftside operand, while array_merge will override existing keys.
> 
> see https://stitcher.io/blog/array-merge-vs+
> 
> But this is not a problem here, because, as I already noticed, the keys in an array are unique.
> 
> I've attached some benchmarks running the current Arr::dot() implementation agains my new implementation. As you can see, the new implementation solves a significant runtime issue.
> 
> ```
> Items: 100
> old Arr::dot: 0.0003 seconds / 20.00 memory
> new Arr::dot: 0.0001 seconds / 20.00 memory
> 
> 
> Items: 1000
> old Arr::dot: 0.0218 seconds / 22.00 memory
> new Arr::dot: 0.0010 seconds / 24.00 memory
> 
> 
> Items: 10000
> old Arr::dot: 3.5038 seconds / 46.00 memory
> new Arr::dot: 0.0129 seconds / 48.50 memory
> 
> 
> Items: 15000
> old Arr::dot: 10.4789 seconds / 64.00 memory
> new Arr::dot: 0.0155 seconds / 68.50 memory
> ```
> 
> for futher information about the union operator see: https://www.php.net/manual/en/language.operators.array.php

~I don't add my benchmark results as they are similar to the original ones~

After some tweak and suggestions (thanks @donnysim and @comes), heres an updated version of the benchmark.  

```
Items: 100
original Arr::dot: 0.0003 seconds / 40.50 memory
new Arr::dot: 0.0002 seconds / 40.50 memory
Items: 1000
original Arr::dot: 0.0213 seconds / 42.50 memory
new Arr::dot: 0.0016 seconds / 42.50 memory
Items: 10000
original Arr::dot: 5.0146 seconds / 68.50 memory
new Arr::dot: 0.0201 seconds / 72.50 memory
Items: 15000
original Arr::dot: 12.8689 seconds / 100.50 memory
new Arr::dot: 0.0272 seconds / 97.50 memory
```
Note : do not compare with original benchmark, it was not run on the same machine

I also updated the tests with `assertSame` instead of `assertEquals` to ensure that the order of the arrays are respected.