### PR TITLE
[10.x] Allow deprecation logging in tests

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -118,7 +118,7 @@ class HandleExceptions
     {
         return ! class_exists(LogManager::class)
             || ! static::$app->hasBeenBootstrapped()
-            || static::$app->runningUnitTests();
+            || (static::$app->runningUnitTests() && ! static::$app['config']->get('logging.deprecations.testsuite'));
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -7,6 +7,7 @@ use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\LogManager;
+use Illuminate\Support\Env;
 use Monolog\Handler\NullHandler;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\ErrorHandler\Error\FatalError;
@@ -118,7 +119,7 @@ class HandleExceptions
     {
         return ! class_exists(LogManager::class)
             || ! static::$app->hasBeenBootstrapped()
-            || (static::$app->runningUnitTests() && ! static::$app['config']->get('logging.deprecations.testsuite'));
+            || (static::$app->runningUnitTests() && ! Env::get('LOG_DEPRECATIONS_WHILE_TESTING'));
     }
 
     /**

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -42,17 +42,18 @@ class HandleExceptionsTest extends TestCase
     protected function tearDown(): void
     {
         Application::setInstance(null);
+        m::close();
     }
 
     public function testPhpDeprecations()
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
-        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+        $logger->expects('channel')->with('deprecations')->andReturnSelf();
+        $logger->expects('warning')->with(sprintf('%s in %s on line %s',
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
             17
@@ -70,16 +71,16 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
         $this->config->set('logging.deprecations', [
             'channel' => 'null',
             'trace' => true,
         ]);
 
-        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(
+        $logger->expects('channel')->with('deprecations')->andReturnSelf();
+        $logger->expects('warning')->with(
             m::on(fn (string $message) => (bool) preg_match(
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
@@ -106,16 +107,16 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
         $this->config->set('logging.deprecations', [
             'channel' => null,
             'trace' => false,
         ]);
 
-        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+        $logger->expects('channel')->with('deprecations')->andReturnSelf();
+        $logger->expects('warning')->with(sprintf('%s in %s on line %s',
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
             17
@@ -138,11 +139,11 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
-        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+        $logger->expects('channel')->with('deprecations')->andReturnSelf();
+        $logger->expects('warning')->with(sprintf('%s in %s on line %s',
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
             17
@@ -160,16 +161,16 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
         $this->config->set('logging.deprecations', [
             'channel' => 'null',
             'trace' => true,
         ]);
 
-        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(
+        $logger->expects('channel')->with('deprecations')->andReturnSelf();
+        $logger->expects('warning')->with(
             m::on(fn (string $message) => (bool) preg_match(
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
@@ -196,8 +197,6 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldNotReceive('channel');
         $logger->shouldNotReceive('warning');
@@ -217,11 +216,11 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
-        $logger->shouldReceive('channel')->andReturnSelf();
-        $logger->shouldReceive('warning');
+        $logger->expects('channel')->andReturnSelf();
+        $logger->expects('warning');
 
         $this->config->set('logging.channels.stack', [
             'driver' => 'stack',
@@ -251,11 +250,11 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
-        $logger->shouldReceive('channel')->andReturnSelf();
-        $logger->shouldReceive('warning');
+        $logger->expects('channel')->andReturnSelf();
+        $logger->expects('warning');
 
         $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
@@ -274,11 +273,11 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
-        $logger->shouldReceive('channel')->andReturnSelf();
-        $logger->shouldReceive('warning');
+        $logger->expects('channel')->andReturnSelf();
+        $logger->expects('warning');
 
         $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
@@ -297,11 +296,11 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
-        $logger->shouldReceive('channel')->andReturnSelf();
-        $logger->shouldReceive('warning');
+        $logger->expects('channel')->andReturnSelf();
+        $logger->expects('warning');
 
         $this->config->set('logging.channels.null', [
             'driver' => 'monolog',
@@ -329,8 +328,8 @@ class HandleExceptionsTest extends TestCase
 
     public function testIgnoreDeprecationIfLoggerUnresolvable()
     {
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(false);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
         $this->handleExceptions()->handleError(
             E_DEPRECATED,
@@ -348,8 +347,8 @@ class HandleExceptionsTest extends TestCase
 
             throw new RuntimeException();
         });
-        $this->app->shouldReceive('runningUnitTests')->andReturn(true);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $this->app->expects('runningUnitTests')->andReturn(true);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
         $this->handleExceptions()->handleError(
             E_DEPRECATED,
@@ -363,12 +362,12 @@ class HandleExceptionsTest extends TestCase
 
     public function testItCanForceViaConfigDeprecationLoggingWhenRunningUnitTests()
     {
-        $this->app->instance(LogManager::class, tap(m::mock(LogManager::class), function ($mock) {
-            $mock->shouldReceive('channel')->andReturnSelf();
-            $mock->shouldReceive('warning');
-        }));
-        $this->app->shouldReceive('runningUnitTests')->andReturn(true);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+        $logger = m::mock(LogManager::class);
+        $logger->expects('channel')->andReturnSelf();
+        $logger->expects('warning');
+        $this->app->instance(LogManager::class, $logger);
+        $this->app->expects('runningUnitTests')->andReturn(true);
+        $this->app->expects('hasBeenBootstrapped')->andReturn(true);
 
         Env::getRepository()->set('LOG_DEPRECATIONS_WHILE_TESTING', true);
 
@@ -399,9 +398,6 @@ class HandleExceptionsTest extends TestCase
 
     public function testHandlerForgetsPreviousApp()
     {
-        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
-        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
-
         $instance = $this->handleExceptions();
 
         $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
@@ -413,7 +409,7 @@ class HandleExceptionsTest extends TestCase
         $this->assertSame($this->app, $appResolver());
 
         $instance->bootstrap($newApp = tap(m::mock(Application::class), function ($app) {
-            $app->shouldReceive('environment')->once()->andReturn(true);
+            $app->expects('environment')->andReturn(true);
         }));
 
         $this->assertNotSame($this->app, $appResolver());

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -16,7 +16,6 @@ class HandleExceptionsTest extends TestCase
 {
     protected $app;
     protected $config;
-    protected $handleExceptions;
 
     protected function setUp(): void
     {
@@ -27,19 +26,14 @@ class HandleExceptionsTest extends TestCase
         $this->app->singleton('config', function () {
             return $this->config;
         });
+    }
 
-        $this->handleExceptions = new HandleExceptions();
-
-        with(new ReflectionClass($this->handleExceptions), function ($reflection) {
-            $property = $reflection->getProperty('app');
-
-            $property->setValue(
-                $this->handleExceptions,
-                tap($this->app, function ($app) {
-                    $app->shouldReceive('runningUnitTests')->andReturn(false);
-                    $app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
-                })
-            );
+    protected function handleExceptions()
+    {
+        return tap(new HandleExceptions(), function ($instance) {
+            with(new ReflectionClass($instance), function ($reflection) use ($instance) {
+                $reflection->getProperty('app')->setValue($instance, $this->app);
+            });
         });
     }
 
@@ -52,6 +46,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
         $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
@@ -60,7 +56,7 @@ class HandleExceptionsTest extends TestCase
             17
         ));
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -72,6 +68,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $this->config->set('logging.deprecations', [
             'channel' => 'null',
@@ -94,7 +92,7 @@ class HandleExceptionsTest extends TestCase
             ))
         );
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -106,6 +104,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $this->config->set('logging.deprecations', [
             'channel' => null,
@@ -119,7 +119,7 @@ class HandleExceptionsTest extends TestCase
             17
         ));
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -136,6 +136,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
         $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
@@ -144,7 +146,7 @@ class HandleExceptionsTest extends TestCase
             17
         ));
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -156,6 +158,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $this->config->set('logging.deprecations', [
             'channel' => 'null',
@@ -178,7 +182,7 @@ class HandleExceptionsTest extends TestCase
             ))
         );
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -190,6 +194,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldNotReceive('channel');
         $logger->shouldNotReceive('warning');
@@ -197,7 +203,7 @@ class HandleExceptionsTest extends TestCase
         $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('Something went wrong');
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_ERROR,
             'Something went wrong',
             '/home/user/laravel/src/Providers/AppServiceProvider.php',
@@ -209,6 +215,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldReceive('channel')->andReturnSelf();
         $logger->shouldReceive('warning');
@@ -220,7 +228,7 @@ class HandleExceptionsTest extends TestCase
         ]);
         $this->config->set('logging.deprecations', 'stack');
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -241,11 +249,13 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldReceive('channel')->andReturnSelf();
         $logger->shouldReceive('warning');
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -262,11 +272,13 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldReceive('channel')->andReturnSelf();
         $logger->shouldReceive('warning');
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -283,6 +295,8 @@ class HandleExceptionsTest extends TestCase
     {
         $logger = m::mock(LogManager::class);
         $this->app->instance(LogManager::class, $logger);
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
         $logger->shouldReceive('channel')->andReturnSelf();
         $logger->shouldReceive('warning');
@@ -292,7 +306,7 @@ class HandleExceptionsTest extends TestCase
             'handler' => CustomNullHandler::class,
         ]);
 
-        $this->handleExceptions->handleError(
+        $this->handleExceptions()->handleError(
             E_USER_DEPRECATED,
             'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
             '/home/user/laravel/routes/web.php',
@@ -323,30 +337,37 @@ class HandleExceptionsTest extends TestCase
 
     public function testForgetApp()
     {
-        $appResolver = fn () => with(new ReflectionClass($this->handleExceptions), function ($reflection) {
+        $instance = $this->handleExceptions();
+
+        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
             $property = $reflection->getProperty('app');
 
-            return $property->getValue($this->handleExceptions);
+            return $property->getValue($instance);
         });
 
         $this->assertNotNull($appResolver());
 
-        handleExceptions::forgetApp();
+        HandleExceptions::forgetApp();
 
         $this->assertNull($appResolver());
     }
 
     public function testHandlerForgetsPreviousApp()
     {
-        $appResolver = fn () => with(new ReflectionClass($this->handleExceptions), function ($reflection) {
+        $this->app->shouldReceive('runningUnitTests')->andReturn(false);
+        $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
+
+        $instance = $this->handleExceptions();
+
+        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
             $property = $reflection->getProperty('app');
 
-            return $property->getValue($this->handleExceptions);
+            return $property->getValue($instance);
         });
 
         $this->assertSame($this->app, $appResolver());
 
-        $this->handleExceptions->bootstrap($newApp = tap(m::mock(Application::class), function ($app) {
+        $instance->bootstrap($newApp = tap(m::mock(Application::class), function ($app) {
             $app->shouldReceive('environment')->once()->andReturn(true);
         }));
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Log\LogManager;
+use Illuminate\Support\Env;
 use Mockery as m;
 use Monolog\Handler\NullHandler;
 use PHPUnit\Framework\TestCase;
@@ -369,7 +370,7 @@ class HandleExceptionsTest extends TestCase
         $this->app->shouldReceive('runningUnitTests')->andReturn(true);
         $this->app->shouldReceive('hasBeenBootstrapped')->andReturn(true);
 
-        $this->app['config']->set('logging.deprecations.testsuite', true);
+        Env::getRepository()->set('LOG_DEPRECATIONS_WHILE_TESTING', true);
 
         $this->handleExceptions()->handleError(
             E_DEPRECATED,


### PR DESCRIPTION
- Had to rework how the tests get the `HandleExceptions` instance as I wanted to add additional tests that had different config.
- Made mocks use `expects` and added `m::close`. Without these the tests don't actually fail if they don't get the method calls - so my tests wouldn't fail.
- Used the ENV because we don't need to clutter the application's config with this option.