### PR TITLE
[10.x] Added Chrono Helper

### DIFF
--- a/src/Illuminate/Support/Chrono.php
+++ b/src/Illuminate/Support/Chrono.php
@@ -37,7 +37,7 @@ class Chrono
     /**
      * Resets the timestamps and cache. Optionally resets memory peak usage.
      *
-     * @param  bool $memory  Whether to reset memory peak usage.
+     * @param  bool  $memory  Whether to reset memory peak usage.
      */
     public static function reset(bool $memory = false): void
     {
@@ -52,19 +52,19 @@ class Chrono
     /**
      * Sets the keys to be included when dumping the stamp data.
      *
-     * @param  string|array|null  $dumpKeys Keys to be dumped.
+     * @param  string|array|null  $dumpKeys  Keys to be dumped.
      */
     public static function dumpKeys(string|array|null $dumpKeys): void
     {
-        static::$dumpKeys = $dumpKeys ? array_flip((array)$dumpKeys) : null;
+        static::$dumpKeys = $dumpKeys ? array_flip((array) $dumpKeys) : null;
     }
 
     /**
      * Creates a timestamp with performance data and optionally dumps it.
      *
-     * @param  bool $dump  Whether to dump the stamp data.
-     * @param  mixed $data  Additional data to be included in the stamp.
-     * @return array  The stamp data.
+     * @param  bool  $dump  Whether to dump the stamp data.
+     * @param  mixed  $data  Additional data to be included in the stamp.
+     * @return array The stamp data.
      */
     public static function stamp(bool $dump = false, mixed $data = null): array
     {
@@ -99,7 +99,7 @@ class Chrono
     /**
      * Retrieves all stored stamps.
      *
-     * @return array  An array of all stamps.
+     * @return array An array of all stamps.
      */
     public static function stamps(): array
     {
@@ -109,10 +109,11 @@ class Chrono
     /**
      * Returns all stamps sorted by a specified key.
      *
-     * @param  string $key  The key to sort by.
-     * @param  int $limit  Limit the returned stamps
-     * @return array  Sorted array of stamps.
-     * @throws InvalidArgumentException  If the provided key is invalid.
+     * @param  string  $key  The key to sort by.
+     * @param  int  $limit  Limit the returned stamps
+     * @return array Sorted array of stamps.
+     *
+     * @throws InvalidArgumentException If the provided key is invalid.
      */
     public static function stampsBy(string $key, int $limit = 0): array
     {
@@ -130,7 +131,7 @@ class Chrono
     /**
      * Dumps the specified stamp data.
      *
-     * @param  array $stamp  The stamp to dump.
+     * @param  array  $stamp  The stamp to dump.
      */
     protected static function dump(array $stamp): void
     {
@@ -144,8 +145,8 @@ class Chrono
     /**
      * Gets the file path relative to the base path.
      *
-     * @param  ?string $file  The file path to process.
-     * @return string  Relative file path.
+     * @param  ?string  $file  The file path to process.
+     * @return string Relative file path.
      */
     protected static function file(?string $file): string
     {
@@ -159,11 +160,11 @@ class Chrono
     /**
      * Collects and returns backtrace debug information.
      *
-     * @return  array  Debug information array.
+     * @return array Debug information array.
      */
     protected static function debug(): array
     {
-        $debug = debug_backtrace(!DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+        $debug = debug_backtrace(! DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 3);
 
         return [
             'file' => static::file($debug[1]['file'] ?? null),

--- a/src/Illuminate/Support/Chrono.php
+++ b/src/Illuminate/Support/Chrono.php
@@ -44,7 +44,7 @@ class Chrono
         static::$stamps = [];
         static::$cache = [];
 
-        if ($memory) {
+        if ($memory && function_exists('memory_reset_peak_usage')) {
             memory_reset_peak_usage();
         }
     }
@@ -132,7 +132,7 @@ class Chrono
      *
      * @param  array $stamp  The stamp to dump.
      */
-    public static function dump(array $stamp): void
+    protected static function dump(array $stamp): void
     {
         if (static::$dumpKeys) {
             $stamp = array_intersect_key($stamp, static::$dumpKeys);

--- a/src/Illuminate/Support/Chrono.php
+++ b/src/Illuminate/Support/Chrono.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Illuminate\Support;
+
+use InvalidArgumentException;
+
+class Chrono
+{
+    /**
+     * Array to store each timestamp along with associated data.
+     *
+     * @var array
+     */
+    protected static array $stamps = [];
+
+    /**
+     * Allowed keys for sorting the stamps in stampsBy method.
+     *
+     * @var array
+     */
+    protected static array $stampsBy = ['relative', 'absolute', 'memory', 'time'];
+
+    /**
+     * Specifies the keys to include when dumping stamp data. If null, all keys are included.
+     *
+     * @var ?array
+     */
+    protected static ?array $dumpKeys = null;
+
+    /**
+     * Cache to store frequently accessed data to improve performance.
+     *
+     * @var array
+     */
+    protected static array $cache = [];
+
+    /**
+     * Resets the timestamps and cache. Optionally resets memory peak usage.
+     *
+     * @param  bool $memory  Whether to reset memory peak usage.
+     */
+    public static function reset(bool $memory = false): void
+    {
+        static::$stamps = [];
+        static::$cache = [];
+
+        if ($memory) {
+            memory_reset_peak_usage();
+        }
+    }
+
+    /**
+     * Sets the keys to be included when dumping the stamp data.
+     *
+     * @param  string|array|null  $dumpKeys Keys to be dumped.
+     */
+    public static function dumpKeys(string|array|null $dumpKeys): void
+    {
+        static::$dumpKeys = $dumpKeys ? array_flip((array)$dumpKeys) : null;
+    }
+
+    /**
+     * Creates a timestamp with performance data and optionally dumps it.
+     *
+     * @param  bool $dump  Whether to dump the stamp data.
+     * @param  mixed $data  Additional data to be included in the stamp.
+     * @return array  The stamp data.
+     */
+    public static function stamp(bool $dump = false, mixed $data = null): array
+    {
+        $time = microtime(true);
+
+        if ($previous = end(static::$stamps)) {
+            unset($previous['previous']);
+
+            $absolute = static::$stamps[0]['time'];
+            $relative = $previous['time'];
+        } else {
+            $absolute = $time;
+            $relative = $time;
+        }
+
+        static::$stamps[] = $stamp = static::debug() + [
+            'time' => $time,
+            'relative' => round($time - $relative, 5),
+            'absolute' => round($time - $absolute, 5),
+            'memory' => round(memory_get_peak_usage(true) / 1024 / 1024, 3),
+            'data' => $data,
+            'previous' => $previous,
+        ];
+
+        if ($dump) {
+            static::dump($stamp);
+        }
+
+        return $stamp;
+    }
+
+    /**
+     * Retrieves all stored stamps.
+     *
+     * @return array  An array of all stamps.
+     */
+    public static function stamps(): array
+    {
+        return static::$stamps;
+    }
+
+    /**
+     * Returns all stamps sorted by a specified key.
+     *
+     * @param  string $key  The key to sort by.
+     * @param  int $limit  Limit the returned stamps
+     * @return array  Sorted array of stamps.
+     * @throws InvalidArgumentException  If the provided key is invalid.
+     */
+    public static function stampsBy(string $key, int $limit = 0): array
+    {
+        if (! in_array($key, static::$stampsBy)) {
+            throw new InvalidArgumentException(sprintf('Invalid Sort Key %s', $key));
+        }
+
+        $stamps = static::$stamps;
+
+        usort($stamps, static fn ($a, $b) => $b[$key] <=> $a[$key]);
+
+        return $limit ? array_slice($stamps, 0, $limit) : $stamps;
+    }
+
+    /**
+     * Dumps the specified stamp data.
+     *
+     * @param  array $stamp  The stamp to dump.
+     */
+    public static function dump(array $stamp): void
+    {
+        if (static::$dumpKeys) {
+            $stamp = array_intersect_key($stamp, static::$dumpKeys);
+        }
+
+        dump($stamp);
+    }
+
+    /**
+     * Gets the file path relative to the base path.
+     *
+     * @param  ?string $file  The file path to process.
+     * @return string  Relative file path.
+     */
+    protected static function file(?string $file): string
+    {
+        if ($file === null) {
+            return '[PHP Kernel]';
+        }
+
+        return substr($file, strlen(static::$cache['base_path'] ??= base_path()));
+    }
+
+    /**
+     * Collects and returns backtrace debug information.
+     *
+     * @return  array  Debug information array.
+     */
+    protected static function debug(): array
+    {
+        $debug = debug_backtrace(!DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+
+        return [
+            'file' => static::file($debug[1]['file'] ?? null),
+            'line' => $debug[1]['line'] ?? null,
+            'class' => $debug[2]['class'] ?? null,
+            'function' => $debug[2]['function'] ?? null,
+            'type' => $debug[2]['type'] ?? null,
+        ];
+    }
+}


### PR DESCRIPTION
### Overview

The idea is to have a fast and simple tool available to track performance issues (time or memory) on app.

As a static class, it can be imported using `use Illuminate\Support\Chrono` in any project file and can be used directly without any prior adjustment.

### Load

The helper can be loaded with `use Illuminate\Support\Chrono`.

### Methods and Examples

```php
public static function reset(bool $memory = false): void
```
Resets timestamps and cache. Optionally resets memory peak usage. Can be used before start first measure, and when measure finish to reset the stored data.

```php
Chrono::reset();
Chrono::reset(true); // Resets memory peak usage too.
```
---

```php
public static function dumpKeys(string|array|null $dumpKeys): void
```

Sets keys to be included when dumping stamp data.

```php
Chrono::dumpKeys(['absolute', 'relative', 'memory']);
```

---

```php
public static function stamp(bool $dump = false, mixed $data = null): array
```

Creates a performance timestamp. Optionally dumps to screen the stamp point.

```php
Chrono::stamp();

Chrono::stamp(true, ['customData' => 'value']);
```

---

```php
public static function stamps(): array
```

Retrieves all stored timestamps.

```php
$stamps = Chrono::stamps();
```

---

```php
public static function stampsBy(string $key, int $limit = 0): array
```

Returns sorted timestamps based on a specified key.

```php
$stampsByMemory = Chrono::stampsBy('memory', 5);
```

---

These examples illustrate basic usage.

### Simple Full Example

```php
<?php
use Illuminate\Support\Chrono;

function slowProcess(): void
{
    Chrono::reset();
    Chrono::dumpKeys(['absolute', 'relative', 'memory']);

    Chrono::stamp();

    foreach ($this->items() as $item) {
        OtherObjectLocal::doImportantStuff($item)
    }

    Chrono::stamp();

    foreach ($this->moreItems() as $item) {
        OtherObjectRemote::doMoreImportantStuff($item)
    }

    Chrono::stamp();

    dump(Chrono::stampsBy('relative', 5));

    Chrono::reset();
}

// OtherObjectLocal.php

use Illuminate\Support\Chrono;

public static function doImportantStuff(array $item): void
{
    Chrono::stamp();

    static::sendToLocal($item);

    Chrono::stamp();
}

// OtherObjectRemote.php

use Illuminate\Support\Chrono;

public static function doMoreImportantStuff(array $item): void
{
    Chrono::stamp();

    static::sendToRemote($item);

    Chrono::stamp();
}
```

### Considerations

It is important to consider its use in environments like Octane, as being a direct static class, it could accumulate a large amount of data over time if the reset is not applied correctly. Since I am not fully familiar with the framework, is there any implementation that performs auto-cleaning for each individual execution/request?