### PR TITLE
[10.x] Add new `belongsToThrough` relationship method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -149,7 +149,7 @@ trait HasRelationships
         );
     }
 
-     /**
+    /**
      * Define a belongs-to-through relationship.
      *
      * @param  string  $related
@@ -170,7 +170,7 @@ trait HasRelationships
 
         return $this->newHasOneThrough(
             $this->newRelatedInstance($related)->newQuery(), $this, $through,
-            $localKey ?: $this->getKeyName(),  $secondLocalKey ?: $through->getKeyName(),
+            $localKey ?: $this->getKeyName(), $secondLocalKey ?: $through->getKeyName(),
             $firstKey, $secondKey,
         );
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -149,6 +149,32 @@ trait HasRelationships
         );
     }
 
+     /**
+     * Define a belongs-to-through relationship.
+     *
+     * @param  string  $related
+     * @param  string  $through
+     * @param  string|null  $firstKey
+     * @param  string|null  $secondKey
+     * @param  string|null  $localKey
+     * @param  string|null  $secondLocalKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function belongsToThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
+    {
+        $through = $this->newRelatedThroughInstance($through);
+
+        $firstKey = $firstKey ?: $this->getForeignKey();
+
+        $secondKey = $secondKey ?: $through->getForeignKey();
+
+        return $this->newHasOneThrough(
+            $this->newRelatedInstance($related)->newQuery(), $this, $through,
+            $localKey ?: $this->getKeyName(),  $secondLocalKey ?: $through->getKeyName(),
+            $firstKey, $secondKey,
+        );
+    }
+
     /**
      * Instantiate a new HasOneThrough relationship.
      *


### PR DESCRIPTION
I was working on a Laravel project at my work and I faced a scenario similar to [mechanics-cars-owners](https://laravel.com/docs/10.x/eloquent-relationships#has-one-through). Laravel introduces the `hasOneThrough` method which uses a `Car` model as a mediator between the `Mechanic` and `Owner` but, Laravel lacks to get the `Mechanic` info through the `Car` in the `Owner` model, **let me illuminate what I mean with a simple example**.

## Before this pull request gets merged

Let's assume that we have `Car` and `Owner` models with these relationships

```PHP
namespace App\Models;

use Illuminate\Database\Eloquent\Model;

class Car extends Model
{
    public function owner()
    {
        return $this->hasOne(Owner::class, 'car_id', 'id');
    }
}
```

```PHP
namespace App\Models;

use Illuminate\Database\Eloquent\Model;

class Owner extends Model
{
    public function car()
    {
        return $this->belongsTo(Car::class, 'car_id', 'id');
    }

    public function mechanic()
    {
        return $this->with(['car.mechanic'])->first();
    }
}
```

In the previous scenario, we used the **Depth Relationship** feature in the `mechanic` method to get his data.

> [!NOTE]
> We can customize the query of that method, It is just a simple example, also I think it's not the best way to accomplish what we need because we get complex and not required data.

## After this pull request gets merged

```PHP
namespace App\Models;

use Illuminate\Database\Eloquent\Model;

class Owner extends Model
{
    public function car()
    {
        return $this->belongsTo(Car::class, 'car_id', 'id');
    }

    public function mechanic()
    {
        return $this->belongsToThrough(Mechanic::class, Car::class, 'car_id', 'mechanic_id');
    }
}
```

> [!NOTE]
> We used the method that I introduced in this PR instead of using the **Depth Relationship**.

**We easily accomplish the task and in the best way 🎉**