### PR TITLE
[10.x] Fix redis tag entries never becoming stale if cache ttl is past time

### DIFF
--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -11,13 +11,13 @@ class RedisTagSet extends TagSet
      * Add a reference entry to the tag set's underlying sorted set.
      *
      * @param  string  $key
-     * @param  int  $ttl
+     * @param  int|null  $ttl
      * @param  string  $updateWhen
      * @return void
      */
-    public function addEntry(string $key, int $ttl = 0, $updateWhen = null)
+    public function addEntry(string $key, int $ttl = null, $updateWhen = null)
     {
-        $ttl = $ttl > 0 ? Carbon::now()->addSeconds($ttl)->getTimestamp() : -1;
+        $ttl = is_null($ttl) ? -1 : Carbon::now()->addSeconds($ttl)->getTimestamp();
 
         foreach ($this->tagIds() as $tagKey) {
             if ($updateWhen) {

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -14,9 +14,19 @@ class RedisTaggedCache extends TaggedCache
      */
     public function add($key, $value, $ttl = null)
     {
+        $seconds = null;
+
+        if ($ttl !== null) {
+            $seconds = $this->getSeconds($ttl);
+
+            if ($seconds <= 0) {
+                return false;
+            }
+        }
+
         $this->tags->addEntry(
             $this->itemKey($key),
-            ! is_null($ttl) ? $this->getSeconds($ttl) : 0
+            $seconds
         );
 
         return parent::add($key, $value, $ttl);
@@ -36,9 +46,15 @@ class RedisTaggedCache extends TaggedCache
             return $this->forever($key, $value);
         }
 
+        $seconds = $this->getSeconds($ttl);
+
+        if ($seconds <= 0) {
+            return false;
+        }
+
         $this->tags->addEntry(
             $this->itemKey($key),
-            $this->getSeconds($ttl)
+            $seconds
         );
 
         return parent::put($key, $value, $ttl);

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use DateTime;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
@@ -133,6 +134,27 @@ class RedisStoreTest extends TestCase
 
         sleep(2);
 
+        Cache::store('redis')->tags(['votes'])->flushStale();
+
+        $keyCount = Cache::store('redis')->connection()->keys('*');
+        $this->assertEquals(0, count($keyCount));
+    }
+
+    public function testPastTtlTagEntriesAreNotAdded()
+    {
+        Cache::store('redis')->clear();
+
+        Cache::store('redis')->tags(['votes'])->add('person-1', 0, new DateTime('yesterday'));
+
+        $keyCount = Cache::store('redis')->connection()->keys('*');
+        $this->assertEquals(0, count($keyCount));
+    }
+
+    public function testPutPastTtlTagEntriesProperlyTurnStale()
+    {
+        Cache::store('redis')->clear();
+
+        Cache::store('redis')->tags(['votes'])->put('person-1', 0, new DateTime('yesterday'));
         Cache::store('redis')->tags(['votes'])->flushStale();
 
         $keyCount = Cache::store('redis')->connection()->keys('*');


### PR DESCRIPTION
With the new redis tags implementation, setting a cache value with a TTL that is in the past resulted in tag entries getting a score of `-1`, thus never being considered stale.

This was because `getSeconds()` returns `0` when given a date in the past and `tags->addEntry()` assumed "forever" when it was passed a TTL of `0`.

This PR fixes that issue for the `add` and `put` methods of `RedisTaggedCache`:

1. For `add()`, when the time is in the past, we simply return early with a `false` (same strategy as parent class)
2. For `put()`, we allow any existing entry to get updated, but the entry will have a score of the current timestamp so it will get cleaned up the next time `flushStale()` is called.