### PR TITLE
[10.x] Improve `collect()->push()` performance

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -967,9 +967,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function push(...$values)
     {
-        foreach ($values as $value) {
-            $this->items[] = $value;
-        }
+        array_push($this->items, ...$values);
 
         return $this;
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -967,7 +967,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function push(...$values)
     {
-        array_push($this->items, ...$values);
+        $this->items = array_merge($this->items, Arr::isList($values) ? $values : array_values($values));
 
         return $this;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4065,12 +4065,14 @@ class SupportCollectionTest extends TestCase
             2 => 6,
             3 => ['a', 'b', 'c'],
             4 => ['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'],
-            5 => 'Jonny from Laroe',
+            5 => 'michael',
+            6 => 'Jonny from Laroe',
         ];
 
         $data = new Collection([4, 5, 6]);
         $data->push(['a', 'b', 'c']);
         $data->push(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $data->push(name: 'michael');
         $actual = $data->push('Jonny from Laroe')->toArray();
 
         $this->assertSame($expected, $actual);
@@ -4091,12 +4093,15 @@ class SupportCollectionTest extends TestCase
             9 => 'a',
             10 => 'b',
             11 => 'c',
+            12 => 'foo',
+            13 => 'bar',
         ];
 
         $data = new Collection([4, 5, 6]);
         $data->push('Jonny', 'from', 'Laroe');
         $data->push(...[11 => 'Jonny', 12 => 'from', 13 => 'Laroe']);
         $data->push(...collect(['a', 'b', 'c']));
+        $data->push(foo: 'foo', bar: 'bar')->toArray();
         $actual = $data->push(...[])->toArray();
 
         $this->assertSame($expected, $actual);


### PR DESCRIPTION
This PR improves the speed of `Collection::make()->push()` by using the array_merge operator instead of the slower foreach

I've attached some benchmarks running the current `Collection::make()->push()` implementation against my new implementation. As you can see, the new implementation solves a significant runtime issue.

```
Items: 100
framework push: 0.0030 seconds / 32.00 memory
new push: 0.0016 seconds / 32.00 memory

Items: 1000
framework push: 0.0010 seconds / 32.00 memory
new push: 0.0007 seconds / 32.00 memory

Items: 10000
framework push: 0.0078 seconds / 44.00 memory
new push: 0.0035 seconds / 44.00 memory

Items: 15000
framework push: 0.0046 seconds / 62.00 memory
new push: 0.0016 seconds / 62.00 memory
```

<details>
<summary>The code for testing the speed</summary>

```php
class FastCollectPush extends Command
{
    protected $signature = 'fast-collect-push';

    public function handle(): void
    {
        foreach ([100, 1_000, 10_000, 15_000] as $itemCount) {
            $this->newLine();

            $data = $this->data($itemCount);

            $this->framework($data);

            $this->newPush($data);
        }
    }

    protected function data(int $itemCount): array
    {
        $subset = [];
        for ($i = 0; $i < $itemCount; $i++) {
            $subset[] = [
                'id' => $i,
                'name' => 'Name '.$i,
                'email' => 'email'.$i.'@example.com',
                'date' => now()->addDays($i)->format('Y-m-d'),
                'another_sub_array' => [
                    'street' => 'Street '.$i,
                    'city' => 'City '.$i,
                    'country' => 'Country '.$i,
                ],
            ];
        }

        $this->info('Items: '.count($subset));

        return $subset;
    }

    protected function framework(array $data): void
    {
        memory_reset_peak_usage();

        $start = hrtime(true);

        collect()->push($data);

        $this->finish('framework push', $start);
    }

    protected function newPush(array $data): void
    {
        memory_reset_peak_usage();

        $start = hrtime(true);

        collect()->newPush($data);

        $this->finish('new push', $start);
    }

    protected function finish(string $title, float $start): void
    {
        $this->info(sprintf($title.': %s seconds / %.2f memory', (hrtime(true) - $start) / 1000000, memory_get_peak_usage(true) / 1024 / 1024)).PHP_EOL;
    }
}
```
</details>