### PR TITLE
[10.x] Fix Laravel Missing Validation rules not working with nested array data

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -265,6 +265,10 @@ class Validator implements ValidatorContract
         'ProhibitedIf',
         'ProhibitedUnless',
         'Prohibits',
+        'MissingIf',
+        'MissingUnless',
+        'MissingWith',
+        'MissingWithAll',
         'Same',
         'Unique',
     ];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2499,9 +2499,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'foo', 'bar' => '2'], ['foo' => 'missing_if:bar,1']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,['foo' => [0 => ['bar' => 1, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_if:foo.*.bar,1']);
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 1, 'baz' => 'should be missing']]], ['foo.*.baz' => 'missing_if:foo.*.bar,1']);
         $this->assertTrue($v->fails());
-        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar is 1.',$v->errors()->first('foo.0.baz'));
+        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar is 1.', $v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateMissingUnless()
@@ -2542,9 +2542,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'foo', 'bar' => '1'], ['foo' => 'missing_unless:bar,1']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,['foo' => [0 => ['bar' => 0, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_unless:foo.*.bar,1']);
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 0, 'baz' => 'should be missing']]], ['foo.*.baz' => 'missing_unless:foo.*.bar,1']);
         $this->assertTrue($v->fails());
-        $this->assertSame('The foo.0.baz field must be missing unless foo.0.bar is 1.',$v->errors()->first('foo.0.baz'));
+        $this->assertSame('The foo.0.baz field must be missing unless foo.0.bar is 1.', $v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateMissingWith()
@@ -2588,9 +2588,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'foo', 'qux' => '1'], ['foo' => 'missing_with:baz,bar']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,['foo' => [0 => ['bar' => 1, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_with:foo.*.bar,foo.*.fred']);
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 1, 'baz' => 'should be missing']]], ['foo.*.baz' => 'missing_with:foo.*.bar,foo.*.fred']);
         $this->assertTrue($v->fails());
-        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar / foo.0.fred is present.',$v->errors()->first('foo.0.baz'));
+        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar / foo.0.fred is present.', $v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateMissingWithAll()
@@ -2634,9 +2634,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [], 'bar' => '2', 'qux' => '2'], ['foo' => 'missing_with_all:baz,bar']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,['foo' => [0 => ['bar' => 1,'fred' => 2, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_with_all:foo.*.bar,foo.*.fred']);
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 1,'fred' => 2, 'baz' => 'should be missing']]], ['foo.*.baz' => 'missing_with_all:foo.*.bar,foo.*.fred']);
         $this->assertTrue($v->fails());
-        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar / foo.0.fred are present.',$v->errors()->first('foo.0.baz'));
+        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar / foo.0.fred are present.', $v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateDeclinedIf()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2498,6 +2498,10 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 'foo', 'bar' => '2'], ['foo' => 'missing_if:bar,1']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 1, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_if:foo.*.bar,1']);
+        $this->assertTrue($v->fails());
+        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar is 1.',$v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateMissingUnless()
@@ -2537,6 +2541,10 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 'foo', 'bar' => '1'], ['foo' => 'missing_unless:bar,1']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 0, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_unless:foo.*.bar,1']);
+        $this->assertTrue($v->fails());
+        $this->assertSame('The foo.0.baz field must be missing unless foo.0.bar is 1.',$v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateMissingWith()
@@ -2579,6 +2587,10 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 'foo', 'qux' => '1'], ['foo' => 'missing_with:baz,bar']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 1, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_with:foo.*.bar,foo.*.fred']);
+        $this->assertTrue($v->fails());
+        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar / foo.0.fred is present.',$v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateMissingWithAll()
@@ -2621,6 +2633,10 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => [], 'bar' => '2', 'qux' => '2'], ['foo' => 'missing_with_all:baz,bar']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,['foo' => [0 => ['bar' => 1,'fred' => 2, 'baz' => 'should be missing']]],['foo.*.baz' => 'missing_with_all:foo.*.bar,foo.*.fred']);
+        $this->assertTrue($v->fails());
+        $this->assertSame('The foo.0.baz field must be missing when foo.0.bar / foo.0.fred are present.',$v->errors()->first('foo.0.baz'));
     }
 
     public function testValidateDeclinedIf()


### PR DESCRIPTION
&ensp; This PR let next validation rules work fine with **nested array data dependacies.**
- missing_if
- missing_unless
- missing_with
- missing_with_all

> I also add assertions for each test validation rule of them

### After this PR
this next validation rule will throw validation  errors
```php
use Illuminate\Support\Facades\Validator;

$rules = ['foo.*.bar' => ['missing_if:foo.*.fez,1']];

$data = [
    'foo' =>  [
        [ 
            'bar' => 'should be missing',
            'fez' => 1 
        ],
        [
            'bar' => 'can be filled',
            'fez' => 10,
        ]
    ]
];

Validator::validate($data,$rules);
# this will throw validation exception with message The foo.0.bar field must be missing when foo.0.fez is 1
```
### Before this PR
These rules escape the validation without throwing any validation error, As the **asterisk** had not been replaced with the current array row index.