### PR TITLE
optimize-getStatusFor-migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -89,17 +89,15 @@ class StatusCommand extends BaseCommand
      */
     protected function getStatusFor(array $ran, array $batches)
     {
+        $ran = array_flip($ran);
+
         return Collection::make($this->getAllMigrationFiles())
                     ->map(function ($migration) use ($ran, $batches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
 
-                        $status = in_array($migrationName, $ran)
-                            ? '<fg=green;options=bold>Ran</>'
+                        $status = array_key_exists($migrationName, $ran)
+                            ? "[{$batches[$migrationName]}] <fg=green;options=bold>Ran</>"
                             : '<fg=yellow;options=bold>Pending</>';
-
-                        if (in_array($migrationName, $ran)) {
-                            $status = '['.$batches[$migrationName].'] '.$status;
-                        }
 
                         return [$migrationName, $status];
                     });


### PR DESCRIPTION
Reduce code and optimize time complexity by replacing 2x`in_array` with `array_key_exists` in a loop.