### PR TITLE
[10.x] Refines Queries from Request

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Refine\RefineQuery;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -1009,6 +1010,18 @@ class Builder implements BuilderContract
         return collect($orders)
             ->filter(fn ($order) => Arr::has($order, 'direction'))
             ->values();
+    }
+
+    /**
+     * Refines the Query Builder using a refiner class.
+     *
+     * @param  string  $refiner
+     * @param  array|null  $data
+     * @return $this
+     */
+    public function refineBy(string $refiner, array $data = null)
+    {
+        return RefineQuery::make($this, $refiner)->refine($data);
     }
 
     /**

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -46,6 +46,7 @@
         "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
         "illuminate/filesystem": "Required to use the migrations (^10.0).",
         "illuminate/pagination": "Required to paginate the result set (^10.0).",
+        "illuminate/refiner": "Required to refine the query by a request query (^10.0).",
         "symfony/finder": "Required to use Eloquent model factories (^6.2)."
     },
     "config": {

--- a/src/Illuminate/Foundation/Console/RefinerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RefinerMakeCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:refiner')]
+class RefinerMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:refiner';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new custom Refiner class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Refiner';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/refiner.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Refiners';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the cast already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/refiner.stub
+++ b/src/Illuminate/Foundation/Console/stubs/refiner.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Refine\Refiner;
+
+class {{ class }} extends Refiner
+{
+    /**
+     * Create a new refiner instance
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -61,6 +61,7 @@ use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
+use Illuminate\Foundation\Console\RefinerMakeCommand;
 use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
@@ -192,6 +193,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ObserverMake' => ObserverMakeCommand::class,
         'PolicyMake' => PolicyMakeCommand::class,
         'ProviderMake' => ProviderMakeCommand::class,
+        'RefinerMake' => RefinerMakeCommand::class,
         'QueueFailedTable' => FailedTableCommand::class,
         'QueueTable' => TableCommand::class,
         'QueueBatchesTable' => BatchesTableCommand::class,

--- a/src/Illuminate/Refine/.gitattributes
+++ b/src/Illuminate/Refine/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Refine/LICENSE.md
+++ b/src/Illuminate/Refine/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Illuminate/Refine/RefineQuery.php
+++ b/src/Illuminate/Refine/RefineQuery.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Refine;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use function array_diff;
+use function is_callable;
+
+class RefineQuery
+{
+    /**
+     * The container resolver.
+     *
+     * @var callable(string $abstract): mixed
+     */
+    protected static $resolver;
+
+    /**
+     * Create a new refine query instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Refine\Refiner  $refiner
+     */
+    public function __construct(protected $builder, protected $refiner)
+    {
+        //
+    }
+
+    /**
+     * Refine the query using the HTTP Request query.
+     *
+     * @param  array|null  $data
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function refine(array $data = null)
+    {
+        $data ??= $this->request()->query();
+
+        $request = $this->request();
+
+        $this->refiner->before($this->builder, $request);
+
+        // Retrieve the keys to use for refinement without the default methods
+        $keys = array_values(array_diff($this->refiner->keys($request), ['keys', 'before', 'after']));
+
+        foreach (Arr::only($data, $keys) as $key => $value) {
+            $method = Str::camel($key);
+
+            if (is_callable([$this->refiner, $method])) {
+                $this->refiner->{$method}($this->builder, $value, $request);
+            }
+        }
+
+        $this->refiner->after($this->builder, $request);
+
+        return $this->builder;
+    }
+
+    /**
+     * Resolve an abstract from the container.
+     *
+     * @param  string  $abstract
+     * @return mixed
+     */
+    protected static function resolve(string $abstract)
+    {
+        return (static::$resolver)($abstract);
+    }
+
+    /**
+     * Retrieve the current request.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function request()
+    {
+        return static::resolve('request');
+    }
+
+    /**
+     * Sets a resolver callable for the given container.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $app
+     * @return void
+     */
+    public static function setResolver($app)
+    {
+        static::$resolver = fn ($abstract) => $app->make($abstract);
+    }
+
+    /**
+     * Unsets the callable resolver.
+     *
+     * @return void
+     */
+    public static function unsetResolver()
+    {
+        static::$resolver = null;
+    }
+
+    /**
+     * Create a new refine query instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  class-string|string  $refiner
+     * @return static
+     */
+    public static function make($builder, string $refiner): static
+    {
+        return new static($builder, static::resolve($refiner));
+    }
+}

--- a/src/Illuminate/Refine/RefineQuery.php
+++ b/src/Illuminate/Refine/RefineQuery.php
@@ -4,6 +4,7 @@ namespace Illuminate\Refine;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+
 use function array_diff;
 use function is_callable;
 
@@ -12,7 +13,7 @@ class RefineQuery
     /**
      * The container resolver.
      *
-     * @var callable(string $abstract): mixed
+     * @var callable(string): mixed
      */
     protected static $resolver;
 

--- a/src/Illuminate/Refine/RefineQueryServiceProvider.php
+++ b/src/Illuminate/Refine/RefineQueryServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Refine;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\ServiceProvider;
+
+class RefineQueryServiceProvider extends ServiceProvider
+{
+    /**
+     * Boot the service provider.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        RefineQuery::setResolver($this->app);
+    }
+}

--- a/src/Illuminate/Refine/RefineQueryServiceProvider.php
+++ b/src/Illuminate/Refine/RefineQueryServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Refine;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\ServiceProvider;
 
 class RefineQueryServiceProvider extends ServiceProvider

--- a/src/Illuminate/Refine/Refiner.php
+++ b/src/Illuminate/Refine/Refiner.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Refine;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+
+abstract class Refiner
+{
+    /**
+     * Return the keys to use to refine the query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string[]
+     */
+    public function keys(Request $request): array
+    {
+        return $request->keys();
+    }
+
+    /**
+     * Run before the refiner executes its matched methods.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function before(Builder $query, Request $request): void
+    {
+        //
+    }
+
+    /**
+     * Run after the refiner has executed all its matched methods.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function after(Builder $query, Request $request): void
+    {
+        //
+    }
+}

--- a/src/Illuminate/Refine/composer.json
+++ b/src/Illuminate/Refine/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "illuminate/refine",
+    "description": "The Illuminate Refine package.",
+    "license": "MIT",
+    "homepage": "https://laravel.com",
+    "support": {
+        "issues": "https://github.com/laravel/framework/issues",
+        "source": "https://github.com/laravel/framework"
+    },
+    "authors": [
+        {
+            "name": "Taylor Otwell",
+            "email": "taylor@laravel.com"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "illuminate/database": "^10.0",
+        "illuminate/http": "^10.0",
+        "illuminate/support": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Illuminate\\Refine\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "10.x-dev"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev"
+}

--- a/tests/Integration/Generators/RefinerMakeCommandTest.php
+++ b/tests/Integration/Generators/RefinerMakeCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class RefinerMakeCommandTest extends TestCase
+{
+    protected $files = [
+        'app/Http/Refiners/Foo.php',
+    ];
+
+    public function testItCanGenerateCastFile()
+    {
+        $this->artisan('make:refiner', ['name' => 'Foo'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Http\Refiners;',
+            'use Illuminate\Refine\Refiner;',
+            'class Foo extends Refiner',
+            'public function __construct()',
+        ], 'app/Http/Refiners/Foo.php');
+    }
+}

--- a/tests/Refine/QueryRefinerTest.php
+++ b/tests/Refine/QueryRefinerTest.php
@@ -127,7 +127,6 @@ class QueryRefinerTest extends TestCase
 
 class MockModel extends Model
 {
-
 }
 
 class MockRefiner extends Refiner

--- a/tests/Refine/QueryRefinerTest.php
+++ b/tests/Refine/QueryRefinerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Illuminate\Tests\Refine;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Refine\RefineQuery;
+use Illuminate\Refine\Refiner;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class QueryRefinerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Model::setConnectionResolver($this->getMockConnectionResolver());
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        Model::unsetConnectionResolver();
+        RefineQuery::unsetResolver();
+    }
+
+    protected function getMockContainer()
+    {
+        return m::mock(Container::class);
+    }
+
+    protected function getMockQueryBuilder()
+    {
+        $mock = m::mock(Builder::class);
+        $mock->shouldReceive('from')->with(m::type('string'))->andReturnSelf();
+
+        return $mock;
+    }
+
+    protected function getMockConnection()
+    {
+        $mock = m::mock(ConnectionInterface::class);
+        $mock->shouldReceive('query')->andReturn($this->getMockQueryBuilder());
+
+        return $mock;
+    }
+
+    protected function getMockConnectionResolver()
+    {
+        $mock = m::mock(ConnectionResolverInterface::class);
+        $mock->shouldReceive('connection')->andReturn($this->getMockConnection());
+
+        return $mock;
+    }
+
+    /**
+     * @return \Illuminate\Database\Query\Builder|\Mockery\Mock
+     */
+    protected function mockRequestWithBuilder(array $data, Model $model, string $refiner)
+    {
+        $request = new Request($data);
+
+        $container = $this->getMockContainer();
+        $container->shouldReceive('make')->with($refiner)->andReturn(new $refiner);
+        $container->shouldReceive('make')->with('request')->andReturn($request);
+        RefineQuery::setResolver($container);
+
+        return $model->getConnection()->query();
+    }
+
+    public function testCallsMatchedMethod()
+    {
+        $model = new MockModel();
+
+        $query = $this->mockRequestWithBuilder(['foo' => 1, 'bar' => 2], $model, MockRefiner::class);
+
+        $query->shouldReceive('where')->with('foo', 1)->andReturnSelf();
+        $query->shouldReceive('where')->with('bar', 4)->andReturnSelf();
+        $query->shouldNotReceive('where')->with('quz', m::type('int'));
+
+        $model->newQuery()->refineBy(MockRefiner::class);
+    }
+
+    public function testCallsBeforeAndAfterMethod()
+    {
+        $model = new MockModel();
+
+        $query = $this->mockRequestWithBuilder(['foo' => 1], $model, MockRefinerAfterBefore::class);
+
+        $query->shouldReceive('where')->with('foo', 1)->andReturnSelf();
+        $query->shouldReceive('where')->with('after', true)->andReturnSelf();
+        $query->shouldReceive('where')->with('before', true)->andReturnSelf();
+        $query->shouldNotReceive('where')->with('bar', m::type('int'));
+        $query->shouldNotReceive('where')->with('quz', m::type('int'));
+
+        $model->newQuery()->refineBy(MockRefinerAfterBefore::class);
+    }
+
+    public function testUsesRuntimeData()
+    {
+        $model = new MockModel();
+
+        $query = $this->mockRequestWithBuilder(['foo' => 1, 'bar' => 2], $model, MockRefiner::class);
+
+        $query->shouldNotReceive('where')->with('foo', 2);
+        $query->shouldReceive('where')->with('bar', 7)->andReturnSelf();
+
+        $model->newQuery()->refineBy(MockRefiner::class, ['bar' => 5]);
+    }
+
+    public function testUsesCustomKeys()
+    {
+        $model = new MockModel();
+
+        $query = $this->mockRequestWithBuilder(['foo' => 1, 'bar' => 2], $model, MockKeysRefiner::class);
+
+        $query->shouldNotReceive('where')->with('foo', 1);
+        $query->shouldReceive('where')->with('bar', 4)->andReturnSelf();
+
+        $model->newQuery()->refineBy(MockKeysRefiner::class);
+    }
+}
+
+class MockModel extends Model
+{
+
+}
+
+class MockRefiner extends Refiner
+{
+    public function foo($builder, $value)
+    {
+        $builder->where('foo', $value);
+    }
+
+    public function bar($builder, $value, $request)
+    {
+        $builder->where('bar', $request->get('bar') + $value);
+    }
+
+    public function quz($builder, $value)
+    {
+        $builder->where('quz', $value);
+    }
+}
+
+class MockRefinerAfterBefore extends MockRefiner
+{
+    public function after(EloquentBuilder $query, Request $request): void
+    {
+        $query->where('after', true);
+    }
+
+    public function before(EloquentBuilder $query, Request $request): void
+    {
+        $query->where('before', true);
+    }
+}
+
+class MockKeysRefiner extends MockRefiner
+{
+    public function keys(Request $request): array
+    {
+        return ['bar'];
+    }
+}


### PR DESCRIPTION
# What?

This is a relatively big-but-small PR that adds the ability to "refine" a query. This allows to refine a database query based on the request query by moving that logic away from the controller. This PR adds the `illuminate/refine` package for the main reason it depends on both `illuminate/database` and `illuminate/http`.

For example, let's imagine we want to filter the posts _safely_ from the database from this request: 

```http request
GET https://mynewssite.com/posts?author_id=1&order_by=published_at
```

The normal way to filter that would be to push that logic into the controller itself:

```php
use Illuminate\Http\Request;
use App\Models\Post;

public function (Request $request)
{
    $request->validate([
        // ... 
    ])

    return Post::when($request->has('author_id'))->where('author_id', $request->get('author_id'))
               ->when($request->has('order_by'))->orderBy($request->get('order_by'))
               ->when($request->has('order_by_desc'))->orderByDesc($request->get('order_by_desc'))
               ->paginate();
}
```

The controller will grow in size at the same time more query keys are expected to manage the query, especially when managing virtual states of models (that are equivalent to multiple WHERE clauses on multiple columns), and adding gates to check if the user _can_ use a given key.

Instead, we could move all that logic into what I define as a "Refiner". This class is relatively simple to understand: for each key _present_ in the Request, call the matching method (in `camelCase`) on the Refiner class.

```php
use Illuminate\Http\Request;
use App\Models\Post;
use App\Http\Refiners\PostRefiner;

public function (Request $request)
{
    $request->validate([
        // ... ALWAYS VALIDATE YOUR INPUT OR QUERY
    ])

    return Post::refineBy(PostRefiner::class)->paginate();
}
```

All the logic is moved down to the "Refiner" class. That class is resolved by the container. That class is managed opaquely by another class (the "Query Refiner") that injects the current Request and the calls over that aforementioned Refiner matching methods. 

That Refiner looks like this:

```php
namespace App\Http\Refiners;

use Illuminate\Refine\Refiner;

class PostRefiner extends Refiner
{
    public function authorId($query, $value)
    {
        $query->where('author_id', $value)
    }
    
    public function orderBy($query, $value)
    {
        $query->orderBy($value);
    }
    
    public function orderByDesc($query, $value)
    {
        $query->orderByDesc($value);
    }
}
```

Not only we moved the refinement outside controller, it also moves the condition away from the actual _refinement_ logic.

The Refiner also allows to execute something on the Builder and Request _before_ and _after_ with the `before()` and `after()` method, respectively.

```php
namespace App\Http\Refiners;

use Illuminate\Refine\Refiner;

class PostRefiner extends Refiner
{
    public function before($builder, $request)
    {
        //...
    }
    
    public function after($builder, $request)
    {
        //...
    }
}
```

Finally, not every request will require all the keys. The developer can choose to limit the keys to use from the request using the `keys()` method. By default, it always returns all the keys from the Request, but in this following example it only checks for two keys.

```php
namespace App\Http\Refiners;

use Illuminate\Http\Request;
use Illuminate\Refine\Refiner;

class PostRefiner extends Refiner
{
    public function keys(Request $request): array
    {
        return ['author_id', 'order_by']
    }
}
```

This PR also includes tests for the Refine, the `make:refiner` command (which creates a file on `app\Http\Refiners`) and its test.