### PR TITLE
[10.x] Make the Schema Builder macroable

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,11 +5,14 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
 
 class Builder
 {
+    use Macroable;
+
     /**
      * The database connection instance.
      *

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -393,7 +393,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         Schema::macro('hasForeignKeyForColumn', function (string $column, string $table, string $foreignTable) {
             return collect(Schema::getForeignKeys($table))
-                ->contains(function (array $foreignKey) use ($column, $table, $foreignTable) {
+                ->contains(function (array $foreignKey) use ($column, $foreignTable) {
                     return collect($foreignKey['columns'])->contains($column)
                         && $foreignKey['foreign_table'] == $foreignTable;
                 });

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -384,4 +384,33 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         DB::statement('create table `test` (`foo` int) WITH system versioning;');
     }
+
+    public function testAddingMacros()
+    {
+        Schema::macro('foo', fn () => 'foo');
+
+        $this->assertEquals('foo', Schema::foo());
+
+        Schema::macro('hasForeignKeyForColumn', function (string $column, string $table, string $foreignTable) {
+            return collect(Schema::getForeignKeys($table))
+                ->contains(function (array $foreignKey) use ($column, $table, $foreignTable) {
+                    return collect($foreignKey['columns'])->contains($column)
+                        && $foreignKey['foreign_table'] == $foreignTable;
+                });
+        });
+
+        Schema::create('questions', function (Blueprint $table) {
+            $table->id();
+            $table->string('body');
+        });
+
+        Schema::create('answers', function (Blueprint $table) {
+            $table->id();
+            $table->string('body');
+            $table->foreignId('question_id')->constrained();
+        });
+
+        $this->assertTrue(Schema::hasForeignKeyForColumn('question_id', 'answers', 'questions'));
+        $this->assertFalse(Schema::hasForeignKeyForColumn('body', 'answers', 'questions'));
+    }
 }


### PR DESCRIPTION
I have just started working on a new side project using [the existing Sakila database][1].

Because I already have a database, I have used the `bennett-treptow/laravel-migration-generator` package to generate migration files.

And because those tables already exist, this is what I have to do in the migration files that create tables:

```php
public function up()
{
    if (Schema::hasTable('actor')) {
            return;
    }

    Schema::create('actor', function (Blueprint $table) {
    // ...
    }
}
```

And I have to do this in migration files that create foreign keys:

```php
public function up()
{
    $foreignKeys = Schema::getForeignKeys('staff');

    foreach ($foreignKeys as $foreignKey) {
        if ($foreignKey['name'] == 'fk_staff_store') {
            return;
        }
    }

    Schema::table('staff', function (Blueprint $table) {
        $table->foreign('store_id', 'fk_staff_store')->references('store_id')->on('store')->onDelete('restrict')->onUpdate('cascade');
    });
}
```
It would be nice to extract the above snippet to a macro in the schema builder like this:

```php
use Illuminate\Database\Schema\Builder;

Builder::macro('hasForeignKey', function ($table, $key) {
    $foreignKeys = Schema::getForeignKeys($table);

    foreach ($foreignKeys as $foreignKey) {
        if ($foreignKey['name'] == $key) {
            return true;
        }
    }

    return false;
});
```

A few more macros that I can think of for the schema builder:

- `hasForeignKeys($table, array $keys)`
- `hasForeignKeyForColumn(string $column, string $table, string $foreignTable)` (used in my test case)
- `hasIndex(string $name, string $table)`

This is a bit verbose. Long story short, I think it's easy to make the schema builder macroable and I can think of quite a few uses for that.



[1]: https://dev.mysql.com/doc/sakila/en/