### PR TITLE
[10.x] Global default options for the http factory

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -37,6 +37,13 @@ class Factory
     protected $globalMiddleware = [];
 
     /**
+     * The options to apply to every request.
+     *
+     * @var array
+     */
+    protected $globalOptions = [];
+
+    /**
      * The stub callables that will handle requests.
      *
      * @var \Illuminate\Support\Collection
@@ -82,6 +89,19 @@ class Factory
         $this->dispatcher = $dispatcher;
 
         $this->stubCallbacks = collect();
+    }
+
+    /**
+     * Set options to apply to every request.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function globalOptions($options)
+    {
+        $this->globalOptions = $options;
+
+        return $this;
     }
 
     /**
@@ -400,7 +420,7 @@ class Factory
      */
     protected function newPendingRequest()
     {
-        return new PendingRequest($this, $this->globalMiddleware);
+        return (new PendingRequest($this, $this->globalMiddleware))->withOptions($this->globalOptions);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -92,19 +92,6 @@ class Factory
     }
 
     /**
-     * Set options to apply to every request.
-     *
-     * @param  array  $options
-     * @return $this
-     */
-    public function globalOptions($options)
-    {
-        $this->globalOptions = $options;
-
-        return $this;
-    }
-
-    /**
      * Add middleware to apply to every request.
      *
      * @param  callable  $middleware
@@ -139,6 +126,19 @@ class Factory
     public function globalResponseMiddleware($middleware)
     {
         $this->globalMiddleware[] = Middleware::mapResponse($middleware);
+
+        return $this;
+    }
+
+    /**
+     * Set the options to apply to every request.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function globalOptions($options)
+    {
+        $this->globalOptions = $options;
 
         return $this;
     }


### PR DESCRIPTION
Adds a mechanism to configure global default options for the HTTP client.

This would be done in a service provider.

```php
Http::globalOptions([
    'timeout' => 5,
    'connect_timeout' => 2,
]);
```

Naming matches the global middleware / instance middleware functions.

```php
// Global...
Http::globalMiddleware(/* ... */);
Http::globalOptions(/* ... */);

// Per request...
Http::withMiddleware(/* ... */);
Http::withOptions(/* ... */);
```

This method does **not merge** options if called more than once. Calling it twice will override the previously specified options.

```php
Http::globalOptions([
    'headers' => [
        'X-Foo' => 'true',
    ],
]);

Http::globalOptions([
    'headers' => [
        'X-Foo' => 'false',
    ],
]);

Http::get('...'); // X-Foo: 'false'
```

If we were to merge options the result would be: `X-Foo: true, false`, thus I felt it was most clear and simple to replace the global options whenever `Http::globalOptions` is called.

This does differ from the `Http::globalMiddleware` where calling it twice will apply both middleware, but I think that is okay and an expected difference.