### PR TITLE
[10.x] Add `assertViewMissingAll` to TestView

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1112,6 +1112,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response view missing a given list of bound data.
+     *
+     * @param  array  $keys
+     * @return $this
+     */
+    public function assertViewMissingAll(array $keys)
+    {
+        foreach ($keys as $key) {
+            $this->assertViewMissing($key);
+        }
+
+        return $this;
+    }
+
+    /**
      * Ensure that the response has a view as its original content.
      *
      * @return $this

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -96,12 +96,31 @@ class TestView
     /**
      * Assert that the response view is missing a piece of bound data.
      *
-     * @param  string  $key
+     * @param  string|array  $key
      * @return $this
      */
     public function assertViewMissing($key)
     {
+        if (is_array($key)) {
+            return $this->assertViewMissingAll($key);
+        }
+
         PHPUnit::assertFalse(Arr::has($this->view->gatherData(), $key));
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response view missing a given list of bound data.
+     *
+     * @param  array  $keys
+     * @return $this
+     */
+    public function assertViewMissingAll(array $keys)
+    {
+        foreach ($keys as $key) {
+            $this->assertViewMissing($key);
+        }
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -220,6 +220,19 @@ class TestResponseTest extends TestCase
         $response->assertViewMissing('baz');
     }
 
+    public function testAssertViewMissingAll()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertViewMissingAll([
+            'name',
+            'milwad',
+        ]);
+    }
+
     public function testAssertViewMissingNested()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
If you used `assertViewMissing` with an array, if one of the items of that array is missing in the data of view, the test will be passed!!
But when you are using `assertViewMissingAll`, if one of the items of the array is missing, the test will fail.