### PR TITLE
[10.x] Allow variable number of arguments for Mockery helpers

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Closure;
 use Illuminate\Foundation\Mix;
 use Illuminate\Foundation\Vite;
 use Illuminate\Support\Facades\Facade;
@@ -55,10 +54,10 @@ trait InteractsWithContainer
      * Mock an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure|null  $mock
+     * @param  mixed  ...$args
      * @return \Mockery\MockInterface
      */
-    protected function mock($abstract, Closure $mock = null)
+    protected function mock($abstract, ...$args)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
@@ -67,10 +66,10 @@ trait InteractsWithContainer
      * Mock a partial instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure|null  $mock
+     * @param  mixed  ...$args
      * @return \Mockery\MockInterface
      */
-    protected function partialMock($abstract, Closure $mock = null)
+    protected function partialMock($abstract, ...$args)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }
@@ -79,10 +78,10 @@ trait InteractsWithContainer
      * Spy an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure|null  $mock
+     * @param  mixed  ...$args
      * @return \Mockery\MockInterface
      */
-    protected function spy($abstract, Closure $mock = null)
+    protected function spy($abstract, ...$args)
     {
         return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -85,10 +85,50 @@ class InteractsWithContainerTest extends TestCase
         $this->forgetMock(InstanceStub::class);
         $this->assertSame('foo', $this->app->make(InstanceStub::class)->execute());
     }
+
+    public function testMock()
+    {
+        $this->mock(InstanceStub::class, function (MockInterface $mock) {
+            $mock->shouldReceive('execute')
+                ->once()
+                ->andReturn('bar');
+        });
+        $this->assertSame('bar', $this->app->make(InstanceStub::class)->execute());
+        $this->assertNull($this->app->make(InstanceStub::class)->property);
+
+        $this->mock(InstanceStub::class)
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturn('baz');
+        $this->assertSame('baz', $this->app->make(InstanceStub::class)->execute());
+        $this->assertNull($this->app->make(InstanceStub::class)->property);
+
+        $this->mock(InstanceStub::class, ['bar'], function (MockInterface $mock) {
+            $mock->shouldReceive('execute')
+                ->once()
+                ->andReturn('bar');
+        });
+        $this->assertSame('bar', $this->app->make(InstanceStub::class)->execute());
+        $this->assertSame('bar', $this->app->make(InstanceStub::class)->property);
+
+        $this->mock(InstanceStub::class, ['baz'])
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturn('baz');
+        $this->assertSame('baz', $this->app->make(InstanceStub::class)->execute());
+        $this->assertSame('baz', $this->app->make(InstanceStub::class)->property);
+    }
 }
 
 class InstanceStub
 {
+    public ?string $property = null;
+
+    public function __construct($param = 'foo')
+    {
+        $this->property = $param;
+    }
+
     public function execute()
     {
         return 'foo';


### PR DESCRIPTION
This PR changes the function signature for the Laravel Mock helpers and adds tests for the mock function.

Currently the Laravel wrapper only accepts exactly 2 arguments, of which the last must always be a Closure.
That Feature (supplying a Closure to the Mockery::mock call) isn't even documented in the official Mockery docs, but other possible arguments, such as supplying arguments for the Mocked Classes constructor are documented.

The underlying Mockery function accepts a single variadic argument (aka an arbitrary number of arguments) and I'd like to change the Laravel helper to mimic that underlying functionality as well.

Strange enough, the implementation of the Laravel wrapper is already set up to handle more than just two arguments, so only the signature needs to change.

This change is fully backwards compatible as the case for passing only 1 or 2 arguments to the function with the second one being a Closure is just a subset of the new signature.

I've added a new TestCase modeled after the one for `forgetMock` and extended the Stub class used in that TestCase to demonstrate that a) this change works as intended and b) the old behavior is unchanged.

Apparently I'm not the only one who never uses the Closure anyway as the only other test for the Mockery wrapper didn't make use of it either, so I added tests for both calling the wrapper with and without a Closure.