### PR TITLE
[10.x] Add ```countFiles``` method to Filesystem

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -132,6 +132,15 @@ interface Filesystem
     public function size($path);
 
     /**
+     * Get count of all files in a directory.
+     *
+     * @param  string|null  $directory
+     * @param  bool  $recursive
+     * @return mixed
+     */
+    public function countFiles($directory = null, $recursive = false);
+
+    /**
      * Get the file's last modification time.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -469,6 +469,16 @@ class Filesystem
     }
 
     /**
+     * @param  string|null  $directory
+     * @param  bool  $recursive
+     * @return bool
+     */
+    public function countFiles($directory = null, $recursive = false)
+    {
+        return count($this->files($directory, $recursive));
+    }
+
+    /**
      * Get the file size of a given file.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -171,6 +171,18 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Get count of all files in a directory.
+     *
+     * @param  string|null  $directory
+     * @param  bool  $recursive
+     * @return int
+     */
+    public function countFiles($directory = null, $recursive = false)
+    {
+        return count($this->files($directory, $recursive));
+    }
+
+    /**
      * Determine if a file or directory exists.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -546,8 +546,6 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-<<<<<<< Updated upstream
-=======
     public function testCountFilesInDirectory()
     {
         $this->filesystem->write('file1.txt', 'Hello World');
@@ -558,7 +556,6 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame(2, $filesystemAdapter->countFiles());
     }
 
->>>>>>> Stashed changes
     public function testGetAllFiles()
     {
         $this->filesystem->write('body.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -546,6 +546,19 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
+<<<<<<< Updated upstream
+=======
+    public function testCountFilesInDirectory()
+    {
+        $this->filesystem->write('file1.txt', 'Hello World');
+        $this->filesystem->write('file2.txt', 'Hello World');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $this->assertSame(2, $filesystemAdapter->countFiles());
+    }
+
+>>>>>>> Stashed changes
     public function testGetAllFiles()
     {
         $this->filesystem->write('body.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -497,6 +497,14 @@ class FilesystemTest extends TestCase
         $this->assertContains(self::$tempDir.'/bar.txt', $glob);
     }
 
+    public function testCountFilesReturnsCorrectNumberOfFiles()
+    {
+        file_put_contents(self::$tempDir.'/foo.txt', 'foo');
+        file_put_contents(self::$tempDir.'/bar.txt', 'bar');
+        $files = new Filesystem;
+        $this->assertSame(2, $files->countFiles(self::$tempDir));
+    }
+
     public function testAllFilesFindsFiles()
     {
         file_put_contents(self::$tempDir.'/foo.txt', 'foo');


### PR DESCRIPTION
I've added a method to Filesystem for counting files in a folder

```php
Storage::countFiles('folder');
```

This allows to have a method without having to go through the ```count()``` method, like this

```php
count(Storage::allFiles('folder'));
```