### PR TITLE
[11.x] Support eager loading with limit

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -454,6 +454,34 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Alias to set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function take($value)
+    {
+        return $this->limit($value);
+    }
+
+    /**
+     * Set the "limit" value of the query.
+     *
+     * @param  int  $value
+     * @return $this
+     */
+    public function limit($value)
+    {
+        if ($this->parent->exists) {
+            $this->query->limit($value);
+        } else {
+            $this->query->groupLimit($value, $this->getExistenceCompareKey());
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the key for comparing against the parent key in "has" query.
      *
      * @return string

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2764,7 +2764,7 @@ class Builder implements BuilderContract
             return $this->processor->processSelect($this, $this->runSelect());
         }));
 
-        if (!isset($this->groupLimit)) {
+        if (! isset($this->groupLimit)) {
             return $items;
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2764,10 +2764,31 @@ class Builder implements BuilderContract
             return $this->processor->processSelect($this, $this->runSelect());
         }));
 
-        if (! isset($this->groupLimit)) {
-            return $items;
-        }
+        return isset($this->groupLimit)
+            ? $this->withoutGroupLimitKeys($items)
+            : $items;
+    }
 
+    /**
+     * Run the query as a "select" statement against the connection.
+     *
+     * @return array
+     */
+    protected function runSelect()
+    {
+        return $this->connection->select(
+            $this->toSql(), $this->getBindings(), ! $this->useWritePdo
+        );
+    }
+
+    /**
+     * Remove the group limit keys from the results in the collection.
+     *
+     * @param  \Illuminate\Support\Collection  $items
+     * @return \Illuminate\Support\Collection
+     */
+    protected function withoutGroupLimitKeys($items)
+    {
         $keysToRemove = ['laravel_row'];
 
         if (is_string($this->groupLimit['column'])) {
@@ -2784,18 +2805,6 @@ class Builder implements BuilderContract
         });
 
         return $items;
-    }
-
-    /**
-     * Run the query as a "select" statement against the connection.
-     *
-     * @return array
-     */
-    protected function runSelect()
-    {
-        return $this->connection->select(
-            $this->toSql(), $this->getBindings(), ! $this->useWritePdo
-        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -153,6 +153,13 @@ class Builder implements BuilderContract
     public $limit;
 
     /**
+     * The maximum number of records to return per group.
+     *
+     * @var array
+     */
+    public $groupLimit;
+
+    /**
      * The number of records to skip.
      *
      * @var int
@@ -2445,6 +2452,22 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "group limit" clause to the query.
+     *
+     * @param  int  $value
+     * @param  string  $column
+     * @return $this
+     */
+    public function groupLimit($value, $column)
+    {
+        if ($value >= 0) {
+            $this->groupLimit = compact('value', 'column');
+        }
+
+        return $this;
+    }
+
+    /**
      * Set the limit and offset for a given page.
      *
      * @param  int  $page
@@ -2737,9 +2760,30 @@ class Builder implements BuilderContract
      */
     public function get($columns = ['*'])
     {
-        return collect($this->onceWithColumns(Arr::wrap($columns), function () {
+        $items = collect($this->onceWithColumns(Arr::wrap($columns), function () {
             return $this->processor->processSelect($this, $this->runSelect());
         }));
+
+        if (!isset($this->groupLimit)) {
+            return $items;
+        }
+
+        $keysToRemove = ['laravel_row'];
+
+        if (is_string($this->groupLimit['column'])) {
+            $column = last(explode('.', $this->groupLimit['column']));
+
+            $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap($column);
+            $keysToRemove[] = '@laravel_group := '.$this->grammar->wrap('pivot_'.$column);
+        }
+
+        $items->each(function ($item) use ($keysToRemove) {
+            foreach ($keysToRemove as $key) {
+                unset($item->$key);
+            }
+        });
+
+        return $items;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
+use PDO;
 
 class MySqlGrammar extends Grammar
 {
@@ -92,6 +93,82 @@ class MySqlGrammar extends Grammar
             'force' => "force index ({$indexHint->index})",
             default => "ignore index ({$indexHint->index})",
         };
+    }
+
+    /**
+     * Compile a group limit clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileGroupLimit(Builder $query)
+    {
+        return $this->useLegacyGroupLimit($query)
+            ? $this->compileLegacyGroupLimit($query)
+            : parent::compileGroupLimit($query);
+    }
+
+    /**
+     * Determine whether to use a legacy group limit clause for MySQL < 8.0.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return bool
+     */
+    public function useLegacyGroupLimit(Builder $query)
+    {
+        $version = $query->getConnection()->getReadPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+        return ! $query->getConnection()->isMaria() && version_compare($version, '8.0.11') < 0;
+    }
+
+    /**
+     * Compile a group limit clause for MySQL < 8.0.
+     *
+     * Derived from https://softonsofa.com/tweaking-eloquent-relations-how-to-get-n-related-models-per-parent/.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileLegacyGroupLimit(Builder $query)
+    {
+        $limit = (int) $query->groupLimit['value'];
+
+        $offset = $query->offset;
+
+        if (isset($offset)) {
+            $offset = (int) $offset;
+            $limit += $offset;
+
+            $query->offset = null;
+        }
+
+        $column = last(explode('.', $query->groupLimit['column']));
+
+        $column = $this->wrap($column);
+
+        $partition = ', @laravel_row := if(@laravel_group = '.$column.', @laravel_row + 1, 1) as `laravel_row`';
+
+        $partition .= ', @laravel_group := '.$column;
+
+        $orders = (array) $query->orders;
+
+        array_unshift($orders, ['column' => $query->groupLimit['column'], 'direction' => 'asc']);
+
+        $query->orders = $orders;
+
+        $components = $this->compileComponents($query);
+
+        $sql = $this->concatenate($components);
+
+        $from = '(select @laravel_row := 0, @laravel_group := 0) as `laravel_vars`, ('.$sql.') as `laravel_table`';
+
+        $sql = 'select `laravel_table`.*'.$partition.' from '.$from.' having `laravel_row` <= '.$limit;
+
+        if (isset($offset)) {
+            $sql .= ' and `laravel_row` > '.$offset;
+        }
+
+        return $sql.' order by `laravel_row`';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -132,7 +132,6 @@ class MySqlGrammar extends Grammar
     protected function compileLegacyGroupLimit(Builder $query)
     {
         $limit = (int) $query->groupLimit['value'];
-
         $offset = $query->offset;
 
         if (isset($offset)) {
@@ -143,16 +142,17 @@ class MySqlGrammar extends Grammar
         }
 
         $column = last(explode('.', $query->groupLimit['column']));
-
         $column = $this->wrap($column);
 
         $partition = ', @laravel_row := if(@laravel_group = '.$column.', @laravel_row + 1, 1) as `laravel_row`';
-
         $partition .= ', @laravel_group := '.$column;
 
         $orders = (array) $query->orders;
 
-        array_unshift($orders, ['column' => $query->groupLimit['column'], 'direction' => 'asc']);
+        array_unshift($orders, [
+            'column' => $query->groupLimit['column'],
+            'direction' => 'asc'
+        ]);
 
         $query->orders = $orders;
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use PDO;
 
 class SQLiteGrammar extends Grammar
 {
@@ -182,6 +183,25 @@ class SQLiteGrammar extends Grammar
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
         return 'json_type('.$field.$path.') is not null';
+    }
+
+    /**
+     * Compile a group limit clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileGroupLimit(Builder $query)
+    {
+        $version = $query->getConnection()->getReadPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+        if (version_compare($version, '3.25.0') >= 0) {
+            return parent::compileGroupLimit($query);
+        }
+
+        $query->groupLimit = null;
+
+        return $this->compileSelect($query);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -313,6 +313,22 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a row number clause.
+     *
+     * @param  string  $partition
+     * @param  string  $orders
+     * @return string
+     */
+    protected function compileRowNumber($partition, $orders)
+    {
+        if (empty($orders)) {
+            $orders = 'order by (select 0)';
+        }
+
+        return parent::compileRowNumber($partition, $orders);
+    }
+
+    /**
      * Compile the "offset" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -114,6 +114,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
     {
         $source = new BelongsToManyCreateOrFirstTestSourceModel();
         $source->id = 123;
+        $source->exists = true;
         $this->mockConnectionForModels(
             [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
             'SQLite',
@@ -157,6 +158,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
     {
         $source = new BelongsToManyCreateOrFirstTestSourceModel();
         $source->id = 123;
+        $source->exists = true;
         $this->mockConnectionForModels(
             [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
             'SQLite',
@@ -227,6 +229,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
     {
         $source = new BelongsToManyCreateOrFirstTestSourceModel();
         $source->id = 123;
+        $source->exists = true;
         $this->mockConnectionForModels(
             [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
             'SQLite',
@@ -309,6 +312,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
             }
         };
         $source->id = 123;
+        $source->exists = true;
         $this->mockConnectionForModels(
             [$source, new BelongsToManyCreateOrFirstTestRelatedModel()],
             'SQLite',

--- a/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
@@ -56,6 +56,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -102,6 +103,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite', [789]);
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -135,6 +137,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -173,6 +176,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -228,6 +232,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite', [789]);
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -264,6 +269,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');
@@ -310,6 +316,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
     {
         $parent = new HasManyThroughCreateOrFirstTestParentModel();
         $parent->id = 123;
+        $parent->exists = true;
         $this->mockConnectionForModel($parent, 'SQLite');
         $parent->getConnection()->shouldReceive('transactionLevel')->andReturn(0);
         $parent->getConnection()->shouldReceive('getName')->andReturn('sqlite');

--- a/tests/Integration/Database/EloquentEagerLoadingLimitTest.php
+++ b/tests/Integration/Database/EloquentEagerLoadingLimitTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentEagerLoadingLimitTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentEagerLoadingLimitTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('post_id');
+            $table->timestamps();
+        });
+
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger('user_id');
+        });
+
+        User::create();
+        User::create();
+
+        Post::create(['user_id' => 1, 'created_at' => new Carbon('2024-01-01 00:00:01')]);
+        Post::create(['user_id' => 1, 'created_at' => new Carbon('2024-01-01 00:00:02')]);
+        Post::create(['user_id' => 1, 'created_at' => new Carbon('2024-01-01 00:00:03')]);
+        Post::create(['user_id' => 2, 'created_at' => new Carbon('2024-01-01 00:00:04')]);
+        Post::create(['user_id' => 2, 'created_at' => new Carbon('2024-01-01 00:00:05')]);
+        Post::create(['user_id' => 2, 'created_at' => new Carbon('2024-01-01 00:00:06')]);
+
+        Comment::create(['post_id' => 1, 'created_at' => new Carbon('2024-01-01 00:00:01')]);
+        Comment::create(['post_id' => 2, 'created_at' => new Carbon('2024-01-01 00:00:02')]);
+        Comment::create(['post_id' => 3, 'created_at' => new Carbon('2024-01-01 00:00:03')]);
+        Comment::create(['post_id' => 4, 'created_at' => new Carbon('2024-01-01 00:00:04')]);
+        Comment::create(['post_id' => 5, 'created_at' => new Carbon('2024-01-01 00:00:05')]);
+        Comment::create(['post_id' => 6, 'created_at' => new Carbon('2024-01-01 00:00:06')]);
+
+        Role::create(['created_at' => new Carbon('2024-01-01 00:00:01')]);
+        Role::create(['created_at' => new Carbon('2024-01-01 00:00:02')]);
+        Role::create(['created_at' => new Carbon('2024-01-01 00:00:03')]);
+        Role::create(['created_at' => new Carbon('2024-01-01 00:00:04')]);
+        Role::create(['created_at' => new Carbon('2024-01-01 00:00:05')]);
+        Role::create(['created_at' => new Carbon('2024-01-01 00:00:06')]);
+
+        DB::table('role_user')->insert([
+            ['role_id' => 1, 'user_id' => 1],
+            ['role_id' => 2, 'user_id' => 1],
+            ['role_id' => 3, 'user_id' => 1],
+            ['role_id' => 4, 'user_id' => 2],
+            ['role_id' => 5, 'user_id' => 2],
+            ['role_id' => 6, 'user_id' => 2],
+        ]);
+    }
+
+    public function testBelongsToMany(): void
+    {
+        $users = User::with(['roles' => fn ($query) => $query->latest()->limit(2)])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertEquals([3, 2], $users[0]->roles->pluck('id')->all());
+        $this->assertEquals([6, 5], $users[1]->roles->pluck('id')->all());
+        $this->assertArrayNotHasKey('laravel_row', $users[0]->roles[0]);
+        $this->assertArrayNotHasKey('@laravel_group := `user_id`', $users[0]->roles[0]);
+    }
+
+    public function testBelongsToManyWithOffset(): void
+    {
+        $users = User::with(['roles' => fn ($query) => $query->latest()->limit(2)->offset(1)])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertEquals([2, 1], $users[0]->roles->pluck('id')->all());
+        $this->assertEquals([5, 4], $users[1]->roles->pluck('id')->all());
+    }
+
+    public function testHasMany(): void
+    {
+        $users = User::with(['posts' => fn ($query) => $query->latest()->limit(2)])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertEquals([3, 2], $users[0]->posts->pluck('id')->all());
+        $this->assertEquals([6, 5], $users[1]->posts->pluck('id')->all());
+        $this->assertArrayNotHasKey('laravel_row', $users[0]->posts[0]);
+        $this->assertArrayNotHasKey('@laravel_group := `user_id`', $users[0]->posts[0]);
+    }
+
+    public function testHasManyWithOffset(): void
+    {
+        $users = User::with(['posts' => fn ($query) => $query->latest()->limit(2)->offset(1)])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertEquals([2, 1], $users[0]->posts->pluck('id')->all());
+        $this->assertEquals([5, 4], $users[1]->posts->pluck('id')->all());
+    }
+
+    public function testHasManyThrough(): void
+    {
+        $users = User::with(['comments' => fn ($query) => $query->latest('comments.created_at')->limit(2)])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertEquals([3, 2], $users[0]->comments->pluck('id')->all());
+        $this->assertEquals([6, 5], $users[1]->comments->pluck('id')->all());
+        $this->assertArrayNotHasKey('laravel_row', $users[0]->comments[0]);
+        $this->assertArrayNotHasKey('@laravel_group := `user_id`', $users[0]->comments[0]);
+    }
+
+    public function testHasManyThroughWithOffset(): void
+    {
+        $users = User::with(['comments' => fn ($query) => $query->latest('comments.created_at')->limit(2)->offset(1)])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertEquals([2, 1], $users[0]->comments->pluck('id')->all());
+        $this->assertEquals([5, 4], $users[1]->comments->pluck('id')->all());
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+class Post extends Model
+{
+    protected $guarded = [];
+}
+
+class Role extends Model
+{
+    protected $guarded = [];
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function comments(): HasManyThrough
+    {
+        return $this->hasManyThrough(Comment::class, Post::class);
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class);
+    }
+}


### PR DESCRIPTION
As discussed: A new version of #26035 that integrates the [eloquent-eager-limit](https://github.com/staudenmeir/eloquent-eager-limit) package.

### Support for MySQL 5.7

According to the current [docs](https://laravel.com/docs/master/database#introduction), Laravel 11 won't support MySQL 5.7 anymore. I still included the legacy workaround for MySQL 5.7 since the necessary code already exists and MySQL 5.7 is still [being tested](https://github.com/laravel/framework/blob/master/.github/workflows/databases.yml#L11). The MySQL support in Laravel 11 is also still [being discussed](https://github.com/laravel/docs/pull/9113).