### PR TITLE
 [11.x] Allow configuring session.partitioned via env

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -210,6 +210,6 @@ return [
     |
     */
 
-    'partitioned' => (bool) env('SESSION_PARTITIONED_COOKIE', false),
+    'partitioned' => env('SESSION_PARTITIONED_COOKIE', false),
 
 ];

--- a/config/session.php
+++ b/config/session.php
@@ -210,6 +210,6 @@ return [
     |
     */
 
-    'partitioned' => false,
+    'partitioned' => (bool) env('SESSION_PARTITIONED_COOKIE', false),
 
 ];


### PR DESCRIPTION
The PR add the config via `SESSION_PARTITIONED_COOKIE` env name.