### PR TITLE
[11.x] Remove Database Deprecations

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -5,21 +5,6 @@ namespace Illuminate\Database\Query\Processors;
 class MySqlProcessor extends Processor
 {
     /**
-     * Process the results of a column listing query.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        return array_map(function ($result) {
-            return ((object) $result)->column_name;
-        }, $results);
-    }
-
-    /**
      * Process the results of a columns query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -31,21 +31,6 @@ class PostgresProcessor extends Processor
     }
 
     /**
-     * Process the results of a column listing query.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        return array_map(function ($result) {
-            return ((object) $result)->column_name;
-        }, $results);
-    }
-
-    /**
      * Process the results of a types query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -120,17 +120,4 @@ class Processor
     {
         return $results;
     }
-
-    /**
-     * Process the results of a column listing query.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        return $results;
-    }
 }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -5,21 +5,6 @@ namespace Illuminate\Database\Query\Processors;
 class SQLiteProcessor extends Processor
 {
     /**
-     * Process the results of a column listing query.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        return array_map(function ($result) {
-            return ((object) $result)->name;
-        }, $results);
-    }
-
-    /**
      * Process the results of a columns query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -56,21 +56,6 @@ class SqlServerProcessor extends Processor
     }
 
     /**
-     * Process the results of a column listing query.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        return array_map(function ($result) {
-            return ((object) $result)->name;
-        }, $results);
-    }
-
-    /**
      * Process the results of a columns query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -207,20 +207,6 @@ class Builder
     }
 
     /**
-     * Get all of the table names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     *
-     * @throws \LogicException
-     */
-    public function getAllTables()
-    {
-        throw new LogicException('This database driver does not support getting all tables.');
-    }
-
-    /**
      * Determine if the given table has a given column.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -67,18 +67,6 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile the query to determine the list of tables.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileTableExists()
-    {
-        return "select * from information_schema.tables where table_schema = ? and table_name = ? and table_type = 'BASE TABLE'";
-    }
-
-    /**
      * Compile the query to determine the tables.
      *
      * @param  string  $database
@@ -109,42 +97,6 @@ class MySqlGrammar extends Grammar
             .'order by table_name',
             $this->quoteString($database)
         );
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all table names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllTables()
-    {
-        return 'SHOW FULL TABLES WHERE table_type = \'BASE TABLE\'';
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all view names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllViews()
-    {
-        return 'SHOW FULL TABLES WHERE table_type = \'VIEW\'';
-    }
-
-    /**
-     * Compile the query to determine the list of columns.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileColumnListing()
-    {
-        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -69,18 +69,6 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Compile the query to determine if a table exists.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileTableExists()
-    {
-        return "select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'";
-    }
-
-    /**
      * Compile the query to determine the tables.
      *
      * @return string
@@ -119,44 +107,6 @@ class PostgresGrammar extends Grammar
             ."where ((t.typrelid = 0 and (ce.relkind = 'c' or ce.relkind is null)) or c.relkind = 'c') "
             ."and not exists (select 1 from pg_depend d where d.objid in (t.oid, t.typelem) and d.deptype = 'e') "
             ."and n.nspname not in ('pg_catalog', 'information_schema')";
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all table names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  string|array  $searchPath
-     * @return string
-     */
-    public function compileGetAllTables($searchPath)
-    {
-        return "select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('".implode("','", (array) $searchPath)."')";
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all view names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  string|array  $searchPath
-     * @return string
-     */
-    public function compileGetAllViews($searchPath)
-    {
-        return "select viewname, concat('\"', schemaname, '\".\"', viewname, '\"') as qualifiedname from pg_catalog.pg_views where schemaname in ('".implode("','", (array) $searchPath)."')";
-    }
-
-    /**
-     * Compile the query to determine the list of columns.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileColumnListing()
-    {
-        return 'select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?';
     }
 
     /**
@@ -508,18 +458,6 @@ class PostgresGrammar extends Grammar
     public function compileDropAllDomains($domains)
     {
         return 'drop domain '.implode(',', $this->escapeNames($domains)).' cascade';
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all type names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllTypes()
-    {
-        return 'select distinct pg_type.typname from pg_type inner join pg_enum on pg_enum.enumtypid = pg_type.oid';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -29,18 +29,6 @@ class SQLiteGrammar extends Grammar
     protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
 
     /**
-     * Compile the query to determine if a table exists.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileTableExists()
-    {
-        return "select * from sqlite_master where type = 'table' and name = ?";
-    }
-
-    /**
      * Compile the query to determine the SQL text that describes the given object.
      *
      * @param  string  $name
@@ -90,43 +78,6 @@ class SQLiteGrammar extends Grammar
     public function compileViews()
     {
         return "select name, sql as definition from sqlite_master where type = 'view' order by name";
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all table names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllTables()
-    {
-        return 'select type, name from sqlite_master where type = \'table\' and name not like \'sqlite_%\'';
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all view names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllViews()
-    {
-        return 'select type, name from sqlite_master where type = \'view\'';
-    }
-
-    /**
-     * Compile the query to determine the list of columns.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  string  $table
-     * @return string
-     */
-    public function compileColumnListing($table)
-    {
-        return 'pragma table_info('.$this->wrap(str_replace('.', '__', $table)).')';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -67,18 +67,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile the query to determine if a table exists.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileTableExists()
-    {
-        return "select * from sys.sysobjects where id = object_id(?) and xtype in ('U', 'V')";
-    }
-
-    /**
      * Compile the query to determine the tables.
      *
      * @return string
@@ -103,43 +91,6 @@ class SqlServerGrammar extends Grammar
         return 'select name, SCHEMA_NAME(v.schema_id) as [schema], definition from sys.views as v '
             .'inner join sys.sql_modules as m on v.object_id = m.object_id '
             .'order by name';
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all table names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllTables()
-    {
-        return "select name, type from sys.tables where type = 'U'";
-    }
-
-    /**
-     * Compile the SQL needed to retrieve all view names.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return string
-     */
-    public function compileGetAllViews()
-    {
-        return "select name, type from sys.objects where type = 'V'";
-    }
-
-    /**
-     * Compile the query to determine the list of columns.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @param  string  $table
-     * @return string
-     */
-    public function compileColumnListing($table)
-    {
-        return "select name from sys.columns where object_id = object_id('$table')";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -59,34 +59,6 @@ class MySqlBuilder extends Builder
     }
 
     /**
-     * Get all of the table names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables()
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews()
-        );
-    }
-
-    /**
      * Get the columns for a given table.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -72,42 +72,6 @@ class PostgresBuilder extends Builder
     }
 
     /**
-     * Get all of the table names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables(
-                $this->parseSearchPath(
-                    $this->connection->getConfig('search_path') ?: $this->connection->getConfig('schema')
-                )
-            )
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews(
-                $this->parseSearchPath(
-                    $this->connection->getConfig('search_path') ?: $this->connection->getConfig('schema')
-                )
-            )
-        );
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void
@@ -163,20 +127,6 @@ class PostgresBuilder extends Builder
 
         $this->connection->statement(
             $this->grammar->compileDropAllViews($views)
-        );
-    }
-
-    /**
-     * Get all of the type names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllTypes()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTypes()
         );
     }
 

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -68,34 +68,6 @@ class SQLiteBuilder extends Builder
     }
 
     /**
-     * Get all of the table names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables()
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews()
-        );
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -51,32 +51,4 @@ class SqlServerBuilder extends Builder
     {
         $this->connection->statement($this->grammar->compileDropAllViews());
     }
-
-    /**
-     * Drop all tables from the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables()
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews()
-        );
-    }
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1214,13 +1214,6 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('drop type "alpha","beta","gamma" cascade', $statement);
     }
 
-    public function testCompileTableExists()
-    {
-        $statement = $this->getGrammar()->compileTableExists();
-
-        $this->assertSame('select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = \'BASE TABLE\'', $statement);
-    }
-
     public function testCompileColumns()
     {
         $statement = $this->getGrammar()->compileColumns('public', 'table');

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
@@ -45,18 +45,12 @@ class DatabaseMySqlSchemaBuilderAlterTableWithEnumTest extends MySqlTestCase
         $this->assertSame('int', Schema::getColumnType('users', 'age'));
     }
 
-    public function testGetAllTablesAndColumnListing()
+    public function testGetTablesAndColumnListing()
     {
-        $tables = Schema::getAllTables();
+        $tables = Schema::getTables();
 
         $this->assertCount(2, $tables);
-        $tableProperties = array_values((array) $tables[0]);
-        $this->assertEquals(['migrations', 'BASE TABLE'], $tableProperties);
-
-        $this->assertInstanceOf(stdClass::class, $tables[1]);
-
-        $tableProperties = array_values((array) $tables[1]);
-        $this->assertEquals(['users', 'BASE TABLE'], $tableProperties);
+        $this->assertEquals(['migrations', 'users'], array_column($tables, 'name'));
 
         $columns = Schema::getColumnListing('users');
 
@@ -68,7 +62,7 @@ class DatabaseMySqlSchemaBuilderAlterTableWithEnumTest extends MySqlTestCase
             $table->integer('id');
             $table->string('title');
         });
-        $tables = Schema::getAllTables();
+        $tables = Schema::getTables();
         $this->assertCount(3, $tables);
         Schema::drop('posts');
     }

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
-use stdClass;
 
 #[RequiresOperatingSystem('Linux|Darwin')]
 #[RequiresPhpExtension('pdo_mysql')]

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Database\SqlServer;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use stdClass;
 
 class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
 {

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -25,20 +25,19 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
         DB::statement('drop view if exists users_view');
     }
 
-    public function testGetAllTables()
+    public function testGetTables()
     {
         DB::statement('create view users_view AS select name, age from users');
 
-        $rows = Schema::getAllTables();
+        $rows = Schema::getTables();
 
-        $this->assertContainsOnlyInstancesOf(stdClass::class, $rows);
         $this->assertGreaterThanOrEqual(2, count($rows));
         $this->assertTrue(
-            collect($rows)->contains(fn ($row) => $row->name === 'migrations' && $row->type === 'U '),
+            collect($rows)->contains('name', 'migrations'),
             'Failed asserting that table "migrations" was returned.'
         );
         $this->assertTrue(
-            collect($rows)->contains(fn ($row) => $row->name === 'users' && $row->type === 'U '),
+            collect($rows)->contains('name', 'users'),
             'Failed asserting that table "users" was returned.'
         );
         $this->assertFalse(
@@ -52,20 +51,18 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
         $this->assertSame(['id', 'name', 'age', 'color'], Schema::getColumnListing('users'));
     }
 
-    public function testGetAllViews()
+    public function testGetViews()
     {
         DB::statement('create view users_view AS select name, age from users');
 
-        $rows = Schema::getAllViews();
+        $rows = Schema::getViews();
 
-        $this->assertContainsOnlyInstancesOf(stdClass::class, $rows);
         $this->assertCount(1, $rows);
-        $this->assertSame('users_view', $rows[0]->name);
-        $this->assertSame('V ', $rows[0]->type);
+        $this->assertSame('users_view', $rows[0]['name']);
     }
 
-    public function testGetAllViewsWhenNoneExist()
+    public function testGetViewsWhenNoneExist()
     {
-        $this->assertSame([], Schema::getAllViews());
+        $this->assertSame([], Schema::getViews());
     }
 }

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use stdClass;
 
 class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -40,18 +40,12 @@ class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
         Schema::drop('users');
     }
 
-    public function testGetAllTablesAndColumnListing()
+    public function testGetTablesAndColumnListing()
     {
-        $tables = Schema::getAllTables();
+        $tables = Schema::getTables();
 
         $this->assertCount(2, $tables);
-        $tableProperties = array_values((array) $tables[0]);
-        $this->assertEquals(['table', 'migrations'], $tableProperties);
-
-        $this->assertInstanceOf(stdClass::class, $tables[1]);
-
-        $tableProperties = array_values((array) $tables[1]);
-        $this->assertEquals(['table', 'users'], $tableProperties);
+        $this->assertEquals(['migrations', 'users'], array_column($tables, 'name'));
 
         $columns = Schema::getColumnListing('users');
 
@@ -63,12 +57,12 @@ class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
             $table->integer('id');
             $table->string('title');
         });
-        $tables = Schema::getAllTables();
+        $tables = Schema::getTables();
         $this->assertCount(3, $tables);
         Schema::drop('posts');
     }
 
-    public function testGetAllViews()
+    public function testGetViews()
     {
         DB::connection('conn1')->statement(<<<'SQL'
 CREATE VIEW users_view
@@ -76,17 +70,15 @@ AS
 SELECT name,age from users;
 SQL);
 
-        $tableView = Schema::getAllViews();
+        $tableView = Schema::getViews();
 
         $this->assertCount(1, $tableView);
-        $this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
-        $this->assertEquals('users_view', $obj->name);
-        $this->assertEquals('view', $obj->type);
+        $this->assertEquals('users_view', $tableView[0]['name']);
 
         DB::connection('conn1')->statement(<<<'SQL'
 DROP VIEW IF EXISTS users_view;
 SQL);
 
-        $this->assertEmpty(Schema::getAllViews());
+        $this->assertEmpty(Schema::getViews());
     }
 }


### PR DESCRIPTION
Removes Schema, Builder, Grammar, and Processor deprecated methods on #49020, #48357, and #49303

* `\Illuminate\Database\Schema\Builder::getAllTables()`
* `\Illuminate\Database\Schema\MySqlBuilder::getAllTables()`
* `\Illuminate\Database\Schema\MySqlBuilder::getAllViews()`
* `\Illuminate\Database\Schema\PostgresBuilder::getAllTables()`
* `\Illuminate\Database\Schema\PostgresBuilder::getAllViews()`
* `\Illuminate\Database\Schema\PostgresBuilder::getAllTypes()`
* `\Illuminate\Database\Schema\SQLiteBuilder::getAllTables()`
* `\Illuminate\Database\Schema\SQLiteBuilder::getAllViews()`
* `\Illuminate\Database\Schema\SqlServerBuilder::getAllTables()`
* `\Illuminate\Database\Schema\SqlServerBuilder::getAllViews()`
* `\Illuminate\Database\Schema\Grammars\MySqlGrammar::compileTableExists()`
* `\Illuminate\Database\Schema\Grammars\MySqlGrammar::compileGetAllTables()`
* `\Illuminate\Database\Schema\Grammars\MySqlGrammar::compileGetAllViews()`
* `\Illuminate\Database\Schema\Grammars\MySqlGrammar::compileColumnListing`
* `\Illuminate\Database\Schema\Grammars\PostgresGrammar::compileTableExists()`
* `\Illuminate\Database\Schema\Grammars\PostgresGrammar::compileGetAllTables()`
* `\Illuminate\Database\Schema\Grammars\PostgresGrammar::compileGetAllViews()`
* `\Illuminate\Database\Schema\Grammars\PostgresGrammar::compileGetAllTypes()`
* `\Illuminate\Database\Schema\Grammars\PostgresGrammar::compileColumnListing`
* `\Illuminate\Database\Schema\Grammars\SQLiteGrammar::compileTableExists()`
* `\Illuminate\Database\Schema\Grammars\SQLiteGrammar::compileGetAllTables()`
* `\Illuminate\Database\Schema\Grammars\SQLiteGrammar::compileGetAllViews()`
* `\Illuminate\Database\Schema\Grammars\SQLiteGrammar::compileColumnListing`
* `\Illuminate\Database\Schema\Grammars\SqlServerGrammar::compileTableExists()`
* `\Illuminate\Database\Schema\Grammars\SqlServerGrammar::compileGetAllTables()`
* `\Illuminate\Database\Schema\Grammars\SqlServerGrammar::compileGetAllViews()`
* `\Illuminate\Database\Schema\Grammars\SqlServerGrammar::compileColumnListing`
* `\Illuminate\Database\Query\Processors\Processor::processColumnListing`
* `\Illuminate\Database\Query\Processors\MySqlProcessor::processColumnListing`
* `\Illuminate\Database\Query\Processors\PostgresProcessor::processColumnListing`
* `\Illuminate\Database\Query\Processors\SQLiteProcessor::processColumnListing`
* `\Illuminate\Database\Query\Processors\SqlServerProcessor::processColumnListing`
