### PR TITLE
[11.x] Add a method to connection for driver and version comparison

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -22,7 +22,7 @@ abstract class DatabaseInspectionCommand extends Command
     protected function getConnectionName(ConnectionInterface $connection, $database)
     {
         return match (true) {
-            $connection instanceof MySqlConnection && $connection->isMaria() => 'MariaDB',
+            $connection instanceof MySqlConnection && $connection->is('mariadb') => 'MariaDB',
             $connection instanceof MySqlConnection => 'MySQL',
             $connection instanceof PostgresConnection => 'PostgreSQL',
             $connection instanceof SQLiteConnection => 'SQLite',

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -39,28 +39,6 @@ class MySqlConnection extends Connection
     }
 
     /**
-     * Determine if the connected database is a MariaDB database.
-     *
-     * @return bool
-     */
-    public function isMaria()
-    {
-        return str_contains($this->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION), 'MariaDB');
-    }
-
-    /**
-     * Get the server version for the connection.
-     *
-     * @return string
-     */
-    public function getServerVersion(): string
-    {
-        return str_contains($version = parent::getServerVersion(), 'MariaDB')
-            ? Str::between($version, '5.5.5-', '-MariaDB')
-            : $version;
-    }
-
-    /**
      * Get the default query grammar instance.
      *
      * @return \Illuminate\Database\Query\Grammars\MySqlGrammar

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -9,8 +9,6 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Database\Schema\MySqlSchemaState;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
-use PDO;
 
 class MySqlConnection extends Connection
 {

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
-use PDO;
 
 class MySqlGrammar extends Grammar
 {
@@ -116,9 +115,7 @@ class MySqlGrammar extends Grammar
      */
     public function useLegacyGroupLimit(Builder $query)
     {
-        $version = $query->getConnection()->getReadPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
-
-        return ! $query->getConnection()->isMaria() && version_compare($version, '8.0.11') < 0;
+        return $query->getConnection()->is('mysql', '<', '8.0.11');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use PDO;
 
 class SQLiteGrammar extends Grammar
 {
@@ -193,9 +192,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function compileGroupLimit(Builder $query)
     {
-        $version = $query->getConnection()->getReadPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
-
-        if (version_compare($version, '3.25.0') >= 0) {
+        if ($query->getConnection()->is('sqlite', '>=', '3.25.0')) {
             return parent::compileGroupLimit($query);
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -357,10 +357,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        $version = $connection->getServerVersion();
-
-        if (($connection->isMaria() && version_compare($version, '10.5.2', '<')) ||
-            (! $connection->isMaria() && version_compare($version, '8.0.3', '<'))) {
+        if ($connection->is([['mariadb', '<', '10.5.2'], ['mysql', '<', '8.0.3']])) {
             $column = collect($connection->getSchemaBuilder()->getColumns($blueprint->getTable()))
                 ->firstWhere('name', $command->from);
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -87,7 +87,7 @@ class MySqlSchemaState extends SchemaState
     {
         $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
-        if ($this->connection->is('mariadb')) {
+        if (! $this->connection->is('mariadb')) {
             $command .= ' --set-gtid-purged=OFF';
         }
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -87,7 +87,7 @@ class MySqlSchemaState extends SchemaState
     {
         $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
-        if (! $this->connection->isMaria()) {
+        if ($this->connection->is('mariadb')) {
             $command .= ' --set-gtid-purged=OFF';
         }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -8,8 +8,6 @@ use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
-use PDO;
 
 class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
 {

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -95,6 +95,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Connection setTablePrefix(string $prefix)
  * @method static \Illuminate\Database\Grammar withTablePrefix(\Illuminate\Database\Grammar $grammar)
  * @method static string getServerVersion()
+ * @method static bool is(string|array|\Closure $driver, string|null $operator = null, string|null $version = null)
  * @method static void resolverFor(string $driver, \Closure $callback)
  * @method static mixed getResolver(string $driver)
  * @method static mixed transaction(\Closure $callback, int $attempts = 1)

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -168,8 +168,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         });
 
         $connection = m::mock(Connection::class);
-        $connection->shouldReceive('getServerVersion')->andReturn('8.0.4');
-        $connection->shouldReceive('isMaria')->andReturn(false);
+        $connection->shouldReceive('is')->with([['mariadb', '<', '10.5.2'], ['mysql', '<', '8.0.3']])->andReturn(false);
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table `users` rename column `foo` to `bar`'], $blueprint->toSql($connection, new MySqlGrammar));
@@ -192,8 +191,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         });
 
         $connection = m::mock(Connection::class);
-        $connection->shouldReceive('isMaria')->andReturn(false);
-        $connection->shouldReceive('getServerVersion')->andReturn('5.7');
+        $connection->shouldReceive('is')->with([['mariadb', '<', '10.5.2'], ['mysql', '<', '8.0.3']])->andReturn(true);
         $connection->shouldReceive('getSchemaBuilder->getColumns')->andReturn([
             ['name' => 'name', 'type' => 'varchar(255)', 'type_name' => 'varchar', 'nullable' => true, 'collation' => 'utf8mb4_unicode_ci', 'default' => 'foo', 'comment' => null, 'auto_increment' => false],
             ['name' => 'id', 'type' => 'bigint unsigned', 'type_name' => 'bigint', 'nullable' => false, 'collation' => null, 'default' => null, 'comment' => 'lorem ipsum', 'auto_increment' => true],
@@ -213,8 +211,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         });
 
         $connection = m::mock(Connection::class);
-        $connection->shouldReceive('isMaria')->andReturn(true);
-        $connection->shouldReceive('getServerVersion')->andReturn('10.1.35');
+        $connection->shouldReceive('is')->with([['mariadb', '<', '10.5.2'], ['mysql', '<', '8.0.3']])->andReturn(true);
         $connection->shouldReceive('getSchemaBuilder->getColumns')->andReturn([
             ['name' => 'name', 'type' => 'varchar(255)', 'type_name' => 'varchar', 'nullable' => true, 'collation' => 'utf8mb4_unicode_ci', 'default' => 'foo', 'comment' => null, 'auto_increment' => false],
             ['name' => 'id', 'type' => 'bigint unsigned', 'type_name' => 'bigint', 'nullable' => false, 'collation' => null, 'default' => null, 'comment' => 'lorem ipsum', 'auto_increment' => true],

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -372,7 +372,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testSystemVersionedTables()
     {
-        if ($this->driver !== 'mysql' || ! $this->getConnection()->isMaria()) {
+        if (! $this->getConnection()->is('mariadb')) {
             $this->markTestSkipped('Test requires a MariaDB connection.');
         }
 


### PR DESCRIPTION
Determining database driver and version to handle different databases' capabilities is tricky, this PR adds a new `is` method to `Connection` for convenient driver and version comparison.

## Usage
Almost all these syntaxes are currently used on the framework:

```php
DB::is('mysql'); // true|false

DB::is('pgsql', '>=', '9.5'); // true|false

DB::is(['mysql', 'mariadb']); // true|false

DB::is([['mysql', '<', '8.0.3'], ['mariadb', '<', '10.5.2']]); // true|false

DB::is(['sqlite' => ['>', '3.35.0'], 'vitess' => ['>', '19.0']]); // true|false

DB::is(fn ($driver, $version) => $driver === 'pgsql' && version_compare($version, '10.0', '<')); // true|false

DB::is(fn ($driver) => $driver === 'sqlsrv' ? 'datetime' : 'timestamp'); // 'timestamp'|'datetime'
```

## Why?
The best reason is the changed code of this PR. We need this method to check driver and actual version of the database to handle different grammar syntaxes, features and capabilities of each one.

## Support
Supported drivers are based on the current usage on the framework, `maridb`, `mysql`, `sqlite`, `pgsql`, `sqlsrv` and `vitess` (i.e PlanetScale).
Other databases (e.g. SingleStoreDB, CockroachDB, Supabase, etc.) may be added later.