### PR TITLE
[10.x] Markdown engine

### DIFF
--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -56,7 +56,7 @@ class MarkdownEngine implements Engine
         $rendered = $this->converter->convert($this->files->get($path));
 
         if ($this->renderCallback) {
-            return (string) call_user_func(
+            $rendered = call_user_func(
                 $this->renderCallback, new HtmlString($rendered->getContent()), $rendered->getDocument(), $data, $path
             );
         }

--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -57,7 +57,7 @@ class MarkdownEngine implements Engine
 
         if ($this->renderCallback) {
             $rendered = call_user_func(
-                $this->renderCallback, new HtmlString($rendered->getContent()), $rendered->getDocument(), $data, $path
+                $this->renderCallback, new HtmlString($rendered->getContent()), $rendered, $data, $path
             );
         }
 

--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Engines;
 
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\HtmlString;
 use Illuminate\View\ComponentSlot;
 use Illuminate\View\Factory;
 use League\CommonMark\ConverterInterface;
@@ -57,7 +58,7 @@ class MarkdownEngine implements Engine
         $rendered = $this->converter->convert($this->files->get($path));
 
         if ($this->renderCallback) {
-            return (string) call_user_func($this->renderCallback, $rendered, $data, $path);
+            return (string) call_user_func($this->renderCallback, new HtmlString($rendered->getContent()), $rendered->getDocument(), $data, $path);
         }
 
         return (string) $rendered;

--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -58,7 +58,9 @@ class MarkdownEngine implements Engine
         $rendered = $this->converter->convert($this->files->get($path));
 
         if ($this->renderCallback) {
-            return (string) call_user_func($this->renderCallback, new HtmlString($rendered->getContent()), $rendered->getDocument(), $data, $path);
+            return (string) call_user_func(
+                $this->renderCallback, new HtmlString($rendered->getContent()), $rendered->getDocument(), $data, $path
+            );
         }
 
         return (string) $rendered;

--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\View\Engines;
+
+use Illuminate\Contracts\View\Engine;
+use Illuminate\Filesystem\Filesystem;
+use League\CommonMark\ConverterInterface;
+use League\CommonMark\Exception\CommonMarkException;
+use League\Config\Exception\ConfigurationExceptionInterface;
+
+class MarkdownEngine implements Engine
+{
+
+    /**
+     * Create a new markdown engine instance.
+     *
+     * @param  Filesystem  $files
+     * @param  ConverterInterface  $converter
+     */
+    public function __construct(
+        public Filesystem $files,
+        public ConverterInterface $converter
+    ) {
+    }
+
+    /**
+     * Get the evaluated contents of the view.
+     *
+     * @param  string  $path
+     * @param  array  $data
+     * @return string
+     *
+     * @throws CommonMarkException
+     * @throws ConfigurationExceptionInterface
+     */
+    public function get($path, array $data = [])
+    {
+        return (string) $this->converter->convert($this->files->get($path));
+    }
+}

--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -44,6 +44,7 @@ class MarkdownEngine implements Engine
      *
      * @param  string  $view
      * @param  string|null  $slot
+     * @return void
      */
     public function setLayout($view, $slot = 'slot')
     {

--- a/src/Illuminate/View/Engines/MarkdownEngine.php
+++ b/src/Illuminate/View/Engines/MarkdownEngine.php
@@ -5,8 +5,6 @@ namespace Illuminate\View\Engines;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\HtmlString;
-use Illuminate\View\ComponentSlot;
-use Illuminate\View\Factory;
 use League\CommonMark\ConverterInterface;
 use League\CommonMark\Exception\CommonMarkException;
 use League\Config\Exception\ConfigurationExceptionInterface;

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -67,6 +67,7 @@ class Factory implements FactoryContract
         'php' => 'php',
         'css' => 'file',
         'html' => 'file',
+        'md' => 'markdown',
     ];
 
     /**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -40,7 +40,7 @@ class FileViewFinder implements ViewFinderInterface
      *
      * @var string[]
      */
-    protected $extensions = ['blade.php', 'php', 'css', 'html'];
+    protected $extensions = ['blade.php', 'php', 'css', 'html', 'md'];
 
     /**
      * Create a new file view loader instance.

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\FileEngine;
 use Illuminate\View\Engines\MarkdownEngine;
 use Illuminate\View\Engines\PhpEngine;
+use League\CommonMark\ConverterInterface;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class ViewServiceProvider extends ServiceProvider
@@ -183,9 +184,10 @@ class ViewServiceProvider extends ServiceProvider
     {
         $resolver->register('markdown', function () {
             return new MarkdownEngine(
-                $this->app['files'],
-                $this->app[GithubFlavoredMarkdownConverter::class],
-                $this->app['view'],
+                $this->app->make('files'),
+                $this->app->bound(ConverterInterface::class)
+                    ? $this->app->make(ConverterInterface::class)
+                    : $this->app->make(GithubFlavoredMarkdownConverter::class),
             );
         });
     }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -7,7 +7,9 @@ use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\FileEngine;
+use Illuminate\View\Engines\MarkdownEngine;
 use Illuminate\View\Engines\PhpEngine;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class ViewServiceProvider extends ServiceProvider
 {
@@ -118,7 +120,7 @@ class ViewServiceProvider extends ServiceProvider
             // Next, we will register the various view engines with the resolver so that the
             // environment will resolve the engines needed for various views based on the
             // extension of view file. We call a method for each of the view's engines.
-            foreach (['file', 'php', 'blade'] as $engine) {
+            foreach (['file', 'php', 'blade', 'markdown'] as $engine) {
                 $this->{'register'.ucfirst($engine).'Engine'}($resolver);
             }
 
@@ -168,6 +170,19 @@ class ViewServiceProvider extends ServiceProvider
             });
 
             return $compiler;
+        });
+    }
+
+    /**
+     * Register the markdown engine implementation.
+     *
+     * @param  \Illuminate\View\Engines\EngineResolver  $resolver
+     * @return void
+     */
+    public function registerMarkdownEngine($resolver)
+    {
+        $resolver->register('markdown', function () {
+            return new MarkdownEngine($this->app['files'], $this->app[GithubFlavoredMarkdownConverter::class]);
         });
     }
 }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -182,7 +182,11 @@ class ViewServiceProvider extends ServiceProvider
     public function registerMarkdownEngine($resolver)
     {
         $resolver->register('markdown', function () {
-            return new MarkdownEngine($this->app['files'], $this->app[GithubFlavoredMarkdownConverter::class]);
+            return new MarkdownEngine(
+                $this->app['files'],
+                $this->app[GithubFlavoredMarkdownConverter::class],
+                $this->app['view'],
+            );
         });
     }
 }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -40,6 +40,7 @@ class ViewFileViewFinderTest extends TestCase
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.css')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.html')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.md')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/nested/foo.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/nested/foo.blade.php', $finder->find('foo'));
@@ -72,6 +73,7 @@ class ViewFileViewFinderTest extends TestCase
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.css')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.html')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.md')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/bar/bar/baz.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));
@@ -86,6 +88,7 @@ class ViewFileViewFinderTest extends TestCase
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.css')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.html')->andReturn(false);
+        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.md')->andReturn(false);
 
         $finder->find('foo');
     }
@@ -122,7 +125,7 @@ class ViewFileViewFinderTest extends TestCase
         $finder->addExtension('baz');
         $finder->addExtension('baz');
 
-        $this->assertCount(5, $finder->getExtensions());
+        $this->assertCount(6, $finder->getExtensions());
     }
 
     public function testPassingViewWithHintReturnsTrue()

--- a/tests/View/ViewMarkdownEngineTest.php
+++ b/tests/View/ViewMarkdownEngineTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\View;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\ComponentSlot;
 use Illuminate\View\Engines\MarkdownEngine;
-use Illuminate\View\Engines\PhpEngine;
 use Illuminate\View\Factory;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use PHPUnit\Framework\TestCase;

--- a/tests/View/ViewMarkdownEngineTest.php
+++ b/tests/View/ViewMarkdownEngineTest.php
@@ -16,7 +16,7 @@ class ViewMarkdownEngineTest extends TestCase
             new GithubFlavoredMarkdownConverter,
         );
 
-        $expected = <<<MARKDOWN
+        $expected = <<<'MARKDOWN'
         <h1>Markdown Example</h1>
         <p>This is an example <a href="https://daringfireball.net/projects/markdown/">markdown</a> file.</p>
         <ul>
@@ -31,7 +31,7 @@ class ViewMarkdownEngineTest extends TestCase
 
     public function testViewsCanBeRenderedInBasicLayout()
     {
-        $expected = <<<MARKDOWN
+        $expected = <<<'MARKDOWN'
         <h1>Markdown Example</h1>
         <p>This is an example <a href="https://daringfireball.net/projects/markdown/">markdown</a> file.</p>
         <ul>

--- a/tests/View/ViewMarkdownEngineTest.php
+++ b/tests/View/ViewMarkdownEngineTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\View;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Engines\MarkdownEngine;
+use Illuminate\View\Engines\PhpEngine;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
+use PHPUnit\Framework\TestCase;
+
+class ViewMarkdownEngineTest extends TestCase
+{
+    public function testViewsMayBeProperlyRendered()
+    {
+        $engine = new MarkdownEngine(new Filesystem, new GithubFlavoredMarkdownConverter);
+
+        $expected = <<<MARKDOWN
+        <h1>Markdown Example</h1>
+        <p>This is an example <a href="https://daringfireball.net/projects/markdown/">markdown</a> file.</p>
+        <ul>
+        <li>Markdown</li>
+        <li>is</li>
+        <li>wonderful.</li>
+        </ul>
+        MARKDOWN;
+
+        $this->assertSame(trim($expected), trim($engine->get(__DIR__.'/fixtures/markdown.md')));
+    }
+}

--- a/tests/View/ViewMarkdownEngineTest.php
+++ b/tests/View/ViewMarkdownEngineTest.php
@@ -3,16 +3,23 @@
 namespace Illuminate\Tests\View;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\ComponentSlot;
 use Illuminate\View\Engines\MarkdownEngine;
 use Illuminate\View\Engines\PhpEngine;
+use Illuminate\View\Factory;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use PHPUnit\Framework\TestCase;
+use Mockery as m;
 
 class ViewMarkdownEngineTest extends TestCase
 {
     public function testViewsMayBeProperlyRendered()
     {
-        $engine = new MarkdownEngine(new Filesystem, new GithubFlavoredMarkdownConverter);
+        $engine = new MarkdownEngine(
+            new Filesystem,
+            new GithubFlavoredMarkdownConverter,
+            m::mock(Factory::class)
+        );
 
         $expected = <<<MARKDOWN
         <h1>Markdown Example</h1>
@@ -25,5 +32,35 @@ class ViewMarkdownEngineTest extends TestCase
         MARKDOWN;
 
         $this->assertSame(trim($expected), trim($engine->get(__DIR__.'/fixtures/markdown.md')));
+    }
+
+    public function testViewsCanBeRenderedInLayout()
+    {
+        $expected = <<<MARKDOWN
+        <h1>Markdown Example</h1>
+        <p>This is an example <a href="https://daringfireball.net/projects/markdown/">markdown</a> file.</p>
+        <ul>
+        <li>Markdown</li>
+        <li>is</li>
+        <li>wonderful.</li>
+        </ul>
+        MARKDOWN;
+
+        $view = m::mock(Factory::class);
+
+        $view->shouldReceive('make')
+            ->once()
+            ->withArgs(function ($view, $data) use ($expected) {
+                return $view === 'layouts.app'
+                    && is_array($data)
+                    && $data['slot'] instanceof ComponentSlot
+                    && trim((string) $data['slot']) === trim($expected);
+            })
+            ->andReturn('rendered with blade');
+
+        $engine = new MarkdownEngine(new Filesystem, new GithubFlavoredMarkdownConverter, $view);
+        $engine->setLayout('layouts.app');
+
+        $this->assertSame('rendered with blade', $engine->get(__DIR__.'/fixtures/markdown.md'));
     }
 }

--- a/tests/View/ViewMarkdownEngineTest.php
+++ b/tests/View/ViewMarkdownEngineTest.php
@@ -11,10 +11,7 @@ class ViewMarkdownEngineTest extends TestCase
 {
     public function testViewsMayBeProperlyRendered()
     {
-        $engine = new MarkdownEngine(
-            new Filesystem,
-            new GithubFlavoredMarkdownConverter,
-        );
+        $engine = new MarkdownEngine(new Filesystem, new GithubFlavoredMarkdownConverter);
 
         $expected = <<<'MARKDOWN'
         <h1>Markdown Example</h1>
@@ -31,6 +28,11 @@ class ViewMarkdownEngineTest extends TestCase
 
     public function testViewsCanBeRenderedInBasicLayout()
     {
+        $engine = new MarkdownEngine(new Filesystem, new GithubFlavoredMarkdownConverter);
+        $engine->renderMarkdownUsing(function ($markdown) {
+            return '<html>'.trim($markdown).'</html>';
+        });
+
         $expected = <<<'MARKDOWN'
         <h1>Markdown Example</h1>
         <p>This is an example <a href="https://daringfireball.net/projects/markdown/">markdown</a> file.</p>
@@ -40,11 +42,6 @@ class ViewMarkdownEngineTest extends TestCase
         <li>wonderful.</li>
         </ul>
         MARKDOWN;
-
-        $engine = new MarkdownEngine(new Filesystem, new GithubFlavoredMarkdownConverter, $view);
-        $engine->renderMarkdownUsing(function ($markdown) {
-            return '<html>'.trim($markdown).'</html>';
-        });
 
         $this->assertSame("<html>{$expected}</html>", $engine->get(__DIR__.'/fixtures/markdown.md'));
     }

--- a/tests/View/fixtures/markdown.md
+++ b/tests/View/fixtures/markdown.md
@@ -1,0 +1,7 @@
+# Markdown Example
+
+This is an example [markdown](https://daringfireball.net/projects/markdown/) file.
+
+- Markdown
+- is
+- wonderful.


### PR DESCRIPTION
This introduces a new view engine for rendering markdown files. It allows you to add `.md` files to your `views/` directory and render them like any other view:

```php
// given a `resources/views/terms/privacy.md` file, this will work:
return view('terms.privacy');
```

If you want to wrap markdown in a layout or manipulate it in some way, you can register a callback:

```php
View::getEngineResolver()
  ->resolve('markdown')
  ->renderMarkdownUsing(function($markdown) {
    return Blade::render('<x-layout>{{ $markdown }}</x-layout>', compact('markdown'));
  });
```

(This callback receives the rendered HTML, the CommonMark `RenderedContentInterface` instance, the data passed to the view, and the path of the markdown file being rendered.)

Personally, I would love to add a `renderMarkdownUsing` method to the `View\Factory` that handled the engine resolution for you, but I wanted to keep this PR as focussed as possible.

By default, the markdown engine will use the `GithubFlavoredMarkdownConverter` (which is the default in existing Laravel markdown implementations), but you can bind any `League\CommonMark\ConverterInterface` interface to the container to make that the default:

```php
// in your service provider's `register` method:
$this->app->bind(ConverterInterface::class, function() {
  return new CommonMarkConverter();
});
```