### PR TITLE
[11.x] Expand Gate::allows & Gate::denies signature

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -318,27 +318,27 @@ class Gate implements GateContract
     }
 
     /**
-     * Determine if the given ability should be granted for the current user.
+     * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function allows($ability, $arguments = [])
+    public function allows($abilities, $arguments = [])
     {
-        return $this->check($ability, $arguments);
+        return $this->check($abilities, $arguments);
     }
 
     /**
-     * Determine if the given ability should be denied for the current user.
+     * Determine if all of the given abilities should be denied for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function denies($ability, $arguments = [])
+    public function denies($abilities, $arguments = [])
     {
-        return ! $this->allows($ability, $arguments);
+        return ! $this->allows($abilities, $arguments);
     }
 
     /**

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -57,22 +57,22 @@ interface Gate
     public function after(callable $callback);
 
     /**
-     * Determine if the given ability should be granted for the current user.
+     * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function allows($ability, $arguments = []);
+    public function allows($abilities, $arguments = []);
 
     /**
-     * Determine if the given ability should be denied for the current user.
+     * Determine if all of the given abilities should be denied for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function denies($ability, $arguments = []);
+    public function denies($abilities, $arguments = []);
 
     /**
      * Determine if all of the given abilities should be granted for the current user.


### PR DESCRIPTION
`Gate::check` method signature was changed in Laravel 5.5:
- #20084

In reality since then `Gate::allows` & `Gate::denies` accepts iterable abilities as well (because they are calling `Gate::check` under the hood).

```php
public function allows($ability, $arguments = [])
{
    return $this->check($ability, $arguments);
}

public function denies($ability, $arguments = [])
{
    return ! $this->allows($ability, $arguments);
}

public function check($abilities, $arguments = [])
{
    return collect($abilities)->every(
        fn ($ability) => $this->inspect($ability, $arguments)->allowed()
    );
}
```

I found in many repositories that ability arrays passed to these methods and decided to fix this undocumented inconsistency by allowing arrays as first argument.

Targeted to master because of the contract change.