### PR TITLE
[10.x] Add `charset` and `collation` method to `Blueprint`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -316,12 +316,12 @@ class Blueprint
     /**
      * Specify the character set that should be used for the table.
      *
-     * @param  string  $characterSet
+     * @param  string  $charset
      * @return void
      */
-    public function charset($characterSet)
+    public function charset($charset)
     {
-        $this->charset = $characterSet;
+        $this->charset = $charset;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -292,28 +292,6 @@ class Blueprint
     }
 
     /**
-     * Specify the charset that should be used for the table.
-     *
-     * @param  string  $charset
-     * @return void
-     */
-    public function charset($charset)
-    {
-        $this->charset = $charset;
-    }
-
-    /**
-     * Specify the collation that should be used for the table.
-     *
-     * @param  string  $collation
-     * @return void
-     */
-    public function collation($collation)
-    {
-        $this->collation = $collation;
-    }
-
-    /**
      * Specify the storage engine that should be used for the table.
      *
      * @param  string  $engine
@@ -333,6 +311,28 @@ class Blueprint
     public function innoDb()
     {
         $this->engine('InnoDB');
+    }
+
+    /**
+     * Specify the character set that should be used for the table.
+     *
+     * @param  string  $characterSet
+     * @return void
+     */
+    public function charset($characterSet)
+    {
+        $this->charset = $characterSet;
+    }
+
+    /**
+     * Specify the collation that should be used for the table.
+     *
+     * @param  string  $collation
+     * @return void
+     */
+    public function collation($collation)
+    {
+        $this->collation = $collation;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -292,6 +292,28 @@ class Blueprint
     }
 
     /**
+     * Specify the charset that should be used for the table.
+     *
+     * @param  string  $charset
+     * @return void
+     */
+    public function charset($charset)
+    {
+        $this->charset = $charset;
+    }
+
+    /**
+     * Specify the collation that should be used for the table.
+     *
+     * @param  string  $collation
+     * @return void
+     */
+    public function collation($collation)
+    {
+        $this->collation = $collation;
+    }
+
+    /**
      * Specify the storage engine that should be used for the table.
      *
      * @param  string  $engine

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -131,8 +131,8 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $blueprint->charset = 'utf8mb4';
-        $blueprint->collation = 'utf8mb4_unicode_ci';
+        $blueprint->charset('utf8mb4');
+        $blueprint->collation('utf8mb4_unicode_ci');
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);


### PR DESCRIPTION
Based on this PR (https://github.com/laravel/framework/pull/49250) and this comment (https://github.com/laravel/framework/pull/49250#issuecomment-1841246345), I have added the methods for collation and charset in the Blueprint class

Before:
```php
Schema::table('foo', function (Blueprint $table) {
    $table->charset = 'utf8mb4';
    $table->collation = 'utf8mb4_unicode_ci';

    // ...
});
```

After:
```php
Schema::table('foo', function (Blueprint $table) {
    $table->charset('utf8mb4');
    $table->collation('utf8mb4_unicode_ci');

    // ...
});
```
