### PR TITLE
[10x.] Use native json_validate in Validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1438,6 +1438,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if (function_exists('json_validate')) {
+            return json_validate($value);
+        }
+
         json_decode($value);
 
         return json_last_error() === JSON_ERROR_NONE;


### PR DESCRIPTION
This change will use the native PHP 8.3 `json_validate` function (if available) when validating that a string is [valid JSON](https://laravel.com/docs/10.x/validation#rule-json)

Related: #48367

