### PR TITLE
[10.x] add digits to `Number::currency()`

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -103,13 +103,18 @@ class Number
      * @param  int|float  $number
      * @param  string  $in
      * @param  string|null  $locale
+     * @param  int|null  $digits
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null)
+    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null, int $digits = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
+
+        if (! is_null($digits)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $digits);
+        }
 
         return $formatter->formatCurrency($number, $in);
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -123,6 +123,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-$5.00', Number::currency(-5));
         $this->assertSame('$5.00', Number::currency(5.00));
         $this->assertSame('$5.32', Number::currency(5.325));
+
+        $this->assertSame('$5', Number::currency(5.00, digits: 0));
+        $this->assertSame('$6', Number::currency(5.99, digits: 0));
     }
 
     public function testToCurrencyWithDifferentLocale()


### PR DESCRIPTION
This PR adds digits to the `Number::currency()` call to allow for better rounding.
