### PR TITLE
[10.x] Dynamic `maxTries` for queued jobs

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -178,6 +178,27 @@ abstract class Queue
                         ? $job->displayName() : get_class($job);
     }
 
+     /**
+     * Get the maximum number of attempts for an object-based queue handler.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function getJobTries($job)
+    {
+        if (! method_exists($job, 'tries') && ! isset($job->tries)) {
+            return;
+        }
+
+        if (isset($job->tries)) {
+            return $job->tries;
+        }
+
+        if (method_exists($job, 'tries') && ! is_null($job->tries())) {
+            return $job->tries();
+        }
+    }
+
     /**
      * Get the backoff for an object-based queue handler.
      *
@@ -199,27 +220,6 @@ abstract class Queue
                 return $backoff instanceof DateTimeInterface
                                 ? $this->secondsUntil($backoff) : $backoff;
             })->implode(',');
-    }
-
-     /**
-     * Get the maximum number of attempts for an object-based queue handler.
-     *
-     * @param  mixed  $job
-     * @return mixed
-     */
-    public function getJobTries($job)
-    {
-        if (! method_exists($job, 'tries') && ! isset($job->tries)) {
-            return;
-        }
-
-        if (isset($job->tries)) {
-            return $job->tries;
-        }
-
-        if(method_exists($job, 'tries') && !is_null($job->tries())) {
-            return $job->tries();
-        }
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -142,7 +142,7 @@ abstract class Queue
             'uuid' => (string) Str::uuid(),
             'displayName' => $this->getDisplayName($job),
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
-            'maxTries' => $job->tries ?? null,
+            'maxTries' => $this->getJobTries($job) ?? null,
             'maxExceptions' => $job->maxExceptions ?? null,
             'failOnTimeout' => $job->failOnTimeout ?? false,
             'backoff' => $this->getJobBackoff($job),
@@ -199,6 +199,27 @@ abstract class Queue
                 return $backoff instanceof DateTimeInterface
                                 ? $this->secondsUntil($backoff) : $backoff;
             })->implode(',');
+    }
+
+     /**
+     * Get the maximum number of attempts for an object-based queue handler.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function getJobTries($job)
+    {
+        if (! method_exists($job, 'tries') && ! isset($job->tries)) {
+            return;
+        }
+
+        if (isset($job->tries)) {
+            return $job->tries;
+        }
+
+        if(method_exists($job, 'tries') && !is_null($job->tries())) {
+            return $job->tries();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR allows a dynamic definition of `maxTries` for a queued job, similar to the `backoff()` method. While it is already possible to define a dynamic value for the `$tries` property in the constructor, this change makes it consistent with the `backoff()` method, creating an improved developer experience.

```php
class TestJob implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    // If the property is still defined, it precedes over the tries() method, 
    // providing the same behavior as the backoff definition 
    public $tries = 3;

    public function tries(): int
    {
        return config('test_job.retries'); // Example: Get the number of tries from config
    }
}
```