### PR TITLE
[10.x] Add mapToInstance() to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -810,6 +810,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Resolves class names contained in collection to an instance using service container.
+     *
+     * @return $this|Collection<class-string>
+     */
+    public function mapToInstance(?array $parameters = [])
+    {
+        return $this->map(fn($class) => app($class, $parameters));
+    }
+
+    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -816,7 +816,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function mapToInstance(?array $parameters = [])
     {
-        return $this->map(fn($class) => app($class, $parameters));
+        return $this->map(fn ($class) => app($class, $parameters));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -809,6 +809,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Resolves class names contained in collection to an instance using service container.
+     *
+     * @return $this|Collection<class-string>
+     */
+    public function mapToInstance(?array $parameters = [])
+    {
+        return $this->passthru('mapToInstance', func_get_args());
+    }
+
+    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use ArrayObject;
 use CachingIterator;
 use Exception;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3163,6 +3163,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMapToInstance($collection)
+    {
+        $data = new $collection([
+            Container::class,
+        ]);
+
+        $data = $data->mapToInstance();
+
+        $this->assertInstanceOf(Container::class, $data->first());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMapWithKeysIntegerKeys($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
A new Collection class `mapToInstance()` helps you to deal with class strings within a collection. It maps them into concrete classes using service container.

```php
$jobs = [
        Job\One::class,
        Job\Two::class,
        Job\Three::class,
];

// Before
collect($elements)->map(fn(string $class) => App::make($class))->each->run();

// Now
collect($elements)->mapToInstance()->each->run();
```

A collection already has support to filter by class names with `whereInstanceOf()`, so this appears to be a consequent extension.