### PR TITLE
Add `getTable` in migration stubs

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -7,11 +7,19 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * Get table name.
+     */
+    public function getTable(): string
+    {
+        return '{{ table }}';
+    }
+
+    /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create($this->getTable(), function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });
@@ -22,6 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('{{ table }}');
+        Schema::dropIfExists($this->getTable());
     }
 };

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -7,11 +7,19 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * Get table name.
+     */
+    public function getTable(): string
+    {
+        return '{{ table }}';
+    }
+
+    /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table($this->getTable(), function (Blueprint $table) {
             //
         });
     }
@@ -21,7 +29,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table($this->getTable(), function (Blueprint $table) {
             //
         });
     }


### PR DESCRIPTION
During development, it sometimes happens that you change the name of a table,making the mistake of only updating the up method.

I simply added a `getTable` method.