### PR TITLE
Fixes the issue where the first http::fake() call's data takes precedence when there are multiple

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -13,7 +13,7 @@ if (! function_exists('collect')) {
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    function collect($value = [])
+    function collect($value = []): Collection
     {
         return new Collection($value);
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -235,6 +235,16 @@ class Factory
     }
 
     /**
+     * Flushes all the request data from fakes.
+     *
+     * @return void
+     */
+    public function flushFakes(): void
+    {
+        $this->stubCallbacks = collect();
+    }
+
+    /**
      * Indicate that an exception should be thrown if any request is not faked.
      *
      * @param  bool  $prevent

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -156,4 +156,16 @@ class Http extends Facade
             static::swap($fake->stubUrl($url, $callback));
         });
     }
+
+    /**
+     * Flushes all the request data from fakes.
+     *
+     * @return \Illuminate\Http\Client\Factory
+     */
+    public static function flushFakes()
+    {
+        return tap(static::getFacadeRoot(), function ($fake) {
+            static::swap($fake->flushFakes());
+        });
+    }
 }

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -20,4 +20,25 @@ class HttpClientTest extends TestCase
 
         $this->assertCount(2, Http::getGlobalMiddleware());
     }
+
+    public function testRequestDataDoesNotPersistAfterFlush(): void
+    {
+        Http::fake([
+                       'https://laravel.com' => Http::response('OK', 200)
+                   ]);
+
+        $body = Http::get('https://laravel.com')->body();
+
+        $this->assertSame('OK', $body);
+
+        Http::flushFakes();
+
+        Http::fake([
+                       'https://laravel.com' => Http::response('Internal Server Error', 500)
+                   ]);
+
+        $body = Http::get('https://laravel.com')->body();
+
+        $this->assertSame('Internal Server Error', $body);
+    }
 }

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -24,8 +24,8 @@ class HttpClientTest extends TestCase
     public function testRequestDataDoesNotPersistAfterFlush(): void
     {
         Http::fake([
-                       'https://laravel.com' => Http::response('OK', 200)
-                   ]);
+            'https://laravel.com' => Http::response('OK', 200),
+        ]);
 
         $body = Http::get('https://laravel.com')->body();
 
@@ -34,8 +34,8 @@ class HttpClientTest extends TestCase
         Http::flushFakes();
 
         Http::fake([
-                       'https://laravel.com' => Http::response('Internal Server Error', 500)
-                   ]);
+            'https://laravel.com' => Http::response('Internal Server Error', 500),
+        ]);
 
         $body = Http::get('https://laravel.com')->body();
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/49398

If we call two `http::fake()` calls in the same test case, the data from the first `http::fake()` always takes precedence. The second `http::fake()` call does not override the first `http::fake()` data.

This is because the underlying Factory is a singleton. Refer: https://github.com/laravel/framework/pull/47915

This PR adds the ability to flush all the fakes in Http Client

```php
Http::flushFakes();
```





