### PR TITLE
Added integer cents and integer coordinates to Number object

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -32,9 +32,9 @@ class Number
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
 
-        if (! is_null($maxPrecision)) {
+        if (!is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
-        } elseif (! is_null($precision)) {
+        } elseif (!is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
 
@@ -54,11 +54,11 @@ class Number
     {
         static::ensureIntlExtensionIsInstalled();
 
-        if (! is_null($after) && $number <= $after) {
+        if (!is_null($after) && $number <= $after) {
             return static::format($number, locale: $locale);
         }
 
-        if (! is_null($until) && $number >= $until) {
+        if (!is_null($until) && $number >= $until) {
             return static::format($number, locale: $locale);
         }
 
@@ -98,7 +98,7 @@ class Number
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::PERCENT);
 
-        if (! is_null($maxPrecision)) {
+        if (!is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
         } else {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
@@ -208,7 +208,7 @@ class Number
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));
             case $number >= 1e15:
-                return sprintf('%s'.end($units), static::summarize($number / 1e15, $precision, $maxPrecision, $units));
+                return sprintf('%s' . end($units), static::summarize($number / 1e15, $precision, $maxPrecision, $units));
         }
 
         $numberExponent = floor(log10($number));
@@ -229,6 +229,38 @@ class Number
     public static function clamp(int|float $number, int|float $min, int|float $max)
     {
         return min(max($number, $min), $max);
+    }
+
+    /**
+     * Return integer representation of float value representing money
+     *
+     * @param  integer|float  $number
+     * @param  boolean  $to 
+     * @return int
+     */
+    public static function cents(int|float $number, bool $to = true)
+    {
+        return (int) (
+            $to || is_float($number)
+            ? $number * 100
+            : $number / 100
+        );
+    }
+
+    /**
+     * Return integer representation of float value representing lat/lng.
+     *
+     * @param  integer|float  $coordinate
+     * @param  boolean  $to
+     * @return int
+     */
+    public static function coordinate(int|float $coordinate, bool $to = true)
+    {
+        return (int) (
+            $to || is_float($coordinate)
+            ? $coordinate * 1_000_000
+            : $coordinate / 1_000_000
+        );
     }
 
     /**
@@ -265,7 +297,7 @@ class Number
      */
     protected static function ensureIntlExtensionIsInstalled()
     {
-        if (! extension_loaded('intl')) {
+        if (!extension_loaded('intl')) {
             throw new RuntimeException('The "intl" PHP extension is required to use this method.');
         }
     }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -294,10 +294,27 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
     }
 
+    public function testCents()
+    {
+        $this->assertSame(10000, Number::cents(100));
+        $this->assertSame(-36550, Number::cents(-365.50));
+        $this->assertSame(150, Number::cents(15000, false));
+    }
+
+    public function testCoordinates()
+    {
+        $this->assertSame(36163911000000, Number::coordinate(36163911));
+        $this->assertSame(-86797372000000, Number::coordinate(-86797372));
+        $this->assertSame(36163911, Number::coordinate(36.163911));
+        $this->assertSame(-86797372, Number::coordinate(-86.797372));
+        $this->assertSame(36163911, Number::coordinate(36163911000000, false));
+        $this->assertSame(-86797372, Number::coordinate(-86797372000000, false));
+    }
+
     protected function needsIntlExtension()
     {
-        if (! extension_loaded('intl')) {
-            $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable '.__CLASS__);
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable ' . __CLASS__);
         }
     }
 }


### PR DESCRIPTION
I am making this PR to add some useful methods to the Number class that does some common calculations that aren't there yet to my knowledge.

One of them being storing floats for money as integers for those (surprisingly many) that do so because of performance. This will make it a bit easier and fluent to do so.

The cents method will convert floats to integers and convert integers to the money cents value to and from it.
The coordinates method does the same thing but with lat/lng decimals.

It doesn't break anything else and it also doesn't require the intl extension.

With this added, in the future I'd can see this being applied easily to custom attribute casting to models to eloquently convert numbers with the support of the number class and the various (and growing) number of useful helper methods.