### PR TITLE
fix `make:model` path prefix with -c  flag Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -134,7 +134,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createController()
     {
-        $controller = Str::studly(class_basename($this->argument('name')));
+        $controller = $this->getNameInput();
 
         $modelName = $this->qualifyClass($this->getNameInput());
 

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -154,10 +154,10 @@ class ModelMakeCommandTest extends TestCase
         ], 'app/Models/Foo/Bar.php');
 
         $this->assertFileContains([
-            'namespace App\Http\Controllers;',
+            'namespace App\Http\Controllers\Foo;',
             'use Illuminate\Http\Request;',
             'class BarController extends Controller',
-        ], 'app/Http/Controllers/BarController.php');
+        ], 'app/Http/Controllers/Foo/BarController.php');
 
         $this->assertFilenameNotExists('database/factories/FooFactory.php');
         $this->assertFilenameNotExists('database/seeders/FooSeeder.php');


### PR DESCRIPTION
fix path prefix when create controller with flag (-c) in `make:model` command :
` php artisan make:model v2/Character -c`
Considering `v2` as controller prefix as well

