### PR TITLE
[10.x] Update the seed method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -311,7 +311,9 @@ trait InteractsWithDatabase
      */
     public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
     {
-        foreach (Arr::wrap($class) as $class) {
+        $classes = is_array($class) ? $class : func_get_args();
+
+        foreach ($classes as $class) {
             $this->artisan('db:seed', ['--class' => $class, '--no-interaction' => true]);
         }
 


### PR DESCRIPTION
Currently we can do one of the followings:

```php
use Database\Seeds\OrderStatusesSeeder;
use Database\Seeds\OrderTypesSeeder;
use Database\Seeds\CountriesSeeder;
use Tests\TestCase;

class SomeTest extends TestCase
{
    public function setUp(): void
    {
        $this->seed([OrderStatusesSeeder::class, OrderTypesSeeder::class, CountriesSeeder::class]);

        // Or
        $this->seed(OrderStatusesSeeder::class)
            ->seed(OrderTypesSeeder::class)
            ->seed(CountriesSeeder::class);
    }
}
```

With this simple change, we can do these, plus all of those above:

```php
$this->seed(OrderStatusesSeeder::class, OrderTypesSeeder::class, CountriesSeeder::class);

// Or
$this->seed(OrderStatusesSeeder::class, OrderTypesSeeder::class)
    ->seed(CountriesSeeder::class, LanguagesSeeder)
    ->seed(SettingsSeeder::class);
```

I struggled to write a test case for the `seed` method, too many dependencies involved. So I have created a fresh Laravel project, [symlink][1] to this feature branch and test the method:

```php
<?php

namespace Tests\Feature;

use Database\Seeders\CountriesSeeder;
use Database\Seeders\CurrenciesSeeder;
use Illuminate\Foundation\Testing\RefreshDatabase;
use Illuminate\Foundation\Testing\WithFaker;
use Tests\TestCase;

class SeedingTest extends TestCase
{
    use RefreshDatabase;

    /**
     * A basic feature test example.
     */
    public function test_seed_method(): void
    {
        $this->seed(CountriesSeeder::class, CurrenciesSeeder::class);

        $this->assertDatabaseHas('countries', ['name' => 'Australia']);
        $this->assertDatabaseHas('currencies', ['name' => 'AUD']);
    }
}
```

It is working as expected.

[1]: https://aschmelyun.com/blog/installing-a-local-composer-package-in-your-php-project/