### PR TITLE
Use the table name assigned in config/session.php

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('sessions', function (Blueprint $table) {
+        Schema::create(config('session.table'), function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
@@ -26,6 +26,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('sessions');
+        Schema::dropIfExists(config('session.table'));
     }
 };


### PR DESCRIPTION
This PR fixes the issue discussed in https://github.com/laravel/framework/issues/28531.

To meet the user's expectations as well as provide more flexibility while operating session migration creation, properly apply the session table name assigned in the `config/session.php` rather than a hardcoded name 'sessions'.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
