### PR TITLE
[10.x] Adds JobQueueing event

### DIFF
--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+use RuntimeException;
+
+class JobQueueing
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Closure|string|object
+     */
+    public $job;
+
+    /**
+     * The job payload.
+     *
+     * @var string|null
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Closure|string|object  $job
+     * @param  string|null  $payload
+     * @return void
+     */
+    public function __construct($connectionName, $job, $payload = null)
+    {
+        $this->connectionName = $connectionName;
+        $this->job = $job;
+        $this->payload = $payload;
+    }
+
+    /**
+     * Get the decoded job payload.
+     *
+     * @return array
+     */
+    public function payload()
+    {
+        if ($this->payload === null) {
+            throw new RuntimeException('The job payload was not provided when the event was dispatched.');
+        }
+
+        return json_decode($this->payload, true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -329,6 +329,7 @@ abstract class Queue
             return $this->container->make('db.transactions')->addCallback(
                 function () use ($payload, $queue, $delay, $callback, $job) {
                     $this->raiseJobQueueingEvent($job, $payload);
+
                     return tap($callback($payload, $queue, $delay), function ($jobId) use ($job, $payload) {
                         $this->raiseJobQueuedEvent($jobId, $job, $payload);
                     });
@@ -337,6 +338,7 @@ abstract class Queue
         }
 
         $this->raiseJobQueueingEvent($job, $payload);
+
         return tap($callback($payload, $queue, $delay), function ($jobId) use ($job, $payload) {
             $this->raiseJobQueuedEvent($jobId, $job, $payload);
         });

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -45,7 +45,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $this->queue->push('foo', ['data'], 'stack');
         $this->queue->push('foo', ['data']);
 
-        $this->container->shouldHaveReceived('bound')->with('events')->times(2);
+        $this->container->shouldHaveReceived('bound')->with('events')->times(4);
 
         Str::createUuidsNormally();
     }
@@ -67,7 +67,7 @@ class QueueBeanstalkdQueueTest extends TestCase
         $this->queue->later(5, 'foo', ['data'], 'stack');
         $this->queue->later(5, 'foo', ['data']);
 
-        $this->container->shouldHaveReceived('bound')->with('events')->times(2);
+        $this->container->shouldHaveReceived('bound')->with('events')->times(4);
 
         Str::createUuidsNormally();
     }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -46,7 +46,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
         $queue->push($job, ['data']);
 
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
     }
@@ -87,7 +87,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
         $queue->later(10, 'foo', ['data']);
 
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
     }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -35,7 +35,7 @@ class QueueRedisQueueTest extends TestCase
 
         $id = $queue->push('foo', ['data']);
         $this->assertSame('foo', $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
     }
@@ -60,7 +60,7 @@ class QueueRedisQueueTest extends TestCase
 
         $id = $queue->push('foo', ['data']);
         $this->assertSame('foo', $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Queue::createPayloadUsing(null);
 
@@ -91,7 +91,7 @@ class QueueRedisQueueTest extends TestCase
 
         $id = $queue->push('foo', ['data']);
         $this->assertSame('foo', $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Queue::createPayloadUsing(null);
 
@@ -120,7 +120,7 @@ class QueueRedisQueueTest extends TestCase
 
         $id = $queue->later(1, 'foo', ['data']);
         $this->assertSame('foo', $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
     }
@@ -147,7 +147,7 @@ class QueueRedisQueueTest extends TestCase
         );
 
         $queue->later($date, 'foo', ['data']);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
 
         Str::createUuidsNormally();
     }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -116,7 +116,7 @@ class QueueSqsQueueTest extends TestCase
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => 5])->andReturn($this->mockedSendMessageResponseModel);
         $id = $queue->later($now->addSeconds(5), $this->mockedJob, $this->mockedData, $this->queueName);
         $this->assertEquals($this->mockedMessageId, $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
     public function testDelayedPushProperlyPushesJobOntoSqs()
@@ -129,7 +129,7 @@ class QueueSqsQueueTest extends TestCase
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDelay])->andReturn($this->mockedSendMessageResponseModel);
         $id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->queueName);
         $this->assertEquals($this->mockedMessageId, $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
     public function testPushProperlyPushesJobOntoSqs()
@@ -141,7 +141,7 @@ class QueueSqsQueueTest extends TestCase
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload])->andReturn($this->mockedSendMessageResponseModel);
         $id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
         $this->assertEquals($this->mockedMessageId, $id);
-        $container->shouldHaveReceived('bound')->with('events')->once();
+        $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 
     public function testSizeProperlyReadsSqsQueueSize()


### PR DESCRIPTION
### Changes
Adds a new `JobQueueing` event that is fired before a job is sent to the queue provider.

It is a copy of the `JobQueued` event but without the `id` property as the `jobId` is returned from the queue provider.

I have included this new `JobQueueing` event in tests where needed.

### Why?
I was discussing gaps in Sentry's performance monitoring with a maintainer of their official Laravel Sentry SDK package.

We believe in one specific scenario it was because it wasn't tracking when jobs were sent to the queue provider (in our case SQS).

For example, you might want  to monitor the time it has taken between `JobQueueing` and `JobQueued` for a job to be sent to the chosen queue provider. 

Some services this maybe instant like `redis` but, we have seen `SQS` sometimes take longer as that is making an api request to a service. 
