### PR TITLE
[10.x] Adds `make:enum` Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:enum')]
+class EnumMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new enum';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'make:enum';
+
+    /**
+     * The type of file being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Enum';
+
+    /**
+     * Get the desired view name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        $name = trim($this->argument('name'));
+
+        $name = str_replace(['\\', '.'], '/', $this->argument('name'));
+
+        return $name;
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath(
+            '/stubs/enum.stub',
+        );
+    }
+
+
+    /**
+     * Get the default namespace for the generator.
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Enums';
+    }
+
+    protected function replaceClass($stub, $name)
+    {
+        $class = str_replace($this->getNamespace($name) . '\\', '', $name);
+
+        return str_replace('{{enum_name}}', $class, $stub);
+    }
+}

--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -4,11 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'make:enum')]
 class EnumMakeCommand extends GeneratorCommand
@@ -62,7 +58,6 @@ class EnumMakeCommand extends GeneratorCommand
         );
     }
 
-
     /**
      * Get the default namespace for the generator.
      *
@@ -70,12 +65,12 @@ class EnumMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\Enums';
+        return $rootNamespace.'\Enums';
     }
 
     protected function replaceClass($stub, $name)
     {
-        $class = str_replace($this->getNamespace($name) . '\\', '', $name);
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
 
         return str_replace('{{enum_name}}', $class, $stub);
     }

--- a/src/Illuminate/Foundation/Console/stubs/enum.stub
+++ b/src/Illuminate/Foundation/Console/stubs/enum.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Enums;
+
+enum {{enum_name}}: int
+{
+    case Example = 1;
+}


### PR DESCRIPTION
This pull request introduces the `make:enum` Artisan command as its initial version, incorporating the essential code for basic functionality.

It draws inspiration from [nunomaduro's pull request](https://github.com/laravel/framework/pull/48330), where the `make:view` Artisan command was introduced, but this time focusing on enums.

Looking ahead:
To enrich the user experience with this command, future updates could allow users to specify the enum type, its cases, and even include general methods typically associated with enums, such as `static translatedCases() ...` and `color()`, to name a few.