### PR TITLE
[10.x] Expose queue name and delay on job queue events

### DIFF
--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -35,20 +35,38 @@ class JobQueued
     public $payload;
 
     /**
+     * The queue name the job is queued on.
+     *
+     * @var string|null
+     */
+    public $queue;
+
+    /**
+     * The delay used to queue the job.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|null
+     */
+    public $delay;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
      * @param  string|int|null  $id
      * @param  \Closure|string|object  $job
      * @param  string|null  $payload
+     * @param  string|null  $queue
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @return void
      */
-    public function __construct($connectionName, $id, $job, $payload = null)
+    public function __construct($connectionName, $id, $job, $payload = null, $queue = null, $delay = null)
     {
         $this->connectionName = $connectionName;
         $this->id = $id;
         $this->job = $job;
         $this->payload = $payload;
+        $this->queue = $queue;
+        $this->delay = $delay;
     }
 
     /**

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -28,18 +28,36 @@ class JobQueueing
     public $payload;
 
     /**
+     * The queue name the job is queued on.
+     *
+     * @var string|null
+     */
+    public $queue;
+
+    /**
+     * The delay used to queue the job.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|null
+     */
+    public $delay;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
      * @param  \Closure|string|object  $job
      * @param  string|null  $payload
+     * @param  string|null  $queue
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @return void
      */
-    public function __construct($connectionName, $job, $payload = null)
+    public function __construct($connectionName, $job, $payload = null, $queue = null, $delay = null)
     {
         $this->connectionName = $connectionName;
         $this->job = $job;
         $this->payload = $payload;
+        $this->queue = $queue;
+        $this->delay = $delay;
     }
 
     /**


### PR DESCRIPTION
### Changes

Add the `queue` and `delay` property to the `JobQueueing` and `JobQueued` events.

### Why?

With the introduction of the `JobQueueing` (#49722) we can now profile what is happening in the application when a job is being queued (for example: getsentry/sentry-laravel#833), however we only know the queue connection and job name. 

It is also useful to know which queue and with what delay a job was queued since they are already available where the events are dispatched I "simply" added them to the event.