### PR TITLE
[10.x] Update AsArrayObject.php to use ARRAY_AS_PROPS flag

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -25,7 +25,7 @@ class AsArrayObject implements Castable
 
                 $data = Json::decode($attributes[$key]);
 
-                return is_array($data) ? new ArrayObject($data) : null;
+                return is_array($data) ? new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS) : null;
             }
 
             public function set($model, $key, $value, $attributes)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Added ARRAY_AS_PROPS flag to allow using array as an object

```php
protected $casts = [
    'options' => AsArrayObject::class,
];
```
```php
$model->options->something = 'whatever';
$model->options->something_else;
```

Before: \
`WARNING  Undefined property: Illuminate\Database\Eloquent\Casts\ArrayObject::$something`\
`WARNING  Undefined property: Illuminate\Database\Eloquent\Casts\ArrayObject::$something_else`

Now:
`it just works`
https://www.php.net/manual/en/class.arrayobject.php#arrayobject.constants.array-as-props

More info https://stackoverflow.com/questions/14610307/spl-arrayobject-arrayobjectstd-prop-list/16619183#16619183