### PR TITLE
Reduce failure rate of Arr::shuffle() tests

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -907,24 +907,34 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1 => 'hAz'], Arr::set($array, 1, 'hAz'));
     }
 
-    public function testShuffle()
+    public function testShuffleProducesDifferentShuffles()
     {
-        $input = ['a', 'b', 'c', 'd', 'e', 'f'];
+        $input = range('a', 'z');
 
-        $this->assertNotEquals(
-            $input,
-            Arr::shuffle($input)
+        $this->assertFalse(
+            Arr::shuffle($input) === Arr::shuffle($input) && Arr::shuffle($input) === Arr::shuffle($input),
+            "The shuffles produced the same output each time, which shouldn't happen."
+        );
+    }
+
+    public function testShuffleActuallyShuffles()
+    {
+        $input = range('a', 'z');
+
+        $this->assertFalse(
+            Arr::shuffle($input) === Arr::shuffle($input) && Arr::shuffle($input) === Arr::shuffle($input),
+            "The shuffles produced the same output each time, which shouldn't happen."
         );
 
-        $this->assertNotEquals(
-            Arr::shuffle($input),
-            Arr::shuffle($input)
+        $this->assertFalse(
+            Arr::shuffle($input) === $input && Arr::shuffle($input) === $input,
+            "The shuffles were unshuffled each time, which shouldn't happen."
         );
     }
 
     public function testShuffleKeepsSameValues()
     {
-        $input = ['a', 'b', 'c', 'd', 'e', 'f'];
+        $input = range('a', 'z');
         $shuffled = Arr::shuffle($input);
         sort($shuffled);
 


### PR DESCRIPTION
This (hopefully) fixes the false positive failure rate on the `Arr::shuffle()` tests introduced in https://github.com/laravel/framework/pull/49642, as per @TimWolla's comments.

I've increase the data set to 26 characters (`A-Z`), and changed it to run `shuffle()` twice in the assertions. This should significantly lower the false positive failure, as the chance of the same shuffle being produced is significantly lower.

I also split the test two into, so they can fail independently.