### PR TITLE
[11.x] Add ExcludesPaths middleware trait

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware\Concerns;
+
+trait ExcludesPaths
+{
+    /**
+     * The URIs that should be excluded.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [];
+
+    /**
+     * Get the URIs that should be excluded.
+     *
+     * @return array
+     */
+    public function getExcludedPaths()
+    {
+        return $this->except;
+    }
+
+    /**
+     * Determine if the request has a URI that should be excluded.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function inExceptArray($request)
+    {
+        foreach ($this->getExcludedPaths() as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -12,16 +12,6 @@ trait ExcludesPaths
     protected $except = [];
 
     /**
-     * Get the URIs that should be excluded.
-     *
-     * @return array
-     */
-    public function getExcludedPaths()
-    {
-        return $this->except;
-    }
-
-    /**
      * Determine if the request has a URI that should be excluded.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -40,5 +30,15 @@ trait ExcludesPaths
         }
 
         return false;
+    }
+
+    /**
+     * Get the URIs that should be excluded.
+     *
+     * @return array
+     */
+    public function getExcludedPaths()
+    {
+        return $this->except;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -6,23 +6,19 @@ use Closure;
 use ErrorException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
+use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PreventRequestsDuringMaintenance
 {
+    use ExcludesPaths;
+
     /**
      * The application implementation.
      *
      * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
-
-    /**
-     * The URIs that should be accessible while maintenance mode is enabled.
-     *
-     * @var array<int, string>
-     */
-    protected $except = [];
 
     /**
      * Create a new middleware instance.
@@ -117,27 +113,6 @@ class PreventRequestsDuringMaintenance
     }
 
     /**
-     * Determine if the request has a URI that should be accessible in maintenance mode.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    protected function inExceptArray($request)
-    {
-        foreach ($this->getExcludedPaths() as $except) {
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if ($request->fullUrlIs($except) || $request->is($except)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Redirect the user back to the root of the application with a maintenance mode bypass cookie.
      *
      * @param  string  $secret
@@ -165,15 +140,5 @@ class PreventRequestsDuringMaintenance
         }
 
         return $headers;
-    }
-
-    /**
-     * Get the URIs that should be accessible even when maintenance mode is enabled.
-     *
-     * @return array
-     */
-    public function getExcludedPaths()
-    {
-        return $this->except;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\InteractsWithTime;
@@ -16,7 +17,8 @@ use Symfony\Component\HttpFoundation\Cookie;
 
 class VerifyCsrfToken
 {
-    use InteractsWithTime;
+    use InteractsWithTime,
+        ExcludesPaths;
 
     /**
      * The application instance.
@@ -31,13 +33,6 @@ class VerifyCsrfToken
      * @var \Illuminate\Contracts\Encryption\Encrypter
      */
     protected $encrypter;
-
-    /**
-     * The URIs that should be excluded from CSRF verification.
-     *
-     * @var array<int, string>
-     */
-    protected $except = [];
 
     /**
      * The globally ignored URIs that should be excluded from CSRF verification.
@@ -115,24 +110,13 @@ class VerifyCsrfToken
     }
 
     /**
-     * Determine if the request has a URI that should pass through CSRF verification.
+     * Get the URIs that should be excluded.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
+     * @return array
      */
-    protected function inExceptArray($request)
+    public function getExcludedPaths()
     {
-        foreach (array_merge($this->except, static::$neverVerify) as $except) {
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if ($request->fullUrlIs($except) || $request->is($except)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_merge($this->except, static::$neverVerify);
     }
 
     /**


### PR DESCRIPTION
_New version of #47198. That PR was closed because Taylor was busy with the Laravel 11 changes. Now that those changes are merged and L11 release is only a couple of weeks away, I'm reopening a PR to add this trait._

The `PreventRequestsDuringMaintenance` and `VerifyCsrfToken` middleware both have code related to excluding certain paths/urls/routes. This PR extracts that code to a dedicated trait, which removes duplicate code from the framework and also makes it possible for applications to use that trait on project-specific middleware that needs the same behavior.