### PR TITLE
[10.x] Add `make` method for NotificationSender instantiation

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -34,8 +34,11 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function send($notifiables, $notification)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
+        NotificationSender::make(
+            $this,
+            $this->container->make(Bus::class),
+            $this->container->make(Dispatcher::class),
+            $this->locale
         )->send($notifiables, $notification);
     }
 
@@ -49,8 +52,11 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function sendNow($notifiables, $notification, array $channels = null)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
+        NotificationSender::make(
+            $this,
+            $this->container->make(Bus::class),
+            $this->container->make(Dispatcher::class),
+            $this->locale
         )->sendNow($notifiables, $notification, $channels);
     }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -62,6 +62,17 @@ class NotificationSender
     }
 
     /**
+     * Create a new NotificationSender instance.
+     *
+     * @param  mixed  ...$parameters
+     * @return static
+     */
+    public static function make(...$parameters)
+    {
+        return new static(...$parameters);
+    }
+
+    /**
      * Send the given notification to the given notifiable entities.
      *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables


### PR DESCRIPTION
This refactor adds a `make` method for creating `NotificationSender` instances and substitutes parenthesis for direct instantiation.