### PR TITLE
[10.x] Fix - The `Translator` may incorrectly report the locale of a missing translation key

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -160,9 +160,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             // the translator was instantiated. Then, we can load the lines and return.
             $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
-            foreach ($locales as $locale) {
+            foreach ($locales as $_locale) {
                 if (! is_null($line = $this->getLine(
-                    $namespace, $group, $locale, $item, $replace
+                    $namespace, $group, $_locale, $item, $replace
                 ))) {
                     return $line;
                 }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -160,9 +160,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             // the translator was instantiated. Then, we can load the lines and return.
             $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
-            foreach ($locales as $_locale) {
+            foreach ($locales as $languageLineLocale) {
                 if (! is_null($line = $this->getLine(
-                    $namespace, $group, $_locale, $item, $replace
+                    $namespace, $group, $languageLineLocale, $item, $replace
                 ))) {
                     return $line;
                 }

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -70,4 +70,17 @@ class TranslatorTest extends TestCase
 
         $this->app['translator']->handleMissingKeysUsing(null);
     }
+
+    public function testItReturnsCorrectLocaleForMissingKeys()
+    {
+        $this->app['translator']->handleMissingKeysUsing(function ($key, $replacements, $locale) {
+            $_SERVER['__missing_translation_key_locale'] = $locale;
+        });
+
+        $this->app['translator']->get('some missing key', [], 'ht');
+
+        $this->assertSame('ht', $_SERVER['__missing_translation_key_locale']);
+
+        $this->app['translator']->handleMissingKeysUsing(null);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When providing a translation key that is missing and specifically specifying the locale, the [Translator](https://github.com/laravel/framework/blob/50c96bdb5e8daf0ef8269e1508dcb870a5e21c16/src/Illuminate/Translation/Translator.php) may report back the wrong locale.

This is due to the `$locale` varaiable name [clashing with a `foreach` loop's inner variable with the same name](https://github.com/laravel/framework/blob/50c96bdb5e8daf0ef8269e1508dcb870a5e21c16/src/Illuminate/Translation/Translator.php#L163-L172).

Examples showcasing the bug:

```php
// Somewhere.php
__('nonexistent', [], 'ht');
```

```php
// app/Providers/AppServiceProvider.php

use Illuminate\Support\Facades\Lang;

class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Lang::handleMissingKeysUsing(
            /**
             * The `$locale` parameter here, instead of being the
             * specified `ht` locale, will either be the default
             * or the fallback locale of the app.
             */
            function (string $key, array $replacements, string $locale, bool $fallback): string {
                Transl::reports()->missingTranslationKeys()->add($key, $replacements, $locale, $fallback);

                return $key;
            }
        );
    }
}
```

I believe the expected and wanted behavior for the `Lang::handleMissingKeysUsing` method is to return the locale that was specified. This PR aims to fix that.
