### PR TITLE
[10.x] Add `Notification` testing helpers

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -539,10 +539,10 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 'channels' => $notifiableChannels,
                 'notifiable' => $notifiable,
                 'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
-                        if ($notifiable instanceof HasLocalePreference) {
-                            return $notifiable->preferredLocale();
-                        }
-                    }),
+                    if ($notifiable instanceof HasLocalePreference) {
+                        return $notifiable->preferredLocale();
+                    }
+                }),
             ];
         }
     }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\AnonymousNotifiable;
@@ -374,5 +376,20 @@ class LocalizedUserStub extends User implements HasLocalePreference
     public function preferredLocale()
     {
         return 'au';
+    }
+}
+
+class QueuableNotificationStub extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
     }
 }


### PR DESCRIPTION
This pull request introduces a new  testing helpers, specifically focusing on detecting if a notification has been queued. Currently, Laravel provides extensive testing helpers for notifications, but lacks a direct method to determine if a notification has been queued.

```php

class InvoicePaid extends Notification implements ShouldQueue
{
    use Queueable;
}


$user = User::first();

$user->notify(new InvoicePaid());

Notification::assertNothingQueued();

Notification::assertQueued($user, InvoicePaid::class);

Notification::assertQueuedCount(1);

Notification::assertNotQueued($user, OrderShippedNotification::class);


