### PR TITLE
[11.x] Uses `SCHEDULE_CACHE_STORE`

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -302,11 +302,13 @@ class Kernel implements KernelContract
     /**
      * Get the name of the cache store that should manage scheduling mutexes.
      *
-     * @return string
+     * @return string|null
      */
     protected function scheduleCache()
     {
-        return $this->app['config']->get('cache.schedule_store', Env::get('SCHEDULE_CACHE_DRIVER'));
+        return $this->app['config']->get('cache.schedule_store', Env::get('SCHEDULE_CACHE_DRIVER', function () {
+            return Env::get('SCHEDULE_CACHE_STORE');
+        }));
     }
 
     /**


### PR DESCRIPTION
This pull request introduces the possibility of defining a `SCHEDULE_CACHE_STORE`, and the priority order is the following:

1. Configuration file via: `config('cache.schedule_store');`
2. Environment variable `SCHEDULE_CACHE_DRIVER` for existing L10 projects skeletons.
3. Environment variable `SCHEDULE_CACHE_STORE` for new ^L11 projects.