### PR TITLE
[10.x] Using the native fopen exception in LockableFile.php

### DIFF
--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Filesystem;
 
-use Exception;
 use Illuminate\Contracts\Filesystem\LockTimeoutException;
 
 class LockableFile

--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -67,11 +67,7 @@ class LockableFile
      */
     protected function createResource($path, $mode)
     {
-        $this->handle = @fopen($path, $mode);
-
-        if (! $this->handle) {
-            throw new Exception('Unable to create lockable file: '.$path.'. Please ensure you have permission to create files in this location.');
-        }
+        $this->handle = fopen($path, $mode);
     }
 
     /**


### PR DESCRIPTION
I am currently getting this error some times:

> [2024-01-29T09:14:01+01:00] production.ERROR: Unable to create lockable file: /app/storage/framework/cache/data/e7/da/e7da1512baf3c3cf089e9ae9a65970e0b433ec82. Please ensure you have permission to create files in this location. {"exception":"[object] (Exception(code: 0): Unable to create lockable file: /app/storage/framework/cache/data/e7/da/e7da1512baf3c3cf089e9ae9a65970e0b433ec82. Please ensure you have permission to create files in this location. at /app/vendor/laravel/framework/src/Illuminate/Filesystem/LockableFile.php:73)

The directory where that lock file should be generated is a network directory that is always available, but the file generation fails, and I have no idea what the problem is, as I have validated and checked that it is correct, and it only fails sometimes.

The solution could be to not catch the error in the fopen and let it throw the native exception on failure instead of manually generating a generic exception without the original error.

This will allow to trace detailed errors in the file creation.