### PR TITLE
[11.x] Infers base path from composer instead

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -20,7 +20,6 @@ use Illuminate\Log\LogServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Composer;
 use Illuminate\Support\Env;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -35,10 +35,10 @@ class FoundationApplicationBuilderTest extends TestCase
         $this->assertSame(__DIR__.'/as-env', $app->basePath());
     }
 
-    public function testBaseDirectoryWithDebugBacktrace()
+    public function testBaseDirectoryWithComposer()
     {
         $app = Application::configure()->create();
 
-        $this->assertSame(dirname(__DIR__), $app->basePath());
+        $this->assertSame(dirname(__DIR__, 2), $app->basePath());
     }
 }


### PR DESCRIPTION
Depends on https://github.com/laravel/framework/pull/49552, and it infers the base path from Composer's runtime information instead of `debug_stacktrace`.