### PR TITLE
[10.x] Improve schema builder `getColumns()` method

### DIFF
--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -107,7 +107,7 @@ class PostgresProcessor extends Processor
             $autoincrement = $result->default !== null && str_starts_with($result->default, 'nextval(');
 
             return [
-                'name' => str_starts_with($result->name, '"') ? str_replace('"', '', $result->name) : $result->name,
+                'name' => $result->name,
                 'type_name' => $result->type_name,
                 'type' => $result->type,
                 'collation' => $result->collation,

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -36,7 +36,7 @@ class SQLiteProcessor extends Processor
 
             return [
                 'name' => $result->name,
-                'type_name' => strtok($type, '('),
+                'type_name' => strtok($type, '(') ?: '',
                 'type' => $type,
                 'collation' => null,
                 'nullable' => (bool) $result->nullable,

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -158,7 +158,7 @@ class MySqlGrammar extends Grammar
         return sprintf(
             'select column_name as `name`, data_type as `type_name`, column_type as `type`, '
             .'collation_name as `collation`, is_nullable as `nullable`, '
-            .'column_default as `default`, column_comment AS `comment`, extra as `extra` '
+            .'column_default as `default`, column_comment as `comment`, extra as `extra` '
             .'from information_schema.columns where table_schema = %s and table_name = %s '
             .'order by ordinal_position asc',
             $this->quoteString($database),

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -168,11 +168,11 @@ class PostgresGrammar extends Grammar
     public function compileColumns($database, $schema, $table)
     {
         return sprintf(
-            'select quote_ident(a.attname) as name, t.typname as type_name, format_type(a.atttypid, a.atttypmod) as type, '
+            'select a.attname as name, t.typname as type_name, format_type(a.atttypid, a.atttypmod) as type, '
             .'(select tc.collcollate from pg_catalog.pg_collation tc where tc.oid = a.attcollation) as collation, '
             .'not a.attnotnull as nullable, '
             .'(select pg_get_expr(adbin, adrelid) from pg_attrdef where c.oid = pg_attrdef.adrelid and pg_attrdef.adnum = a.attnum) as default, '
-            .'(select pg_description.description from pg_description where pg_description.objoid = c.oid and a.attnum = pg_description.objsubid) as comment '
+            .'col_description(c.oid, a.attnum) as comment '
             .'from pg_attribute a, pg_class c, pg_type t, pg_namespace n '
             .'where c.relname = %s and n.nspname = %s and a.attnum > 0 and a.attrelid = c.oid and a.atttypid = t.oid and n.oid = c.relnamespace '
             .'order by a.attnum',

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -121,7 +121,7 @@ class SQLiteGrammar extends Grammar
     public function compileColumns($table)
     {
         return sprintf(
-            "select name, type, not 'notnull' as 'nullable', dflt_value as 'default', pk as 'primary' "
+            'select name, type, not "notnull" as "nullable", dflt_value as "default", pk as "primary" '
             .'from pragma_table_info(%s) order by cid asc',
             $this->wrap(str_replace('.', '__', $table))
         );

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -162,7 +162,8 @@ class SqlServerGrammar extends Grammar
             .'join sys.schemas as scm on obj.schema_id = scm.schema_id '
             .'left join sys.default_constraints def on col.default_object_id = def.object_id and col.object_id = def.parent_object_id '
             ."left join sys.extended_properties as prop on obj.object_id = prop.major_id and col.column_id = prop.minor_id and prop.name = 'MS_Description' "
-            ."where obj.type = 'U' and obj.name = %s and scm.name = SCHEMA_NAME()",
+            ."where obj.type = 'U' and obj.name = %s and scm.name = SCHEMA_NAME() "
+            ."order by col.column_id",
             $this->quoteString($table),
         );
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -162,8 +162,8 @@ class SqlServerGrammar extends Grammar
             .'join sys.schemas as scm on obj.schema_id = scm.schema_id '
             .'left join sys.default_constraints def on col.default_object_id = def.object_id and col.object_id = def.parent_object_id '
             ."left join sys.extended_properties as prop on obj.object_id = prop.major_id and col.column_id = prop.minor_id and prop.name = 'MS_Description' "
-            ."where obj.type = 'U' and obj.name = %s and scm.name = SCHEMA_NAME() "
-            ."order by col.column_id",
+            ."where obj.type in ('U', 'V') and obj.name = %s and scm.name = SCHEMA_NAME() "
+            .'order by col.column_id',
             $this->quoteString($table),
         );
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -214,12 +214,10 @@ class SchemaBuilderTest extends DatabaseTestCase
         Schema::create('foo', function (Blueprint $table) {
             $table->id();
             $table->string('bar')->nullable();
-            $table->string('baz')->default('test')->comment('lorem ipsum');
+            $table->string('baz')->default('test');
         });
 
         $columns = Schema::getColumns('foo');
-
-        var_dump($columns);
 
         $this->assertCount(3, $columns);
         $this->assertTrue(collect($columns)->contains(
@@ -229,17 +227,18 @@ class SchemaBuilderTest extends DatabaseTestCase
             fn ($column) => $column['name'] === 'bar' && $column['nullable']
         ));
         $this->assertTrue(collect($columns)->contains(
-            fn ($column) => $column['name'] === 'baz' && ! $column['nullable'] && $column['default'] === 'test'
+            fn ($column) => $column['name'] === 'baz' && ! $column['nullable'] && str_contains($column['default'], 'test')
         ));
     }
 
     public function testGetColumnsOnView()
     {
-        DB::statement('create view foo (name) as select 1');
+        DB::statement('create view foo (bar) as select 1');
 
         $columns = Schema::getColumns('foo');
 
-        var_dump($columns);
+        $this->assertCount(1, $columns);
+        $this->assertTrue($columns[0]['name'] === 'bar');
     }
 
     public function testGetIndexes()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -209,6 +209,39 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertEmpty($types);
     }
 
+    public function testGetColumns()
+    {
+        Schema::create('foo', function (Blueprint $table) {
+            $table->id();
+            $table->string('bar')->nullable();
+            $table->string('baz')->default('test')->comment('lorem ipsum');
+        });
+
+        $columns = Schema::getColumns('foo');
+
+        var_dump($columns);
+
+        $this->assertCount(3, $columns);
+        $this->assertTrue(collect($columns)->contains(
+            fn ($column) => $column['name'] === 'id' && $column['auto_increment'] && ! $column['nullable']
+        ));
+        $this->assertTrue(collect($columns)->contains(
+            fn ($column) => $column['name'] === 'bar' && $column['nullable']
+        ));
+        $this->assertTrue(collect($columns)->contains(
+            fn ($column) => $column['name'] === 'baz' && ! $column['nullable'] && $column['default'] === 'test'
+        ));
+    }
+
+    public function testGetColumnsOnView()
+    {
+        DB::statement('create view foo (name) as select 1');
+
+        $columns = Schema::getColumns('foo');
+
+        var_dump($columns);
+    }
+
     public function testGetIndexes()
     {
         Schema::create('foo', function (Blueprint $table) {


### PR DESCRIPTION
This PR does:
- Enhance `Schema::getColumns()` to also work for the given database view (as requested here https://github.com/laravel/framework/pull/48864#issuecomment-1803731047)
- Minor enhancement for retrieving column's comment on PostgreSQL that makes the query more optimized
- Add order clause to the query that retrieves columns on SQL Server
- Fix column escaping when retrieving column's on SQLite
- Add more integration tests for `Schema::getColumns()`

Related to #48357 