### PR TITLE
[10.x] Fix whenAggregated when default is not specified

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -320,6 +320,10 @@ trait ConditionallyLoadsAttributes
      */
     public function whenAggregated($relationship, $column, $aggregate, $value = null, $default = null)
     {
+        if (func_num_args() < 5) {
+            $default = new MissingValue;
+        }
+        
         $attribute = (string) Str::of($relationship)->snake()->append('_')->append($aggregate)->append('_')->finish($column);
 
         if (! isset($this->resource->getAttributes()[$attribute])) {

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -502,8 +502,6 @@ class ResourceTest extends TestCase
             'data' => [
                 'id' => 5,
                 'title' => 'Test Title',
-                'average_rating' => null,
-                'minimum_rating' => null,
                 'maximum_rating' => 'Default Value',
             ],
         ]);


### PR DESCRIPTION
#47417 intoduced whenAggregated method to ConditionallyLoadsAttributes trait but it returns null instead of MissingValue when the default value is not specified.

According to the documentation and PHPDoc it should return MissingValue in order to be removed from the resource response before it is sent to the client.