### PR TITLE
[10.x] Illuminate\Filesystem\join_paths(): Argument #2 must be of type string, null given

### DIFF
--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -7,10 +7,10 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      * Join the given paths together.
      *
      * @param  string|null  $basePath
-     * @param  string  ...$paths
+     * @param  string|null  ...$paths
      * @return string
      */
-    function join_paths($basePath, string ...$paths)
+    function join_paths($basePath, ?string ...$paths)
     {
         foreach ($paths as $index => $path) {
             if (empty($path)) {

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -7,7 +7,7 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      * Join the given paths together.
      *
      * @param  string|null  $basePath
-     * @param  string|null  ...$paths
+     * @param  string  ...$paths
      * @return string
      */
     function join_paths($basePath, ?string ...$paths)

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -10,7 +10,7 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      * @param  string  ...$paths
      * @return string
      */
-    function join_paths($basePath, ?string ...$paths)
+    function join_paths($basePath, ...$paths)
     {
         foreach ($paths as $index => $path) {
             if (empty($path)) {

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -21,7 +21,6 @@ class JoinPathsHelperTest extends TestCase
     {
         yield ['app/Http/Kernel.php', join_paths('app', 'Http', 'Kernel.php')];
         yield ['app/Http/Kernel.php', join_paths('app', '', 'Http', 'Kernel.php')];
-        yield ['app/Http/Kernel.php', join_paths('app', null, 'Http', 'Kernel.php')];
     }
 
     #[RequiresOperatingSystem('Windows')]
@@ -35,6 +34,5 @@ class JoinPathsHelperTest extends TestCase
     {
         yield ['app\Http\Kernel.php', join_paths('app', 'Http', 'Kernel.php')];
         yield ['app\Http\Kernel.php', join_paths('app', '', 'Http', 'Kernel.php')];
-        yield ['app\Http\Kernel.php', join_paths('app', null, 'Http', 'Kernel.php')];
     }
 }

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -21,6 +21,7 @@ class JoinPathsHelperTest extends TestCase
     {
         yield ['app/Http/Kernel.php', join_paths('app', 'Http', 'Kernel.php')];
         yield ['app/Http/Kernel.php', join_paths('app', '', 'Http', 'Kernel.php')];
+        yield ['app/Http/Kernel.php', join_paths('app', null, 'Http', 'Kernel.php')];
     }
 
     #[RequiresOperatingSystem('Windows')]
@@ -34,5 +35,6 @@ class JoinPathsHelperTest extends TestCase
     {
         yield ['app\Http\Kernel.php', join_paths('app', 'Http', 'Kernel.php')];
         yield ['app\Http\Kernel.php', join_paths('app', '', 'Http', 'Kernel.php')];
+        yield ['app\Http\Kernel.php', join_paths('app', null, 'Http', 'Kernel.php')];
     }
 }


### PR DESCRIPTION
Fixes #49466 