### PR TITLE
Add temporaryDownloadUrl method to FilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -770,6 +770,25 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Get a temporary download URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
+     * @return array
+     *
+     * @throws \RuntimeException
+     */
+    public function temporaryDownloadUrl($path, $expiration, array $options = [])
+    {
+        if (method_exists($this->adapter, 'temporaryDownloadUrl')) {
+            return $this->adapter->temporaryDownloadUrl($path, $expiration, $options);
+        }
+
+        throw new RuntimeException('This driver does not support creating temporary download URLs.');
+    }
+
+    /**
      * Concatenate a path to a URL.
      *
      * @param  string  $url

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -61,6 +61,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static bool providesTemporaryUrls()
  * @method static string temporaryUrl(string $path, \DateTimeInterface $expiration, array $options = [])
  * @method static array temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [])
+ * @method static array temporaryDownloadUrl(string $path, \DateTimeInterface $expiration, array $options = [])
  * @method static \League\Flysystem\FilesystemOperator getDriver()
  * @method static \League\Flysystem\FilesystemAdapter getAdapter()
  * @method static array getConfig()


### PR DESCRIPTION
For an implementation using Azure Blob Storage, we needed a way to create a temporary URL that triggers a download. Temporary URLs and file downloads are supported in Laravel filesystems, but this doesn't work out of the box for Azure Blob Storage.

As you can see in the macro below, a `content_disposition` option is required to generate the download URL. The content disposition is used when generating the shared access signature in the URL.

I found out that there's already a `temporaryUploadUrl` method for S3 drivers, which could also be useful for an Azure Blob Storage adapter. 

Adding a `temporaryDownloadUrl` method seems to make sense to me.

```php
public function temporaryDownloadUrl(): callable
{
    return function (string $path, DateTimeInterface $expiration, ?string $filename = null, array $options = []): string {

        $filename = str_replace('%', '', Str::ascii($filename ?? basename($path)));

        $options = array_merge([
            'content_disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $filename),
        ], $options);

        return $this->temporaryUrl($path, $expiration, $options);
    };
}
```