### PR TITLE
[10.x] Drop the primary key if it exists when adding a new primary key

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -406,7 +406,7 @@ class MySqlGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('alter table %s add primary key %s(%s)',
+        return sprintf('alter table %s drop index if exists `PRIMARY`, add primary key %s(%s)',
             $this->wrapTable($blueprint),
             $command->algorithm ? 'using '.$command->algorithm : '',
             $this->columnize($command->columns)

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -345,7 +345,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add primary key (`foo`)', $statements[0]);
+        $this->assertSame('alter table `users` drop index if exists `PRIMARY`, add primary key (`foo`)', $statements[0]);
     }
 
     public function testAddingPrimaryKeyWithAlgorithm()
@@ -355,7 +355,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add primary key using hash(`foo`)', $statements[0]);
+        $this->assertSame('alter table `users` drop index if exists `PRIMARY`, add primary key using hash(`foo`)', $statements[0]);
     }
 
     public function testAddingUniqueKey()


### PR DESCRIPTION
When attempting to change the primary key for a table, if one already exists this causes an error 1068. Attempting to use dropPrimary() along with primary() causes error 1075, due to primary and dropPrimary being two different commands.

The fix attempts to drop the PRIMARY index if it does exist.