### PR TITLE
[10.x] feat: add base argument to Stringable->toInteger()

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1282,7 +1282,6 @@ class Stringable implements JsonSerializable, ArrayAccess
      * Get the underlying string value as an integer.
      *
      * @param  int  $base
-     *
      * @return int
      */
     public function toInteger($base = 10)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1281,11 +1281,13 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Get the underlying string value as an integer.
      *
+     * @param  int  $base
+     *
      * @return int
      */
-    public function toInteger()
+    public function toInteger($base = 10)
     {
-        return intval($this->value);
+        return intval($this->value, $base);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hi! 
When parsing hexstrings using Stringable interface I've discovered that currently there is no option to parse raw vaues in base different than 10. This super simple PR allows that by adding `int $base` as an argument to `->toInteger()` method. 

### Before:
```php
$stringable = Str::of($hexData)->after('#')->beforeLast("\r");
$value = intval($stringable, 16);
```

### After:
```php
$value = Str::of($hexData)->after('#')->beforeLast("\r")->toInteger(16);
```
