### PR TITLE
Adjust Eloquent Builder __call to return the result of the forwardCallTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1969,9 +1969,7 @@ class Builder implements BuilderContract
             return $this->toBase()->{$method}(...$parameters);
         }
 
-        $this->forwardCallTo($this->query, $method, $parameters);
-
-        return $this;
+        return $this->forwardCallTo($this->query, $method, $parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1969,7 +1969,12 @@ class Builder implements BuilderContract
             return $this->toBase()->{$method}(...$parameters);
         }
 
-        return $this->forwardCallTo($this->query, $method, $parameters);
+        $result = $this->forwardCallTo($this->query, $method, $parameters);
+        if($result === $this->query) {
+            return $this;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2268,6 +2268,20 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select 1', $builder->toRawSQL());
     }
 
+    public function testPassthruMethodsCallsReturnsTheResultOfTheForwardedCall(){
+        $query = m::mock(BaseBuilder::class);
+
+        $mockResponse = 1;
+        $query
+            ->shouldReceive('getCountForPagination')
+            ->andReturn($mockResponse)
+            ->once();
+
+        $builder = new Builder($query);
+
+        $this->assertSame(1, $builder->getCountForPagination());
+    }
+
     public function testPassthruArrayElementsMustAllBeLowercase()
     {
         $builder = new class(m::mock(BaseBuilder::class)) extends Builder


### PR DESCRIPTION
The Eloquent builder `__call` method forwards a call to the Base builder. The problem is that the result of the forwarded call is ignored. This PR fixes that by returning the value of `forwardCallTo`.