### PR TITLE
[10.x] Add the feature of deleting the prunable model quietly

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -25,7 +25,8 @@ class PruneCommand extends Command
                                 {--model=* : Class names of the models to be pruned}
                                 {--except=* : Class names of the models to be excluded from pruning}
                                 {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
-                                {--pretend : Display the number of prunable records found instead of deleting them}';
+                                {--pretend : Display the number of prunable records found instead of deleting them}
+                                {--delete-quietly : Delete the model quietly without firing any events}';
 
     /**
      * The console command description.
@@ -98,7 +99,7 @@ class PruneCommand extends Command
             : $this->option('chunk');
 
         $total = $this->isPrunable($model)
-            ? $instance->pruneAll($chunkSize)
+            ? $instance->pruneAll($chunkSize, $this->option('delete-quietly'))
             : 0;
 
         if ($total == 0) {

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -26,7 +26,7 @@ class PruneCommand extends Command
                                 {--except=* : Class names of the models to be excluded from pruning}
                                 {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
                                 {--pretend : Display the number of prunable records found instead of deleting them}
-                                {--delete-quietly : Delete the model quietly without firing any events}';
+                                {--delete-quietly : Delete the model quietly without firing the deleted event method}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -11,17 +11,18 @@ trait Prunable
      * Prune all prunable models in the database.
      *
      * @param  int  $chunkSize
+     * @param  bool  $deleteQuitely
      * @return int
      */
-    public function pruneAll(int $chunkSize = 1000)
+    public function pruneAll(int $chunkSize = 1000, bool $deleteQuitely = null)
     {
         $total = 0;
 
         $this->prunable()
             ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($this))), function ($query) {
                 $query->withTrashed();
-            })->chunkById($chunkSize, function ($models) use (&$total) {
-                $models->each->prune();
+            })->chunkById($chunkSize, function ($models) use (&$total, $deleteQuitely) {
+                $models->each->prune($deleteQuitely);
 
                 $total += $models->count();
 
@@ -44,15 +45,22 @@ trait Prunable
     /**
      * Prune the model in the database.
      *
+     * @param  bool  $deleteQuitely
      * @return bool|null
      */
-    public function prune()
+    public function prune($deleteQuitely)
     {
         $this->pruning();
 
+        if (!empty($deleteQuitely)) {
+            return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+                ? $this->forceDeleteQuietly()
+                : $this->deleteQuietly();
+        }
+
         return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
-                ? $this->forceDelete()
-                : $this->delete();
+            ? $this->forceDelete()
+            : $this->delete();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -52,7 +52,7 @@ trait Prunable
     {
         $this->pruning();
 
-        if (!empty($deleteQuitely)) {
+        if (! empty($deleteQuitely)) {
             return in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
                 ? $this->forceDeleteQuietly()
                 : $this->deleteQuietly();


### PR DESCRIPTION
This feature is an extension of the [Mass Pruning](https://laravel.com/docs/10.x/eloquent#mass-pruning) feature, which enables us to delete the additional resources that are related to model instances that we want to delete without firing the `deleted` event, which the `Mass Pruning` feature lacks, cause of the non-existent of the `pruning` method.

Let's demonstrate the previous scenario with the next examples:

## The command without passing the new option

```PHP
/**
 * Define the application's command schedule.
 */
protected function schedule(Schedule $schedule): void
{
    $schedule->command('model:prun');
}
```

When we run the scheduling command the `deleted` event's method will be fired which may exist in the `Model Class` or `Eloquent Observer`

## The command with passing the new option

```PHP
/**
 * Define the application's command schedule.
 */
protected function schedule(Schedule $schedule): void
{
    $schedule->command('model:prun --delete-quietly');
}
```

The previous line will run the pruning model command without firing the `deleted` event method 🚀

> [!IMPORTANT]
> This pull request is not considered a breaking change