### PR TITLE
[10.x] Enhanced ForeignKeyDefinition with Additional Cascade and Restriction Functions

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -133,4 +133,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->restrictOnUpdate()->nullOnDelete();
     }
+
+    /**
+     * Indicate that updates should have no-action and deletes should be null.
+     *
+     * @return $this
+     */
+    public function noActionAndNull()
+    {
+        return $this->noActionOnUpdate()->nullOnDelete();
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -103,4 +103,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->restrictOnUpdate()->restrictOnDelete();
     }
+
+    /**
+     * Indicate that updates and deletes should have "no action".
+     *
+     * @return $this
+     */
+    public function noActionAlways()
+    {
+        return $this->noActionOnUpdate()->noActionOnDelete();
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -93,4 +93,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->cascadeOnUpdate()->cascadeOnDelete();
     }
+
+    /**
+     * Indicate that updates and deletes should be restricted.
+     *
+     * @return $this
+     */
+    public function restrictAlways()
+    {
+        return $this->restrictOnUpdate()->restrictOnDelete();
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -113,4 +113,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->noActionOnUpdate()->noActionOnDelete();
     }
+
+    /**
+     * Indicate that updates should cascade and deletes should be null.
+     *
+     * @return $this
+     */
+    public function cascadeAndNull()
+    {
+        return $this->cascadeOnUpdate()->nullOnDelete();
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -123,4 +123,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->cascadeOnUpdate()->nullOnDelete();
     }
+
+    /**
+     * Indicate that updates should be restricted and deletes should be null.
+     *
+     * @return $this
+     */
+    public function restrictAndNull()
+    {
+        return $this->restrictOnUpdate()->nullOnDelete();
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -83,4 +83,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->onDelete('no action');
     }
+
+    /**
+     * Indicate that updates and deletes should cascade.
+     *
+     * @return $this
+     */
+    public function cascadeAlways()
+    {
+        return $this->cascadeOnUpdate()->cascadeOnDelete();
+    }
 }


### PR DESCRIPTION
This pull request introduces several new features to the `ForeignKeyDefinition` class, enhancing its functionality for defining foreign key relationships. The new functions include `cascadeAlways`, `restrictAlways`, and `noActionAlways`, which allow users to specify that both updates and deletes should either cascade, be restricted, or have "no action." Additionally, three new functions—`cascadeAndNull`, `restrictAndNull`, and `noActionAndNull`—are introduced to indicate that updates should have a specific behavior, and deletes should set the foreign key value to null. These additions provide developers with more flexibility and control when defining foreign key constraints in their database schemas.
