### PR TITLE
[11.x] Pass app to `then` callable in `withRouting`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -176,7 +176,7 @@ class ApplicationBuilder
             }
 
             if (is_callable($then)) {
-                $then();
+                $then($this->app);
             }
         };
     }


### PR DESCRIPTION
Hey folks!

The new Laravel skeleton is so clean. One especially neat feature is the update to registering route files. As you know, using the `then` callable allows for defining any custom route files without resorting to setting a custom `using` callable.

```php
return Application::configure()
    ->withProviders()
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',

        then: fn () => Route::prefix('local')->group(base_path('routes/local.php')),
    )
```

This PR updates the `ApplicationBuilder` to ensure that `then` is given the application instance. This allows easily checking, for example, the current environment:

```php
return Application::configure()
    ->withProviders()
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',

        then: function ($app) {
            if ($app->environment('local')) {
                Route::prefix('local')->group(base_path('routes/local.php'));
            }
        }
    )
```

I know that you could also use the `app()` helper here, but this seems like an obvious alternative that doesn't hold maintenance burden.

Thanks for all the hard work, and I'm super excited for Laravel 11!

Kind Regards,
Luke 