### PR TITLE
[10.x] Implement "max" validation rule for passwords

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -38,6 +38,13 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $min = 8;
 
     /**
+     * The maximum size of the password.
+     *
+     * @var int
+     */
+    protected $max;
+
+    /**
      * If the password requires at least one uppercase and one lowercase letter.
      *
      * @var bool
@@ -204,6 +211,19 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Sets the maximum size of the password.
+     *
+     * @param  int  $size
+     * @return $this
+     */
+    public function max($size)
+    {
+        $this->max = $size;
+
+        return $this;
+    }
+
+    /**
      * Ensures the password has not been compromised in data leaks.
      *
      * @param  int  $threshold
@@ -298,6 +318,10 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         )->after(function ($validator) use ($attribute, $value) {
             if (! is_string($value)) {
                 return;
+            }
+
+            if ($this->max && mb_strlen($value) > $this->max) {
+                $validator->addFailure($attribute, 'max.string');
             }
 
             if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -200,7 +200,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Sets the minimum size of the password.
+     * Set the minimum size of the password.
      *
      * @param  int  $size
      * @return $this
@@ -211,7 +211,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Sets the maximum size of the password.
+     * Set the maximum size of the password.
      *
      * @param  int  $size
      * @return $this

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -42,6 +42,15 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes(new Password(8), ['88888888']);
     }
 
+    public function testMax()
+    {
+        $this->fails(Password::min(2)->max(4), ['aaaaa', '11111111'], [
+            'validation.max.string',
+        ]);
+
+        $this->passes(Password::min(2)->max(3), ['aa', '111']);
+    }
+
     public function testConditional()
     {
         $is_privileged_user = true;


### PR DESCRIPTION
Adds a max length validation rule for the Password rule object for consistency with the min length rule.
This would come into action when defining a [default password rule](https://laravel.com/docs/10.x/validation#defining-default-password-rules).
`Password::min(8)->rules('max:32');`
vs.
`Password::min(8)->max(32);`