### PR TITLE
[10.x] Improve numeric comparison for custom casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2101,7 +2101,7 @@ trait HasAttributes
         }
 
         return is_numeric($attribute) && is_numeric($original)
-            && strcmp((string) $attribute, (string) $original) === 0;
+            && BigDecimal::of($attribute)->isEqualTo($original);
     }
 
     /**

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -169,6 +169,33 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $this->assertSame((new Decimal('320.988'))->getValue(), $model->price->getValue());
     }
 
+    public function testDirtyOnCustomNumericCasts()
+    {
+        $model = new TestEloquentModelWithCustomCast;
+        $model->price = '123.00';
+        $model->save();
+
+        $this->assertFalse($model->isDirty());
+
+        $model->price = '123.00';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '123.0';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '123';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '00123.00';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '123.4000';
+        $this->assertTrue($model->isDirty('price'));
+
+        $model->price = '123.0004';
+        $this->assertTrue($model->isDirty('price'));
+    }
+
     public function testSerializableCasts()
     {
         $model = new TestEloquentModelWithCustomCast;


### PR DESCRIPTION
This pull request improved numeric comparison for custom casts in originalIsEquivalent method.
After the improvement, changes like '9.00' to '9.0'  no longer trigger a dirty state.

```php
// app/Models/Order.php
class Order extends Model
{
    protected $casts = [
        'amount' => DecimalCast::class,
    ];
}

// app/Http/Controllers/OrdersController.php
$order = new Order();
$order->amount = '9.00';
$order->save();

// Update the amount
$order->amount = '9.0';
```

Before:
```php
dd( $order->isDirty('amount') ); // return true
```

After:
```php
dd( $order->isDirty('amount') ); // return false
```