### PR TITLE
[10.x] Add Luhn Validation Rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -89,6 +89,7 @@ return [
         'numeric' => 'The :attribute field must be less than or equal to :value.',
         'string' => 'The :attribute field must be less than or equal to :value characters.',
     ],
+    'luhn' => 'The :attribute is invalid.',
     'mac_address' => 'The :attribute field must be a valid MAC address.',
     'max' => [
         'array' => 'The :attribute field must not have more than :max items.',

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1410,6 +1410,38 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid luhn number.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateLuhn($attribute, $value)
+    {
+        if (! is_numeric($value)) {
+            return false;
+        }
+
+        $value = (string) $value;
+
+        $sum = 0;
+
+        $length = strlen($value);
+
+        for ($position = 1 - ($length % 2); $position < $length; $position += 2) {
+            $sum += $value[$position];
+        }
+
+        for ($position = ($length % 2); $position < $length; $position += 2) {
+            $number = $value[$position] * 2;
+
+            $sum += $number < 10 ? $number : $number - 9;
+        }
+
+        return $sum % 10 === 0;
+    }
+
+    /**
      * Validate that an attribute is a valid MAC address.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4162,6 +4162,29 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testValidateLuhn()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => '4242424242424242'], ['x' => 'luhn']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 4242424242424242], ['x' => 'luhn']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 4_242_424_242_424_242], ['x' => 'luhn']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '554'], ['x' => 'luhn']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '555'], ['x' => 'luhn']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'asdf'], ['x' => 'luhn']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateMacAddress()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This pull request adds a new rule for validating Luhn numbers. It is based on the Luhn algorithm, which is used to validate credit card numbers, IMEI numbers [and more](https://en.wikipedia.org/wiki/Luhn_algorithm#:~:text=The%20Luhn%20algorithm%20is%20used%20in%20a%20variety%20of%20systems%3A). The algorithm is described here: https://en.wikipedia.org/wiki/Luhn_algorithm.

This rule is also implemented in [Symfony](https://symfony.com/doc/current/reference/constraints/Luhn.html), [CakePHP](https://api.cakephp.org/5.0/class-Cake.Validation.Validation.html#luhn()), and other major frameworks.