### PR TITLE
[10.x] Fix LazilyRefreshDatabase when testing artisan commands

### DIFF
--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -24,7 +24,13 @@ trait LazilyRefreshDatabase
 
             RefreshDatabaseState::$lazilyRefreshed = true;
 
+            $shouldMockOutput = $this->mockConsoleOutput;
+
+            $this->mockConsoleOutput = false;
+
             $this->baseRefreshDatabase();
+
+            $this->mockConsoleOutput = $shouldMockOutput;
         };
 
         $database->beforeStartingTransaction($callback);


### PR DESCRIPTION
I just bumped into a situation, when using the `LazilyRefreshDatabase` trait in the base test case causes an issue with asserting artisan output. I belive this is a bug.

-------
I have the following command:

```php
namespace App\Console\Commands;

use Illuminate\Console\Command;

class ClearCarts extends Command
{
    protected $signature = 'app:clear-carts';

    protected $description = 'Command description';

    public function handle()
    {
        \App\Models\Cart::query()->truncate();

        $this->info('All carts have been deleted.');
    }
}
```

And the following test:

```php
namespace Tests\Unit;

use Tests\TestCase;

class CartTest extends TestCase
{
    public function test_clear_carts_command(): void
    {
        $this->artisan('app:clear-carts')
            ->expectsOutputToContain('All carts have been deleted.')
            ->assertSuccessful();
    }
}
```

> [!NOTE]
> The `Tests\TestCase` uses the `Illuminate\Foundation\Testing\LazilyRefreshDatabase` trait.

---------

When running the test it fails, because the command interacts with the DB, so it refreshes the DB by running the `artisan:migrate` command. At this point the migrate command mocks the console output and messes up the test.

A simple solution to disable output mocking when running artisan migrate, then restore the mocking output state.