### PR TITLE
[10.x] Add Str::randomDigits method 

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -932,6 +932,12 @@ class Str
         })($length);
     }
 
+    public static function randomDigits($length = 16)
+    {
+        $min = pow(10, $length - 1);
+        $max = pow(10, $length) - 1;
+        return rand($min, $max);
+    }
     /**
      * Set the callable that will be used to generate random strings.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -935,8 +935,9 @@ class Str
     /**
      * Generate a random digits with a specified number of places.
      *
-     * @param int $length
+     * @param  int  $length
      * @return int
+     *
      * @throws \Exception
      */
     public static function randomDigits($length = 16): int

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -933,19 +933,18 @@ class Str
     }
 
     /**
-     * Generate a random digits with a specified number of places.
+     * Generate a random digits string that has a specified length.
      *
-     * @param  int  $length
-     * @return int
+     * @param int $length
+     * @return string
      *
      * @throws \Exception
      */
-    public static function randomDigits($length = 16): int
+    public static function randomDigits(int $length = 16): string
     {
-        $min = pow(10, $length - 1);
         $max = pow(10, $length) - 1;
 
-        return random_int($min, $max);
+        return sprintf("%0" . $length . "d", random_int(1, $max));
     }
     /**
      * Set the callable that will be used to generate random strings.

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -937,6 +937,7 @@ class Str
      *
      * @param  int  $length
      * @return int
+     *
      * @throws \Exception
      */
     public static function randomDigits($length = 16): int

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -932,11 +932,19 @@ class Str
         })($length);
     }
 
-    public static function randomDigits($length = 16)
+    /**
+     * Generate a random digits with a specified number of places.
+     *
+     * @param int $length
+     * @return int
+     * @throws \Exception
+     */
+    public static function randomDigits($length = 16): int
     {
         $min = pow(10, $length - 1);
         $max = pow(10, $length) - 1;
-        return rand($min, $max);
+
+        return random_int($min, $max);
     }
     /**
      * Set the callable that will be used to generate random strings.

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -935,7 +935,7 @@ class Str
     /**
      * Generate a random digits with a specified number of places.
      *
-     * @param int $length
+     * @param  int  $length
      * @return int
      * @throws \Exception
      */

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1330,6 +1330,18 @@ class SupportStrTest extends TestCase
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }
+
+    public function testRandomDigits()
+    {
+        $randomDigits = Str::randomDigits(6);
+
+        $this->assertIsInt($randomDigits);
+        $this->assertEquals(6, strlen($randomDigits));
+        $this->assertThat($randomDigits, $this->logicalAnd(
+            $this->greaterThanOrEqual(100000),
+            $this->lessThanOrEqual(999999)
+        ));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1335,10 +1335,10 @@ class SupportStrTest extends TestCase
     {
         $randomDigits = Str::randomDigits(6);
 
-        $this->assertIsInt($randomDigits);
         $this->assertEquals(6, strlen($randomDigits));
-        $this->assertThat($randomDigits, $this->logicalAnd(
-            $this->greaterThanOrEqual(100000),
+
+        $this->assertThat((int)$randomDigits, $this->logicalAnd(
+            $this->greaterThanOrEqual(1),
             $this->lessThanOrEqual(999999)
         ));
     }


### PR DESCRIPTION
**Description:** 

This PR adds a method `randomDigits` to the Str support class.

**Examples:**

```php
Str::randomDigits(6); // 789645
Str::randomDigits(3) // 318
```
**Limitations:** 

The size limit for integers is platform-dependent. On most 64-bit systems, it is 9223372036854775807, which is 2^63 - 1. Therefore, this method can only generate a number that has 18 digits or less (for 64-bit systems).