### PR TITLE
[10.x] Add Collection::select() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -492,6 +492,20 @@ class Arr
     }
 
     /**
+     * Select an array of values from an array.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
+     */
+    public static function select($array, $keys)
+    {
+        return static::map($array, function ($item) use ($keys) {
+            return array_intersect_key($item, array_flip((array) $keys));
+        });
+    }
+
+    /**
      * Pluck an array of values from an array.
      *
      * @param  iterable  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -919,6 +919,27 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the values for the specified keys from an array.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string|null  $keys
+     * @return static
+     */
+    public function select($keys)
+    {
+        if (is_null($keys)) {
+            return new static($this->items);
+        }
+
+        if ($keys instanceof Enumerable) {
+            $keys = $keys->all();
+        }
+
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return new static(Arr::select($this->items, $keys));
+    }
+
+    /**
      * Get and remove the last N items from the collection.
      *
      * @param  int  $count

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -919,7 +919,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get the values for the specified keys from an array.
+     * Select specific values from the items within the collection.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string|null  $keys
      * @return static

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -954,7 +954,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the values for the specified keys from an array.
+     * Select specific values from the items within the collection.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string  $keys
      * @return static
@@ -973,6 +973,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             } else {
                 foreach ($this as $item) {
                     $itemKeys = array_flip($keys);
+
                     $result = [];
 
                     foreach ($item as $key => $value) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -954,6 +954,46 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the values for the specified keys from an array.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string  $keys
+     * @return static
+     */
+    public function select($keys)
+    {
+        if ($keys instanceof Enumerable) {
+            $keys = $keys->all();
+        } elseif (! is_null($keys)) {
+            $keys = is_array($keys) ? $keys : func_get_args();
+        }
+
+        return new static(function () use ($keys) {
+            if (is_null($keys)) {
+                yield from $this;
+            } else {
+                foreach ($this as $item) {
+                    $itemKeys = array_flip($keys);
+                    $result = [];
+
+                    foreach ($item as $key => $value) {
+                        if (array_key_exists($key, $itemKeys)) {
+                            $result[$key] = $value;
+
+                            unset($itemKeys[$key]);
+
+                            if (empty($itemKeys)) {
+                                continue;
+                            }
+                        }
+                    }
+
+                    yield $result;
+                }
+            }
+        });
+    }
+
+    /**
      * Push all of the given items onto the collection.
      *
      * @param  iterable<array-key, TValue>  $source

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4231,6 +4231,37 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSelect($collection)
+    {
+        $data = new $collection([
+            ['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Jess', 'last' => 'Archer', 'email' => 'jessarcher@gmail.com'],
+        ]);
+
+        $this->assertEquals($data->all(), $data->select(null)->all());
+        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+
+        $this->assertEquals([
+            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com']
+        ], $data->select(['first', 'email'])->all());
+
+        $this->assertEquals([
+            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com']
+        ], $data->select('first', 'email')->all());
+
+        $this->assertEquals([
+            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com']
+        ], $data->select(collect(['first', 'email']))->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testGettingAvgItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4245,17 +4245,17 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com']
+            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select(['first', 'email'])->all());
 
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com']
+            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select('first', 'email')->all());
 
         $this->assertEquals([
             ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com']
+            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select(collect(['first', 'email']))->all());
     }
 


### PR DESCRIPTION
This adds a new `Collection::select()` method that selects a certain number of keys from a multi-dimensional array. 

It's kind of like `only` except for arrays of arrays.

It's also like `pluck` except it supports multiple keys. 

The naming is inspired by SQL and the Query Builder. 

`$users->select('id', 'name', 'email'])` would be the equivalent of:

```php
$users = $users->map(function ($user) {
  return collect($user)->only(['id', 'name', 'email']);
});
```