### PR TITLE
[10.x] Update pagination tailwind.blade.php

### DIFF
--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -40,7 +40,7 @@
             </div>
 
             <div>
-                <span class="relative z-0 inline-flex shadow-sm rounded-md">
+                <span class="relative z-0 inline-flex rtl:flex-row-reverse shadow-sm rounded-md">
                     {{-- Previous Page Link --}}
                     @if ($paginator->onFirstPage())
                         <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">


### PR DESCRIPTION
Hi,

On current rtl Tailwind pagination we see it like that:

![image](https://github.com/laravel/framework/assets/16271253/4b11ae23-fadb-417a-a8ab-12e4b114ef53)

We need to apply `flex-row-reverse` when `rtl` to be like:

![image](https://github.com/laravel/framework/assets/16271253/4acff849-e069-49ba-959b-bad0f05ee1e0)

Thank.