### PR TITLE
[10.x] Introducing `beforeStartingTransaction` callback and use it in `LazilyRefreshDatabase`

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -119,8 +119,8 @@ trait ManagesTransactions
      */
     public function beginTransaction()
     {
-        foreach ($this->beforeStartingTransaction as $beforeStartingTransactionCallback) {
-            $beforeStartingTransactionCallback($this);
+        foreach ($this->beforeStartingTransaction as $callback) {
+            $callback($this);
         }
 
         $this->createTransaction();

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -122,7 +122,7 @@ trait ManagesTransactions
         foreach ($this->beforeStartingTransaction as $beforeStartingTransactionCallback) {
             $beforeStartingTransactionCallback($this);
         }
-        
+
         $this->createTransaction();
 
         $this->transactions++;

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -119,6 +119,10 @@ trait ManagesTransactions
      */
     public function beginTransaction()
     {
+        foreach ($this->beforeStartingTransaction as $beforeStartingTransactionCallback) {
+            $beforeStartingTransactionCallback($this);
+        }
+        
         $this->createTransaction();
 
         $this->transactions++;

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -183,18 +183,18 @@ class Connection implements ConnectionInterface
     protected $pretending = false;
 
     /**
-     * All of the callbacks that should be invoked before a query is executed.
-     *
-     * @var \Closure[]
-     */
-    protected $beforeExecutingCallbacks = [];
-
-    /**
      * All of the callbacks that should be invoked before a transaction is started.
      *
      * @var \Closure[]
      */
     protected $beforeStartingTransaction = [];
+
+    /**
+     * All of the callbacks that should be invoked before a query is executed.
+     *
+     * @var \Closure[]
+     */
+    protected $beforeExecutingCallbacks = [];
 
     /**
      * The instance of Doctrine connection.
@@ -1029,19 +1029,6 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Register a hook to be run just before a database query is executed.
-     *
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function beforeExecuting(Closure $callback)
-    {
-        $this->beforeExecutingCallbacks[] = $callback;
-
-        return $this;
-    }
-
-    /**
      * Register a hook to be run just before a database transaction is started.
      *
      * @param  \Closure  $callback
@@ -1050,6 +1037,19 @@ class Connection implements ConnectionInterface
     public function beforeStartingTransaction(Closure $callback)
     {
         $this->beforeStartingTransaction[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a hook to be run just before a database query is executed.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function beforeExecuting(Closure $callback)
+    {
+        $this->beforeExecutingCallbacks[] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -190,6 +190,13 @@ class Connection implements ConnectionInterface
     protected $beforeExecutingCallbacks = [];
 
     /**
+     * All of the callbacks that should be invoked before a transaction is started.
+     *
+     * @var \Closure[]
+     */
+    protected $beforeStartingTransaction = [];
+
+    /**
      * The instance of Doctrine connection.
      *
      * @var \Doctrine\DBAL\Connection
@@ -1030,6 +1037,19 @@ class Connection implements ConnectionInterface
     public function beforeExecuting(Closure $callback)
     {
         $this->beforeExecutingCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a hook to be run just before a database transaction is started.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function beforeStartingTransaction(Closure $callback)
+    {
+        $this->beforeStartingTransaction[] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -17,7 +17,7 @@ trait LazilyRefreshDatabase
     {
         $database = $this->app->make('db');
 
-        $database->beforeExecuting(function () {
+        $callback = function () {
             if (RefreshDatabaseState::$lazilyRefreshed) {
                 return;
             }
@@ -25,7 +25,10 @@ trait LazilyRefreshDatabase
             RefreshDatabaseState::$lazilyRefreshed = true;
 
             $this->baseRefreshDatabase();
-        });
+        };
+
+        $database->beforeExecuting($callback);
+        $database->beforeStartingTransaction($callback);
 
         $this->beforeApplicationDestroyed(function () {
             RefreshDatabaseState::$lazilyRefreshed = false;

--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -27,8 +27,8 @@ trait LazilyRefreshDatabase
             $this->baseRefreshDatabase();
         };
 
-        $database->beforeExecuting($callback);
         $database->beforeStartingTransaction($callback);
+        $database->beforeExecuting($callback);
 
         $this->beforeApplicationDestroyed(function () {
             RefreshDatabaseState::$lazilyRefreshed = false;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -484,6 +484,18 @@ class DatabaseConnectionTest extends TestCase
         $connection->select('foo bar', ['baz']);
     }
 
+    public function testBeforeStartingTransactionHooksCanBeRegistered()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The callback was fired');
+
+        $connection = $this->getMockConnection();
+        $connection->beforeStartingTransaction(function () {
+            throw new Exception('The callback was fired');
+        });
+        $connection->beginTransaction();
+    }
+
     public function testPretendOnlyLogsQueries()
     {
         $connection = $this->getMockConnection();


### PR DESCRIPTION
This PR fixes #49852.

* It comes with a `beforeStartingTransaction()` method to add callbacks to `Illuminate\Database\Connection` that get executed before a transaction starts.
* This is used in the `LazilyRefreshDatabase` trait so the database is also refreshed before a transaction starts.