### PR TITLE
[10.x] Add 'whereSlug' method for route parameter validation against slug format

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -40,6 +40,17 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters must have slug format.
+     *
+     * @param  array|string  $parameters
+     * @return $this
+     */
+    public function whereSlug($parameters)
+    {
+        return $this->assignExpressionToParameters($parameters, '[a-z0-9-_]+');
+    }
+
+    /**
      * Specify that the given route parameters must be ULIDs.
      *
      * @param  array|string  $parameters

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -84,6 +84,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar whereAlpha(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereAlphaNumeric(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereNumber(array|string $parameters)
+ * @method static \Illuminate\Routing\RouteRegistrar whereSlug(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUlid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUuid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereIn(array|string $parameters, array $values)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -917,7 +917,6 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
-
     public function testWhereSlugRegistration()
     {
         $wheres = ['foo' => '[a-z0-9-_]+', 'bar' => '[a-z0-9-_]+'];

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -917,6 +917,20 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+
+    public function testWhereSlugRegistration()
+    {
+        $wheres = ['foo' => '[a-z0-9-_]+', 'bar' => '[a-z0-9-_]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereSlug(['foo', 'bar']);
+        $this->router->get('/api/{bar}/{foo}')->whereSlug(['bar', 'foo']);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testWhereAlphaNumericRegistration()
     {
         $wheres = ['1a2b3c' => '[a-zA-Z0-9]+'];


### PR DESCRIPTION
Slugs are a crucial component in many web applications, used for creating user-friendly and readable URLs. So I propose the addition of the whereSlug method. This method enables effective validation of route parameters against a slug format, ensuring that only safe characters are used (lowercase letters, numbers, hyphens, and underscores). This enhances the security and integrity of URLs, as well as simplifies development.

The whereSlug method is versatile and can be applied to any route parameter, not limited to specific use cases. Here's an example of its usage:

```
Route::get('/foo/{bar}')->whereSlug('bar');
```

With this addition, developers can easily ensure that route parameters are in the correct slug format, enhancing the quality and reliability of routes in Laravel.