### PR TITLE
[10.x] Support Factory for models anywhere under App

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -786,6 +786,10 @@ abstract class Factory
 
             $appNamespace = static::appNamespace();
 
+            if (class_exists($appNamespace.$namespacedFactoryBasename)) {
+                return $appNamespace.$namespacedFactoryBasename;
+            }
+
             return class_exists($appNamespace.'Models\\'.$namespacedFactoryBasename)
                         ? $appNamespace.'Models\\'.$namespacedFactoryBasename
                         : $appNamespace.$factoryBasename;

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
+use Illuminate\Tests\Database\Fixtures\SomePath\Models\SomeModel;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -579,6 +580,10 @@ class DatabaseEloquentFactoryTest extends TestCase
         $factory = Price::factory();
 
         $this->assertSame(Price::class, $factory->modelName());
+
+        $factory = SomeModel::factory();
+
+        $this->assertSame(SomeModel::class, $factory->modelName());
     }
 
     public function test_resolve_non_app_nested_model_factories()

--- a/tests/Database/Fixtures/Factories/SomePath/Models/SomeModelFactory.php
+++ b/tests/Database/Fixtures/Factories/SomePath/Models/SomeModelFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Factories\SomePath\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SomeModelFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+}

--- a/tests/Database/Fixtures/SomePath/Models/SomeModel.php
+++ b/tests/Database/Fixtures/SomePath/Models/SomeModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\SomePath\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\Fixtures\Factories\SomePath\Models\SomeModelFactory;
+
+class SomeModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'table_name';
+
+    public static function factory()
+    {
+        return SomeModelFactory::new();
+    }
+}


### PR DESCRIPTION
Currently model factories support only models directly under `App\` or nested under `App\Models\`

This change allows models to be nested anywhere under `App\`

Model: \App\Component\Models\Component
Factory: \Database\Factories\Component\Models\ComponentFactory
