### PR TITLE
[10.x] Fix improving numeric comparison for custom casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2102,7 +2102,7 @@ trait HasAttributes
         }
 
         try {
-            return BigDecimal::of($attribute)->isEqualTo($original);
+            return $original !== null && BigDecimal::of($attribute)->isEqualTo($original);
         } catch (BrickNumberFormatException $e) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2104,7 +2104,8 @@ trait HasAttributes
         try {
             return $original !== null && BigDecimal::of($attribute)->isEqualTo($original);
         } catch (BrickNumberFormatException $e) {
-            return false;
+            return is_numeric($attribute) && is_numeric($original)
+                && strcmp((string) $attribute, (string) $original) === 0;
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2103,9 +2103,8 @@ trait HasAttributes
 
         try {
             return BigDecimal::of($attribute)->isEqualTo($original);
-        }
-        catch (BrickNumberFormatException $e) {
-            return false
+        } catch (BrickNumberFormatException $e) {
+            return false;
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 use BackedEnum;
 use Brick\Math\BigDecimal;
 use Brick\Math\Exception\MathException as BrickMathException;
+use Brick\Math\Exception\NumberFormatException as BrickNumberFormatException;
 use Brick\Math\RoundingMode;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
@@ -2100,8 +2101,12 @@ trait HasAttributes
             return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
         }
 
-        return is_numeric($attribute) && is_numeric($original)
-            && strcmp((string) $attribute, (string) $original) === 0;
+        try {
+            return BigDecimal::of($attribute)->isEqualTo($original);
+        }
+        catch (BrickNumberFormatException $e) {
+            return false
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2102,10 +2102,10 @@ trait HasAttributes
         }
 
         try {
-            return $original !== null && BigDecimal::of($attribute)->isEqualTo($original);
-        } catch (BrickNumberFormatException $e) {
             return is_numeric($attribute) && is_numeric($original)
-                && strcmp((string) $attribute, (string) $original) === 0;
+                && BigDecimal::of($attribute)->isEqualTo($original);
+        } catch (BrickNumberFormatException $e) {
+            return false;
         }
     }
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -169,6 +169,36 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $this->assertSame((new Decimal('320.988'))->getValue(), $model->price->getValue());
     }
 
+    public function testDirtyOnCustomNumericCasts()
+    {
+        $model = new TestEloquentModelWithCustomCast;
+        $model->price = '123.00';
+        $model->save();
+
+        $this->assertFalse($model->isDirty());
+
+        $model->price = '123.00';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '123.0';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '123';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '00123.00';
+        $this->assertFalse($model->isDirty('price'));
+
+        $model->price = '123 '; // with space
+        $this->assertTrue($model->isDirty('price'));
+
+        $model->price = '123.4000';
+        $this->assertTrue($model->isDirty('price'));
+
+        $model->price = '123.0004';
+        $this->assertTrue($model->isDirty('price'));
+    }
+
     public function testSerializableCasts()
     {
         $model = new TestEloquentModelWithCustomCast;


### PR DESCRIPTION
Reintroduce #49504 by adding BigDecimal operations inside try block to fix #49701. Bricks' BigDecimal has different numeric check vs is_numeric with its own regex.