### PR TITLE
[10.x] Enhancements for `Number` Class; Introducing `usingLocale` && `getLocale`

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -18,6 +18,17 @@ class Number
     protected static $locale = 'en';
 
     /**
+     * Create a new fluent Number instance.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    public function __construct(string $locale = 'en')
+    {
+        static::$locale = $locale;
+    }
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -256,6 +267,27 @@ class Number
     public static function useLocale(string $locale)
     {
         static::$locale = $locale;
+    }
+
+    /**
+     * Create a new fluent Number instance.
+     *
+     * @param  string  $locale
+     * @return \Illuminate\Support\Number
+     */
+    public static function usingLocale(string $locale)
+    {
+        return new static($locale);
+    }
+
+    /**
+     * Get the locale in use for this instance.
+     *
+     * @return string
+     */
+    public static function getLocale()
+    {
+        return static::$locale;
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -273,7 +273,7 @@ class Number
      * Create a new fluent Number instance.
      *
      * @param  string  $locale
-     * @return \Illuminate\Support\Number
+     * @return self
      */
     public static function usingLocale(string $locale)
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Although the Number class was designed to be used statically, because it is still a class we can take advantage of certain concepts to improve the user experience, in addition to offering some new methods.

`__construct`: Using a constructor we can easily do things like:

Before:
```php
Number::useLocale('en');

Number::spell(10);
```

After:
```php
Number::usingLocale('en')->spell(10);

// or ...

$number = new Number('en');

// ...
```

Also, I've introduced the `getLocale` that offers us the ability to retrieve the current locale in use for that instance.