### PR TITLE
IsSlug String Method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -540,6 +540,21 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid Slug.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isSlug($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^[a-z0-9]+(?:-[a-z0-9]+|_[a-z0-9]+)*$/', $value) === 1;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value
@@ -860,7 +875,8 @@ class Str
                 ']', '|', ':', ';',
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
-        ]))->filter()->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
+        ]))->filter()->each(
+            fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
         )->flatten();
 
         $length = $length - $password->count();

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -173,9 +173,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('[...]is a beautiful morn[...]', Str::excerpt('This is a beautiful morning', 'beautiful', ['omission' => '[...]', 'radius' => 5]));
         $this->assertSame(
             'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
-            Str::excerpt('This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
+            Str::excerpt(
+                'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?',
+                'very',
                 ['omission' => '[...]'],
-            ));
+            )
+        );
 
         $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
         $this->assertSame('...ayl...', Str::excerpt('taylor', 'Y', ['radius' => 1]));
@@ -1296,6 +1299,15 @@ class SupportStrTest extends TestCase
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }
+
+    public function testItCanDetectForValidSlug()
+    {
+        $this->assertTrue(Str::isSlug('valid-slug'));
+        $this->assertTrue(Str::isSlug('another_valid_slug'));
+        $this->assertFalse(Str::isSlug('invalid@slug'));
+        $this->assertFalse(Str::isSlug('InvalidSlug'));
+    }
+
 }
 
 class StringableObjectStub


### PR DESCRIPTION
### Pull Request: Feature Addition - isSlug Method
This pull request introduces a new method, isSlug, to the Str class in the Laravel framework. The purpose of this method is to validate whether a given string adheres to the common rules for a URL slug. This can be useful for developers who want to ensure that a string is suitable for use in URLs.

### Changes 

- Added isSlug method to Illuminate\Support\Str.php.
- Implemented a regular expression check to validate the format of the string.
- Added corresponding tests in tests/Support/SupportStrTest.php.
- Updated the documentation to include information about the new method.

### Usage
``` php
// Example Usage:
$isSlug = Str::isValidSlug('valid-slug');
// Output: true

$isSlug = Str::isValidSlug('invalid@slug');
// Output: false
```

### Testing

- All tests pass locally using PHPUnit.
- Added test cases to cover various scenarios.

### Additional Notes

- This feature was implemented to address the need for a convenient method to validate URL slugs within Laravel applications.
- Follows Laravel's coding standards and conventions.
