### PR TITLE
Check that the app logger has a driver() function, preventing fatal errors

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -198,7 +198,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             };
 
             $resetScope = function () use ($app) {
-                if (method_exists($app['log']->driver(), 'withoutContext')) {
+                if (method_exists($app['log'], 'driver') && method_exists($app['log']->driver(), 'withoutContext')) {
                     $app['log']->withoutContext();
                 }
 


### PR DESCRIPTION
It appears that when the application logger is used and workers with a Redis connection are registered, it is assumed that the existing logger implements a 'driver' function, which then gets called for another method. Whenever a logger instance is attached that does not have the 'driver' function, the code breaks with a fatal error:
In QueueServiceProvider.php line 201:

Call to undefined method Monolog\Logger::driver()

Unsure of what the $resetScope callback is actually used for, I found that adding an additional check to see if the 'driver' function exists is small enough of a change that creating a new unit tests would be overkill. This pull request also does not break any currently running tests.
