### PR TITLE
[10.x] Adds support for parse callbacks from anonymous classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -810,6 +810,17 @@ class Str
      */
     public static function parseCallback($callback, $default = null)
     {
+        if (static::contains($callback, "@anonymous\0")) {
+            if (static::substrCount($callback, '@') > 1) {
+                return [
+                    static::beforeLast($callback, '@'),
+                    static::afterLast($callback, '@')
+                ];
+            }
+
+            return [$callback, $default];
+        }
+
         return static::contains($callback, '@') ? explode('@', $callback, 2) : [$callback, $default];
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -814,7 +814,7 @@ class Str
             if (static::substrCount($callback, '@') > 1) {
                 return [
                     static::beforeLast($callback, '@'),
-                    static::afterLast($callback, '@')
+                    static::afterLast($callback, '@'),
                 ];
             }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -328,9 +328,15 @@ class SupportStrTest extends TestCase
 
     public function testParseCallback()
     {
+        $this->assertEquals(['Class', 'method'], Str::parseCallback('Class@method'));
         $this->assertEquals(['Class', 'method'], Str::parseCallback('Class@method', 'foo'));
         $this->assertEquals(['Class', 'foo'], Str::parseCallback('Class', 'foo'));
         $this->assertEquals(['Class', null], Str::parseCallback('Class'));
+
+        $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", 'method'], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec@method"));
+        $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", 'method'], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec@method", 'foo'));
+        $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", 'foo'], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec", 'foo'));
+        $this->assertEquals(["Class@anonymous\0/laravel/382.php:8$2ec", null], Str::parseCallback("Class@anonymous\0/laravel/382.php:8$2ec"));
     }
 
     public function testSlug()


### PR DESCRIPTION
This pull request adds support for parse callbacks from anonymous classes. This will fix [https://github.com/livewire/volt/issues/80](https://github.com/livewire/volt/issues/80), as currently model route binding is not working as expected when using callbacks from anonymous classes. This issue is due to the 'parseCallback' method not supporting anonymous class names like: `Livewire\Volt\Component@anonymous\x00/Users/nunomaduro/Work/Code/laravel-volt/vendor/orchestra/testbench-core/laravel/storage/framework/views/2b8da6b9fd24ea5feb790aeaf6138f04.php:8$3d5@mount`.