### PR TITLE
Fixes second run of `about` command on Octane

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -159,6 +159,8 @@ class AboutCommand extends Command
      */
     protected function gatherApplicationInformation()
     {
+        self::$data = [];
+
         $formatEnabledStatus = fn ($value) => $value ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF';
         $formatCachedStatus = fn ($value) => $value ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>';
 


### PR DESCRIPTION
## Scenario

I have a monitoring endpont that shows the output of the `about`command.

I'm calling:

```php
Artisan::call('about', ['--json' => true]);
```

## Problem

When serving the app using Swoole, the first request runs as expected, but the second execution throws `BindingResolutionException: Target class [env] does not exist.`

## Fix

Reset the static variable `AboutCommand::$data` every time before gather the application information.

