### PR TITLE
[10.x] Use locks for queue job popping for PlanetScale's MySQL-compatible Vitess 19 engine

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -268,7 +268,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
 
         if (($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=')) ||
             ($databaseEngine === 'mariadb' && version_compare($databaseVersion, '10.6.0', '>=')) ||
-            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))) {
+            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) ||
+            ($databaseEngine === 'vitess' && version_compare($databaseVersion, '19.0', '>='))) {
             return 'FOR UPDATE SKIP LOCKED';
         }
 


### PR DESCRIPTION
https://github.com/vitessio/vitess/pull/13965