### PR TITLE
[10.x] Adds `FormRequest@getRules()` method

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -116,8 +116,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function createDefaultValidator(ValidationFactory $factory)
     {
         $validator = $factory->make(
-            $this->validationData(), $this->getRules(),
-            $this->messages(), $this->attributes()
+            $this->validationData(),
+            $this->validationRules(),
+            $this->messages(),
+            $this->attributes(),
         )->stopOnFirstFailure($this->stopOnFirstFailure);
 
         if ($this->isPrecognitive()) {
@@ -130,15 +132,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * Get the validator rules for this form request.
-     *
-     * @return array
-     */
-    protected function getRules()
-    {
-        return method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
-    }
-    /**
      * Get data to be validated from the request.
      *
      * @return array
@@ -146,6 +139,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function validationData()
     {
         return $this->all();
+    }
+
+    /**
+     * Get the validation rules for this form request.
+     *
+     * @return array
+     */
+    protected function validationRules()
+    {
+        return method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -115,10 +115,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function createDefaultValidator(ValidationFactory $factory)
     {
-        $rules = method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
-
         $validator = $factory->make(
-            $this->validationData(), $rules,
+            $this->validationData(), $this->getRules(),
             $this->messages(), $this->attributes()
         )->stopOnFirstFailure($this->stopOnFirstFailure);
 
@@ -131,6 +129,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
         return $validator;
     }
 
+    /**
+     * Get the validator rules for this form request.
+     *
+     * @return array
+     */
+    protected function getRules()
+    {
+        return method_exists($this, 'rules') ? $this->container->call([$this, 'rules']) : [];
+    }
     /**
      * Get data to be validated from the request.
      *

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -497,7 +497,6 @@ class FoundationTestFormRequestWithoutRulesMethod extends FormRequest
     }
 }
 
-
 class FoundationTestFormRequestWithGetRules extends FormRequest
 {
     public static $useRuleSet = 'a';
@@ -515,5 +514,3 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
         }
     }
 }
-
-;

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -306,7 +306,7 @@ class FoundationFormRequestTest extends TestCase
                    ->andReturn($this->createMockRedirectResponse());
 
         $generator->shouldReceive('previous')->zeroOrMoreTimes()
-                   ->andReturn('previous');
+                  ->andReturn('previous');
 
         return $redirector;
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -503,7 +503,7 @@ class FoundationTestFormRequestWithGetRules extends FormRequest
 {
     public static $useRuleSet = 'a';
 
-    protected function getRules(): array
+    protected function validationRules(): array
     {
         if (self::$useRuleSet === 'a') {
             return [

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -272,7 +272,7 @@ class FoundationFormRequestTest extends TestCase
         $request = $class::create('/', 'GET', $payload);
 
         return $request->setRedirector($this->createMockRedirector($request))
-            ->setContainer($container);
+                       ->setContainer($container);
     }
 
     /**
@@ -284,7 +284,7 @@ class FoundationFormRequestTest extends TestCase
     protected function createValidationFactory($container)
     {
         $translator = m::mock(Translator::class)->shouldReceive('get')
-            ->zeroOrMoreTimes()->andReturn('error')->getMock();
+                       ->zeroOrMoreTimes()->andReturn('error')->getMock();
 
         return new ValidationFactory($translator, $container);
     }
@@ -300,13 +300,13 @@ class FoundationFormRequestTest extends TestCase
         $redirector = $this->mocks['redirector'] = m::mock(Redirector::class);
 
         $redirector->shouldReceive('getUrlGenerator')->zeroOrMoreTimes()
-            ->andReturn($generator = $this->createMockUrlGenerator());
+                   ->andReturn($generator = $this->createMockUrlGenerator());
 
         $redirector->shouldReceive('to')->zeroOrMoreTimes()
-            ->andReturn($this->createMockRedirectResponse());
+                   ->andReturn($this->createMockRedirectResponse());
 
         $generator->shouldReceive('previous')->zeroOrMoreTimes()
-            ->andReturn('previous');
+                   ->andReturn('previous');
 
         return $redirector;
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -151,7 +151,8 @@ class FoundationFormRequestTest extends TestCase
 
     public function testAfterMethod()
     {
-        $request = new class extends FormRequest {
+        $request = new class extends FormRequest
+        {
             public $value = 'value-from-request';
 
             public function rules()
@@ -161,7 +162,8 @@ class FoundationFormRequestTest extends TestCase
 
             protected function failedValidation(Validator $validator)
             {
-                throw new class($validator) extends Exception {
+                throw new class($validator) extends Exception
+                {
                     public function __construct(public $validator)
                     {
                         //
@@ -174,7 +176,7 @@ class FoundationFormRequestTest extends TestCase
                 return [
                     new AfterValidationRule($dep->value),
                     new InvokableAfterValidationRule($this->value),
-                    fn($validator) => $validator->errors()->add('closure', 'true'),
+                    fn ($validator) => $validator->errors()->add('closure', 'true'),
                 ];
             }
         };


### PR DESCRIPTION
# What
A way to override how the rules for a form request are retrieved without having to touch the `createDefaultValidator()` function.

# Why?
Maybe you don't want to name your child class' method `rules()`. I don't know why that would be a big deal, but maybe you don't.

For my team, we are reimagining our API design so that multiple user roles can access common endpoints (`/transactions`, `/media`, etc). However, the list transactions endpoint for one user type will have a totally different set of filters than those of another user type. (For instance, admin can search across all user's transactions but filter by sending bank, whereas that option wouldn't be visible for the average user).

```php
class ListTransactionsRequest extends FormRequest
{
    public function rules(): array
    {
        if ($this->user()->role == 'admin') {
            return [
                'sender_bank_id' => ['nullable', 'int'],
                'user_status' => ['nullable', Rule::in(['deliquent', 'active', 'expired'])],
                // ...
            ];
        }
        else if ($this->user()->role == 'payer') {
            return [
                'date' => ['date:Y-m-d'],
                // ...
            ];
        }
        else if ($this->user()->role == 'user') {
            // ...
        }
    }
}
```

We have hundreds of requests in our application, so this pattern is tricky and to be avoided.  For us, it's a lot easier to do something like this:

```php
class ListTransactionsRequest extends FormRequest
{
    protected function getRules(): array
    {
        return match($this->user()->role) {
            'payer' => $this->rulesForPayer(),
            'admin' => $this->rulesForAdmin(),
            // ...
        }
    }

    private function ruleForPayer()
    {
        return [
            'date' => ['date:Y-m-d'],
            // ...
        ];
    }
}
```

# Potential Side Effects
Most common users, this should have no impact. The only place where it might be a problem is if a user has a child class (extending from `FormRequest`) which has its own `getRules()` method on it prior to this change.