### PR TITLE
[10.x] Remove timestamp overrides from using pivotParent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -51,9 +51,6 @@ trait AsPivot
             ->forceFill($attributes)
             ->syncOriginal();
 
-        // We store off the parent instance so we will access the timestamp column names
-        // for the model, since the pivot model timestamps aren't easily configurable
-        // from the developer's point of view. We can use the parents to get these.
         $instance->pivotParent = $parent;
 
         $instance->exists = $exists;
@@ -223,30 +220,6 @@ trait AsPivot
     public function hasTimestampAttributes($attributes = null)
     {
         return array_key_exists($this->getCreatedAtColumn(), $attributes ?? $this->attributes);
-    }
-
-    /**
-     * Get the name of the "created at" column.
-     *
-     * @return string
-     */
-    public function getCreatedAtColumn()
-    {
-        return $this->pivotParent
-            ? $this->pivotParent->getCreatedAtColumn()
-            : parent::getCreatedAtColumn();
-    }
-
-    /**
-     * Get the name of the "updated at" column.
-     *
-     * @return string
-     */
-    public function getUpdatedAtColumn()
-    {
-        return $this->pivotParent
-            ? $this->pivotParent->getUpdatedAtColumn()
-            : parent::getUpdatedAtColumn();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -139,19 +139,6 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertSame('pivot', $pivot->getTable());
     }
 
-    public function testPivotModelWithParentReturnsParentsTimestampColumns()
-    {
-        $parent = m::mock(Model::class);
-        $parent->shouldReceive('getCreatedAtColumn')->andReturn('parent_created_at');
-        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('parent_updated_at');
-
-        $pivotWithParent = new Pivot;
-        $pivotWithParent->pivotParent = $parent;
-
-        $this->assertSame('parent_created_at', $pivotWithParent->getCreatedAtColumn());
-        $this->assertSame('parent_updated_at', $pivotWithParent->getUpdatedAtColumn());
-    }
-
     public function testPivotModelWithoutParentReturnsModelTimestampColumns()
     {
         $model = new DummyModel;


### PR DESCRIPTION
**Problem/Motivation**
We have explicitly added a `UPDATED_AT` constant override in our Pivot model but because of this code we are getting an exception thrown that the table doesn't have that `pivot.updated_at` column. This was traced back to this PRs change which looks at first glance fraught with error since it assumes some columns on a model that don't exist and belong to a totally different model.


The base Model class has default values that are fairly easy to change as we did but not adhered to as we found out.

**Proposed Change**
Remove the overridden methods that look at the `pivotParent` for column names at all. 

I'd also considered removing that `pivotParent` property all together but didn't want to break anyones code (Minimum viable change), though I'll add a "pivot parent" is a confusing concept to me as a pivot table has a different "parent" depending at which way you look at it... 