### PR TITLE
[10.x] Fix installing DBAL on a fresh app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,7 @@
         "psr/simple-cache-implementation": "1.0|2.0|3.0"
     },
     "conflict": {
+        "carbonphp/carbon-doctrine-types": "^3.0",
         "tightenco/collect": "<5.5.33"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,8 @@
         "psr/simple-cache-implementation": "1.0|2.0|3.0"
     },
     "conflict": {
-        "carbonphp/carbon-doctrine-types": "^3.0",
+        "carbonphp/carbon-doctrine-types": ">=3.0",
+        "doctrine/dbal": ">=4.0",
         "tightenco/collect": "<5.5.33"
     },
     "autoload": {


### PR DESCRIPTION
# DBAL issue

We cannot install DBAL on a fresh Laravel application.

```
composer create-project laravel/laravel dbal-test
cd dbal-test
composer require doctrine/dbal ❌
composer require doctrine/dbal -w ❌
composer require doctrine/dbal -W ❌
composer require doctrine/dbal:\* ❌
composer require doctrine/dbal carbonphp/carbon-doctrine-types ✅
```

Framework issue: https://github.com/laravel/framework/issues/49403

Solutions to try and make it better...

## conflict

Add conflict with `carbonphp/carbon-doctrine-types:^2.0`

- `composer update` ✅
- `composer update laravel/framework` ❌
- `composer update laravel/framework -w` ❌
- `composer update laravel/framework -W` ❌
- `composer update laravel/framework carbonphp/carbon-doctrine-types` ✅

## require

Add require of `carbonphp/carbon-doctrine-types:^2.0`

- `composer update` ✅
- `composer update laravel/framework` ❌
- `composer update laravel/framework -w` ✅
- `composer update laravel/framework -W` ✅
- `composer update laravel/framework carbonphp/carbon-doctrine-types` ✅

## docs

We could just document that you need to `composer require doctrine/dbal carbonphp/carbon-doctrine-types` to install dbal, but that feels weird to me.

## Why `conflict`

Although `require` offers the best user experience, we don't require this package.

- Adding a conflict will unblock new applications.
- Any long lived application is less likely to randomly need to install `dbal` as they likely have already had a need for it.
- We can handle incoming GitHub issues with by telling them to `composer update laravel/framework carbonphp/carbon-doctrine-types`

> [!Note]
> I do not like any of these solutions.

## Update

I've opened an issue on Carbon (https://github.com/briannesbitt/Carbon/issues/2905) to ask them to make the dependency opt in.