### PR TITLE
[10.x] Expand Gate::allows & Gate::denies signature

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -318,27 +318,27 @@ class Gate implements GateContract
     }
 
     /**
-     * Determine if the given ability should be granted for the current user.
+     * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function allows($ability, $arguments = [])
+    public function allows($abilities, $arguments = [])
     {
-        return $this->check($ability, $arguments);
+        return $this->check($abilities, $arguments);
     }
 
     /**
-     * Determine if the given ability should be denied for the current user.
+     * Determine if all of the given abilities should be denied for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function denies($ability, $arguments = [])
+    public function denies($abilities, $arguments = [])
     {
-        return ! $this->allows($ability, $arguments);
+        return ! $this->allows($abilities, $arguments);
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -330,7 +330,7 @@ class Gate implements GateContract
     }
 
     /**
-     * Determine if all of the given abilities should be denied for the current user.
+     * Determine if any of the given abilities should be denied for the current user.
      *
      * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -57,22 +57,22 @@ interface Gate
     public function after(callable $callback);
 
     /**
-     * Determine if the given ability should be granted for the current user.
+     * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function allows($ability, $arguments = []);
+    public function allows($abilities, $arguments = []);
 
     /**
-     * Determine if the given ability should be denied for the current user.
+     * Determine if all of the given abilities should be denied for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function denies($ability, $arguments = []);
+    public function denies($abilities, $arguments = []);
 
     /**
      * Determine if all of the given abilities should be granted for the current user.

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -66,7 +66,7 @@ interface Gate
     public function allows($abilities, $arguments = []);
 
     /**
-     * Determine if all of the given abilities should be denied for the current user.
+     * Determine if any of the given abilities should be denied for the current user.
      *
      * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -325,6 +325,47 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->denies('deny'));
     }
 
+    public function testArrayAbilitiesInAllows()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('allow_1', function ($user) {
+            return false;
+        });
+        $gate->define('allow_2', function ($user) {
+            return true;
+        });
+        $gate->define('deny', function ($user) {
+            return false;
+        });
+
+        $this->assertTrue($gate->allows(['allow_1']));
+        $this->assertTrue($gate->allows(['allow_1', 'allow_2']));
+        $this->assertFalse($gate->allows(['allow_1', 'allow_2', 'deny']));
+        $this->assertFalse($gate->allows(['deny', 'allow_1', 'allow_2']));
+    }
+
+    public function testArrayAbilitiesInDenies()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('deny_1', function ($user) {
+            return false;
+        });
+        $gate->define('deny_2', function ($user) {
+            return false;
+        });
+        $gate->define('allow', function ($user) {
+            return true;
+        });
+
+        $this->assertTrue($gate->denies(['deny_1']));
+        $this->assertTrue($gate->denies(['deny_1', 'deny_2']));
+        $this->assertTrue($gate->denies(['deny_1', 'allow']));
+        $this->assertTrue($gate->denies(['allow', 'deny_1']));
+        $this->assertFalse($gate->denies(['allow']));
+    }
+
     public function testCurrentUserThatIsOnGateAlwaysInjectedIntoClosureCallbacks()
     {
         $gate = $this->getBasicGate();

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -330,7 +330,7 @@ class AuthAccessGateTest extends TestCase
         $gate = $this->getBasicGate();
 
         $gate->define('allow_1', function ($user) {
-            return false;
+            return true;
         });
         $gate->define('allow_2', function ($user) {
             return true;


### PR DESCRIPTION
Alternative MR targeted to 11.x (master):
- #49500

`Gate::check` method signature was changed in Laravel 5.5:
- #20084

In reality since then `Gate::allows` & `Gate::denies` accepts iterable abilities as well (because they are calling `Gate::check` under the hood).

```php
public function allows($ability, $arguments = [])
{
    return $this->check($ability, $arguments);
}

public function denies($ability, $arguments = [])
{
    return ! $this->allows($ability, $arguments);
}

public function check($abilities, $arguments = [])
{
    return collect($abilities)->every(
        fn ($ability) => $this->inspect($ability, $arguments)->allowed()
    );
}
```

I found in many repositories that ability arrays passed to these methods and decided to fix this undocumented inconsistency by allowing arrays as first argument.