### PR TITLE
[10.x] Introduce Observe attribute for models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Observe.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Observe.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Observe
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array|string  $classes
+     * @return void
+     */
+    public function __construct(array|string $classes)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Eloquent\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-class Observe
+class ObservedBy
 {
     /**
      * Create a new attribute instance.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Eloquent\Attributes\Observe;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -48,7 +48,7 @@ trait HasEvents
     {
         $reflectionClass = new ReflectionClass(static::class);
 
-        return collect($reflectionClass->getAttributes(Observe::class))
+        return collect($reflectionClass->getAttributes(ObservedBy::class))
             ->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
             ->all();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Eloquent\Attributes\Observe;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use ReflectionClass;
 
 trait HasEvents
 {
@@ -26,6 +28,31 @@ trait HasEvents
      * @var array
      */
     protected $observables = [];
+
+    /**
+     * Boot the has event trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasEvents()
+    {
+        static::observe(static::resolveObserveAttributes());
+    }
+
+    /**
+     * Resolve the observe class names from the attributes.
+     *
+     * @return array
+     */
+    public static function resolveObserveAttributes()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+
+        return collect($reflectionClass->getAttributes(Observe::class))
+            ->map(fn ($attribute) => $attribute->getArguments())
+            ->flatten()
+            ->all();
+    }
 
     /**
      * Register observers with the model.

--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends TestCase
@@ -29,8 +30,8 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
      */
     public function testUserIsNotInstanceOfMustVerifyEmail()
     {
-        $user = $this->getMockBuilder(User::class)->getMock();
-        $user->expects($this->never())->method('sendEmailVerificationNotification');
+        $user = m::mock(User::class);
+        $user->shouldNotReceive('sendEmailVerificationNotification');
 
         $listener = new SendEmailVerificationNotification;
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1894,7 +1894,6 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
-
     public function testModelObserversCanBeAttachedToModelsWithStringUsingAttribute()
     {
         EloquentModelWithObserveAttributeStub::setEventDispatcher($events = m::mock(Dispatcher::class));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -15,7 +15,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Illuminate\Database\Eloquent\Attributes\Observe;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -3355,13 +3355,13 @@ class EloquentNonPrimaryUlidModelStub extends EloquentModelStub
     }
 }
 
-#[Observe(EloquentTestObserverStub::class)]
+#[ObservedBy(EloquentTestObserverStub::class)]
 class EloquentModelWithObserveAttributeStub extends EloquentModelStub
 {
     //
 }
 
-#[Observe([EloquentTestObserverStub::class])]
+#[ObservedBy([EloquentTestObserverStub::class])]
 class EloquentModelWithObserveAttributeUsingArrayStub extends EloquentModelStub
 {
     //

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Attributes\Observe;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -1893,6 +1894,27 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
+
+    public function testModelObserversCanBeAttachedToModelsWithStringUsingAttribute()
+    {
+        EloquentModelWithObserveAttributeStub::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelWithObserveAttributeStub', EloquentTestObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelWithObserveAttributeStub', EloquentTestObserverStub::class.'@saved');
+        $events->shouldReceive('forget');
+        EloquentModelWithObserveAttributeStub::flushEventListeners();
+    }
+
+    public function testModelObserversCanBeAttachedToModelsThroughAnArrayUsingAttribute()
+    {
+        EloquentModelWithObserveAttributeUsingArrayStub::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelWithObserveAttributeUsingArrayStub', EloquentTestObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelWithObserveAttributeUsingArrayStub', EloquentTestObserverStub::class.'@saved');
+        $events->shouldReceive('forget');
+        EloquentModelWithObserveAttributeUsingArrayStub::flushEventListeners();
+    }
+
     public function testThrowExceptionOnAttachingNotExistsModelObserverWithString()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -3332,6 +3354,18 @@ class EloquentNonPrimaryUlidModelStub extends EloquentModelStub
     {
         return ['ulid'];
     }
+}
+
+#[Observe(EloquentTestObserverStub::class)]
+class EloquentModelWithObserveAttributeStub extends EloquentModelStub
+{
+    //
+}
+
+#[Observe([EloquentTestObserverStub::class])]
+class EloquentModelWithObserveAttributeUsingArrayStub extends EloquentModelStub
+{
+    //
 }
 
 class EloquentModelSavingEventStub


### PR DESCRIPTION
This pull request introduces a new attribute class for registering model observers.

Example:

```php
#[Observe(UserObserver::class)]
class User extends Authenticatable
{
    //
}
```

This change means you don't have to register the observers in a service provider. It just makes the code clearer and less confusing, making it easier to understand what's going on.
