### PR TITLE
[11.x] Fixes `dd` when content has empty lines

### DIFF
--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -57,6 +57,8 @@ class CliDumper extends BaseCliDumper
         $this->basePath = $basePath;
         $this->output = $output;
         $this->compiledViewPath = $compiledViewPath;
+        
+        $this->setColors($this->supportsColors());
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -57,7 +57,7 @@ class CliDumper extends BaseCliDumper
         $this->basePath = $basePath;
         $this->output = $output;
         $this->compiledViewPath = $compiledViewPath;
-        
+
         $this->setColors($this->supportsColors());
     }
 


### PR DESCRIPTION
This pull request fixes the `dd` function error while dumping content with empty lines:

```
dd(PHP_EOL . 'foo' . PHP_EOL); // Typed property Symfony\Component\VarDumper\Dumper\CliDumper::$colors must not be accessed before initialization
``` 