### PR TITLE
[10.x] Switch to hash_equals in `File::hasSameHash()`

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -546,7 +546,7 @@ class Filesystem
     {
         $hash = @md5_file($firstFile);
 
-        return $hash && $hash === @md5_file($secondFile);
+        return $hash && hash_equals($hash, (string) @md5_file($secondFile));
     }
 
     /**


### PR DESCRIPTION
PR follow-up to https://github.com/laravel/framework/discussions/49718

No new tests required.

Uses the timing-attack-safe `hash_equals()` instead of a simple string comparison.

See the discussion thread for more detail.