### PR TITLE
[10.x] Fix assertStatus() parameter order

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -144,7 +144,7 @@ class TestResponse implements ArrayAccess
     {
         $message = $this->statusMessageWithDetails($status, $actual = $this->getStatusCode());
 
-        PHPUnit::assertSame($actual, $status, $message);
+        PHPUnit::assertSame($status, $actual, $message);
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -596,7 +596,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [405] but received 200.\nFailed asserting that 405 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [405] but received 200.\nFailed asserting that 200 is identical to 405.");
 
         $response->assertMethodNotAllowed();
     }
@@ -614,7 +614,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [406] but received 200.\nFailed asserting that 406 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [406] but received 200.\nFailed asserting that 200 is identical to 406.");
 
         $response->assertNotAcceptable();
         $this->fail();
@@ -665,7 +665,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [400] but received 200.\nFailed asserting that 400 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [400] but received 200.\nFailed asserting that 200 is identical to 400.");
 
         $response->assertBadRequest();
         $this->fail();
@@ -684,7 +684,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [408] but received 200.\nFailed asserting that 408 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [408] but received 200.\nFailed asserting that 200 is identical to 408.");
 
         $response->assertRequestTimeout();
         $this->fail();
@@ -703,7 +703,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [402] but received 200.\nFailed asserting that 402 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [402] but received 200.\nFailed asserting that 200 is identical to 402.");
 
         $response->assertPaymentRequired();
         $this->fail();
@@ -722,7 +722,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [301] but received 200.\nFailed asserting that 301 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [301] but received 200.\nFailed asserting that 200 is identical to 301.");
 
         $response->assertMovedPermanently();
         $this->fail();
@@ -741,7 +741,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [302] but received 200.\nFailed asserting that 302 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [302] but received 200.\nFailed asserting that 200 is identical to 302.");
 
         $response->assertFound();
         $this->fail();
@@ -760,7 +760,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [304] but received 200.\nFailed asserting that 304 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [304] but received 200.\nFailed asserting that 200 is identical to 304.");
 
         $response->assertNotModified();
         $this->fail();
@@ -779,7 +779,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [307] but received 200.\nFailed asserting that 307 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [307] but received 200.\nFailed asserting that 200 is identical to 307.");
 
         $response->assertTemporaryRedirect();
         $this->fail();
@@ -798,7 +798,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [308] but received 200.\nFailed asserting that 308 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [308] but received 200.\nFailed asserting that 200 is identical to 308.");
 
         $response->assertPermanentRedirect();
         $this->fail();
@@ -817,7 +817,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [409] but received 200.\nFailed asserting that 409 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [409] but received 200.\nFailed asserting that 200 is identical to 409.");
 
         $response->assertConflict();
         $this->fail();
@@ -836,7 +836,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [410] but received 200.\nFailed asserting that 410 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [410] but received 200.\nFailed asserting that 200 is identical to 410.");
 
         $response->assertGone();
     }
@@ -854,7 +854,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [429] but received 200.\nFailed asserting that 429 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [429] but received 200.\nFailed asserting that 200 is identical to 429.");
 
         $response->assertTooManyRequests();
         $this->fail();
@@ -873,7 +873,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [202] but received 200.\nFailed asserting that 202 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [202] but received 200.\nFailed asserting that 200 is identical to 202.");
 
         $response->assertAccepted();
         $this->fail();
@@ -920,7 +920,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [500] but received 200.\nFailed asserting that 500 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [500] but received 200.\nFailed asserting that 200 is identical to 500.");
 
         $response->assertInternalServerError();
     }
@@ -938,7 +938,7 @@ class TestResponseTest extends TestCase
         );
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Expected response status code [503] but received 200.\nFailed asserting that 503 is identical to 200.");
+        $this->expectExceptionMessage("Expected response status code [503] but received 200.\nFailed asserting that 200 is identical to 503.");
 
         $response->assertServiceUnavailable();
     }


### PR DESCRIPTION
The `PHPUnit::assertSame()` method expects as first argument the expected value, and the actual value as second parameter. Laravel's `$response->assertStatus()` has these two arguments swapped.

Due to this swap, error messages (in this case of `assertMethodNotAllowed()`) are rendered like:

```
Expected response status code [405] but received 200.\nFailed asserting that 405 is identical to 200.
```

However, as we are asserting that a MethodNotAllowed (code 405) occurs, the expected message should be the following, as we are asserting the value to be identical to 405:
```
Expected response status code [405] but received 200.\nFailed asserting that 200 is identical to 405.
```

This PR fixes the swapped parameters, thereby fixing these presented messages. It fixes `assertStatus()` as well as all status code methods `assert{statusCodeName}()` in the `AssertsStatusCodes` trait