### PR TITLE
[11.x] Export `cache`, `jobs`, `failed_jobs` or `sessions` migration schema if the file doesn't exists based on new skeleton.

### DIFF
--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -65,6 +65,6 @@ class FailedTableCommand extends MigrationGeneratorCommand
             '{%s,%s}',
             $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '0001_01_01_000003_create_jobs_table.php'),
-        )) !== 0;
+        ))) !== 0;
     }
 }

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -48,4 +48,23 @@ class FailedTableCommand extends MigrationGeneratorCommand
     {
         return __DIR__.'/stubs/failed_jobs.stub';
     }
+
+    /**
+     * Determine whether a migration for the table already exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    protected function migrationExists($table)
+    {
+        if ($table !== 'failed_jobs') {
+            return parent::migrationExists($table);
+        }
+
+        return count($this->files->glob(sprintf(
+            '{%s,%s}',
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '0001_01_01_000003_create_jobs_table.php'),
+        )) !== 0;
+    }
 }

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -65,6 +65,6 @@ class TableCommand extends MigrationGeneratorCommand
             '{%s,%s}',
             $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '0001_01_01_000003_create_jobs_table.php'),
-        )) !== 0;
+        ))) !== 0;
     }
 }

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -48,4 +48,23 @@ class TableCommand extends MigrationGeneratorCommand
     {
         return __DIR__.'/stubs/jobs.stub';
     }
+
+    /**
+     * Determine whether a migration for the table already exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    protected function migrationExists($table)
+    {
+        if ($table !== 'jobs') {
+            return parent::migrationExists($table);
+        }
+
+        return count($this->files->glob(sprintf(
+            '{%s,%s}',
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '0001_01_01_000003_create_jobs_table.php'),
+        )) !== 0;
+    }
 }

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -48,4 +48,19 @@ class SessionTableCommand extends MigrationGeneratorCommand
     {
         return __DIR__.'/stubs/database.stub';
     }
+
+    /**
+     * Determine whether a migration for the table already exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    protected function migrationExists($table)
+    {
+        return count($this->files->glob(sprintf(
+            '{%s,%s}',
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
+            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '0001_01_01_000000_create_users_table.php'),
+        )) !== 0;
+    }
 }

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -61,6 +61,6 @@ class SessionTableCommand extends MigrationGeneratorCommand
             '{%s,%s}',
             $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '0001_01_01_000000_create_users_table.php'),
-        )) !== 0;
+        ))) !== 0;
     }
 }

--- a/tests/Foundation/Console/AboutCommandTest.php
+++ b/tests/Foundation/Console/AboutCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Attributes\WithMigration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -10,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 #[WithMigration]
 class AboutCommandTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * @param  \Closure(bool):mixed  $format
      * @param  mixed  $expected

--- a/tests/Foundation/Console/AboutCommandTest.php
+++ b/tests/Foundation/Console/AboutCommandTest.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Foundation\Console\AboutCommand;
+use Orchestra\Testbench\Attributes\WithMigration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[WithMigration]
 class AboutCommandTest extends TestCase
 {
     /**

--- a/tests/Foundation/Console/AboutCommandTest.php
+++ b/tests/Foundation/Console/AboutCommandTest.php
@@ -3,16 +3,11 @@
 namespace Illuminate\Tests\Foundation\Console;
 
 use Illuminate\Foundation\Console\AboutCommand;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Orchestra\Testbench\Attributes\WithMigration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-#[WithMigration]
 class AboutCommandTest extends TestCase
 {
-    use RefreshDatabase;
-
     /**
      * @param  \Closure(bool):mixed  $format
      * @param  mixed  $expected

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -3,10 +3,12 @@
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
 use Illuminate\Testing\Assert;
+use Orchestra\Testbench\Attributes\WithEnv;
 use Orchestra\Testbench\TestCase;
 
 use function Orchestra\Testbench\remote;
 
+#[WithEnv('APP_MAINTENANCE_STORE', 'array')]
 class AboutCommandTest extends TestCase
 {
     public function testItCanDisplayAboutCommandAsJson()
@@ -31,12 +33,12 @@ class AboutCommandTest extends TestCase
 
             Assert::assertArraySubset([
                 'broadcasting' => 'log',
-                'cache' => 'file',
+                'cache' => 'database',
                 'database' => 'testing',
                 'logs' => ['single'],
                 'mail' => 'smtp',
                 'queue' => 'database',
-                'session' => 'file',
+                'session' => 'database',
             ], $output['drivers']);
         });
     }

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -8,15 +8,20 @@ use Illuminate\Foundation\Events\MaintenanceModeDisabled;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\Http\Middleware\PreventRequestsDuringMaintenance as TestbenchPreventRequestsDuringMaintenance;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 
+#[WithMigration]
 class MaintenanceModeTest extends TestCase
 {
+    use RefreshDatabase;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -8,30 +8,26 @@ use Illuminate\Foundation\Events\MaintenanceModeDisabled;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
-use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\Attributes\WithEnv;
 use Orchestra\Testbench\Http\Middleware\PreventRequestsDuringMaintenance as TestbenchPreventRequestsDuringMaintenance;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 
-#[WithMigration]
+#[WithEnv('APP_MAINTENANCE_DRIVER', 'file')]
 class MaintenanceModeTest extends TestCase
 {
-    use RefreshDatabase;
-
     protected function setUp(): void
     {
+        $this->beforeApplicationDestroyed(function () {
+            @unlink(storage_path('framework/down'));
+        });
+
         parent::setUp();
 
         $this->withoutMiddleware(TestbenchPreventRequestsDuringMaintenance::class);
-    }
-
-    protected function tearDown(): void
-    {
-        @unlink(storage_path('framework/down'));
     }
 
     public function testBasicMaintenanceModeResponse()


### PR DESCRIPTION
Also update integration tests based on latest Laravel 11 skeleton defaults.