### PR TITLE
[10.x] Add an option to specify the default path to the models directory for `php artisan model:prune`

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -23,7 +23,8 @@ class PruneCommand extends Command
                                 {--model=* : Class names of the models to be pruned}
                                 {--except=* : Class names of the models to be excluded from pruning}
                                 {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
-                                {--pretend : Display the number of prunable records found instead of deleting them}';
+                                {--pretend : Display the number of prunable records found instead of deleting them}
+                                {--default-path=Models : The default path where models are located}';
 
     /**
      * The console command description.
@@ -121,7 +122,7 @@ class PruneCommand extends Command
      */
     protected function getDefaultPath()
     {
-        return app_path('Models');
+        return app_path($this->option('default-path'));
     }
 
     /**

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -24,7 +24,7 @@ class PruneCommand extends Command
                                 {--except=* : Class names of the models to be excluded from pruning}
                                 {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
                                 {--pretend : Display the number of prunable records found instead of deleting them}
-                                {--path=Models : The default path where models are located}';
+                                {--path=* : Absolute path(s) to directories where models are located}';
 
     /**
      * The console command description.
@@ -97,7 +97,7 @@ class PruneCommand extends Command
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 
-        return collect((new Finder)->in($this->getDefaultPath())->files()->name('*.php'))
+        return collect((new Finder)->in($this->getPath())->files()->name('*.php'))
             ->map(function ($model) {
                 $namespace = $this->laravel->getNamespace();
 
@@ -120,9 +120,14 @@ class PruneCommand extends Command
      *
      * @return string
      */
-    protected function getDefaultPath()
+    protected function getPath()
     {
-        return app_path($this->option('path'));
+
+        if (! empty($path = $this->option('path'))) {
+            return $path;
+        }
+
+        return app_path('Models');
     }
 
     /**

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -116,13 +116,12 @@ class PruneCommand extends Command
     }
 
     /**
-     * Get the default path where models are located.
+     * Get the path where models are located.
      *
      * @return string
      */
     protected function getPath()
     {
-
         if (! empty($path = $this->option('path'))) {
             return $path;
         }

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -24,7 +24,7 @@ class PruneCommand extends Command
                                 {--except=* : Class names of the models to be excluded from pruning}
                                 {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
                                 {--pretend : Display the number of prunable records found instead of deleting them}
-                                {--default-path=Models : The default path where models are located}';
+                                {--path=Models : The default path where models are located}';
 
     /**
      * The console command description.
@@ -122,7 +122,7 @@ class PruneCommand extends Command
      */
     protected function getDefaultPath()
     {
-        return app_path($this->option('default-path'));
+        return app_path($this->option('path'));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When running `php artisan model:prune`, the `PruneCommand` hard codes the model directory to be `app_path('Models')`. Our app uses a different naming convention. As a result, our models are kept in a different directory. We recently upgraded from php 8.1 to 8.3 and when we did, this command started throwing an `Symfony\Component\Finder\Exception\DirectoryNotFoundException` every time we run `php artisan model:prune`. We could use the `--model` option to specify an individual model, but that gets unwieldy if we're using this on more than one model.

We put a temporary workaround in place that extends this command and modifies the `getDefaultPath()` method to return the one we need, but it seemed to me like Laravel shouldn't assume that all apps would use a `Models` directory.

This PR adds a `--path` option to the command which allows users to specify which app path they would like to use. The option value defaults to `Models` to maintain backwards compatibility.

Usage example:

```
php artisan model:prune --path="CustomModelPath"
```

I eyeballed the existing automated tests to try to add one here, but I wasn't sure how exactly to do that. I'd be happy to write some if I could get some guidance.