### PR TITLE
[10.x] Add recursive sorting methods for a collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1366,6 +1366,33 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Recursively sort the collection by keys and values.
+     *
+     * @param int $options
+     * @param bool $descending
+     * @return static
+     */
+    public function sortRecursive($options = SORT_REGULAR, $descending = false)
+    {
+        $items = $this->items;
+
+        return new static(Arr::sortRecursive($items, $options = SORT_REGULAR, $descending = false));
+    }
+
+    /**
+     * Recursively sort the collection by keys and values in descending order.
+     *
+     * @param int $options
+     * @return static
+     */
+    public function sortRecursiveDesc($options = SORT_REGULAR)
+    {
+        $items = $this->items;
+
+        return new static(Arr::sortRecursiveDesc($items, $options = SORT_REGULAR));
+    }
+
+    /**
      * Sort the collection using the given callback.
      *
      * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1366,30 +1366,26 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Recursively sort the collection by keys and values.
+     * Recursively sort an array by keys and values.
      *
-     * @param int $options
-     * @param bool $descending
+     * @param  int  $options
+     * @param  bool  $descending
      * @return static
      */
     public function sortRecursive($options = SORT_REGULAR, $descending = false)
     {
-        $items = $this->items;
-
-        return new static(Arr::sortRecursive($items, $options = SORT_REGULAR, $descending = false));
+        return new static(Arr::sortRecursive($this->items, $options = SORT_REGULAR, $descending = false));
     }
 
     /**
-     * Recursively sort the collection by keys and values in descending order.
+     * Recursively sort an array by keys and values in descending order.
      *
-     * @param int $options
+     * @param  int  $options
      * @return static
      */
     public function sortRecursiveDesc($options = SORT_REGULAR)
     {
-        $items = $this->items;
-
-        return new static(Arr::sortRecursiveDesc($items, $options = SORT_REGULAR));
+        return new static(Arr::sortRecursiveDesc($this->items, $options = SORT_REGULAR));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1354,6 +1354,29 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Recursively sort an array by keys and values.
+     *
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortRecursive($options = SORT_REGULAR, $descending = false)
+    {
+        return $this->passthru('sortRecursive', func_get_args());
+    }
+
+    /**
+     * Recursively sort an array by keys and values in descending order.
+     *
+     * @param  int  $options
+     * @return static
+     */
+    public function sortRecursiveDesc($options = SORT_REGULAR)
+    {
+        return $this->passthru('sortRecursiveDesc', func_get_args());
+    }
+
+    /**
      * Sort the collection using the given callback.
      *
      * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1987,6 +1987,128 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortRecursive($collection): void
+    {
+        $data = new $collection([
+            'users' => [
+                [
+                    // should sort associative arrays by keys
+                    'name' => 'joe',
+                    'mail' => 'joe@example.com',
+                    // should sort deeply nested arrays
+                    'numbers' => [2, 1, 0],
+                ],
+                [
+                    'name' => 'jane',
+                    'age' => 25,
+                ],
+            ],
+            'repositories' => [
+                // should use weird `sort()` behavior on arrays of arrays
+                ['id' => 1],
+                ['id' => 0],
+            ],
+            // should sort non-associative arrays by value
+            20 => [2, 1, 0],
+            30 => [
+                // should sort non-incrementing numerical keys by keys
+                2 => 'a',
+                1 => 'b',
+                0 => 'c',
+            ],
+        ]);
+
+        $expect = new $collection([
+            20 => [0, 1, 2],
+            30 => [
+                0 => 'c',
+                1 => 'b',
+                2 => 'a',
+            ],
+            'repositories' => [
+                ['id' => 0],
+                ['id' => 1],
+            ],
+            'users' => [
+                [
+                    'age' => 25,
+                    'name' => 'jane',
+                ],
+                [
+                    'mail' => 'joe@example.com',
+                    'name' => 'joe',
+                    'numbers' => [0, 1, 2],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals($expect, $data->sortRecursive());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortRecursiveDesc($collection): void
+    {
+        $data = new $collection([
+            'users' => [
+                [
+                    // should sort associative arrays by keys
+                    'name' => 'joe',
+                    'mail' => 'joe@example.com',
+                    // should sort deeply nested arrays
+                    'numbers' => [2, 1, 0],
+                ],
+                [
+                    'name' => 'jane',
+                    'age' => 25,
+                ],
+            ],
+            'repositories' => [
+                // should use weird `sort()` behavior on arrays of arrays
+                ['id' => 1],
+                ['id' => 0],
+            ],
+            // should sort non-associative arrays by value
+            20 => [2, 1, 0],
+            30 => [
+                // should sort non-incrementing numerical keys by keys
+                2 => 'a',
+                1 => 'b',
+                0 => 'c',
+            ],
+        ]);
+
+        $expect = new $collection([
+            "users" => [
+                [
+                    "numbers" => [2, 1, 0],
+                    "name" => "joe",
+                    "mail" => "joe@example.com",
+                ],
+                1 => [
+                    "name" => "jane",
+                    "age" => 25,
+                ]
+            ],
+            "repositories" => [
+                ["id" => 1],
+                ["id" => 0]
+            ],
+            30 => [
+                2 => "a",
+                1 => "b",
+                0 => "c",
+            ],
+            20 => [2, 1, 0,]
+        ]);
+
+        $this->assertEquals($expect, $data->sortRecursiveDesc());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortWithCallback($collection)
     {
         $data = (new $collection([5, 3, 1, 2, 4]))->sort(function ($a, $b) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2085,18 +2085,18 @@ class SupportCollectionTest extends TestCase
                 1 => [
                     'name' => 'jane',
                     'age' => 25,
-                ]
+                ],
             ],
             'repositories' => [
                 ['id' => 1],
-                ['id' => 0]
+                ['id' => 0],
             ],
             30 => [
                 2 => 'a',
                 1 => 'b',
                 0 => 'c',
             ],
-            20 => [2, 1, 0,]
+            20 => [2, 1, 0]
         ]);
 
         $this->assertEquals($expect, $data->sortRecursiveDesc());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2096,7 +2096,7 @@ class SupportCollectionTest extends TestCase
                 1 => 'b',
                 0 => 'c',
             ],
-            20 => [2, 1, 0]
+            20 => [2, 1, 0],
         ]);
 
         $this->assertEquals($expect, $data->sortRecursiveDesc());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1984,9 +1984,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['T10', 'T2', 'T1'], $data->values()->all());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
+    #[DataProvider('collectionClassProvider')]
     public function testSortRecursive($collection): void
     {
         $data = new $collection([
@@ -2045,9 +2043,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expect, $data->sortRecursive());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
+    #[DataProvider('collectionClassProvider')]
     public function testSortRecursiveDesc($collection): void
     {
         $data = new $collection([
@@ -2080,25 +2076,25 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $expect = new $collection([
-            "users" => [
+            'users' => [
                 [
-                    "numbers" => [2, 1, 0],
-                    "name" => "joe",
-                    "mail" => "joe@example.com",
+                    'numbers' => [2, 1, 0],
+                    'name' => 'joe',
+                    'mail' => 'joe@example.com',
                 ],
                 1 => [
-                    "name" => "jane",
-                    "age" => 25,
+                    'name' => 'jane',
+                    'age' => 25,
                 ]
             ],
-            "repositories" => [
-                ["id" => 1],
-                ["id" => 0]
+            'repositories' => [
+                ['id' => 1],
+                ['id' => 0]
             ],
             30 => [
-                2 => "a",
-                1 => "b",
-                0 => "c",
+                2 => 'a',
+                1 => 'b',
+                0 => 'c',
             ],
             20 => [2, 1, 0,]
         ]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2016,7 +2016,7 @@ class SupportCollectionTest extends TestCase
             ],
         ]);
 
-        $expect = new $collection([
+        $expect = [
             20 => [0, 1, 2],
             30 => [
                 0 => 'c',
@@ -2038,9 +2038,9 @@ class SupportCollectionTest extends TestCase
                     'numbers' => [0, 1, 2],
                 ],
             ],
-        ]);
+        ];
 
-        $this->assertEquals($expect, $data->sortRecursive());
+        $this->assertEquals($expect, $data->sortRecursive()->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -2075,7 +2075,7 @@ class SupportCollectionTest extends TestCase
             ],
         ]);
 
-        $expect = new $collection([
+        $expect = [
             'users' => [
                 [
                     'numbers' => [2, 1, 0],
@@ -2097,9 +2097,9 @@ class SupportCollectionTest extends TestCase
                 0 => 'c',
             ],
             20 => [2, 1, 0],
-        ]);
+        ];
 
-        $this->assertEquals($expect, $data->sortRecursiveDesc());
+        $this->assertEquals($expect, $data->sortRecursiveDesc()->all());
     }
 
     /**

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1154,6 +1154,28 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testLazySortRecursiveDescIsLazy(): void
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->sortRecursiveDesc();
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->sortRecursiveDesc()->all();
+        });
+    }
+
+    public function testLazySortRecursiveIsLazy(): void
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->sortRecursive();
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->sortRecursive()->all();
+        });
+    }
+
     public function testSortDescIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
I have added two new methods for sorting a collection recursively: one for ascending order `sortRecursive` and another for descending order `sortRecursiveDesc`.
