### PR TITLE
[11.x] Expose queue name and delay on job queue events

### DIFF
--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Queue\Events;
 
-use RuntimeException;
-
 class JobQueued
 {
     /**
@@ -12,6 +10,20 @@ class JobQueued
      * @var string
      */
     public $connectionName;
+
+    /**
+     * The queue name the job is queued on.
+     *
+     * @var string
+     */
+    public $queue;
+
+    /**
+     * The delay used to queue the job.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|null
+     */
+    public $delay;
 
     /**
      * The job ID.
@@ -30,7 +42,7 @@ class JobQueued
     /**
      * The job payload.
      *
-     * @var string|null
+     * @var string
      */
     public $payload;
 
@@ -38,14 +50,18 @@ class JobQueued
      * Create a new event instance.
      *
      * @param  string  $connectionName
+     * @param  string  $queue
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  string|int|null  $id
      * @param  \Closure|string|object  $job
-     * @param  string|null  $payload
+     * @param  string  $payload
      * @return void
      */
-    public function __construct($connectionName, $id, $job, $payload = null)
+    public function __construct($connectionName, $queue, $delay, $id, $job, $payload)
     {
         $this->connectionName = $connectionName;
+        $this->queue = $queue;
+        $this->delay = $delay;
         $this->id = $id;
         $this->job = $job;
         $this->payload = $payload;
@@ -58,10 +74,6 @@ class JobQueued
      */
     public function payload()
     {
-        if ($this->payload === null) {
-            throw new RuntimeException('The job payload was not provided when the event was dispatched.');
-        }
-
         return json_decode($this->payload, true, flags: JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -42,7 +42,7 @@ class JobQueued
     /**
      * The amount of time the job was delayed.
      *
-     * @var \DateTimeInterface|\DateInterval|int|null
+     * @var int|null
      */
     public $delay;
 
@@ -54,7 +54,7 @@ class JobQueued
      * @param  string|int|null  $id
      * @param  \Closure|string|object  $job
      * @param  string  $payload
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @param  int|null  $delay
      * @return void
      */
     public function __construct($connectionName, $queue, $id, $job, $payload, $delay)

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -12,18 +12,11 @@ class JobQueued
     public $connectionName;
 
     /**
-     * The queue name the job is queued on.
+     * The queue name.
      *
      * @var string
      */
     public $queue;
-
-    /**
-     * The delay used to queue the job.
-     *
-     * @var \DateTimeInterface|\DateInterval|int|null
-     */
-    public $delay;
 
     /**
      * The job ID.
@@ -47,24 +40,31 @@ class JobQueued
     public $payload;
 
     /**
+     * The amount of time the job was delayed.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|null
+     */
+    public $delay;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  string|int|null  $id
      * @param  \Closure|string|object  $job
      * @param  string  $payload
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @return void
      */
-    public function __construct($connectionName, $queue, $delay, $id, $job, $payload)
+    public function __construct($connectionName, $queue, $id, $job, $payload, $delay)
     {
         $this->connectionName = $connectionName;
         $this->queue = $queue;
-        $this->delay = $delay;
         $this->id = $id;
         $this->job = $job;
         $this->payload = $payload;
+        $this->delay = $delay;
     }
 
     /**

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -12,18 +12,11 @@ class JobQueueing
     public $connectionName;
 
     /**
-     * The queue name the job is queued on.
+     * The queue name.
      *
      * @var string
      */
     public $queue;
-
-    /**
-     * The delay used to queue the job.
-     *
-     * @var \DateTimeInterface|\DateInterval|int|null
-     */
-    public $delay;
 
     /**
      * The job instance.
@@ -40,22 +33,29 @@ class JobQueueing
     public $payload;
 
     /**
+     * The number of seconds the job was delayed.
+     *
+     * @var int|null
+     */
+    public $delay;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  \Closure|string|object  $job
      * @param  string  $payload
+     * @param  int|null  $delay
      * @return void
      */
-    public function __construct($connectionName, $queue, $delay, $job, $payload)
+    public function __construct($connectionName, $queue, $job, $payload, $delay)
     {
         $this->connectionName = $connectionName;
         $this->queue = $queue;
-        $this->delay = $delay;
         $this->job = $job;
         $this->payload = $payload;
+        $this->delay = $delay;
     }
 
     /**

--- a/src/Illuminate/Queue/Events/JobQueueing.php
+++ b/src/Illuminate/Queue/Events/JobQueueing.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Queue\Events;
 
-use RuntimeException;
-
 class JobQueueing
 {
     /**
@@ -12,6 +10,20 @@ class JobQueueing
      * @var string
      */
     public $connectionName;
+
+    /**
+     * The queue name the job is queued on.
+     *
+     * @var string
+     */
+    public $queue;
+
+    /**
+     * The delay used to queue the job.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|null
+     */
+    public $delay;
 
     /**
      * The job instance.
@@ -23,7 +35,7 @@ class JobQueueing
     /**
      * The job payload.
      *
-     * @var string|null
+     * @var string
      */
     public $payload;
 
@@ -31,13 +43,17 @@ class JobQueueing
      * Create a new event instance.
      *
      * @param  string  $connectionName
+     * @param  string  $queue
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @param  \Closure|string|object  $job
-     * @param  string|null  $payload
+     * @param  string  $payload
      * @return void
      */
-    public function __construct($connectionName, $job, $payload = null)
+    public function __construct($connectionName, $queue, $delay, $job, $payload)
     {
         $this->connectionName = $connectionName;
+        $this->queue = $queue;
+        $this->delay = $delay;
         $this->job = $job;
         $this->payload = $payload;
     }
@@ -49,10 +65,6 @@ class JobQueueing
      */
     public function payload()
     {
-        if ($this->payload === null) {
-            throw new RuntimeException('The job payload was not provided when the event was dispatched.');
-        }
-
         return json_decode($this->payload, true, flags: JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
This is #49833 but against master to be able to re-order arguments. Also removed default `null` for the `$payload` argument since that was also done for BC reasons.

### Changes

Add the `queue` and `delay` property to the `JobQueueing` and `JobQueued` events.

### Why?

With the introduction of the `JobQueueing` (#49722) we can now profile what is happening in the application when a job is being queued (for example: getsentry/sentry-laravel#833), however we only know the queue connection and job name. 

It is also useful to know which queue and with what delay a job was queued since they are already available where the events are dispatched I "simply" added them to the event.