### PR TITLE
[10.x] Fix Stringable::convertCase() return type

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -205,7 +205,7 @@ class Stringable implements JsonSerializable, ArrayAccess
      *
      * @param  int  $mode
      * @param  string  $encoding
-     * @return string
+     * @return static
      */
     public function convertCase(int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
     {


### PR DESCRIPTION
Return type was _string_ instead of _static_, broking method chaining on IDEs.
