### PR TITLE
[10.x] Create a method to convert base64 file to a file in the Filesystem class

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/InvalidBase64FileException.php
+++ b/src/Illuminate/Contracts/Filesystem/InvalidBase64FileException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Filesystem;
+
+use Exception;
+
+class InvalidBase64FileException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -368,6 +368,7 @@ class Filesystem
         }
 
         $decoded = base64_decode($base64, true);
+
         return ($decoded !== false) && (strlen($decoded) > 0);
     }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -359,7 +359,7 @@ class Filesystem
      */
     public function isBase64File(string $base64)
     {
-        if (strpos($base64, ';base64,') !== false) {
+        if (str_contains($base64, ';base64,')) {
             $base64 = explode(';base64,', $base64)[1];
         }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -40,7 +40,7 @@ class Filesystem
      */
     public function missing($path)
     {
-        return !$this->exists($path);
+        return ! $this->exists($path);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -346,6 +346,7 @@ class Filesystem
         }
 
         $data_uri = Str::between($base64File, 'data:', ';');
+
         if (str_contains($base64File, $data_uri)) {
 
             $base64File = explode(',', $base64File, 2)[1];

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -345,7 +345,9 @@ class Filesystem
             throw new InvalidBase64FileException();
         }
 
-        if (strpos($base64File, 'data:image') !== false) {
+        $data_uri = Str::between($base64File, 'data:', ';');
+        if (str_contains($base64File, $data_uri)) {
+
             $base64File = explode(',', $base64File, 2)[1];
         }
 
@@ -360,7 +362,7 @@ class Filesystem
      */
     public function isBase64File(string $base64)
     {
-        if (strpos($base64, ';base64,') !== false) {
+        if (str_contains($base64, ';base64,')) {
             $base64 = explode(';base64,', $base64)[1];
         }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -399,7 +399,7 @@ class Filesystem
 
         $mode = $this->isDirectory($target) ? 'J' : 'H';
 
-        exec("mklink /{$mode} ".escapeshellarg($link) . ' ' . escapeshellarg($target));
+        exec("mklink /{$mode} ".escapeshellarg($link).' '.escapeshellarg($target));
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -810,7 +810,7 @@ class Filesystem
     {
         $allDirectories = $this->directories($directory);
 
-        if (!empty($allDirectories)) {
+        if (! empty($allDirectories)) {
             foreach ($allDirectories as $directoryName) {
                 $this->deleteDirectory($directoryName);
             }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -344,7 +344,7 @@ class Filesystem
             throw new InvalidBase64FileException();
         }
 
-        if (strpos($base64File, 'data:image') !== false) {
+        if (str_contains($base64File, 'data:image')) {
             $base64File = explode(',', $base64File, 2)[1];
         }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -348,8 +348,7 @@ class Filesystem
             $base64File = explode(',', $base64File, 2)[1];
         }
 
-        $file_data = base64_decode($base64File);
-        return $file_data;
+        return base64_decode($base64File);
     }
 
     /**

--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -42,16 +42,16 @@ trait FileHelpers
     public function hashName($path = null)
     {
         if ($path) {
-            $path = rtrim($path, '/').'/';
+            $path = rtrim($path, '/') . '/';
         }
 
         $hash = $this->hashName ?: $this->hashName = Str::random(40);
 
         if ($extension = $this->guessExtension()) {
-            $extension = '.'.$extension;
+            $extension = '.' . $extension;
         }
 
-        return $path.$hash.$extension;
+        return $path . $hash . $extension;
     }
 
     /**

--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -42,16 +42,16 @@ trait FileHelpers
     public function hashName($path = null)
     {
         if ($path) {
-            $path = rtrim($path, '/') . '/';
+            $path = rtrim($path, '/').'/';
         }
 
         $hash = $this->hashName ?: $this->hashName = Str::random(40);
 
         if ($extension = $this->guessExtension()) {
-            $extension = '.' . $extension;
+            $extension = '.'.$extension;
         }
 
-        return $path . $hash . $extension;
+        return $path.$hash.$extension;
     }
 
     /**


### PR DESCRIPTION
Description
I added a method in the file facade to convert a base64file to a file data that can be saved in a file. I also create a helper function to check if the string is a valid base64 file and it throws the following exception if it is not a valid base64 file.

Use case
It is a simple out of the box method that allows users convert their base64 images directly into a file data that they can save into a file. I have had to create methods in my laravel applications for handling this so i thought to create a method that will make this seamless and easy.

Additions:
I initially made this compatible for only base64 images but made a new pull request for other file types.