### PR TITLE
Add a `assertDatabaseHasCount` assertion to the available database assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
+use Illuminate\Testing\Constraints\HasCountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\NotSoftDeletedInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
@@ -64,6 +65,24 @@ trait InteractsWithDatabase
     {
         $this->assertThat(
             $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), $count)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the count of table entries where condition is met.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  int  $count
+     * @param  array  $data
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseHasCount($table, int $count, array $data, $connection = null)
+    {
+        $this->assertThat(
+            $this->getTable($table), new HasCountInDatabase($this->getConnection($connection, $table), $count, $data)
         );
 
         return $this;

--- a/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Testing\Constraints;
+
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Constraint\Constraint;
+use ReflectionClass;
+
+class HasCountInDatabase extends Constraint
+{
+    /**
+     * The database connection.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The expected table entries count that will be checked against the actual count.
+     *
+     * @var int
+     */
+    protected $expectedCount;
+
+    /**
+     * The data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The actual table entries count that will be checked against the expected count.
+     *
+     * @var int
+     */
+    protected $actualCount;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  int  $expectedCount
+     * @param  array  $data
+     * @return void
+     */
+    public function __construct(Connection $database, int $expectedCount, array $data)
+    {
+        $this->expectedCount = $expectedCount;
+
+        $this->data = $data;
+
+        $this->database = $database;
+    }
+
+    /**
+     * Check if the expected and actual count are equal.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table): bool
+    {
+        $this->actualCount = $this->database->table($table)->where($this->data)->count();
+
+        return $this->actualCount === $this->expectedCount;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table): string
+    {
+        return sprintf(
+            "table [%s] matches expected entries count of %s for the given conditions. Entries found: %s.\n",
+            $table, $this->expectedCount, $this->actualCount
+        );
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toString($options = 0): string
+    {
+        return (new ReflectionClass($this))->name;
+    }
+}


### PR DESCRIPTION
I sometimes find myself with the need of asserting that a table in the database contains a given number of records matching a given query constraints.

This new assertion functions similarly to the existing assertDatabaseHas method but includes an additional parameter for the expected number of rows.

To illustrate, here are two practical use cases:

```php
public function test_it_does_not_allow_to_create_users_with_already_taken_emails(): void
{
    $email = 'user@domain.com';
    $user = User::factory()->make(['email' => $email]);

    $response = $this->json('POST', "/users", ['email' => $email]);

    $response->assertStatus(422);
    $this->assertDatabaseHasCount('users', 1, ['email' => $email]);
}

public function test_it_successfully_duplicates_a_task(): void
{
    $taskTitle = 'Locate the Ark of the Covenant.';
    $task = Task::factory()->create(['title' => $taskTitle]);

    $response = $this->json('POST', "/tasks/{$task->id}/duplicate");

    $response->assertStatus(200);
    $this->assertDatabaseHasCount('tasks', 2, ['title' => $taskTitle]);
}
```

I think this is a simple, yet useful addition, and a handy tool that allows for more precise testing.

