### PR TITLE
[10.x] Fix deprecation with null value in cache FileStore

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -290,9 +290,11 @@ class FileStore implements Store, LockProvider
         // just return null. Otherwise, we'll get the contents of the file and get
         // the expiration UNIX timestamps from the start of the file's contents.
         try {
-            $expire = substr(
-                $contents = $this->files->get($path, true), 0, 10
-            );
+            if (is_null($contents = $this->files->get($path, true))) {
+                return $this->emptyPayload();
+            }
+
+            $expire = substr($contents, 0, 10);
         } catch (Exception) {
             return $this->emptyPayload();
         }


### PR DESCRIPTION
This fixes a long outstanding deprecation in our test suite where nothing was found for the given path of a cache FileStore.