### PR TITLE
[11.x] Adds `once` memoization function

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -249,8 +249,8 @@ abstract class TestCase extends BaseTestCase
         Component::forgetFactory();
         ConvertEmptyStringsToNull::flushState();
         HandleExceptions::flushState();
-        Queue::createPayloadUsing(null);
         Once::flush();
+        Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -16,6 +16,7 @@ use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
@@ -249,6 +250,7 @@ abstract class TestCase extends BaseTestCase
         ConvertEmptyStringsToNull::flushState();
         HandleExceptions::flushState();
         Queue::createPayloadUsing(null);
+        Once::flush();
         RegisterProviders::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -34,7 +34,6 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     public function register()
     {
         $this->configureSerializableClosureUses();
-        $this->configureOnce();
 
         $this->registerManager();
         $this->registerConnection();
@@ -65,21 +64,6 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
 
             return $data;
         });
-    }
-
-    /**
-     * Configure the once instance to flush after each job.
-     *
-     * @return void
-     */
-    public function configureOnce()
-    {
-        $this->app['events']->listen([
-            Events\JobProcessed::class,
-            Events\JobExceptionOccurred::class,
-            Events\JobReleasedAfterException::class,
-            Events\JobFailed::class,
-        ], fn () => Once::flush());
     }
 
     /**

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Foundation\Auth\User;
 use WeakMap;
 
 class Once

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -42,13 +42,40 @@ class Once
     }
 
     /**
-     * Flush the once instance.
+     * Get the value of the given onceable.
+     *
+     * @param  Onceable  $onceable
+     * @return mixed
+     */
+    public function value(Onceable $onceable)
+    {
+        if (! static::$enabled) {
+            return call_user_func($onceable->callable);
+        }
+
+        $object = $onceable->object ?: $this;
+
+        $hash = $onceable->hash;
+
+        if (isset($this->values[$object][$hash])) {
+            return $this->values[$object][$hash];
+        }
+
+        if (! isset($this->values[$object])) {
+            $this->values[$object] = [];
+        }
+
+        return $this->values[$object][$hash] = call_user_func($onceable->callable);
+    }
+
+    /**
+     * Re-enable the once instance if it was disabled.
      *
      * @return void
      */
-    public static function flush()
+    public static function enable()
     {
-        static::$instance = null;
+        static::$enabled = true;
     }
 
     /**
@@ -62,38 +89,12 @@ class Once
     }
 
     /**
-     * Re-enable the once instance, if it was disabled.
+     * Flush the once instance.
      *
      * @return void
      */
-    public static function enable()
+    public static function flush()
     {
-        static::$enabled = true;
-    }
-
-    /**
-     * Get the value of the given onceable.
-     *
-     * @param  Onceable  $onceable
-     * @return mixed
-     */
-    public function value(Onceable $onceable)
-    {
-        if (! static::$enabled) {
-            return call_user_func($onceable->callable);
-        }
-
-        $object = $onceable->object ?: $this;
-        $hash = $onceable->hash;
-
-        if (isset($this->values[$object][$hash])) {
-            return $this->values[$object][$hash];
-        }
-
-        if (! isset($this->values[$object])) {
-            $this->values[$object] = [];
-        }
-
-        return $this->values[$object][$hash] = call_user_func($onceable->callable);
+        static::$instance = null;
     }
 }

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Foundation\Auth\User;
+use WeakMap;
+
+class Once
+{
+    /**
+     * The current globally used instance.
+     *
+     * @var static|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Indicates if the once instance is enabled.
+     *
+     * @var bool
+     */
+    protected static $enabled = true;
+
+    /**
+     * Create a new once instance.
+     *
+     * @param  \WeakMap<object, Onceable>  $values
+     * @param  bool  $enabled
+     * @return void
+     */
+    protected function __construct(protected WeakMap $values)
+    {
+        //
+    }
+
+    /**
+     * Create a new once instance.
+     *
+     * @return static
+     */
+    public static function instance(): static
+    {
+        return static::$instance ??= new static(new WeakMap);
+    }
+
+    /**
+     * Flush the once instance.
+     *
+     * @return void
+     */
+    public static function flush()
+    {
+        static::$instance = null;
+    }
+
+    /**
+     * Disable the once instance.
+     *
+     * @return void
+     */
+    public static function disable()
+    {
+        static::$enabled = false;
+    }
+
+    /**
+     * Re-enable the once instance, if it was disabled.
+     *
+     * @return void
+     */
+    public static function enable()
+    {
+        static::$enabled = true;
+    }
+
+    /**
+     * Get the value of the given onceable.
+     *
+     * @param  Onceable  $onceable
+     * @return mixed
+     */
+    public function value(Onceable $onceable)
+    {
+        if (! static::$enabled) {
+            return value($onceable->callable);
+        }
+
+        $object = $onceable->object ?: $this;
+        $hash = $onceable->hash;
+
+        if (isset($this->values[$object][$hash])) {
+            return $this->values[$object][$hash];
+        }
+
+        if (! isset($this->values[$object])) {
+            $this->values[$object] = [];
+        }
+
+        return $this->values[$object][$hash] = value($onceable->callable);
+    }
+}

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -11,14 +11,14 @@ class Once
      *
      * @var static|null
      */
-    protected static $instance = null;
+    protected static ?self $instance = null;
 
     /**
      * Indicates if the once instance is enabled.
      *
      * @var bool
      */
-    protected static $enabled = true;
+    protected static bool $enabled = true;
 
     /**
      * Create a new once instance.
@@ -36,7 +36,7 @@ class Once
      *
      * @return static
      */
-    public static function instance(): static
+    public static function instance()
     {
         return static::$instance ??= new static(new WeakMap);
     }

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -23,8 +23,7 @@ class Once
     /**
      * Create a new once instance.
      *
-     * @param  \WeakMap<object, Onceable>  $values
-     * @param  bool  $enabled
+     * @param  \WeakMap<object, array<string, mixed>>  $values
      * @return void
      */
     protected function __construct(protected WeakMap $values)

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -42,15 +42,13 @@ class Once
     }
 
     /**
-     * Flush the once instance, and re-enable it if it was disabled.
+     * Flush the once instance.
      *
      * @return void
      */
     public static function flush()
     {
         static::$instance = null;
-
-        static::$enabled = true;
     }
 
     /**

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -42,13 +42,15 @@ class Once
     }
 
     /**
-     * Flush the once instance.
+     * Flush the once instance, and re-enable it if it was disabled.
      *
      * @return void
      */
     public static function flush()
     {
         static::$instance = null;
+
+        static::$enabled = true;
     }
 
     /**

--- a/src/Illuminate/Support/Once.php
+++ b/src/Illuminate/Support/Once.php
@@ -80,7 +80,7 @@ class Once
     public function value(Onceable $onceable)
     {
         if (! static::$enabled) {
-            return value($onceable->callable);
+            return call_user_func($onceable->callable);
         }
 
         $object = $onceable->object ?: $this;
@@ -94,6 +94,6 @@ class Once
             $this->values[$object] = [];
         }
 
-        return $this->values[$object][$hash] = value($onceable->callable);
+        return $this->values[$object][$hash] = call_user_func($onceable->callable);
     }
 }

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -37,7 +37,7 @@ class Onceable
     /**
      * Computes the object of the onceable from the given trace, if any.
      *
-     * @param  array<int, array<string, mixed>> $trace
+     * @param  array<int, array<string, mixed>>  $trace
      * @return object|null
      */
     protected static function objectFromTrace(array $trace)
@@ -58,7 +58,7 @@ class Onceable
             $trace[1]['args']
         );
 
-        $prefix = ($trace[1]['class'] ?? '') . $trace[1]['function'];
+        $prefix = ($trace[1]['class'] ?? '').$trace[1]['function'];
 
         if (str_contains($prefix, '{closure}')) {
             $prefix = $trace[0]['line'];

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -66,12 +66,13 @@ class Onceable
             $callable instanceof Closure ? (new ReflectionClosure($callable))->getClosureUsedVariables() : [],
         );
 
-        $prefix = ($trace[1]['class'] ?? '').$trace[1]['function'];
-
-        if (str_contains($prefix, '{closure}')) {
-            $prefix = $trace[0]['line'];
-        }
-
-        return md5($prefix.serialize($uses));
+        return md5(sprintf(
+            '%s@%s%s:%s (%s)',
+            $trace[0]['file'],
+            isset($trace[1]['class']) ? ($trace[1]['class'].'@') : '',
+            $trace[1]['function'],
+            $trace[0]['line'],
+            serialize($uses),
+        ));
     }
 }

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -28,7 +28,7 @@ class Onceable
      * @param  array<int, array<string, mixed>>  $trace
      * @return static|null
      */
-    public static function tryFrom(array $trace, callable $callable)
+    public static function tryFromTrace(array $trace, callable $callable)
     {
         if (! is_null($hash = static::hashFromTrace($trace))) {
             $object = static::objectFromTrace($trace);

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Support\Exceptions\UntraceableOnceException;
-
 class Onceable
 {
     /**

--- a/src/Illuminate/Support/Onceable.php
+++ b/src/Illuminate/Support/Onceable.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Onceable
+{
+    /**
+     * Create a new onceable instance.
+     *
+     * @param  string  $hash
+     * @param  mixed  $object
+     * @param  callable  $callable
+     * @return void
+     */
+    public function __construct(
+        public string $hash,
+        public object|null $object,
+        public $callable
+    ) {
+        //
+    }
+
+    /**
+     * Creates a new onceable instance from the given trace.
+     *
+     * @param  array<int, array<string, mixed>>  $trace
+     * @return static
+     */
+    public static function fromTrace(array $trace, callable $callable)
+    {
+        $hash = static::hashFromTrace($trace);
+        $object = static::objectFromTrace($trace);
+
+        return new static($hash, $object, $callable);
+    }
+
+    /**
+     * Computes the object of the onceable from the given trace, if any.
+     *
+     * @param  array<int, array<string, mixed>> $trace
+     * @return object|null
+     */
+    protected static function objectFromTrace(array $trace)
+    {
+        return $trace[1]['object'] ?? null;
+    }
+
+    /**
+     * Computes the hash of the onceable from the given trace.
+     *
+     * @param  array<int, array<string, mixed>>  $trace
+     * @return string
+     */
+    public static function hashFromTrace(array $trace)
+    {
+        $arguments = array_map(
+            fn (mixed $argument) => is_object($argument) ? spl_object_hash($argument) : $argument,
+            $trace[1]['args']
+        );
+
+        $prefix = ($trace[1]['class'] ?? '') . $trace[1]['function'];
+
+        if (str_contains($prefix, '{closure}')) {
+            $prefix = $trace[0]['line'];
+        }
+
+        return md5($prefix.serialize($arguments));
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -203,7 +203,7 @@ if (! function_exists('once')) {
      *
      * @template  TReturnType
      *
-     * @param  (callable(): TReturnType)  $callback
+     * @param  callable(): TReturnType  $callback
      * @return TReturnType
      */
     function once(callable $callback)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -5,6 +5,8 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Once;
+use Illuminate\Support\Onceable;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -192,6 +194,26 @@ if (! function_exists('object_get')) {
         }
 
         return $object;
+    }
+}
+
+if (! function_exists('once')) {
+    /**
+     * Ensures a callable is only called once, and returns the result on subsequent calls.
+     *
+     * @template  TReturnType
+     *
+     * @param  (callable(): TReturnType)  $callback
+     * @return TReturnType
+     */
+    function once(callable $callback)
+    {
+        $onceable = Onceable::fromTrace(
+            debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2),
+            $callback,
+        );
+
+        return Once::instance()->value($onceable);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -213,7 +213,7 @@ if (! function_exists('once')) {
             $callback,
         );
 
-        return $onceable ? Once::instance()->value($onceable) : $callback();
+        return $onceable ? Once::instance()->value($onceable) : call_user_func($callback);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -208,12 +208,12 @@ if (! function_exists('once')) {
      */
     function once(callable $callback)
     {
-        $onceable = Onceable::fromTrace(
+        $onceable = Onceable::tryFrom(
             debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2),
             $callback,
         );
 
-        return Once::instance()->value($onceable);
+        return $onceable ? Once::instance()->value($onceable) : $callback();
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -208,7 +208,7 @@ if (! function_exists('once')) {
      */
     function once(callable $callback)
     {
-        $onceable = Onceable::tryFrom(
+        $onceable = Onceable::tryFromTrace(
             debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2),
             $callback,
         );

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -176,7 +176,8 @@ class OnceTest extends TestCase
     {
         $this->markTestSkipped('This test shows a limitation of the current implementation.');
 
-        $first = once(fn () => rand(1, PHP_INT_MAX)); $second = once(fn () => rand(1, PHP_INT_MAX));
+        $first = once(fn () => rand(1, PHP_INT_MAX));
+        $second = once(fn () => rand(1, PHP_INT_MAX));
 
         $this->assertNotSame($first, $second);
     }

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -120,6 +120,16 @@ class OnceTest extends TestCase
         $this->assertSame($results[0], $results[1]);
     }
 
+    public function testUsageOfThis()
+    {
+        $instance = new MyClass();
+
+        $first = $instance->callRand();
+        $second = $instance->callRand();
+
+        $this->assertSame($first, $second);
+    }
+
     public function testInvokables()
     {
         $invokable = new class
@@ -355,5 +365,10 @@ class MyClass
     public static function staticRand()
     {
         return once(fn () => rand(1, PHP_INT_MAX));
+    }
+
+    public function callRand()
+    {
+        return once(fn () => $this->rand());
     }
 }

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -2,14 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use Carbon\CarbonInterval;
-use Exception;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Once;
-use Illuminate\Support\Sleep;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 class OnceTest extends TestCase
 {
@@ -23,7 +17,8 @@ class OnceTest extends TestCase
 
     public function testResultIsMemoized()
     {
-        $instance = new class {
+        $instance = new class
+        {
             public function rand()
             {
                 return once(fn () => rand(1, PHP_INT_MAX));
@@ -38,7 +33,8 @@ class OnceTest extends TestCase
 
     public function testCallableIsOnlyCalledOnce()
     {
-        $instance = new class {
+        $instance = new class
+        {
             public int $count = 0;
 
             public function increment()
@@ -81,7 +77,8 @@ class OnceTest extends TestCase
 
     public function testResultIsNotMemoizedWhenUsesChange()
     {
-        $instance = new class() {
+        $instance = new class()
+        {
             public function rand(string $letter)
             {
                 return once(function () use ($letter) {
@@ -178,14 +175,16 @@ class OnceTest extends TestCase
 
     public function testResultIsMemoizedWhenCalledFromMethodsWithSameName()
     {
-        $instanceA = new class {
+        $instanceA = new class
+        {
             public function rand()
             {
                 return once(fn () => rand(1, PHP_INT_MAX));
             }
         };
 
-        $instanceB = new class {
+        $instanceB = new class
+        {
             public function rand()
             {
                 return once(fn () => rand(1, PHP_INT_MAX));
@@ -200,10 +199,11 @@ class OnceTest extends TestCase
 
     public function testRecursiveOnceCalls()
     {
-        $instance = new class {
+        $instance = new class
+        {
             public function rand()
             {
-                return once(fn() => once(fn() => rand(1, PHP_INT_MAX)));
+                return once(fn () => once(fn () => rand(1, PHP_INT_MAX)));
             }
         };
 

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -159,6 +159,22 @@ class OnceTest extends TestCase
         $this->assertSame($first, $second);
     }
 
+    public function testFirstClassCallableSyntaxWithArraySyntax()
+    {
+        $instance = new class
+        {
+            public function rand()
+            {
+                return once([MyClass::class, 'staticRand']);
+            }
+        };
+
+        $first = $instance->rand();
+        $second = $instance->rand();
+
+        $this->assertSame($first, $second);
+    }
+
     public function testStaticMemoization()
     {
         $first = MyClass::staticRand();

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -56,10 +56,20 @@ class OnceTest extends TestCase
         $instance = new MyClass();
 
         $first = $instance->rand();
+
         Once::flush();
+
         $second = $instance->rand();
 
         $this->assertNotSame($first, $second);
+
+        Once::disable();
+        Once::flush();
+
+        $first = $instance->rand();
+        $second = $instance->rand();
+
+        $this->assertSame($first, $second);
     }
 
     public function testNotMemoizedWhenObjectIsGarbageCollected()

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -318,7 +318,27 @@ class OnceTest extends TestCase
 
         $this->assertSame($first, $second);
     }
+
+    public function testGlobalClosures()
+    {
+        $first = $GLOBALS['onceable1']();
+        $second = $GLOBALS['onceable1']();
+
+        $this->assertSame($first, $second);
+
+        $third = $GLOBALS['onceable2']();
+        $fourth = $GLOBALS['onceable2']();
+
+        $this->assertSame($third, $fourth);
+
+        $this->assertNotSame($first, $third);
+    }
 }
+
+$letter = 'a';
+
+$GLOBALS['onceable1'] = fn () => once(fn () => $letter.rand(1, PHP_INT_MAX));
+$GLOBALS['onceable2'] = fn () => once(fn () => $letter.rand(1, PHP_INT_MAX));
 
 function my_rand()
 {

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -152,14 +152,33 @@ class OnceTest extends TestCase
         $this->assertSame($first, $fourth);
     }
 
-    public function testResultMayBeMemoizedWithinEval()
+    public function testResultIsNotMemoizedWhenCalledWithinEvals()
     {
-        $resolver = eval('return fn () => once( function () { return random_int(1, 1000); } ) ;');
+        $firstResolver = eval('return fn () => once( function () { return random_int(1, 1000); } ) ;');
 
-        $first = $resolver();
-        $second = $resolver();
+        $firstA = $firstResolver();
+        $firstB = $firstResolver();
 
-        $this->assertSame($first, $second);
+        $secondResolver = eval('return fn () => fn () => once( function () { return random_int(1, 1000); } ) ;');
+
+        $secondA = $secondResolver()();
+        $secondB = $secondResolver()();
+
+        $third = eval('return once( function () { return random_int(1, 1000); } ) ;');
+        $fourth = eval('return once( function () { return random_int(1, 1000); } ) ;');
+
+        $this->assertNotSame($firstA, $firstB);
+        $this->assertNotSame($secondA, $secondB);
+        $this->assertNotSame($third, $fourth);
+    }
+
+    public function testResultIsDifferentWhenCalledFromSameLine()
+    {
+        $this->markTestSkipped('This test shows a limitation of the current implementation.');
+
+        $first = once(fn () => rand(1, PHP_INT_MAX)); $second = once(fn () => rand(1, PHP_INT_MAX));
+
+        $this->assertNotSame($first, $second);
     }
 
     public function testResultIsDifferentWhenCalledFromDifferentClosures()

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -114,7 +114,7 @@ class OnceTest extends TestCase
     {
         $invokable = new class
         {
-            static $count = 0;
+            public static $count = 0;
 
             public function __invoke()
             {
@@ -122,7 +122,7 @@ class OnceTest extends TestCase
             }
         };
 
-        $instance = new class ($invokable)
+        $instance = new class($invokable)
         {
             public function __construct(protected $invokable)
             {

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Carbon\CarbonInterval;
+use Exception;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Once;
+use Illuminate\Support\Sleep;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class OnceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Once::flush();
+        Once::enable();
+    }
+
+    public function testResultIsMemoized()
+    {
+        $instance = new class {
+            public function rand()
+            {
+                return once(fn () => rand(1, PHP_INT_MAX));
+            }
+        };
+
+        $first = $instance->rand();
+        $second = $instance->rand();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testCallableIsOnlyCalledOnce()
+    {
+        $instance = new class {
+            public int $count = 0;
+
+            public function increment()
+            {
+                return once(fn () => ++$this->count);
+            }
+        };
+
+        $first = $instance->increment();
+        $second = $instance->increment();
+
+        $this->assertSame(1, $first);
+        $this->assertSame(1, $second);
+        $this->assertSame(1, $instance->count);
+    }
+
+    public function testResultIsNotMemoizedWhenFlushed()
+    {
+        $instance = new MyClass();
+
+        $first = $instance->rand();
+        Once::flush();
+        $second = $instance->rand();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testResultIsNotMemoizedWhenObjectIsGarbageCollected()
+    {
+        $instance = new MyClass();
+
+        $first = $instance->rand();
+        unset($instance);
+        gc_collect_cycles();
+        $instance = new MyClass();
+        $second = $instance->rand();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testResultIsNotMemoizedWhenUsesChange()
+    {
+        $instance = new class() {
+            public function rand(string $letter)
+            {
+                return once(function () use ($letter) {
+                    return $letter.rand(1, 10000000);
+                });
+            }
+        };
+
+        $first = $instance->rand('a');
+        $second = $instance->rand('b');
+
+        $this->assertNotSame($first, $second);
+
+        $first = $instance->rand('a');
+        $second = $instance->rand('a');
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testResultIsMemoizedWhenCalledStatically()
+    {
+        $first = MyClass::staticRand();
+        $second = MyClass::staticRand();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testResultIsMemoizedWhenCalledWithinAClosure()
+    {
+        $resolver = fn () => once(fn () => rand(1, PHP_INT_MAX));
+
+        $first = $resolver();
+        $second = $resolver();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testResultIsMemoizedWhenCalledGlobally()
+    {
+        $first = my_rand();
+        $second = my_rand();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testResultIsNotMemoizedWhenOnceIsDisabled()
+    {
+        Once::disable();
+
+        $first = my_rand();
+        $second = my_rand();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testResultMayBeMemoizedTemporarily()
+    {
+        $first = my_rand();
+        $second = my_rand();
+
+        Once::disable();
+
+        $third = my_rand();
+
+        Once::enable();
+
+        $fourth = my_rand();
+
+        $this->assertSame($first, $second);
+        $this->assertNotSame($first, $third);
+        $this->assertSame($first, $fourth);
+    }
+
+    public function testResultMayBeMemoizedWithinEval()
+    {
+        $resolver = eval('return fn () => once( function () { return random_int(1, 1000); } ) ;');
+
+        $first = $resolver();
+        $second = $resolver();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testResultIsDifferentWhenCalledFromDifferentClosures()
+    {
+        $resolver = fn () => once(fn () => rand(1, PHP_INT_MAX));
+        $resolver2 = fn () => once(fn () => rand(1, PHP_INT_MAX));
+
+        $first = $resolver();
+        $second = $resolver2();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testResultIsMemoizedWhenCalledFromMethodsWithSameName()
+    {
+        $instanceA = new class {
+            public function rand()
+            {
+                return once(fn () => rand(1, PHP_INT_MAX));
+            }
+        };
+
+        $instanceB = new class {
+            public function rand()
+            {
+                return once(fn () => rand(1, PHP_INT_MAX));
+            }
+        };
+
+        $first = $instanceA->rand();
+        $second = $instanceB->rand();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testRecursiveOnceCalls()
+    {
+        $instance = new class {
+            public function rand()
+            {
+                return once(fn() => once(fn() => rand(1, PHP_INT_MAX)));
+            }
+        };
+
+        $first = $instance->rand();
+        $second = $instance->rand();
+
+        $this->assertSame($first, $second);
+    }
+}
+
+function my_rand()
+{
+    return once(fn () => rand(1, PHP_INT_MAX));
+}
+
+class MyClass
+{
+    public function rand()
+    {
+        return once(fn () => rand(1, PHP_INT_MAX));
+    }
+
+    public static function staticRand()
+    {
+        return once(fn () => rand(1, PHP_INT_MAX));
+    }
+}

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -69,7 +69,7 @@ class OnceTest extends TestCase
         $first = $instance->rand();
         $second = $instance->rand();
 
-        $this->assertSame($first, $second);
+        $this->assertNotSame($first, $second);
     }
 
     public function testNotMemoizedWhenObjectIsGarbageCollected()

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -2,6 +2,16 @@
 
 use function PHPStan\Testing\assertType;
 
+assertType('int', once(fn () => 1));
+
+assertType('User', once(fn () => new User()));
+
+$value = once(function () { // @phpstan-ignore-line
+    //
+});
+
+assertType('null', $value);
+
 assertType('User', with(new User()));
 assertType('bool', with(new User())->save());
 


### PR DESCRIPTION
Inspired by @taylorotwell's [tweet](https://twitter.com/taylorotwell/status/794622206567444481) and Spatie's [once](https://github.com/spatie/once) package, this pull request proposes the addition of the `once` memoization function in Laravel 11.

This function is extremely useful for caching a costly computation without the need to create a temporary like a nullable property on the class itself. Here is a practical example:

```php
class User extends Model
{
    public function stats(): array
    {
        return once(function () {
            // Expensive operations to generate user stats, multiple db queries, etc...

            return $stats;
        });
    }
}
```

Behind the scenes, this function is incredibly smart. It ensures that a callable is called only once, returning the same result on subsequent calls. If the `once` function is called within an object instance, the memoized result will be associated only with that instance.

```php
// Assuming you have two User instances: $userA and $userB

$userA->stats();
$userA->stats(); // cached result from previous line...

$userB->stats(); // Not using $userA cached results, because $userB !== $userA
$userB->stats(); // cached result from previous line...
```

**Things to Be Decided:**
- [x] ~~Should we flush the cache of `once` at the framework level at any lifecycle stage, such as `RequestHandled` or `JobProcessed`?~~ We decided to flush `Once` after each job, after each test case, and after each request (at Octane listener level)

**Limitation:** This function currently has a limitation where `once` calls within the same line are considered the same call. For example: `$a = once(fn () => 1); $b = once(fn () => 2); echo $b; // outputs 1`.