### PR TITLE
[10.x] Add exit code to queue:clear, and queue:forget commands

### DIFF
--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -57,9 +57,9 @@ class ClearCommand extends Command
             $this->components->info('Cleared '.$count.' '.Str::plural('job', $count).' from the ['.$queueName.'] queue');
         } else {
             $this->components->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
-        }
 
-        return 0;
+            return 1;
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -60,6 +60,8 @@ class ClearCommand extends Command
 
             return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -25,7 +25,7 @@ class ForgetFailedCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int|null
      */
     public function handle()
     {
@@ -33,6 +33,8 @@ class ForgetFailedCommand extends Command
             $this->components->info('Failed job deleted successfully.');
         } else {
             $this->components->error('No failed job matches the given ID.');
+
+            return 1;
         }
     }
 }


### PR DESCRIPTION
When `$this->error()` is called it makes sense to return exit code 1 to show that the command did not complete successfully. The exit code is easier to detect programmatically in comparison to looking for `$this->error()` output.

These commands now match the behaviour of the `queue:prune-failed` command.
