### PR TITLE
[11.x] Add methods to `ProcessResult` interface

### DIFF
--- a/src/Illuminate/Contracts/Process/ProcessResult.php
+++ b/src/Illuminate/Contracts/Process/ProcessResult.php
@@ -40,11 +40,27 @@ interface ProcessResult
     public function output();
 
     /**
+     * Determine if the output contains the given string.
+     *
+     * @param  string  $output
+     * @return bool
+     */
+    public function seeInOutput(string $output);
+
+    /**
      * Get the error output of the process.
      *
      * @return string
      */
     public function errorOutput();
+
+    /**
+     * Determine if the error output contains the given string.
+     *
+     * @param  string  $output
+     * @return bool
+     */
+    public function seeInErrorOutput(string $output);
 
     /**
      * Throw an exception if the process failed.


### PR DESCRIPTION
Add missing methods to  `ProcessResult` interface