### PR TITLE
[11.x] Fix nullable date validation without format

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -256,6 +256,13 @@ trait ValidatesAttributes
             $date = $this->getDateTimestamp($this->getValue($parameters[0]));
         }
 
+        if (is_null($date)
+            && array_key_exists($parameters[0], $this->rules)
+            && is_null($this->getValue($parameters[0]))
+        ) {
+            return true;
+        }
+
         return $this->compare($this->getDateTimestamp($value), $date, $operator);
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6034,7 +6034,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => null], ['start' => 'before:ends', 'ends' => 'nullable']);
-        $this->assertTrue($v->fails());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => date('d/m/Y')], ['x' => 'date_format:d/m/Y|after:yesterday|before:tomorrow']);
         $this->assertTrue($v->passes());
@@ -6186,7 +6186,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['foo' => '2012-01-15 11:00', 'bar' => null], ['foo' => 'before_or_equal:bar', 'bar' => 'nullable']);
-        $this->assertTrue($v->fails());
+        $this->assertTrue($v->passes());
     }
 
     public function testSometimesAddingRules()


### PR DESCRIPTION
This PR attempts to fix `before` and `after` validation, when the `date` rule is present and the compared value is `null`. Based on this issue https://github.com/laravel/framework/issues/40525, this is a known bug: https://github.com/laravel/framework/issues/40525#issuecomment-1018656414.

This caused minor issues in an application we worked on, because we do want to accept dates, without forcing any date format for various reasons.

As this comment https://github.com/laravel/framework/issues/40525#issuecomment-1018439797 says, currently the `date` and `date_format` validation rules handle `null` values differently.


Some related PRs/Issues:

- https://github.com/laravel/framework/pull/40543
- https://github.com/laravel/framework/pull/39937
- https://github.com/laravel/framework/issues/40086

-------

What this PR does:

- checks whether the compared attribute/values could be converted to a date object or not
- checks whether the compared value is a concrete date or an attribute
- whether it is an attribute, then checks if it is `null` or not

If all the checks are `true` then the validation should pass, so the `date|after:start` rule now works the same as the `date_format:Y-m-d|after:start`.

-------

I think this is a minor breaking change, so I target the 11.x branch, also I updated the related tests.