### PR TITLE
[10.x] Support for multiple exception type handling in rescue() helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -733,9 +733,10 @@ if (! function_exists('rescue')) {
      * @param  callable(): TRescueValue  $callback
      * @param  (callable(\Throwable): TRescueFallback)|TRescueFallback  $rescue
      * @param  bool|callable  $report
+     * @param  null|array<string, (callable(\Throwable): TRescueFallback)|TRescueFallback>  $catch
      * @return TRescueValue|TRescueFallback
      */
-    function rescue(callable $callback, $rescue = null, $report = true)
+    function rescue(callable $callback, $rescue = null, $report = true, $catch = null)
     {
         try {
             return $callback();
@@ -744,7 +745,11 @@ if (! function_exists('rescue')) {
                 report($e);
             }
 
-            return value($rescue, $e);
+            return match (true) {
+                is_array($catch) && array_key_exists(get_class($e), $catch) => value($catch[get_class($e)], $e),
+                is_array($catch) && array_key_exists('default', $catch) => value($catch['default'], $e),
+                default => value($rescue, $e),
+            };
         }
     }
 }

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -71,7 +71,7 @@ class FoundationHelpersTest extends TestCase
             }, catch: [
                 TypeError::class => 'typeerror rescued!',
                 Exception::class => 'exception rescued!',
-                RuntimeException::class => 'runtime rescued',
+                RuntimeException::class => 'runtime rescued!',
             ])
         );
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Exception;
-use TypeError;
-use RuntimeException;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
+use TypeError;
 
 class FoundationHelpersTest extends TestCase
 {
@@ -92,12 +92,12 @@ class FoundationHelpersTest extends TestCase
             rescue(function () {
                 throw new InvalidArgumentException();
             }, 
-            'none from catch rescued!',
-            catch: [
-                TypeError::class => 'typeerror rescued!',
-                Exception::class => 'exception rescued!',
-                RuntimeException::class => 'runtime rescued!',
-            ])
+                'none from catch rescued!',
+                catch: [
+                    TypeError::class => 'typeerror rescued!',
+                    Exception::class => 'exception rescued!',
+                    RuntimeException::class => 'runtime rescued!',
+                ])
         );
     }
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -92,7 +92,7 @@ class FoundationHelpersTest extends TestCase
             rescue(function () {
                 throw new InvalidArgumentException();
             }, 
-            'none from catch rescued',
+            'none from catch rescued!',
             catch: [
                 TypeError::class => 'typeerror rescued!',
                 Exception::class => 'exception rescued!',

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -65,7 +65,7 @@ class FoundationHelpersTest extends TestCase
         );
 
         $this->assertEquals(
-            'exception rescued!',
+            'runtime rescued!',
             rescue(function () {
                 throw new RuntimeException();
             }, catch: [

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Exception;
+use TypeError;
+use RuntimeException;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
 class FoundationHelpersTest extends TestCase
@@ -49,6 +52,52 @@ class FoundationHelpersTest extends TestCase
             rescue(function () use ($testClass) {
                 $testClass->test([]);
             }, 'rescued!')
+        );
+
+        $this->assertEquals(
+            'typeerror rescued!',
+            rescue(function () use ($testClass) {
+                $testClass->test([]);
+            }, catch: [
+                Exception::class => 'exception rescued!',
+                TypeError::class => 'typeerror rescued!',
+            ])
+        );
+
+        $this->assertEquals(
+            'exception rescued!',
+            rescue(function () {
+                throw new RuntimeException();
+            }, catch: [
+                TypeError::class => 'typeerror rescued!',
+                Exception::class => 'exception rescued!',
+                RuntimeException::class => 'runtime rescued',
+            ])
+        );
+
+        $this->assertEquals(
+            'default rescued!',
+            rescue(function () {
+                throw new InvalidArgumentException();
+            }, catch: [
+                TypeError::class => 'typeerror rescued!',
+                Exception::class => 'exception rescued!',
+                RuntimeException::class => 'runtime rescued!',
+                'default' => 'default rescued!',
+            ])
+        );
+
+        $this->assertEquals(
+            'none from catch rescued!',
+            rescue(function () {
+                throw new InvalidArgumentException();
+            }, 
+            'none from catch rescued',
+            catch: [
+                TypeError::class => 'typeerror rescued!',
+                Exception::class => 'exception rescued!',
+                RuntimeException::class => 'runtime rescued!',
+            ])
         );
     }
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -91,7 +91,7 @@ class FoundationHelpersTest extends TestCase
             'none from catch rescued!',
             rescue(function () {
                 throw new InvalidArgumentException();
-            }, 
+            },
                 'none from catch rescued!',
                 catch: [
                     TypeError::class => 'typeerror rescued!',


### PR DESCRIPTION
According to [docs](https://laravel.com/docs/10.x/helpers#method-rescue) `rescue()` helper catches any exceptions that occur during its execution (usually exception is expected to be thrown in first parameter closure), but there's not any posibility to catch multiple types of exception. 
This is much more useful when callback function is expected to throw multiple type of exception.

So I added new parameter where you can pass any value or closure that handles any type of exceptions.

See before and after examples below:

**Before**
```php
  $data = rescue(function () {
    if(/** some condition */) {
      throw new RuntimeException();
    }
    else if(/** some other condition */) {
      throw new Exception();
    } 
    else {
      // do something
    }
  }, function (Throwable $e) {
    
    if(get_class($e) === 'RuntimeException' /** or is_a($e, RuntimeException::class) */) {
      return 'runtime exception caught';
    } 
    else if(get_class($e) === 'Exception') {
      return 'runtime exception caught';
    }
    
    return 'default';
  });
```

**After**
```php
$data = rescue(function () {
  if(/** some condition */) {
    throw new RuntimeException();
  }
  else if(/** some other condition */) {
    throw new Exception();
  } 
  else {
    // do something
  }
}, catch: [
  RuntimeException::class => fn() => "runtime exception rescued",
  Exception::class => 'exception rescued',
  'default' => 'some other exception rescued'
]);
```

Everythig will work as expected if you don't pass `catch` parameter