### PR TITLE
[10.x] Add `php artisan migrate:redo` command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RedoCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RedoCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Database\Console\Migrations;
+
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
+
+class RedoCommand extends BaseCommand
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'migrate:redo';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rollback and rerun 1 or more latest database migrations';
+
+    /**
+     * The migrator instance.
+     *
+     * @var \Illuminate\Database\Migrations\Migrator
+     */
+    protected $migrator;
+
+    /**
+     * Create a new migration rollback command instance.
+     *
+     * @param  \Illuminate\Database\Migrations\Migrator  $migrator
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct();
+
+        $this->migrator = $migrator;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        $this->call('migrate:rollback', array_filter([
+            '--step' => $this->option('step') ?? 1,
+        ]));
+
+        $this->call('migrate', array_filter([
+            '--step' => $this->option('step') ?? 1,
+        ]));
+
+        return 0;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted and re-applied'],
+        ];
+    }
+}

--- a/src/Illuminate/Database/Console/Migrations/RedoCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RedoCommand.php
@@ -55,11 +55,7 @@ class RedoCommand extends BaseCommand
             return 1;
         }
 
-        $this->call('migrate:rollback', array_filter([
-            '--step' => $this->option('step') ?? 1,
-        ]));
-
-        $this->call('migrate', array_filter([
+        $this->call('migrate:refresh', array_filter([
             '--step' => $this->option('step') ?? 1,
         ]));
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Console\Migrations\FreshCommand;
 use Illuminate\Database\Console\Migrations\InstallCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Console\Migrations\RedoCommand;
 use Illuminate\Database\Console\Migrations\RefreshCommand;
 use Illuminate\Database\Console\Migrations\ResetCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
@@ -31,6 +32,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         'MigrateRefresh' => RefreshCommand::class,
         'MigrateReset' => ResetCommand::class,
         'MigrateRollback' => RollbackCommand::class,
+        'MigrateRedo' => RedoCommand::class,
         'MigrateStatus' => StatusCommand::class,
         'MigrateMake' => MigrateMakeCommand::class,
     ];
@@ -193,6 +195,13 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     {
         $this->app->singleton(RollbackCommand::class, function ($app) {
             return new RollbackCommand($app['migrator']);
+        });
+    }
+
+    protected function registerMigrateRedoCommand()
+    {
+        $this->app->singleton(RedoCommand::class, function ($app) {
+            return new RedoCommand($app['migrator']);
         });
     }
 


### PR DESCRIPTION
A lot of developers (myself included) often have to rollback and re-run the newly-created migration because we had a last-second decision that we need to add another column, or change the column structure.

I know that there is  an option to do `php artisan migrate:refresh --step=1`  - but the command often needs an additional alias due to its length - because most of the time we don't need to refresh **all** the migrations (as it does with no parameters), but only the recent one.

So, such command would help us save the time developing and quickly editing new migrations !

Just in case, it also accepts ``--step` parameter, which defaults to 1 but can be set to any number.