### PR TITLE
[10.x] Adds method to skip seeder

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -49,6 +49,22 @@ abstract class Seeder
 
             $name = get_class($seeder);
 
+            if (
+                method_exists($this, 'skip') &&
+                ($this->container ? $this->container->call([$this, 'skip']) : $this->skip())
+            ) {
+                if ($silent === false && isset($this->command)) {
+                    with(new TwoColumnDetail($this->command->getOutput()))->render(
+                        $name,
+                        '<fg=blue;options=bold>SKIPPED</>'
+                    );
+                }
+
+                static::$called[] = $class;
+
+                continue;
+            }
+
             if ($silent === false && isset($this->command)) {
                 with(new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,


### PR DESCRIPTION
# What?

After someone shot down my last PR, I came back with a vengeance to make seeders _skippable_. If the seeder declares `skip()` and returns _truthy_, the seeder will be skipped and the console will show that. Simple as that.

```
class UserSeeder extends Seeder
{
    public function skip()
    {
        // Don't run this seeder if the user database has records.
        return User::query()->exists()
    }
}
```

I think this approach is more palatable for the developer for five reasons:

1. Separates the skip logic from the seeding logic.
2. Informs through the console if the seeder was skipped. 
3. The `skip()` is called using the Container (for dependency injection).
4. Only works if the method exists.
5. Keeps the seeder benchmark outside the skip.

The only caveat I see is if the seeder is being called particularly, since it won't run anyway if the `skip()` returns true.