### PR TITLE
[10.x] Add dependency resolver attributes

### DIFF
--- a/src/Illuminate/Config/Attributes/InjectFromConfig.php
+++ b/src/Illuminate/Config/Attributes/InjectFromConfig.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Config\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\DependencyResolver;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class InjectFromConfig implements DependencyResolver
+{
+    /**
+     * Key to get from config.
+     *
+     * @var string|array
+     */
+    private $key;
+
+    /**
+     * Default in case config is not present or bound.
+     *
+     * @var mixed
+     */
+    private $default;
+
+    /**
+     * Create a new InjectFromConfig instance.
+     *
+     * @param  array|string  $key
+     * @param  mixed  $default
+     * @return void
+     */
+    public function __construct($key, $default = null)
+    {
+        $this->key = $key;
+        $this->default = $default;
+    }
+
+    /**
+     * Resolve the dependency from the container.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function resolve(Container $container): mixed
+    {
+        if (! $container->bound('config')) {
+            return value($this->default);
+        }
+
+        return $container->make('config')->get($this->key, $this->default);
+    }
+}

--- a/src/Illuminate/Contracts/Container/DependencyResolver.php
+++ b/src/Illuminate/Contracts/Container/DependencyResolver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Container;
+
+interface DependencyResolver
+{
+    /**
+     * Resolve the dependency from the container.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public function resolve(Container $container): mixed;
+}

--- a/tests/Config/Attributes/InjectFromConfigTest.php
+++ b/tests/Config/Attributes/InjectFromConfigTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Config\Attributes;
+
+use Illuminate\Config\Attributes\InjectFromConfig;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Container\Container;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class InjectFromConfigTest extends TestCase
+{
+    public function testItReturnsDefaultWhenConfigNotBound()
+    {
+        $attribute = new InjectFromConfig('app.name', 'default');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('config')->once()->andReturnFalse();
+
+        $this->assertSame('default', $attribute->resolve($container));
+    }
+
+    public function testItGetsFromConfig()
+    {
+        $attribute = new InjectFromConfig('app.name', 'default');
+
+        $config = m::mock(Repository::class);
+        $config->shouldReceive('get')->with('app.name', 'default')->once()->andReturn('Laravel');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('bound')->with('config')->once()->andReturnTrue();
+        $container->shouldReceive('make')->with('config')->once()->andReturn($config);
+
+        $this->assertSame('Laravel', $attribute->resolve($container));
+    }
+}


### PR DESCRIPTION
# Premise of this PR
This PR adds the ability to have an implementation decide where to get dependencies from without explicit binding.

I often use the container for container to resolve services/actions etc in my code to have IoC but
find e.g. giving config values to those classes cumbersome, especially if all other dependencies
can be resolved by the container itself except one (api key for example).

An alternative would be contextual binding, but I personally don't like having references to parameters
that my IDE doesn't understand. Renaming it would probably break the code unless you search for it.
Of course having automated tests would prevent mistakes like that to a certain extend, but I often
mock my dependencies instead of letting them resolve.

This issue was addressed by https://github.com/laravel/framework/pull/46530 but very specific to config.
This PR attempts to provide a more generic solution.

# Examples
**Before 1:**
```php
<?php

namespace App\Providers;

use App\ApiClient;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function register(): void
    {
        $this->app->bind(ApiClient::class, function () {
            return new ApiClient(
                key: config('services.api.key'),
            );
        });
    }
}

```
```php
<?php

namespace App;

class ApiClient
{
    public function __construct(
        private readonly string $key,
    ) {
        //
    }
}
```

**Before 2:**
```php
<?php

namespace App\Providers;

use App\ApiClient;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function register(): void
    {
        $this->app->when(ApiClient::class)
            ->needs('$key')
            ->giveConfig('services.api.key');
    }
}

```
```php
<?php

namespace App;

class ApiClient
{
    public function __construct(
        private readonly string $key,
    ) {
        //
    }
}
```

**After:**
_No binding needed_
```php
<?php

namespace App;

use Illuminate\Config\Attributes\InjectFromConfig;

class ApiClient
{
    public function __construct(
        #[InjectFromConfig('services.api.key')]
        private readonly string $key,
    ) {
        //
    }
}
```

# Benchmarks
My main concern with adding this would be performance due to the usage of reflection, this was
actually not that bad in my opinion. Here are a few test cases, feel free to suggest more scenarios.
_Tested on a 2023 M2 MacBook Air 16GB_

**Test 1:**
```php
$container = new Container();

Benchmark::dd(function () use ($container) {
    $container->make(ContainerConcreteStub::class);
}, 100);
```
Before: 0.001ms
After: 0.002ms

**Test 2:**
```php
$container = new Container();

Benchmark::dd(function () use ($container) {
    $container->make(ContainerDefaultValueStub::class);
}, 100);
```
Before: 0.004ms
After: 0.005ms

**Test 3:**
```php
$container = new Container();

$container->bind(IContainerContractStub::class, ContainerImplementationStub::class);

Benchmark::dd(function () use ($container) {
    $container->make(ContainerNestedDependentStub::class);
}, 100);
```
Before: 0.007ms
After: 0.007ms

# Breaking changes
As far as I can tell this does not break existing code.

# Final thoughts
The performance was my main concern like I pointed out earlier. I however also don't know if this is
"too much" for the container, I have always seen the container as fairly straight forward and I think
this feature might lean more toward the "syntactic sugar"-side.

It might be worth it to add a setting to enable or disable this for people who which to avoid the
performance penalty caused by reflection. This will probably have to be set quite early in the
framework lifecycle to guaranty consistent results, not too sure.

Feel free to give feedback. Thanks