### PR TITLE
[10.x] fix Rule::unless for callable $condition

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -56,7 +56,7 @@ class Rule
      */
     public static function unless($condition, $rules, $defaultRules = [])
     {
-        return new ConditionalRules(! $condition, $rules, $defaultRules);
+        return new ConditionalRules($condition, $defaultRules, $rules);
     }
 
     /**

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -28,6 +28,10 @@ class ValidationRuleParserTest extends TestCase
             'zip' => ['required', Rule::when($isAdmin, function (Fluent $input) {
                 return ['min:2'];
             })],
+            'when_cb_true' => Rule::when(fn () => true, ['required'], ['nullable']),
+            'when_cb_false' => Rule::when(fn () => false, ['required'], ['nullable']),
+            'unless_cb_true' => Rule::unless(fn () => true, ['required'], ['nullable']),
+            'unless_cb_false' => Rule::unless(fn () => false, ['required'], ['nullable']),
         ]);
 
         $this->assertEquals([
@@ -39,6 +43,10 @@ class ValidationRuleParserTest extends TestCase
             'city' => ['required', 'min:2'],
             'state' => ['required', 'min:2'],
             'zip' => ['required', 'min:2'],
+            'when_cb_true' => ['required'],
+            'when_cb_false' => ['nullable'],
+            'unless_cb_true' => ['nullable'],
+            'unless_cb_false' => ['required'],
         ], $rules);
     }
 


### PR DESCRIPTION
When `$condition` is a `callable` then `(! $condition)` does not invert the callbacks result, but is always `false` instead. It is easier to flip `$defaultRules`and `$rules`.