### PR TITLE
[10.x] Fix cannot bind an instance to a static closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
+use ReflectionFunction;
 use Throwable;
 
 /**
@@ -446,7 +447,7 @@ abstract class Factory
                 return $this->parentResolvers();
             }], $states->all()));
         })->reduce(function ($carry, $state) use ($parent) {
-            if ($state instanceof Closure) {
+            if ($state instanceof Closure && ! (new ReflectionFunction($state))->isStatic()) {
                 $state = $state->bindTo($this);
             }
 


### PR DESCRIPTION
## Description:
- Fix cannot bind an instance to a static closure

```
// Before
            if ($state instanceof Closure ) {
                $state = $state->bindTo($this);
            }
 // After
             if ($state instanceof Closure && !(new ReflectionFunction($state))->isStatic()) {
                $state = $state->bindTo($this);
            }
```
## Impact and Reason for Change:
**Prevents Error**: This change prevents the "Cannot bind an instance to a static closure" error, ensuring smoother code execution when handling different types of closures.
**Enhances Code Robustness**: It improves the robustness of your code by correctly handling different scenarios without causing runtime errors.
**Compatibility and Flexibility**: This change accommodates the use of both regular and static closures in the same context, increasing the flexibility of your code.
In summary, this change is a significant improvement in how you handle closures, making your code more reliable and flexible when working with various types of closures.