### PR TITLE
[10.x] Include system versioned tables for MariaDB

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -88,7 +88,7 @@ class MySqlGrammar extends Grammar
         return sprintf(
             'select table_name as `name`, (data_length + index_length) as `size`, '
             .'table_comment as `comment`, engine as `engine`, table_collation as `collation` '
-            ."from information_schema.tables where table_schema = %s and table_type = 'BASE TABLE' "
+            ."from information_schema.tables where table_schema = %s and table_type in ('BASE TABLE', 'SYSTEM VERSIONED') "
             .'order by table_name',
             $this->quoteString($database)
         );

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -370,7 +370,9 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testSystemVersionTables()
     {
-        var_dump($this->driver);
+        if ($this->driver !== 'mysql' || ! $this->getConnection()->isMaria()) {
+            $this->markTestSkipped('Test requires a MariaDB connection.');
+        }
 
         DB::statement('create table `test` (`foo` int) WITH system versioning;');
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -368,7 +368,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         ));
     }
 
-    public function testSystemVersionTables()
+    public function testSystemVersionedTables()
     {
         if ($this->driver !== 'mysql' || ! $this->getConnection()->isMaria()) {
             $this->markTestSkipped('Test requires a MariaDB connection.');

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -367,4 +367,19 @@ class SchemaBuilderTest extends DatabaseTestCase
                 && $foreign['foreign_columns'] === ['b', 'a']
         ));
     }
+
+    public function testSystemVersionTables()
+    {
+        var_dump($this->driver);
+
+        DB::statement('create table `test` (`foo` int) WITH system versioning;');
+
+        $this->assertTrue(Schema::hasTable('test'));
+
+        Schema::dropAllTables();
+
+        $this->artisan('migrate:install');
+
+        DB::statement('create table `test` (`foo` int) WITH system versioning;');
+    }
 }


### PR DESCRIPTION
Fixes #49400 

This PR includes "system versioned" tables when retrieving/dropping tables on MariaDB.