### PR TITLE
[11.x] Add path method to Illuminate\Contracts\Filesystem\Filesystem interfa…

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -35,6 +35,14 @@ interface Filesystem
     public function get($path);
 
     /**
+     * Returns the path of a file.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function path($path);
+
+    /**
      * Get a resource to read the file.
      *
      * @param  string  $path

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -19,6 +19,14 @@ interface Filesystem
     const VISIBILITY_PRIVATE = 'private';
 
     /**
+     * Get the full path to the file that exists at the given relative path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function path($path);
+
+    /**
      * Determine if a file exists.
      *
      * @param  string  $path
@@ -33,14 +41,6 @@ interface Filesystem
      * @return string|null
      */
     public function get($path);
-
-    /**
-     * Returns the path of a file.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function path($path);
 
     /**
      * Get a resource to read the file.


### PR DESCRIPTION
The **Illuminate\Contracts\Filesystem\Filesystem** interface by default doesn't have a **path($path)** method. The absence of this function in the interface raises a code highlight error when using **Illuminate\Support\Facades\Storage** after specifying a disk before using the **path** method.

### Eg.
**$imagePath = Illuminate\Support\Facades\Storage::disk('public')->path('my-image.jpg');**