### PR TITLE
[10.x] Added model stub without HasFactory trait

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -168,7 +168,7 @@ class ModelMakeCommand extends GeneratorCommand
      *
      * @return string
      */
-    protected function getStub()
+    protected function getStub(): string
     {
         if ($this->option('pivot')) {
             return $this->resolveStubPath('/stubs/model.pivot.stub');
@@ -176,6 +176,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('morph-pivot')) {
             return $this->resolveStubPath('/stubs/model.morph-pivot.stub');
+        }
+
+        if (! $this->option('factory')) {
+            return $this->resolveStubPath('/stubs/model.no-factory.stub');
         }
 
         return $this->resolveStubPath('/stubs/model.stub');

--- a/src/Illuminate/Foundation/Console/stubs/model.no-factory.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.no-factory.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Model;
+
+class {{ class }} extends Model
+{
+    //
+}


### PR DESCRIPTION
Hi!

I like to have no errors and warnings in my project files but sometimes, after the model is created, I see this error:
![image](https://github.com/laravel/framework/assets/75097934/4e03a065-b3dc-495d-881a-49f9f2e3c4cc)

Sometimes we don't need Factory for models, but the default stub usees the HasFactory trait by default. But if we want to use factory we got an exception:
![image](https://github.com/laravel/framework/assets/75097934/ab7c744b-978f-438c-902e-4d122371a1ba)

So, I added an additional condition and stub for don't use HasFactory trait if the factory option isn't checked
