### PR TITLE
[10.x] Add Conditionable to Pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -5,11 +5,14 @@ namespace Illuminate\Pipeline;
 use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
+use Illuminate\Support\Traits\Conditionable;
 use RuntimeException;
 use Throwable;
 
 class Pipeline implements PipelineContract
 {
+    use Conditionable;
+
     /**
      * The container implementation.
      *

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -259,6 +259,7 @@ class PipelineTest extends TestCase
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);
         unset($_SERVER['__test.pipe.one']);
 
+        $_SERVER['__test.pipe.one'] = null;
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->when(false, function (Pipeline $pipeline) {
@@ -270,6 +271,7 @@ class PipelineTest extends TestCase
 
         $this->assertSame('foo', $result);
         $this->assertNull($_SERVER['__test.pipe.one']);
+        unset($_SERVER['__test.pipe.one']);
     }
 }
 

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -243,6 +243,34 @@ class PipelineTest extends TestCase
 
         unset($_SERVER['__test.pipe.one']);
     }
+
+    public function testPipelineConditionable()
+    {
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->when(true, function (Pipeline $pipeline) {
+                $pipeline->pipe([PipelineTestPipeOne::class]);
+            })
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
+        unset($_SERVER['__test.pipe.one']);
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->when(false, function (Pipeline $pipeline) {
+                $pipeline->pipe([PipelineTestPipeOne::class]);
+            })
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertNull($_SERVER['__test.pipe.one']);
+    }
 }
 
 class PipelineTestPipeOne


### PR DESCRIPTION
This PR adds `Conditionable` trait to `Pipeline` class.

before this PR:
```PHP
$pipeline = Pipeline::send($user)
    ->through([
        GenerateProfilePhoto::class,
    ]);
 
if (! $user->isAdmin) {
    $pipeline->pipe([
        SendWelcomeEmail::class,
        ActivateSubscription::class,
    ]);
}
 
$user = $pipeline->then(fn (User $user) => $user);
```

after this PR:
```PHP
$user = Pipeline::send($user)
    ->through([
        GenerateProfilePhoto::class,
    ])
    ->when(! $user->isAdmin, function (Pipeline $pipeline) {
        $pipeline->pipe([
            SendWelcomeEmail::class,
            ActivateSubscription::class,
        ]);
    })
    ->then(fn (User $user) => $user);
```