### PR TITLE
Allow \Blade::stringable() to be called on native Iterables

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -162,6 +162,10 @@ trait CompilesEchos
             return call_user_func($this->echoHandlers[get_class($value)], $value);
         }
 
+        if (is_iterable($value) && isset($this->echoHandlers['iterable'])) {
+            return call_user_func($this->echoHandlers['iterable'], $value);
+        }
+
         return $value;
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -81,6 +81,34 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     }
 
     /**
+     * @dataProvider handlerWorksWithIterableDataProvider
+     */
+    public function testHandlerWorksWithIterables($blade, $closure, $expectedOutput)
+    {
+        $this->compiler->stringable('iterable', $closure);
+
+        app()->singleton('blade.compiler', function () {
+            return $this->compiler;
+        });
+
+        ob_start();
+        eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertSame($expectedOutput, $output);
+    }
+
+    public static function handlerWorksWithIterableDataProvider()
+    {
+        return [
+            ['{{[1,"two",3]}}', function(iterable $arr) {
+                return implode(', ', $arr);
+            }, "1, two, 3"],
+        ];
+    }
+
+    /**
      * @dataProvider nonStringableDataProvider
      */
     public function testHandlerWorksWithNonStringables($blade, $expectedOutput)


### PR DESCRIPTION
\Blade::stringable() currently allows applications to define how specific objects are converted to strings. However, it does not currently allow custom echo handler for native types. For the most part, this is fine because native types are automatically converted to Strings - however, this isn't the case for iterables.

The PR allows for applications to define custom echo handlers to iterables. For example, an application can add support for automatically outputting an array as a comma separated list.