### PR TITLE
[10.x] Added methods for querying by route key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -256,7 +256,7 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the route key to the query.
      *
-     * @param string|Model|iterable<string>|Arrayable<int,string>  $key
+     * @param  string|Model|iterable<string>|Arrayable<int,string>  $key
      * @return $this
      */
     public function whereRouteKey(string|Model|iterable|Arrayable $key): static
@@ -306,7 +306,7 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the route key to the query.
      *
-     * @param string|Model|iterable<string>|Arrayable<int,string> $key
+     * @param  string|Model|iterable<string>|Arrayable<int,string>  $key
      * @return $this
      */
     public function whereRouteKeyNot(string|Model $key): static
@@ -526,7 +526,7 @@ class Builder implements BuilderContract
     /**
      * Find multiple models by their route keys.
      *
-     * @param Arrayable<int,string>|iterable<string>  $keys
+     * @param  Arrayable<int,string>|iterable<string>  $keys
      * @param  string[]|string  $columns
      * @return \Illuminate\Database\Eloquent\Collection
      */
@@ -629,7 +629,7 @@ class Builder implements BuilderContract
      * Find a model by its route key or return fresh model instance.
      *
      * @param  string|Model|iterable<string>|Arrayable<int,string>  $key
-     * @param string|string[] $columns
+     * @param  string|string[]  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function findByRouteKeyOrNew(string|Model|iterable|Arrayable $key, array|string $columns = ['*'])
@@ -668,7 +668,7 @@ class Builder implements BuilderContract
      * Find a model by its route key or call a callback.
      *
      * @param  string|Model|iterable<string>|Arrayable<int,string>  $key
-     * @param  string|string[]|Closure $columns
+     * @param  string|string[]|Closure  $columns
      * @param  Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
      */

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -256,13 +256,19 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the route key to the query.
      *
-     * @param  string|Model  $key
+     * @param string|Model|iterable<string>|Arrayable<int,string>  $key
      * @return $this
      */
-    public function whereRouteKey(string|Model $key): static
+    public function whereRouteKey(string|Model|iterable|Arrayable $key): static
     {
         if ($key instanceof Model) {
             $key = $key->getRouteKey();
+        }
+
+        if (is_iterable($key) || $key instanceof Arrayable) {
+            $this->query->whereIn($this->model->getQualifiedRouteKeyName(), $key);
+
+            return $this;
         }
 
         return $this->where($this->model->getQualifiedRouteKeyName(), '=', $key);
@@ -300,13 +306,19 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the route key to the query.
      *
-     * @param  string|Model  $key
+     * @param string|Model|iterable<string>|Arrayable<int,string> $key
      * @return $this
      */
     public function whereRouteKeyNot(string|Model $key): static
     {
         if ($key instanceof Model) {
             $key = $key->getRouteKey();
+        }
+
+        if (is_iterable($key) || $key instanceof Arrayable) {
+            $this->query->whereNotIn($this->model->getQualifiedRouteKeyName(), $key);
+
+            return $this;
         }
 
         return $this->where($this->model->getQualifiedRouteKeyName(), '!=', $key);
@@ -514,7 +526,7 @@ class Builder implements BuilderContract
      * @param  string[]|string  $columns
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function findManyByRouteKey(iterable|Arrayable $keys, array|string $columns = ['*']): Collection
+    public function findManyByRouteKey(iterable|Arrayable $keys, array|string $columns = ['*'])
     {
         $keys = $keys instanceof Arrayable ? $keys->toArray() : $keys;
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -265,7 +265,7 @@ class Builder implements BuilderContract
             $key = $key->getRouteKey();
         }
 
-        return $this->where($this->model->getRouteKeyName(), '=', $key);
+        return $this->where($this->model->getQualifiedRouteKeyName(), '=', $key);
     }
 
     /**
@@ -309,7 +309,7 @@ class Builder implements BuilderContract
             $key = $key->getRouteKey();
         }
 
-        return $this->where($this->model->getRouteKeyName(), '!=', $key);
+        return $this->where($this->model->getQualifiedRouteKeyName(), '!=', $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -256,19 +256,13 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the route key to the query.
      *
-     * @param  mixed  $key
+     * @param  string|Model  $key
      * @return $this
      */
-    public function whereRouteKey(mixed $key): static
+    public function whereRouteKey(string|Model $key): static
     {
         if ($key instanceof Model) {
             $key = $key->getRouteKey();
-        }
-
-        if (is_array($key) || $key instanceof Arrayable) {
-            $this->query->whereIn($this->model->getRouteKeyName(), $key);
-
-            return $this;
         }
 
         return $this->where($this->model->getRouteKeyName(), '=', $key);
@@ -306,19 +300,13 @@ class Builder implements BuilderContract
     /**
      * Add a where clause on the route key to the query.
      *
-     * @param  mixed  $key
+     * @param  string|Model  $key
      * @return $this
      */
-    public function whereRouteKeyNot(mixed $key): static
+    public function whereRouteKeyNot(string|Model $key): static
     {
         if ($key instanceof Model) {
             $key = $key->getRouteKey();
-        }
-
-        if (is_array($key) || $key instanceof Arrayable) {
-            $this->query->whereIn($this->model->getRouteKeyName(), $key);
-
-            return $this;
         }
 
         return $this->where($this->model->getRouteKeyName(), '!=', $key);
@@ -492,11 +480,11 @@ class Builder implements BuilderContract
     /**
      * Find a model by its route key.
      *
-     * @param  mixed  $key
+     * @param  string  $key
      * @param  string[]|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
      */
-    public function findByRouteKey(mixed $key, array|string $columns = ['*'])
+    public function findByRouteKey(string $key, array|string $columns = ['*'])
     {
         return $this->whereRouteKey($key)->first($columns);
     }
@@ -522,7 +510,7 @@ class Builder implements BuilderContract
     /**
      * Find multiple models by their route keys.
      *
-     * @param Arrayable|iterable  $keys
+     * @param Arrayable<int,string>|iterable<string>  $keys
      * @param  string[]|string  $columns
      * @return \Illuminate\Database\Eloquent\Collection
      */
@@ -574,13 +562,13 @@ class Builder implements BuilderContract
     /**
      * Find a model by its route key or throw an exception.
      *
-     * @param  mixed  $key
+     * @param  string  $key
      * @param  string[]|string  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
      */
-    public function findByRouteKeyOrFail(mixed $key, array|string $columns = ['*']): mixed
+    public function findByRouteKeyOrFail(string $key, array|string $columns = ['*']): mixed
     {
         $result = $this->findByRouteKey($key, $columns);
 
@@ -612,11 +600,11 @@ class Builder implements BuilderContract
     /**
      * Find a model by its route key or return fresh model instance.
      *
-     * @param  mixed  $key
+     * @param  string  $key
      * @param string|string[] $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function findByRouteKeyOrNew(mixed $key, array|string $columns = ['*'])
+    public function findByRouteKeyOrNew(string $key, array|string $columns = ['*'])
     {
         if (! is_null($model = $this->findByRouteKey($key, $columns))) {
             return $model;
@@ -651,12 +639,12 @@ class Builder implements BuilderContract
     /**
      * Find a model by its route key or call a callback.
      *
-     * @param  mixed  $key
+     * @param  string  $key
      * @param  string|string[]|Closure $columns
      * @param  Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
      */
-    public function findByRouteKeyOr(mixed $key, array|string|Closure $columns = ['*'], Closure $callback = null): mixed
+    public function findByRouteKeyOr(string $key, array|string|Closure $columns = ['*'], Closure $callback = null): mixed
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -315,6 +315,16 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get the array of route keys.
+     *
+     * @return array<int, array-key>
+     */
+    public function modelRouteKeys()
+    {
+        return array_map(fn ($model) => $model->getRouteKey(), $this->items);
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  iterable<array-key, TModel>  $items

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1907,6 +1907,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Get the table qualified route key name.
+     *
+     * @return string
+     */
+    public function getQualifiedRouteKeyName()
+    {
+        return $this->qualifyColumn($this->getRouteKeyName());
+    }
+
+    /**
      * Get the auto-incrementing key type.
      *
      * @return string

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -231,6 +231,22 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3], $c->modelKeys());
     }
 
+    public function testCollectionDictionaryReturnsModelRouteKeys()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getRouteKey')->andReturn('model_a');
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getRouteKey')->andReturn('model_b');
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getRouteKey')->andReturn('model_c');
+
+        $c = new Collection([$one, $two, $three]);
+
+        $this->assertEquals(['model_a', 'model_b', 'model_c'], $c->modelRouteKeys());
+    }
+
     public function testCollectionMergesWithGivenCollection()
     {
         $one = m::mock(Model::class);


### PR DESCRIPTION
Route keys are a well-known concept in Laravel when it comes to Eloquent Model. They can be defined for any model by overriding the `getRouteKeyName` method and are used by the framework when resolving substitutions inside requests.

However, in order to query models by route key, you currently need to instantiate a new object just to get what is actually a configuration variable, by doing things like:
```php
// Get a post by its route key (typically a slug)
$post = Post::query()
    ->where((new Post())->getRouteKeyName(), $mySlugThatCouldBeInRequestBodyOrQuery)
    ->firstOrFail();
```

This PR proposes treating route keys as being as important as primary keys, by introducing methods for querying by route key to the Eloquent Builder, modelled after the already existing methods for querying by primary key:

| New method             | Equivalent when querying by primary key |
|------------------------|-----------------------------------------|
| `findByRouteKey`       | `find`                                  |
| `findByRouteKeyOrFail` | `findOrFail`                            |
| `findByRouteKeyOrNew`  | `findOrNew`                             |
| `findByRouteKeyOr`     | `findOr`                                |
| `findManyByRouteKey`   | `findMany`                              |
| `whereRouteKey`        | `whereKey`                              |
| `whereRouteKeyNot`     | `whereKeyNot`                           |


### Usefulness
A point could be made that since route keys are just that, keys to be used by the router, a need for manually querying by them outside of substituting bindings is not that stringent. However, I found myself needing this several times when developing applications.

For example, I like to keep consistency in the way I expose the identity of entities to consumers by only using route keys.
So, I use the route key both when referencing a certain seller for example in routes, like `/api/sellers/{seller}` , when referencing it in the body of a request (e.g create a new order section for a specific seller, where the `sellerKey` would be passed in the request body) and when referencing it from query parameters (`api/products?filters[sellerKey]={seller}`)