### PR TITLE
[11.x] Reverts 49764

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",
         "monolog/monolog": "^3.0",
-        "nesbot/carbon": "^3.0.0-beta.3@beta",
+        "nesbot/carbon": "^2.67",
         "nunomaduro/termwind": "^2.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
+use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
 use Ramsey\Uuid\Uuid;
@@ -11,6 +12,15 @@ use Symfony\Component\Uid\Ulid;
 class Carbon extends BaseCarbon
 {
     use Conditionable, Dumpable;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setTestNow($testNow = null)
+    {
+        BaseCarbon::setTestNow($testNow);
+        BaseCarbonImmutable::setTestNow($testNow);
+    }
 
     /**
      * Create a Carbon instance from a given ordered UUID or ULID.

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -403,7 +403,7 @@ class Sleep
         }
 
         foreach (static::$sequence as $duration) {
-            PHPUnit::assertSame(0, (int) $duration->totalMicroseconds, vsprintf('Unexpected sleep duration of [%s] found.', [
+            PHPUnit::assertSame(0, $duration->totalMicroseconds, vsprintf('Unexpected sleep duration of [%s] found.', [
                 $duration->cascade()->forHumans([
                     'options' => 0,
                     'minimumUnit' => 'microsecond',

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,7 +23,7 @@
         "illuminate/conditionable": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
-        "nesbot/carbon": "^3.0.0-beta.3@beta",
+        "nesbot/carbon": "^2.67",
         "voku/portable-ascii": "^2.0"
     },
     "conflict": {

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -56,7 +56,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1.5)->minutes();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 90_000_000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 90_000_000);
     }
 
     public function testItCanSpecifyMinute()
@@ -65,7 +65,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->minute();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 60_000_000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 60_000_000);
     }
 
     public function testItCanSpecifySeconds()
@@ -74,7 +74,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1.5)->seconds();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_500_000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1_500_000);
     }
 
     public function testItCanSpecifySecond()
@@ -83,7 +83,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->second();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_000_000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1_000_000);
     }
 
     public function testItCanSpecifyMilliseconds()
@@ -92,7 +92,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1.5)->milliseconds();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_500.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1_500);
     }
 
     public function testItCanSpecifyMillisecond()
@@ -101,7 +101,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->millisecond();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1_000);
     }
 
     public function testItCanSpecifyMicroseconds()
@@ -111,7 +111,7 @@ class SleepTest extends TestCase
         $sleep = Sleep::for(1.5)->microseconds();
 
         // rounded as microseconds is the smallest unit supported...
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1);
     }
 
     public function testItCanSpecifyMicrosecond()
@@ -120,7 +120,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(1)->microsecond();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1);
     }
 
     public function testItCanChainDurations()
@@ -130,7 +130,7 @@ class SleepTest extends TestCase
         $sleep = Sleep::for(1)->second()
                       ->and(500)->microseconds();
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1000500.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1000500);
     }
 
     public function testItCanUseDateInterval()
@@ -139,7 +139,7 @@ class SleepTest extends TestCase
 
         $sleep = Sleep::for(CarbonInterval::seconds(1)->addMilliseconds(5));
 
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1_005_000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1_005_000);
     }
 
     public function testItThrowsForUnknownTimeUnit()
@@ -425,17 +425,17 @@ class SleepTest extends TestCase
 
         Sleep::for(5)->seconds();
 
-        Sleep::assertSlept(fn (CarbonInterval $duration) => (float) $duration->totalSeconds === 5.0);
+        Sleep::assertSlept(fn (CarbonInterval $duration) => $duration->totalSeconds === 5);
 
         try {
-            Sleep::assertSlept(fn (CarbonInterval $duration) => (float) $duration->totalSeconds === 5.0, 2);
+            Sleep::assertSlept(fn (CarbonInterval $duration) => $duration->totalSeconds === 5, 2);
             $this->fail();
         } catch (AssertionFailedError $e) {
             $this->assertSame("The expected sleep was found [1] times instead of [2].\nFailed asserting that 1 is identical to 2.", $e->getMessage());
         }
 
         try {
-            Sleep::assertSlept(fn (CarbonInterval $duration) => (float) $duration->totalSeconds === 6.0);
+            Sleep::assertSlept(fn (CarbonInterval $duration) => $duration->totalSeconds === 6);
             $this->fail();
         } catch (AssertionFailedError $e) {
             $this->assertSame("The expected sleep was found [0] times instead of [1].\nFailed asserting that 0 is identical to 1.", $e->getMessage());
@@ -462,15 +462,15 @@ class SleepTest extends TestCase
 
         // A static macro can be referenced
         $sleep = Sleep::forSomeConfiguredAmountOfTime();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 3000000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 3000000);
 
         // A macro can specify a new duration
         $sleep = $sleep->useSomeOtherAmountOfTime();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1234000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1234000);
 
         // A macro can supplement an existing duration
         $sleep = $sleep->andSomeMoreGranularControl();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1234567.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1234567);
     }
 
     public function testItCanReplacePreviouslyDefinedDurations()
@@ -482,13 +482,13 @@ class SleepTest extends TestCase
         });
 
         $sleep = Sleep::for(1)->second();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 1000000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 1000000);
 
         $sleep->setDuration(2)->second();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 2000000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 2000000);
 
         $sleep->setDuration(500)->milliseconds();
-        $this->assertSame((float) $sleep->duration->totalMicroseconds, 500000.0);
+        $this->assertSame($sleep->duration->totalMicroseconds, 500000);
     }
 
     public function testItCanSleepConditionallyWhen()
@@ -549,8 +549,8 @@ class SleepTest extends TestCase
             Sleep::for(2)->millisecond(),
         ]);
 
-        $this->assertSame(3.0, (float) $countA);
-        $this->assertSame(3.0, (float) $countB);
+        $this->assertSame(3, $countA);
+        $this->assertSame(3, $countB);
     }
 
     public function testItDoesntRunCallbacksWhenNotFaking()


### PR DESCRIPTION
This pull request reverts https://github.com/laravel/framework/pull/49764, as we are planning to keep using Carbon 2 for Laravel 11 and use Carbon 3 (once is stable) for Laravel 12.

At the moment, dozens / hundreds of packages don't support Carbon 3 - so this could potentially become the biggest pain point while upgrading applications to Laravel 11.