### PR TITLE
prevent exceptions when the sort key is passed incorrectly

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -112,11 +112,12 @@ class RouteListCommand extends Command
      */
     protected function getRoutes()
     {
-        $routes = collect($this->router->getRoutes())->map(function ($route) {
-            return $this->getRouteInformation($route);
-        })->filter()->all();
+        $routes = collect($this->router->getRoutes())
+            ->map(fn ($route) => $this->getRouteInformation($route))
+            ->filter()
+            ->all();
 
-        if (($sort = $this->option('sort')) !== null) {
+        if (in_array($sort = strtolower($this->option('sort')), $this->getColumns())) {
             $routes = $this->sortRoutes($sort, $routes);
         } else {
             $routes = $this->sortRoutes('uri', $routes);


### PR DESCRIPTION
In this PR, we will prevent an exception when the sorting key is passed incorrectly. 

### Problem:
Imagine a situation where a client calls `php artisan route:list` command with a `sort` switch filled like `foobar`.
```
php artisan route:list --sort=foobar
```
In this scenario, the code throws an exception because it tries to access an undefined key in the route array:

This exception will throw at _vendor/laravel/framework/src/Illuminate/Foundation/Console/RouteListCommand.php:163_:
```php
160  protected function sortRoutes($sort, array $routes)
161  {
162      return Arr::sort($routes, function ($route) use ($sort) {
163          return $route[$sort];
164      });
165  }
```
>    ErrorException 
> 
>   Undefined array key "foobar"
>
>   at vendor/laravel/framework/src/Illuminate/Foundation/Console/RouteListCommand.php:163



### Soloution:
So, in order to prevent this situation, we can check whether the sorting key exists in the columns provided in the route list. If it doesn't exist, we can use the default key to sort the results and return them.
```php
120  if (in_array($sort = strtolower($this->option('sort')), $this->getColumns())) {
121      $routes = $this->sortRoutes($sort, $routes);
122  } else {
123      $routes = $this->sortRoutes('uri', $routes);
124  }
```

First, we lowercase the input string in line 120 to ignore case-sensitive situations, providing a better experience for the framework's clients:
```php
strtolower($this->option('sort'))
```

Next, we check the sorting key in the columns array using `getColumns` method which returns an array of columns that we have:
```php
in_array($sort = strtolower($this->option('sort')), $this->getColumns())
```
And finally, we decide which sorting key should be passed to sort the routes.

### Test:
To write a scenario for this feature, I had to assign the router object to a property of the test class to add some new routes for my scenario.

In the test scenario, I add two more routes to the router object, which are not initially sorted by `uri`. So, when the sort key is passed incorrectly, the code will sort the routes list based on `uri` by default without throwing any exceptions.
```php
public function testRoutesAreSortedByDefaultKeyIfSortingKeyIsPassedIncorrectly()
{
    $this->router->get('/b', function () {
        return 'Hello World';
    });

    $this->router->get('/a', function () {
        return 'Hello World';
    });

    $this->app->call('route:list', ['--json' => true, '--sort' => 'foo', '-vv' => true]);
    $output = $this->app->output();

    $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"a","name":null,"action":"Closure","middleware":[]},{"domain":null,"method":"GET|HEAD","uri":"b","name":null,"action":"Closure","middleware":[]},{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]}]';

    $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
}

```
