### PR TITLE
[10.x] Move `Illuminate\Foundation\Application::joinPaths()` to `Illuminate\Filesystem\join_paths()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,7 @@
         "files": [
             "src/Illuminate/Collections/helpers.php",
             "src/Illuminate/Events/functions.php",
+            "src/Illuminate/Filesystem/functions.php",
             "src/Illuminate/Foundation/helpers.php",
             "src/Illuminate/Support/helpers.php"
         ],

--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -5,6 +5,8 @@ namespace Illuminate\Console;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
 
+use function Illuminate\Filesystem\join_paths;
+
 abstract class MigrationGeneratorCommand extends Command
 {
     /**
@@ -114,7 +116,7 @@ abstract class MigrationGeneratorCommand extends Command
     protected function migrationExists($table)
     {
         return count($this->files->glob(
-            $this->laravel->joinPaths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php')
+            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php')
         )) !== 0;
     }
 }

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -24,7 +24,10 @@
     "autoload": {
         "psr-4": {
             "Illuminate\\Filesystem\\": ""
-        }
+        },
+        "files": [
+            "functions.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -7,7 +7,7 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      * Join the given paths together.
      *
      * @param  string  $basePath
-     * @param  string  $paths
+     * @param  string  ...$paths
      * @return string
      */
     function join_paths(string $basePath, string ...$paths)

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -12,8 +12,14 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      */
     function join_paths($basePath, string ...$paths)
     {
-        return $basePath.collect($paths)->reject(fn ($path) => empty($path))
-                ->transform(fn ($path) => DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR))
-                ->join('');
+        foreach ($paths as $index => $path) {
+            if (empty($path)) {
+                unset($paths[$index]);
+            } else {
+                $paths[$index] = DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR);
+            }
+        }
+
+        return $basePath.implode('', $paths);
     }
 }

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -7,11 +7,13 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      * Join the given paths together.
      *
      * @param  string  $basePath
-     * @param  string  $path
+     * @param  string  $paths
      * @return string
      */
-    function join_paths($basePath, $path = '')
+    function join_paths(string $basePath, string ...$paths)
     {
-        return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
+        return $basePath.collect($paths)->reject(fn ($path) => empty($path))
+                ->transform(fn ($path) => DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR))
+                ->join('');
     }
 }

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+if (! function_exists('Illuminate\Filesystem\join_paths')) {
+    /**
+     * Join the given paths together.
+     *
+     * @param  string  $basePath
+     * @param  string  $path
+     * @return string
+     */
+    function join_paths($basePath, $path = '')
+    {
+        return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
+    }
+}

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -6,11 +6,11 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
     /**
      * Join the given paths together.
      *
-     * @param  string  $basePath
+     * @param  string|null  $basePath
      * @param  string  ...$paths
      * @return string
      */
-    function join_paths(string $basePath, string ...$paths)
+    function join_paths($basePath, string ...$paths)
     {
         return $basePath.collect($paths)->reject(fn ($path) => empty($path))
                 ->transform(fn ($path) => DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR))

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,6 +29,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+use function Illuminate\Filesystem\join_paths;
+
 class Application extends Container implements ApplicationContract, CachesConfiguration, CachesRoutes, HttpKernelInterface
 {
     use Macroable;
@@ -586,7 +588,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function joinPaths($basePath, $path = '')
     {
-        return $basePath.($path != '' ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : '');
+        return join_paths($basePath, $path);
     }
 
     /**

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\TestCase;
+
+use function Illuminate\Filesystem\join_paths;
+
+class JoinPathsHelperTest extends TestCase
+{
+    #[RequiresOperatingSystem('Linux|DAR')]
+    #[DataProvider('unixDataProvider')]
+    public function testItCanMergePathsForUnix(string $expected, string $given)
+    {
+        $this->assertSame($expected, $given);
+    }
+
+    public static function unixDataProvider()
+    {
+        yield ['app/Http/Kernel.php', join_paths('app', 'Http', 'Kernel.php')];
+        yield ['app/Http/Kernel.php', join_paths('app', '', 'Http', 'Kernel.php')];
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    #[DataProvider('windowsDataProvider')]
+    public function testItCanMergePathsForWindows(string $expected, string $given)
+    {
+        $this->assertSame($expected, $given);
+    }
+
+    public static function windowsDataProvider()
+    {
+        yield ['app\Http\Kernel.php', join_paths('app', 'Http', 'Kernel.php')];
+        yield ['app\Http\Kernel.php', join_paths('app', '', 'Http', 'Kernel.php')];
+    }
+}


### PR DESCRIPTION
This feature doesn't require anything from the application instance so it should be safe to add it under `Filesystem` component. This would also solve https://github.com/laravel/lumen-framework/issues/1273