### PR TITLE
[10.x] Extend $wrap value when resource is empty

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -94,8 +94,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     protected static function newCollection($resource)
     {
-        return tap(new AnonymousResourceCollection($resource, static::class),
-            fn(AnonymousResourceCollection $newCollection) => $newCollection::wrap(self::$wrap));
+        return new AnonymousResourceCollection($resource, static::class);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -93,7 +93,8 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     protected static function newCollection($resource)
     {
-        return new AnonymousResourceCollection($resource, static::class);
+        return tap(new AnonymousResourceCollection($resource, static::class),
+            fn(AnonymousResourceCollection $newCollection) => $newCollection::wrap(self::$wrap));
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -82,6 +82,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+            $collection::wrap(self::$wrap);
         });
     }
 

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -82,7 +82,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
-            $collection::wrap(self::$wrap);
+            $collection::wrap(static::$wrap);
         });
     }
 


### PR DESCRIPTION
### Issue
When Creating a json resource and use it like this `ExampleResource::collection($exampleModels)`, and the `$exampleModels` are empty, the `AnonymousResourceCollection` will not extend the `$wrap` value of the `ExampleResource`.

### Fix
Set the wrap value when initiate the AnonymousResourceCollection

- [x] Unit Tests without failures. 