### PR TITLE
[11.x] Improves `make:test` command

### DIFF
--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -14,7 +14,7 @@ trait CreatesMatchingTest
      */
     protected function addTestOptions()
     {
-        foreach (['test' => 'PHPUnit', 'pest' => 'Pest'] as $option => $name) {
+        foreach (['test' => 'Test', 'pest' => 'Pest', 'phpunit' => 'PHPUnit'] as $option => $name) {
             $this->getDefinition()->addOption(new InputOption(
                 $option,
                 null,
@@ -32,13 +32,14 @@ trait CreatesMatchingTest
      */
     protected function handleTestCreation($path)
     {
-        if (! $this->option('test') && ! $this->option('pest')) {
+        if (! $this->option('test') && ! $this->option('pest') && ! $this->option('phpunit')) {
             return false;
         }
 
         return $this->callSilent('make:test', [
             'name' => Str::of($path)->after($this->laravel['path'])->beforeLast('.php')->append('Test')->replace('\\', '/'),
             '--pest' => $this->option('pest'),
+            '--phpunit' => $this->option('phpunit'),
         ]) == 0;
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -151,7 +151,7 @@ class TestMakeCommand extends GeneratorCommand
         }
 
         return $this->option('pest') || (
-            function_exists('\Pest\\version') && file_exists(base_path('tests') . '/Pest.php')
+            function_exists('\Pest\\version') && file_exists(base_path('tests').'/Pest.php')
         );
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -140,7 +140,7 @@ class TestMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determines if Pest is being used.
+     * Determine if Pest is being used by the application.
      *
      * @return bool
      */
@@ -150,8 +150,8 @@ class TestMakeCommand extends GeneratorCommand
             return false;
         }
 
-        return $this->option('pest') || (
-            function_exists('\Pest\\version') && file_exists(base_path('tests').'/Pest.php')
-        );
+        return $this->option('pest') ||
+            (function_exists('\Pest\\version') &&
+             file_exists(base_path('tests').'/Pest.php'));
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -44,7 +44,7 @@ class TestMakeCommand extends GeneratorCommand
     {
         $suffix = $this->option('unit') ? '.unit.stub' : '.stub';
 
-        return $this->option('pest')
+        return $this->usingPest()
             ? $this->resolveStubPath('/stubs/pest'.$suffix)
             : $this->resolveStubPath('/stubs/test'.$suffix);
     }
@@ -108,9 +108,10 @@ class TestMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the test already exists'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the test even if the test already exists'],
             ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test'],
-            ['pest', 'p', InputOption::VALUE_NONE, 'Create a Pest test'],
+            ['pest', null, InputOption::VALUE_NONE, 'Create a Pest test'],
+            ['phpunit', null, InputOption::VALUE_NONE, 'Create a PHPUnit test'],
         ];
     }
 
@@ -128,17 +129,29 @@ class TestMakeCommand extends GeneratorCommand
         }
 
         $type = select('Which type of test would you like?', [
-            'feature' => 'Feature (PHPUnit)',
-            'unit' => 'Unit (PHPUnit)',
-            'pest-feature' => 'Feature (Pest)',
-            'pest-unit' => 'Unit (Pest)',
+            'feature' => 'Feature',
+            'unit' => 'Unit',
         ]);
 
         match ($type) {
             'feature' => null,
             'unit' => $input->setOption('unit', true),
-            'pest-feature' => $input->setOption('pest', true),
-            'pest-unit' => tap($input)->setOption('pest', true)->setOption('unit', true),
         };
+    }
+
+    /**
+     * Determines if Pest is being used.
+     *
+     * @return bool
+     */
+    protected function usingPest()
+    {
+        if ($this->option('phpunit')) {
+            return false;
+        }
+
+        return $this->option('pest') || (
+            function_exists('\Pest\\version') && file_exists(base_path('tests') . '/Pest.php')
+        );
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -220,7 +220,7 @@ class ViewMakeCommand extends GeneratorCommand
         }
 
         return $this->option('pest') || (
-            function_exists('\Pest\\version') && file_exists(base_path('tests') . '/Pest.php')
+            function_exists('\Pest\\version') && file_exists(base_path('tests').'/Pest.php')
         );
     }
 

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -209,22 +209,6 @@ class ViewMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determines if Pest is being used.
-     *
-     * @return bool
-     */
-    protected function usingPest()
-    {
-        if ($this->option('phpunit')) {
-            return false;
-        }
-
-        return $this->option('pest') || (
-            function_exists('\Pest\\version') && file_exists(base_path('tests').'/Pest.php')
-        );
-    }
-
-    /**
      * Get the view name for the test.
      *
      * @return string
@@ -235,6 +219,22 @@ class ViewMakeCommand extends GeneratorCommand
             ->replace('/', '.')
             ->lower()
             ->value();
+    }
+
+    /**
+     * Determine if Pest is being used by the application.
+     *
+     * @return bool
+     */
+    protected function usingPest()
+    {
+        if ($this->option('phpunit')) {
+            return false;
+        }
+
+        return $this->option('pest') ||
+            (function_exists('\Pest\\version') &&
+             file_exists(base_path('tests').'/Pest.php'));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -130,7 +130,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function handleTestCreation($path): bool
     {
-        if (! $this->option('test') && ! $this->option('pest')) {
+        if (! $this->option('test') && ! $this->option('pest') && ! $this->option('phpunit')) {
             return false;
         }
 
@@ -201,11 +201,27 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getTestStub()
     {
-        $stubName = 'view.'.($this->option('pest') ? 'pest' : 'test').'.stub';
+        $stubName = 'view.'.($this->usingPest() ? 'pest' : 'test').'.stub';
 
         return file_exists($customPath = $this->laravel->basePath("stubs/$stubName"))
             ? $customPath
             : __DIR__.'/stubs/'.$stubName;
+    }
+
+    /**
+     * Determines if Pest is being used.
+     *
+     * @return bool
+     */
+    protected function usingPest()
+    {
+        if ($this->option('phpunit')) {
+            return false;
+        }
+
+        return $this->option('pest') || (
+            function_exists('\Pest\\version') && file_exists(base_path('tests') . '/Pest.php')
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the `make:test` command and the "CreatesMatchingTest.php" trait by detecting the underlying testing framework during stub selection.

It also adds a `--phpunit` option, alongside the existing `--pest`, for those who wish to explicitly create a PHPUnit test.