### PR TITLE
[10.x] Introducing `isEmpty` and `isNotEmpty` to `ComponentAttributeBag`

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -221,26 +221,6 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
     }
 
     /**
-     * Check if the attribute bag is empty.
-     *
-     * @return bool
-     */
-    public function isEmpty(): bool
-    {
-        return (string) $this === '';
-    }
-
-    /**
-     * Check if the attribute bag is not empty.
-     *
-     * @return bool
-     */
-    public function isNotEmpty(): bool
-    {
-        return ! $this->isEmpty();
-    }
-
-    /**
      * Extract prop names from given keys.
      *
      * @param  mixed|array  $keys
@@ -368,6 +348,26 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
         }
 
         return $value;
+    }
+
+    /**
+     * Determine if the attribute bag is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return trim((string) $this) === '';
+    }
+
+    /**
+     * Determine if the attribute bag is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -221,6 +221,26 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
     }
 
     /**
+     * Check if the attribute bag is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return (string) $this === '';
+    }
+
+    /**
+     * Check if the attribute bag is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
      * Extract prop names from given keys.
      *
      * @param  mixed|array  $keys

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -128,4 +128,18 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertFalse((bool) $bag->has('name', 'class'));
         $this->assertTrue((bool) $bag->missing('class'));
     }
+
+    public function testAttributeIsEmpty()
+    {
+        $bag = new ComponentAttributeBag([]);
+
+        $this->assertTrue((bool) $bag->isEmpty());
+    }
+
+    public function testAttributeIsNotEmpty()
+    {
+        $bag = new ComponentAttributeBag(['name' => 'test']);
+
+        $this->assertTrue((bool) $bag->isNotEmpty());
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Due to the format of the `ComponentAttributeBag` class at this time when using a component this way:

```blade
<x-button>
    Laravel
</x-button>
```

The output of checks like `empty($attributes)` will return `false` even if the property `$attributes` is empty:

![CleanShot 2023-12-17 at 00 10 47](https://github.com/laravel/framework/assets/60591772/8de68829-ff26-463d-811b-008c67fd84de)

With this pull request, we introduce two methods that test the state of attributes:

```blade
@if ($attributes->isEmpty())
...
@endif

@if ($attributes->isNotEmpty())
...
@endif
```