### PR TITLE
[10.x] Add `dispatchMany` to Bus facade

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -74,8 +74,21 @@ class Dispatcher implements QueueingDispatcher
     public function dispatch($command)
     {
         return $this->queueResolver && $this->commandShouldBeQueued($command)
-                        ? $this->dispatchToQueue($command)
-                        : $this->dispatchNow($command);
+            ? $this->dispatchToQueue($command)
+            : $this->dispatchNow($command);
+    }
+
+    /**
+     * Dispatch multiple commands to their appropriate handler.
+     *
+     * @param  iterable  $commands
+     * @return mixed
+     */
+    public function dispatchMany(iterable $commands)
+    {
+        foreach ($commands as $command) {
+            $this->dispatch($command);
+        }
     }
 
     /**

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -33,6 +33,22 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(m::mock(ShouldQueue::class));
     }
 
+    public function testMultipleCommandsThatShouldQueueAreQueued()
+    {
+        $container = new Container;
+        $dispatcher = new Dispatcher($container, function () {
+            $mock = m::mock(Queue::class);
+            $mock->shouldReceive('push')->twice();
+
+            return $mock;
+        });
+
+        $dispatcher->dispatchMany([
+            m::mock(ShouldQueue::class),
+            m::mock(ShouldQueue::class),
+        ]);
+    }
+
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
     {
         $container = new Container;


### PR DESCRIPTION
I often find myself having to dispatch jobs that I don't need to chain or batch.

```php
// Before
foreach($jobs as $job){
    Bus::dispatch($job);
}

// After
Bus::dispatchMany($jobs);
```