### PR TITLE
[11.x] Fake Queue Interactions

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -147,11 +147,13 @@ trait InteractsWithQueue
             "Job was expected to be released, but was not."
         );
 
-        PHPUnit::assertSame(
-            $delay,
-            $this->job->releaseDelay,
-            "Expected job to be released with delay of [{$delay}] seconds, but was released with delay of [{$this->job->releaseDelay}] seconds."
-        );
+        if (! is_null($delay)) {
+            PHPUnit::assertSame(
+                $delay,
+                $this->job->releaseDelay,
+                "Expected job to be released with delay of [{$delay}] seconds, but was released with delay of [{$this->job->releaseDelay}] seconds."
+            );
+        }
 
         return $this;
     }
@@ -163,7 +165,7 @@ trait InteractsWithQueue
      */
     private function ensureQueueInteractionsHaveBeenFaked()
     {
-        if ($this->job instanceof FakeJob) {
+        if (! $this->job instanceof FakeJob) {
             throw new RuntimeException('Queue interactions have not been faked.');
         }
     }

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -4,8 +4,11 @@ namespace Illuminate\Queue;
 
 use DateTimeInterface;
 use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Queue\Jobs\FakeJob;
 use Illuminate\Support\InteractsWithTime;
 use InvalidArgumentException;
+use PHPUnit\Framework\Assert as PHPUnit;
+use RuntimeException;
 use Throwable;
 
 trait InteractsWithQueue
@@ -76,6 +79,92 @@ trait InteractsWithQueue
 
         if ($this->job) {
             return $this->job->release($delay);
+        }
+    }
+
+    /**
+     * Indicate that queue interactions like fail, delete, and release should be faked.
+     *
+     * @return $this
+     */
+    public function withFakeQueueInteractions()
+    {
+        $this->job = new FakeJob;
+
+        return $this;
+    }
+
+    /**
+     * Assert that the job was deleted from the queue.
+     *
+     * @return $this
+     */
+    public function assertDeleted()
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            $this->job->isDeleted(),
+            "Job was expected to be deleted, but was not."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the job was manually failed.
+     *
+     * @return $this
+     */
+    public function assertFailed()
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            $this->job->hasFailed(),
+            "Job was expected to be manually failed, but was not."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the job was released back onto the queue.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @return $this
+     */
+    public function assertReleased($delay = null)
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        $delay = $delay instanceof DateTimeInterface
+            ? $this->secondsUntil($delay)
+            : $delay;
+
+        PHPUnit::assertTrue(
+            $this->job->isReleased(),
+            "Job was expected to be released, but was not."
+        );
+
+        PHPUnit::assertSame(
+            $delay,
+            $this->job->releaseDelay,
+            "Expected job to be released with delay of [{$delay}] seconds, but was released with delay of [{$this->job->releaseDelay}] seconds."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Ensure that queue interactions have been faked.
+     *
+     * @return void
+     */
+    private function ensureQueueInteractionsHaveBeenFaked()
+    {
+        if ($this->job instanceof FakeJob) {
+            throw new RuntimeException('Queue interactions have not been faked.');
         }
     }
 

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -105,7 +105,7 @@ trait InteractsWithQueue
 
         PHPUnit::assertTrue(
             $this->job->isDeleted(),
-            "Job was expected to be deleted, but was not."
+            'Job was expected to be deleted, but was not.'
         );
 
         return $this;
@@ -122,7 +122,7 @@ trait InteractsWithQueue
 
         PHPUnit::assertTrue(
             $this->job->hasFailed(),
-            "Job was expected to be manually failed, but was not."
+            'Job was expected to be manually failed, but was not.'
         );
 
         return $this;
@@ -144,7 +144,7 @@ trait InteractsWithQueue
 
         PHPUnit::assertTrue(
             $this->job->isReleased(),
-            "Job was expected to be released, but was not."
+            'Job was expected to be released, but was not.'
         );
 
         if (! is_null($delay)) {

--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Jobs;
 
+use Illuminate\Support\Str;
+
 class FakeJob extends Job
 {
     /**
@@ -25,7 +27,7 @@ class FakeJob extends Job
      */
     public function getJobId()
     {
-        return once(fn () => Str::uuid());
+        return once(fn () => (string) Str::uuid());
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Queue\Jobs;
+
+class FakeJob extends Job
+{
+    /**
+     * The number of seconds the released job was delayed.
+     *
+     * @var int
+     */
+    public $releaseDelay;
+
+    /**
+     * The exception the job failed with.
+     *
+     * @var \Throwable
+     */
+    public $failedWith;
+
+    /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    public function getJobId()
+    {
+        return once(fn () => Str::uuid());
+    }
+
+    /**
+     * Get the raw body of the job.
+     *
+     * @return string
+     */
+    public function getRawBody()
+    {
+        return '';
+    }
+
+    /**
+     * Release the job back into the queue after (n) seconds.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        $this->released = true;
+        $this->releaseDelay = $delay;
+    }
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->deleted = true;
+    }
+
+    /**
+     * Delete the job, call the "failed" method, and raise the failed job event.
+     *
+     * @param  \Throwable|null  $e
+     * @return void
+     */
+    public function fail($exception = null)
+    {
+        $this->failed = true;
+        $this->failedWith = $exception;
+    }
+}


### PR DESCRIPTION
Currently, it's not obvious how to assert that a job was released, deleted, or manually failed from within the job itself. For example, given this job `handle` method:

```php
public function handle(): void
{
    if ($someCondition) {
        $this->release(30);
    }
}
```

It is not clear to the end user how to test this nor is it documented. The best way to do this currently would be to extend your job class and define stub / fake methods for `release`, `delete`, and `fail`.

This PR introduces a new `withFakeQueueInteractions` method on the `InteractsWithQueue` trait as well as relevant assertions. Now the job above could be tested like so:

```php
public function test_job_is_released(): void
{
    $job = (new TestJob)->withFakeQueueInteractions();

    $job->handle();

    $job->assertReleased(30);

    // $job->assertDeleted();
    // $job->assertFailed();
}
```