### PR TITLE
[10.x] Fix docs ResourceCollection and JsonCollection 

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -121,7 +121,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Transform the resource into an array.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     * @return array<int|string, mixed>
      */
     public function toArray(Request $request)
     {

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -95,7 +95,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      * Transform the resource into a JSON array.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     * @return array<int|string, mixed>
      */
     public function toArray(Request $request)
     {


### PR DESCRIPTION
### Description
In this pull request, I have updated the PHPDoc for the function [function name]. Previously, the PHPDoc for this function was described as follows:

```
@return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
```
However, I have changed it to:

```
@return array<int|string, mixed>
```
### Reason for Change:

This update aims to clarify the return type of the function. The previous description indicated that the function could return an array, an Arrayable object, or a JsonSerializable object. However, it was not clear about the specific structure of the array.
By using array<int|string, mixed>, I have clarified that this function returns an array with keys that can be either integers or strings, and the values can be of any type.
This helps improve the clarity and transparency of the code and better supports static analysis and code suggestion in IDE tools.
### Impact:

This change does not affect the functionality of the function. It simply provides clearer information about the expected return data type.
It helps developers who read and use this function to better understand the data structure they can expect from it.
Looking forward to your feedback and suggestions. If there are any questions or concerns about this change, please feel free to discuss.