### PR TITLE
[10.x] Make `hasIndex()` Order-sensitive 

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -403,26 +403,14 @@ class Builder
     {
         $type = is_null($type) ? $type : strtolower($type);
 
-        if (is_array($index)) {
-            sort($index);
-        }
-
         foreach ($this->getIndexes($table) as $value) {
             $typeMatches = is_null($type)
                 || ($type === 'primary' && $value['primary'])
                 || ($type === 'unique' && $value['unique'])
                 || $type === $value['type'];
 
-            if ($value['name'] === $index && $typeMatches) {
+            if (($value['name'] === $index || $value['columns'] === $index) && $typeMatches) {
                 return true;
-            }
-
-            if (is_array($index)) {
-                sort($value['columns']);
-
-                if ($value['columns'] === $index && $typeMatches) {
-                    return true;
-                }
             }
         }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -288,9 +288,9 @@ class SchemaBuilderTest extends DatabaseTestCase
         ));
         $this->assertTrue(Schema::hasIndex('foo', 'foo_baz_bar_unique'));
         $this->assertTrue(Schema::hasIndex('foo', 'foo_baz_bar_unique', 'unique'));
-        $this->assertTrue(Schema::hasIndex('foo', ['bar', 'baz']));
-        $this->assertTrue(Schema::hasIndex('foo', ['bar', 'baz'], 'unique'));
-        $this->assertFalse(Schema::hasIndex('foo', ['bar', 'baz'], 'primary'));
+        $this->assertTrue(Schema::hasIndex('foo', ['baz', 'bar']));
+        $this->assertTrue(Schema::hasIndex('foo', ['baz', 'bar'], 'unique'));
+        $this->assertFalse(Schema::hasIndex('foo', ['baz', 'bar'], 'primary'));
     }
 
     public function testGetIndexesWithCompositeKeys()
@@ -333,6 +333,26 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertCount(2, $indexes);
         $this->assertTrue(collect($indexes)->contains(fn ($index) => $index['columns'] === ['id'] && $index['primary']));
         $this->assertTrue(collect($indexes)->contains('name', 'articles_body_title_fulltext'));
+    }
+
+    public function testHasIndexOrder()
+    {
+        Schema::create('foo', function (Blueprint $table) {
+            $table->integer('bar');
+            $table->integer('baz');
+            $table->integer('qux');
+
+            $table->unique(['bar', 'baz']);
+            $table->index(['baz', 'bar']);
+            $table->index(['baz', 'qux']);
+        });
+
+        $this->assertTrue(Schema::hasIndex('foo', ['bar', 'baz']));
+        $this->assertTrue(Schema::hasIndex('foo', ['bar', 'baz'], 'unique'));
+        $this->assertTrue(Schema::hasIndex('foo', ['baz', 'bar']));
+        $this->assertFalse(Schema::hasIndex('foo', ['baz', 'bar'], 'unique'));
+        $this->assertTrue(Schema::hasIndex('foo', ['baz', 'qux']));
+        $this->assertFalse(Schema::hasIndex('foo', ['qux', 'baz']));
     }
 
     public function testGetForeignKeys()


### PR DESCRIPTION
As pointed out here https://github.com/laravel/framework/pull/49796#issuecomment-1909454059, the initial implementation of `Schema::hasIndex()` was order-insensitive to be more flexible. But as databases differentiate between columns order of an index, this may causes false positive when using this method. This PR fixes that before release of `Schema::hasIndex()`.

Note: the changed assertions are added on #49796 and are not released yet, so this not a breaking change.