### PR TITLE
[10.x] Allow job chains to be conditionally dispatched

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -132,7 +132,7 @@ class PendingChain
     }
 
     /**
-     * Dispatch the job with the given arguments.
+     * Dispatch the job chain.
      *
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
@@ -164,5 +164,27 @@ class PendingChain
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
 
         return app(Dispatcher::class)->dispatch($firstJob);
+    }
+
+    /**
+     * Dispatch the job chain if the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return \Illuminate\Foundation\Bus\PendingDispatch|null
+     */
+    public function dispatchIf($boolean)
+    {
+        return value($boolean) ? $this->dispatch() : null;
+    }
+
+    /**
+     * Dispatch the job chain unless the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return \Illuminate\Foundation\Bus\PendingDispatch|null
+     */
+    public function dispatchUnless($boolean)
+    {
+        return ! value($boolean) ? $this->dispatch() : null;
     }
 }

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -495,6 +495,54 @@ class JobChainingTest extends QueueTestCase
 
         $this->assertEquals('sync1', $batch->connection());
     }
+
+    public function testJobsAreChainedWhenDispatchIfIsTrue()
+    {
+        JobChainingTestFirstJob::withChain([
+            new JobChainingTestSecondJob,
+        ])->dispatchIf(true);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testJobsAreNotChainedWhenDispatchIfIsFalse()
+    {
+        JobChainingTestFirstJob::withChain([
+            new JobChainingTestSecondJob,
+        ])->dispatchIf(false);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertFalse(JobChainingTestFirstJob::$ran);
+        $this->assertFalse(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testJobsAreChainedWhenDispatchUnlessIsFalse()
+    {
+        JobChainingTestFirstJob::withChain([
+            new JobChainingTestSecondJob,
+        ])->dispatchUnless(false);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testJobsAreNotChainedWhenDispatchUnlessIsTrue()
+    {
+        JobChainingTestFirstJob::withChain([
+            new JobChainingTestSecondJob,
+        ])->dispatchUnless(true);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertFalse(JobChainingTestFirstJob::$ran);
+        $this->assertFalse(JobChainingTestSecondJob::$ran);
+    }
 }
 
 class JobChainingTestFirstJob implements ShouldQueue


### PR DESCRIPTION
This PR introduces `dispatchIf()` and `dispatchUnless()` methods to the `PendingChain` class.

This allows developers to conditionally dispatch job chains in the same way they can for individual jobs, which streamlines logic and improves code readability. Adding these methods doesn't impact existing job chain implementations and maintains backward compatibility.


```
Bus::chain([
    new JobA(),
    new JobB(),
    new JobC(),
])->dispatchIf(true);

Bus::chain([
    new JobA(),
    new JobB(),
    new JobC(),
])->dispatchUnless(false);
```