### PR TITLE
[10.x] Add prependReportable and prependRenderable methods to Handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -171,6 +171,23 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
+     * Register a reportable callback to the beginning of the stack.
+     *
+     * @param callable $reportUsing
+     * @return \Illuminate\Foundation\Exceptions\ReportableHandler
+     */
+    public function prependReportable(callable $reportUsing)
+    {
+        if (! $reportUsing instanceof Closure) {
+            $reportUsing = Closure::fromCallable($reportUsing);
+        }
+
+        return tap(new ReportableHandler($reportUsing), function ($callback) {
+            array_unshift($this->reportCallbacks, $callback);
+        });
+    }
+
+    /**
      * Register a reportable callback.
      *
      * @param  callable  $reportUsing
@@ -185,6 +202,23 @@ class Handler implements ExceptionHandlerContract
         return tap(new ReportableHandler($reportUsing), function ($callback) {
             $this->reportCallbacks[] = $callback;
         });
+    }
+
+     /**
+     * Register a renderable callback to the beginning of the stack.
+     *
+     * @param  callable  $renderUsing
+     * @return $this
+     */
+    public function prependRenderable(callable $renderUsing)
+    {
+        if (! $renderUsing instanceof Closure) {
+            $renderUsing = Closure::fromCallable($renderUsing);
+        }
+
+        array_unshift($this->renderCallbacks, $renderUsing);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -173,7 +173,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a reportable callback to the beginning of the stack.
      *
-     * @param callable $reportUsing
+     * @param  callable  $reportUsing
      * @return \Illuminate\Foundation\Exceptions\ReportableHandler
      */
     public function prependReportable(callable $reportUsing)
@@ -204,7 +204,7 @@ class Handler implements ExceptionHandlerContract
         });
     }
 
-     /**
+    /**
      * Register a renderable callback to the beginning of the stack.
      *
      * @param  callable  $renderUsing


### PR DESCRIPTION
The `prependReportable` method allows us to add reportable exceptions to the beginning of the reportable exceptions list. This can be useful when we want certain exceptions to be reported before others.

The `prependRenderable` method allows us to add renderable exceptions to the beginning of the renderable exceptions list. This can be useful when we want certain exceptions to be rendered before others.

These methods enhance the flexibility of exception handling in our application, allowing us to prioritize how exceptions are reported and rendered. For example, in the service provider, when we want to make sure that it is given the highest priority:
```php
$this->app->make(ExceptionHandler::class)->prependRenderable(function (\Exception $e) {
});
```