### PR TITLE
[11.x] Add createAndRefresh method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1032,7 +1032,7 @@ class Builder implements BuilderContract
      */
     public function createAndRefresh(array $attributes = [])
     {
-        return $this->create($attributes)->refresh();
+        return $this->getConnection()->transaction(fn () => $this->create($attributes)->fresh());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1032,10 +1032,7 @@ class Builder implements BuilderContract
      */
     public function createAndRefresh(array $attributes = [])
     {
-        return tap($this->newModelInstance($attributes), function ($instance) {
-            $instance->save();
-            $instance->refresh();
-        });
+        return $this->create($attributes)->refresh();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1025,6 +1025,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Save a new model and return the fresh model instance reloaded.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model|$this
+     */
+    public function createAndRefresh(array $attributes = [])
+    {
+        return tap($this->newModelInstance($attributes), function ($instance) {
+            $instance->save();
+            $instance->refresh();
+        });
+    }
+
+    /**
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes

--- a/tests/Integration/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBuilderTest.php
@@ -21,6 +21,10 @@ class DatabaseEloquentBuilderTest extends DatabaseTestCase
 
         $model = new class extends Model {
             protected $table = 'sample';
+
+            protected $fillable = [
+                'name',
+            ];
         };
 
         $record = $model->newModelQuery()->createAndRefresh([

--- a/tests/Integration/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBuilderTest.php
@@ -19,7 +19,8 @@ class DatabaseEloquentBuilderTest extends DatabaseTestCase
             $table->timestamps();
         });
 
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
             protected $table = 'sample';
 
             protected $fillable = [

--- a/tests/Integration/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DatabaseEloquentBuilderTest extends DatabaseTestCase
+{
+    public function testCreateAndRefresh()
+    {
+        Schema::create('sample', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->tinyInteger('status')->default(1);
+            $table->timestamps();
+        });
+
+        $model = new class extends Model {
+            protected $table = 'sample';
+        };
+
+        $record = $model->newModelQuery()->createAndRefresh([
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $this->assertDatabaseHas('sample', [
+            'name' => 'Taylor Otwell',
+            'status' => '1',
+        ]);
+
+        $this->assertIsInt($record->id);
+        $this->assertSame('Taylor Otwell', $record->name);
+        $this->assertSame(1, $record->status);
+    }
+}

--- a/tests/Integration/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBuilderTest.php
@@ -26,6 +26,10 @@ class DatabaseEloquentBuilderTest extends DatabaseTestCase
             protected $fillable = [
                 'name',
             ];
+
+            protected $casts = [
+                'status' => 'integer',
+            ];
         };
 
         $record = $model->newModelQuery()->createAndRefresh([

--- a/tests/Integration/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBuilderTest.php
@@ -37,8 +37,10 @@ class DatabaseEloquentBuilderTest extends DatabaseTestCase
             'status' => '1',
         ]);
 
-        $this->assertIsInt($record->id);
+        $this->assertNotNull($record->id);
         $this->assertSame('Taylor Otwell', $record->name);
         $this->assertSame(1, $record->status);
+        $this->assertNotNull($record->created_at);
+        $this->assertNotNull($record->updated_at);
     }
 }


### PR DESCRIPTION
## Feature Proposal
This pull request introduces a new method, createAndRefresh, to the Eloquent Model class in Laravel. This method is an enhancement over the traditional create() method, addressing a specific limitation related to default values in the database.

## Motivation and Context
The standard create() method in Eloquent creates a new model instance and saves it to the database. However, it does not retrieve default values set by the database for attributes that were not explicitly provided. For example, if the database sets a default timestamp or generates a unique identifier, these values are not available in the model instance returned by create().

## Implementation Details
createAndRefresh addresses this limitation by refreshing the model after saving it. This ensures that any default values set by the database are reflected in the returned model instance.
The method creates a new model instance with the given attributes, saves it to the database, and then performs a refresh operation.

## Benefits
Ensures that the returned model instance includes all database-generated values, such as default values for unspecified attributes or auto-generated IDs.
Simplifies workflows by reducing the need for additional code to manually refresh the model after creation.