### PR TITLE
[10.x] Refactoring `SerializeModels` dropping `getPropertyValue` method

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -36,7 +36,7 @@ trait SerializesModels
                 continue;
             }
 
-            $value = $this->getPropertyValue($property);
+            $value = $property->getValue($this);
 
             if ($property->hasDefaultValue() && $value === $property->getDefaultValue()) {
                 continue;
@@ -93,16 +93,5 @@ trait SerializesModels
                 $this, $this->getRestoredPropertyValue($values[$name])
             );
         }
-    }
-
-    /**
-     * Get the property value for the given property.
-     *
-     * @param  \ReflectionProperty  $property
-     * @return mixed
-     */
-    protected function getPropertyValue(ReflectionProperty $property)
-    {
-        return $property->getValue($this);
     }
 }

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -4,7 +4,6 @@ namespace Illuminate\Queue;
 
 use Illuminate\Queue\Attributes\WithoutRelations;
 use ReflectionClass;
-use ReflectionProperty;
 
 trait SerializesModels
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As `SerializeModels` is a trait, access to the `$this` object reflects the class that uses the trait, and this will cause possible errors if a method with the same name as `getPropertyValue` is defined in the class that uses the trait, the job class, but returning a different format than expected to the `__serialize`.

