### PR TITLE
[11.x] Uses stable version of Sanctum

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -90,7 +90,7 @@ class ApiInstallCommand extends Command
     protected function installSanctum()
     {
         $this->requireComposerPackages($this->option('composer'), [
-            'laravel/sanctum:dev-master',
+            'laravel/sanctum:^4.0',
         ]);
 
         $php = (new PhpExecutableFinder())->find(false) ?: 'php';


### PR DESCRIPTION
This pull request makes the `install:api` Artisan command use the stable version of Sanctum v4 is possible.