### PR TITLE
[10.x] Add APA style title helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -120,7 +120,6 @@ class Str
      */
     public static function apa($value)
     {
-        // Define minor words to be lowercase
         $minorWords = ['and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an', 'the', 'at', 'by', 'for', 'in', 'of', 'off', 'on', 'per', 'to', 'up', 'via'];
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1286,7 +1286,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function apaTitle($value)
+    public static function apa($value)
     {
         $minorWords = [
             'and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an',

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -68,7 +68,7 @@ class Str
     /**
      * Get a new stringable object from the given string.
      *
-     * @param  string  $string
+     * @param string $string
      * @return \Illuminate\Support\Stringable
      */
     public static function of($string)
@@ -79,8 +79,8 @@ class Str
     /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function after($subject, $search)
@@ -91,8 +91,8 @@ class Str
     /**
      * Return the remainder of a string after the last occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function afterLast($subject, $search)
@@ -101,7 +101,7 @@ class Str
             return $subject;
         }
 
-        $position = strrpos($subject, (string) $search);
+        $position = strrpos($subject, (string)$search);
 
         if ($position === false) {
             return $subject;
@@ -111,23 +111,73 @@ class Str
     }
 
     /**
+     * Convert the given string to APA-style case.
+     * Based on the rules provided by the APA:
+     * https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function apa($value)
+    {
+        // Define minor words to be lowercase
+        $minorWords = ['and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an', 'the', 'at', 'by', 'for', 'in', 'of', 'off', 'on', 'per', 'to', 'up', 'via'];
+        $endPunctuation = ['.', '!', '?', ':', '—', ','];
+
+        // Split the string into words
+        $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+
+        // Capitalize the first word
+        $words[0] = ucfirst(mb_strtolower($words[0]));
+
+        // Capitalize major words and handle lowercase minor words
+        for ($i = 0; $i < count($words); $i++) {
+            // Check if the word is a major word or a minor word
+            $lowercaseWord = mb_strtolower($words[$i]);
+
+            // Handle hyphenated major words
+            if (str_contains($lowercaseWord, '-')) {
+                $hyphenatedWords = explode('-', $lowercaseWord);
+                $hyphenatedWords = array_map(function ($part) use ($minorWords) {
+                    return (in_array($part, $minorWords) && mb_strlen($part) <= 3) ? $part : ucfirst($part);
+                }, $hyphenatedWords);
+                $words[$i] = implode('-', $hyphenatedWords);
+            } else {
+                // Handle lowercase minor words
+                if (
+                    in_array($lowercaseWord, $minorWords) &&
+                    mb_strlen($lowercaseWord) <= 3 &&
+                    !($i === 0 || in_array(mb_substr($words[$i - 1], -1), $endPunctuation))
+                ) {
+                    $words[$i] = $lowercaseWord;
+                } else {
+                    $words[$i] = ucfirst($lowercaseWord);
+                }
+            }
+        }
+
+        // Join the words back into a string
+        return implode(' ', $words);
+    }
+
+    /**
      * Transliterate a UTF-8 value to ASCII.
      *
-     * @param  string  $value
-     * @param  string  $language
+     * @param string $value
+     * @param string $language
      * @return string
      */
     public static function ascii($value, $language = 'en')
     {
-        return ASCII::to_ascii((string) $value, $language);
+        return ASCII::to_ascii((string)$value, $language);
     }
 
     /**
      * Transliterate a string to its closest ASCII representation.
      *
-     * @param  string  $string
-     * @param  string|null  $unknown
-     * @param  bool|null  $strict
+     * @param string $string
+     * @param string|null $unknown
+     * @param bool|null $strict
      * @return string
      */
     public static function transliterate($string, $unknown = '?', $strict = false)
@@ -138,8 +188,8 @@ class Str
     /**
      * Get the portion of a string before the first occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function before($subject, $search)
@@ -148,7 +198,7 @@ class Str
             return $subject;
         }
 
-        $result = strstr($subject, (string) $search, true);
+        $result = strstr($subject, (string)$search, true);
 
         return $result === false ? $subject : $result;
     }
@@ -156,8 +206,8 @@ class Str
     /**
      * Get the portion of a string before the last occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function beforeLast($subject, $search)
@@ -178,9 +228,9 @@ class Str
     /**
      * Get the portion of a string between two given values.
      *
-     * @param  string  $subject
-     * @param  string  $from
-     * @param  string  $to
+     * @param string $subject
+     * @param string $from
+     * @param string $to
      * @return string
      */
     public static function between($subject, $from, $to)
@@ -195,9 +245,9 @@ class Str
     /**
      * Get the smallest possible portion of a string between two given values.
      *
-     * @param  string  $subject
-     * @param  string  $from
-     * @param  string  $to
+     * @param string $subject
+     * @param string $from
+     * @param string $to
      * @return string
      */
     public static function betweenFirst($subject, $from, $to)
@@ -212,7 +262,7 @@ class Str
     /**
      * Convert a value to camel case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function camel($value)
@@ -227,8 +277,8 @@ class Str
     /**
      * Get the character at the specified index.
      *
-     * @param  string  $subject
-     * @param  int  $index
+     * @param string $subject
+     * @param int $index
      * @return string|false
      */
     public static function charAt($subject, $index)
@@ -245,9 +295,9 @@ class Str
     /**
      * Determine if a given string contains a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|iterable<string>  $needles
-     * @param  bool  $ignoreCase
+     * @param string $haystack
+     * @param string|iterable<string> $needles
+     * @param bool $ignoreCase
      * @return bool
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
@@ -256,8 +306,8 @@ class Str
             $haystack = mb_strtolower($haystack);
         }
 
-        if (! is_iterable($needles)) {
-            $needles = (array) $needles;
+        if (!is_iterable($needles)) {
+            $needles = (array)$needles;
         }
 
         foreach ($needles as $needle) {
@@ -276,15 +326,15 @@ class Str
     /**
      * Determine if a given string contains all array values.
      *
-     * @param  string  $haystack
-     * @param  iterable<string>  $needles
-     * @param  bool  $ignoreCase
+     * @param string $haystack
+     * @param iterable<string> $needles
+     * @param bool $ignoreCase
      * @return bool
      */
     public static function containsAll($haystack, $needles, $ignoreCase = false)
     {
         foreach ($needles as $needle) {
-            if (! static::contains($haystack, $needle, $ignoreCase)) {
+            if (!static::contains($haystack, $needle, $ignoreCase)) {
                 return false;
             }
         }
@@ -295,9 +345,9 @@ class Str
     /**
      * Convert the case of a string.
      *
-     * @param  string  $string
-     * @param  int  $mode
-     * @param  string|null  $encoding
+     * @param string $string
+     * @param int $mode
+     * @param string|null $encoding
      * @return string
      */
     public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
@@ -308,18 +358,18 @@ class Str
     /**
      * Determine if a given string ends with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|iterable<string>  $needles
+     * @param string $haystack
+     * @param string|iterable<string> $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
     {
-        if (! is_iterable($needles)) {
-            $needles = (array) $needles;
+        if (!is_iterable($needles)) {
+            $needles = (array)$needles;
         }
 
         foreach ($needles as $needle) {
-            if ((string) $needle !== '' && str_ends_with($haystack, $needle)) {
+            if ((string)$needle !== '' && str_ends_with($haystack, $needle)) {
                 return true;
             }
         }
@@ -330,9 +380,9 @@ class Str
     /**
      * Extracts an excerpt from text that matches the first instance of a phrase.
      *
-     * @param  string  $text
-     * @param  string  $phrase
-     * @param  array  $options
+     * @param string $text
+     * @param string $phrase
+     * @param array $options
      * @return string|null
      */
     public static function excerpt($text, $phrase = '', $options = [])
@@ -340,7 +390,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/iu', (string) $text, $matches);
+        preg_match('/^(.*?)(' . preg_quote((string)$phrase, '/') . ')(.*)$/iu', (string)$text, $matches);
 
         if (empty($matches)) {
             return null;
@@ -349,15 +399,15 @@ class Str
         $start = ltrim($matches[1]);
 
         $start = str(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
-            fn ($startWithRadius) => $startWithRadius->exactly($start),
-            fn ($startWithRadius) => $startWithRadius->prepend($omission),
+            fn($startWithRadius) => $startWithRadius->exactly($start),
+            fn($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
         $end = str(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
-            fn ($endWithRadius) => $endWithRadius->exactly($end),
-            fn ($endWithRadius) => $endWithRadius->append($omission),
+            fn($endWithRadius) => $endWithRadius->exactly($end),
+            fn($endWithRadius) => $endWithRadius->append($omission),
         );
 
         return $start->append($matches[2], $end)->toString();
@@ -366,47 +416,47 @@ class Str
     /**
      * Cap a string with a single instance of a given value.
      *
-     * @param  string  $value
-     * @param  string  $cap
+     * @param string $value
+     * @param string $cap
      * @return string
      */
     public static function finish($value, $cap)
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
     }
 
     /**
      * Wrap the string with the given strings.
      *
-     * @param  string  $value
-     * @param  string  $before
-     * @param  string|null  $after
+     * @param string $value
+     * @param string $before
+     * @param string|null $after
      * @return string
      */
     public static function wrap($value, $before, $after = null)
     {
-        return $before.$value.($after ??= $before);
+        return $before . $value . ($after ??= $before);
     }
 
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|iterable<string>  $pattern
-     * @param  string  $value
+     * @param string|iterable<string> $pattern
+     * @param string $value
      * @return bool
      */
     public static function is($pattern, $value)
     {
-        $value = (string) $value;
+        $value = (string)$value;
 
-        if (! is_iterable($pattern)) {
+        if (!is_iterable($pattern)) {
             $pattern = [$pattern];
         }
 
         foreach ($pattern as $pattern) {
-            $pattern = (string) $pattern;
+            $pattern = (string)$pattern;
 
             // If the given value is an exact match we can of course return true right
             // from the beginning. Otherwise, we will translate asterisks and do an
@@ -422,7 +472,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
+            if (preg_match('#^' . $pattern . '\z#u', $value) === 1) {
                 return true;
             }
         }
@@ -433,23 +483,23 @@ class Str
     /**
      * Determine if a given string is 7 bit ASCII.
      *
-     * @param  string  $value
+     * @param string $value
      * @return bool
      */
     public static function isAscii($value)
     {
-        return ASCII::is_ascii((string) $value);
+        return ASCII::is_ascii((string)$value);
     }
 
     /**
      * Determine if a given value is valid JSON.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      * @return bool
      */
     public static function isJson($value)
     {
-        if (! is_string($value)) {
+        if (!is_string($value)) {
             return false;
         }
 
@@ -469,13 +519,13 @@ class Str
     /**
      * Determine if a given value is a valid URL.
      *
-     * @param  mixed  $value
-     * @param  array  $protocols
+     * @param mixed $value
+     * @param array $protocols
      * @return bool
      */
     public static function isUrl($value, array $protocols = [])
     {
-        if (! is_string($value)) {
+        if (!is_string($value)) {
             return false;
         }
 
@@ -512,12 +562,12 @@ class Str
     /**
      * Determine if a given value is a valid UUID.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      * @return bool
      */
     public static function isUuid($value)
     {
-        if (! is_string($value)) {
+        if (!is_string($value)) {
             return false;
         }
 
@@ -527,12 +577,12 @@ class Str
     /**
      * Determine if a given value is a valid ULID.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      * @return bool
      */
     public static function isUlid($value)
     {
-        if (! is_string($value)) {
+        if (!is_string($value)) {
             return false;
         }
 
@@ -542,7 +592,7 @@ class Str
     /**
      * Convert a string to kebab case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function kebab($value)
@@ -553,8 +603,8 @@ class Str
     /**
      * Return the length of the given string.
      *
-     * @param  string  $value
-     * @param  string|null  $encoding
+     * @param string $value
+     * @param string|null $encoding
      * @return int
      */
     public static function length($value, $encoding = null)
@@ -565,9 +615,9 @@ class Str
     /**
      * Limit the number of characters in a string.
      *
-     * @param  string  $value
-     * @param  int  $limit
-     * @param  string  $end
+     * @param string $value
+     * @param int $limit
+     * @param string $end
      * @return string
      */
     public static function limit($value, $limit = 100, $end = '...')
@@ -576,13 +626,13 @@ class Str
             return $value;
         }
 
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
     }
 
     /**
      * Convert the given string to lower-case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function lower($value)
@@ -593,41 +643,41 @@ class Str
     /**
      * Limit the number of words in a string.
      *
-     * @param  string  $value
-     * @param  int  $words
-     * @param  string  $end
+     * @param string $value
+     * @param int $words
+     * @param string $end
      * @return string
      */
     public static function words($value, $words = 100, $end = '...')
     {
-        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
+        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
 
-        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
+        if (!isset($matches[0]) || static::length($value) === static::length($matches[0])) {
             return $value;
         }
 
-        return rtrim($matches[0]).$end;
+        return rtrim($matches[0]) . $end;
     }
 
     /**
      * Converts GitHub flavored Markdown into HTML.
      *
-     * @param  string  $string
-     * @param  array  $options
+     * @param string $string
+     * @param array $options
      * @return string
      */
     public static function markdown($string, array $options = [])
     {
         $converter = new GithubFlavoredMarkdownConverter($options);
 
-        return (string) $converter->convert($string);
+        return (string)$converter->convert($string);
     }
 
     /**
      * Converts inline Markdown into HTML.
      *
-     * @param  string  $string
-     * @param  array  $options
+     * @param string $string
+     * @param array $options
      * @return string
      */
     public static function inlineMarkdown($string, array $options = [])
@@ -639,17 +689,17 @@ class Str
 
         $converter = new MarkdownConverter($environment);
 
-        return (string) $converter->convert($string);
+        return (string)$converter->convert($string);
     }
 
     /**
      * Masks a portion of a string with a repeated character.
      *
-     * @param  string  $string
-     * @param  string  $character
-     * @param  int  $index
-     * @param  int|null  $length
-     * @param  string  $encoding
+     * @param string $string
+     * @param string $character
+     * @param int $index
+     * @param int|null $length
+     * @param string $encoding
      * @return string
      */
     public static function mask($string, $character, $index, $length = null, $encoding = 'UTF-8')
@@ -675,21 +725,21 @@ class Str
         $segmentLen = mb_strlen($segment, $encoding);
         $end = mb_substr($string, $startIndex + $segmentLen);
 
-        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen).$end;
+        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen) . $end;
     }
 
     /**
      * Get the string matching the given pattern.
      *
-     * @param  string  $pattern
-     * @param  string  $subject
+     * @param string $pattern
+     * @param string $subject
      * @return string
      */
     public static function match($pattern, $subject)
     {
         preg_match($pattern, $subject, $matches);
 
-        if (! $matches) {
+        if (!$matches) {
             return '';
         }
 
@@ -699,20 +749,20 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|iterable<string>  $pattern
-     * @param  string  $value
+     * @param string|iterable<string> $pattern
+     * @param string $value
      * @return bool
      */
     public static function isMatch($pattern, $value)
     {
-        $value = (string) $value;
+        $value = (string)$value;
 
-        if (! is_iterable($pattern)) {
+        if (!is_iterable($pattern)) {
             $pattern = [$pattern];
         }
 
         foreach ($pattern as $pattern) {
-            $pattern = (string) $pattern;
+            $pattern = (string)$pattern;
 
             if (preg_match($pattern, $value) === 1) {
                 return true;
@@ -725,8 +775,8 @@ class Str
     /**
      * Get the string matching the given pattern.
      *
-     * @param  string  $pattern
-     * @param  string  $subject
+     * @param string $pattern
+     * @param string $subject
      * @return \Illuminate\Support\Collection
      */
     public static function matchAll($pattern, $subject)
@@ -743,9 +793,9 @@ class Str
     /**
      * Pad both sides of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
      * @return string
      */
     public static function padBoth($value, $length, $pad = ' ')
@@ -758,17 +808,17 @@ class Str
         $shortLeft = floor($short / 2);
         $shortRight = ceil($short / 2);
 
-        return mb_substr(str_repeat($pad, $shortLeft), 0, $shortLeft).
-               $value.
-               mb_substr(str_repeat($pad, $shortRight), 0, $shortRight);
+        return mb_substr(str_repeat($pad, $shortLeft), 0, $shortLeft) .
+            $value .
+            mb_substr(str_repeat($pad, $shortRight), 0, $shortRight);
     }
 
     /**
      * Pad the left side of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
      * @return string
      */
     public static function padLeft($value, $length, $pad = ' ')
@@ -779,15 +829,15 @@ class Str
 
         $short = max(0, $length - mb_strlen($value));
 
-        return mb_substr(str_repeat($pad, $short), 0, $short).$value;
+        return mb_substr(str_repeat($pad, $short), 0, $short) . $value;
     }
 
     /**
      * Pad the right side of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
      * @return string
      */
     public static function padRight($value, $length, $pad = ' ')
@@ -798,14 +848,14 @@ class Str
 
         $short = max(0, $length - mb_strlen($value));
 
-        return $value.mb_substr(str_repeat($pad, $short), 0, $short);
+        return $value . mb_substr(str_repeat($pad, $short), 0, $short);
     }
 
     /**
      * Parse a Class[@]method style callback into class and method.
      *
-     * @param  string  $callback
-     * @param  string|null  $default
+     * @param string $callback
+     * @param string|null $default
      * @return array<int, string|null>
      */
     public static function parseCallback($callback, $default = null)
@@ -827,8 +877,8 @@ class Str
     /**
      * Get the plural form of an English word.
      *
-     * @param  string  $value
-     * @param  int|array|\Countable  $count
+     * @param string $value
+     * @param int|array|\Countable $count
      * @return string
      */
     public static function plural($value, $count = 2)
@@ -839,8 +889,8 @@ class Str
     /**
      * Pluralize the last word of an English, studly caps case string.
      *
-     * @param  string  $value
-     * @param  int|array|\Countable  $count
+     * @param string $value
+     * @param int|array|\Countable $count
      * @return string
      */
     public static function pluralStudly($value, $count = 2)
@@ -849,17 +899,17 @@ class Str
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts).self::plural($lastWord, $count);
+        return implode('', $parts) . self::plural($lastWord, $count);
     }
 
     /**
      * Generate a random, secure password.
      *
-     * @param  int  $length
-     * @param  bool  $letters
-     * @param  bool  $numbers
-     * @param  bool  $symbols
-     * @param  bool  $spaces
+     * @param int $length
+     * @param bool $letters
+     * @param bool $numbers
+     * @param bool $symbols
+     * @param bool $spaces
      * @return string
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
@@ -883,34 +933,34 @@ class Str
                 ']', '|', ':', ';',
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
-        ]))->filter()->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
+        ]))->filter()->each(fn($c) => $password->push($c[random_int(0, count($c) - 1)])
         )->flatten();
 
         $length = $length - $password->count();
 
         return $password->merge($options->pipe(
-            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
+            fn($c) => Collection::times($length, fn() => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }
 
     /**
      * Find the multi-byte safe position of the first occurrence of a given substring in a string.
      *
-     * @param  string  $haystack
-     * @param  string  $needle
-     * @param  int  $offset
-     * @param  string|null  $encoding
+     * @param string $haystack
+     * @param string $needle
+     * @param int $offset
+     * @param string|null $encoding
      * @return int|false
      */
     public static function position($haystack, $needle, $offset = 0, $encoding = null)
     {
-        return mb_strpos($haystack, (string) $needle, $offset, $encoding);
+        return mb_strpos($haystack, (string)$needle, $offset, $encoding);
     }
 
     /**
      * Generate a more truly "random" alpha-numeric string.
      *
-     * @param  int  $length
+     * @param int $length
      * @return string
      */
     public static function random($length = 16)
@@ -921,7 +971,7 @@ class Str
             while (($len = strlen($string)) < $length) {
                 $size = $length - $len;
 
-                $bytesSize = (int) ceil($size / 3) * 3;
+                $bytesSize = (int)ceil($size / 3) * 3;
 
                 $bytes = random_bytes($bytesSize);
 
@@ -935,7 +985,7 @@ class Str
     /**
      * Set the callable that will be used to generate random strings.
      *
-     * @param  callable|null  $factory
+     * @param callable|null $factory
      * @return void
      */
     public static function createRandomStringsUsing(callable $factory = null)
@@ -946,8 +996,8 @@ class Str
     /**
      * Set the sequence that will be used to generate random strings.
      *
-     * @param  array  $sequence
-     * @param  callable|null  $whenMissing
+     * @param array $sequence
+     * @param callable|null $whenMissing
      * @return void
      */
     public static function createRandomStringsUsingSequence(array $sequence, $whenMissing = null)
@@ -990,8 +1040,8 @@ class Str
     /**
      * Repeat the given string.
      *
-     * @param  string  $string
-     * @param  int  $times
+     * @param string $string
+     * @param int $times
      * @return string
      */
     public static function repeat(string $string, int $times)
@@ -1002,9 +1052,9 @@ class Str
     /**
      * Replace a given value in the string sequentially with an array.
      *
-     * @param  string  $search
-     * @param  iterable<string>  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param iterable<string> $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceArray($search, $replace, $subject)
@@ -1018,7 +1068,7 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= self::toStringOr(array_shift($replace) ?? $search, $search).$segment;
+            $result .= self::toStringOr(array_shift($replace) ?? $search, $search) . $segment;
         }
 
         return $result;
@@ -1027,14 +1077,14 @@ class Str
     /**
      * Convert the given value to a string or return the given fallback on failure.
      *
-     * @param  mixed  $value
-     * @param  string  $fallback
+     * @param mixed $value
+     * @param string $fallback
      * @return string
      */
     private static function toStringOr($value, $fallback)
     {
         try {
-            return (string) $value;
+            return (string)$value;
         } catch (Throwable $e) {
             return $fallback;
         }
@@ -1043,10 +1093,10 @@ class Str
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|iterable<string>  $search
-     * @param  string|iterable<string>  $replace
-     * @param  string|iterable<string>  $subject
-     * @param  bool  $caseSensitive
+     * @param string|iterable<string> $search
+     * @param string|iterable<string> $replace
+     * @param string|iterable<string> $subject
+     * @param bool $caseSensitive
      * @return string|string[]
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
@@ -1064,21 +1114,21 @@ class Str
         }
 
         return $caseSensitive
-                ? str_replace($search, $replace, $subject)
-                : str_ireplace($search, $replace, $subject);
+            ? str_replace($search, $replace, $subject)
+            : str_ireplace($search, $replace, $subject);
     }
 
     /**
      * Replace the first occurrence of a given value in the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceFirst($search, $replace, $subject)
     {
-        $search = (string) $search;
+        $search = (string)$search;
 
         if ($search === '') {
             return $subject;
@@ -1096,14 +1146,14 @@ class Str
     /**
      * Replace the first occurrence of the given value if it appears at the start of the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceStart($search, $replace, $subject)
     {
-        $search = (string) $search;
+        $search = (string)$search;
 
         if ($search === '') {
             return $subject;
@@ -1119,14 +1169,14 @@ class Str
     /**
      * Replace the last occurrence of a given value in the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceLast($search, $replace, $subject)
     {
-        $search = (string) $search;
+        $search = (string)$search;
 
         if ($search === '') {
             return $subject;
@@ -1144,14 +1194,14 @@ class Str
     /**
      * Replace the last occurrence of a given value if it appears at the end of the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceEnd($search, $replace, $subject)
     {
-        $search = (string) $search;
+        $search = (string)$search;
 
         if ($search === '') {
             return $subject;
@@ -1167,10 +1217,10 @@ class Str
     /**
      * Replace the patterns matching the given regular expression.
      *
-     * @param  string  $pattern
-     * @param  \Closure|string  $replace
-     * @param  array|string  $subject
-     * @param  int  $limit
+     * @param string $pattern
+     * @param \Closure|string $replace
+     * @param array|string $subject
+     * @param int $limit
      * @return string|string[]|null
      */
     public static function replaceMatches($pattern, $replace, $subject, $limit = -1)
@@ -1185,9 +1235,9 @@ class Str
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param  string|iterable<string>  $search
-     * @param  string|iterable<string>  $subject
-     * @param  bool  $caseSensitive
+     * @param string|iterable<string> $search
+     * @param string|iterable<string> $subject
+     * @param bool $caseSensitive
      * @return string
      */
     public static function remove($search, $subject, $caseSensitive = true)
@@ -1197,14 +1247,14 @@ class Str
         }
 
         return $caseSensitive
-                    ? str_replace($search, '', $subject)
-                    : str_ireplace($search, '', $subject);
+            ? str_replace($search, '', $subject)
+            : str_ireplace($search, '', $subject);
     }
 
     /**
      * Reverse the given string.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function reverse(string $value)
@@ -1215,21 +1265,21 @@ class Str
     /**
      * Begin a string with a single instance of a given value.
      *
-     * @param  string  $value
-     * @param  string  $prefix
+     * @param string $value
+     * @param string $prefix
      * @return string
      */
     public static function start($value, $prefix)
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
     }
 
     /**
      * Convert the given string to upper-case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function upper($value)
@@ -1240,7 +1290,7 @@ class Str
     /**
      * Convert the given string to title case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function title($value)
@@ -1251,7 +1301,7 @@ class Str
     /**
      * Convert the given string to title case for each word.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function headline($value)
@@ -1270,7 +1320,7 @@ class Str
     /**
      * Get the singular form of an English word.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function singular($value)
@@ -1281,10 +1331,10 @@ class Str
     /**
      * Generate a URL friendly "slug" from a given string.
      *
-     * @param  string  $title
-     * @param  string  $separator
-     * @param  string|null  $language
-     * @param  array<string, string>  $dictionary
+     * @param string $title
+     * @param string $separator
+     * @param string|null $language
+     * @param array<string, string> $dictionary
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
@@ -1294,20 +1344,20 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
 
         // Replace dictionary words
         foreach ($dictionary as $key => $value) {
-            $dictionary[$key] = $separator.$value.$separator;
+            $dictionary[$key] = $separator . $value . $separator;
         }
 
         $title = str_replace(array_keys($dictionary), array_values($dictionary), $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace
-        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
@@ -1315,8 +1365,8 @@ class Str
     /**
      * Convert a string to snake case.
      *
-     * @param  string  $value
-     * @param  string  $delimiter
+     * @param string $value
+     * @param string $delimiter
      * @return string
      */
     public static function snake($value, $delimiter = '_')
@@ -1327,10 +1377,10 @@ class Str
             return static::$snakeCache[$key][$delimiter];
         }
 
-        if (! ctype_lower($value)) {
+        if (!ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;
@@ -1339,7 +1389,7 @@ class Str
     /**
      * Remove all "extra" blank space from the given string.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function squish($value)
@@ -1350,18 +1400,18 @@ class Str
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|iterable<string>  $needles
+     * @param string $haystack
+     * @param string|iterable<string> $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)
     {
-        if (! is_iterable($needles)) {
+        if (!is_iterable($needles)) {
             $needles = [$needles];
         }
 
         foreach ($needles as $needle) {
-            if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
+            if ((string)$needle !== '' && str_starts_with($haystack, $needle)) {
                 return true;
             }
         }
@@ -1372,7 +1422,7 @@ class Str
     /**
      * Convert a value to studly caps case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function studly($value)
@@ -1385,7 +1435,7 @@ class Str
 
         $words = explode(' ', static::replace(['-', '_'], ' ', $value));
 
-        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
+        $studlyWords = array_map(fn($word) => static::ucfirst($word), $words);
 
         return static::$studlyCache[$key] = implode($studlyWords);
     }
@@ -1393,10 +1443,10 @@ class Str
     /**
      * Returns the portion of the string specified by the start and length parameters.
      *
-     * @param  string  $string
-     * @param  int  $start
-     * @param  int|null  $length
-     * @param  string  $encoding
+     * @param string $string
+     * @param int $start
+     * @param int|null $length
+     * @param string $encoding
      * @return string
      */
     public static function substr($string, $start, $length = null, $encoding = 'UTF-8')
@@ -1407,15 +1457,15 @@ class Str
     /**
      * Returns the number of substring occurrences.
      *
-     * @param  string  $haystack
-     * @param  string  $needle
-     * @param  int  $offset
-     * @param  int|null  $length
+     * @param string $haystack
+     * @param string $needle
+     * @param int $offset
+     * @param int|null $length
      * @return int
      */
     public static function substrCount($haystack, $needle, $offset = 0, $length = null)
     {
-        if (! is_null($length)) {
+        if (!is_null($length)) {
             return substr_count($haystack, $needle, $offset, $length);
         }
 
@@ -1425,10 +1475,10 @@ class Str
     /**
      * Replace text within a portion of a string.
      *
-     * @param  string|string[]  $string
-     * @param  string|string[]  $replace
-     * @param  int|int[]  $offset
-     * @param  int|int[]|null  $length
+     * @param string|string[] $string
+     * @param string|string[] $replace
+     * @param int|int[] $offset
+     * @param int|int[]|null $length
      * @return string|string[]
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
@@ -1443,8 +1493,8 @@ class Str
     /**
      * Swap multiple keywords in a string with other keywords.
      *
-     * @param  array  $map
-     * @param  string  $subject
+     * @param array $map
+     * @param string $subject
      * @return string
      */
     public static function swap(array $map, $subject)
@@ -1455,8 +1505,8 @@ class Str
     /**
      * Take the first or last {$limit} characters of a string.
      *
-     * @param  string  $string
-     * @param  int  $limit
+     * @param string $string
+     * @param int $limit
      * @return string
      */
     public static function take($string, int $limit): string
@@ -1471,29 +1521,29 @@ class Str
     /**
      * Make a string's first character lowercase.
      *
-     * @param  string  $string
+     * @param string $string
      * @return string
      */
     public static function lcfirst($string)
     {
-        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
+        return static::lower(static::substr($string, 0, 1)) . static::substr($string, 1);
     }
 
     /**
      * Make a string's first character uppercase.
      *
-     * @param  string  $string
+     * @param string $string
      * @return string
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
     }
 
     /**
      * Split a string into pieces by uppercase characters.
      *
-     * @param  string  $string
+     * @param string $string
      * @return string[]
      */
     public static function ucsplit($string)
@@ -1504,8 +1554,8 @@ class Str
     /**
      * Get the number of words a string contains.
      *
-     * @param  string  $string
-     * @param  string|null  $characters
+     * @param string $string
+     * @param string|null $characters
      * @return int
      */
     public static function wordCount($string, $characters = null)
@@ -1516,10 +1566,10 @@ class Str
     /**
      * Wrap a string to a given number of characters.
      *
-     * @param  string  $string
-     * @param  int  $characters
-     * @param  string  $break
-     * @param  bool  $cutLongWords
+     * @param string $string
+     * @param int $characters
+     * @param string $break
+     * @param bool $cutLongWords
      * @return string
      */
     public static function wordWrap($string, $characters = 75, $break = "\n", $cutLongWords = false)
@@ -1535,8 +1585,8 @@ class Str
     public static function uuid()
     {
         return static::$uuidFactory
-                    ? call_user_func(static::$uuidFactory)
-                    : Uuid::uuid4();
+            ? call_user_func(static::$uuidFactory)
+            : Uuid::uuid4();
     }
 
     /**
@@ -1567,7 +1617,7 @@ class Str
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param  callable|null  $factory
+     * @param callable|null $factory
      * @return void
      */
     public static function createUuidsUsing(callable $factory = null)
@@ -1578,8 +1628,8 @@ class Str
     /**
      * Set the sequence that will be used to generate UUIDs.
      *
-     * @param  array  $sequence
-     * @param  callable|null  $whenMissing
+     * @param array $sequence
+     * @param callable|null $whenMissing
      * @return void
      */
     public static function createUuidsUsingSequence(array $sequence, $whenMissing = null)
@@ -1612,14 +1662,14 @@ class Str
     /**
      * Always return the same UUID when generating new UUIDs.
      *
-     * @param  \Closure|null  $callback
+     * @param \Closure|null $callback
      * @return \Ramsey\Uuid\UuidInterface
      */
     public static function freezeUuids(Closure $callback = null)
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(fn () => $uuid);
+        Str::createUuidsUsing(fn() => $uuid);
 
         if ($callback !== null) {
             try {
@@ -1645,7 +1695,7 @@ class Str
     /**
      * Generate a ULID.
      *
-     * @param  \DateTimeInterface|null  $time
+     * @param \DateTimeInterface|null $time
      * @return \Symfony\Component\Uid\Ulid
      */
     public static function ulid($time = null)
@@ -1674,7 +1724,7 @@ class Str
     /**
      * Set the callable that will be used to generate ULIDs.
      *
-     * @param  callable|null  $factory
+     * @param callable|null $factory
      * @return void
      */
     public static function createUlidsUsing(callable $factory = null)
@@ -1685,8 +1735,8 @@ class Str
     /**
      * Set the sequence that will be used to generate ULIDs.
      *
-     * @param  array  $sequence
-     * @param  callable|null  $whenMissing
+     * @param array $sequence
+     * @param callable|null $whenMissing
      * @return void
      */
     public static function createUlidsUsingSequence(array $sequence, $whenMissing = null)
@@ -1719,14 +1769,14 @@ class Str
     /**
      * Always return the same ULID when generating new ULIDs.
      *
-     * @param  Closure|null  $callback
+     * @param Closure|null $callback
      * @return Ulid
      */
     public static function freezeUlids(Closure $callback = null)
     {
         $ulid = Str::ulid();
 
-        Str::createUlidsUsing(fn () => $ulid);
+        Str::createUlidsUsing(fn() => $ulid);
 
         if ($callback !== null) {
             try {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1243,20 +1243,9 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function proper($value)
-    {
-        return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
-    }
-
-    /**
-     * Convert the given string to proper case.
-     *
-     * @param  string  $value
-     * @return string
-     */
     public static function title($value)
     {
-        return static::proper($value);
+        return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
     }
 
     /**
@@ -1270,8 +1259,8 @@ class Str
         $parts = explode(' ', $value);
 
         $parts = count($parts) > 1
-            ? array_map([static::class, 'proper'], $parts)
-            : array_map([static::class, 'proper'], static::ucsplit(implode('_', $parts)));
+            ? array_map([static::class, 'title'], $parts)
+            : array_map([static::class, 'title'], static::ucsplit(implode('_', $parts)));
 
         $collapsed = static::replace(['-', '_', ' '], '_', implode('_', $parts));
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -68,7 +68,7 @@ class Str
     /**
      * Get a new stringable object from the given string.
      *
-     * @param string $string
+     * @param  string  $string
      * @return \Illuminate\Support\Stringable
      */
     public static function of($string)
@@ -79,8 +79,8 @@ class Str
     /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function after($subject, $search)
@@ -91,8 +91,8 @@ class Str
     /**
      * Return the remainder of a string after the last occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function afterLast($subject, $search)
@@ -101,7 +101,7 @@ class Str
             return $subject;
         }
 
-        $position = strrpos($subject, (string)$search);
+        $position = strrpos($subject, (string) $search);
 
         if ($position === false) {
             return $subject;
@@ -155,21 +155,21 @@ class Str
     /**
      * Transliterate a UTF-8 value to ASCII.
      *
-     * @param string $value
-     * @param string $language
+     * @param  string  $value
+     * @param  string  $language
      * @return string
      */
     public static function ascii($value, $language = 'en')
     {
-        return ASCII::to_ascii((string)$value, $language);
+        return ASCII::to_ascii((string) $value, $language);
     }
 
     /**
      * Transliterate a string to its closest ASCII representation.
      *
-     * @param string $string
-     * @param string|null $unknown
-     * @param bool|null $strict
+     * @param  string  $string
+     * @param  string|null  $unknown
+     * @param  bool|null  $strict
      * @return string
      */
     public static function transliterate($string, $unknown = '?', $strict = false)
@@ -180,8 +180,8 @@ class Str
     /**
      * Get the portion of a string before the first occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function before($subject, $search)
@@ -190,7 +190,7 @@ class Str
             return $subject;
         }
 
-        $result = strstr($subject, (string)$search, true);
+        $result = strstr($subject, (string) $search, true);
 
         return $result === false ? $subject : $result;
     }
@@ -198,8 +198,8 @@ class Str
     /**
      * Get the portion of a string before the last occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function beforeLast($subject, $search)
@@ -220,9 +220,9 @@ class Str
     /**
      * Get the portion of a string between two given values.
      *
-     * @param string $subject
-     * @param string $from
-     * @param string $to
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
      * @return string
      */
     public static function between($subject, $from, $to)
@@ -237,9 +237,9 @@ class Str
     /**
      * Get the smallest possible portion of a string between two given values.
      *
-     * @param string $subject
-     * @param string $from
-     * @param string $to
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
      * @return string
      */
     public static function betweenFirst($subject, $from, $to)
@@ -254,7 +254,7 @@ class Str
     /**
      * Convert a value to camel case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function camel($value)
@@ -269,8 +269,8 @@ class Str
     /**
      * Get the character at the specified index.
      *
-     * @param string $subject
-     * @param int $index
+     * @param  string  $subject
+     * @param  int  $index
      * @return string|false
      */
     public static function charAt($subject, $index)
@@ -287,9 +287,9 @@ class Str
     /**
      * Determine if a given string contains a given substring.
      *
-     * @param string $haystack
-     * @param string|iterable<string> $needles
-     * @param bool $ignoreCase
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
@@ -298,8 +298,8 @@ class Str
             $haystack = mb_strtolower($haystack);
         }
 
-        if (!is_iterable($needles)) {
-            $needles = (array)$needles;
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
         }
 
         foreach ($needles as $needle) {
@@ -318,15 +318,15 @@ class Str
     /**
      * Determine if a given string contains all array values.
      *
-     * @param string $haystack
-     * @param iterable<string> $needles
-     * @param bool $ignoreCase
+     * @param  string  $haystack
+     * @param  iterable<string>  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
     public static function containsAll($haystack, $needles, $ignoreCase = false)
     {
         foreach ($needles as $needle) {
-            if (!static::contains($haystack, $needle, $ignoreCase)) {
+            if (! static::contains($haystack, $needle, $ignoreCase)) {
                 return false;
             }
         }
@@ -337,9 +337,9 @@ class Str
     /**
      * Convert the case of a string.
      *
-     * @param string $string
-     * @param int $mode
-     * @param string|null $encoding
+     * @param  string  $string
+     * @param  int  $mode
+     * @param  string|null  $encoding
      * @return string
      */
     public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
@@ -350,18 +350,18 @@ class Str
     /**
      * Determine if a given string ends with a given substring.
      *
-     * @param string $haystack
-     * @param string|iterable<string> $needles
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
     {
-        if (!is_iterable($needles)) {
-            $needles = (array)$needles;
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
         }
 
         foreach ($needles as $needle) {
-            if ((string)$needle !== '' && str_ends_with($haystack, $needle)) {
+            if ((string) $needle !== '' && str_ends_with($haystack, $needle)) {
                 return true;
             }
         }
@@ -372,9 +372,9 @@ class Str
     /**
      * Extracts an excerpt from text that matches the first instance of a phrase.
      *
-     * @param string $text
-     * @param string $phrase
-     * @param array $options
+     * @param  string  $text
+     * @param  string  $phrase
+     * @param  array  $options
      * @return string|null
      */
     public static function excerpt($text, $phrase = '', $options = [])
@@ -382,7 +382,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)(' . preg_quote((string)$phrase, '/') . ')(.*)$/iu', (string)$text, $matches);
+        preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/iu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;
@@ -391,15 +391,15 @@ class Str
         $start = ltrim($matches[1]);
 
         $start = str(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
-            fn($startWithRadius) => $startWithRadius->exactly($start),
-            fn($startWithRadius) => $startWithRadius->prepend($omission),
+            fn ($startWithRadius) => $startWithRadius->exactly($start),
+            fn ($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
         $end = str(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
-            fn($endWithRadius) => $endWithRadius->exactly($end),
-            fn($endWithRadius) => $endWithRadius->append($omission),
+            fn ($endWithRadius) => $endWithRadius->exactly($end),
+            fn ($endWithRadius) => $endWithRadius->append($omission),
         );
 
         return $start->append($matches[2], $end)->toString();
@@ -408,47 +408,47 @@ class Str
     /**
      * Cap a string with a single instance of a given value.
      *
-     * @param string $value
-     * @param string $cap
+     * @param  string  $value
+     * @param  string  $cap
      * @return string
      */
     public static function finish($value, $cap)
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
     }
 
     /**
      * Wrap the string with the given strings.
      *
-     * @param string $value
-     * @param string $before
-     * @param string|null $after
+     * @param  string  $value
+     * @param  string  $before
+     * @param  string|null  $after
      * @return string
      */
     public static function wrap($value, $before, $after = null)
     {
-        return $before . $value . ($after ??= $before);
+        return $before.$value.($after ??= $before);
     }
 
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param string|iterable<string> $pattern
-     * @param string $value
+     * @param  string|iterable<string>  $pattern
+     * @param  string  $value
      * @return bool
      */
     public static function is($pattern, $value)
     {
-        $value = (string)$value;
+        $value = (string) $value;
 
-        if (!is_iterable($pattern)) {
+        if (! is_iterable($pattern)) {
             $pattern = [$pattern];
         }
 
         foreach ($pattern as $pattern) {
-            $pattern = (string)$pattern;
+            $pattern = (string) $pattern;
 
             // If the given value is an exact match we can of course return true right
             // from the beginning. Otherwise, we will translate asterisks and do an
@@ -464,7 +464,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^' . $pattern . '\z#u', $value) === 1) {
+            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
                 return true;
             }
         }
@@ -475,23 +475,23 @@ class Str
     /**
      * Determine if a given string is 7 bit ASCII.
      *
-     * @param string $value
+     * @param  string  $value
      * @return bool
      */
     public static function isAscii($value)
     {
-        return ASCII::is_ascii((string)$value);
+        return ASCII::is_ascii((string) $value);
     }
 
     /**
      * Determine if a given value is valid JSON.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isJson($value)
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 
@@ -511,13 +511,13 @@ class Str
     /**
      * Determine if a given value is a valid URL.
      *
-     * @param mixed $value
-     * @param array $protocols
+     * @param  mixed  $value
+     * @param  array  $protocols
      * @return bool
      */
     public static function isUrl($value, array $protocols = [])
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 
@@ -554,12 +554,12 @@ class Str
     /**
      * Determine if a given value is a valid UUID.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isUuid($value)
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 
@@ -569,12 +569,12 @@ class Str
     /**
      * Determine if a given value is a valid ULID.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return bool
      */
     public static function isUlid($value)
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 
@@ -584,7 +584,7 @@ class Str
     /**
      * Convert a string to kebab case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function kebab($value)
@@ -595,8 +595,8 @@ class Str
     /**
      * Return the length of the given string.
      *
-     * @param string $value
-     * @param string|null $encoding
+     * @param  string  $value
+     * @param  string|null  $encoding
      * @return int
      */
     public static function length($value, $encoding = null)
@@ -607,9 +607,9 @@ class Str
     /**
      * Limit the number of characters in a string.
      *
-     * @param string $value
-     * @param int $limit
-     * @param string $end
+     * @param  string  $value
+     * @param  int  $limit
+     * @param  string  $end
      * @return string
      */
     public static function limit($value, $limit = 100, $end = '...')
@@ -618,13 +618,13 @@ class Str
             return $value;
         }
 
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
+        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
     }
 
     /**
      * Convert the given string to lower-case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function lower($value)
@@ -635,41 +635,41 @@ class Str
     /**
      * Limit the number of words in a string.
      *
-     * @param string $value
-     * @param int $words
-     * @param string $end
+     * @param  string  $value
+     * @param  int  $words
+     * @param  string  $end
      * @return string
      */
     public static function words($value, $words = 100, $end = '...')
     {
-        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
+        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
 
-        if (!isset($matches[0]) || static::length($value) === static::length($matches[0])) {
+        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
             return $value;
         }
 
-        return rtrim($matches[0]) . $end;
+        return rtrim($matches[0]).$end;
     }
 
     /**
      * Converts GitHub flavored Markdown into HTML.
      *
-     * @param string $string
-     * @param array $options
+     * @param  string  $string
+     * @param  array  $options
      * @return string
      */
     public static function markdown($string, array $options = [])
     {
         $converter = new GithubFlavoredMarkdownConverter($options);
 
-        return (string)$converter->convert($string);
+        return (string) $converter->convert($string);
     }
 
     /**
      * Converts inline Markdown into HTML.
      *
-     * @param string $string
-     * @param array $options
+     * @param  string  $string
+     * @param  array  $options
      * @return string
      */
     public static function inlineMarkdown($string, array $options = [])
@@ -681,17 +681,17 @@ class Str
 
         $converter = new MarkdownConverter($environment);
 
-        return (string)$converter->convert($string);
+        return (string) $converter->convert($string);
     }
 
     /**
      * Masks a portion of a string with a repeated character.
      *
-     * @param string $string
-     * @param string $character
-     * @param int $index
-     * @param int|null $length
-     * @param string $encoding
+     * @param  string  $string
+     * @param  string  $character
+     * @param  int  $index
+     * @param  int|null  $length
+     * @param  string  $encoding
      * @return string
      */
     public static function mask($string, $character, $index, $length = null, $encoding = 'UTF-8')
@@ -717,21 +717,21 @@ class Str
         $segmentLen = mb_strlen($segment, $encoding);
         $end = mb_substr($string, $startIndex + $segmentLen);
 
-        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen) . $end;
+        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen).$end;
     }
 
     /**
      * Get the string matching the given pattern.
      *
-     * @param string $pattern
-     * @param string $subject
+     * @param  string  $pattern
+     * @param  string  $subject
      * @return string
      */
     public static function match($pattern, $subject)
     {
         preg_match($pattern, $subject, $matches);
 
-        if (!$matches) {
+        if (! $matches) {
             return '';
         }
 
@@ -741,20 +741,20 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param string|iterable<string> $pattern
-     * @param string $value
+     * @param  string|iterable<string>  $pattern
+     * @param  string  $value
      * @return bool
      */
     public static function isMatch($pattern, $value)
     {
-        $value = (string)$value;
+        $value = (string) $value;
 
-        if (!is_iterable($pattern)) {
+        if (! is_iterable($pattern)) {
             $pattern = [$pattern];
         }
 
         foreach ($pattern as $pattern) {
-            $pattern = (string)$pattern;
+            $pattern = (string) $pattern;
 
             if (preg_match($pattern, $value) === 1) {
                 return true;
@@ -767,8 +767,8 @@ class Str
     /**
      * Get the string matching the given pattern.
      *
-     * @param string $pattern
-     * @param string $subject
+     * @param  string  $pattern
+     * @param  string  $subject
      * @return \Illuminate\Support\Collection
      */
     public static function matchAll($pattern, $subject)
@@ -785,9 +785,9 @@ class Str
     /**
      * Pad both sides of a string with another.
      *
-     * @param string $value
-     * @param int $length
-     * @param string $pad
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
      * @return string
      */
     public static function padBoth($value, $length, $pad = ' ')
@@ -800,17 +800,17 @@ class Str
         $shortLeft = floor($short / 2);
         $shortRight = ceil($short / 2);
 
-        return mb_substr(str_repeat($pad, $shortLeft), 0, $shortLeft) .
-            $value .
-            mb_substr(str_repeat($pad, $shortRight), 0, $shortRight);
+        return mb_substr(str_repeat($pad, $shortLeft), 0, $shortLeft).
+               $value.
+               mb_substr(str_repeat($pad, $shortRight), 0, $shortRight);
     }
 
     /**
      * Pad the left side of a string with another.
      *
-     * @param string $value
-     * @param int $length
-     * @param string $pad
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
      * @return string
      */
     public static function padLeft($value, $length, $pad = ' ')
@@ -821,15 +821,15 @@ class Str
 
         $short = max(0, $length - mb_strlen($value));
 
-        return mb_substr(str_repeat($pad, $short), 0, $short) . $value;
+        return mb_substr(str_repeat($pad, $short), 0, $short).$value;
     }
 
     /**
      * Pad the right side of a string with another.
      *
-     * @param string $value
-     * @param int $length
-     * @param string $pad
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
      * @return string
      */
     public static function padRight($value, $length, $pad = ' ')
@@ -840,14 +840,14 @@ class Str
 
         $short = max(0, $length - mb_strlen($value));
 
-        return $value . mb_substr(str_repeat($pad, $short), 0, $short);
+        return $value.mb_substr(str_repeat($pad, $short), 0, $short);
     }
 
     /**
      * Parse a Class[@]method style callback into class and method.
      *
-     * @param string $callback
-     * @param string|null $default
+     * @param  string  $callback
+     * @param  string|null  $default
      * @return array<int, string|null>
      */
     public static function parseCallback($callback, $default = null)
@@ -869,8 +869,8 @@ class Str
     /**
      * Get the plural form of an English word.
      *
-     * @param string $value
-     * @param int|array|\Countable $count
+     * @param  string  $value
+     * @param  int|array|\Countable  $count
      * @return string
      */
     public static function plural($value, $count = 2)
@@ -881,8 +881,8 @@ class Str
     /**
      * Pluralize the last word of an English, studly caps case string.
      *
-     * @param string $value
-     * @param int|array|\Countable $count
+     * @param  string  $value
+     * @param  int|array|\Countable  $count
      * @return string
      */
     public static function pluralStudly($value, $count = 2)
@@ -891,17 +891,17 @@ class Str
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts) . self::plural($lastWord, $count);
+        return implode('', $parts).self::plural($lastWord, $count);
     }
 
     /**
      * Generate a random, secure password.
      *
-     * @param int $length
-     * @param bool $letters
-     * @param bool $numbers
-     * @param bool $symbols
-     * @param bool $spaces
+     * @param  int  $length
+     * @param  bool  $letters
+     * @param  bool  $numbers
+     * @param  bool  $symbols
+     * @param  bool  $spaces
      * @return string
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
@@ -925,34 +925,34 @@ class Str
                 ']', '|', ':', ';',
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
-        ]))->filter()->each(fn($c) => $password->push($c[random_int(0, count($c) - 1)])
+        ]))->filter()->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
         )->flatten();
 
         $length = $length - $password->count();
 
         return $password->merge($options->pipe(
-            fn($c) => Collection::times($length, fn() => $c[random_int(0, $c->count() - 1)])
+            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }
 
     /**
      * Find the multi-byte safe position of the first occurrence of a given substring in a string.
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int $offset
-     * @param string|null $encoding
+     * @param  string  $haystack
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  string|null  $encoding
      * @return int|false
      */
     public static function position($haystack, $needle, $offset = 0, $encoding = null)
     {
-        return mb_strpos($haystack, (string)$needle, $offset, $encoding);
+        return mb_strpos($haystack, (string) $needle, $offset, $encoding);
     }
 
     /**
      * Generate a more truly "random" alpha-numeric string.
      *
-     * @param int $length
+     * @param  int  $length
      * @return string
      */
     public static function random($length = 16)
@@ -963,7 +963,7 @@ class Str
             while (($len = strlen($string)) < $length) {
                 $size = $length - $len;
 
-                $bytesSize = (int)ceil($size / 3) * 3;
+                $bytesSize = (int) ceil($size / 3) * 3;
 
                 $bytes = random_bytes($bytesSize);
 
@@ -977,7 +977,7 @@ class Str
     /**
      * Set the callable that will be used to generate random strings.
      *
-     * @param callable|null $factory
+     * @param  callable|null  $factory
      * @return void
      */
     public static function createRandomStringsUsing(callable $factory = null)
@@ -988,8 +988,8 @@ class Str
     /**
      * Set the sequence that will be used to generate random strings.
      *
-     * @param array $sequence
-     * @param callable|null $whenMissing
+     * @param  array  $sequence
+     * @param  callable|null  $whenMissing
      * @return void
      */
     public static function createRandomStringsUsingSequence(array $sequence, $whenMissing = null)
@@ -1032,8 +1032,8 @@ class Str
     /**
      * Repeat the given string.
      *
-     * @param string $string
-     * @param int $times
+     * @param  string  $string
+     * @param  int  $times
      * @return string
      */
     public static function repeat(string $string, int $times)
@@ -1044,9 +1044,9 @@ class Str
     /**
      * Replace a given value in the string sequentially with an array.
      *
-     * @param string $search
-     * @param iterable<string> $replace
-     * @param string $subject
+     * @param  string  $search
+     * @param  iterable<string>  $replace
+     * @param  string  $subject
      * @return string
      */
     public static function replaceArray($search, $replace, $subject)
@@ -1060,7 +1060,7 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= self::toStringOr(array_shift($replace) ?? $search, $search) . $segment;
+            $result .= self::toStringOr(array_shift($replace) ?? $search, $search).$segment;
         }
 
         return $result;
@@ -1069,14 +1069,14 @@ class Str
     /**
      * Convert the given value to a string or return the given fallback on failure.
      *
-     * @param mixed $value
-     * @param string $fallback
+     * @param  mixed  $value
+     * @param  string  $fallback
      * @return string
      */
     private static function toStringOr($value, $fallback)
     {
         try {
-            return (string)$value;
+            return (string) $value;
         } catch (Throwable $e) {
             return $fallback;
         }
@@ -1085,10 +1085,10 @@ class Str
     /**
      * Replace the given value in the given string.
      *
-     * @param string|iterable<string> $search
-     * @param string|iterable<string> $replace
-     * @param string|iterable<string> $subject
-     * @param bool $caseSensitive
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $replace
+     * @param  string|iterable<string>  $subject
+     * @param  bool  $caseSensitive
      * @return string|string[]
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
@@ -1106,21 +1106,21 @@ class Str
         }
 
         return $caseSensitive
-            ? str_replace($search, $replace, $subject)
-            : str_ireplace($search, $replace, $subject);
+                ? str_replace($search, $replace, $subject)
+                : str_ireplace($search, $replace, $subject);
     }
 
     /**
      * Replace the first occurrence of a given value in the string.
      *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
      * @return string
      */
     public static function replaceFirst($search, $replace, $subject)
     {
-        $search = (string)$search;
+        $search = (string) $search;
 
         if ($search === '') {
             return $subject;
@@ -1138,14 +1138,14 @@ class Str
     /**
      * Replace the first occurrence of the given value if it appears at the start of the string.
      *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
      * @return string
      */
     public static function replaceStart($search, $replace, $subject)
     {
-        $search = (string)$search;
+        $search = (string) $search;
 
         if ($search === '') {
             return $subject;
@@ -1161,14 +1161,14 @@ class Str
     /**
      * Replace the last occurrence of a given value in the string.
      *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
      * @return string
      */
     public static function replaceLast($search, $replace, $subject)
     {
-        $search = (string)$search;
+        $search = (string) $search;
 
         if ($search === '') {
             return $subject;
@@ -1186,14 +1186,14 @@ class Str
     /**
      * Replace the last occurrence of a given value if it appears at the end of the string.
      *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
      * @return string
      */
     public static function replaceEnd($search, $replace, $subject)
     {
-        $search = (string)$search;
+        $search = (string) $search;
 
         if ($search === '') {
             return $subject;
@@ -1209,10 +1209,10 @@ class Str
     /**
      * Replace the patterns matching the given regular expression.
      *
-     * @param string $pattern
-     * @param \Closure|string $replace
-     * @param array|string $subject
-     * @param int $limit
+     * @param  string  $pattern
+     * @param  \Closure|string  $replace
+     * @param  array|string  $subject
+     * @param  int  $limit
      * @return string|string[]|null
      */
     public static function replaceMatches($pattern, $replace, $subject, $limit = -1)
@@ -1227,9 +1227,9 @@ class Str
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param string|iterable<string> $search
-     * @param string|iterable<string> $subject
-     * @param bool $caseSensitive
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $subject
+     * @param  bool  $caseSensitive
      * @return string
      */
     public static function remove($search, $subject, $caseSensitive = true)
@@ -1239,14 +1239,14 @@ class Str
         }
 
         return $caseSensitive
-            ? str_replace($search, '', $subject)
-            : str_ireplace($search, '', $subject);
+                    ? str_replace($search, '', $subject)
+                    : str_ireplace($search, '', $subject);
     }
 
     /**
      * Reverse the given string.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function reverse(string $value)
@@ -1257,21 +1257,21 @@ class Str
     /**
      * Begin a string with a single instance of a given value.
      *
-     * @param string $value
-     * @param string $prefix
+     * @param  string  $value
+     * @param  string  $prefix
      * @return string
      */
     public static function start($value, $prefix)
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
+        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
     }
 
     /**
      * Convert the given string to upper-case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function upper($value)
@@ -1282,7 +1282,7 @@ class Str
     /**
      * Convert the given string to title case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function title($value)
@@ -1293,7 +1293,7 @@ class Str
     /**
      * Convert the given string to title case for each word.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function headline($value)
@@ -1312,7 +1312,7 @@ class Str
     /**
      * Get the singular form of an English word.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function singular($value)
@@ -1323,10 +1323,10 @@ class Str
     /**
      * Generate a URL friendly "slug" from a given string.
      *
-     * @param string $title
-     * @param string $separator
-     * @param string|null $language
-     * @param array<string, string> $dictionary
+     * @param  string  $title
+     * @param  string  $separator
+     * @param  string|null  $language
+     * @param  array<string, string>  $dictionary
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
@@ -1336,20 +1336,20 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
 
         // Replace dictionary words
         foreach ($dictionary as $key => $value) {
-            $dictionary[$key] = $separator . $value . $separator;
+            $dictionary[$key] = $separator.$value.$separator;
         }
 
         $title = str_replace(array_keys($dictionary), array_values($dictionary), $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace
-        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
@@ -1357,8 +1357,8 @@ class Str
     /**
      * Convert a string to snake case.
      *
-     * @param string $value
-     * @param string $delimiter
+     * @param  string  $value
+     * @param  string  $delimiter
      * @return string
      */
     public static function snake($value, $delimiter = '_')
@@ -1369,10 +1369,10 @@ class Str
             return static::$snakeCache[$key][$delimiter];
         }
 
-        if (!ctype_lower($value)) {
+        if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;
@@ -1381,7 +1381,7 @@ class Str
     /**
      * Remove all "extra" blank space from the given string.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function squish($value)
@@ -1392,18 +1392,18 @@ class Str
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param string $haystack
-     * @param string|iterable<string> $needles
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)
     {
-        if (!is_iterable($needles)) {
+        if (! is_iterable($needles)) {
             $needles = [$needles];
         }
 
         foreach ($needles as $needle) {
-            if ((string)$needle !== '' && str_starts_with($haystack, $needle)) {
+            if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
                 return true;
             }
         }
@@ -1414,7 +1414,7 @@ class Str
     /**
      * Convert a value to studly caps case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function studly($value)
@@ -1427,7 +1427,7 @@ class Str
 
         $words = explode(' ', static::replace(['-', '_'], ' ', $value));
 
-        $studlyWords = array_map(fn($word) => static::ucfirst($word), $words);
+        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 
         return static::$studlyCache[$key] = implode($studlyWords);
     }
@@ -1435,10 +1435,10 @@ class Str
     /**
      * Returns the portion of the string specified by the start and length parameters.
      *
-     * @param string $string
-     * @param int $start
-     * @param int|null $length
-     * @param string $encoding
+     * @param  string  $string
+     * @param  int  $start
+     * @param  int|null  $length
+     * @param  string  $encoding
      * @return string
      */
     public static function substr($string, $start, $length = null, $encoding = 'UTF-8')
@@ -1449,15 +1449,15 @@ class Str
     /**
      * Returns the number of substring occurrences.
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int $offset
-     * @param int|null $length
+     * @param  string  $haystack
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  int|null  $length
      * @return int
      */
     public static function substrCount($haystack, $needle, $offset = 0, $length = null)
     {
-        if (!is_null($length)) {
+        if (! is_null($length)) {
             return substr_count($haystack, $needle, $offset, $length);
         }
 
@@ -1467,10 +1467,10 @@ class Str
     /**
      * Replace text within a portion of a string.
      *
-     * @param string|string[] $string
-     * @param string|string[] $replace
-     * @param int|int[] $offset
-     * @param int|int[]|null $length
+     * @param  string|string[]  $string
+     * @param  string|string[]  $replace
+     * @param  int|int[]  $offset
+     * @param  int|int[]|null  $length
      * @return string|string[]
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
@@ -1485,8 +1485,8 @@ class Str
     /**
      * Swap multiple keywords in a string with other keywords.
      *
-     * @param array $map
-     * @param string $subject
+     * @param  array  $map
+     * @param  string  $subject
      * @return string
      */
     public static function swap(array $map, $subject)
@@ -1497,8 +1497,8 @@ class Str
     /**
      * Take the first or last {$limit} characters of a string.
      *
-     * @param string $string
-     * @param int $limit
+     * @param  string  $string
+     * @param  int  $limit
      * @return string
      */
     public static function take($string, int $limit): string
@@ -1513,29 +1513,29 @@ class Str
     /**
      * Make a string's first character lowercase.
      *
-     * @param string $string
+     * @param  string  $string
      * @return string
      */
     public static function lcfirst($string)
     {
-        return static::lower(static::substr($string, 0, 1)) . static::substr($string, 1);
+        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 
     /**
      * Make a string's first character uppercase.
      *
-     * @param string $string
+     * @param  string  $string
      * @return string
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
+        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 
     /**
      * Split a string into pieces by uppercase characters.
      *
-     * @param string $string
+     * @param  string  $string
      * @return string[]
      */
     public static function ucsplit($string)
@@ -1546,8 +1546,8 @@ class Str
     /**
      * Get the number of words a string contains.
      *
-     * @param string $string
-     * @param string|null $characters
+     * @param  string  $string
+     * @param  string|null  $characters
      * @return int
      */
     public static function wordCount($string, $characters = null)
@@ -1558,10 +1558,10 @@ class Str
     /**
      * Wrap a string to a given number of characters.
      *
-     * @param string $string
-     * @param int $characters
-     * @param string $break
-     * @param bool $cutLongWords
+     * @param  string  $string
+     * @param  int  $characters
+     * @param  string  $break
+     * @param  bool  $cutLongWords
      * @return string
      */
     public static function wordWrap($string, $characters = 75, $break = "\n", $cutLongWords = false)
@@ -1577,8 +1577,8 @@ class Str
     public static function uuid()
     {
         return static::$uuidFactory
-            ? call_user_func(static::$uuidFactory)
-            : Uuid::uuid4();
+                    ? call_user_func(static::$uuidFactory)
+                    : Uuid::uuid4();
     }
 
     /**
@@ -1609,7 +1609,7 @@ class Str
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param callable|null $factory
+     * @param  callable|null  $factory
      * @return void
      */
     public static function createUuidsUsing(callable $factory = null)
@@ -1620,8 +1620,8 @@ class Str
     /**
      * Set the sequence that will be used to generate UUIDs.
      *
-     * @param array $sequence
-     * @param callable|null $whenMissing
+     * @param  array  $sequence
+     * @param  callable|null  $whenMissing
      * @return void
      */
     public static function createUuidsUsingSequence(array $sequence, $whenMissing = null)
@@ -1654,14 +1654,14 @@ class Str
     /**
      * Always return the same UUID when generating new UUIDs.
      *
-     * @param \Closure|null $callback
+     * @param  \Closure|null  $callback
      * @return \Ramsey\Uuid\UuidInterface
      */
     public static function freezeUuids(Closure $callback = null)
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(fn() => $uuid);
+        Str::createUuidsUsing(fn () => $uuid);
 
         if ($callback !== null) {
             try {
@@ -1687,7 +1687,7 @@ class Str
     /**
      * Generate a ULID.
      *
-     * @param \DateTimeInterface|null $time
+     * @param  \DateTimeInterface|null  $time
      * @return \Symfony\Component\Uid\Ulid
      */
     public static function ulid($time = null)
@@ -1716,7 +1716,7 @@ class Str
     /**
      * Set the callable that will be used to generate ULIDs.
      *
-     * @param callable|null $factory
+     * @param  callable|null  $factory
      * @return void
      */
     public static function createUlidsUsing(callable $factory = null)
@@ -1727,8 +1727,8 @@ class Str
     /**
      * Set the sequence that will be used to generate ULIDs.
      *
-     * @param array $sequence
-     * @param callable|null $whenMissing
+     * @param  array  $sequence
+     * @param  callable|null  $whenMissing
      * @return void
      */
     public static function createUlidsUsingSequence(array $sequence, $whenMissing = null)
@@ -1761,14 +1761,14 @@ class Str
     /**
      * Always return the same ULID when generating new ULIDs.
      *
-     * @param Closure|null $callback
+     * @param  Closure|null  $callback
      * @return Ulid
      */
     public static function freezeUlids(Closure $callback = null)
     {
         $ulid = Str::ulid();
 
-        Str::createUlidsUsing(fn() => $ulid);
+        Str::createUlidsUsing(fn () => $ulid);
 
         if ($callback !== null) {
             try {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -124,18 +124,13 @@ class Str
         $minorWords = ['and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an', 'the', 'at', 'by', 'for', 'in', 'of', 'off', 'on', 'per', 'to', 'up', 'via'];
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        // Split the string into words
         $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
 
-        // Capitalize the first word
         $words[0] = ucfirst(mb_strtolower($words[0]));
 
-        // Capitalize major words and handle lowercase minor words
         for ($i = 0; $i < count($words); $i++) {
-            // Check if the word is a major word or a minor word
             $lowercaseWord = mb_strtolower($words[$i]);
 
-            // Handle hyphenated major words
             if (str_contains($lowercaseWord, '-')) {
                 $hyphenatedWords = explode('-', $lowercaseWord);
                 $hyphenatedWords = array_map(function ($part) use ($minorWords) {
@@ -143,7 +138,6 @@ class Str
                 }, $hyphenatedWords);
                 $words[$i] = implode('-', $hyphenatedWords);
             } else {
-                // Handle lowercase minor words
                 if (
                     in_array($lowercaseWord, $minorWords) &&
                     mb_strlen($lowercaseWord) <= 3 &&
@@ -156,7 +150,6 @@ class Str
             }
         }
 
-        // Join the words back into a string
         return implode(' ', $words);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1243,7 +1243,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function properCase($value)
+    public static function proper($value)
     {
         return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
     }
@@ -1256,31 +1256,26 @@ class Str
      */
     public static function title($value)
     {
-        return static::properCase($value);
+        return static::proper($value);
     }
 
     /**
      * Convert the given string to proper case for each word.
      *
      * @param  string  $value
-     * @param  bool  $title
      * @return string
      */
-    public static function headline($value, $title = false)
+    public static function headline($value)
     {
         $parts = explode(' ', $value);
 
-        $method = $title ? 'lower' : 'properCase';
-
         $parts = count($parts) > 1
-            ? array_map([static::class, $method], $parts)
-            : array_map([static::class, $method], static::ucsplit(implode('_', $parts)));
+            ? array_map([static::class, 'proper'], $parts)
+            : array_map([static::class, 'proper'], static::ucsplit(implode('_', $parts)));
 
         $collapsed = static::replace(['-', '_', ' '], '_', implode('_', $parts));
 
-        $headline = implode(' ', array_filter(explode('_', $collapsed)));
-
-        return $title ? static::titleCase($headline) : $headline;
+        return implode(' ', array_filter(explode('_', $collapsed)));
     }
 
     /**
@@ -1291,7 +1286,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function titleCase($value)
+    public static function apaTitle($value)
     {
         $minorWords = [
             'and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an',

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1280,7 +1280,7 @@ class Str
 
         $headline = implode(' ', array_filter(explode('_', $collapsed)));
 
-        return $title ? Str::titleCase($headline) : $headline;
+        return $title ? static::titleCase($headline) : $headline;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -115,7 +115,7 @@ class Str
      * Based on the rules provided by the APA:
      * https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function apa($value)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -822,9 +822,9 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @return static
      */
-    public function apaTitle()
+    public function apa()
     {
-        return new static(Str::apaTitle($this->value));
+        return new static(Str::apa($this->value));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -78,6 +78,16 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Convert the given string to APA-style case.
+     *
+     * @return static
+     */
+    public function apa()
+    {
+        return new static(Str::apa($this->value));
+    }
+
+    /**
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $language

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -78,16 +78,6 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Convert the given string to APA-style case.
-     *
-     * @return static
-     */
-    public function apa()
-    {
-        return new static(Str::apa($this->value));
-    }
-
-    /**
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $language
@@ -798,13 +788,44 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Convert the given string to title case.
+     * Convert the given string to proper case.
+     *
+     * @return static
+     */
+    public function properCase()
+    {
+        return new static(Str::properCase($this->value));
+    }
+
+    /**
+     * Convert the given string to proper case.
      *
      * @return static
      */
     public function title()
     {
-        return new static(Str::title($this->value));
+        return $this->properCase();
+    }
+
+    /**
+     * Convert the given string to proper case for each word.
+     *
+     * @param  bool  $title
+     * @return static
+     */
+    public function headline($title = false)
+    {
+        return new static(Str::headline($this->value, $title));
+    }
+
+    /**
+     * Convert the given string to APA-style title case.
+     *
+     * @return static
+     */
+    public function titleCase()
+    {
+        return new static(Str::titleCase($this->value));
     }
 
     /**
@@ -817,16 +838,6 @@ class Stringable implements JsonSerializable, ArrayAccess
     public function transliterate($unknown = '?', $strict = false)
     {
         return new static(Str::transliterate($this->value, $unknown, $strict));
-    }
-
-    /**
-     * Convert the given string to title case for each word.
-     *
-     * @return static
-     */
-    public function headline()
-    {
-        return new static(Str::headline($this->value));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -792,19 +792,9 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @return static
      */
-    public function proper()
-    {
-        return new static(Str::proper($this->value));
-    }
-
-    /**
-     * Convert the given string to proper case.
-     *
-     * @return static
-     */
     public function title()
     {
-        return $this->proper();
+        return new static(Str::title($this->value));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -792,9 +792,9 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @return static
      */
-    public function properCase()
+    public function proper()
     {
-        return new static(Str::properCase($this->value));
+        return new static(Str::proper($this->value));
     }
 
     /**
@@ -804,18 +804,17 @@ class Stringable implements JsonSerializable, ArrayAccess
      */
     public function title()
     {
-        return $this->properCase();
+        return $this->proper();
     }
 
     /**
      * Convert the given string to proper case for each word.
      *
-     * @param  bool  $title
      * @return static
      */
-    public function headline($title = false)
+    public function headline()
     {
-        return new static(Str::headline($this->value, $title));
+        return new static(Str::headline($this->value));
     }
 
     /**
@@ -823,9 +822,9 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @return static
      */
-    public function titleCase()
+    public function apaTitle()
     {
-        return new static(Str::titleCase($this->value));
+        return new static(Str::apaTitle($this->value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -67,6 +67,37 @@ class SupportStrTest extends TestCase
         $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
     }
 
+    public function testStringApa()
+    {
+        $this->assertSame('Tom and Jerry', Str::apa('tom and jerry'));
+        $this->assertSame('Tom and Jerry', Str::apa('TOM AND JERRY'));
+        $this->assertSame('Tom and Jerry', Str::apa('Tom And Jerry'));
+
+        $this->assertSame('Back to the Future', Str::apa('back to the future'));
+        $this->assertSame('Back to the Future', Str::apa('BACK TO THE FUTURE'));
+        $this->assertSame('Back to the Future', Str::apa('Back To The Future'));
+
+        $this->assertSame('This, Then That', Str::apa('this, then that'));
+        $this->assertSame('This, Then That', Str::apa('THIS, THEN THAT'));
+        $this->assertSame('This, Then That', Str::apa('This, Then That'));
+
+        $this->assertSame('Bond. James Bond.', Str::apa('bond. james bond.'));
+        $this->assertSame('Bond. James Bond.', Str::apa('BOND. JAMES BOND.'));
+        $this->assertSame('Bond. James Bond.', Str::apa('Bond. James Bond.'));
+
+        $this->assertSame('Self-Report', Str::apa('self-report'));
+        $this->assertSame('Self-Report', Str::apa('Self-report'));
+        $this->assertSame('Self-Report', Str::apa('SELF-REPORT'));
+
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('as the world turns, so are the days of our lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('As The World Turns, So Are The Days Of Our Lives'));
+
+        $this->assertSame('To Kill a Mockingbird', Str::apa('to kill a mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::apa('TO KILL A MOCKINGBIRD'));
+        $this->assertSame('To Kill a Mockingbird', Str::apa('To Kill A Mockingbird'));
+    }
+
     public function testStringWithoutWordsDoesntProduceError()
     {
         $nbsp = chr(0xC2).chr(0xA0);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -43,14 +43,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('Jefferson Costella', Str::headline('jefFErson coSTella'));
         $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses-_Laravel'));
         $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses__Laravel'));
-        $this->assertSame('Jefferson Costella in the Laravel', Str::headline('jefferson_costella in_the__Laravel', title: true));
-        $this->assertSame('Jefferson Costella In The Laravel', Str::headline('jefferson_costella in_the__Laravel', title: false));
 
         $this->assertSame('Laravel P H P Framework', Str::headline('laravel_p_h_p_framework'));
         $this->assertSame('Laravel P H P Framework', Str::headline('laravel _p _h _p _framework'));
         $this->assertSame('Laravel Php Framework', Str::headline('laravel_php_framework'));
         $this->assertSame('Laravel Ph P Framework', Str::headline('laravel-phP-framework'));
-        $this->assertSame('Laravel Ph P Framework', Str::headline('laravel-phP-framework', title: true));
         $this->assertSame('Laravel Php Framework', Str::headline('laravel  -_-  php   -_-   framework   '));
 
         $this->assertSame('Foo Bar', Str::headline('fooBar'));
@@ -72,33 +69,33 @@ class SupportStrTest extends TestCase
 
     public function testStringApa()
     {
-        $this->assertSame('Tom and Jerry', Str::titleCase('tom and jerry'));
-        $this->assertSame('Tom and Jerry', Str::titleCase('TOM AND JERRY'));
-        $this->assertSame('Tom and Jerry', Str::titleCase('Tom And Jerry'));
+        $this->assertSame('Tom and Jerry', Str::apaTitle('tom and jerry'));
+        $this->assertSame('Tom and Jerry', Str::apaTitle('TOM AND JERRY'));
+        $this->assertSame('Tom and Jerry', Str::apaTitle('Tom And Jerry'));
 
-        $this->assertSame('Back to the Future', Str::titleCase('back to the future'));
-        $this->assertSame('Back to the Future', Str::titleCase('BACK TO THE FUTURE'));
-        $this->assertSame('Back to the Future', Str::titleCase('Back To The Future'));
+        $this->assertSame('Back to the Future', Str::apaTitle('back to the future'));
+        $this->assertSame('Back to the Future', Str::apaTitle('BACK TO THE FUTURE'));
+        $this->assertSame('Back to the Future', Str::apaTitle('Back To The Future'));
 
-        $this->assertSame('This, Then That', Str::titleCase('this, then that'));
-        $this->assertSame('This, Then That', Str::titleCase('THIS, THEN THAT'));
-        $this->assertSame('This, Then That', Str::titleCase('This, Then That'));
+        $this->assertSame('This, Then That', Str::apaTitle('this, then that'));
+        $this->assertSame('This, Then That', Str::apaTitle('THIS, THEN THAT'));
+        $this->assertSame('This, Then That', Str::apaTitle('This, Then That'));
 
-        $this->assertSame('Bond. James Bond.', Str::titleCase('bond. james bond.'));
-        $this->assertSame('Bond. James Bond.', Str::titleCase('BOND. JAMES BOND.'));
-        $this->assertSame('Bond. James Bond.', Str::titleCase('Bond. James Bond.'));
+        $this->assertSame('Bond. James Bond.', Str::apaTitle('bond. james bond.'));
+        $this->assertSame('Bond. James Bond.', Str::apaTitle('BOND. JAMES BOND.'));
+        $this->assertSame('Bond. James Bond.', Str::apaTitle('Bond. James Bond.'));
 
-        $this->assertSame('Self-Report', Str::titleCase('self-report'));
-        $this->assertSame('Self-Report', Str::titleCase('Self-report'));
-        $this->assertSame('Self-Report', Str::titleCase('SELF-REPORT'));
+        $this->assertSame('Self-Report', Str::apaTitle('self-report'));
+        $this->assertSame('Self-Report', Str::apaTitle('Self-report'));
+        $this->assertSame('Self-Report', Str::apaTitle('SELF-REPORT'));
 
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::titleCase('as the world turns, so are the days of our lives'));
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::titleCase('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::titleCase('As The World Turns, So Are The Days Of Our Lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apaTitle('as the world turns, so are the days of our lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apaTitle('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apaTitle('As The World Turns, So Are The Days Of Our Lives'));
 
-        $this->assertSame('To Kill a Mockingbird', Str::titleCase('to kill a mockingbird'));
-        $this->assertSame('To Kill a Mockingbird', Str::titleCase('TO KILL A MOCKINGBIRD'));
-        $this->assertSame('To Kill a Mockingbird', Str::titleCase('To Kill A Mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::apaTitle('to kill a mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::apaTitle('TO KILL A MOCKINGBIRD'));
+        $this->assertSame('To Kill a Mockingbird', Str::apaTitle('To Kill A Mockingbird'));
     }
 
     public function testStringWithoutWordsDoesntProduceError()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -43,11 +43,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Jefferson Costella', Str::headline('jefFErson coSTella'));
         $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses-_Laravel'));
         $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses__Laravel'));
+        $this->assertSame('Jefferson Costella in the Laravel', Str::headline('jefferson_costella in_the__Laravel', title: true));
+        $this->assertSame('Jefferson Costella In The Laravel', Str::headline('jefferson_costella in_the__Laravel', title: false));
 
         $this->assertSame('Laravel P H P Framework', Str::headline('laravel_p_h_p_framework'));
         $this->assertSame('Laravel P H P Framework', Str::headline('laravel _p _h _p _framework'));
         $this->assertSame('Laravel Php Framework', Str::headline('laravel_php_framework'));
         $this->assertSame('Laravel Ph P Framework', Str::headline('laravel-phP-framework'));
+        $this->assertSame('Laravel Ph P Framework', Str::headline('laravel-phP-framework', title: true));
         $this->assertSame('Laravel Php Framework', Str::headline('laravel  -_-  php   -_-   framework   '));
 
         $this->assertSame('Foo Bar', Str::headline('fooBar'));
@@ -69,33 +72,33 @@ class SupportStrTest extends TestCase
 
     public function testStringApa()
     {
-        $this->assertSame('Tom and Jerry', Str::apa('tom and jerry'));
-        $this->assertSame('Tom and Jerry', Str::apa('TOM AND JERRY'));
-        $this->assertSame('Tom and Jerry', Str::apa('Tom And Jerry'));
+        $this->assertSame('Tom and Jerry', Str::titleCase('tom and jerry'));
+        $this->assertSame('Tom and Jerry', Str::titleCase('TOM AND JERRY'));
+        $this->assertSame('Tom and Jerry', Str::titleCase('Tom And Jerry'));
 
-        $this->assertSame('Back to the Future', Str::apa('back to the future'));
-        $this->assertSame('Back to the Future', Str::apa('BACK TO THE FUTURE'));
-        $this->assertSame('Back to the Future', Str::apa('Back To The Future'));
+        $this->assertSame('Back to the Future', Str::titleCase('back to the future'));
+        $this->assertSame('Back to the Future', Str::titleCase('BACK TO THE FUTURE'));
+        $this->assertSame('Back to the Future', Str::titleCase('Back To The Future'));
 
-        $this->assertSame('This, Then That', Str::apa('this, then that'));
-        $this->assertSame('This, Then That', Str::apa('THIS, THEN THAT'));
-        $this->assertSame('This, Then That', Str::apa('This, Then That'));
+        $this->assertSame('This, Then That', Str::titleCase('this, then that'));
+        $this->assertSame('This, Then That', Str::titleCase('THIS, THEN THAT'));
+        $this->assertSame('This, Then That', Str::titleCase('This, Then That'));
 
-        $this->assertSame('Bond. James Bond.', Str::apa('bond. james bond.'));
-        $this->assertSame('Bond. James Bond.', Str::apa('BOND. JAMES BOND.'));
-        $this->assertSame('Bond. James Bond.', Str::apa('Bond. James Bond.'));
+        $this->assertSame('Bond. James Bond.', Str::titleCase('bond. james bond.'));
+        $this->assertSame('Bond. James Bond.', Str::titleCase('BOND. JAMES BOND.'));
+        $this->assertSame('Bond. James Bond.', Str::titleCase('Bond. James Bond.'));
 
-        $this->assertSame('Self-Report', Str::apa('self-report'));
-        $this->assertSame('Self-Report', Str::apa('Self-report'));
-        $this->assertSame('Self-Report', Str::apa('SELF-REPORT'));
+        $this->assertSame('Self-Report', Str::titleCase('self-report'));
+        $this->assertSame('Self-Report', Str::titleCase('Self-report'));
+        $this->assertSame('Self-Report', Str::titleCase('SELF-REPORT'));
 
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('as the world turns, so are the days of our lives'));
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('As The World Turns, So Are The Days Of Our Lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::titleCase('as the world turns, so are the days of our lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::titleCase('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::titleCase('As The World Turns, So Are The Days Of Our Lives'));
 
-        $this->assertSame('To Kill a Mockingbird', Str::apa('to kill a mockingbird'));
-        $this->assertSame('To Kill a Mockingbird', Str::apa('TO KILL A MOCKINGBIRD'));
-        $this->assertSame('To Kill a Mockingbird', Str::apa('To Kill A Mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::titleCase('to kill a mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::titleCase('TO KILL A MOCKINGBIRD'));
+        $this->assertSame('To Kill a Mockingbird', Str::titleCase('To Kill A Mockingbird'));
     }
 
     public function testStringWithoutWordsDoesntProduceError()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -69,33 +69,33 @@ class SupportStrTest extends TestCase
 
     public function testStringApa()
     {
-        $this->assertSame('Tom and Jerry', Str::apaTitle('tom and jerry'));
-        $this->assertSame('Tom and Jerry', Str::apaTitle('TOM AND JERRY'));
-        $this->assertSame('Tom and Jerry', Str::apaTitle('Tom And Jerry'));
+        $this->assertSame('Tom and Jerry', Str::apa('tom and jerry'));
+        $this->assertSame('Tom and Jerry', Str::apa('TOM AND JERRY'));
+        $this->assertSame('Tom and Jerry', Str::apa('Tom And Jerry'));
 
-        $this->assertSame('Back to the Future', Str::apaTitle('back to the future'));
-        $this->assertSame('Back to the Future', Str::apaTitle('BACK TO THE FUTURE'));
-        $this->assertSame('Back to the Future', Str::apaTitle('Back To The Future'));
+        $this->assertSame('Back to the Future', Str::apa('back to the future'));
+        $this->assertSame('Back to the Future', Str::apa('BACK TO THE FUTURE'));
+        $this->assertSame('Back to the Future', Str::apa('Back To The Future'));
 
-        $this->assertSame('This, Then That', Str::apaTitle('this, then that'));
-        $this->assertSame('This, Then That', Str::apaTitle('THIS, THEN THAT'));
-        $this->assertSame('This, Then That', Str::apaTitle('This, Then That'));
+        $this->assertSame('This, Then That', Str::apa('this, then that'));
+        $this->assertSame('This, Then That', Str::apa('THIS, THEN THAT'));
+        $this->assertSame('This, Then That', Str::apa('This, Then That'));
 
-        $this->assertSame('Bond. James Bond.', Str::apaTitle('bond. james bond.'));
-        $this->assertSame('Bond. James Bond.', Str::apaTitle('BOND. JAMES BOND.'));
-        $this->assertSame('Bond. James Bond.', Str::apaTitle('Bond. James Bond.'));
+        $this->assertSame('Bond. James Bond.', Str::apa('bond. james bond.'));
+        $this->assertSame('Bond. James Bond.', Str::apa('BOND. JAMES BOND.'));
+        $this->assertSame('Bond. James Bond.', Str::apa('Bond. James Bond.'));
 
-        $this->assertSame('Self-Report', Str::apaTitle('self-report'));
-        $this->assertSame('Self-Report', Str::apaTitle('Self-report'));
-        $this->assertSame('Self-Report', Str::apaTitle('SELF-REPORT'));
+        $this->assertSame('Self-Report', Str::apa('self-report'));
+        $this->assertSame('Self-Report', Str::apa('Self-report'));
+        $this->assertSame('Self-Report', Str::apa('SELF-REPORT'));
 
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apaTitle('as the world turns, so are the days of our lives'));
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apaTitle('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
-        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apaTitle('As The World Turns, So Are The Days Of Our Lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('as the world turns, so are the days of our lives'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('AS THE WORLD TURNS, SO ARE THE DAYS OF OUR LIVES'));
+        $this->assertSame('As the World Turns, So Are the Days of Our Lives', Str::apa('As The World Turns, So Are The Days Of Our Lives'));
 
-        $this->assertSame('To Kill a Mockingbird', Str::apaTitle('to kill a mockingbird'));
-        $this->assertSame('To Kill a Mockingbird', Str::apaTitle('TO KILL A MOCKINGBIRD'));
-        $this->assertSame('To Kill a Mockingbird', Str::apaTitle('To Kill A Mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::apa('to kill a mockingbird'));
+        $this->assertSame('To Kill a Mockingbird', Str::apa('TO KILL A MOCKINGBIRD'));
+        $this->assertSame('To Kill a Mockingbird', Str::apa('To Kill A Mockingbird'));
     }
 
     public function testStringWithoutWordsDoesntProduceError()


### PR DESCRIPTION
This PR provides support for APA style title casing through the `Str::apa($string)` or `str($string)->apa()` helpers.

Style as defined here: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case