### PR TITLE
Add define guards to redirectTo method

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -18,6 +18,13 @@ class Authenticate implements AuthenticatesRequests
     protected $auth;
 
     /**
+     * Define the applying guars
+     * 
+     * @param array
+     */
+    protected $guards = [];
+
+    /**
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
@@ -72,6 +79,8 @@ class Authenticate implements AuthenticatesRequests
             $guards = [null];
         }
 
+        $this->guards = $guards;
+
         foreach ($guards as $guard) {
             if ($this->auth->guard($guard)->check()) {
                 return $this->auth->shouldUse($guard);
@@ -93,7 +102,7 @@ class Authenticate implements AuthenticatesRequests
     protected function unauthenticated($request, array $guards)
     {
         throw new AuthenticationException(
-            'Unauthenticated.', $guards, $this->redirectTo($request, $guards)
+            'Unauthenticated.', $guards, $this->redirectTo($request)
         );
     }
 
@@ -101,10 +110,9 @@ class Authenticate implements AuthenticatesRequests
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param string[]  $guards
      * @return string|null
      */
-    protected function redirectTo(Request $request, array $guards)
+    protected function redirectTo(Request $request)
     {
         //
     }

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -93,7 +93,7 @@ class Authenticate implements AuthenticatesRequests
     protected function unauthenticated($request, array $guards)
     {
         throw new AuthenticationException(
-            'Unauthenticated.', $guards, $this->redirectTo($request)
+            'Unauthenticated.', $guards, $this->redirectTo($request, $guards)
         );
     }
 
@@ -101,9 +101,10 @@ class Authenticate implements AuthenticatesRequests
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param string[]  $guards
      * @return string|null
      */
-    protected function redirectTo(Request $request)
+    protected function redirectTo(Request $request, array $guards)
     {
         //
     }


### PR DESCRIPTION
Sometimes when we use the different guards on multi-level applications we need to direct use on the appropriate level based on defined guards.

Version: Lavarel 10.x
Module: Auth

This PR should help to know the define guard redirectTo method when we define it. And let's user take action to define what level of application should load and prevent creating an appropriate middleware again for managing authentication

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
