### PR TITLE
[10.x] Allow Vite asset path customization

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Exception;
+use Illuminate\Config\Repository;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
@@ -54,6 +55,13 @@ class Vite implements Htmlable
      * @var string
      */
     protected $manifestFilename = 'manifest.json';
+
+    /**
+     * The custom asset path resolver.
+     *
+     * @var callable|null
+     */
+    protected $assetPathResolver = null;
 
     /**
      * The script tag attributes resolvers.
@@ -156,6 +164,19 @@ class Vite implements Htmlable
     public function useManifestFilename($filename)
     {
         $this->manifestFilename = $filename;
+
+        return $this;
+    }
+
+    /**
+     * Resolve asset paths using the provided resolver.
+     *
+     * @param  callable|null  $urlResolver
+     * @return $this
+     */
+    public function createAssetPathsUsing($resolver)
+    {
+        $this->assetPathResolver = $resolver;
 
         return $this;
     }
@@ -688,7 +709,7 @@ class Vite implements Htmlable
      */
     protected function assetPath($path, $secure = null)
     {
-        return asset($path, $secure);
+        return ($this->assetPathResolver ?? asset(...))($path, $secure);
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation;
 
 use Exception;
-use Illuminate\Config\Repository;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -657,6 +657,33 @@ class FoundationViteTest extends TestCase
         $this->cleanViteHotFile('cold');
     }
 
+    public function testViteCanAssetPath()
+    {
+        $this->makeViteManifest([
+            'resources/images/profile.png' => [
+                'src' => 'resources/images/profile.png',
+                'file' => 'assets/profile.versioned.png',
+            ],
+        ], $buildDir = Str::random());
+        $vite = app(Vite::class)->useBuildDirectory($buildDir);
+        $this->app['config']->set('app.asset_url', 'https://cdn.app.com');
+
+        // default behaviour...
+        $this->assertSame("https://cdn.app.com/{$buildDir}/assets/profile.versioned.png", $vite->asset('resources/images/profile.png'));
+
+        // custom behaviour
+        $vite->createAssetPathsUsing(function ($path) {
+            return 'https://tenant-cdn.app.com/'.$path;
+        });
+        $this->assertSame("https://tenant-cdn.app.com/{$buildDir}/assets/profile.versioned.png", $vite->asset('resources/images/profile.png'));
+
+        // restore default behaviour...
+        $vite->createAssetPathsUsing(null);
+        $this->assertSame("https://cdn.app.com/{$buildDir}/assets/profile.versioned.png", $vite->asset('resources/images/profile.png'));
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     public function testViteIsMacroable()
     {
         $this->makeViteManifest([

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1164,21 +1164,21 @@ class FoundationViteTest extends TestCase
     {
         $buildDir = Str::random();
         $this->makeViteManifest([
-            'resources/js/app.css' =>  [
-                'file' =>  'assets/app-versioned.css',
-                'src' =>  'resources/js/app.css',
+            'resources/js/app.css' => [
+                'file' => 'assets/app-versioned.css',
+                'src' => 'resources/js/app.css',
             ],
-            'resources/js/Pages/Welcome.vue' =>  [
-                'file' =>  'assets/Welcome-versioned.js',
-                'src' =>  'resources/js/Pages/Welcome.vue',
-                'imports' =>  [
+            'resources/js/Pages/Welcome.vue' => [
+                'file' => 'assets/Welcome-versioned.js',
+                'src' => 'resources/js/Pages/Welcome.vue',
+                'imports' => [
                     'resources/js/app.js',
                 ],
             ],
-            'resources/js/app.js' =>  [
-                'file' =>  'assets/app-versioned.js',
-                'src' =>  'resources/js/app.js',
-                'css' =>  [
+            'resources/js/app.js' => [
+                'file' => 'assets/app-versioned.js',
+                'src' => 'resources/js/app.js',
+                'css' => [
                     'assets/app-versioned.css',
                 ],
             ],


### PR DESCRIPTION
Alternative to https://github.com/laravel/framework/pull/49378

We currently rely on the `asset` helper to generate the build asset paths for Vite.

In some applications, it may be that you have global assets and user local assets (tenants) that have different URLs.

This means you cannot rely on the `asset` helper to generate URLs to both types of assets.

It is also true that you cannot dynamically change the config value `app.asset_url` once the `UrlGenerator` has been resolved.

To get around these limitations, I've added an "advanced" customisation that allows apps to override how Vite generates it's asset URLs.

This could be placed in a service provider...

```php
Vite::createAssetPathsUsing(function ($path, $secure) {
    return //...
});
```

Or even inline in your Blade files...

```blade
{{
   Vite::createAssetPathsUsing(function ($path, $secure) {
    return //...
   });
}}
<!-- ... --->
{{
   Vite::createAssetPathsUsing(function ($path, $secure) {
    return //...
   });
}}
```