### PR TITLE
[10.x] Add SQLite support for `whereJsonContains` method

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -147,6 +147,31 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function compileJsonContains($column, $value)
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($column);
+
+        return 'exists (select 1 from json_each('.$field.$path.') where '.$this->wrap('json_each.value').' is '.$value.')';
+    }
+
+    /**
+     * Prepare the binding for a "JSON contains" statement.
+     *
+     * @param  mixed  $binding
+     * @return mixed
+     */
+    public function prepareBindingForJsonContains($binding)
+    {
+        return $binding;
+    }
+
+    /**
      * Compile a "JSON contains key" statement into SQL.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5192,10 +5192,15 @@ SQL;
 
     public function testWhereJsonContainsSqlite()
     {
-        $this->expectException(RuntimeException::class);
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereJsonContains('options', 'en')->toSql();
+        $this->assertSame('select * from "users" where exists (select 1 from json_each("options") where "json_each"."value" is ?)', $builder->toSql());
+        $this->assertEquals(['en'], $builder->getBindings());
 
         $builder = $this->getSQLiteBuilder();
-        $builder->select('*')->from('users')->whereJsonContains('options->languages', ['en'])->toSql();
+        $builder->select('*')->from('users')->whereJsonContains('users.options->language', 'en')->toSql();
+        $this->assertSame('select * from "users" where exists (select 1 from json_each("users"."options", \'$."language"\') where "json_each"."value" is ?)', $builder->toSql());
+        $this->assertEquals(['en'], $builder->getBindings());
     }
 
     public function testWhereJsonContainsSqlServer()
@@ -5244,10 +5249,15 @@ SQL;
 
     public function testWhereJsonDoesntContainSqlite()
     {
-        $this->expectException(RuntimeException::class);
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereJsonDoesntContain('options', 'en')->toSql();
+        $this->assertSame('select * from "users" where not exists (select 1 from json_each("options") where "json_each"."value" is ?)', $builder->toSql());
+        $this->assertEquals(['en'], $builder->getBindings());
 
         $builder = $this->getSQLiteBuilder();
-        $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', ['en'])->toSql();
+        $builder->select('*')->from('users')->whereJsonDoesntContain('users.options->language', 'en')->toSql();
+        $this->assertSame('select * from "users" where not exists (select 1 from json_each("users"."options", \'$."language"\') where "json_each"."value" is ?)', $builder->toSql());
+        $this->assertEquals(['en'], $builder->getBindings());
     }
 
     public function testWhereJsonDoesntContainSqlServer()


### PR DESCRIPTION
This PR adds basic support for `whereJsonContains` query method to SQLite databases.

SQLite added JSON support by default as of version 3.38.0.
Nonetheless, the SQLiteGrammar does not currently support `whereJsonContains` and `whereJsonDoesntContain` methods regardless of the SQLite version (as discussed [here](https://github.com/laravel/docs/pull/9198) and in #49217).

While SQLite does not provide a rigorous definition of JSON containment like [PostgreSQL](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT), a basic form of JSON lookup as described [in the current Laravel documentation](https://laravel.com/docs/10.x/queries#json-where-clauses) ("_You may use `whereJsonContains` to query JSON arrays_") can still be provided.

This integration makes it possible to perform against a SQLite database queries like the following:
```php
$users = DB::table('users')
                ->whereJsonContains('options->languages', 'en')
                ->get();
```
which would be compiled to
```sql
select * from "users" where exists (select 1 from json_each("options", '$."languages"') where "json_each"."value" is ?)
```
The provided implementation uses a correlated scalar subquery and the table-valued function `json_each` to perform a lookup not only among the elements of a JSON array as described in Laravel's docs but also among the values of an object (I didn't find any value in restricting the capabilities of this method a priori; a developer could simply add an explicit `where` clause to strictly ensure that the queried JSON element is an array).
This query would return both the following rows:

| id | options |
| - | - |
1 | `{"languages":["en","it"]}`
2 | `{"languages":{"a":"en","b":"it"}}`

The `is` operator is chosen in favor of `=` because it can handle also `null` comparisons; for instance, using the `=` operator, `whereJsonContains('options->languages', null)` would not return a user with `{"languages":[null]}` as one could reasonably expect.

I was able to find only one caveat to this implementation: a [well-known quirk](https://sqlite.org/forum/forumpost/2d4a3cd308) of the `is` operator to be aware of is that any string starting with a non-zero digit is considered the same as `true` (and any string not starting with a non-zero digit is considered the same as `false`). The following method invocation
```php
whereJsonContains('options->languages', false)
```
would compile to
```sql
where "json_each"."value" is false
```
that would return both the following rows:
| id | options |
| - | - |
1 | `{"languages":[false]}`
2 | `{"languages":["hello"]}`