### PR TITLE
[10.x] Dynamo Batch Repository - Match Default Horizon Sort

### DIFF
--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -102,6 +102,7 @@ class DynamoBatchRepository implements BatchRepository
                 ':id' => array_filter(['S' => $before]),
             ]),
             'Limit' => $limit,
+            'ScanIndexForward' => false,
         ]);
 
         return array_map(


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The Dynamo Batch Repository `get` method sort does not match Horizon's default sort with latest at the top. Utilise `ScanIndexForward` set to false to match the default behaviour of Horizon