### PR TITLE
[10.x] Fixes parameter type in `ManagesFrequencies`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -583,7 +583,7 @@ trait ManagesFrequencies
      * Schedule the event to run quarterly on a given day and time.
      *
      * @param  int  $dayOfQuarter
-     * @param  int  $time
+     * @param  string  $time
      * @return $this
      */
     public function quarterlyOn($dayOfQuarter = 1, $time = '0:0')


### PR DESCRIPTION
The parameter type in the PHPdoc should be string, according to the default value of the parameter. 

Other methods of the class with similar logic are using also string for $time parameter.

This fix will resolve some IDEs warnings. 