### PR TITLE
[10.x] Ability to establish connection without using Config Repository

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -132,7 +132,7 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
-     * Establish a fresh connection .
+     * Establish a fresh connection.
      *
      * @param  string  $name
      * @param  array  $config

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -246,7 +246,7 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * If the event dispatcher is available dispatches the ConnectionEstablished event.
      *
-     * @param  Connection  $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return void
      */
     protected function dispatchConnectionEstablishedEvent(Connection $connection): void

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -136,7 +136,7 @@ class DatabaseManager implements ConnectionResolverInterface
      *
      * @param  string  $name
      * @param  array  $config
-     * @return ConnectionInterface
+     * @return \Illuminate\Database\ConnectionInterface
      */
     public function overrideUsing(string $name, array $config): ConnectionInterface
     {

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -114,7 +114,6 @@ class DatabaseManager implements ConnectionResolverInterface
      * @param  array  $config
      * @return \Illuminate\Database\ConnectionInterface
      */
-
     public function connectUsing(string $name, array $config): ConnectionInterface
     {
         if (isset($this->connections[$name])) {
@@ -247,7 +246,7 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * If the event dispatcher is available dispatches the ConnectionEstablished event.
      *
-     * @param Connection $connection
+     * @param  Connection  $connection
      * @return void
      */
     protected function dispatchConnectionEstablishedEvent(Connection $connection): void

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Illuminate\Tests\Integration\Database;
 

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -79,7 +79,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
     public function testEstablishingAConnectionWillDispatchAnEvent()
     {
-        /** @var Dispatcher $dispatcher */
+        /** @var \Illuminate\Events\Dispatcher $dispatcher */
         $dispatcher = $this->app->make(Dispatcher::class);
 
         $event = null;

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -62,10 +62,10 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
         $resultBeforeOverride = $connection->select("SELECT name FROM sqlite_master WHERE type='table';");
 
-        $connection = $manager->overrideUsing('my-phpunit-connection', [
+        $connection = $manager->connectUsing('my-phpunit-connection', [
             'driver' => 'sqlite',
             'database' => ':memory:',
-        ]);
+        ], force: true);
 
         // After purging a connection of a :memory: SQLite database
         // anything that was created before the override will no

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -13,7 +13,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 {
     public function testEstablishDatabaseConnection()
     {
-        /** @var DatabaseManager $manager */
+        /** @var \Illuminate\Database\DatabaseManager $manager */
         $manager = $this->app->make(DatabaseManager::class);
 
         $connection = $manager->connectUsing('my-phpunit-connection', [
@@ -32,7 +32,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
     public function testThrowExceptionIfConnectionAlreadyExists()
     {
-        /** @var DatabaseManager $manager */
+        /** @var \Illuminate\Database\DatabaseManager $manager */
         $manager = $this->app->make(DatabaseManager::class);
 
         $manager->connectUsing('my-phpunit-connection', [
@@ -50,7 +50,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
 
     public function testOverrideExistingConnection()
     {
-        /** @var DatabaseManager $manager */
+        /** @var \Illuminate\Database\DatabaseManager $manager */
         $manager = $this->app->make(DatabaseManager::class);
 
         $connection = $manager->connectUsing('my-phpunit-connection', [
@@ -88,7 +88,7 @@ class DatabaseConnectionsTest extends DatabaseTestCase
             $event = $e;
         });
 
-        /** @var DatabaseManager $manager */
+        /** @var \Illuminate\Database\DatabaseManager $manager */
         $manager = $this->app->make(DatabaseManager::class);
 
         $manager->connectUsing('my-phpunit-connection', [

--- a/tests/Integration/Database/DatabaseConnectionsTest.php
+++ b/tests/Integration/Database/DatabaseConnectionsTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Events\ConnectionEstablished;
+use Illuminate\Events\Dispatcher;
+use RuntimeException;
+
+class DatabaseConnectionsTest extends DatabaseTestCase
+{
+    public function testEstablishDatabaseConnection()
+    {
+        /** @var DatabaseManager $manager */
+        $manager = $this->app->make(DatabaseManager::class);
+
+        $connection = $manager->connectUsing('my-phpunit-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $connection->statement('CREATE TABLE test_1 (id INTEGER PRIMARY KEY)');
+
+        $connection->statement('INSERT INTO test_1 (id) VALUES (1)');
+
+        $result = $connection->selectOne('SELECT COUNT(*) as total FROM test_1');
+
+        self::assertSame(1, $result->total);
+    }
+
+    public function testThrowExceptionIfConnectionAlreadyExists()
+    {
+        /** @var DatabaseManager $manager */
+        $manager = $this->app->make(DatabaseManager::class);
+
+        $manager->connectUsing('my-phpunit-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+
+        $manager->connectUsing('my-phpunit-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+    }
+
+    public function testOverrideExistingConnection()
+    {
+        /** @var DatabaseManager $manager */
+        $manager = $this->app->make(DatabaseManager::class);
+
+        $connection = $manager->connectUsing('my-phpunit-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $connection->statement('CREATE TABLE test_1 (id INTEGER PRIMARY KEY)');
+
+        $resultBeforeOverride = $connection->select("SELECT name FROM sqlite_master WHERE type='table';");
+
+        $connection = $manager->overrideUsing('my-phpunit-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        // After purging a connection of a :memory: SQLite database
+        // anything that was created before the override will no
+        // longer be available. It's a new and fresh database
+        $resultAfterOverride = $connection->select("SELECT name FROM sqlite_master WHERE type='table';");
+
+        self::assertSame('test_1', $resultBeforeOverride[0]->name);
+
+        self::assertEmpty($resultAfterOverride);
+    }
+
+    public function testEstablishingAConnectionWillDispatchAnEvent()
+    {
+        /** @var Dispatcher $dispatcher */
+        $dispatcher = $this->app->make(Dispatcher::class);
+
+        $event = null;
+
+        $dispatcher->listen(ConnectionEstablished::class, function (ConnectionEstablished $e) use (&$event) {
+            $event = $e;
+        });
+
+        /** @var DatabaseManager $manager */
+        $manager = $this->app->make(DatabaseManager::class);
+
+        $manager->connectUsing('my-phpunit-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        self::assertInstanceOf(
+            ConnectionEstablished::class,
+            $event,
+            'Expected the ConnectionEstablished event to be dispatched when establishing a connection.'
+        );
+
+        self::assertSame('my-phpunit-connection', $event->connectionName);
+    }
+}


### PR DESCRIPTION
This PR is a follow-up on this comment I left on another PR: https://github.com/laravel/framework/pull/49385#issuecomment-1872542306

The following diagram helps understand the changes:

![image](https://github.com/laravel/framework/assets/9533181/b2c754ff-a6d7-4d77-933e-da7930244198)

![image](https://github.com/laravel/framework/assets/9533181/7953284f-ae0a-4507-937e-2ebd5d56c749)

If merged, this PR will allow Laravel users to establish a runtime database connection without having to first make a global runtime change to the Config repository, essentially creating an alternative decoupled to Illuminate/Config/Repository.