### PR TITLE
[11.x] Use secure randomness in Arr::random() and Arr::shuffle()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -731,20 +731,11 @@ class Arr
      * Shuffle the given array and return the result.
      *
      * @param  array  $array
-     * @param  int|null  $seed
      * @return array
      */
-    public static function shuffle($array, $seed = null)
+    public static function shuffle($array)
     {
-        if (is_null($seed)) {
-            shuffle($array);
-        } else {
-            mt_srand($seed);
-            shuffle($array);
-            mt_srand();
-        }
-
-        return $array;
+        return (new Randomizer)->shuffleArray($array);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -6,6 +6,7 @@ use ArgumentCountError;
 use ArrayAccess;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use Random\Randomizer;
 
 class Arr
 {
@@ -661,24 +662,24 @@ class Arr
             );
         }
 
+        if (empty($array) || (! is_null($number) && $number <= 0)) {
+            return is_null($number) ? null : [];
+        }
+
+        $keys = (new Randomizer)->pickArrayKeys($array, $requested);
+
         if (is_null($number)) {
-            return $array[array_rand($array)];
+            return $array[$keys[0]];
         }
-
-        if ((int) $number === 0) {
-            return [];
-        }
-
-        $keys = array_rand($array, $number);
 
         $results = [];
 
         if ($preserveKeys) {
-            foreach ((array) $keys as $key) {
+            foreach ($keys as $key) {
                 $results[$key] = $array[$key];
             }
         } else {
-            foreach ((array) $keys as $key) {
+            foreach ($keys as $key) {
                 $results[] = $array[$key];
             }
         }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1125,12 +1125,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Shuffle the items in the collection.
      *
-     * @param  int|null  $seed
      * @return static
      */
-    public function shuffle($seed = null)
+    public function shuffle()
     {
-        return new static(Arr::shuffle($this->items, $seed));
+        return new static(Arr::shuffle($this->items));
     }
 
     /**

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -889,10 +889,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Shuffle the items in the collection.
      *
-     * @param  int|null  $seed
      * @return static
      */
-    public function shuffle($seed = null);
+    public function shuffle();
 
     /**
      * Create chunks representing a "sliding window" view of the items in the collection.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1058,12 +1058,11 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Shuffle the items in the collection.
      *
-     * @param  int|null  $seed
      * @return static
      */
-    public function shuffle($seed = null)
+    public function shuffle()
     {
-        return $this->passthru('shuffle', func_get_args());
+        return $this->passthru('shuffle');
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1062,7 +1062,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function shuffle()
     {
-        return $this->passthru('shuffle');
+        return $this->passthru('shuffle', []);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -907,12 +907,28 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1 => 'hAz'], Arr::set($array, 1, 'hAz'));
     }
 
-    public function testShuffleWithSeed()
+    public function testShuffle()
     {
-        $this->assertEquals(
-            Arr::shuffle(range(0, 100, 10), 1234),
-            Arr::shuffle(range(0, 100, 10), 1234)
+        $input = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+        $this->assertNotEquals(
+            $input,
+            Arr::shuffle($input)
         );
+
+        $this->assertNotEquals(
+            Arr::shuffle($input),
+            Arr::shuffle($input)
+        );
+    }
+
+    public function testShuffleKeepsSameValues()
+    {
+        $input = ['a', 'b', 'c', 'd', 'e', 'f'];
+        $shuffled = Arr::shuffle($input);
+        sort($shuffled);
+
+        $this->assertEquals($input, $shuffled);
     }
 
     public function testEmptyShuffle()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -443,17 +443,6 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
-    public function testCollectionShuffleWithSeed($collection)
-    {
-        $data = new $collection(range(0, 100, 10));
-
-        $firstRandom = $data->shuffle(1234);
-        $secondRandom = $data->shuffle(1234);
-
-        $this->assertEquals($firstRandom, $secondRandom);
-    }
-
-    #[DataProvider('collectionClassProvider')]
     public function testSkipMethod($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6]);


### PR DESCRIPTION
This is my long-awaited second attempt at https://github.com/laravel/framework/pull/46105.

The implementations of `Arr::random()` and `Arr::shuffle()`, which are also used by `Collection`, currently use insecure randomness from `array_rand()` and `shuffle()`. This replaces those insecure functions with the secure `Randomizer::pickArrayKeys()` and `Randomizer::shuffleArray()`.

As far as I can tell, these are the last two "random" functions in the framework that aren't using secure randomness. `Str::random()` was already random, and `Str::password()` suffered from an unsecure shuffle which this PR fixes.

I know there was an idea to introduce a standalone `Random` class into Laravel - which is what I've made with https://github.com/valorin/random. Making something like that as part of the Laravel core is still an option, if that is worth doing? This would allow for custom `Randomizer` Engines to support seeding, etc.
(Note, my package supports older versions of PHP, while a Laravel core version would just need to be 8.2+.)

Additionally, as part of this change, I removed the `$seed` functionality from `shuffle()`. If you're relying on seeding randomness, you should be directly implementing seeded randomness functions to ensure nothing changes code wise - rather than relying on third party functions that aren't guaranteed to not change. The old PR failed because a bunch of folks were seeding randomness outside these functions while also expecting specific results from the different functions.

For folks who don't want to implement their own seeded random functions, my Random package offers a good solution to seeded randomness: https://github.com/valorin/random.

If seeds are being used for tests - we could look at replicating the _random string factory_ in use for `Str::random()` within `Arr` as a testing helper?

This is targeted at v11, since it contains backwards compatibility breaks.