### PR TITLE
[10.x] Add `MailMessage` helpers for plain text email notifications

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -130,6 +130,37 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
+     * Set the plain text view for the mail message.
+     *
+     * @param  string  $textView
+     * @param  array  $data
+     * @return $this
+     */
+    public function text($textView, array $data = [])
+    {
+        return $this->view([
+            'html' => is_string($this->view) ? $this->view : null,
+            'text' => $textView,
+            'raw' => null,
+        ], $data);
+    }
+
+    /**
+     * Set the raw body for the mail message.
+     *
+     * @param  string  $rawText
+     * @return $this
+     */
+    public function raw($rawText)
+    {
+        return $this->view([
+            'html' => is_string($this->view) ? $this->view : null,
+            'text' => null,
+            'raw' => $rawText,
+        ]);
+    }
+
+    /**
      * Set the Markdown template for the notification.
      *
      * @param  string  $view

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -139,22 +139,9 @@ class MailMessage extends SimpleMessage implements Renderable
     public function text($textView, array $data = [])
     {
         return $this->view([
-            'html' => is_array($this->view) ? $this->view['html'] ?? null : $this->view,
+            'html' => is_array($this->view) ? ($this->view['html'] ?? null) : $this->view,
             'text' => $textView,
         ], $data);
-    }
-
-    /**
-     * Set the raw body for the mail message.
-     *
-     * @param  string  $rawText
-     * @return $this
-     */
-    public function raw($rawText)
-    {
-        return $this->view([
-            'raw' => $rawText,
-        ]);
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -139,9 +139,8 @@ class MailMessage extends SimpleMessage implements Renderable
     public function text($textView, array $data = [])
     {
         return $this->view([
-            'html' => is_string($this->view) ? $this->view : null,
+            'html' => is_array($this->view) ? $this->view['html'] ?? null : $this->view,
             'text' => $textView,
-            'raw' => null,
         ], $data);
     }
 
@@ -154,8 +153,6 @@ class MailMessage extends SimpleMessage implements Renderable
     public function raw($rawText)
     {
         return $this->view([
-            'html' => is_string($this->view) ? $this->view : null,
-            'text' => null,
             'raw' => $rawText,
         ]);
     }


### PR DESCRIPTION
Currently, it is quite hard to send plain text only emails from a `Notification`. This was discussed in the following thread on Laracasts [Plain text emails for notifications?](https://laracasts.com/discuss/channels/laravel/plain-text-emails-for-notifications) and the [proposed workaround](https://github.com/laravel/ideas/issues/1240) was to use a `Mailable` instead.

But the recipient is not set on a `Mailable` as it would be set automatically in the `MailChannel` when sending out a `MailMessage`. Also, when we use `MailMessage` in all our notification's `toMail()` methods, why should we choose a different solution for something that can be easily accomplished with `MailMessage`?

`MailMessage` actually already supports plain text emails for quite some time, see [Mailer.php#L381-L390](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Mail/Mailer.php#L381-L390):

```php
        // If this view is an array but doesn't contain numeric keys, we will assume
        // the views are being explicitly specified and will extract them via the
        // named keys instead, allowing the developers to use one or the other.
        if (is_array($view)) {
            return [
                $view['html'] ?? null,
                $view['text'] ?? null,
                $view['raw'] ?? null,
            ];
        }
```

This array syntax is currently undocumented and hard to find in `MailMessage`, whereas `Mailable` offers a `text()` helper method. So why not just adding two helpers to `MailMessage`!

- `text($textView, array $data = [])`: Set the plain text view for the mail message.
- `raw($rawText)`: Set the raw body for the mail message.

The methods of this PR are just proxying to the existing `view()` method and respect the previous view value where it makes sense.