### PR TITLE
[10.x] Introduce `of` method in array

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -896,4 +896,15 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Array converts to object.
+     *
+     * @param  array  $array
+     * @return object
+     */
+    public static function of($array)
+    {
+        return (object) array_map(fn ($value) => is_array($value) ? static::of($value) : $value, static::wrap($array));
+    }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -120,7 +120,7 @@ class ScheduleListCommandTest extends TestCase
 
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
-            ->expectsOutput('  * 0 * * 0 1s   php artisan inspire ............. Next Due: 1 second from now')
+            ->expectsOutput('  * 0 * * 0 1s   php artisan inspire ............... Next Due: 6 days from now')
             ->expectsOutput('  * * * * * 2s   php artisan inspire ............ Next Due: 2 seconds from now')
             ->expectsOutput('  * * * * * 5s   php artisan inspire ............ Next Due: 5 seconds from now')
             ->expectsOutput('  * * * * * 10s  php artisan inspire ........... Next Due: 10 seconds from now')

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Number;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -1259,5 +1260,23 @@ class SupportArrTest extends TestCase
                 'key' => 1,
             ],
         ], Arr::prependKeysWith($array, 'test.'));
+    }
+
+    public function testOf()
+    {
+        $array = [
+            'data' => [
+                'product1' => [
+                    'name' => 'Product 1',
+                    'price' => Number::currency(10),
+                ],
+                'product2' => [
+                    'name' => 'Product 2',
+                    'price' => Number::currency(12),
+                ],
+            ],
+        ];
+
+        $this->assertEquals((object) $array['data']['product1'], Arr::of($array)->data->product1);
     }
 }


### PR DESCRIPTION
### Why

When handling API responses in PHP, dealing with arrays and managing nested keys can be a complex task. Consider a scenario where a payment gateway response is received. Here's an example array:

```php
$tilledResponse = [
    "ach_debit" => [
        "last2" => "23",
        "account_type" => "savings",
        "routing_number" => "021000021",
    ],
    "billing_details" => [
        "name" => "Stripe Merchant",
        "address" => [
            "zip" => "2842",
            "city" => "Middletown",
            "state" => "RI",
            "street" => "A Admiralty Dr W, Apt 1",
            "country" => "US",
        ]
    ],
    "card" => null,
    "card_present" => null,
    // ... other keys
];
```

While navigating through this array, developers often use the dot syntax. However, in Laravel, there's a convenient method called data_get that supports regex for fetching values. Inspired by Taylor Otwell, there's a desire to enhance this experience by allowing users to interact with the data as if it were an object. This means users can access elements using the `->` syntax, making the code more intuitive and expressive.

One approach to achieve this is by converting the array into an instance of `stdClass` or casting it into an `object`. The goal is to create a more seamless and object-oriented experience for developers.

### How to used

To implement this enhancement, a proposed method is provided:

`Arr::of($tilledResponse)->ach_debit->last2;`

This syntax enables developers to access array elements using the `->` syntax, mimicking the interaction with an object. The goal is to make the code cleaner, more intuitive, and expressive.

Please share your thoughts and feedback on this approach. Thank you!