### PR TITLE
[10.x] Add `SessionGuard::logoutOnce()` method

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -269,6 +269,20 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
+     * Log the current user out for the current request without affecting sessions or cookies.
+     *
+     * @return bool
+     */
+    public function logoutOnce()
+    {
+        $this->user = null;
+
+        $this->loggedOut = true;
+
+        return true;
+    }
+
+    /**
      * Validate a user's credentials.
      *
      * @param  array  $credentials

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -36,6 +36,7 @@ use RuntimeException;
  * @method static \Illuminate\Contracts\Auth\Authenticatable|bool onceUsingId(mixed $id)
  * @method static bool viaRemember()
  * @method static void logout()
+ * @method static bool logoutOnce()
  * @method static \Symfony\Component\HttpFoundation\Response|null basic(string $field = 'email', array $extraConditions = [])
  * @method static \Symfony\Component\HttpFoundation\Response|null onceBasic(string $field = 'email', array $extraConditions = [])
  * @method static bool attemptWhen(array $credentials = [], array|callable|null $callbacks = null, bool $remember = false)

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -606,6 +606,15 @@ class AuthGuardTest extends TestCase
         $this->assertNull($guard->getUser());
     }
 
+    public function testLogoutOnce()
+    {
+        $user = m::mock(Authenticatable::class);
+        $guard = $this->getGuard();
+        $guard->setUser($user);
+        $guard->logoutOnce();
+        $this->assertNull($guard->user());
+    }
+
     protected function getGuard()
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();


### PR DESCRIPTION
In the same way that we can use `Auth::once()` or `Auth::setUser()` to temporarily log a user in just for the current request, without persisting to the session – I've run into a similar situation where I need to temporarily log a user **out** just for the current request, without removing the session state.

Currently it is not possible to do this. Calling `Auth::forgetUser()` does set the user to null, but, since the internal `loggedOut` flag remains set to false, the next call to `Auth::user()` re-authenticates the user using the session details.

One solution would be to update `Auth::forgetUser()` so that it sets the `loggedOut` flag to true, so that subsequent calls to `Auth::user()` return null. However, this change could be considered breaking - in theory it's possible that people may be relying on `forgetUser` to force a "refresh" of the authenticated user.

For this reason, I am proposing to add a new method called `logoutOnce()` which does this.