### PR TITLE
[11.x] Add default max length for Password rule object

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -42,7 +42,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @var int
      */
-    protected $max;
+    protected $max = 72;
 
     /**
      * If the password requires at least one uppercase and one lowercase letter.
@@ -218,7 +218,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function max($size)
     {
-        $this->max = $size;
+        $this->max = (int) $size;
 
         return $this;
     }
@@ -312,16 +312,12 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
 
         $validator = Validator::make(
             $this->data,
-            [$attribute => array_merge(['string', 'min:'.$this->min], $this->customRules)],
+            [$attribute => array_merge(['string', 'min:'.$this->min, 'max:'.$this->max], $this->customRules)],
             $this->validator->customMessages,
             $this->validator->customAttributes
         )->after(function ($validator) use ($attribute, $value) {
             if (! is_string($value)) {
                 return;
-            }
-
-            if ($this->max && mb_strlen($value) > $this->max) {
-                $validator->addFailure($attribute, 'max.string');
             }
 
             if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -44,6 +44,10 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testMax()
     {
+        $this->fails(Password::min(2), [str_repeat('a', 73)], [
+            'validation.max.string',
+        ]);
+
         $this->fails(Password::min(2)->max(4), ['aaaaa', '11111111'], [
             'validation.max.string',
         ]);
@@ -139,7 +143,7 @@ class ValidationPasswordRuleTest extends TestCase
             '%HurHUnw7zM!',
             'rundeliekend',
             '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
-            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
+            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwS',
         ]);
     }
 


### PR DESCRIPTION
Set the default max length for the Password rule object to 72 chars, see #49739 