### PR TITLE
[10.x] Fix env:decrypt output path

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -72,11 +72,13 @@ class EnvironmentDecryptCommand extends Command
 
         $key = $this->parseKey($key);
 
-        $encryptedFile = ($this->option('env')
+        $environmentFile = ($this->option('env')
                     ? base_path('.env').'.'.$this->option('env')
-                    : $this->laravel->environmentFilePath()).'.encrypted';
+                    : $this->laravel->environmentFilePath());
 
-        $outputFile = $this->outputFilePath();
+        $encryptedFile = $environmentFile.'.encrypted';
+
+        $outputFile = $this->outputFilePath(basename($environmentFile));
 
         if (Str::endsWith($outputFile, '.encrypted')) {
             $this->components->error('Invalid filename.');
@@ -136,11 +138,10 @@ class EnvironmentDecryptCommand extends Command
      *
      * @return string
      */
-    protected function outputFilePath()
+    protected function outputFilePath(string $environmentFile)
     {
         $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
-
-        $outputFile = $this->option('filename') ?: ('.env'.($this->option('env') ? '.'.$this->option('env') : ''));
+        $outputFile = $this->option('filename') ?: $environmentFile;
         $outputFile = ltrim($outputFile, DIRECTORY_SEPARATOR);
 
         return $path.$outputFile;


### PR DESCRIPTION
This PR attempts to resolve issues raised in [#4940](https://github.com/laravel/framework/pull/49406/files).

 When using a `.env.testing` file and explicitly setting the environment at the system level like so:

```shell
APP_ENV=testing php artisan env:decrypt
```

The command will find the encrypted `.env.testing` due to the use of `$this->laravel->environmentFilePath()` to resolve the current environment file.

However, when writing the file, this was not taken into account so it would be written to `.env` instead of `.env.testing`.

This PR uses the environment filepath established earlier in the command to keep things consistent.
