### PR TITLE
[10.x] fix: Restore the original error/exception handler on terminating app

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -43,9 +43,14 @@ class HandleExceptions
 
         error_reporting(-1);
 
-        set_error_handler($this->forwardsTo('handleError'));
+        $originalErrorHandler = set_error_handler($this->forwardsTo('handleError'));
 
-        set_exception_handler($this->forwardsTo('handleException'));
+        $originalExceptionHandler = set_exception_handler($this->forwardsTo('handleException'));
+
+        $app->terminating(static function () use ($originalErrorHandler, $originalExceptionHandler): void {
+            set_error_handler($originalErrorHandler);
+            set_exception_handler($originalExceptionHandler);
+        });
 
         register_shutdown_function($this->forwardsTo('handleShutdown'));
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -410,6 +410,7 @@ class HandleExceptionsTest extends TestCase
 
         $instance->bootstrap($newApp = tap(m::mock(Application::class), function ($app) {
             $app->expects('environment')->andReturn(true);
+            $app->expects('terminating');
         }));
 
         $this->assertNotSame($this->app, $appResolver());


### PR DESCRIPTION
Resolves #49237, #49593

HandleExceptions bootstrapper sets an error handler for the application, but does not restore the original handler after the run. This causes failure on isolated tests in PHPUnit on PHP 8.3. In addition, PHPUnit is going to detect the error handler which is not restored and **mark as risky test** since PHPUnit v11 (See https://github.com/sebastianbergmann/phpunit/pull/5619).

Related pull request: https://github.com/sebastianbergmann/phpunit/pull/5677