### PR TITLE
[10.x] Make ComponentAttributeBag Arrayable

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use ArrayAccess;
 use ArrayIterator;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
@@ -14,7 +15,7 @@ use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
 
-class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable
+class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable
 {
     use Conditionable, Macroable;
 
@@ -482,6 +483,16 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      * @return mixed
      */
     public function jsonSerialize(): mixed
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Convert the object into an array.
+     *
+     * @return array
+     */
+    public function toArray()
     {
         return $this->attributes;
     }


### PR DESCRIPTION
This PR adds the `Arrayable` interface to the `ComponentAttributeBag`.

In some cases, the `ComponentAttributeBag` class is not being converted to array, while it should.

Followup of https://github.com/laravel/framework/pull/48338

-------

```php
$bag1 = new ComponentAttributeBag([....]);
$bag2 = new ComponentAttributeBag([....]);

collect([$bag1, $bag2])->toArray(); // returns an array of objects and not arrays, while it should
```