### PR TITLE
[10.x] Allow job batches to be conditionally dispatched

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -344,4 +344,26 @@ class PendingBatch
             new BatchDispatched($batch)
         );
     }
+
+    /**
+     * Dispatch the batch if the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return \Illuminate\Bus\Batch|null
+     */
+    public function dispatchIf($boolean)
+    {
+        return value($boolean) ? $this->dispatch() : null;
+    }
+
+    /**
+     * Dispatch the batch unless the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @return \Illuminate\Bus\Batch|null
+     */
+    public function dispatchUnless($boolean)
+    {
+        return ! value($boolean) ? $this->dispatch() : null;
+    }
 }

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -88,4 +88,102 @@ class BusPendingBatchTest extends TestCase
 
         $pendingBatch->dispatch();
     }
+
+    public function test_batch_is_dispatched_when_dispatchif_is_true()
+    {
+        $container = new Container;
+
+        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher->shouldReceive('dispatch')->once();
+        $container->instance(Dispatcher::class, $eventDispatcher);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $pendingBatch = new PendingBatch($container, new Collection([$job]));
+
+        $repository = m::mock(BatchRepository::class);
+        $repository->shouldReceive('store')->once()->andReturn($batch = m::mock(stdClass::class));
+        $batch->shouldReceive('add')->once()->andReturn($batch = m::mock(Batch::class));
+
+        $container->instance(BatchRepository::class, $repository);
+
+        $result = $pendingBatch->dispatchIf(true);
+
+        $this->assertInstanceOf(Batch::class, $result);
+    }
+
+    public function test_batch_is_not_dispatched_when_dispatchif_is_false()
+    {
+        $container = new Container;
+
+        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+        $container->instance(Dispatcher::class, $eventDispatcher);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $pendingBatch = new PendingBatch($container, new Collection([$job]));
+
+        $repository = m::mock(BatchRepository::class);
+        $container->instance(BatchRepository::class, $repository);
+
+        $result = $pendingBatch->dispatchIf(false);
+
+        $this->assertNull($result);
+    }
+
+    public function test_batch_is_dispatched_when_dispatchunless_is_false()
+    {
+        $container = new Container;
+
+        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher->shouldReceive('dispatch')->once();
+        $container->instance(Dispatcher::class, $eventDispatcher);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $pendingBatch = new PendingBatch($container, new Collection([$job]));
+
+        $repository = m::mock(BatchRepository::class);
+        $repository->shouldReceive('store')->once()->andReturn($batch = m::mock(stdClass::class));
+        $batch->shouldReceive('add')->once()->andReturn($batch = m::mock(Batch::class));
+
+        $container->instance(BatchRepository::class, $repository);
+
+        $result = $pendingBatch->dispatchUnless(false);
+
+        $this->assertInstanceOf(Batch::class, $result);
+    }
+
+    public function test_batch_is_not_dispatched_when_dispatchunless_is_true()
+    {
+        $container = new Container;
+
+        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+        $container->instance(Dispatcher::class, $eventDispatcher);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $pendingBatch = new PendingBatch($container, new Collection([$job]));
+
+        $repository = m::mock(BatchRepository::class);
+        $container->instance(BatchRepository::class, $repository);
+
+        $result = $pendingBatch->dispatchUnless(true);
+
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
Similar to #49624 this PR introduces `dispatchIf()` and `dispatchUnless()` methods to the `PendingBatch` class.

This allows developers to conditionally dispatch batches in the same way they can for individual jobs and chains, which streamlines logic and improves code readability. Adding these methods doesn't impact existing batch implementations and maintains backward compatibility.


```
Bus::batch([
    new JobA(),
    new JobB(),
    new JobC(),
])->dispatchIf(true);

Bus::batch([
    new JobA(),
    new JobB(),
    new JobC(),
])->dispatchUnless(false);
```