### PR TITLE
[10.x] Add `Model::defaultRouteKeyName()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -211,6 +211,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $isBroadcasting = true;
 
     /**
+     * @var string|null
+     */
+    protected static $defaultRouteKeyName = null;
+
+    /**
      * The name of the "created at" column.
      *
      * @var string|null
@@ -495,6 +500,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         } finally {
             static::$isBroadcasting = $isBroadcasting;
         }
+    }
+
+    /**
+     * Register the default routing key.
+     *
+     * @param  string|null  $defaultRouteKeyName
+     * @return void
+     */
+    public static function defaultRouteKeyName(?string $defaultRouteKeyName)
+    {
+        static::$defaultRouteKeyName = $defaultRouteKeyName;
     }
 
     /**
@@ -2031,7 +2047,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getRouteKeyName()
     {
-        return $this->getKeyName();
+        return static::$defaultRouteKeyName ?? $this->getKeyName();
     }
 
     /**


### PR DESCRIPTION
This is a **WIP** as I have not written tests yet.

Add the ability to default for route keys.

**Why is this necessary?**
It's not strictly necessary at all, just a touch of developer experience.

**Doesn't this already work with the primary key?**
Yes! However, [OWASP recommends using longer, random strings](https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html#:~:text=As%20an%20additional,do%20so%20securely.) in URL routes. Laravel friend @tpetry also [recommends using UUIDs as a supplement to incrementing int IDs](https://sqlfordevs.com/uuid-prevent-enumeration-attack) rather than a replacement.

We use both big ints and UUIDs for our models, so the primary key remains `id`, but for all public references via our API, it's `uuid`.

This is a nice helper to encourage security best practices while also not incurring the performance penalties and general frustration of using UUIDs as PK/FK.

**Alternatives**
Add the following to every model (possibly by employing a trait) or create a BaseModel class that all Models extend from:

```php
public function getRouteKeyName()
{
    return 'uuid';
}
```
