### PR TITLE
[10.x] Avoid TypeError when using json validation rule when PHP < 8.3

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1430,11 +1430,11 @@ trait ValidatesAttributes
      */
     public function validateJson($attribute, $value)
     {
-        if (is_array($value)) {
+        if (is_array($value) || is_null($value)) {
             return false;
         }
 
-        if (! is_scalar($value) && ! is_null($value) && ! method_exists($value, '__toString')) {
+        if (! is_scalar($value) && ! method_exists($value, '__toString')) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Exceptions\MathException;
+use Illuminate\Support\Stringable;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\DatabasePresenceVerifierInterface;
@@ -2817,6 +2818,14 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['array']], ['foo' => 'json']);
         $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'json']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => new Stringable('[]')], ['foo' => 'json']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateBoolean()


### PR DESCRIPTION
#49413 introduced a bug when the value under json validation is `null` in PHP < 8.3 and a deprecation warning in PHP 8.3.

To reproduce you can execute the following in tinker:

```php
$v = Validator::make(['x' => null], ['x' => 'json']); var_dump($v->passes());
```

When using PHP 8.2.13 the result is (TypeError is thrown):

![image](https://github.com/laravel/framework/assets/227148/1aa52cd0-4e6e-424d-81a2-b0acee80131e)

When using PHP 8.3.1 the result is (Deprecation warning):

![image](https://github.com/laravel/framework/assets/227148/21333b47-715c-44b5-bc15-8e790786d768)

The change adds a couple of assertions in Illuminate\Tests\Validation\ValidationValidatorTest::testValidateJson() to verify validateJson fails when value is null; and verify validateJson passes when value implements `__toString()` and returns a valid JSON string.

The fix simply returns `false` when $value is null.
