### PR TITLE
[11.x] Fix modifying columns with default value and other minor schema enhancements

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -116,7 +116,7 @@ class MySqlGrammar extends Grammar
      */
     public function useLegacyGroupLimit(Builder $query)
     {
-        $version = $query->getConnection()->getReadPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $version = $query->getConnection()->getServerVersion();
 
         return ! $query->getConnection()->isMaria() && version_compare($version, '8.0.11') < 0;
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
-use PDO;
 
 class MySqlGrammar extends Grammar
 {

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use PDO;
 
 class SQLiteGrammar extends Grammar
 {

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -193,7 +193,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function compileGroupLimit(Builder $query)
     {
-        $version = $query->getConnection()->getReadPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $version = $query->getConnection()->getServerVersion();
 
         if (version_compare($version, '3.25.0') >= 0) {
             return parent::compileGroupLimit($query);

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Fluent;
  * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
- * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
+ * @method $this collation(string $collation) Specify a collation for the column
  * @method $this comment(string $comment) Add a comment to the column (MySQL/PostgreSQL)
  * @method $this default(mixed $value) Specify a "default" value for the column
  * @method $this first() Place the column "first" in the table (MySQL)

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -327,7 +327,9 @@ class MySqlGrammar extends Grammar
                     default => $column['type_name'],
                 },
                 'nullable' => $column['nullable'],
-                'default' => $column['default'],
+                'default' => $column['default'] && str_starts_with(strtolower($column['default']), 'current_timestamp')
+                    ? new Expression($column['default'])
+                    : $column['default'],
                 'autoIncrement' => $column['auto_increment'],
                 'collation' => $column['collation'],
                 'comment' => $column['comment'],

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1039,7 +1039,11 @@ class MySqlGrammar extends Grammar
 
         return sprintf('%s%s',
             $subtype ?? 'geometry',
-            $column->srid ? ' srid '.$column->srid : ''
+            match (true) {
+                $column->srid && $this->connection?->isMaria() => ' ref_system_id='.$column->srid,
+                (bool) $column->srid => ' srid '.$column->srid,
+                default => '',
+            }
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -264,7 +264,7 @@ class SQLiteGrammar extends Grammar
                             'change' => true,
                             'type' => $column['type_name'],
                             'nullable' => $column['nullable'],
-                            'default' => $column['default'],
+                            'default' => $column['default'] ? new Expression($column['default']) : null,
                             'autoIncrement' => $column['auto_increment'],
                             'collation' => $column['collation'],
                             'comment' => $column['comment'],

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -83,7 +83,7 @@ trait DatabaseTruncation
 
         $connection->unsetEventDispatcher();
 
-        collect(static::$allTables[$name] ??= array_column($connection->getSchemaBuilder()->getTables(), 'name'))
+        collect(static::$allTables[$name] ??= $connection->getSchemaBuilder()->getTableListing())
             ->when(
                 property_exists($this, 'tablesToTruncate'),
                 fn ($tables) => $tables->intersect($this->tablesToTruncate),

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -111,6 +111,26 @@ class SchemaBuilderTest extends DatabaseTestCase
         }
     }
 
+    public function testRenameColumnWithDefault()
+    {
+        Schema::create('test', static function (Blueprint $table) {
+            $table->timestamp('foo')->useCurrent();
+            $table->string('bar')->default('value');
+        });
+
+        $columns = Schema::getColumns('test');
+        $defaultFoo = collect($columns)->firstWhere('name', 'foo')['default'];
+        $defaultBar = collect($columns)->firstWhere('name', 'bar')['default'];
+
+        Schema::table('test', static function (Blueprint $table) {
+            $table->renameColumn('foo', 'new_foo');
+            $table->renameColumn('bar', 'new_bar');
+        });
+
+        $this->assertEquals(collect(Schema::getColumns('test'))->firstWhere('name', 'new_foo')['default'], $defaultFoo);
+        $this->assertEquals(collect(Schema::getColumns('test'))->firstWhere('name', 'new_bar')['default'], $defaultBar);
+    }
+
     public function testGetTables()
     {
         Schema::create('foo', function (Blueprint $table) {


### PR DESCRIPTION
This PR does:

* Fix modifying columns on SQLite when table has a column with default value.
* Fix renaming columns on legacy MySQL and MariaDB when column's default value is an expression (only `current_timestamp` is allowed as expression on MySQL < 8.0.13).
* Add support for specifying SRID for spatial column types on MariaDB ([docs](https://mariadb.com/kb/en/create-table/#ref_system_id)).
* Use `Schema::getTableListing()` on `DatabaseTruncation`.
* Use `Connection::getServerVersion()` to get database version.
* Fix PHPDoc on `ColumnDefinition` for `collation` that also works on SQLite.