### PR TITLE
[10.x] Add `beforeSending` hook in Mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1775,7 +1775,7 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Register a callback to be called before the mailable is sent.
+     * Perform any work that should take place before the mailable is sent.
      *
      * @return $this
      */

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -209,7 +209,8 @@ class Mailable implements MailableContract, Renderable
                      ->buildTags($message)
                      ->buildMetadata($message)
                      ->runCallbacks($message)
-                     ->buildAttachments($message);
+                     ->buildAttachments($message)
+                     ->beforeSending();
             });
         });
     }
@@ -1770,6 +1771,16 @@ class Mailable implements MailableContract, Renderable
     {
         $this->mailer = $mailer;
 
+        return $this;
+    }
+
+    /**
+     * Register a callback to be called before the mailable is sent.
+     *
+     * @return $this
+     */
+    public function beforeSending()
+    {
         return $this;
     }
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1194,6 +1194,32 @@ class MailMailableTest extends TestCase
         $mailable->assertHasMetadata('user_id', 1);
         $mailable->assertHasSubject('test subject');
     }
+
+    public function testBeforeSending()
+    {
+        $view = m::mock(Factory::class);
+
+        $mailer = new Mailer('array', $view, new ArrayTransport);
+
+        $mailable = new class() extends Mailable
+        {
+            public function beforeSending()
+            {
+                throw new \Exception('Do not send mail.');
+            }
+
+            public function build()
+            {
+                $this
+                    ->to('hello@laravel.com')
+                    ->html('Test content');
+            }
+        };
+
+        $this->expectExceptionMessage('Do not send mail.');
+
+        $mailer->send($mailable);
+    }
 }
 
 class MailableHeadersStub extends Mailable


### PR DESCRIPTION
## Problem
Sometimes when sending an email, you may want to do something additional prior to the email actually being sent - such as changing the status of another model to `sending` or aborting if some other check fails.

## Current Solution
You can put all of this in the `build` method of the Mailable but then that method gets quite large.

You also have access to the `MessageSending` event but this gives you a Symfony email where you don't have access to the Mailable properties such as any models passed in the constructor.

## Proposed Solution
Similar to the `configure` hook in model factories, the `beforeSending` hook gives you the ability to perform any operations required just before the email is sent, including aborting if required.

A potential use case could be;

```php
class InvoiceMail extends Mailable
{
    // ...

    public function beforeSending()
    {
        SystemEmail::where('owner_id', $this->invoice->id)
            ->where('owner_type', 'invoice')
            ->where('reference', $this->sendingReference)
            ->update([
                'sent_at' => Carbon::now(),
                'status' => InvoiceMailStatus::Sending,
            ]);
    }

   // ...
}
```

You could also do something like throw an Exception if the Invoice has already been sent but typically this might live in a wrapping job.