### PR TITLE
[11.x] Avoids `SQLiteConnection::__construct` throwing exceptions

### DIFF
--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Query\Processors\SQLiteProcessor;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Database\Schema\SqliteSchemaState;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Filesystem\Filesystem;
 
 class SQLiteConnection extends Connection
@@ -31,9 +33,21 @@ class SQLiteConnection extends Connection
             return;
         }
 
-        $enableForeignKeyConstraints
-            ? $this->getSchemaBuilder()->enableForeignKeyConstraints()
-            : $this->getSchemaBuilder()->disableForeignKeyConstraints();
+        $schemaBuilder = $this->getSchemaBuilder();
+
+        try {
+            $enableForeignKeyConstraints
+                ? $schemaBuilder->enableForeignKeyConstraints()
+                : $schemaBuilder->disableForeignKeyConstraints();
+        } catch (QueryException $e) {
+            // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tortor
+            // nisl, sollicitudin sit amet tortor in, scelerisque placerat ligula. Pe
+            // llentesque eget nulla non justo egestas aliquet. Vivamus eget rhonc.
+
+            if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
+                throw $e;
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -38,10 +38,6 @@ class SQLiteConnection extends Connection
                 ? $schemaBuilder->enableForeignKeyConstraints()
                 : $schemaBuilder->disableForeignKeyConstraints();
         } catch (QueryException $e) {
-            // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tortor
-            // nisl, sollicitudin sit amet tortor in, scelerisque placerat ligula. Pe
-            // llentesque eget nulla non justo egestas aliquet. Vivamus eget rhonc.
-
             if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
                 throw $e;
             }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -8,8 +8,6 @@ use Illuminate\Database\Query\Processors\SQLiteProcessor;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Database\Schema\SqliteSchemaState;
-use Illuminate\Database\QueryException;
-use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Filesystem\Filesystem;
 
 class SQLiteConnection extends Connection

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -163,6 +164,19 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $store->forgetIfExpired('foo');
 
         $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
+    }
+
+    public function testResolvingSQLiteConnectionDoesNotThrowExceptions()
+    {
+        $originalConfiguration = config('database');
+
+        app('config')->set('database.default', 'sqlite');
+        app('config')->set('database.connections.sqlite.database', __DIR__ .'/non-existing-file');
+
+        $store = $this->getStore();
+        $this->assertInstanceOf(SQLiteConnection::class, $store->getConnection());
+
+        app('config')->set('database', $originalConfiguration);
     }
 
     /**

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -171,7 +171,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $originalConfiguration = config('database');
 
         app('config')->set('database.default', 'sqlite');
-        app('config')->set('database.connections.sqlite.database', __DIR__ .'/non-existing-file');
+        app('config')->set('database.connections.sqlite.database', __DIR__.'/non-existing-file');
 
         $store = $this->getStore();
         $this->assertInstanceOf(SQLiteConnection::class, $store->getConnection());


### PR DESCRIPTION
In Laravel 11, the database driver is the default store for the cache. Sometimes, if the user chooses SQLite as the database driver, SQLite will be used for caching. Typically, when the user creates a fresh Laravel application, the `database/database.sqlite` file may not exist, which can cause issues when starting a fresh Laravel application (via laravel new) or even just executing `php artisan` in the console:
```
   Illuminate\Database\QueryException

  Database file at path [/Users/nunomaduro/Work/Code/laravel/database/database.sqlite] does not exist. Ensure this is an absolute path to the database. (Connection: sqlite, SQL: PRAGMA foreign_keys = ON;)
```

This pull request addresses the issue by effectively ignoring the error in the constructor. While this approach may seem simplistic, it is the safest solution for two reasons:

1. Users who directly access the PDO will still have the query (update) executed, ensuring no change in behavior.
2. Users who later access the database, such as through the cache (for example, using `cache::get`), will still encounter the "Database does not exist" error.