### PR TITLE
[10.x] Add multiple channels/routes to AnonymousNotifiable at once

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -62,7 +62,7 @@ class Notification extends Facade
      */
     public static function routes(array $channels)
     {
-        $notifiable = new AnonymousNotifiable();
+        $notifiable = new AnonymousNotifiable;
 
         foreach ($channels as $channel => $route) {
             $notifiable->route($channel, $route);

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -55,6 +55,23 @@ class Notification extends Facade
     }
 
     /**
+     * Begin sending a notification to an anonymous notifiable on the given channels.
+     *
+     * @param  array  $channels
+     * @return \Illuminate\Notifications\AnonymousNotifiable
+     */
+    public static function routes(array $channels)
+    {
+        $notifiable = new AnonymousNotifiable();
+
+        foreach ($channels as $channel => $route) {
+            $notifiable->route($channel, $route);
+        }
+
+        return $notifiable;
+    }
+
+    /**
      * Begin sending a notification to an anonymous notifiable.
      *
      * @param  string  $channel

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -28,6 +28,20 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
         ], $_SERVER['__notifiable.route']);
     }
 
+    public function testAnonymousNotifiableWithMultipleRoutes()
+    {
+        $_SERVER['__notifiable.route'] = [];
+
+        NotificationFacade::routes([
+            'testchannel' => 'enzo',
+            'anothertestchannel' => 'enzo@deepblue.com',
+        ])->notify(new TestMailNotificationForAnonymousNotifiable());
+
+        $this->assertEquals([
+            'enzo', 'enzo@deepblue.com',
+        ], $_SERVER['__notifiable.route']);
+    }
+
     public function testFaking()
     {
         $fake = NotificationFacade::fake();


### PR DESCRIPTION
This PR adds the ability to configure multiple routes at once for on-demand notifications.

```php
NotificationFacade::routes([
    'mail' => ['example@test.local' => 'Test Customer'],
    'vonage' => '+3620123456',
])->notify(new OrderStatusChanged($order));
```