### PR TITLE
[10.x] Fix not extending the `$wrap` property when initiate `AnonymousResourceCollection`

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -82,6 +82,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+            $collection::wrap(static::$wrap);
         });
     }
 


### PR DESCRIPTION
@taylorotwell appreciate your feedback on my previous PR.

### Use Case
```
class SampleResource extends JsonResource
{
    public static $wrap = 'customValue';
}

$emptyCollection = collect([])

return SampleResource::collection($emptyCollection)
```

Current http response:
```
{
    "data": []
}
```

Expected http response:
```
{
    "customValue": []
}
```