### PR TITLE
[10.x] `Model::preventAccessingMissingAttributes()` raises exception for enums & primitive castable attributes that were not retrieved

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2126,9 +2126,14 @@ trait HasAttributes
         // an appropriate native PHP type dependent upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
-            if (! array_key_exists($key, $this->attributes)) {
+            // If the key is for a castable primitive type or an enum, but the value is not found in
+            // the retrieved attributes, we may throw an exception that the attribute is missing.
+            if (! array_key_exists($key, $this->attributes)
+                && ($this->isEnumCastable($key) || in_array($this->getCastType($key), static::$primitiveCastTypes))
+            ) {
                 $this->throwMissingAttributeExceptionIfApplicable($key);
             }
+
             return $this->castAttribute($key, $value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2126,6 +2126,9 @@ trait HasAttributes
         // an appropriate native PHP type dependent upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
+            if (! array_key_exists($key, $this->attributes)) {
+                $this->throwMissingAttributeExceptionIfApplicable($key);
+            }
             return $this->castAttribute($key, $value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2126,7 +2126,8 @@ trait HasAttributes
         // an appropriate native PHP type dependent upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
-            if (! array_key_exists($key, $this->attributes) &&
+            if (static::preventsAccessingMissingAttributes() &&
+                ! array_key_exists($key, $this->attributes) &&
                 ($this->isEnumCastable($key) ||
                  in_array($this->getCastType($key), static::$primitiveCastTypes))) {
                 $this->throwMissingAttributeExceptionIfApplicable($key);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2126,11 +2126,9 @@ trait HasAttributes
         // an appropriate native PHP type dependent upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
-            // If the key is for a castable primitive type or an enum, but the value is not found in
-            // the retrieved attributes, we may throw an exception that the attribute is missing.
-            if (! array_key_exists($key, $this->attributes)
-                && ($this->isEnumCastable($key) || in_array($this->getCastType($key), static::$primitiveCastTypes))
-            ) {
+            if (! array_key_exists($key, $this->attributes) &&
+                ($this->isEnumCastable($key) ||
+                 in_array($this->getCastType($key), static::$primitiveCastTypes))) {
                 $this->throwMissingAttributeExceptionIfApplicable($key);
             }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -7,6 +7,8 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
 use Foo\Bar\EloquentModelNamespacedStub;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -22,6 +24,7 @@ use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -2576,6 +2579,48 @@ class DatabaseEloquentModelTest extends TestCase
         }
     }
 
+    public function testThrowsWhenAccessingMissingAttributesWhichArePrimitiveCasts()
+    {
+        $originalMode = Model::preventsAccessingMissingAttributes();
+        Model::preventAccessingMissingAttributes();
+
+        $model = new EloquentModelWithPrimitiveCasts(['id' => 1]);
+        $model->exists = true;
+
+        $exceptionCount = 0;
+        $primitiveCasts = EloquentModelWithPrimitiveCasts::makePrimitiveCastsArray();
+        try {
+            try {
+                $this->assertEquals(null, $model->backed_enum);
+            } catch (MissingAttributeException) {
+                $exceptionCount++;
+            }
+
+            foreach($primitiveCasts as $key => $type) {
+                try {
+                    $v = $model->{$key};
+                } catch (MissingAttributeException) {
+                    $exceptionCount++;
+                }
+            }
+
+            $this->assertInstanceOf(Address::class, $model->address);
+
+            $this->assertEquals(1, $model->id);
+            $this->assertEquals('ok', $model->this_is_fine);
+            $this->assertEquals('ok', $model->this_is_also_fine);
+
+            // Primitive castables, enum castable
+            $expectedExceptionCount = count($primitiveCasts) + 1;
+            $this->assertEquals($expectedExceptionCount, $exceptionCount);
+        } finally {
+            Model::preventAccessingMissingAttributes($originalMode);
+        }
+
+
+
+    }
+
     public function testUsesOverriddenHandlerWhenAccessingMissingAttributes()
     {
         $originalMode = Model::preventsAccessingMissingAttributes();
@@ -3348,4 +3393,70 @@ class Uppercase implements CastsInboundAttributes
 class CustomCollection extends BaseCollection
 {
     //
+}
+
+class EloquentModelWithPrimitiveCasts extends Model
+{
+    public $fillable = ['id'];
+
+    public $casts = [
+        'backed_enum' => CastableBackedEnum::class,
+        'address' => Address::class,
+    ];
+
+    public static function makePrimitiveCastsArray(): array
+    {
+        $toReturn = [];
+
+        foreach(static::$primitiveCastTypes as $index => $primitiveCastType) {
+            $toReturn['primitive_cast_' . $index] = $primitiveCastType;
+        }
+
+        return $toReturn;
+    }
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->mergeCasts(self::makePrimitiveCastsArray());
+    }
+
+    public function getThisIsFineAttribute($value) {
+        return 'ok';
+    }
+
+    public function thisIsAlsoFine(): Attribute
+    {
+        return Attribute::get(fn() => 'ok');
+    }
+}
+
+enum CastableBackedEnum: string {
+    case Value1 = 'value1';
+}
+
+class Address implements Castable
+{
+    public static function castUsing(array $arguments): CastsAttributes
+    {
+        return new class implements CastsAttributes
+        {
+            public function get(Model $model, string $key, mixed $value, array $attributes): Address
+            {
+                return new Address(
+                    $attributes['address_line_one'],
+                    $attributes['address_line_two']
+                );
+            }
+
+            public function set(Model $model, string $key, mixed $value, array $attributes): array
+            {
+                return [
+                    'address_line_one' => $value->lineOne,
+                    'address_line_two' => $value->lineTwo,
+                ];
+            }
+        };
+    }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2616,9 +2616,6 @@ class DatabaseEloquentModelTest extends TestCase
         } finally {
             Model::preventAccessingMissingAttributes($originalMode);
         }
-
-
-
     }
 
     public function testUsesOverriddenHandlerWhenAccessingMissingAttributes()
@@ -3432,7 +3429,8 @@ class EloquentModelWithPrimitiveCasts extends Model
     }
 }
 
-enum CastableBackedEnum: string {
+enum CastableBackedEnum: string
+{
     case Value1 = 'value1';
 }
 

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\MissingAttributeException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
 
@@ -74,6 +76,21 @@ class DatabaseEloquentWithCastsTest extends TestCase
             ->createOrFirst(['time' => '07:30']);
 
         $this->assertSame($time1->id, $time2->id);
+    }
+
+    public function testThrowsExceptionWhenPrevents()
+    {
+        Time::create(['time' => now()]);
+        $originalMode = Model::preventsAccessingMissingAttributes();
+        Model::preventAccessingMissingAttributes();
+
+        $this->expectException(MissingAttributeException::class);
+        try {
+            $time = Time::query()->select('id')->first();
+            $this->assertNull($time->time);
+        } finally {
+            Model::preventAccessingMissingAttributes($originalMode);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -78,7 +78,7 @@ class DatabaseEloquentWithCastsTest extends TestCase
         $this->assertSame($time1->id, $time2->id);
     }
 
-    public function testThrowsExceptionWhenPrevents()
+    public function testThrowsExceptionIfCastableAttributeWasNotRetrievedAndPreventMissingAttributesIsEnabled()
     {
         Time::create(['time' => now()]);
         $originalMode = Model::preventsAccessingMissingAttributes();


### PR DESCRIPTION
Revisiting https://github.com/laravel/framework/pull/49470

In hopes to resolve https://github.com/laravel/framework/issues/49434

Previously, a castable attribute that was not retrieved from the DB would not raise this exception. By checking that the attribute was retrieved before attempting to cast the attribute, the preventAccessingMissingAttributes works intuitively in such a case. We will only raise the exception for primitive castables and enums, as it is possible that other custom casters are "virtual" and do not correspond to DB columns.