### PR TITLE
[10.x] Release action

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,28 +19,15 @@ jobs:
         id: version
         run: VERSION=${{ inputs.version }} echo "::set-output name=version::${VERSION#v}"
 
-      - name: Update version
+      - name: Update Application.php version
         run: |
           sed -i "s/const VERSION = '.*';/const VERSION = '${{ steps.version.outputs.version }}';/g" src/Illuminate/Foundation/Application.php
           git add src/Illuminate/Foundation/Application.php
-          git commit -m "Update version to ${{ steps.version.outputs.version }}"
+          git commit -m "Update version to v${{ steps.version.outputs.version }}"
           git push origin ${{ github.ref_name }}
 
-      - name: SSH into splitter server
-        uses: appleboy/ssh-action@master
-        with:
-          host: 104.248.56.26
-          username: forge
-          key: ${{ secrets.SSH_PRIVATE_KEY_SPLITTER }}
-
-      - name: Change directory
-        run: cd laravel-${{ github.ref_name }}
-
-      - name: Pull in latest changes
-        run: git pull origin ${{ github.ref_name }}
-
       - name: Run release script
-        run: bash bin/release ${{ steps.version.outputs.version }}
+        run: bash bin/release v${{ steps.version.outputs.version }}
 
       - name: Generate Release Notes
         id: notes

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,11 +19,11 @@ jobs:
         id: version
         run: VERSION=${{ inputs.version }} echo "::set-output name=version::${VERSION#v}"
 
-      - name: Update version
+      - name: Update Application.php version
         run: |
           sed -i "s/const VERSION = '.*';/const VERSION = '${{ steps.version.outputs.version }}';/g" src/Illuminate/Foundation/Application.php
           git add src/Illuminate/Foundation/Application.php
-          git commit -m "Update version to ${{ steps.version.outputs.version }}"
+          git commit -m "Update version to v${{ steps.version.outputs.version }}"
           git push origin ${{ github.ref_name }}
 
       - name: SSH into splitter server
@@ -40,7 +40,7 @@ jobs:
         run: git pull origin ${{ github.ref_name }}
 
       - name: Run release script
-        run: bash bin/release ${{ steps.version.outputs.version }}
+        run: bash bin/release v${{ steps.version.outputs.version }}
 
       - name: Generate Release Notes
         id: notes

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,66 @@
+name: manual release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Remove optional "v" prefix
+        id: version
+        run: VERSION=${{ inputs.version }} echo "::set-output name=version::${VERSION#v}"
+
+      - name: Update version
+        run: |
+          sed -i "s/const VERSION = '.*';/const VERSION = '${{ steps.version.outputs.version }}';/g" src/Illuminate/Foundation/Application.php
+          git add src/Illuminate/Foundation/Application.php
+          git commit -m "Update version to ${{ steps.version.outputs.version }}"
+          git push origin ${{ github.ref_name }}
+
+      - name: SSH into splitter server
+        uses: appleboy/ssh-action@master
+        with:
+          host: 104.248.56.26
+          username: forge
+          key: ${{ secrets.SSH_PRIVATE_KEY_SPLITTER }}
+
+      - name: Change directory
+        run: cd laravel-${{ github.ref_name }}
+
+      - name: Pull in latest changes
+        run: git pull origin ${{ github.ref_name }}
+
+      - name: Run release script
+        run: bash bin/release ${{ steps.version.outputs.version }}
+
+      - name: Generate Release Notes
+        id: notes
+        uses: RedCrafter07/release-notes-action@main
+        with:
+          tag-name: v${{ steps.version.outputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
+
+      - name: Cleanup release notes
+        run: |
+          sed -i '/## What\'\''s Changed/q' ${{ steps.notes.outputs.release-notes }}
+          sed -i '/## Contributors/,$d' ${{ steps.notes.outputs.release-notes }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          release_name: v${{ steps.version.outputs.version }}
+          body: ${{ steps.notes.outputs.release-notes }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,15 +19,28 @@ jobs:
         id: version
         run: VERSION=${{ inputs.version }} echo "::set-output name=version::${VERSION#v}"
 
-      - name: Update Application.php version
+      - name: Update version
         run: |
           sed -i "s/const VERSION = '.*';/const VERSION = '${{ steps.version.outputs.version }}';/g" src/Illuminate/Foundation/Application.php
           git add src/Illuminate/Foundation/Application.php
-          git commit -m "Update version to v${{ steps.version.outputs.version }}"
+          git commit -m "Update version to ${{ steps.version.outputs.version }}"
           git push origin ${{ github.ref_name }}
 
+      - name: SSH into splitter server
+        uses: appleboy/ssh-action@master
+        with:
+          host: 104.248.56.26
+          username: forge
+          key: ${{ secrets.SSH_PRIVATE_KEY_SPLITTER }}
+
+      - name: Change directory
+        run: cd laravel-${{ github.ref_name }}
+
+      - name: Pull in latest changes
+        run: git pull origin ${{ github.ref_name }}
+
       - name: Run release script
-        run: bash bin/release v${{ steps.version.outputs.version }}
+        run: bash bin/release ${{ steps.version.outputs.version }}
 
       - name: Generate Release Notes
         id: notes

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -2,8 +2,50 @@
 
 set -e
 
+# Make sure the release tag is provided.
+if (( "$#" != 1 ))
+then
+    echo "Tag has to be provided."
+
+    exit 1
+fi
+
 RELEASE_BRANCH="10.x"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 VERSION=$1
+
+# Make sure current branch and release branch match.
+if [[ "$RELEASE_BRANCH" != "$CURRENT_BRANCH" ]]
+then
+    echo "Release branch ($RELEASE_BRANCH) does not match the current active branch ($CURRENT_BRANCH)."
+
+    exit 1
+fi
+
+# Make sure the working directory is clear.
+if [[ ! -z "$(git status --porcelain)" ]]
+then
+    echo "Your working directory is dirty. Did you forget to commit your changes?"
+
+    exit 1
+fi
+
+# Make sure latest changes are fetched first.
+git fetch origin
+
+# Make sure that release branch is in sync with origin.
+if [[ $(git rev-parse HEAD) != $(git rev-parse origin/$RELEASE_BRANCH) ]]
+then
+    echo "Your branch is out of date with its upstream. Did you forget to pull or push any changes before releasing?"
+
+    exit 1
+fi
+
+# Always prepend with "v"
+if [[ $VERSION != v*  ]]
+then
+    VERSION="v$VERSION"
+fi
 
 # Tag Framework
 git tag $VERSION

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -2,50 +2,8 @@
 
 set -e
 
-# Make sure the release tag is provided.
-if (( "$#" != 1 ))
-then
-    echo "Tag has to be provided."
-
-    exit 1
-fi
-
 RELEASE_BRANCH="10.x"
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 VERSION=$1
-
-# Make sure current branch and release branch match.
-if [[ "$RELEASE_BRANCH" != "$CURRENT_BRANCH" ]]
-then
-    echo "Release branch ($RELEASE_BRANCH) does not match the current active branch ($CURRENT_BRANCH)."
-
-    exit 1
-fi
-
-# Make sure the working directory is clear.
-if [[ ! -z "$(git status --porcelain)" ]]
-then
-    echo "Your working directory is dirty. Did you forget to commit your changes?"
-
-    exit 1
-fi
-
-# Make sure latest changes are fetched first.
-git fetch origin
-
-# Make sure that release branch is in sync with origin.
-if [[ $(git rev-parse HEAD) != $(git rev-parse origin/$RELEASE_BRANCH) ]]
-then
-    echo "Your branch is out of date with its upstream. Did you forget to pull or push any changes before releasing?"
-
-    exit 1
-fi
-
-# Always prepend with "v"
-if [[ $VERSION != v*  ]]
-then
-    VERSION="v$VERSION"
-fi
 
 # Tag Framework
 git tag $VERSION


### PR DESCRIPTION
This PR adds a releases GitHub Action which will help us automate the release process. From a new dropdown menu in the action tab we can always do a new release by inputting a new tag. The action will then subsequently update the version in `Application.php`, start the release script, generate release notes and add a new GitHub release. 