### PR TITLE
[10.x] Allow array of exceptions to be passed in `stopIgnoring`

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -385,7 +385,7 @@ class Handler implements ExceptionHandlerContract
     public function stopIgnoring($exceptions)
     {
         $exceptions = is_string($exceptions) ? func_get_args() : $exceptions;
-        
+
         $this->dontReport = collect($this->dontReport)
                 ->reject(fn ($ignored) => in_array($ignored, $exceptions))->values()->all();
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -379,16 +379,18 @@ class Handler implements ExceptionHandlerContract
     /**
      * Remove the given exception class from the list of exceptions that should be ignored.
      *
-     * @param  string  $exception
+     * @param  string|array  $exceptions
      * @return $this
      */
-    public function stopIgnoring(string $exception)
+    public function stopIgnoring($exceptions)
     {
+        $exceptions = is_string($exceptions) ? func_get_args() : $exceptions;
+        
         $this->dontReport = collect($this->dontReport)
-                ->reject(fn ($ignored) => $ignored === $exception)->values()->all();
+                ->reject(fn ($ignored) => in_array($ignored, $exceptions))->values()->all();
 
         $this->internalDontReport = collect($this->internalDontReport)
-                ->reject(fn ($ignored) => $ignored === $exception)->values()->all();
+                ->reject(fn ($ignored) => in_array($ignored, $exceptions))->values()->all();
 
         return $this;
     }


### PR DESCRIPTION
This pr allows passing an array of exceptions which prevents unnecessary method chaining and is more in line with similar laravel functionality.

Instead of:
```php
$this->stopIgnoring(ModelNotFoundException::class);
$this->stopIgnoring(RecordsNotFoundException::class);
$this->stopIgnoring(ValidationException::class);
```
The following is accepted:
```php
$this->stopIgnoring([
    ModelNotFoundException::class,
    RecordsNotFoundException::class,
    ValidationException::class
]);
```