### PR TITLE
[10.x] Allow testing prompts validation

### DIFF
--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -134,7 +134,7 @@ trait ConfiguresPrompts
                 $this->components->error(is_string($required) ? $required : 'Required.');
 
                 if ($this->laravel->runningUnitTests()) {
-                    throw new PromptValidationException();
+                    throw new PromptValidationException;
                 } else {
                     continue;
                 }
@@ -147,7 +147,7 @@ trait ConfiguresPrompts
                     $this->components->error($error);
 
                     if ($this->laravel->runningUnitTests()) {
-                        throw new PromptValidationException();
+                        throw new PromptValidationException;
                     } else {
                         continue;
                     }

--- a/src/Illuminate/Console/PromptValidationException.php
+++ b/src/Illuminate/Console/PromptValidationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Console;
+
+use RuntimeException;
+
+class PromptValidationException extends RuntimeException
+{
+}

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Testing;
 
 use Illuminate\Console\OutputStyle;
+use Illuminate\Console\PromptValidationException;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
@@ -300,6 +301,8 @@ class PendingCommand
             }
 
             throw $e;
+        } catch (PromptValidationException) {
+            $exitCode = Command::FAILURE;
         }
 
         if ($this->expectedExitCode !== null) {

--- a/tests/Integration/Console/PromptsValidationTest.php
+++ b/tests/Integration/Console/PromptsValidationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Testing\Console;
+namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;

--- a/tests/Testing/Console/PromptsValidationTest.php
+++ b/tests/Testing/Console/PromptsValidationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Orchestra\Testbench\TestCase;
+
+use function Laravel\Prompts\text;
+
+class PromptsValidationTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app[Kernel::class]->registerCommand(new DummyPromptsValidationCommand());
+    }
+
+    public function testValidationForPrompts()
+    {
+        $this
+            ->artisan(DummyPromptsValidationCommand::class)
+            ->expectsQuestion('Test', 'bar')
+            ->expectsOutputToContain('error!');
+    }
+}
+
+class DummyPromptsValidationCommand extends Command
+{
+    protected $signature = 'prompts-validation-test';
+
+    public function handle()
+    {
+        text('Test', validate: fn ($value) => $value == 'foo' ? '' : 'error!');
+    }
+}


### PR DESCRIPTION
When running tests, Laravel Prompts fall back to the console components.

The fallback takes care of running the console components repeatedly until their validation passes.

This is convenient when we want to interact with the user but it should not happen when our tests run as we may want to test the input validation in our console commands.

This PR lets us test the user input validation when we use Laravel Prompts in our console commands.