### PR TITLE
[10.x] Adds seeding within transaction

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
+++ b/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Console\Seeds;
+
+trait WithDatabaseTransaction
+{
+    /**
+     * If database transaction should be used.
+     *
+     * @return bool
+     */
+    protected function useDatabaseTransaction()
+    {
+        return true;
+    }
+
+    /**
+     * Wraps the seeder call in a database transaction.
+     *
+     * @param  callable  $callback
+     * @return callable
+     */
+    public function withDatabaseTransaction(callable $callback)
+    {
+        if (isset($this->container)) {
+            return fn() => $this->container->make('db.connection')->transaction($callback);
+        }
+
+        return $callback;
+    }
+}

--- a/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
+++ b/src/Illuminate/Database/Console/Seeds/WithDatabaseTransaction.php
@@ -23,7 +23,7 @@ trait WithDatabaseTransaction
     public function withDatabaseTransaction(callable $callback)
     {
         if (isset($this->container)) {
-            return fn() => $this->container->make('db.connection')->transaction($callback);
+            return fn () => $this->container->make('db.connection')->transaction($callback);
         }
 
         return $callback;

--- a/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
+++ b/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
@@ -3,6 +3,7 @@
 namespace {{ namespace }};
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Console\Seeds\WithDatabaseTransaction;
 use Illuminate\Database\Seeder;
 
 class {{ class }} extends Seeder

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database;
 use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\Console\Seeds\WithDatabaseTransaction;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -188,6 +189,10 @@ abstract class Seeder
 
         if (isset($uses[WithoutModelEvents::class])) {
             $callback = $this->withoutModelEvents($callback);
+        }
+
+        if (isset($uses[WithDatabaseTransaction::class]) && $this->useDatabaseTransaction()) {
+            $callback = $this->withDatabaseTransaction($callback);
         }
 
         return $callback();

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -126,7 +126,7 @@ class SeedCommandTest extends TestCase
         $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
 
         $connection = m::mock(ConnectionInterface::class);
-        $connection->shouldReceive('transaction')->andReturn(fn($callback) => Assert::assertTrue($callback()));
+        $connection->shouldReceive('transaction')->andReturn(fn ($callback) => Assert::assertTrue($callback()));
 
         $container = m::mock(Container::class);
         $container->shouldReceive('call');


### PR DESCRIPTION
# What?

This PR adds the ability to declare a seeder run inside a database transaction by using the `WithDatabaseTransaction` trait. The aim is to avoid incomplete or orphaned records when the seeder fails during development, forcing the developer to truncate the tables affected manually.

```php
namespace Database\Seeders;

use Illuminate\Database\Seeder;
use Illuminate\Database\Console\Seeds\WithDatabaseTransaction;
use App\Models\Post;
use App\Models\Comment;

class CommentSeeder extends Seeder
{
    use WithDatabaseTransaction;

    public function run()
    {
        return Comment::factory(1000000)
                      ->sequence(fn() => ['post_id' => Post::inRandomOrder()->value('id')])
                      ->create();
    }
}
```


While this can be done manually using `DB::transaction`, the trait allows the developer to programmatically wrap it. For example, the developer can disable them for SQLite `:memory:` database, or for others RDMS on large lists of seeded records.

```php
public function useDatabaseTransaction()
{
    $connection = Post::query()->getConnection();

    // Only run transactions when SQLite uses a file database for better performance.
    return $connection->getDriverName() === 'sqlite'
        && $connection->getConfig('database') !== ':memory:';
}
```