### PR TITLE
[10.x] Officially support floats in trans_choice and Translator::choice

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -18,7 +18,7 @@ interface Translator
      * Get a translation according to an integer value.
      *
      * @param  string  $key
-     * @param  \Countable|int|array  $number
+     * @param  \Countable|int|float|array  $number
      * @param  array  $replace
      * @param  string|null  $locale
      * @return string

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -929,7 +929,7 @@ if (! function_exists('trans_choice')) {
      * Translates the given message based on a count.
      *
      * @param  string  $key
-     * @param  \Countable|int|array  $number
+     * @param  \Countable|int|float|array  $number
      * @param  array  $replace
      * @param  string|null  $locale
      * @return string

--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -57,7 +57,7 @@ class PotentiallyTranslatedString implements Stringable
     /**
      * Translates the string based on a count.
      *
-     * @param  \Countable|int|array  $number
+     * @param  \Countable|int|float|array  $number
      * @param  array  $replace
      * @param  string|null  $locale
      * @return $this

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -183,7 +183,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Get a translation according to an integer value.
      *
      * @param  string  $key
-     * @param  \Countable|int|array  $number
+     * @param  \Countable|int|float|array  $number
      * @param  array  $replace
      * @param  string|null  $locale
      * @return string

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -123,7 +123,7 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
     }
 
-    public function testChoiceMethodProperlyLoadsAndRetrievesItem()
+    public function testChoiceMethodProperlyLoadsAndRetrievesItemForAnInt()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
@@ -131,6 +131,16 @@ class TranslationTranslatorTest extends TestCase
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
         $t->choice('foo', 10, ['replace']);
+    }
+
+    public function testChoiceMethodProperlyLoadsAndRetrievesItemForAFloat()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->once()->with('line', 1.2, 'en')->andReturn('choiced');
+
+        $t->choice('foo', 1.2, ['replace']);
     }
 
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()


### PR DESCRIPTION
(If this should target 11.x as its considered a breaking change, then let me know and I'll change the target branch)

This already works fine with no further changes needed, so I'm not sure if there's a reason that floats were never officially supported. This is how it is currently, which you can see works perfectly fine:

Given:

```php
// lang/en/foo.php
return [
    'hours' => 'A total of :hours hour|A total of :hours hours',
];
```

Then:

```php
trans_choice('foo.hours', 1, ['hours' => 1]) === 'A total of 1 hour'
trans_choice('foo.hours', 1.0, ['hours' => 1.0]) === 'A total of 1 hour'
trans_choice('foo.hours', 1.1, ['hours' => 1.1]) === 'A total of 1.1 hours'
trans_choice('foo.hours', 0.9, ['hours' => 0.9]) === 'A total of 0.9 hours'
````

However, when running phpstan & larastan on a Laravel project that passes a `float` to `trans_choice` when wanting to display text similar to those examples ("A total of X hour[s]") it results in an error because the only documented allowed types are `\Countable|int|array` which doesn't include `float`.