### PR TITLE
[11.x] Fix adding constraints on sqlite

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -105,7 +105,7 @@ abstract class Grammar extends BaseGrammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
-        throw new RuntimeException('This database driver does not support adding primary key.');
+        throw new RuntimeException('This database driver does not support adding a primary key.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -97,6 +97,18 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a primary key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compilePrimary(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('This database driver does not support adding primary key.');
+    }
+
+    /**
      * Compile a fulltext index key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -189,12 +189,18 @@ class SQLiteGrammar extends Grammar
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
+        $primaryKey = tap($this->getCommandByName($blueprint, 'primary'), fn($pk) => $pk?->shouldBeSkipped());
+
+        $foreignKeys = tap($this->getCommandsByName($blueprint, 'foreign'),
+            fn ($commands) => collect($commands)->each->shouldBeSkipped()
+        );
+
         return sprintf('%s table %s (%s%s%s)',
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint)),
-            $this->addForeignKeys($this->getCommandsByName($blueprint, 'foreign')),
-            $this->addPrimaryKeys($this->getCommandByName($blueprint, 'primary'))
+            $this->addForeignKeys($foreignKeys),
+            $this->addPrimaryKeys($primaryKey)
         );
     }
 
@@ -419,7 +425,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileForeign(Blueprint $blueprint, Fluent $command)
     {
-        // Handled on table creation...
+        throw new RuntimeException('This database driver does not support adding foreign key constraints.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -189,7 +189,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
-        $primaryKey = tap($this->getCommandByName($blueprint, 'primary'), fn($pk) => $pk?->shouldBeSkipped());
+        $primaryKey = tap($this->getCommandByName($blueprint, 'primary'), fn ($pk) => $pk?->shouldBeSkipped());
 
         $foreignKeys = tap($this->getCommandsByName($blueprint, 'foreign'),
             fn ($commands) => collect($commands)->each->shouldBeSkipped()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -306,31 +306,31 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrained();
-        $blueprint->foreignId('laravel_idea_id')->constrained();
-        $blueprint->foreignId('team_id')->references('id')->on('teams');
-        $blueprint->foreignId('team_column_id')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
             'alter table "users" add column "foo" integer not null',
-            'alter table "users" add column "company_id" integer not null',
-            'alter table "users" add column "laravel_idea_id" integer not null',
-            'alter table "users" add column "team_id" integer not null',
-            'alter table "users" add column "team_column_id" integer not null',
         ], $statements);
     }
 
-    public function testAddingForeignIdSpecifyingIndexNameInConstraint()
+    public function testAddingForeignKeyConstraint()
     {
+        $this->expectException(\RuntimeException::class);
+
         $blueprint = new Blueprint('users');
-        $blueprint->foreignId('company_id')->constrained(indexName: 'my_index');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertSame([
-            'alter table "users" add column "company_id" integer not null',
-        ], $statements);
+        $blueprint->foreignId('company_id')->constrained();
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
+    public function testAlterTableAddingPrimaryKey()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->primary('id');
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingBigIncrementingID()
@@ -727,20 +727,11 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignUuid = $blueprint->foreignUuid('foo');
-        $blueprint->foreignUuid('company_id')->constrained();
-        $blueprint->foreignUuid('laravel_idea_id')->constrained();
-        $blueprint->foreignUuid('team_id')->references('id')->on('teams');
-        $blueprint->foreignUuid('team_column_id')->constrained('teams');
-
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
             'alter table "users" add column "foo" varchar not null',
-            'alter table "users" add column "company_id" varchar not null',
-            'alter table "users" add column "laravel_idea_id" varchar not null',
-            'alter table "users" add column "team_id" varchar not null',
-            'alter table "users" add column "team_column_id" varchar not null',
         ], $statements);
     }
 


### PR DESCRIPTION
SQLite schema grammar silently ignores adding primary key and foreign key constraints when altering table, this PR fixes that. I understand that this was to preventing failure when running tests using SQLite, but please consider that **it's more important to let the user know that these constraints are not actually added**. A simple workaround for users that use SQLite for running tests is to simply check for their database before adding constraints:

```php
Schema::table('posts', function (Blueprint $table) {
    // ...

    if (! Schema::getConnection() instanceof \Illuminate\Database\SQLiteConnection) {
        $table->foreign('user_id')->references('id')->on('users');
    }
});
```

Or alternatively if #49723 merged:
```php
Schema::table('posts', function (Blueprint $table) {
    // ...

    if (! DB::is('sqlite')) {
        $table->foreign('user_id')->references('id')->on('users');
    }
});
```