### PR TITLE
[10.x] add `hasDuplicate`  method to  the collection class

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -598,6 +598,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection has duplicate items.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
+     * @return bool
+     */
+    public function hasDuplicate($key = null)
+    {
+        if (is_null($key)) {
+            return $this->duplicates($key)->isNotEmpty();
+        }
+        
+        return $this->duplicates()->isNotEmpty();
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  callable|string  $value


### PR DESCRIPTION
The hasDuplicate  method Determine if the collection has duplicate items:

```
$collection = collect(['a', 'b', 'a', 'c', 'b']);
 
$collection->hasDuplicate();
 
// true
```

If the collection contains arrays or objects, you can pass the key of the attributes

```
$employees = collect([
    ['email' => 'abigail@example.com', 'position' => 'Developer'],
    ['email' => 'james@example.com', 'position' => 'Designer'],
    ['email' => 'victoria@example.com', 'position' => 'Developer'],
]);
 
$employees->hasDuplicate('position');

// true
```