### PR TITLE
[10.x] Add `assertCount` test helper

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -121,6 +121,22 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
+     * Assert the total count of jobs that were pushed.
+     *
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function assertCount($expectedCount)
+    {
+        $actualCount = $this->size();
+
+        PHPUnit::assertSame(
+            $expectedCount, $actualCount,
+            "Expected {$expectedCount} jobs to be pushed, but found {$actualCount} instead."
+        );
+    }
+
+    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string  $queue

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -121,22 +121,6 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
-     * Assert the total count of jobs that were pushed.
-     *
-     * @param  int  $expectedCount
-     * @return void
-     */
-    public function assertCount($expectedCount)
-    {
-        $actualCount = $this->size();
-
-        PHPUnit::assertSame(
-            $expectedCount, $actualCount,
-            "Expected {$expectedCount} jobs to be pushed, but found {$actualCount} instead."
-        );
-    }
-
-    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string  $queue
@@ -291,6 +275,22 @@ class QueueFake extends QueueManager implements Fake, Queue
         PHPUnit::assertCount(
             0, $this->pushed($job, $callback),
             "The unexpected [{$job}] job was pushed."
+        );
+    }
+
+    /**
+     * Assert the total count of jobs that were pushed.
+     *
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function assertCount($expectedCount)
+    {
+        $actualCount = collect($this->jobs)->flatten(1)->count();
+
+        PHPUnit::assertSame(
+            $expectedCount, $actualCount,
+            "Expected {$expectedCount} jobs to be pushed, but found {$actualCount} instead."
         );
     }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -176,6 +176,18 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class, 2);
     }
 
+    public function testAssertCount()
+    {
+        $this->fake->push(function () {
+
+        });
+
+        $this->fake->push($this->job);
+        $this->fake->push($this->job);
+
+        $this->fake->assertCount(3);
+    }
+
     public function testAssertNothingPushed()
     {
         $this->fake->assertNothingPushed();

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -179,7 +179,7 @@ class SupportTestingQueueFakeTest extends TestCase
     public function testAssertCount()
     {
         $this->fake->push(function () {
-
+            // Do nothing
         });
 
         $this->fake->push($this->job);


### PR DESCRIPTION
Adds a new method `assertCount` for asserting the total count of pushed jobs.