### PR TITLE
[11.x] Uses PHP 8.2 on StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,6 @@
 php:
   preset: laravel
-  version: 8.1
+  version: 8.2
   finder:
     not-name:
       - bad-syntax-strategy.php


### PR DESCRIPTION
This pull request modifies configuration so it uses PHP 8.2 on StyleCI.