### PR TITLE
[11.x] Uses Carbon `^3.0` instead of `^3.0.0-beta.3@beta`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require nesbot/carbon:^3.0.0-beta.3@beta --no-interaction --no-update
+          command: composer require nesbot/carbon:^3.0 --no-interaction --no-update
 
       - name: Set PHPUnit
         uses: nick-fields/retry@v2

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem": "^3.8.0",
         "monolog/monolog": "^3.0",
-        "nesbot/carbon": "^2.72.2|^3.0.0-beta.3@beta",
+        "nesbot/carbon": "^2.72.2|^3.0",
         "nunomaduro/termwind": "^2.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,7 +23,7 @@
         "illuminate/conditionable": "^11.0",
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
-        "nesbot/carbon": "^2.72.2|^3.0.0-beta.3@beta",
+        "nesbot/carbon": "^2.72.2|^3.0",
         "voku/portable-ascii": "^2.0"
     },
     "conflict": {


### PR DESCRIPTION
This pull request makes composer use Carbon `^3.0` instead of `^3.0.0-beta.3@beta`.