### PR TITLE
[10.x] Add a `threshold` parameter to the `Number::spell` helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -46,6 +46,7 @@ class Number
      *
      * @param  int|float  $number
      * @param  string|null  $locale
+     * @param  int|null  $threshold
      * @return string
      */
     public static function spell(int|float $number, ?string $locale = null, ?int $threshold = null)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -46,12 +46,17 @@ class Number
      *
      * @param  int|float  $number
      * @param  string|null  $locale
+     * @param  int|null  $after
      * @param  int|null  $until
      * @return string
      */
-    public static function spell(int|float $number, ?string $locale = null, ?int $until = null)
+    public static function spell(int|float $number, ?string $locale = null, ?int $after = null, ?int $until = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (! is_null($after) && $number <= $after) {
+            return static::format($number, locale: $locale);
+        }
 
         if (! is_null($until) && $number >= $until) {
             return static::format($number, locale: $locale);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -46,14 +46,14 @@ class Number
      *
      * @param  int|float  $number
      * @param  string|null  $locale
-     * @param  int|null  $threshold
+     * @param  int|null  $until
      * @return string
      */
-    public static function spell(int|float $number, ?string $locale = null, ?int $threshold = null)
+    public static function spell(int|float $number, ?string $locale = null, ?int $until = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
-        if (! is_null($threshold) && $number > $threshold) {
+        if (! is_null($until) && $number >= $until) {
             return static::format($number, locale: $locale);
         }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -48,9 +48,13 @@ class Number
      * @param  string|null  $locale
      * @return string
      */
-    public static function spell(int|float $number, ?string $locale = null)
+    public static function spell(int|float $number, ?string $locale = null, ?int $threshold = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (! is_null($threshold) && $number > $threshold) {
+            return static::format($number, locale: $locale);
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -77,6 +77,17 @@ class SupportNumberTest extends TestCase
         $this->assertSame('trois', Number::spell(3, 'fr'));
     }
 
+    public function testSpelloutWithThreshold()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('ten', Number::spell(10, threshold: 10));
+        $this->assertSame('11', Number::spell(11, threshold: 10));
+
+        $this->assertSame('ten thousand', Number::spell(10000, threshold: 50000));
+        $this->assertSame('100,000', Number::spell(100000, threshold: 50000));
+    }
+
     public function testOrdinal()
     {
         $this->assertSame('1st', Number::ordinal(1));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -81,6 +81,10 @@ class SupportNumberTest extends TestCase
     {
         $this->needsIntlExtension();
 
+        $this->assertSame('9', Number::spell(9, after: 10));
+        $this->assertSame('10', Number::spell(10, after: 10));
+        $this->assertSame('eleven', Number::spell(11, after: 10));
+
         $this->assertSame('nine', Number::spell(9, until: 10));
         $this->assertSame('10', Number::spell(10, until: 10));
         $this->assertSame('11', Number::spell(11, until: 10));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -81,11 +81,12 @@ class SupportNumberTest extends TestCase
     {
         $this->needsIntlExtension();
 
-        $this->assertSame('ten', Number::spell(10, threshold: 10));
-        $this->assertSame('11', Number::spell(11, threshold: 10));
+        $this->assertSame('nine', Number::spell(9, until: 10));
+        $this->assertSame('10', Number::spell(10, until: 10));
+        $this->assertSame('11', Number::spell(11, until: 10));
 
-        $this->assertSame('ten thousand', Number::spell(10000, threshold: 50000));
-        $this->assertSame('100,000', Number::spell(100000, threshold: 50000));
+        $this->assertSame('ten thousand', Number::spell(10000, until: 50000));
+        $this->assertSame('100,000', Number::spell(100000, until: 50000));
     }
 
     public function testOrdinal()


### PR DESCRIPTION
Adds a parameter to limit how high numbers are spelled out. Perfect for when you only want let's say numbers 0-10 spelled out!

```php
Number::spell(8, threshold: 10); // eight
Number::spell(9, threshold: 10); // nine
Number::spell(10, threshold: 10); // ten
Number::spell(11, threshold: 10); // 11
Number::spell(12, threshold: 10); // 12
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
