### PR TITLE
[10.x] Fixes the `Arr::dot()` method to properly handle indexes array

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -113,13 +113,13 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results[] = static::dot($value, $prepend.$key.'.');
+                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
             } else {
-                $results[] = [$prepend.$key => $value];
+                $results[$prepend.$key] = $value;
             }
         }
 
-        return array_merge(...$results);
+        return $results;
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -99,6 +99,9 @@ class SupportArrTest extends TestCase
 
     public function testDot()
     {
+        $array = Arr::dot(['foo' => ['bar' => 'baz']]);
+        $this->assertSame(['foo.bar' => 'baz'], $array);
+
         $array = Arr::dot([10 => 100]);
         $this->assertSame([10 => 100], $array);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -99,8 +99,11 @@ class SupportArrTest extends TestCase
 
     public function testDot()
     {
-        $array = Arr::dot(['foo' => ['bar' => 'baz']]);
-        $this->assertSame(['foo.bar' => 'baz'], $array);
+        $array = Arr::dot([10 => 100]);
+        $this->assertSame([10 => 100], $array);
+
+        $array = Arr::dot(['foo' => [10 => 100]]);
+        $this->assertSame(['foo.10' => 100], $array);
 
         $array = Arr::dot([]);
         $this->assertSame([], $array);


### PR DESCRIPTION
### Description
This PR addresses the issue where the `Arr::dot()` function was incorrectly reindexing arrays with integer keys when flattening them. 
The previous implementation used `array_merge`, which reindexed numeric keys, leading to unexpected results.

 v10.39.0 vs v10.37.1

<img width="794" alt="image" src="https://github.com/laravel/framework/assets/29700073/15f12335-d743-49e9-a43b-de56a80dd7ab">

This problem could cause by #49386 