### PR TITLE
[10.x] Added Mappable trait and map function

### DIFF
--- a/src/Illuminate/Support/Traits/Mappable.php
+++ b/src/Illuminate/Support/Traits/Mappable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Mappable
+{
+    /**
+     * Call the given Closure with this instance then return new instance.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function map($callback)
+    {
+        return map($this, $callback);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -310,6 +310,20 @@ if (! function_exists('tap')) {
     }
 }
 
+if (! function_exists('map')) {
+    /**
+     * Call the given Closure with the given value then return new value.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @return mixed
+     */
+    function map($value, $callback)
+    {
+        return $callback($value);
+    }
+}
+
 if (! function_exists('throw_if')) {
     /**
      * Throw the given exception if the given condition is true.

--- a/tests/Support/SupportMappableTest.php
+++ b/tests/Support/SupportMappableTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Mappable;
+use Illuminate\Support\Traits\Tappable;
+use PHPUnit\Framework\TestCase;
+
+class SupportMappableTest extends TestCase
+{
+    public function testMappableClassWithCallback()
+    {
+        $name = MappableClass::make()->tap(function ($mappable) {
+            $mappable->setName('MyName');
+        })->map(function ($mappable) {
+            return Str::of($mappable->getName())->snake()->toString();
+        });
+
+        $this->assertSame('my_name', $name);
+    }
+
+    public function testMappableClassWithInvokableClass()
+    {
+        $name = MappableClass::make()->tap(new class
+        {
+            public function __invoke($mappable)
+            {
+                $mappable->setName('MyName');
+            }
+        })->map(new class
+        {
+            public function __invoke($mappable)
+            {
+                return Str::of($mappable->getName())->snake()->toString();
+            }
+        });
+
+        $this->assertSame('my_name', $name);
+    }
+
+    public function testMappableClassWithNoneInvokableClass()
+    {
+        $this->expectException('Error');
+
+        $name = MappableClass::make()->tap(function ($mappable) {
+            $mappable->setName('MyName');
+        })->map(new class
+        {
+            public function getSnakeName($mappable)
+            {
+                return Str::of($mappable->getName())->snake()->toString();
+            }
+        })->getName();
+
+        $this->assertSame('my_name', $name);
+    }
+}
+
+
+class MappableClass
+{
+    use Tappable;
+    use Mappable;
+
+    private $name;
+
+    public static function make()
+    {
+        return new static;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
This pull request introduces the `map` function and the `Mappable` trait. The aim of these additions is to facilitate  transformations of objects.

1. **`map` Function**: This utility function takes any value and a callback, applying the callback to the value and returning the result. It can be flexibly used not only for array or collection operations but for any type of value.

2. **`Mappable` Trait**: This trait provides the functionality of adding a `map` method to specific classes, allowing the instance itself to be passed to a callback function. This facilitates a more readable and declarative approach when transforming properties or states of objects.

These features are particularly useful in data transformation and pipeline processing. They are intended to enhance code reusability and readability, assisting developers in adopting a more declarative programming style.