### PR TITLE
[10.x] Add helper methods to create and drop pivot tables in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -130,6 +130,35 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'covid19'));
     }
 
+    public function testCreateAndDropPivotTable()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        $this->schemaBuilder()->createPivotFor(\Illuminate\Foundation\Auth\User::class, \EloquentModelUuidStub::class);
+
+        $this->assertTrue($this->schemaBuilder()->hasTable('eloquent_model_uuid_stub_user'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('eloquent_model_uuid_stub_user', 'user_id'));
+
+        $this->schemaBuilder()->dropPivotFor(\Illuminate\Foundation\Auth\User::class, \EloquentModelUuidStub::class);
+        $this->assertFalse($this->schemaBuilder()->hasTable('eloquent_model_uuid_stub_user'));
+    }
+
+    public function testCreatePivotTableWithCallback()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        $this->schemaBuilder()->createPivotFor(
+            \Illuminate\Foundation\Auth\User::class,
+            \EloquentModelUuidStub::class,
+            function (Blueprint $table) {
+                $table->string('some_other_data');
+            }
+        );
+
+        $this->assertTrue($this->schemaBuilder()->hasTable('eloquent_model_uuid_stub_user'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('eloquent_model_uuid_stub_user', 'some_other_data'));
+    }
+
     private function schemaBuilder()
     {
         return $this->db->connection()->getSchemaBuilder();

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -148,7 +148,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
 
         $this->schemaBuilder()->createPivotFor(
-            \Illuminate\Foundation\Auth\User::class,
+            new \Illuminate\Foundation\Auth\User,
             \EloquentModelUuidStub::class,
             function (Blueprint $table) {
                 $table->string('some_other_data');


### PR DESCRIPTION
This PR automates a fairly common task by adding two convenience methods that can be used as follows:

```php
<?php

use App\Models\Post;
use App\Models\Author;
use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

return new class extends Migration
{
    /**
     * Run the migrations.
     */
    public function up(): void
    {
        Schema::createPivotFor(Post::class, Author::class);
        /* instead of:
        Schema::create('author_post', function (Blueprint $table) {
            $table->id();
            $table->foreignIdFor(Author::class)->constrained();
            $table->foreignIdFor(Post::class)->constrained();
        }
        */
    }
    /**
     * Reverse the migrations.
     */
    public function down(): void
    {
        Schema::dropPivotFor(Author::class, Post::class);
    }
}
```
This creates the table (named as the alphabetically ordered snake-case singular of the two models) and then adds foreign keys for the two models. I think it fits well with the Laravel philosophy of not having to worry about low-level details like table names. As far as I could tell, this is the same method that is used in the relationship methods to create the name of a pivot table.

A third argument to `createPivotFor()` is a callback that allows for additional columns to be added, e.g.
```php
public function up(): void
{
    Schema::createPivotFor(Post::class, Author::class, function (Blueprint $table) {
        $table->string('some_other_data');
        $table->int('more_pivot_info');
    });
}
```
Tests have also been added; hopefully they are complete enough, and in the right place.
