### PR TITLE
[10.x] Validation message placeholder is not getting replaced (#49841)

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -321,6 +321,10 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             }
 
             if ($this->max && mb_strlen($value) > $this->max) {
+                $validator->addReplacer('max.string', function ($message, $attribute, $rule, $parameters, $validator) {
+                    return str_replace(':max', $validator->getDisplayableAttribute($this->max), $message);
+                });
+
                 $validator->addFailure($attribute, 'max.string');
             }
 


### PR DESCRIPTION
This PR is a fix for the issue - validation message placeholder is not replaced #49841