### PR TITLE
[10.x] Bugfix: NotificationFake::sendNow skips notifications without shouldSend method

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -306,10 +306,10 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                     $notifiableChannels,
                     fn ($channel) => $notification->shouldSend($notifiable, $channel) !== false
                 );
-            }
 
-            if (empty($notifiableChannels)) {
-                continue;
+                if (empty($notifiableChannels)) {
+                    continue;
+                }
             }
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [


### PR DESCRIPTION
Resolves bug found in issue https://github.com/laravel/framework/issues/49790
