### PR TITLE
[11.x] Add 'trashing' Eloquent event for soft deletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -89,10 +89,14 @@ trait SoftDeletes
     /**
      * Perform the actual delete query on this model instance.
      *
-     * @return void
+     * @return bool
      */
     protected function runSoftDelete()
     {
+        if ($this->fireModelEvent('trashing') === false) {
+            return false;
+        }
+
         $query = $this->setKeysForSaveQuery($this->newModelQuery());
 
         $time = $this->freshTimestamp();
@@ -107,11 +111,17 @@ trait SoftDeletes
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
         }
 
-        $query->update($columns);
+        foreach ($this->getDirty() as $attribute => $value) {
+            $columns[$attribute] = $value;
+        }
+
+        $result = $query->update($columns);
 
         $this->syncOriginalAttributes(array_keys($columns));
 
         $this->fireModelEvent('trashed', false);
+
+        return $result;
     }
 
     /**
@@ -160,6 +170,17 @@ trait SoftDeletes
     public function trashed()
     {
         return ! is_null($this->{$this->getDeletedAtColumn()});
+    }
+
+    /**
+     * Register a "softDeleting" model event callback with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function softDeleting($callback)
+    {
+        static::registerModelEvent('trashing', $callback);
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -124,4 +124,9 @@ class DatabaseSoftDeletingTraitStub
     {
         return 1;
     }
+
+    public function getDirty()
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
The existing Eloquent events for soft deletes include `trashed`, `restoring`, `restored`, `forceDeleting`, and `forceDeleted`. This proposal adds the missing `trashing` Eloquent event, which triggers before a model is soft deleted.

With `softDeleting()`, it's now possible to alter model attributes just before soft deletion, without requiring an additional database write operation:

```php
static::softDeleting(function ($model) {
    $model->status = 'deleted';
});
```

This approach is more efficient compared to using `softDeleted()` where an extra DB write is needed:

```php
static::softDeleted(function ($model) {
    $model->status = 'deleted';
    $model->saveQuietly();
});
```

Returning `false` from the `softDeleting()` callback halts the deletion process. This aligns with the behavior of other "-ing" events:

```php
static::softDeleting(function ($model) {
    return false;
});
```

Note: _This patch changes the return type of `runSoftDelete()` from `void` to `bool`, which is a low-risk break in back compat, but a break nonetheless._