### PR TITLE
[10.x] Fix return value and docblock

### DIFF
--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -108,12 +108,14 @@ class TestView
 
     /**
      * Assert that the view's rendered content is empty.
+     *
+     * @return $this
      */
     public function assertViewEmpty()
     {
         PHPUnit::assertEmpty($this->rendered);
 
-        return true;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This is a follow-up to #49558 - I had fixed this but accidentally didn't push the latest commits in the original PR.

This fixes the return type to match the other assertions, allowing it to be chained, and update the docblocks.