### PR TITLE
[10.x] Unified Pivot and Model Doc Block `$guarded`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -19,7 +19,7 @@ class Pivot extends Model
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array
+     * @var array<string>|bool
      */
     protected $guarded = [];
 }


### PR DESCRIPTION
If the behavior of `$guarded` in Pivot is the same as in Model, they must have the same Doc Block.