### PR TITLE
[10.x] Update routes and events "is cached" check to is_file

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1144,7 +1144,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        return $this['files']->exists($this->getCachedRoutesPath());
+        return is_file($this->getCachedRoutesPath());
     }
 
     /**
@@ -1164,7 +1164,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function eventsAreCached()
     {
-        return $this['files']->exists($this->getCachedEventsPath());
+        return is_file($this->getCachedEventsPath());
     }
 
     /**


### PR DESCRIPTION
The method that checks for a cached configuration file uses is_file (and was changed a few years back from file_exists during a mass update).  These methods weren't updated as they weren't directly calling file_exists, but under the hood that's effectively all this method does after looking up the Filesystem service.

This brings these methods in line with other usages of is_file and trims an unnecessary service lookup from the call stack.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
