### PR TITLE
[10.x] Allow Factory::count() to consume callables to be able to generate randomness during runtime.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -202,7 +202,7 @@ abstract class Factory
     public function raw($attributes = [], ?Model $parent = null)
     {
         $count = $this->getCount();
-        
+
         if ($count === null) {
             return $this->state($attributes)->getExpandedAttributes($parent);
         }
@@ -385,7 +385,7 @@ abstract class Factory
     public function make($attributes = [], ?Model $parent = null)
     {
         $count = $this->getCount();
-   
+
         if (! empty($attributes)) {
             return $this->state($attributes)->make([], $parent);
         }
@@ -731,14 +731,15 @@ abstract class Factory
     }
 
     /**
-     * Get the count variable and maybe convert it to int
+     * Get the count variable and maybe convert it to int.
      *
      * @return int|null
      */
-    protected function getCount() {
+    protected function getCount()
+    {
         $count = $this->count;
 
-        if(is_callable($count)) {
+        if (is_callable($count)) {
             return $count();
         }
 
@@ -811,7 +812,7 @@ abstract class Factory
         };
 
         return $this->model ?? $resolver($this);
-    }    
+    }
 
     /**
      * Specify the callback that should be invoked to guess model names based on factory names.


### PR DESCRIPTION
Often one needs some randomness in generating Factories for the development environment. For this case the count method in the Factory Base class should accept a callable in addition to int or null. It's optional to be used by developers and i think it has no breaking changes or follow up problems - at least i cannot think of anything.

What could be done with this addition?

```
AnyModel::factory()->count(function() {
    return fake()->randomDigitNotNull();
});

AnyModel::factory()->count(fn() => fake()->randomDigitNotNull());
```

Hope this is of interest!