### PR TITLE
[10.x] Add support for array-based use statements in Blade templates

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -12,11 +12,25 @@ trait CompilesUseStatements
      */
     protected function compileUse($expression)
     {
-        $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
+        $expression = preg_replace("/[\(\)]/", '', $expression);
 
-        $use = ltrim(trim($segments[0], " '\""), '\\');
-        $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';
+        // if it is not start with '[' therefore it is single namespace
+        // so we need to convert it to $namespace => $alias expression
+        if (! str_starts_with($expression, '[')) {
+            $expression = str_replace(',', '=>', $expression);
+        }
 
-        return "<?php use \\{$use}{$as}; ?>";
+        // it is start with '[' therefore it is array and it may have multiple namespaces
+        // as it won't be valid json we need to parse it manually and get namespaces and aliases
+        // below code is to get namespaces and aliases from [$namespace => $alias, ...] expression
+        $namespaces = explode(',', trim(preg_replace('/\\\\/', '\\', $expression), '[]'));
+
+        $useStatements = '<?php';
+        foreach ($namespaces as $namespace) {
+            [$use, $as] = array_pad(explode('=>', $namespace, 2), 2, '');
+            $useStatements .= ' use \\'.ltrim(trim($use, " '\""), '\\').($as ? ' as '.ltrim(trim($as, " '\""), '\\') : '').';';
+        }
+
+        return $useStatements.' ?>';
     }
 }

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -31,4 +31,32 @@ class BladeUseTest extends AbstractBladeTestCase
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithArrayAreCompiled()
+    {
+        $string = "Foo @use(['SomeNamespace\SomeClass', 'AnotherNamespace\AnotherClass']) bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass; use \AnotherNamespace\AnotherClass; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithArrayAndBackslashAtBeginningAreCompiled()
+    {
+        $string = "Foo @use(['\SomeNamespace\SomeClass', '\AnotherNamespace\AnotherClass']) bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass; use \AnotherNamespace\AnotherClass; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithArrayAndAsAreCompiled()
+    {
+        $string = "Foo @use(['SomeNamespace\SomeClass' => 'Foo', 'AnotherNamespace\AnotherClass' => 'Bar']) bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; use \AnotherNamespace\AnotherClass as Bar; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithArrayAndAsAreCompiledWithNumericKeys()
+    {
+        $string = "Foo @use(['SomeNamespace\SomeClass', 'AnotherNamespace\AnotherClass' => 'Bar']) bar";
+        $expected = "Foo <?php use \SomeNamespace\SomeClass; use \AnotherNamespace\AnotherClass as Bar; ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
# Add support for array-based use statements in Blade templates

This PR adds support for array-based use statements in Blade templates. This is useful when you want to use multiple classes from the same namespace.

#### usage example

```php
@use(['App\Models\User', 'App\Models\Post'])

// is equivalent to

<?php use \App\Models\User; use \App\Models\Post; ?>

// and

@use(['App\Models\User' =>'ModelUser', 'App\Models\Post' => 'ModelPost'])

// is equivalent to

<?php use \App\Models\User as ModelUser; use \App\Models\Post as ModelPost; ?>
```

and old syntax still works

```php
@use('App\Models\User')

// is equivalent to

<?php use \App\Models\User; ?>

// and
@use('App\Models\User', 'ModelUser')

// is equivalent to

<?php use \App\Models\User as ModelUser; ?>

```