### PR TITLE
[10.x] Improves performance of `Str::after()` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -89,13 +89,13 @@ class Str
             return $subject;
         }
 
-        $position = strpos($subject, (string) $search);
+        $position = mb_strpos($subject, (string) $search);
 
         if ($position === false) {
             return $subject;
         }
 
-        return substr($subject, $position + strlen($search));
+        return mb_substr($subject, $position + strlen($search));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -86,7 +86,7 @@ class Str
     public static function after($subject, $search)
     {
         if ($search === '') {
-                return $subject;
+            return $subject;
         }
         $pos = strpos($subject, $search);
         return $pos === false ? $subject : substr($subject, $pos + strlen($search));

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -85,7 +85,11 @@ class Str
      */
     public static function after($subject, $search)
     {
-        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+        if ($search === '') {
+                return $subject;
+        }
+        $pos = strpos($subject, $search);
+        return $pos === false ? $subject : substr($subject, $pos + strlen($search));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,8 +88,14 @@ class Str
         if ($search === '') {
             return $subject;
         }
-        $pos = strpos($subject, $search);
-        return $pos === false ? $subject : substr($subject, $pos + strlen($search));
+
+        $position = strpos($subject, (string) $search);
+
+        if ($position === false) {
+            return $subject;
+        }
+
+        return substr($subject, $position + strlen($search));
     }
 
     /**


### PR DESCRIPTION
Array functions like explode use more memory.
Please check the xdebug output.
![xdebug](https://i.imgur.com/OfOh3Ps.png)
 
