### PR TITLE
[10.x] fix Before/After validation rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -253,13 +253,13 @@ trait ValidatesAttributes
         }
 
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
-            $secondValue = $this->getValue($parameters[0]);
+            $comparedValue = $this->getValue($parameters[0]);
 
-            if (! is_string($secondValue) && ! is_numeric($secondValue) && ! $secondValue instanceof DateTimeInterface) {
+            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
                 return false;
             }
 
-            $date = $this->getDateTimestamp($secondValue);
+            $date = $this->getDateTimestamp($comparedValue);
         }
 
         return $this->compare($this->getDateTimestamp($value), $date, $operator);

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -253,7 +253,13 @@ trait ValidatesAttributes
         }
 
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
-            $date = $this->getDateTimestamp($this->getValue($parameters[0]));
+            $secondValue = $this->getValue($parameters[0]);
+
+            if (! is_string($secondValue) && ! is_numeric($secondValue) && ! $secondValue instanceof DateTimeInterface) {
+                return false;
+            }
+
+            $date = $this->getDateTimestamp($secondValue);
         }
 
         return $this->compare($this->getDateTimestamp($value), $date, $operator);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5980,6 +5980,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '0001-01-01T00:00'], ['x' => 'after:1970-01-01']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|after:x']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
+        $this->assertTrue($v->fails());
     }
 
     public function testBeforeAndAfterWithFormat()


### PR DESCRIPTION
fixing https://github.com/laravel/framework/issues/49863

added test cases to make sure it is fixed
```php
$v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|after:x']);
$this->assertTrue($v->fails());

$v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
$this->assertTrue($v->fails());
```
