### PR TITLE
[10.x] Revert parameter name change

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -320,25 +320,25 @@ class Gate implements GateContract
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function allows($abilities, $arguments = [])
+    public function allows($ability, $arguments = [])
     {
-        return $this->check($abilities, $arguments);
+        return $this->check($ability, $arguments);
     }
 
     /**
      * Determine if any of the given abilities should be denied for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function denies($abilities, $arguments = [])
+    public function denies($ability, $arguments = [])
     {
-        return ! $this->allows($abilities, $arguments);
+        return ! $this->allows($ability, $arguments);
     }
 
     /**

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -59,20 +59,20 @@ interface Gate
     /**
      * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function allows($abilities, $arguments = []);
+    public function allows($ability, $arguments = []);
 
     /**
      * Determine if any of the given abilities should be denied for the current user.
      *
-     * @param  iterable|string  $abilities
+     * @param  iterable|string  $ability
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function denies($abilities, $arguments = []);
+    public function denies($ability, $arguments = []);
 
     /**
      * Determine if all of the given abilities should be granted for the current user.


### PR DESCRIPTION
Reverts a potential break in https://github.com/laravel/framework/pull/49503 for apps using named parameters.