### PR TITLE
[10.x] class-name string argument for global scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -26,9 +26,11 @@ trait HasGlobalScopes
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
         } elseif ($scope instanceof Scope) {
             return static::$globalScopes[static::class][get_class($scope)] = $scope;
+        } elseif (is_string($scope) && class_exists($scope) && is_subclass_of($scope, Scope::class)) {
+            return static::$globalScopes[static::class][$scope] = new $scope;
         }
 
-        throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
+        throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope or be a class name of a class extending '.Scope::class);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -43,6 +43,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
+    public function testClassNameGlobalScopeIsApplied()
+    {
+        $model = new EloquentClassNameGlobalScopesTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testClosureGlobalScopeIsApplied()
     {
         $model = new EloquentClosureGlobalScopesTestModel;
@@ -185,6 +193,18 @@ class EloquentGlobalScopesTestModel extends Model
     public static function boot()
     {
         static::addGlobalScope(new ActiveScope);
+
+        parent::boot();
+    }
+}
+
+class EloquentClassNameGlobalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScope(ActiveScope::class);
 
         parent::boot();
     }


### PR DESCRIPTION
This pull request adds the ability to use class names instead of class instances when adding global scopes.

This change ensures consistency with other global scope methods like `hasGlobalScope`, `getGlobalScope`, and `Builder::withoutGlobalScope`. Additionally, it enhances flexibility in situations where concrete instances can't be used, such as with attributes.

Example:
```php
  /**
   * The "booted" method of the model.
   */
  protected static function booted(): void
  {
      static::addGlobalScope(AncientScope::class);
  }
```