### PR TITLE
[10.x] Introduce methods for handling nil and max UUIDs

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1710,6 +1710,30 @@ class Str
     }
 
     /**
+     * Determine if given value is Nil UUID
+     *
+     * @param string $uuid
+     *
+     * @return bool
+     */
+    public static function isNilUuid(string $uuid): bool
+    {
+        return Uuid::NIL === $uuid;
+    }
+
+    /**
+     * Determine if given value is Max UUID
+     *
+     * @param string $uuid
+     *
+     * @return bool
+     */
+    public static function isMaxUuid(string $uuid): bool
+    {
+        return Uuid::MAX === $uuid;
+    }
+
+    /**
      * Generate a ULID.
      *
      * @param  \DateTimeInterface|null  $time

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Exception;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
 
@@ -1237,6 +1238,26 @@ class SupportStrTest extends TestCase
         $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
 
         Str::createUuidsNormally();
+    }
+
+    public function testIsNilUuid()
+    {
+        $this->assertTrue(str::isNilUuid(Uuid::NIL));
+    }
+
+    public function testIsNotNilUuid()
+    {
+        $this->assertFalse(str::isNilUuid(Str::uuid()));
+    }
+
+    public function testIsMaxUuid()
+    {
+        $this->assertTrue(str::isMaxUuid(Uuid::MAX));
+    }
+
+    public function testIsNotMaxUuid()
+    {
+        $this->assertFalse(str::isMaxUuid(Str::uuid()));
     }
 
     public function testItCanSpecifyAFallbackForASequence()


### PR DESCRIPTION
This pull request introduces `isNilUuid` and `isMaxUuid` methods to enhance Laravel's UUID handling capabilities. These methods offer a clear and expressive API for working with UUIDs in various scenarios. `isNilUuid` facilitates error handling and represents uninitialized states, while `isMaxUuid` is useful for range checks and scenarios where UUIDs need to be within specific bounds.

These additions align with Laravel's commitment to clean, readable code and provide developers with valuable tools for UUID manipulation. The methods are implemented with simplicity and efficiency in mind, contributing to a more robust and expressive UUID handling framework within Laravel.

I believe that these methods will bring tangible benefits to developers working with UUIDs in Laravel applications, promoting code clarity and aligning with best practices in UUID handling. I look forward to your feedback and collaboration on this enhancement.
