### PR TITLE
[10.x] Printing Name of The Method that Calls `ensureIntlExtensionIsInstalled` in `Number` class.

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -266,9 +266,9 @@ class Number
     protected static function ensureIntlExtensionIsInstalled()
     {
         if (! extension_loaded('intl')) {
-            $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+            $method = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
-            throw new RuntimeException('The "intl" PHP extension is required to use the method: '.$caller);
+            throw new RuntimeException('The "intl" PHP extension is required to use the ['.$method.'] method.');
         }
     }
 }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -265,8 +265,10 @@ class Number
      */
     protected static function ensureIntlExtensionIsInstalled()
     {
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+
         if (! extension_loaded('intl')) {
-            throw new RuntimeException('The "intl" PHP extension is required to use this method.');
+            throw new RuntimeException('The "intl" PHP extension is required to use the method: ' . $caller);
         }
     }
 }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -268,7 +268,7 @@ class Number
         $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         if (! extension_loaded('intl')) {
-            throw new RuntimeException('The "intl" PHP extension is required to use the method: ' . $caller);
+            throw new RuntimeException('The "intl" PHP extension is required to use the method: '.$caller);
         }
     }
 }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -265,9 +265,9 @@ class Number
      */
     protected static function ensureIntlExtensionIsInstalled()
     {
-        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
-
         if (! extension_loaded('intl')) {
+            $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+
             throw new RuntimeException('The "intl" PHP extension is required to use the method: '.$caller);
         }
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

With this pull request, we introduce a guide to understanding which method generated the exception through the Number class.