### PR TITLE
[10.x] Fix use statement compilation in Blade templates

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -14,8 +14,8 @@ trait CompilesUseStatements
     {
         $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
-        $use = trim($segments[0], " '\"");
-        $as = isset($segments[1]) ? ' as '.ltrim(trim($segments[1], " '\""), '\\') : '';
+        $use = ltrim(trim($segments[0], " '\""), '\\');
+        $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';
 
         return "<?php use \\{$use}{$as}; ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -15,7 +15,7 @@ trait CompilesUseStatements
         $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
         $use = trim($segments[0], " '\"");
-        $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';
+        $as = isset($segments[1]) ? ' as '.ltrim(trim($segments[0], " '\""), '\\') : '';
 
         return "<?php use \\{$use}{$as}; ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -15,7 +15,7 @@ trait CompilesUseStatements
         $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
         $use = trim($segments[0], " '\"");
-        $as = isset($segments[1]) ? ' as '.ltrim(trim($segments[0], " '\""), '\\') : '';
+        $as = isset($segments[1]) ? ' as '.ltrim(trim($segments[1], " '\""), '\\') : '';
 
         return "<?php use \\{$use}{$as}; ?>";
     }

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -20,6 +20,13 @@ class BladeUseTest extends AbstractBladeTestCase
 
     public function testUseStatementsWithBackslashAtBeginningAreCompiled()
     {
+        $string = "Foo @use('\SomeNamespace\SomeClass') bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithBackslashAtBeginningAreCompiledAndAliased()
+    {
         $string = "Foo @use('\SomeNamespace\SomeClass', 'Foo') bar";
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -25,7 +25,7 @@ class BladeUseTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testUseStatementsWithBackslashAtBeginningAreCompiledAndAliased()
+    public function testUseStatementsWithBackslashAtBeginningAndAliasedAreCompiled()
     {
         $string = "Foo @use('\SomeNamespace\SomeClass', 'Foo') bar";
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -17,4 +17,11 @@ class BladeUseTest extends AbstractBladeTestCase
         $expected = "Foo <?php use \SomeNamespace\SomeClass; ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithBackslashAtBeginningAreCompiled()
+    {
+        $string = "Foo @use('\SomeNamespace\SomeClass', 'Foo') bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR solves a bug for statements with a backslash at the beginning...

#### failing test case
```php
@use('\SomeNamespace\SomeClass') // not working as expected

public function testUseStatementsWithBackslashAtBeginningAreCompiled()
{
    $string = "Foo @use('\SomeNamespace\SomeClass', 'Foo') bar";
    $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
    $this->assertEquals($expected, $this->compiler->compileString($string));
}
```

if you have merged #49478 then close this.