### PR TITLE
[10.x] Simplify Arr::dot

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -109,7 +109,7 @@ class Arr
      */
     public static function dot($array, $prepend = '')
     {
-        $results = [[]];
+        $results = [];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {


### PR DESCRIPTION
For each element in the input array, a new array is append in `$result`. The initial empty array is therefore useless. 