### PR TITLE
[10.x] Make use of environments in env:encrypt and env:decrypt consistent.

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -72,8 +72,12 @@ class EnvironmentDecryptCommand extends Command
 
         $key = $this->parseKey($key);
 
-        $encryptedFile = ($this->option('env')
-                    ? base_path('.env').'.'.$this->option('env')
+        $env = (null !== $this->option('env')
+            ? $this->option('env')
+            : Env::get('APP_ENV'));
+
+        $encryptedFile = (null !== $env
+                    ? base_path('.env').($env ? '.'.$env : '')
                     : $this->laravel->environmentFilePath()).'.encrypted';
 
         $outputFile = $this->outputFilePath();
@@ -139,8 +143,13 @@ class EnvironmentDecryptCommand extends Command
     protected function outputFilePath()
     {
         $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
+        $env = (null !== $this->option('env')
+            ? $this->option('env')
+            : Env::get('APP_ENV'));
 
-        $outputFile = $this->option('filename') ?: ('.env'.($this->option('env') ? '.'.$this->option('env') : ''));
+        $outputFile = (null !== $env
+            ? base_path('.env').($env ? '.'.$env : '')
+            : $this->laravel->environmentFilePath());
         $outputFile = ltrim($outputFile, DIRECTORY_SEPARATOR);
 
         return $path.$outputFile;

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -63,9 +64,13 @@ class EnvironmentEncryptCommand extends Command
 
         $keyPassed = $key !== null;
 
-        $environmentFile = $this->option('env')
-                            ? base_path('.env').'.'.$this->option('env')
-                            : $this->laravel->environmentFilePath();
+        $env = (null !== $this->option('env')
+            ? $this->option('env')
+            : Env::get('APP_ENV'));
+
+        $environmentFile = (null !== $env
+                    ? base_path('.env').($env ? '.'.$env : '')
+                    : $this->laravel->environmentFilePath());
 
         $encryptedFile = $environmentFile.'.encrypted';
 


### PR DESCRIPTION
Hey,

when I am in `APP_ENV=test`, `env:decrypt` will decrypt `.env.test.encrypted` to `.env` and not to `env.test`. I had to specify `--env=test` for it to decrypt `.env.test.encrypted` to `.env.test`, even though I am already in the `test` environment. Also there is no way to decrypt `.env.encrypted` as long as I am inside of an `APP_ENV=test` because `--env` is not checked for an empty value.

Along the same lines I can not encrypt `.env` as long as I am in `APP_ENV=test`. 

This PR makes:
- use `APP_ENV` consistent, so we don't cross-decrypt `.env.${APP_ENV}.encypted` to `.env` but to .`env.${APP_ENV}` instead.
- allow `--env=` to be set empty and en-/decrypt `.env` to/from `.env.encrypted` even when running in an `APP_ENV=`