### PR TITLE
[11.x] Remove base controller if it doesn't exist

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -132,7 +132,7 @@ class ControllerMakeCommand extends GeneratorCommand
         if ($baseControllerExists) {
             $replace["use {$controllerNamespace}\Controller;\n"] = '';
         } else {
-            $replace[" extends Controller"] = '';
+            $replace[' extends Controller'] = '';
             $replace["use {$rootNamespace}Http\Controllers\Controller;\n"] = '';
         }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -110,6 +110,7 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
+        $rootNamespace = $this->rootNamespace();
         $controllerNamespace = $this->getNamespace($name);
 
         $replace = [];
@@ -126,11 +127,20 @@ class ControllerMakeCommand extends GeneratorCommand
             $replace['abort(404);'] = '//';
         }
 
-        $replace["use {$controllerNamespace}\Controller;\n"] = '';
+        $baseControllerExists = class_exists($rootNamespace.'Http\Controllers\Controller');
 
-        return str_replace(
+        if ($baseControllerExists) {
+            $replace["use {$controllerNamespace}\Controller;\n"] = '';
+        } else {
+            $replace[" extends Controller"] = '';
+            $replace["use {$rootNamespace}Http\Controllers\Controller;\n"] = '';
+        }
+
+        $class = str_replace(
             array_keys($replace), array_values($replace), parent::buildClass($name)
         );
+
+        return $class;
     }
 
     /**

--- a/tests/Integration/Generators/ControllerMakeCommandTest.php
+++ b/tests/Integration/Generators/ControllerMakeCommandTest.php
@@ -19,7 +19,7 @@ class ControllerMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class FooController extends Controller',
+            'class FooController',
         ], 'app/Http/Controllers/FooController.php');
 
         $this->assertFileNotContains([
@@ -37,7 +37,7 @@ class ControllerMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class FooController extends Controller',
+            'class FooController',
             'public function __invoke(Request $request)',
         ], 'app/Http/Controllers/FooController.php');
     }
@@ -50,7 +50,7 @@ class ControllerMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class FooController extends Controller',
+            'class FooController',
             'public function __invoke(Request $request)',
         ], 'app/Http/Controllers/FooController.php');
     }
@@ -103,7 +103,7 @@ class ControllerMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class FooController extends Controller',
+            'class FooController',
             'public function index()',
             'public function store(Request $request)',
             'public function update(Request $request, string $id)',
@@ -124,7 +124,7 @@ class ControllerMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class FooController extends Controller',
+            'class FooController',
             'public function __invoke(Request $request)',
         ], 'app/Http/Controllers/FooController.php');
 

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -69,7 +69,7 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class FooController extends Controller',
+            'class FooController',
         ], 'app/Http/Controllers/FooController.php');
 
         $this->assertFileNotContains([
@@ -156,7 +156,7 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFileContains([
             'namespace App\Http\Controllers;',
             'use Illuminate\Http\Request;',
-            'class BarController extends Controller',
+            'class BarController',
         ], 'app/Http/Controllers/BarController.php');
 
         $this->assertFilenameNotExists('database/factories/FooFactory.php');


### PR DESCRIPTION
This removes the base controller extension and import if no such base class exists.