### PR TITLE
[11.x] Flush Statics

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -24,7 +24,7 @@ class AuthenticationException extends Exception
     /**
      * The callback that should be used to generate the authentication redirect path.
      *
-     * @var callable
+     * @var callable|null
      */
     protected static $redirectToCallback;
 
@@ -74,10 +74,10 @@ class AuthenticationException extends Exception
     /**
      * Specify the callback that should be used to generate the redirect path.
      *
-     * @param  callable  $redirectToCallback
+     * @param  callable|null  $redirectToCallback
      * @return void
      */
-    public static function redirectUsing(callable $redirectToCallback)
+    public static function redirectUsing(callable|null $redirectToCallback)
     {
         static::$redirectToCallback = $redirectToCallback;
     }

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -20,7 +20,7 @@ class Authenticate implements AuthenticatesRequests
     /**
      * The callback that should be used to generate the authentication redirect path.
      *
-     * @var callable
+     * @var callable|null
      */
     protected static $redirectToCallback;
 
@@ -122,10 +122,10 @@ class Authenticate implements AuthenticatesRequests
     /**
      * Specify the callback that should be used to generate the redirect path.
      *
-     * @param  callable  $redirectToCallback
+     * @param  callable|null  $redirectToCallback
      * @return void
      */
-    public static function redirectUsing(callable $redirectToCallback)
+    public static function redirectUsing(callable|null $redirectToCallback)
     {
         static::$redirectToCallback = $redirectToCallback;
     }

--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -70,10 +70,10 @@ class RedirectIfAuthenticated
     /**
      * Specify the callback that should be used to generate the redirect path.
      *
-     * @param  callable  $redirectToCallback
+     * @param  callable|null  $redirectToCallback
      * @return void
      */
-    public static function redirectUsing(callable $redirectToCallback)
+    public static function redirectUsing(callable|null $redirectToCallback)
     {
         static::$redirectToCallback = $redirectToCallback;
     }

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -121,4 +121,15 @@ class ResetPassword extends Notification
     {
         static::$toMailCallback = $callback;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$toMailCallback = null;
+        static::$createUrlCallback = null;
+    }
 }

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -111,4 +111,15 @@ class VerifyEmail extends Notification
     {
         static::$toMailCallback = $callback;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$createUrlCallback = null;
+        static::$toMailCallback = null;
+    }
 }

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -142,7 +142,7 @@ class Signals
     /**
      * Set the availability resolver.
      *
-     * @param  callable(): bool
+     * @param  (callable(): bool)|null
      * @return void
      */
     public static function resolveAvailabilityUsing($resolver)

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -240,4 +240,15 @@ class EncryptCookies
     {
         return static::$serialize;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$neverEncrypt = [];
+        static::$serialize = false;
+    }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1634,4 +1634,14 @@ class Connection implements ConnectionInterface
     {
         return static::$resolvers[$driver] ?? null;
     }
+
+    /**
+     * Flush the connection resolvers.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$resolvers = [];
+    }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1636,7 +1636,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Flush the connection resolvers.
+     * Flush the global state.
      *
      * @return void
      */

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -110,4 +110,14 @@ class DatabaseServiceProvider extends ServiceProvider
             return new QueueEntityResolver;
         });
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$fakers = [];
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2048,4 +2048,14 @@ class Builder implements BuilderContract
     {
         $this->query = clone $this->query;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$macros = [];
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -51,4 +51,15 @@ class Json
     {
         static::$decoder = $decoder;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$encoder = null;
+        static::$decoder = null;
+    }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -100,5 +100,6 @@ class TrimStrings extends TransformsRequest
     public static function flushState()
     {
         static::$skipCallbacks = [];
+        static::$neverTrim = [];
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -230,4 +230,14 @@ class VerifyCsrfToken
     {
         return EncryptCookies::serialized('XSRF-TOKEN');
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$neverVerify = [];
+    }
 }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -85,10 +85,10 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Register the callback that will be used to load the application's routes.
      *
-     * @param  \Closure  $routesCallback
+     * @param  \Closure|null  $routesCallback
      * @return void
      */
-    public static function loadRoutesUsing(Closure $routesCallback)
+    public static function loadRoutesUsing(Closure|null $routesCallback)
     {
         self::$alwaysLoadRoutesUsing = $routesCallback;
     }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
@@ -247,6 +248,7 @@ abstract class TestCase extends BaseTestCase
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();
+        Connection::flushState();
         ConvertEmptyStringsToNull::flushState();
         HandleExceptions::flushState();
         Once::flush();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -25,6 +25,7 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Foundation\Vite;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -291,6 +292,7 @@ abstract class TestCase extends BaseTestCase
         Sleep::fake(false);
         TrimStrings::flushState();
         TrustProxies::flushState();
+        VerifyCsrfToken::flushState();
         VerifyEmail::flushState();
         Vite::flushState();
         Worker::flushState();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -28,6 +28,7 @@ use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Vite;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Mail\Mailable;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
@@ -274,6 +275,7 @@ abstract class TestCase extends BaseTestCase
         HandleExceptions::flushState();
         Json::flushState();
         JsonResource::wrap('data');
+        Mailable::buildViewDataUsing(null);
         Once::flush();
         Queue::createPayloadUsing(null);
         RedirectIfAuthenticated::redirectUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
@@ -261,6 +262,7 @@ abstract class TestCase extends BaseTestCase
         HandleExceptions::flushState();
         Once::flush();
         Queue::createPayloadUsing(null);
+        RedirectIfAuthenticated::redirectUsing(null);
         RegisterProviders::flushState();
         ResetPassword::flushState();
         ScheduleListCommand::resolveTerminalWidthUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -26,6 +26,7 @@ use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Vite;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -287,6 +288,7 @@ abstract class TestCase extends BaseTestCase
         RedirectIfAuthenticated::redirectUsing(null);
         RegisterProviders::flushState();
         ResetPassword::flushState();
+        RouteServiceProvider::loadRoutesUsing(null);
         ScheduleListCommand::resolveTerminalWidthUsing(null);
         Signals::resolveAvailabilityUsing(null);
         Sleep::fake(false);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -17,6 +17,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseServiceProvider;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
@@ -268,6 +269,7 @@ abstract class TestCase extends BaseTestCase
         DatabaseServiceProvider::flushState();
         EncryptCookies::flushState();
         HandleExceptions::flushState();
+        Json::flushState();
         Once::flush();
         Queue::createPayloadUsing(null);
         RedirectIfAuthenticated::redirectUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -13,6 +13,7 @@ use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Signals;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
@@ -261,6 +262,7 @@ abstract class TestCase extends BaseTestCase
         Connection::flushState();
         Container::setInstance(null);
         ConvertEmptyStringsToNull::flushState();
+        EncryptCookies::flushState();
         HandleExceptions::flushState();
         Once::flush();
         Queue::createPayloadUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,6 +29,7 @@ use Illuminate\Foundation\Vite;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Mail\Mailable;
+use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
@@ -261,6 +262,7 @@ abstract class TestCase extends BaseTestCase
         $this->originalDeprecationHandler = null;
 
         AboutCommand::flushState();
+        AbstractCursorPaginator::currentCursorResolver(null);
         AbstractPaginator::flushState();
         Artisan::forgetBootstrappers();
         Authenticate::redirectUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -15,6 +15,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Connection;
+use Illuminate\Database\DatabaseServiceProvider;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
@@ -262,6 +263,7 @@ abstract class TestCase extends BaseTestCase
         Connection::flushState();
         Container::setInstance(null);
         ConvertEmptyStringsToNull::flushState();
+        DatabaseServiceProvider::flushState();
         EncryptCookies::flushState();
         HandleExceptions::flushState();
         Once::flush();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,6 +29,7 @@ use Illuminate\Foundation\Vite;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Mail\Mailable;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
@@ -260,6 +261,7 @@ abstract class TestCase extends BaseTestCase
         $this->originalDeprecationHandler = null;
 
         AboutCommand::flushState();
+        AbstractPaginator::flushState();
         Artisan::forgetBootstrappers();
         Authenticate::redirectUsing(null);
         AuthenticationException::redirectUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseServiceProvider;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
@@ -257,6 +258,7 @@ abstract class TestCase extends BaseTestCase
         Artisan::forgetBootstrappers();
         Authenticate::redirectUsing(null);
         AuthenticationException::redirectUsing(null);
+        Builder::flushState();
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
@@ -250,6 +251,7 @@ abstract class TestCase extends BaseTestCase
 
         AboutCommand::flushState();
         Artisan::forgetBootstrappers();
+        Authenticate::redirectUsing(null);
         AuthenticationException::redirectUsing(null);
         Component::flushCache();
         Component::forgetComponentsResolver();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -32,6 +32,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Queue\Queue;
+use Illuminate\Queue\Worker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
@@ -292,6 +293,7 @@ abstract class TestCase extends BaseTestCase
         TrustProxies::flushState();
         VerifyEmail::flushState();
         Vite::flushState();
+        Worker::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
+use Illuminate\Console\Signals;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
@@ -259,6 +260,7 @@ abstract class TestCase extends BaseTestCase
         RegisterProviders::flushState();
         ResetPassword::flushState();
         ScheduleListCommand::resolveTerminalWidthUsing(null);
+        Signals::resolveAvailabilityUsing(null);
         Sleep::fake(false);
         TrimStrings::flushState();
         VerifyEmail::flushState();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -27,6 +27,7 @@ use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Vite;
 use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
@@ -272,6 +273,7 @@ abstract class TestCase extends BaseTestCase
         EncryptCookies::flushState();
         HandleExceptions::flushState();
         Json::flushState();
+        JsonResource::wrap('data');
         Once::flush();
         Queue::createPayloadUsing(null);
         RedirectIfAuthenticated::redirectUsing(null);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
@@ -257,6 +258,7 @@ abstract class TestCase extends BaseTestCase
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
         ResetPassword::flushState();
+        ScheduleListCommand::resolveTerminalWidthUsing(null);
         Sleep::fake(false);
         TrimStrings::flushState();
         VerifyEmail::flushState();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -11,6 +11,7 @@ use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Signals;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
@@ -258,6 +259,7 @@ abstract class TestCase extends BaseTestCase
         Component::forgetComponentsResolver();
         Component::forgetFactory();
         Connection::flushState();
+        Container::setInstance(null);
         ConvertEmptyStringsToNull::flushState();
         HandleExceptions::flushState();
         Once::flush();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
@@ -249,6 +250,7 @@ abstract class TestCase extends BaseTestCase
 
         AboutCommand::flushState();
         Artisan::forgetBootstrappers();
+        AuthenticationException::redirectUsing(null);
         Component::flushCache();
         Component::forgetComponentsResolver();
         Component::forgetFactory();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Connection;
@@ -258,6 +259,7 @@ abstract class TestCase extends BaseTestCase
         ResetPassword::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();
+        VerifyEmail::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -35,6 +35,7 @@ use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\Worker;
+use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
@@ -292,6 +293,7 @@ abstract class TestCase extends BaseTestCase
         ScheduleListCommand::resolveTerminalWidthUsing(null);
         Signals::resolveAvailabilityUsing(null);
         Sleep::fake(false);
+        ThrottleRequests::shouldHashKeys();
         TrimStrings::flushState();
         TrustProxies::flushState();
         VerifyCsrfToken::flushState();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Connection;
@@ -254,6 +255,7 @@ abstract class TestCase extends BaseTestCase
         Once::flush();
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
+        ResetPassword::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -36,6 +36,7 @@ use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\Worker;
 use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ValidateSignature;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
@@ -296,6 +297,7 @@ abstract class TestCase extends BaseTestCase
         ThrottleRequests::shouldHashKeys();
         TrimStrings::flushState();
         TrustProxies::flushState();
+        ValidateSignature::flushState();
         VerifyCsrfToken::flushState();
         VerifyEmail::flushState();
         Vite::flushState();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -26,6 +26,7 @@ use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Vite;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
@@ -280,6 +281,7 @@ abstract class TestCase extends BaseTestCase
         Signals::resolveAvailabilityUsing(null);
         Sleep::fake(false);
         TrimStrings::flushState();
+        TrustProxies::flushState();
         VerifyEmail::flushState();
         Vite::flushState();
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -25,6 +25,7 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Foundation\Vite;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
@@ -280,6 +281,7 @@ abstract class TestCase extends BaseTestCase
         Sleep::fake(false);
         TrimStrings::flushState();
         VerifyEmail::flushState();
+        Vite::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -803,4 +803,14 @@ class Vite implements Htmlable
     {
         return $this->__invoke($this->entryPoints)->toHtml();
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$manifests = [];
+    }
 }

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -149,4 +149,14 @@ class TrustProxies
     {
         return static::$alwaysTrust ?: $this->proxies;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$alwaysTrust = null;
+    }
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -183,7 +183,7 @@ class Mailable implements MailableContract, Renderable
     /**
      * The callback that should be invoked while building the view data.
      *
-     * @var callable
+     * @var callable|null
      */
     public static $viewDataCallback;
 
@@ -1789,10 +1789,10 @@ class Mailable implements MailableContract, Renderable
     /**
      * Register a callback to be called while building the view data.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @return void
      */
-    public static function buildViewDataUsing(callable $callback)
+    public static function buildViewDataUsing(callable|null $callback)
     {
         static::$viewDataCallback = $callback;
     }

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -90,7 +90,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * The current cursor resolver callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected static $currentCursorResolver;
 
@@ -502,10 +502,10 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Set the current cursor resolver callback.
      *
-     * @param  \Closure  $resolver
+     * @param  \Closure|null  $resolver
      * @return void
      */
-    public static function currentCursorResolver(Closure $resolver)
+    public static function currentCursorResolver(Closure|null $resolver)
     {
         static::$currentCursorResolver = $resolver;
     }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -84,28 +84,28 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     /**
      * The current path resolver callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected static $currentPathResolver;
 
     /**
      * The current page resolver callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected static $currentPageResolver;
 
     /**
      * The query string resolver callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected static $queryStringResolver;
 
     /**
      * The view factory resolver callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected static $viewFactoryResolver;
 
@@ -794,5 +794,20 @@ abstract class AbstractPaginator implements Htmlable, Stringable
     public function __toString()
     {
         return (string) $this->render();
+    }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$currentPathResolver = null;
+        static::$currentPageResolver = null;
+        static::$queryStringResolver = null;
+        static::$viewFactoryResolver = null;
+        static::$defaultView = 'pagination::tailwind';
+        static::$defaultSimpleView = 'pagination::simple-tailwind';
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -873,4 +873,14 @@ class Worker
     {
         $this->manager = $manager;
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$popCallbacks = [];
+    }
 }

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -107,4 +107,14 @@ class ValidateSignature
             array_merge(static::$neverValidate, Arr::wrap($parameters))
         ));
     }
+
+    /**
+     * Flush the global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$neverValidate = [];
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1827,5 +1827,8 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
+        static::$uuidFactory = null;
+        static::$ulidFactory = null;
+        static::$randomStringFactory = null;
     }
 }


### PR DESCRIPTION
WIP.

Generated with:

```sh
grep -R -E " static [A-Za-z_]* ?\\\$" src > statics.txt
```

## Candidates for conversion to a constant.

- [ ] src/Illuminate/Encryption/Encrypter.php:    private static $supportedCiphers = [

## Statics to check

- [ ] src/Illuminate/Collections/Traits/EnumeratesValues.php:    protected static $proxies = [
- [ ] src/Illuminate/Console/View/Components/Line.php:    protected static $styles = [
- [ ] src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php:    protected static $guardableColumns = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php:    protected static $unguarded = false;
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    protected static $attributeMutatorCache = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    protected static $castTypeCache = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    protected static $getAttributeMutatorCache = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    protected static $mutatorCache = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    protected static $primitiveCastTypes = [
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    protected static $setAttributeMutatorCache = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    public static $encrypter;
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:    public static $snakeAttributes = true;
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php:    protected static $relationResolvers = [];
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php:    public static $manyMethods = [
- [ ] src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php:    protected static $ignoreTimestampsOn = [];
- [ ] src/Illuminate/Database/Eloquent/Factories/Factory.php:    protected static $factoryNameResolver;
- [ ] src/Illuminate/Database/Eloquent/Factories/Factory.php:    protected static $modelNameResolver;
- [ ] src/Illuminate/Database/Eloquent/Factories/Factory.php:    public static $namespace = 'Database\\Factories\\';
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $booted = [];
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $discardedAttributeViolationCallback;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $dispatcher;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $globalScopes = [];
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $ignoreOnTouch = [];
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $isBroadcasting = true;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $lazyLoadingViolationCallback;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $missingAttributeViolationCallback;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $modelsShouldPreventAccessingMissingAttributes = false;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $modelsShouldPreventLazyLoading = false;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $modelsShouldPreventSilentlyDiscardingAttributes = false;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $resolver;
- [ ] src/Illuminate/Database/Eloquent/Model.php:    protected static $traitInitializers = [];
- [ ] src/Illuminate/Database/Eloquent/Relations/Relation.php:    protected static $constraints = true;
- [ ] src/Illuminate/Database/Eloquent/Relations/Relation.php:    protected static $requireMorphMap = false;
- [ ] src/Illuminate/Database/Eloquent/Relations/Relation.php:    protected static $selfJoinCount = 0;
- [ ] src/Illuminate/Database/Eloquent/Relations/Relation.php:    public static $morphMap = [];
- [ ] src/Illuminate/Database/Migrations/Migrator.php:    protected static $requiredPathCache = [];
- [ ] src/Illuminate/Database/Schema/Builder.php:    public static $defaultMorphKeyType = 'int';
- [ ] src/Illuminate/Database/Schema/Builder.php:    public static $defaultStringLength = 255;
- [ ] src/Illuminate/Database/Seeder.php:    protected static $called = [];
- [ ] src/Illuminate/Encryption/Encrypter.php:    private static $supportedCiphers = [
- [ ] src/Illuminate/Foundation/AliasLoader.php:    protected static $facadeNamespace = 'Facades\\';
- [ ] src/Illuminate/Foundation/AliasLoader.php:    protected static $instance;
- [ ] src/Illuminate/Foundation/Bootstrap/RegisterProviders.php:    protected static $bootstrapProviderPath;
- [ ] src/Illuminate/Foundation/Bootstrap/RegisterProviders.php:    protected static $merge = [];
- [ ] src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php:    protected static $adjustableTraces = [
- [ ] src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php:    protected static $dumpSourceResolver;
- [ ] src/Illuminate/Foundation/Console/ChannelListCommand.php:    protected static $terminalWidthResolver;
- [ ] src/Illuminate/Foundation/Console/EventListCommand.php:    protected static $eventsResolver;
- [ ] src/Illuminate/Foundation/Console/RouteListCommand.php:    protected static $terminalWidthResolver;
- [ ] src/Illuminate/Foundation/Console/ServeCommand.php:    public static $passthroughVariables = [
- [ ] src/Illuminate/Foundation/Events/DiscoverEvents.php:    public static $guessClassNamesUsingCallback;
- [ ] src/Illuminate/Foundation/Mix.php:        static $manifests = [];
- [ ] src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php:    private static $connectionFailedOnceWithDefaultsSkip = false;
- [ ] src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php:    public static $latestResponse;
- [ ] src/Illuminate/Foundation/Testing/DatabaseTruncation.php:    protected static array $allTables;
- [ ] src/Illuminate/Foundation/Testing/RefreshDatabaseState.php:    public static $inMemoryConnections = [];
- [ ] src/Illuminate/Foundation/Testing/RefreshDatabaseState.php:    public static $lazilyRefreshed = false;
- [ ] src/Illuminate/Foundation/Testing/RefreshDatabaseState.php:    public static $migrated = false;
- [ ] src/Illuminate/Http/Testing/MimeType.php:    private static $mime;
- [ ] src/Illuminate/Macroable/Traits/Macroable.php:    protected static $macros = [];
- [ ] src/Illuminate/Routing/Middleware/ValidateSignature.php:    protected static $neverValidate = [];
- [ ] src/Illuminate/Routing/ResourceRegistrar.php:    protected static $parameterMap = [];
- [ ] src/Illuminate/Routing/ResourceRegistrar.php:    protected static $singularParameters = true;
- [ ] src/Illuminate/Routing/ResourceRegistrar.php:    protected static $verbs = [
- [ ] src/Illuminate/Routing/Route.php:    public static $validators;
- [ ] src/Illuminate/Routing/Router.php:    public static $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
- [ ] src/Illuminate/Session/Middleware/AuthenticateSession.php:    protected static $redirectToCallback;
- [ ] src/Illuminate/Support/ConfigurationUrlParser.php:    protected static $driverAliases = [
- [ ] src/Illuminate/Support/DateFactory.php:    protected static $callable;
- [ ] src/Illuminate/Support/DateFactory.php:    protected static $dateClass;
- [ ] src/Illuminate/Support/DateFactory.php:    protected static $factory;
- [ ] src/Illuminate/Support/Env.php:    protected static $putenv = true;
- [ ] src/Illuminate/Support/Env.php:    protected static $repository;
- [ ] src/Illuminate/Support/Facades/Facade.php:    protected static $app;
- [ ] src/Illuminate/Support/Facades/Facade.php:    protected static $cached = true;
- [ ] src/Illuminate/Support/Facades/Facade.php:    protected static $resolvedInstance;
- [ ] src/Illuminate/Support/Facades/Pipeline.php:    protected static $cached = false;
- [ ] src/Illuminate/Support/Facades/Schema.php:    protected static $cached = false;
- [ ] src/Illuminate/Support/Lottery.php:    protected static $resultFactory;
- [ ] src/Illuminate/Support/Number.php:    protected static $locale = 'en';
- [ ] src/Illuminate/Support/Once.php:    protected static bool $enabled = true;
- [ ] src/Illuminate/Support/Pluralizer.php:    protected static $inflector;
- [ ] src/Illuminate/Support/Pluralizer.php:    protected static $language = 'english';
- [ ] src/Illuminate/Support/Pluralizer.php:    public static $uncountable = [
- [ ] src/Illuminate/Support/ServiceProvider.php:    protected static $publishableMigrationPaths = [];
- [ ] src/Illuminate/Support/ServiceProvider.php:    public static $publishGroups = [];
- [ ] src/Illuminate/Support/ServiceProvider.php:    public static $publishes = [];
- [ ] src/Illuminate/Support/Traits/CapsuleManagerTrait.php:    protected static $instance;
- [ ] src/Illuminate/Testing/Concerns/RunsInParallel.php:    protected static $applicationResolver;
- [ ] src/Illuminate/Testing/Concerns/RunsInParallel.php:    protected static $runnerResolver;
- [ ] src/Illuminate/Testing/Concerns/TestDatabases.php:    protected static $schemaIsUpToDate = false;
- [ ] src/Illuminate/Validation/Rules/File.php:    public static $defaultCallback;
- [ ] src/Illuminate/Validation/Rules/Password.php:    public static $defaultCallback;
- [ ] src/Illuminate/View/Compilers/Concerns/CompilesComponents.php:    protected static $componentHashStack = [];
- [ ] src/Illuminate/View/Component.php:    protected static $bladeViewCache = [];
- [ ] src/Illuminate/View/Component.php:    protected static $componentsResolver;
- [ ] src/Illuminate/View/Component.php:    protected static $constructorParametersCache = [];
- [ ] src/Illuminate/View/Component.php:    protected static $factory;
- [ ] src/Illuminate/View/Component.php:    protected static $methodCache = [];
- [ ] src/Illuminate/View/Component.php:    protected static $propertyCache = [];
- [ ] src/Illuminate/View/Concerns/ManagesLayouts.php:    protected static $parentPlaceholder = [];
- [ ] src/Illuminate/View/Concerns/ManagesLayouts.php:    protected static $parentPlaceholderSalt;
- [ ] src/Illuminate/View/DynamicComponent.php:    protected static $compiler;
- [ ] src/Illuminate/View/DynamicComponent.php:    protected static $componentClasses = [];
- [x] src/Illuminate/Auth/AuthenticationException.php:    protected static $redirectToCallback;
- [x] src/Illuminate/Auth/Middleware/Authenticate.php:    protected static $redirectToCallback;
- [x] src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php:    protected static $redirectToCallback;
- [x] src/Illuminate/Auth/Notifications/ResetPassword.php:    public static $createUrlCallback;
- [x] src/Illuminate/Auth/Notifications/ResetPassword.php:    public static $toMailCallback;
- [x] src/Illuminate/Auth/Notifications/VerifyEmail.php:    public static $createUrlCallback;
- [x] src/Illuminate/Auth/Notifications/VerifyEmail.php:    public static $toMailCallback;
- [x] src/Illuminate/Console/Application.php:    protected static $bootstrappers = [];
- [x] src/Illuminate/Console/Scheduling/ScheduleListCommand.php:    protected static $terminalWidthResolver;
- [x] src/Illuminate/Console/Signals.php:    protected static $availabilityResolver;
- [x] src/Illuminate/Container/Container.php:    protected static $instance;
- [x] src/Illuminate/Cookie/Middleware/EncryptCookies.php:    protected static $neverEncrypt = [];
- [x] src/Illuminate/Cookie/Middleware/EncryptCookies.php:    protected static $serialize = false;
- [x] src/Illuminate/Database/Connection.php:    protected static $resolvers = [];
- [x] src/Illuminate/Database/DatabaseServiceProvider.php:    protected static $fakers = [];
- [x] src/Illuminate/Database/Eloquent/Builder.php:    protected static $macros = [];
- [x] src/Illuminate/Database/Eloquent/Casts/Json.php:    protected static $decoder;
- [x] src/Illuminate/Database/Eloquent/Casts/Json.php:    protected static $encoder;
- [x] src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:    protected static $app;
- [x] src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:    public static $reservedMemory;
- [x] src/Illuminate/Foundation/Console/AboutCommand.php:    protected static $customDataResolvers = [];
- [x] src/Illuminate/Foundation/Console/AboutCommand.php:    protected static $data = [];
- [x] src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php:    protected static $skipCallbacks = [];
- [x] src/Illuminate/Foundation/Http/Middleware/TrimStrings.php:    protected static $neverTrim = [];
- [x] src/Illuminate/Foundation/Http/Middleware/TrimStrings.php:    protected static $skipCallbacks = [];
- [x] src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php:    protected static $neverVerify = [];
- [x] src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php:    protected static $alwaysLoadRoutesUsing;
- [x] src/Illuminate/Foundation/Vite.php:    protected static $manifests = [];
- [x] src/Illuminate/Http/Middleware/TrustProxies.php:    protected static $alwaysTrust;
- [x] src/Illuminate/Http/Resources/Json/JsonResource.php:    public static $wrap = 'data';
- [x] src/Illuminate/Mail/Mailable.php:    public static $viewDataCallback;
- [x] src/Illuminate/Pagination/AbstractCursorPaginator.php:    protected static $currentCursorResolver;
- [x] src/Illuminate/Pagination/AbstractPaginator.php:    protected static $currentPageResolver;
- [x] src/Illuminate/Pagination/AbstractPaginator.php:    protected static $currentPathResolver;
- [x] src/Illuminate/Pagination/AbstractPaginator.php:    protected static $queryStringResolver;
- [x] src/Illuminate/Pagination/AbstractPaginator.php:    protected static $viewFactoryResolver;
- [x] src/Illuminate/Pagination/AbstractPaginator.php:    public static $defaultSimpleView = 'pagination::simple-tailwind';
- [x] src/Illuminate/Pagination/AbstractPaginator.php:    public static $defaultView = 'pagination::tailwind';
- [x] src/Illuminate/Queue/Queue.php:    protected static $createPayloadCallbacks = [];
- [x] src/Illuminate/Queue/Worker.php:    protected static $popCallbacks = [];
- [x] src/Illuminate/Routing/Middleware/ThrottleRequests.php:    protected static $shouldHashKeys = true;
- [x] src/Illuminate/Support/Sleep.php:    protected static $fake = false;
- [x] src/Illuminate/Support/Sleep.php:    protected static $sequence = [];
- [x] src/Illuminate/Support/Sleep.php:    public static $fakeSleepCallbacks = [];
- [x] src/Illuminate/Support/Str.php:    protected static $camelCache = [];
- [x] src/Illuminate/Support/Str.php:    protected static $randomStringFactory;
- [x] src/Illuminate/Support/Str.php:    protected static $snakeCache = [];
- [x] src/Illuminate/Support/Str.php:    protected static $studlyCache = [];
- [x] src/Illuminate/Support/Str.php:    protected static $ulidFactory;
- [x] src/Illuminate/Support/Str.php:    protected static $uuidFactory;
