### PR TITLE
[10.x] Add `onSuccess` method to `Response` class

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -220,6 +220,21 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Execute the given callback if the request wat successfull.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onSuccess(callable $callback)
+    {
+        if ($this->successful()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the response cookies.
      *
      * @return \GuzzleHttp\Cookie\CookieJar

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1235,6 +1235,70 @@ class HttpClientTest extends TestCase
         $this->assertSame(501, $response->status());
     }
 
+    public function testOnSuccessDoesntCallClosureOnInformational()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 101),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(101, $response->status());
+    }
+
+    public function testOnSuccessDoesntCallClosureOnRedirection()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 301),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(301, $response->status());
+    }
+
+    public function testOnSuccessDoesntCallClosureOnClientError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(401, $response->status());
+    }
+
+    public function testOnSuccessCallsClosureOnSuccess()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(201, $status);
+        $this->assertSame(201, $response->status());
+    }
+
     public function testSinkToFile()
     {
         $this->factory->fakeSequence()->push('abc123');

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1283,6 +1283,22 @@ class HttpClientTest extends TestCase
         $this->assertSame(401, $response->status());
     }
 
+    public function testOnSuccessDoesntCallClosureOnServerError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 501),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onSuccess(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(501, $response->status());
+    }
+
     public function testOnSuccessCallsClosureOnSuccess()
     {
         $status = 0;


### PR DESCRIPTION
This PR introduces a new method, `onSuccess`, to the `Illuminate\Http\Client\Response` class. This method allows users to execute a given callback if the HTTP request was successful. The purpose is to provide a convenient way to handle success scenarios without explicitly checking the success status in the calling code.

Additionally, Laravel already includes an `onError` method in the HTTP client, enabling users to easily handle errors. The combination of these methods allows for cleaner and more expressive chaining in HTTP client usage.

``` php
   
use Illuminate\Support\Facades\Http;

$response = Http::get('https://example.com/api/data')
    ->onSuccess(function ($response) {
        // Handle successful response
        $data = $response->json();
        // ... your logic here ...
    })
    ->onError(function ($response) {
        // ... your error handling logic here ...
    });
```