### PR TITLE
Added Boolean return for update/delete Eloquent methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1404,14 +1404,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // by the timestamp. Then we will go ahead and delete the model instance.
         $this->touchOwners();
 
-        $this->performDeleteOnModel();
+        $deleted = $this->performDeleteOnModel();
 
         // Once the model has been deleted, we will fire off the deleted event so that
         // the developers may hook into post-delete operations. We will then return
-        // a boolean true as the delete is presumably successful on the database.
-        $this->fireModelEvent('deleted', false);
+        // a boolean indicating if the delete was successful on the database.
+        if ($deleted) {
+            $this->fireModelEvent('deleted', false);
+        }
 
-        return true;
+        return (bool) $deleted;
     }
 
     /**
@@ -1455,13 +1457,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Perform the actual delete query on this model instance.
      *
-     * @return void
+     * @return bool
      */
     protected function performDeleteOnModel()
     {
-        $this->setKeysForSaveQuery($this->newModelQuery())->delete();
+        $deleted = $this->setKeysForSaveQuery($this->newModelQuery())->delete();
 
-        $this->exists = false;
+        if ($deleted) {
+            $this->exists = false;
+        }
+
+        return $deleted;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1210,14 +1210,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $dirty = $this->getDirtyForUpdate();
 
         if (count($dirty) > 0) {
-            $this->setKeysForSaveQuery($query)->update($dirty);
+            $updated = $this->setKeysForSaveQuery($query)->update($dirty);
+            if ($updated) {
+                $this->syncChanges();
 
-            $this->syncChanges();
-
-            $this->fireModelEvent('updated', false);
+                $this->fireModelEvent('updated', false);
+            }
         }
 
-        return true;
+        return (bool) ($updated ?? false);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -89,7 +89,7 @@ trait SoftDeletes
     /**
      * Perform the actual delete query on this model instance.
      *
-     * @return void
+     * @return bool
      */
     protected function runSoftDelete()
     {
@@ -107,11 +107,15 @@ trait SoftDeletes
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
         }
 
-        $query->update($columns);
+        $updated = $query->update($columns);
 
-        $this->syncOriginalAttributes(array_keys($columns));
+        if ($updated) {
+            $this->syncOriginalAttributes(array_keys($columns));
 
-        $this->fireModelEvent('trashed', false);
+            $this->fireModelEvent('trashed', false);
+        }
+
+        return (bool) $updated;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -932,6 +932,19 @@ class DatabaseEloquentModelTest extends TestCase
         $model->delete();
     }
 
+    public function testDeleteReturnsFalseIfBuilderDeleteReturnsFalse()
+    {
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'touchOwners'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('delete')->once()->andReturn(0);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('touchOwners');
+        $model->exists = true;
+        $model->id = 1;
+        $this->assertFalse($model->delete());
+    }
+
     public function testPushNoRelations()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -741,6 +741,24 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
     }
 
+    public function testUpdateProcessReturnsFalseIfBuilderUpdateReturnsFalse()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->once()->with('id', '=', 1);
+        $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(0);
+
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model->id = 1;
+        $model->syncOriginal();
+        $model->name = 'taylor';
+        $model->exists = true;
+        $this->assertFalse($model->save());
+    }
+
     public function testTimestampsAreReturnedAsObjects()
     {
         $model = $this->getMockBuilder(EloquentDateModelStub::class)->onlyMethods(['getDateFormat'])->getMock();

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -24,7 +24,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $query->shouldReceive('update')->once()->with([
             'deleted_at' => 'date-time',
             'updated_at' => 'date-time',
-        ]);
+        ])->andReturn(1);
         $model->shouldReceive('syncOriginalAttributes')->once()->with([
             'deleted_at',
             'updated_at',
@@ -33,6 +33,20 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $model->delete();
 
         $this->assertInstanceOf(Carbon::class, $model->deleted_at);
+    }
+
+    public function testDeleteReturnFalseIfBuilderReturnFalse()
+    {
+        $model = m::mock(DatabaseSoftDeletingTraitStub::class);
+        $model->makePartial();
+        $model->shouldReceive('newModelQuery')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('update')->once()->with([
+            'deleted_at' => 'date-time',
+            'updated_at' => 'date-time',
+        ])->andReturn(0);
+        $model->shouldReceive('usesTimestamps')->once()->andReturn(true);
+        $this->assertFalse($model->delete());
     }
 
     public function testRestore()


### PR DESCRIPTION
Last day I had an issue related to deleting a model. The code (simplified version for the sake of example) looked something like this:
`
$user = User::select('some_column')->first();
$user->delete(); // returns true
`
But surprisingly, I could still see the user in my database even though `->delete()` had returned `true` to me! I figured this happened because I had not selected the primary key column in my select statement which makes sense. However, I wondered why the `->delete()` method is returning a true if it couldn't delete it.

I took a look at the `src/Illuminate/Database/Eloquent/Model::delete()` method:

```
...
$this->performDeleteOnModel();

// Once the model has been deleted, we will fire off the deleted event so that
// the developers may hook into post-delete operations. We will then return
// a boolean true as the delete is presumably successful on the database.
$this->fireModelEvent('deleted', false);

return true;
```

As it's shown here, it doesn't actually care about what `performDeleteOnModel()` has returned.

This PR Contains code for such cases so that the delete (and soft delete) method would return true only if the query ran successfully.
While looking around I noticed the same thing applies to updates as well so the same changes have been applied to it.