### PR TITLE
[11.x] Improves `Application::configure` method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Closure;
+use Composer\Autoload\ClassLoader;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
@@ -226,14 +227,26 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $baseDirectory = match (true) {
             is_string($baseDirectory) => $baseDirectory,
-            isset($_ENV['APP_BASE_PATH']) => $_ENV['APP_BASE_PATH'],
-            default => dirname(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file'], 2),
+            default => static::inferBaseDirectory(),
         };
 
         return (new Configuration\ApplicationBuilder(new static($baseDirectory)))
             ->withKernels()
             ->withEvents()
             ->withCommands();
+    }
+
+    /**
+     * Infer the application's base directory from the environment.
+     *
+     * @return string
+     */
+    public static function inferBaseDirectory()
+    {
+        return match (true) {
+            isset($_ENV['APP_BASE_PATH']) => $_ENV['APP_BASE_PATH'],
+            default => dirname(array_keys(ClassLoader::getRegisteredLoaders())[0]),
+        };
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -224,9 +224,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public static function configure(string $baseDirectory = null)
     {
-        $baseDirectory = $ENV['APP_BASE_PATH'] ?? ($baseDirectory ?: dirname(dirname(
-            debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file']
-        )));
+        $baseDirectory = match (true) {
+            is_string($baseDirectory) => $baseDirectory,
+            isset($_ENV['APP_BASE_PATH']) => $_ENV['APP_BASE_PATH'],
+            default => dirname(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file'], 2),
+        };
 
         return (new Configuration\ApplicationBuilder(new static($baseDirectory)))
             ->withKernels()

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class FoundationApplicationBuilderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        unset($_ENV['APP_BASE_PATH']);
+
+        parent::tearDown();
+    }
+
+    public function testBaseDirectoryWithArg()
+    {
+        $_ENV['APP_BASE_PATH'] = __DIR__.'/as-env';
+
+        $app = Application::configure(__DIR__.'/as-arg')->create();
+
+        $this->assertSame(__DIR__.'/as-arg', $app->basePath());
+    }
+
+    public function testBaseDirectoryWithEnv()
+    {
+        $_ENV['APP_BASE_PATH'] = __DIR__.'/as-env';
+
+        $app = Application::configure()->create();
+
+        $this->assertSame(__DIR__.'/as-env', $app->basePath());
+    }
+
+    public function testBaseDirectoryWithDebugBacktrace()
+    {
+        $app = Application::configure()->create();
+
+        $this->assertSame(dirname(__DIR__), $app->basePath());
+    }
+}

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -35,10 +35,10 @@ class FoundationApplicationBuilderTest extends TestCase
         $this->assertSame(__DIR__.'/as-env', $app->basePath());
     }
 
-    public function testBaseDirectoryWithDebugBacktrace()
+    public function testBaseDirectoryWithComposer()
     {
         $app = Application::configure()->create();
 
-        $this->assertSame(dirname(__DIR__), $app->basePath());
+        $this->assertSame(dirname(__DIR__, 2), $app->basePath());
     }
 }


### PR DESCRIPTION
This pull request improves the `Application::configure` method by doing a couple of things:

- First, it uses `$_ENV` instead of `$ENV`, as `$ENV` does not exist. This is likely a bug.
- Second, it establishes the following priority for determining the baseDirectory:
   1. Argument, if provided.
   2. Environment variable, if available.
   3. Debug BackTrace.]
- Finally, adds tests.