### PR TITLE
[10.x] Allow brick/math 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.9.3|^0.10.2|^0.11",
+        "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.3.2",
         "egulias/email-validator": "^3.2.1|^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.1",
         "ext-pdo": "*",
-        "brick/math": "^0.9.3|^0.10.2|^0.11",
+        "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
         "illuminate/collections": "^10.0",
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -1,55 +1,60 @@
 {
-    "name": "illuminate/database",
-    "description": "The Illuminate Database package.",
-    "license": "MIT",
-    "homepage": "https://laravel.com",
-    "support": {
-        "issues": "https://github.com/laravel/framework/issues",
-        "source": "https://github.com/laravel/framework"
-    },
-    "keywords": ["laravel", "database", "sql", "orm"],
-    "authors": [
-        {
-            "name": "Taylor Otwell",
-            "email": "taylor@laravel.com"
-        }
-    ],
-    "require": {
-        "php": "^8.1",
-        "ext-pdo": "*",
-        "brick/math": "^0.9.3|^0.10.2|^0.11",
-        "illuminate/collections": "^10.0",
-        "illuminate/container": "^10.0",
-        "illuminate/contracts": "^10.0",
-        "illuminate/macroable": "^10.0",
-        "illuminate/support": "^10.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Illuminate\\Database\\": ""
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "10.x-dev"
-        }
-    },
-    "conflict": {
-        "carbonphp/carbon-doctrine-types": ">=3.0",
-        "doctrine/dbal": ">=4.0"
-    },
-    "suggest": {
-        "ext-filter": "Required to use the Postgres database driver.",
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
-        "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
-        "illuminate/console": "Required to use the database commands (^10.0).",
-        "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
-        "illuminate/filesystem": "Required to use the migrations (^10.0).",
-        "illuminate/pagination": "Required to paginate the result set (^10.0).",
-        "symfony/finder": "Required to use Eloquent model factories (^6.2)."
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev"
+  "name": "illuminate/database",
+  "description": "The Illuminate Database package.",
+  "license": "MIT",
+  "homepage": "https://laravel.com",
+  "support": {
+    "issues": "https://github.com/laravel/framework/issues",
+    "source": "https://github.com/laravel/framework"
+  },
+  "keywords": [
+    "laravel",
+    "database",
+    "sql",
+    "orm"
+  ],
+  "authors": [
+    {
+      "name": "Taylor Otwell",
+      "email": "taylor@laravel.com"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "ext-pdo": "*",
+    "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
+    "illuminate/collections": "^10.0",
+    "illuminate/container": "^10.0",
+    "illuminate/contracts": "^10.0",
+    "illuminate/macroable": "^10.0",
+    "illuminate/support": "^10.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Illuminate\\Database\\": ""
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "10.x-dev"
+    }
+  },
+  "conflict": {
+    "carbonphp/carbon-doctrine-types": ">=3.0",
+    "doctrine/dbal": ">=4.0"
+  },
+  "suggest": {
+    "ext-filter": "Required to use the Postgres database driver.",
+    "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
+    "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
+    "illuminate/console": "Required to use the database commands (^10.0).",
+    "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
+    "illuminate/filesystem": "Required to use the migrations (^10.0).",
+    "illuminate/pagination": "Required to paginate the result set (^10.0).",
+    "symfony/finder": "Required to use Eloquent model factories (^6.2)."
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "minimum-stability": "dev"
 }

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -1,60 +1,55 @@
 {
-  "name": "illuminate/database",
-  "description": "The Illuminate Database package.",
-  "license": "MIT",
-  "homepage": "https://laravel.com",
-  "support": {
-    "issues": "https://github.com/laravel/framework/issues",
-    "source": "https://github.com/laravel/framework"
-  },
-  "keywords": [
-    "laravel",
-    "database",
-    "sql",
-    "orm"
-  ],
-  "authors": [
-    {
-      "name": "Taylor Otwell",
-      "email": "taylor@laravel.com"
-    }
-  ],
-  "require": {
-    "php": "^8.1",
-    "ext-pdo": "*",
-    "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
-    "illuminate/collections": "^10.0",
-    "illuminate/container": "^10.0",
-    "illuminate/contracts": "^10.0",
-    "illuminate/macroable": "^10.0",
-    "illuminate/support": "^10.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Illuminate\\Database\\": ""
-    }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "10.x-dev"
-    }
-  },
-  "conflict": {
-    "carbonphp/carbon-doctrine-types": ">=3.0",
-    "doctrine/dbal": ">=4.0"
-  },
-  "suggest": {
-    "ext-filter": "Required to use the Postgres database driver.",
-    "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
-    "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
-    "illuminate/console": "Required to use the database commands (^10.0).",
-    "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
-    "illuminate/filesystem": "Required to use the migrations (^10.0).",
-    "illuminate/pagination": "Required to paginate the result set (^10.0).",
-    "symfony/finder": "Required to use Eloquent model factories (^6.2)."
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "minimum-stability": "dev"
+    "name": "illuminate/database",
+    "description": "The Illuminate Database package.",
+    "license": "MIT",
+    "homepage": "https://laravel.com",
+    "support": {
+        "issues": "https://github.com/laravel/framework/issues",
+        "source": "https://github.com/laravel/framework"
+    },
+    "keywords": ["laravel", "database", "sql", "orm"],
+    "authors": [
+        {
+            "name": "Taylor Otwell",
+            "email": "taylor@laravel.com"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "ext-pdo": "*",
+        "brick/math": "^0.9.3|^0.10.2|^0.11",
+        "illuminate/collections": "^10.0",
+        "illuminate/container": "^10.0",
+        "illuminate/contracts": "^10.0",
+        "illuminate/macroable": "^10.0",
+        "illuminate/support": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Illuminate\\Database\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "10.x-dev"
+        }
+    },
+    "conflict": {
+        "carbonphp/carbon-doctrine-types": ">=3.0",
+        "doctrine/dbal": ">=4.0"
+    },
+    "suggest": {
+        "ext-filter": "Required to use the Postgres database driver.",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
+        "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
+        "illuminate/console": "Required to use the database commands (^10.0).",
+        "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
+        "illuminate/filesystem": "Required to use the migrations (^10.0).",
+        "illuminate/pagination": "Required to paginate the result set (^10.0).",
+        "symfony/finder": "Required to use Eloquent model factories (^6.2)."
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.1",
         "ext-filter": "*",
         "ext-mbstring": "*",
-        "brick/math": "^0.9.3|^0.10.2|^0.11",
+        "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
         "egulias/email-validator": "^3.2.5|^4.0",
         "illuminate/collections": "^10.0",
         "illuminate/container": "^10.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -1,48 +1,48 @@
 {
-  "name": "illuminate/validation",
-  "description": "The Illuminate Validation package.",
-  "license": "MIT",
-  "homepage": "https://laravel.com",
-  "support": {
-    "issues": "https://github.com/laravel/framework/issues",
-    "source": "https://github.com/laravel/framework"
-  },
-  "authors": [
-    {
-      "name": "Taylor Otwell",
-      "email": "taylor@laravel.com"
-    }
-  ],
-  "require": {
-    "php": "^8.1",
-    "ext-filter": "*",
-    "ext-mbstring": "*",
-    "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
-    "egulias/email-validator": "^3.2.5|^4.0",
-    "illuminate/collections": "^10.0",
-    "illuminate/container": "^10.0",
-    "illuminate/contracts": "^10.0",
-    "illuminate/macroable": "^10.0",
-    "illuminate/support": "^10.0",
-    "illuminate/translation": "^10.0",
-    "symfony/http-foundation": "^6.4",
-    "symfony/mime": "^6.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "Illuminate\\Validation\\": ""
-    }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "10.x-dev"
-    }
-  },
-  "suggest": {
-    "illuminate/database": "Required to use the database presence verifier (^10.0)."
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "minimum-stability": "dev"
+    "name": "illuminate/validation",
+    "description": "The Illuminate Validation package.",
+    "license": "MIT",
+    "homepage": "https://laravel.com",
+    "support": {
+        "issues": "https://github.com/laravel/framework/issues",
+        "source": "https://github.com/laravel/framework"
+    },
+    "authors": [
+        {
+            "name": "Taylor Otwell",
+            "email": "taylor@laravel.com"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "ext-filter": "*",
+        "ext-mbstring": "*",
+        "brick/math": "^0.9.3|^0.10.2|^0.11",
+        "egulias/email-validator": "^3.2.5|^4.0",
+        "illuminate/collections": "^10.0",
+        "illuminate/container": "^10.0",
+        "illuminate/contracts": "^10.0",
+        "illuminate/macroable": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/translation": "^10.0",
+        "symfony/http-foundation": "^6.4",
+        "symfony/mime": "^6.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Illuminate\\Validation\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "10.x-dev"
+        }
+    },
+    "suggest": {
+        "illuminate/database": "Required to use the database presence verifier (^10.0)."
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -1,48 +1,48 @@
 {
-    "name": "illuminate/validation",
-    "description": "The Illuminate Validation package.",
-    "license": "MIT",
-    "homepage": "https://laravel.com",
-    "support": {
-        "issues": "https://github.com/laravel/framework/issues",
-        "source": "https://github.com/laravel/framework"
-    },
-    "authors": [
-        {
-            "name": "Taylor Otwell",
-            "email": "taylor@laravel.com"
-        }
-    ],
-    "require": {
-        "php": "^8.1",
-        "ext-filter": "*",
-        "ext-mbstring": "*",
-        "brick/math": "^0.9.3|^0.10.2|^0.11",
-        "egulias/email-validator": "^3.2.5|^4.0",
-        "illuminate/collections": "^10.0",
-        "illuminate/container": "^10.0",
-        "illuminate/contracts": "^10.0",
-        "illuminate/macroable": "^10.0",
-        "illuminate/support": "^10.0",
-        "illuminate/translation": "^10.0",
-        "symfony/http-foundation": "^6.4",
-        "symfony/mime": "^6.2"
-    },
-    "autoload": {
-        "psr-4": {
-            "Illuminate\\Validation\\": ""
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "10.x-dev"
-        }
-    },
-    "suggest": {
-        "illuminate/database": "Required to use the database presence verifier (^10.0)."
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "minimum-stability": "dev"
+  "name": "illuminate/validation",
+  "description": "The Illuminate Validation package.",
+  "license": "MIT",
+  "homepage": "https://laravel.com",
+  "support": {
+    "issues": "https://github.com/laravel/framework/issues",
+    "source": "https://github.com/laravel/framework"
+  },
+  "authors": [
+    {
+      "name": "Taylor Otwell",
+      "email": "taylor@laravel.com"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "ext-filter": "*",
+    "ext-mbstring": "*",
+    "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
+    "egulias/email-validator": "^3.2.5|^4.0",
+    "illuminate/collections": "^10.0",
+    "illuminate/container": "^10.0",
+    "illuminate/contracts": "^10.0",
+    "illuminate/macroable": "^10.0",
+    "illuminate/support": "^10.0",
+    "illuminate/translation": "^10.0",
+    "symfony/http-foundation": "^6.4",
+    "symfony/mime": "^6.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "Illuminate\\Validation\\": ""
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "10.x-dev"
+    }
+  },
+  "suggest": {
+    "illuminate/database": "Required to use the database presence verifier (^10.0)."
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "minimum-stability": "dev"
 }


### PR DESCRIPTION
Allows brick/math version 0.12 besides version 0.9.3, 0.10, and 0.11

See https://github.com/brick/math/releases/tag/0.12.0
Doesn't seem to contain breaking changes for Laravel. 

Followed in https://github.com/laravel/framework/pull/45762 footsteps. 