### PR TITLE
[10.x] Allow Uuid and Ulid in Carbon::createFromId()

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -29,9 +29,11 @@ class Carbon extends BaseCarbon
      */
     public static function createFromId($id)
     {
-        return Ulid::isValid($id)
-            ? static::createFromInterface(Ulid::fromString($id)->getDateTime())
-            : static::createFromInterface(Uuid::fromString($id)->getDateTime());
+        if (is_string($id)) {
+            $id = Ulid::isValid($id) ? Ulid::fromString($id) : Uuid::fromString($id);
+        }
+
+        return static::createFromInterface($id->getDateTime());
     }
 
     /**


### PR DESCRIPTION
PHPDoc of `\Illuminate\Support\Carbon::createFromId` says it accepts `Uuid|Ulid|string` but since `$id` parameter is always passed to `isValid` which only accepts `string`, in practice, `createFromId` also only accepts `string`.

With the following change, creating `Carbon` objects from Uuid and Ulid objects using this method would also work.