### PR TITLE
[10.x] Remove invalid `RedisCluster::client()` call

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -199,10 +199,6 @@ class PhpRedisConnector implements Connector
                 $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $options['failover']);
             }
 
-            if (! empty($options['name'])) {
-                $client->client('SETNAME', $options['name']);
-            }
-
             if (array_key_exists('serializer', $options)) {
                 $client->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
             }


### PR DESCRIPTION
Remove `RedisCluster::client()` call that never worked. Setting `redis.options.name` triggers:

```
RedisCluster::client(): Invalid CLIENT subcommand
```

Because the `RedisCluster` class has a [different signature](https://github.com/phpredis/phpredis/blob/develop/redis_cluster.stub.php#L200-L203) for the `client()` method, requiring it to be called for each master.

I think removing it is better, than adding the `foreach ($this->client->_masters())` on every single connect.