### PR TITLE
[10.x] Fix parentOfParameter method

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -583,7 +583,7 @@ class Route
     {
         $key = array_search($parameter, array_keys($this->parameters));
 
-        if ($key === 0) {
+        if ($key === 0 || $key === false) {
             return;
         }
 


### PR DESCRIPTION
Recently I noticed, if I pass a non-existing parameter name to the `parentOfParameter` method, it throws an error with a `Undefined array key -1` message.

--------

Since the passed parameter is not present, its parent should be `null`.