### PR TITLE
[10.x] Add `Str::split()` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1370,6 +1370,26 @@ class Str
     }
 
     /**
+     * Split a string using a regular expression or by length.
+     *
+     * @param  string  $value
+     * @param  string|int  $pattern
+     * @param  int  $limit
+     * @param  int  $flags
+     * @return \Illuminate\Support\Collection<int, string>
+     */
+    public static function split($value, $pattern, $limit = -1, $flags = 0)
+    {
+        if (filter_var($pattern, FILTER_VALIDATE_INT) !== false) {
+            return collect(mb_str_split($value, $pattern));
+        }
+
+        $segments = preg_split($pattern, $value, $limit, $flags);
+
+        return ! empty($segments) ? collect($segments) : collect();
+    }
+
+    /**
      * Convert a value to studly caps case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -283,13 +283,7 @@ class Stringable implements JsonSerializable, ArrayAccess
      */
     public function split($pattern, $limit = -1, $flags = 0)
     {
-        if (filter_var($pattern, FILTER_VALIDATE_INT) !== false) {
-            return collect(mb_str_split($this->value, $pattern));
-        }
-
-        $segments = preg_split($pattern, $this->value, $limit, $flags);
-
-        return ! empty($segments) ? collect($segments) : collect();
+        return Str::split($this->value, $pattern, $limit, $flags);
     }
 
     /**


### PR DESCRIPTION
With this change, developers can now use the `split` method, which has a simplified syntax, to accomplish string splitting more directly and conveniently without needing a `Stringable` class.