### PR TITLE
[10.x] Fix bug in ArrayLock getCurrentOwner

### DIFF
--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -87,6 +87,10 @@ class ArrayLock extends Lock
      */
     protected function getCurrentOwner()
     {
+        if (!$this->exists()) {
+            return null;
+        }
+
         return $this->store->locks[$this->name]['owner'];
     }
 

--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -87,7 +87,7 @@ class ArrayLock extends Lock
      */
     protected function getCurrentOwner()
     {
-        if (!$this->exists()) {
+        if (! $this->exists()) {
             return null;
         }
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -292,5 +292,37 @@ class CacheArrayStoreTest extends TestCase
         $wannabeOwner->forceRelease();
 
         $this->assertFalse($wannabeOwner->release());
+    }    
+
+    public function testOwnerStatusCanBeCheckedAfterRestoringLock()
+    {
+        $store = new ArrayStore;
+        $firstLock = $store->lock('foo', 10);
+        
+        $this->assertTrue($firstLock->get());
+        $owner = $firstLock->owner();
+
+        $secondLock = $store->restoreLock('foo', $owner);
+        $this->assertTrue($secondLock->isOwnedByCurrentProcess());
+    }
+
+    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    {
+        $store = new ArrayStore;
+        $firstLock = $store->lock('foo', 10);
+
+        $this->assertTrue($firstLock->get());
+
+        $secondLock = $store->restoreLock('foo', 'other_owner');
+
+        $this->assertFalse($secondLock->isOwnedByCurrentProcess());
+    }
+
+    public function testRestoringNonExistingLockDoesNotOwnAnything()
+    {
+        $store = new ArrayStore;
+        $firstLock = $store->restoreLock('foo', 'owner');
+
+        $this->assertFalse($firstLock->isOwnedByCurrentProcess());
     }
 }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -292,13 +292,13 @@ class CacheArrayStoreTest extends TestCase
         $wannabeOwner->forceRelease();
 
         $this->assertFalse($wannabeOwner->release());
-    }    
+    }
 
     public function testOwnerStatusCanBeCheckedAfterRestoringLock()
     {
         $store = new ArrayStore;
         $firstLock = $store->lock('foo', 10);
-        
+
         $this->assertTrue($firstLock->get());
         $owner = $firstLock->owner();
 


### PR DESCRIPTION
After making isOwnedByCurrentProcess public, the function getCurrentOwner can be called without checking if the lock exists first.

I introduced this bug in https://github.com/laravel/framework/pull/49272