### PR TITLE
[10.x] Add Number::random and other helpers to improve testing

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -242,9 +242,8 @@ class Number
     /**
      * Generate random numbers.
      *
-     * @param int $min
-     * @param int $max
-     *
+     * @param  int  $min
+     * @param  int  $max
      * @return int
      */
     public static function random(int $min, int $max): int

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -249,7 +249,7 @@ class Number
     public static function random(int $min, int $max): int
     {
         return (static::$randomNumberFactory ?? function (int $min, int $max) {
-            return mt_rand($min, $max);
+            return random_int($min, $max);
         })($min, $max);
     }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -307,7 +307,7 @@ class SupportNumberTest extends TestCase
         $this->assertNotSame(4, Number::random(5, 10));
     }
 
-    public function testItCanSpecifyASequenceOfRandomStringsToUtilise()
+    public function testItCanSpecifyASequenceOfRandomNumbersToUtilise()
     {
         Number::createRandomNumbersUsingSequence([
             0 => fn (int $min, int $max) => $min - 1,
@@ -327,7 +327,7 @@ class SupportNumberTest extends TestCase
         Number::createRandomNumbersNormally();
     }
 
-    public function testItCanSpecifyAFallbackForARandomStringSequence()
+    public function testItCanSpecifyAFallbackForARandomNumberSequence()
     {
         Number::createRandomNumbersUsingSequence([
             fn (int $min, int $max) => $min - 1,

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -331,7 +331,7 @@ class SupportNumberTest extends TestCase
     {
         Number::createRandomNumbersUsingSequence([
             fn (int $min, int $max) => $min - 1,
-            fn (int $min, int $max) => $min - 5
+            fn (int $min, int $max) => $min - 5,
         ], fn () => throw new Exception('Out of random numbers.'));
 
         Number::random(5, 10);


### PR DESCRIPTION
This PR adds similiar feature that we already have with `Str::random($length)`. 
Code mostly copied from `Str::random` and other methods to keep similiar features / usage.

Added methods are:

`Number::random(int $min, int $max)` - Generates random number using `random_int` by default.

`Number::createRandomNumbersUsing(callable $factory = null)` - Override factory to create random numbers, useful in unit testing when we are using `random_int` and cannot really test generated number, now we can (refactor of `random_int` to `Number::random` is needed in projects.

`Number::createRandomNumbersUsingSequence(array $sequence, $whenMissing = null)` - Override factory in sequence, optionally set second parameter to return different random number, defaults to `random_int`.


Usage in tests:

```php
// method in Email model / classs
public function getSecondsToSend()
{
    return Number::random(10, 60); // Delay between 10 to 60 seconds.
}
```

```php
Number::createRandomNumbersUsing(fn (int $min, int $max) => 0);

// Call other project feature
$seconds = $email->getSecondsToSend();

expect($seconds)->toBe(0); // Previously we just checked that its number and between specific range
```