### PR TITLE
[10.x] Add `Number::clamp`

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -134,6 +134,19 @@ class Number
     }
 
     /**
+     * Clamp the given number between the given minimum and maximum.
+     *
+     * @param int|float $number
+     * @param int|float $min
+     * @param int|float $max
+     * @return int|float
+     */
+    public static function clamp(int|float $number, int|float $min, int|float $max)
+    {
+        return min(max($number, $min), $max);
+    }
+
+    /**
      * Convert the number to its human readable equivalent.
      *
      * @param  int  $number

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -134,19 +134,6 @@ class Number
     }
 
     /**
-     * Clamp the given number between the given minimum and maximum.
-     *
-     * @param  int|float  $number
-     * @param  int|float  $min
-     * @param  int|float  $max
-     * @return int|float
-     */
-    public static function clamp(int|float $number, int|float $min, int|float $max)
-    {
-        return min(max($number, $min), $max);
-    }
-
-    /**
      * Convert the number to its human readable equivalent.
      *
      * @param  int  $number
@@ -219,6 +206,19 @@ class Number
         $number /= pow(10, $displayExponent);
 
         return trim(sprintf('%s%s', static::format($number, $precision, $maxPrecision), $units[$displayExponent] ?? ''));
+    }
+
+    /**
+     * Clamp the given number between the given minimum and maximum.
+     *
+     * @param  int|float  $number
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @return int|float
+     */
+    public static function clamp(int|float $number, int|float $min, int|float $max)
+    {
+        return min(max($number, $min), $max);
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -136,9 +136,9 @@ class Number
     /**
      * Clamp the given number between the given minimum and maximum.
      *
-     * @param int|float $number
-     * @param int|float $min
-     * @param int|float $max
+     * @param  int|float  $number
+     * @param  int|float  $min
+     * @param  int|float  $max
      * @return int|float
      */
     public static function clamp(int|float $number, int|float $min, int|float $max)

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -157,6 +157,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
     }
 
+    public function testClamp()
+    {
+        $this->assertSame(2, Number::clamp(1, 2, 3));
+        $this->assertSame(3, Number::clamp(5, 2, 3));
+        $this->assertSame(5, Number::clamp(5, 1, 10));
+        $this->assertSame(4.5, Number::clamp(4.5, 1, 10));
+        $this->assertSame(1, Number::clamp(-10, 1, 5));
+    }
+
     public function testToHuman()
     {
         $this->assertSame('1', Number::forHumans(1));


### PR DESCRIPTION
This PR extends the `Number` class to introduce a `clamp` method, that clamps a given number between two numbers.

Originally from https://github.com/jbrooksuk/php-clamp, but with the `Number` class, it makes sense to bring it in.