### PR TITLE
[10.x] Add method to create request

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -711,6 +711,17 @@ trait MakesHttpRequests
     }
 
     /**
+     * Create the request instance used for testing from the given Symfony request.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $symfonyRequest
+     * @return \Illuminate\Http\Request
+     */
+    protected function createTestRequest($symfonyRequest)
+    {
+        return Request::createFromBase($symfonyRequest);
+    }
+
+    /**
      * Create the test response instance from the given response.
      *
      * @param  \Illuminate\Http\Response  $response
@@ -725,16 +736,5 @@ trait MakesHttpRequests
                     : new LoggedExceptionCollection
             );
         });
-    }
-
-    /**
-     * Create the request instance used for testing from the given symfony request.
-     *
-     * @param  \Symfony\Component\HttpFoundation\Request  $symfonyRequest
-     * @return \Illuminate\Http\Request
-     */
-    protected function createTestRequest($symfonyRequest)
-    {
-        return Request::createFromBase($symfonyRequest);
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -583,7 +583,7 @@ trait MakesHttpRequests
         );
 
         $response = $kernel->handle(
-            $request = Request::createFromBase($symfonyRequest)
+            $request = $this->createTestRequest($symfonyRequest)
         );
 
         $kernel->terminate($request, $response);
@@ -725,5 +725,16 @@ trait MakesHttpRequests
                     : new LoggedExceptionCollection
             );
         });
+    }
+
+    /**
+     * Create the request instance used for testing from the given symfony request.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $symfonyRequest
+     * @return \Illuminate\Http\Request
+     */
+    protected function createTestRequest($symfonyRequest)
+    {
+        return Request::createFromBase($symfonyRequest);
     }
 }


### PR DESCRIPTION
Add method to create request, instead of creating it inline. This makes it easier to override the way the test request is created. One use case  I have is binding and setting a route to the request for certain tests.