### PR TITLE
[11.x] Update domain and URI parsing

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -69,7 +69,6 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
-    *
      * @param  \Illuminate\Routing\Route  $route
      * @return string
      */

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -59,13 +59,30 @@ class RouteCollection extends AbstractRouteCollection
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->getDomain().$route->uri();
+        $domainAndUri = $this->parseDomainAndUri($route);
 
         foreach ($route->methods() as $method) {
             $this->routes[$method][$domainAndUri] = $route;
         }
 
         $this->allRoutes[$method.$domainAndUri] = $route;
+    }
+
+    /**
+    *
+    * @param  \Illuminate\Routing\Route  $route
+    * @return string
+    */
+    protected function parseDomainAndUri($route)
+    {
+        if(!is_null($route->getDomain())) {
+            return str($route->getDomain())
+                ->append('/', $route->uri())
+                ->whenEndsWith('//', fn ($str) => str($str)->replace('//', '/'))
+                ->value();
+        }
+
+        return $route->getDomain().$route->uri();
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -70,12 +70,12 @@ class RouteCollection extends AbstractRouteCollection
 
     /**
     *
-    * @param  \Illuminate\Routing\Route  $route
-    * @return string
-    */
+     * @param  \Illuminate\Routing\Route  $route
+     * @return string
+     */
     protected function parseDomainAndUri($route)
     {
-        if(!is_null($route->getDomain())) {
+        if (! is_null($route->getDomain())) {
             return str($route->getDomain())
                 ->append('/', $route->uri())
                 ->whenEndsWith('//', fn ($str) => str($str)->replace('//', '/'))


### PR DESCRIPTION
This PR updates the parsing of the domain and URI of a given route before it is pushed into the route collection. It mainly has to do with routes that have a `domain` defined. 

At the moment, the following route 
```php
Route::domain('router.test')->group(function () {
    Route::middleware([
        'auth:sanctum',
        config('jetstream.auth_session'),
        'verified',
    ])->group(function () {
        Route::get('/dashboard', function () {
            return Inertia::render('Dashboard');
        })->name('dashboard');
    });
});
```
When calling 
```php
Route::getRoutes();
``` 

Will return 

```php
"router.testdashboard" => Illuminate\Routing\Route
```
<img width="1392" alt="Xnapper-2024-01-25-12 08 09" src="https://github.com/laravel/framework/assets/11172883/8ea47161-b49f-45bb-a783-c37ff9e6bf7a">


After this PR it will show 
```php
"router.test/dashboard" => Illuminate\Routing\Route
```

<img width="1392" alt="Xnapper-2024-01-25-12 10 04" src="https://github.com/laravel/framework/assets/11172883/9b38a6a4-2445-417e-ac6f-be8d8cd76bf1">
