### PR TITLE
[10.x] Prevents `trim` in `ComponentAttributeBag::__toString()` when `$value` is array

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -507,7 +507,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
         $string = '';
 
         foreach ($this->attributes as $key => $value) {
-            if ($value === false || is_null($value)) {
+            if ($value === false || is_null($value) || is_array($value)) {
                 continue;
             }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When we are dealing with components and we pass an attribute that is an array when trying to print the attributes we will have an error due to the attempt to trim an array:

```blade
<x-test foo="bar" :test="['foo' => 'bar']" />
```

Result:

![CleanShot 2024-01-05 at 15 32 40](https://github.com/laravel/framework/assets/60591772/e17b614d-1f11-4bd1-9748-75d8f264ed09)

There are two solutions for this:

1. Throw an exception that indicates the error _(attempts to trim an array)_ or;
2. Ignore when `$value` is an array.

I preferred the second, but I would like to hear the opinion of the Laravel team, on whether the first is correct. This way I can adapt the pull request.