### PR TITLE
[10.x] Allows specifying the name of the stubs to be published

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -16,9 +16,9 @@ class StubPublishCommand extends Command
      * @var string
      */
     protected $signature = 'stub:publish
-                    {name? : Published stubs will be limited to files that start with this name}
                     {--existing : Publish and overwrite only the files that have already been published}
-                    {--force : Overwrite any existing files}';
+                    {--force : Overwrite any existing files}
+                    {--only= : Published stubs will be limited to files that start with the given value}';
 
     /**
      * The console command description.
@@ -84,15 +84,15 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => 'middleware.stub',
         ];
 
-        if ($this->hasArgument('name')) {
+        if ($this->option('only')) {
             $stubs = array_filter(
                 $stubs,
-                fn ($name) => str_starts_with($name, strtolower($this->argument('name'))),
+                fn ($name) => str_starts_with($name, strtolower($this->option('only'))),
             );
         }
 
         if (count($stubs) === 0) {
-            $this->components->error('No stubs matched the given name.');
+            $this->components->error('No stubs matched the given options.');
 
             return self::FAILURE;
         }

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -91,6 +91,12 @@ class StubPublishCommand extends Command
             );
         }
 
+        if (count($stubs) === 0) {
+            $this->components->error('No stubs matched the given name.');
+
+            return self::FAILURE;
+        }
+
         $this->laravel['events']->dispatch($event = new PublishingStubs($stubs));
 
         foreach ($event->stubs as $from => $to) {

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -16,6 +16,7 @@ class StubPublishCommand extends Command
      * @var string
      */
     protected $signature = 'stub:publish
+                    {name? : Published stubs will be limited to files that start with this name}
                     {--existing : Publish and overwrite only the files that have already been published}
                     {--force : Overwrite any existing files}';
 
@@ -82,6 +83,13 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => 'controller.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => 'middleware.stub',
         ];
+
+        if ($this->hasArgument('name')) {
+            $stubs = array_filter(
+                $stubs,
+                fn ($name) => str_starts_with($name, strtolower($this->argument('name'))),
+            );
+        }
 
         $this->laravel['events']->dispatch($event = new PublishingStubs($stubs));
 


### PR DESCRIPTION
Hey all,

This is a small PR that allows you to limit the stubs that are published when running `php artisan stub:publish`.

## Usage

If you only want to publish stubs for migrations, execute `php artisan stub:publish --only=migration`. Any stubs that start with `migration` will be published.

If you omit the name, all stubs will be published as before. If no stubs match the given name, an error will be displayed to the user.

I contributed this because I'm often interested in editing just one stub, and don't want to have to delete all of the stubs that get published into the application. Thought is was a nice little DX improvement.

As always, thank you for your hard work.

Kind Regards,
Luke