### PR TITLE
[11.x] Allows deleting `CreatesApplication` trait

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -224,9 +224,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public static function configure(string $baseDirectory = null)
     {
-        $baseDirectory = $ENV['APP_BASE_PATH'] ?? ($baseDirectory ?: dirname(dirname(
-            debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file']
-        )));
+        $baseDirectory = match (true) {
+            is_string($baseDirectory) => $baseDirectory,
+            isset($_ENV['APP_BASE_PATH']) => $_ENV['APP_BASE_PATH'],
+            default => dirname(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0]['file'], 2),
+        };
 
         return (new Configuration\ApplicationBuilder(new static($baseDirectory)))
             ->withKernels()

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -20,7 +20,6 @@ use Illuminate\Log\LogServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Composer;
 use Illuminate\Support\Env;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
@@ -71,11 +72,12 @@ abstract class TestCase extends BaseTestCase
     /**
      * Creates the application.
      *
-     * Needs to be implemented by subclasses.
-     *
-     * @return \Symfony\Component\HttpKernel\HttpKernelInterface
+     * @return \Illuminate\Foundation\Application
      */
-    abstract public function createApplication();
+    public function createApplication()
+    {
+        return require Application::inferBaseDirectory() . '/bootstrap/app.php';
+    }
 
     /**
      * Setup the test environment.

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
@@ -76,7 +77,11 @@ abstract class TestCase extends BaseTestCase
      */
     public function createApplication()
     {
-        return require Application::inferBaseDirectory() . '/bootstrap/app.php';
+        $app = require Application::inferBaseDirectory() . '/bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -77,7 +77,7 @@ abstract class TestCase extends BaseTestCase
      */
     public function createApplication()
     {
-        $app = require Application::inferBaseDirectory() . '/bootstrap/app.php';
+        $app = require Application::inferBaseDirectory().'/bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
 

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Testing\Concerns;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Testing\ParallelConsoleOutput;
 use RuntimeException;
@@ -176,8 +177,7 @@ trait RunsInParallel
                 };
 
                 return $applicationCreator->createApplication();
-            } elseif (file_exists($path = getcwd().'/bootstrap/app.php') ||
-                      file_exists($path = getcwd().'/.laravel/app.php')) {
+            } elseif (file_exists($path = (Application::inferBaseDirectory() . '/bootstrap/app.php'))) {
                 $app = require $path;
 
                 $app->make(Kernel::class)->bootstrap();

--- a/src/Illuminate/Testing/Concerns/RunsInParallel.php
+++ b/src/Illuminate/Testing/Concerns/RunsInParallel.php
@@ -177,7 +177,7 @@ trait RunsInParallel
                 };
 
                 return $applicationCreator->createApplication();
-            } elseif (file_exists($path = (Application::inferBaseDirectory() . '/bootstrap/app.php'))) {
+            } elseif (file_exists($path = (Application::inferBaseDirectory().'/bootstrap/app.php'))) {
                 $app = require $path;
 
                 $app->make(Kernel::class)->bootstrap();

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class FoundationApplicationBuilderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        unset($_ENV['APP_BASE_PATH']);
+
+        parent::tearDown();
+    }
+
+    public function testBaseDirectoryWithArg()
+    {
+        $_ENV['APP_BASE_PATH'] = __DIR__.'/as-env';
+
+        $app = Application::configure(__DIR__.'/as-arg')->create();
+
+        $this->assertSame(__DIR__.'/as-arg', $app->basePath());
+    }
+
+    public function testBaseDirectoryWithEnv()
+    {
+        $_ENV['APP_BASE_PATH'] = __DIR__.'/as-env';
+
+        $app = Application::configure()->create();
+
+        $this->assertSame(__DIR__.'/as-env', $app->basePath());
+    }
+
+    public function testBaseDirectoryWithDebugBacktrace()
+    {
+        $app = Application::configure()->create();
+
+        $this->assertSame(dirname(__DIR__), $app->basePath());
+    }
+}

--- a/tests/Foundation/FoundationApplicationBuilderTest.php
+++ b/tests/Foundation/FoundationApplicationBuilderTest.php
@@ -35,10 +35,10 @@ class FoundationApplicationBuilderTest extends TestCase
         $this->assertSame(__DIR__.'/as-env', $app->basePath());
     }
 
-    public function testBaseDirectoryWithDebugBacktrace()
+    public function testBaseDirectoryWithComposer()
     {
         $app = Application::configure()->create();
 
-        $this->assertSame(dirname(__DIR__), $app->basePath());
+        $this->assertSame(dirname(__DIR__, 2), $app->basePath());
     }
 }


### PR DESCRIPTION
This pull request depends on https://github.com/laravel/framework/pull/49553, and it allows the removal of the `CreatesApplication` trait from Laravel's application skeleton.

If this pull request gets merged, the following packages's stubs need to be adjusted, their respective (develop|master) L11 branches:

- dusk
- browser-testing-kit
- etc.

