### PR TITLE
[10.x] Remove unused code from `PhpRedisConnector`

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -63,9 +63,7 @@ class PhpRedisConnector implements Connector
      */
     protected function buildClusterConnectionString(array $server)
     {
-        return $this->formatHost($server).':'.$server['port'].'?'.Arr::query(Arr::only($server, [
-            'database', 'password', 'prefix', 'read_timeout',
-        ]));
+        return $this->formatHost($server).':'.$server['port'];
     }
 
     /**


### PR DESCRIPTION
PhpRedis doesn't parse the cluster query string, never has. This must have been a relic from the Predis migration when copying code.

You can give `RedisCluster` a string like `127.0.0.1:7000?prefix=1` but in C it will be stripped because `atoi()` is used.