### PR TITLE
[11.x] Fix adding stored columns on SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -269,9 +269,7 @@ class SQLiteGrammar extends Grammar
     {
         $columns = $this->prefixArray('add column', $this->getColumns($blueprint));
 
-        return collect($columns)->reject(function ($column) {
-            return preg_match('/as \(.*\) stored/', $column) > 0;
-        })->map(function ($column) use ($blueprint) {
+        return collect($columns)->map(function ($column) use ($blueprint) {
             return 'alter table '.$this->wrapTable($blueprint).' '.$column;
         })->all();
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -882,10 +882,11 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->integer('discounted_stored')->storedAs('"price" - 5')->nullable(false);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(2, $statements);
+        $this->assertCount(3, $statements);
         $expected = [
             'alter table "products" add column "price" integer not null',
             'alter table "products" add column "discounted_virtual" integer not null as ("price" - 5)',
+            'alter table "products" add column "discounted_stored" integer not null as ("price" - 5) stored',
         ];
         $this->assertSame($expected, $statements);
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -387,6 +387,24 @@ class SchemaBuilderTest extends DatabaseTestCase
         DB::statement('create table `test` (`foo` int) WITH system versioning;');
     }
 
+    public function testAddingStoredColumnOnSqlite()
+    {
+        if ($this->driver !== 'sqlite') {
+            $this->markTestSkipped('Test requires a SQLite connection.');
+        }
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->integer('price');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->integer('virtual_column')->virtualAs('"price" - 5');
+            $table->integer('stored_column')->storedAs('"price" - 5');
+        });
+
+        $this->assertTrue(Schema::hasColumns('test', ['virtual_column', 'stored_column']));
+    }
+
     public function testAddingMacros()
     {
         Schema::macro('foo', fn () => 'foo');


### PR DESCRIPTION
SQLite schema grammar silently ignores adding `stored` columns, although it is allowed if the table is empty. This PR fixes this to avoid confusion for user and allows SQLite to handle this instead, by adding the stored column or showing a proper error message.