### PR TITLE
[10.x] Implement 'config_or_fail' Helper Function for Strict Configuration Handling

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -275,6 +275,30 @@ if (! function_exists('config')) {
     }
 }
 
+if (! function_exists('config_or_fail')) {
+    /**
+     * Retrieve a configuration value or fail with an exception if the key does not exist.
+     *
+     * Similar to config helper but throws an exception if the specified configuration key is not found.
+     *
+     * @param  string  $key  The configuration key to retrieve.
+     * @param  string|null  $exceptionMessage  Optional custom message for the thrown exception.
+     * @return mixed The configuration value if the key exists.
+     *
+     * @throws \RuntimeException If the configuration key is not found.
+     */
+    function config_or_fail($key, $exceptionMessage = null)
+    {
+        $value = config($key, '__no_value__');
+
+        if ($value === '__no_value__') {
+            throw new \RuntimeException($exceptionMessage ?: "Configuration key '{$key}' not found.");
+        }
+
+        return $value;
+    }
+}
+
 if (! function_exists('config_path')) {
     /**
      * Get the configuration path.


### PR DESCRIPTION
This function extends the existing `config` helper by adding strict error handling. If a configuration key is missing or its value is explicitly set to null, the function will throw a RuntimeException. This behavior ensures that critical configuration values are always present and correctly set.

**Usage Sample**
Imagine we have a critical configuration value in our `config/services.php` file, like an API key for a payment gateway:

```php
try {
    $paymentGatewayApiKey = config_or_fail('services.payment_gateway.api_key');
} catch (\RuntimeException $e) {
    // Handle the exception, maybe log the error or alert the team
    Log::error($e->getMessage());
}
