### PR TITLE
[10.x] Add `Arr:renameKey` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -729,6 +729,7 @@ class Arr
             if ($keysOld[0] === $keysNew[0]) {
                 $keyOld = array_shift($keysOld);
                 array_shift($keysNew);
+
                 return $rename($arr[$keyOld], $keysOld, $keysNew);
             }
             if (array_key_exists($keysNew[0], $arr)) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -700,11 +700,11 @@ class Arr
      */
     public static function renameKey(&$array, $oldKey, $newKey)
     {
-        if($oldKey === $newKey || !self::has($array, $oldKey)) {
+        if ($oldKey === $newKey || ! self::has($array, $oldKey)) {
             return $array;
         }
 
-        if(self::has($array, $newKey)){
+        if (self::has($array, $newKey)) {
             throw new InvalidArgumentException(
                 "The new key '{$newKey}' already exists in the array."
             );
@@ -714,31 +714,31 @@ class Arr
         $keysNew = explode('.', $newKey);
 
         // ensure that the count of keys is same and there is only 1 different level between the keys
-        if(count($keysOld) !== count($keysNew) || count(array_diff($keysOld, $keysNew)) !== 1){
+        if (count($keysOld) !== count($keysNew) || count(array_diff($keysOld, $keysNew)) !== 1) {
             throw new InvalidArgumentException(
                 "The new key '{$newKey}' is not a valid replacement for '{$oldKey}'."
             );
         }
 
-        while(end($keysOld) === end($keysNew)){
+        while (end($keysOld) === end($keysNew)) {
             array_pop($keysOld);
             array_pop($keysNew);
         }
 
-
         $rename = function (&$arr, $keysOld, $keysNew) use (&$rename, $oldKey, $newKey) {
-            if($keysOld[0] === $keysNew[0]){
+            if ($keysOld[0] === $keysNew[0]) {
                 $keyOld = array_shift($keysOld);
                 array_shift($keysNew);
                 return $rename($arr[$keyOld], $keysOld, $keysNew);
             }
-            if(array_key_exists($keysNew[0], $arr)){
+            if (array_key_exists($keysNew[0], $arr)) {
                 throw new InvalidArgumentException(
                     "The new key '{$newKey}' is not a valid replacement for '{$oldKey}'. The part '{$keysNew[0]}' of the new key already exists in the array."
                 );
             }
             $arr[$keysNew[0]] = $arr[$keysOld[0]];
             unset($arr[$keysOld[0]]);
+
             return $arr;
         };
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1260,4 +1260,45 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testRenameKey()
+    {
+        $arr = [
+            'id' => '123',
+            'data' => [
+                'name' => 'John',
+                'age' => 30,
+                'keys' => [
+                    'key' => 1,
+                ],
+                'ext_keys' => [
+                    'key' => 1,
+                ],
+            ],
+        ];
+
+        $throwException = false;
+        try {
+            Arr::renameKey($arr, 'data.keys.key', 'data.new_keys.new_key');
+        } catch (InvalidArgumentException) {
+            $throwException = true;
+        }
+        $this->assertTrue($throwException, 'Exception should be thrown when the count of different keys is not 1');
+
+        $throwException = false;
+        try {
+            Arr::renameKey($arr, 'data.keys.key', 'data.ext_keys.key');
+        } catch (InvalidArgumentException $e) {
+            $throwException = true;
+        }
+        $this->assertTrue($throwException, 'Exception should be thrown when the new key conflicts with an existing key');
+
+        Arr::renameKey($arr, 'data.keys.key', 'data.new_keys.key');
+        $this->assertArrayHasKey('new_keys', $arr['data']);
+        $this->assertArrayNotHasKey('keys', $arr['data']);
+
+        Arr::renameKey($arr, 'id', 'new_id');
+        $this->assertArrayHasKey('new_id', $arr);
+        $this->assertArrayNotHasKey('id', $arr);
+    }
 }


### PR DESCRIPTION
Created a new array helper method: `Arr:renameKey`

Example:

```php
$arr = [
    'id' => '123',
    'data' => [
        'name' => 'John',
        'age' => 30,
        'keys' => [
            'key' => 1,
        ],
        'ext_keys' => [
            'key' => 1,
        ],
    ],
];

Arr::renameKey($arr, 'data.keys.key', 'data.new_keys.key');

array_key_exists('new_keys', $arr['data']); // true
array_key_exists('keys', $arr['data']); // false


```
