### PR TITLE
Support AWS-SDK since 3.286.2 breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
     "require-dev": {
         "ext-gmp": "*",
         "ably/ably-php": "^1.0",
-        "aws/aws-sdk-php": "^3.235.5",
+        "aws/aws-sdk-php": "3.288.1",
         "doctrine/dbal": "^3.5.1",
         "fakerphp/faker": "^1.21",
         "guzzlehttp/guzzle": "^7.5",

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -52,7 +52,7 @@ class SqsJob extends Job implements JobContract
         parent::release($delay);
 
         $this->sqs->changeMessageVisibility([
-            'QueueUrl' => $this->queue,
+            'Endpoint' => $this->queue,
             'ReceiptHandle' => $this->job['ReceiptHandle'],
             'VisibilityTimeout' => $delay,
         ]);
@@ -68,7 +68,7 @@ class SqsJob extends Job implements JobContract
         parent::delete();
 
         $this->sqs->deleteMessage([
-            'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
+            'Endpoint' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
         ]);
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -70,7 +70,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function size($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([
-            'QueueUrl' => $this->getQueue($queue),
+            'Endpoint' => $this->getQueue($queue),
             'AttributeNames' => ['ApproximateNumberOfMessages'],
         ]);
 
@@ -111,7 +111,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function pushRaw($payload, $queue = null, array $options = [])
     {
         return $this->sqs->sendMessage([
-            'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload,
+            'Endpoint' => $this->getQueue($queue), 'MessageBody' => $payload,
         ])->get('MessageId');
     }
 
@@ -133,7 +133,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $delay,
             function ($payload, $queue, $delay) {
                 return $this->sqs->sendMessage([
-                    'QueueUrl' => $this->getQueue($queue),
+                    'Endpoint' => $this->getQueue($queue),
                     'MessageBody' => $payload,
                     'DelaySeconds' => $this->secondsUntil($delay),
                 ])->get('MessageId');
@@ -169,7 +169,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     public function pop($queue = null)
     {
         $response = $this->sqs->receiveMessage([
-            'QueueUrl' => $queue = $this->getQueue($queue),
+            'Endpoint' => $queue = $this->getQueue($queue),
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 
@@ -191,7 +191,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     {
         return tap($this->size($queue), function () use ($queue) {
             $this->sqs->purgeQueue([
-                'QueueUrl' => $this->getQueue($queue),
+                'Endpoint' => $this->getQueue($queue),
             ]);
         });
     }


### PR DESCRIPTION
# Why
Version 3.286.2 of aws-sdk-php changes the way QueueUrl is handled after switching SQS Client to the Json protocol.
https://github.com/aws/aws-sdk-php/releases/tag/3.286.2

This works fine if you're actually using an SQS queue-name only, but if you're using a different full URL for local (i.e. elasticmq) it forcibly attempts to hit the default AWS SQS url instead.

Also the versions 3 -> 3.288.1 are affected by the following security warning:
```
+-------------------+----------------------------------------------------------------------------------+
| Package           | aws/aws-sdk-php                                                                  |
| CVE               | CVE-2023-51651                                                                   |
| Title             | Potential URI resolution path traversal in the AWS SDK for PHP                   |
| URL               | https://nvd.nist.gov/vuln/detail/CVE-2023-51651                                  |
| Affected versions | >=3.0.0,<3.288.1                                                                 |
| Reported at       | 2023-11-22T00:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```

Therefore I've updated the composer json to require the latest safe release from aws-sdk-php

# Thoughts before submitting for review
The way I've done it will more than likely break it for people that aren't using the full URL.
 Ideally we would:
* Manually build it to the full AWS SQS url if it isn't already a url.
* Or, maybe more preferably, we only use Endpoint if it's actually a full URL (prefix + queue + suffix)

