### PR TITLE
[10.x] Add frequencies method to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -442,6 +442,34 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Retrieve frequency of items from the collection.
+     *
+     * @param  (callable(TValue): bool)|string|null  $callback
+     * @param  bool  $strict
+     * @return static
+     */
+    public function frequencies($key = null)
+    {
+        if ($this->count() === 0) {
+            return null;
+        }
+
+        $collection = isset($key) ? $this->pluck($key) : $this;
+
+        $counts = new static;
+
+        $collection->each(function ($value) use (&$counts) {
+            if (! in_array(gettype($value), ['boolean', 'integer', 'string'])) {
+                return;
+            }
+
+            $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1;
+        });
+
+        return $counts;
+    }
+
+    /**
      * Get an item from the collection by key.
      *
      * @template TGetDefault

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -511,6 +511,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Retrieve frequency of items from the collection.
+     *
+     * @param  (callable(TValue): bool)|string|null  $callback
+     * @param  bool  $strict
+     * @return static
+     */
+    public function frequencies($key = null)
+    {
+        return $this->collect()->frequencies($key);
+    }
+
+    /**
      * Get an item by key.
      *
      * @template TGetDefault

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1641,6 +1641,49 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testFrequenciesOnNullCollection($collection)
+    {
+        $data = new $collection;
+        $this->assertNull($data->frequencies());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFrequencies($collection)
+    {
+        $data = new $collection([1, 2, 3, 4, 4, 5]);
+        $this->assertEquals([1 => 1, 2 => 1, 3 => 1, 4 => 2, 5 => 1], $data->frequencies()->all());
+
+        // works with mix of primitives
+        $data = new $collection([1, '1', 2, '2', true, false, 3]);
+        $this->assertEquals([1 => 3, 2 => 2, 0 => 1, 3 => 1], $data->frequencies()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFrequenciesValueByKey($collection)
+    {
+        $data = new $collection([
+            (object) ['foo' => 1],
+            (object) ['foo' => 1],
+            (object) ['foo' => 2],
+            (object) ['foo' => 4],
+        ]);
+        $data2 = new Collection([
+            ['foo' => 1],
+            ['foo' => 1],
+            ['foo' => 2],
+            ['foo' => 4],
+        ]);
+        $this->assertEquals([1 => 2, 2 => 1, 4 => 1], $data->frequencies('foo')->all());
+        $this->assertEquals($data2->frequencies('foo'), $data->frequencies('foo'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testEach($collection)
     {
         $c = new $collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);


### PR DESCRIPTION
The `frequencies` method returns the [frequency values](https://en.wikipedia.org/wiki/Frequency_(statistics)) of a given key:

```php
collect([1, 2, 2, 2, 3, 3, 4])->frequencies()->all();

// [1 => 1, 2 => 3, 3 => 2, 4 => 1] 
```

Since our collection functions heavily rely on arrays, the best way I can think of to count is by using the array key and incrementing the count each time a value occurs. Thus, we can only count 3 types of data that support being a key of an array in PHP: `boolean`, `integer`, and `string`.

```php
collect([1, '1', 2, '2', true, false, 3])->frequencies()->all();

// [1 => 3, 2 => 2, 0 => 1, 3 => 1]
```
If the collection contains arrays or objects, we can pass the key of the attributes that we want to check for duplicate values:
```php
$employees = collect([
    ['email' => 'abigail@example.com', 'position' => 'Developer'],
    ['email' => 'james@example.com', 'position' => 'Designer'],
    ['email' => 'victoria@example.com', 'position' => 'Developer'],
]);

$employees->frequencies('position')->all();
// ['Developer' => 2, 'Designer' => 1]