### PR TITLE
prevent exceptions when the sort key is passed incorrectly

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -112,9 +112,10 @@ class RouteListCommand extends Command
      */
     protected function getRoutes()
     {
-        $routes = collect($this->router->getRoutes())->map(function ($route) {
-            return $this->getRouteInformation($route);
-        })->filter()->all();
+        $routes = collect($this->router->getRoutes())
+            ->map(fn ($route) => $this->getRouteInformation($route))
+            ->filter()
+            ->all();
 
         if (in_array($sort = strtolower($this->option('sort')), $this->getColumns())) {
             $routes = $this->sortRoutes($sort, $routes);

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -116,7 +116,7 @@ class RouteListCommand extends Command
             return $this->getRouteInformation($route);
         })->filter()->all();
 
-        if (($sort = $this->option('sort')) !== null) {
+        if (in_array($sort = strtolower($this->option('sort')), $this->getColumns())) {
             $routes = $this->sortRoutes($sort, $routes);
         } else {
             $routes = $this->sortRoutes('uri', $routes);


### PR DESCRIPTION
For more clarity and to prevent exceptions when the sort key is passed incorrectly, we can add safeguards to our code.

**In the current version, if a sort key is passed incorrectly, we face an Undefined array key exception at line 160**