### PR TITLE
[10.x] Add `Arr::flip()` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -482,6 +482,17 @@ class Arr
     }
 
     /**
+     * Flip the items in the array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function flip($array)
+    {
+        return array_flip($array);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array
@@ -490,7 +501,7 @@ class Arr
      */
     public static function only($array, $keys)
     {
-        return array_intersect_key($array, array_flip((array) $keys));
+        return array_intersect_key($array, static::flip((array) $keys));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -422,7 +422,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function flip()
     {
-        return new static(array_flip($this->items));
+        return new static(Arr::flip($this->items));
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -673,6 +673,12 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, ['user', 1], ['user', 0]));
     }
 
+    public function testFlip()
+    {
+        $data = Arr::flip(['name' => 'michael', 'framework' => 'laravel']);
+        $this->assertEquals(['michael' => 'name', 'laravel' => 'framework'], $data);
+    }
+
     public function testArrayPluckWithNestedArrays()
     {
         $array = [


### PR DESCRIPTION
This PR adds the ability to flip the array