### PR TITLE
[11.x] Improves Trust Proxies Configuration

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 
@@ -181,4 +182,17 @@ return [
         // 'Example' => App\Facades\Example::class,
     ])->toArray(),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Trust Proxies Support
+    |--------------------------------------------------------------------------
+    |
+    | If your application is served through load balancers or other reverse proxies,
+    | you may configure their addresses and the headers to trust below.
+    |
+    */
+    'trustedproxy' => [
+        'proxies' => env('TRUSTEDPROXY_PROXIES', '*'),
+        'headers' => env('TRUSTEDPROXY_HEADERS'),
+    ],
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies = '*';
+    protected $proxies;
 
     /**
      * The proxy header mappings.

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -19,11 +19,7 @@ class TrustProxies
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_FOR |
-                         Request::HEADER_X_FORWARDED_HOST |
-                         Request::HEADER_X_FORWARDED_PORT |
-                         Request::HEADER_X_FORWARDED_PROTO |
-                         Request::HEADER_X_FORWARDED_AWS_ELB;
+    protected $headers;
 
     /**
      * Handle an incoming request.

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -96,7 +96,7 @@ class TrustProxies
             return $this->headers;
         }
 
-        return match ($this->headers) {
+        return match ($this->headers ?: config('trustedproxy.headers')) {
             'HEADER_X_FORWARDED_AWS_ELB' => Request::HEADER_X_FORWARDED_AWS_ELB,
             'HEADER_X_FORWARDED_TRAEFIK' => Request::HEADER_X_FORWARDED_TRAEFIK,
             'HEADER_FORWARDED' => Request::HEADER_FORWARDED,

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -98,6 +98,7 @@ class TrustProxies
 
         return match ($this->headers) {
             'HEADER_X_FORWARDED_AWS_ELB' => Request::HEADER_X_FORWARDED_AWS_ELB,
+            'HEADER_X_FORWARDED_TRAEFIK' => Request::HEADER_X_FORWARDED_TRAEFIK,
             'HEADER_FORWARDED' => Request::HEADER_FORWARDED,
             'HEADER_X_FORWARDED_FOR' => Request::HEADER_X_FORWARDED_FOR,
             'HEADER_X_FORWARDED_HOST' => Request::HEADER_X_FORWARDED_HOST,

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -326,8 +326,8 @@ class TrustProxiesTest extends TestCase
     {
         $request = $this->createProxiedRequest();
 
-        // trust *all* "X-Forwarded-*" headers
-        $trustedProxy = $this->createTrustedProxy('HEADER_X_FORWARDED_ALL', '192.168.1.1, 192.168.1.2');
+        // trust the default headers
+        $trustedProxy = $this->createTrustedProxy(null, '192.168.1.1, 192.168.1.2');
         $trustedProxy->handle($request, function (Request $request) {
             $this->assertEquals($request->getTrustedHeaderSet(), $this->headerAll,
                 'Assert trusted proxy used all "X-Forwarded-*" header');

--- a/tests/Integration/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Integration/Http/Middleware/TrustProxiesTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Http\Middleware;
 
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Orchestra\Testbench\TestCase;
@@ -27,7 +27,7 @@ class TrustProxiesTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $kernel = $app->make(Kernel::class);
-        $kernel->prependMiddleware(HandleCors::class);
+        $kernel->prependMiddleware(TrustProxies::class);
 
         $router = $app['router'];
 

--- a/tests/Integration/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Integration/Http/Middleware/TrustProxiesTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Http\Middleware;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Middleware\TrustProxies;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Orchestra\Testbench\TestCase;
 
@@ -35,7 +34,6 @@ class TrustProxiesTest extends TestCase
 
         parent::getEnvironmentSetUp($app);
     }
-
 
     public function testDefaultConfigurationDoesNotTrustAnyProxies()
     {

--- a/tests/Integration/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Integration/Http/Middleware/TrustProxiesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Middleware;
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Orchestra\Testbench\TestCase;
+
+class TrustProxiesTest extends TestCase
+{
+    use ValidatesRequests;
+
+    protected const TEST_REQUEST_HEADERS =[
+        'HTTP_X_FORWARDED_FOR' => '173.174.200.38',         // X-Forwarded-For    -- getClientIp()
+        'HTTP_X_FORWARDED_HOST' => 'serversforhackers.com', // X-Forwarded-Host   -- getHosts()
+        'HTTP_X_FORWARDED_PORT' => '443',                   // X-Forwarded-Port   -- getPort()
+        'HTTP_X_FORWARDED_PREFIX' => '/prefix',             // X-Forwarded-Prefix -- getBaseUrl()
+        'HTTP_X_FORWARDED_PROTO' => 'https',                // X-Forwarded-Proto  -- getScheme() / isSecure()
+        'SERVER_PORT' => 80,
+        'HTTP_HOST' => 'localhost',
+        'REMOTE_ADDR' => '192.168.10.10',
+    ];
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $kernel = $app->make(Kernel::class);
+        $kernel->prependMiddleware(HandleCors::class);
+
+        $router = $app['router'];
+
+        $this->addWebRoutes($router);
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+
+    public function testDefaultConfigurationDoesNotTrustAnyProxies()
+    {
+        $crawler = $this->call('POST', 'web/ping', [], [], [],
+            self::TEST_REQUEST_HEADERS
+        );
+
+        $this->assertEquals('192.168.10.10', $crawler->baseRequest->getClientIp(), 'client ip not taken from untrusted proxy');
+        $this->assertEquals('localhost', $crawler->baseRequest->getHost(), 'host not taken from untrusted proxy');
+        $this->assertEquals(80, $crawler->baseRequest->getPort(), 'port not taken from untrusted proxy');
+        $this->assertEquals('http', $crawler->baseRequest->getScheme(), 'scheme not taken from untrusted proxy');
+        $this->assertEquals('', $crawler->baseRequest->getBaseUrl(), 'base url not taken from untrusted proxy');
+    }
+
+    public function testTrustingAllProxies()
+    {
+        $this->app['config']->set('trustedproxy.proxies', '*');
+
+        $crawler = $this->call('POST', 'web/ping', [], [], [],
+            self::TEST_REQUEST_HEADERS
+        );
+
+        // repeat the assertions from the previous test but with updated values
+        $this->assertEquals('173.174.200.38', $crawler->baseRequest->getClientIp(), 'client ip taken from trusted proxy');
+        $this->assertEquals('serversforhackers.com', $crawler->baseRequest->getHost(), 'host taken from trusted proxy');
+        $this->assertEquals(443, $crawler->baseRequest->getPort(), 'port taken from trusted proxy');
+        $this->assertEquals('https', $crawler->baseRequest->getScheme(), 'scheme taken from trusted proxy');
+        $this->assertEquals('/prefix', $crawler->baseRequest->getBaseUrl(), 'base url taken from trusted proxy');
+
+    }
+
+    protected function addWebRoutes(Router $router)
+    {
+        $router->post('web/ping', [
+            'uses' => function () {
+                return 'PONG';
+            },
+        ]);
+    }
+
+}


### PR DESCRIPTION
This pull request adds the ability to configure trust proxies and trust proxy headers through environment variables. The default configuration is not to trust any proxy (reverting to the default from 10.x and before). It also adds a new integration test for trust proxies configuration and fixes some minor inconsistencies as described below.

# Benefits
- Not trusting proxies by default mitigates the serious security risks that can arise from unwarranted trust in proxy headers (especially X-Forwarded-For)
- New env variables provide a convenient way for developers to adapt the settings to their specific environment
- Backwards compatibility: Fully backwards compatible to 10.x and prior versions. The trusted proxy host default stays the same, and we ensure that one header (HEADER_X_FORWARDED_PREFIX) is always included in the trusted set

# Main Change: Add Environment Variables to make Trust Proxies Configurable

```
TRUSTEDPROXY_PROXIES=* # or e.g. a comma-separated list of IPS
TRUSTEDPROXY_HEADERS=HEADER_X_FORWARDED_AWS_ELB # see TrustProxies.php::getTrustedHeaderNames
```
Default values:

- TRUSTEDPROXY_PROXIES = null (reverting to 10.x)
- TRUSTEDPROXY_HEADERS = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_PREFIX | Request::HEADER_X_FORWARDED_AWS_ELB (ensures the Request::HEADER_X_FORWARDED_PREFIX is always included, which was not ensured before)

A new integration test has been added for the configuration.

# Other changes

- Update tests/Http/Middleware/TrustProxiesTest.php to reflect that HEADER_X_FORWARDED_ALL was removed in symfony
- Ensure default values for trusted proxy headers are set in one place only. Before, the default value could be set either through the default value of the TrustProxy::headers property or through the getTrustedHeaderNames method, depending on context, and values were slightly different. Now the default header is only set in the latter method to ensure consistency.
- Add HEADER_X_FORWARDED_TRAEFIK as a possible header configuration value