### PR TITLE
[10.x] Only set `defaultCasters` if not previously set

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -83,11 +83,11 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerDumper()
     {
-        AbstractCloner::$defaultCasters[ConnectionInterface::class] = [StubCaster::class, 'cutInternals'];
-        AbstractCloner::$defaultCasters[Container::class] = [StubCaster::class, 'cutInternals'];
-        AbstractCloner::$defaultCasters[Dispatcher::class] = [StubCaster::class, 'cutInternals'];
-        AbstractCloner::$defaultCasters[Factory::class] = [StubCaster::class, 'cutInternals'];
-        AbstractCloner::$defaultCasters[Grammar::class] = [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[ConnectionInterface::class] ??= [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Container::class] ??= [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Dispatcher::class] ??= [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Factory::class] ??= [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Grammar::class] ??= [StubCaster::class, 'cutInternals'];
 
         $basePath = $this->app->basePath();
 


### PR DESCRIPTION
Because the `FoundationServiceProvider` instantiates a `VarCloner` **very** early in the Laravel boot lifecycle, it is impossible to register custom casters, which is how [laravel-dumper](https://github.com/glhd/laravel-dumper) works. To work around this change, it's necessary to register custom casters before Laravel boots at all. Unfortunately, because the `FoundationServiceProvider` also registers default casters, those defaults override and defaults set in another package or in application code.

The easiest solution is to just switch to null coalescing assignment, so that Laravel only registers default casters if they haven't been registered elsewhere.