### PR TITLE
[10.x] add addGlobalScopes method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -34,6 +34,23 @@ trait HasGlobalScopes
     }
 
     /**
+     * Register multiple global scopes on the model.
+     *
+     * @param  array  $scopes
+     * @return void
+     */
+    public static function addGlobalScopes(array $scopes)
+    {
+        foreach ($scopes as $key => $scope) {
+            if (is_string($key)) {
+                static::addGlobalScope($key, $scope);
+            } else {
+                static::addGlobalScope($scope);
+            }
+        }
+    }
+
+    /**
      * Determine if a model has a global scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -59,6 +59,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
+    public function testGlobalScopesCanBeRegisteredViaArray()
+    {
+        $model = new EloquentGlobalScopesArrayTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testClosureGlobalScopeCanBeRemoved()
     {
         $model = new EloquentClosureGlobalScopesTestModel;
@@ -205,6 +213,21 @@ class EloquentClassNameGlobalScopesTestModel extends Model
     public static function boot()
     {
         static::addGlobalScope(ActiveScope::class);
+
+        parent::boot();
+    }
+}
+
+class EloquentGlobalScopesArrayTestModel extends Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScopes([
+            'active_scope' => new ActiveScope,
+            fn ($query) => $query->orderBy('name'),
+        ]);
 
         parent::boot();
     }


### PR DESCRIPTION
This PR adds a method `addGlobalScopes` which lets you register several global scopes all at once.

Example:

```php
  /**
   * The "booted" method of the model.
   */
  protected static function booted(): void
  {
      static::addGlobalScopes([FirstScope::class, SecondScope::class]);
  }
```

It's also possible to use custom keys and/or pass in closures as the scope just like the `addGlobalScope` method.