### PR TITLE
[11.x] Fix configure() return type

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -221,7 +221,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * Begin configuring a new Laravel application instance.
      *
      * @param  string|null  $baseDirectory
-     * @return \Illuminate\Foundation\ApplicationBuilder
+     * @return \Illuminate\Foundation\Configuration\ApplicationBuilder
      */
     public static function configure(string $baseDirectory = null)
     {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Illuminate\Foundation\Configuration\ApplicationBuilder;
 use Illuminate\Foundation\Events\LocaleUpdated;
 use Illuminate\Http\Request;
 use Illuminate\Log\LogServiceProvider;
@@ -221,9 +222,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * Begin configuring a new Laravel application instance.
      *
      * @param  string|null  $baseDirectory
-     * @return \Illuminate\Foundation\Configuration\ApplicationBuilder
      */
-    public static function configure(string $baseDirectory = null)
+    public static function configure(string $baseDirectory = null): ApplicationBuilder
     {
         $baseDirectory = match (true) {
             is_string($baseDirectory) => $baseDirectory,


### PR DESCRIPTION
Hi everyone,

I've upgrade my personal and Rector website to Laravel 11 to try out new configuration API:

* https://github.com/rectorphp/getrector-com/pull/1924
* https://github.com/TomasVotruba/tomasvotruba.com/pull/1439
 
All is good! 
One glitch is that the IDE autocomplete didn't work for me. I though there is some IDE cache, but in the end it was the return type issue.

This should fix it :+1: 

Using native return type seems a good idea, as we're using PHP 8.2 as min, and the incorrect return native type declaration would show this bug even in the PR adding this feature.

Let me know what you think and what should I improve :pray: 

