### PR TITLE
[10.x] `Model::preventAccessingMissingAttributes()` raises exception for castable attributes that were not retrieved

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2126,6 +2126,9 @@ trait HasAttributes
         // an appropriate native PHP type dependent upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
+            if (! array_key_exists($key, $this->attributes)) {
+                $this->throwMissingAttributeExceptionIfApplicable($key);
+            }
             return $this->castAttribute($key, $value);
         }
 

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\MissingAttributeException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
 
@@ -74,6 +76,21 @@ class DatabaseEloquentWithCastsTest extends TestCase
             ->createOrFirst(['time' => '07:30']);
 
         $this->assertSame($time1->id, $time2->id);
+    }
+
+    public function testThrowsExceptionWhenPrevents()
+    {
+        Time::create(['time' => now()]);
+        $originalMode = Model::preventsAccessingMissingAttributes();
+        Model::preventAccessingMissingAttributes();
+
+        $this->expectException(MissingAttributeException::class);
+        try {
+            $time = Time::query()->select('id')->first();
+            $this->assertNull($time->time);
+        } finally {
+            Model::preventAccessingMissingAttributes($originalMode);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -78,7 +78,7 @@ class DatabaseEloquentWithCastsTest extends TestCase
         $this->assertSame($time1->id, $time2->id);
     }
 
-    public function testThrowsExceptionWhenPrevents()
+    public function testThrowsExceptionIfCastableAttributeWasNotRetrievedAndPreventMissingAttributesIsEnabled()
     {
         Time::create(['time' => now()]);
         $originalMode = Model::preventsAccessingMissingAttributes();


### PR DESCRIPTION
To resolve https://github.com/laravel/framework/issues/49434

Previously, a castable attribute that was not retrieved from the DB would not raise this exception. By checking that the attribute was retrieved before attempting to cast the attribute, the preventAccessingMissingAttributes works intuitively in such a case.