### PR TITLE
[10.x] Add the possibility to change global options for HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -35,6 +36,24 @@ class Factory
      * @var array
      */
     protected $globalMiddleware = [];
+
+    /**
+     * The global options to apply on every request.
+     *
+     * @var array
+     */
+    protected $globalOptions = [];
+
+    /**
+     * The list of allowed global options to apply on every request.
+     *
+     * @var string[]
+     */
+    protected $avaialableGlobalOptions = [
+        'connect_timeout',
+        'http_errors',
+        'timeout'
+    ];
 
     /**
      * The stub callables that will handle requests.
@@ -93,6 +112,19 @@ class Factory
     public function globalMiddleware($middleware)
     {
         $this->globalMiddleware[] = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Add global options to apply on every request.
+     *
+     * @param array $options
+     * @return $this
+     */
+    public function globalOptions(array $options)
+    {
+        $this->globalOptions = Arr::only($options, $this->avaialableGlobalOptions);
 
         return $this;
     }
@@ -400,7 +432,7 @@ class Factory
      */
     protected function newPendingRequest()
     {
-        return new PendingRequest($this, $this->globalMiddleware);
+        return new PendingRequest($this, $this->globalMiddleware, $this->globalOptions);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -49,7 +49,7 @@ class Factory
      *
      * @var string[]
      */
-    protected $avaialableGlobalOptions = [
+    protected $availableGlobalOptions = [
         'connect_timeout',
         'http_errors',
         'timeout'
@@ -124,7 +124,7 @@ class Factory
      */
     public function globalOptions(array $options)
     {
-        $this->globalOptions = Arr::only($options, $this->avaialableGlobalOptions);
+        $this->globalOptions = Arr::only($options, $this->availableGlobalOptions);
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -220,20 +220,21 @@ class PendingRequest
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
      * @param  array  $middleware
+     * @param  array  $options
      * @return void
      */
-    public function __construct(Factory $factory = null, $middleware = [])
+    public function __construct(Factory $factory = null, $middleware = [], $options = [])
     {
         $this->factory = $factory;
         $this->middleware = new Collection($middleware);
 
         $this->asJson();
 
-        $this->options = [
+        $this->options = array_merge([
             'connect_timeout' => 10,
             'http_errors' => false,
             'timeout' => 30,
-        ];
+        ], $options);
 
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $pendingRequest) {
             $pendingRequest->request = $request;

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Client\Factory;
 
 /**
  * @method static \Illuminate\Http\Client\Factory globalMiddleware(callable $middleware)
+ * @method static \Illuminate\Http\Client\Factory globalOptions(array $options)
  * @method static \Illuminate\Http\Client\Factory globalRequestMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\Factory globalResponseMiddleware(callable $middleware)
  * @method static \GuzzleHttp\Promise\PromiseInterface response(array|string|null $body = null, int $status = 200, array $headers = [])

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2634,6 +2634,23 @@ class HttpClientTest extends TestCase
         $this->assertSame('', $responses[1]->header('X-Foo'));
     }
 
+    public function testItCanAddGlobalOptions()
+    {
+        $options = [
+            'connect_timeout' => 5,
+            'http_errors' => true,
+            'timeout' => 10,
+            'foo' => 'bar'
+        ];
+
+        $this->factory->globalOptions($options);
+
+        $this->assertSame($this->factory->getOptions()['timeout'], $options['timeout']);
+        $this->assertSame($this->factory->getOptions()['connect_timeout'], $options['connect_timeout']);
+        $this->assertSame($this->factory->getOptions()['http_errors'], $options['http_errors']);
+        $this->assertArrayNotHasKey('foo', $this->factory->getOptions());
+    }
+
     public function testItReturnsResponse(): void
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR adds an option to change the default HTTP client configuration. In my case, it would be useful for the timeout option, since I want to increase it on a project level, but I guess that other people also would like to change `http_errors` or maybe even `connect_timeout`. 

So the goal is to do something like this in the service provider boot method

```php
Http::globalOptions([
     'timeout' => 60,
     'http_errors' => true
]);
```

Let me know what you think about it.


