### PR TITLE
[10.x] Add 'notifyIf' and 'notifyUnless' methods for conditional notification sending

### DIFF
--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -21,7 +21,7 @@ trait RoutesNotifications
     /**
      * Send the notification if the given truth test passes.
      *
-     * @param bool  $boolean
+     * @param  bool  $boolean
      * @param  mixed  $instance
      * @return void
      */
@@ -35,7 +35,7 @@ trait RoutesNotifications
     /**
      * Send the notification unless the given truth test passes.
      *
-     * @param bool  $boolean
+     * @param  bool  $boolean
      * @param  mixed  $instance
      * @return void
      */

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -19,6 +19,34 @@ trait RoutesNotifications
     }
 
     /**
+     * Send the notification if the given truth test passes.
+     *
+     * @param bool $boolean
+     * @param  mixed  $instance
+     * @return void
+     */
+    public function notifyIf($boolean, $instance)
+    {
+        if ($boolean) {
+            app(Dispatcher::class)->send($this, $instance);
+        }
+    }
+
+    /**
+     * Send the notification unless the given truth test passes.
+     *
+     * @param bool $boolean
+     * @param  mixed  $instance
+     * @return void
+     */
+    public function notifyUnless($boolean, $instance)
+    {
+        if (! $boolean) {
+            app(Dispatcher::class)->send($this, $instance);
+        }
+    }
+
+    /**
      * Send the given notification immediately.
      *
      * @param  mixed  $instance

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -21,7 +21,7 @@ trait RoutesNotifications
     /**
      * Send the notification if the given truth test passes.
      *
-     * @param bool $boolean
+     * @param bool  $boolean
      * @param  mixed  $instance
      * @return void
      */
@@ -35,7 +35,7 @@ trait RoutesNotifications
     /**
      * Send the notification unless the given truth test passes.
      *
-     * @param bool $boolean
+     * @param bool  $boolean
      * @param  mixed  $instance
      * @return void
      */

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -27,10 +27,54 @@ class NotificationRoutesNotificationsTest extends TestCase
         $container->instance(Dispatcher::class, $factory);
         $notifiable = new RoutesNotificationsTestInstance;
         $instance = new stdClass;
-        $factory->shouldReceive('send')->with($notifiable, $instance);
+        $factory->shouldReceive('send')->with($notifiable, $instance)->times(1);
         Container::setInstance($container);
 
         $notifiable->notify($instance);
+    }
+
+    public function testNotificationDispatchesConditionallyWithBoolean()
+    {
+        $notifiable = new RoutesNotificationsTestInstance;
+        $instance = new stdClass;
+
+        $containerOne = new Container;
+        $factoryOne = m::mock(Dispatcher::class);
+        $containerOne->instance(Dispatcher::class, $factoryOne);
+        $factoryOne->shouldReceive('send')->with($notifiable, $instance)->times(1);
+        Container::setInstance($containerOne);
+
+        $notifiable->notifyIf(true, $instance);
+
+        $containerTwo = new Container;
+        $factoryTwo = m::mock(Dispatcher::class);
+        $containerTwo->instance(Dispatcher::class, $factoryTwo);
+        $factoryTwo->shouldNotReceive('send')->with($notifiable, $instance);
+        Container::setInstance($containerTwo);
+
+        $notifiable->notifyIf(false, $instance);
+    }
+
+    public function testNotificationDoesNotDispatchConditionallyWithBoolean()
+    {
+        $notifiable = new RoutesNotificationsTestInstance;
+        $instance = new stdClass;
+
+        $containerOne = new Container;
+        $factoryOne = m::mock(Dispatcher::class);
+        $containerOne->instance(Dispatcher::class, $factoryOne);
+        $factoryOne->shouldReceive('send')->with($notifiable, $instance)->times(1);
+        Container::setInstance($containerOne);
+
+        $notifiable->notifyUnless(false, $instance);
+
+        $containerTwo = new Container;
+        $factoryTwo = m::mock(Dispatcher::class);
+        $containerTwo->instance(Dispatcher::class, $factoryTwo);
+        $factoryTwo->shouldNotReceive('send')->with($notifiable, $instance);
+        Container::setInstance($containerTwo);
+
+        $notifiable->notifyUnless(true, $instance);
     }
 
     public function testNotificationCanBeSentNow()
@@ -40,7 +84,7 @@ class NotificationRoutesNotificationsTest extends TestCase
         $container->instance(Dispatcher::class, $factory);
         $notifiable = new RoutesNotificationsTestInstance;
         $instance = new stdClass;
-        $factory->shouldReceive('sendNow')->with($notifiable, $instance, null);
+        $factory->shouldReceive('sendNow')->with($notifiable, $instance, null)->times(1);
         Container::setInstance($container);
 
         $notifiable->notifyNow($instance);


### PR DESCRIPTION
This PR adds two methods named `notifyIf` and `notifyUnless` to provide conditional notification sending via the `Notifiable` trait. This will work similarly to `dispatchIf` and `dispatchUnless` of Job dispatching. 

An example code would look like: 
```
use App\Notifications\InvoicePaid;
 
$user->notifyIf($condition, new InvoicePaid($invoice));
```

I've added relevant tests for these methods as well. 

**Note:** While adding a test for this, I've found that the existing test requires a fix. The `shouldReceive`method in the Mock instance expects 'zero or more times' calling of the method. That's why even if we remove the `$notifiable->notify($instance);` line from the `testNotificationCanBeDispatched` test method, it still passes. I've added a `times(1)` condition to fix this. 