### PR TITLE
[10.x] Implement getOrFail method to retrieve configuration values

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
+use RuntimeException;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -54,6 +55,23 @@ class Repository implements ArrayAccess, ConfigContract
         }
 
         return Arr::get($this->items, $key, $default);
+    }
+
+    /**
+     * Get the specified configuration value or throw an exception if the key does not exist.
+     *
+     * @param  array|string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public function getOrFail($key)
+    {
+        if (! $this->has($key)) {
+            throw new RuntimeException("Expected configuration key [$key] does not exist.");
+        }
+
+        return $this->get($key);
     }
 
     /**

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class RepositoryTest extends TestCase
 {
@@ -142,6 +143,18 @@ class RepositoryTest extends TestCase
     public function testGetWithDefault()
     {
         $this->assertSame('default', $this->repository->get('not-exist', 'default'));
+    }
+
+    public function testGetOrFailReturnsExpectedValue(): void
+    {
+        $this->assertSame('bar', $this->repository->getOrFail('foo'));
+    }
+
+    public function testGetOrFailThrowsExceptionForInvalidKey(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('Expected configuration key [not-exist] does not exist.'));
+
+        $this->repository->getOrFail('not-exist');
     }
 
     public function testSet()


### PR DESCRIPTION
The `getOrFail` method acts as a wrapper around `config()->get()` and `config()->has()`. This simplifies the process of retrieving configurations, and if the key does not exist, a RuntimeException will be thrown.

```php
$value = config()->getOrFail('not-exist'); // Will throw an exception
```