### PR TITLE
[10.x] Add storage:unlink command

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageDeleteLinksCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageDeleteLinksCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'storage:delete-links')]
+class StorageDeleteLinksCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'storage:delete-links';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete existing links configured for the application';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        foreach ($this->links() as $link => $target) {
+            if (! file_exists($link) || ! is_link($link)) {
+                continue;
+            }
+
+            $this->laravel->make('files')->delete($link);
+
+            $this->components->info("The [$link] link has been deleted.");
+        }
+    }
+
+    /**
+     * Get the symbolic links that are configured for the application.
+     *
+     * @return array
+     */
+    protected function links()
+    {
+        return $this->laravel['config']['filesystems.links'] ??
+               [public_path('storage') => storage_path('app/public')];
+    }
+}

--- a/src/Illuminate/Foundation/Console/StorageUnlinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageUnlinkCommand.php
@@ -5,15 +5,15 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'storage:delete-links')]
-class StorageDeleteLinksCommand extends Command
+#[AsCommand(name: 'storage:unlink')]
+class StorageUnlinkCommand extends Command
 {
     /**
      * The console command signature.
      *
      * @var string
      */
-    protected $signature = 'storage:delete-links';
+    protected $signature = 'storage:unlink';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/StorageUnlinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageUnlinkCommand.php
@@ -20,7 +20,7 @@ class StorageUnlinkCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Delete existing links configured for the application';
+    protected $description = 'Delete existing symbolic links configured for the application';
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -69,6 +69,7 @@ use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ScopeMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Foundation\Console\StorageDeleteLinksCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
@@ -157,6 +158,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleWork' => ScheduleWorkCommand::class,
         'ScheduleInterrupt' => ScheduleInterruptCommand::class,
         'ShowModel' => ShowModelCommand::class,
+        'StorageDeleteLinks' => StorageDeleteLinksCommand::class,
         'StorageLink' => StorageLinkCommand::class,
         'Up' => UpCommand::class,
         'ViewCache' => ViewCacheCommand::class,

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -69,8 +69,8 @@ use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ScopeMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
-use Illuminate\Foundation\Console\StorageDeleteLinksCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
+use Illuminate\Foundation\Console\StorageUnlinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
 use Illuminate\Foundation\Console\UpCommand;
@@ -158,8 +158,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleWork' => ScheduleWorkCommand::class,
         'ScheduleInterrupt' => ScheduleInterruptCommand::class,
         'ShowModel' => ShowModelCommand::class,
-        'StorageDeleteLinks' => StorageDeleteLinksCommand::class,
         'StorageLink' => StorageLinkCommand::class,
+        'StorageUnlink' => StorageUnlinkCommand::class,
         'Up' => UpCommand::class,
         'ViewCache' => ViewCacheCommand::class,
         'ViewClear' => ViewClearCommand::class,


### PR DESCRIPTION
An application may have multiple symlinks in different places and needs the ability to delete all symlinks.

I suggest adding a command to **delete** symbolic links.

Usage example:

```bash
php artisan storage:unlink
```

P.S. In my previous PR (#49792) recommended adding a new command.