### PR TITLE
[11.x] Fix modifying auto-increment columns

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -16,17 +16,17 @@ use Illuminate\Support\Fluent;
  * @method $this first() Place the column "first" in the table (MySQL)
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
  * @method $this generatedAs(string|\Illuminate\Database\Query\Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
- * @method $this index(string $indexName = null) Add an index
+ * @method $this index(bool|string $indexName = null) Add an index
  * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
- * @method $this primary() Add a primary index
- * @method $this fulltext(string $indexName = null) Add a fulltext index
- * @method $this spatialIndex(string $indexName = null) Add a spatial index
+ * @method $this primary(bool $value = true) Add a primary index
+ * @method $this fulltext(bool|string $indexName = null) Add a fulltext index
+ * @method $this spatialIndex(bool|string $indexName = null) Add a spatial index
  * @method $this startingValue(int $startingValue) Set the starting value of an auto-incrementing field (MySQL/PostgreSQL)
  * @method $this storedAs(string $expression) Create a stored generated column (MySQL/PostgreSQL/SQLite)
  * @method $this type(string $type) Specify a type for the column
- * @method $this unique(string $indexName = null) Add a unique index
+ * @method $this unique(bool|string $indexName = null) Add a unique index
  * @method $this unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method $this useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method $this useCurrentOnUpdate() Set the TIMESTAMP column to use CURRENT_TIMESTAMP when updating (MySQL)

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -242,7 +242,7 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
-     * Get the primary key command if it exists on the blueprint.
+     * Get the command with a given name if it exists on the blueprint.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  string  $name
@@ -269,6 +269,24 @@ abstract class Grammar extends BaseGrammar
         return array_filter($blueprint->getCommands(), function ($value) use ($name) {
             return $value->name == $name;
         });
+    }
+
+    /*
+     * Determine if a command with a given name exists on the blueprint.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  string  $name
+     * @return bool
+     */
+    protected function hasCommand(Blueprint $blueprint, $name)
+    {
+        foreach ($blueprint->getCommands() as $command) {
+            if ($command->name === $name) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1232,7 +1232,9 @@ class MySqlGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
-            return ' auto_increment primary key';
+            return $this->hasCommand($blueprint, 'primary') || ($column->change && ! $column->primary)
+                ? ' auto_increment'
+                : ' auto_increment primary key';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -731,7 +731,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeInteger(Fluent $column)
     {
-        return $column->autoIncrement && is_null($column->generatedAs) ? 'serial' : 'integer';
+        return $column->autoIncrement && is_null($column->generatedAs) && ! $column->change ? 'serial' : 'integer';
     }
 
     /**
@@ -742,7 +742,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeBigInteger(Fluent $column)
     {
-        return $column->autoIncrement && is_null($column->generatedAs) ? 'bigserial' : 'bigint';
+        return $column->autoIncrement && is_null($column->generatedAs) && ! $column->change ? 'bigserial' : 'bigint';
     }
 
     /**
@@ -775,7 +775,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeSmallInteger(Fluent $column)
     {
-        return $column->autoIncrement && is_null($column->generatedAs) ? 'smallserial' : 'smallint';
+        return $column->autoIncrement && is_null($column->generatedAs) && ! $column->change ? 'smallserial' : 'smallint';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1089,8 +1089,10 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if ($column->change && ! $column->autoIncrement) {
-            return is_null($column->default) ? 'drop default' : 'set default '.$this->getDefaultValue($column->default);
+        if ($column->change) {
+            if (! $column->autoIncrement || ! is_null($column->generatedAs)) {
+                return is_null($column->default) ? 'drop default' : 'set default '.$this->getDefaultValue($column->default);
+            }
         }
 
         if (! is_null($column->default)) {

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1089,7 +1089,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if ($column->change) {
+        if ($column->change && ! $column->autoIncrement) {
             return is_null($column->default) ? 'drop default' : 'set default '.$this->getDefaultValue($column->default);
         }
 
@@ -1183,7 +1183,7 @@ class PostgresGrammar extends Grammar
         }
 
         if ($column->change) {
-            $changes = ['drop identity if exists'];
+            $changes = $column->autoIncrement && is_null($sql) ? [] : ['drop identity if exists'];
 
             if (! is_null($sql)) {
                 $changes[] = 'add '.$sql;

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1108,6 +1108,7 @@ class PostgresGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (! $column->change
+            && ! $this->hasCommand($blueprint, 'primary')
             && (in_array($column->type, $this->serials) || ($column->generatedAs !== null))
             && $column->autoIncrement) {
             return ' primary key';

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -987,7 +987,7 @@ class SqlServerGrammar extends Grammar
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
         if (! $column->change && in_array($column->type, $this->serials) && $column->autoIncrement) {
-            return ' identity primary key';
+            return $this->hasCommand($blueprint, 'primary') ? ' identity' : ' identity primary key';
         }
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -201,7 +201,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             "alter table `users` change `name` `title` varchar(255) collate 'utf8mb4_unicode_ci' null default 'foo'",
-            "alter table `users` change `id` `key` bigint unsigned not null auto_increment primary key comment 'lorem ipsum'",
+            "alter table `users` change `id` `key` bigint unsigned not null auto_increment comment 'lorem ipsum'",
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -222,7 +222,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             "alter table `users` change `name` `title` varchar(255) collate 'utf8mb4_unicode_ci' null default 'foo'",
-            "alter table `users` change `id` `key` bigint unsigned not null auto_increment primary key comment 'lorem ipsum'",
+            "alter table `users` change `id` `key` bigint unsigned not null auto_increment comment 'lorem ipsum'",
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 

--- a/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
@@ -103,7 +103,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             ."modify `difficulty` enum('easy', 'hard') character set utf8mb4 collate 'unicode' not null default 'easy', "
             .'modify `positions` multipolygon srid 1234 as (expression) stored, '
             .'change `old_name` `new_name` varchar(50) not null, '
-            ."modify `id` bigint unsigned not null auto_increment primary key comment 'my comment' first",
+            ."modify `id` bigint unsigned not null auto_increment comment 'my comment' first",
             'alter table `users` auto_increment = 10',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }

--- a/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
@@ -119,10 +119,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-            .'alter column "code" type serial, '
-            .'alter column "code" set not null, '
-            .'alter column "code" drop default, '
-            .'alter column "code" drop identity if exists',
+            .'alter column "code" type integer, '
+            .'alter column "code" set not null',
             'alter sequence users_code_seq restart with 10',
             'comment on column "users"."code" is \'my comment\'',
         ], $blueprint->toSql($connection, new PostgresGrammar));

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -190,27 +190,6 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
     }
 
-    public function testModifyingColumnToAutoIncrementColumnOnPgsql()
-    {
-        if ($this->driver !== 'pgsql') {
-            $this->markTestSkipped('Test requires a PostgreSQL connection.');
-        }
-
-        Schema::create('test', function (Blueprint $table) {
-            $table->unsignedBigInteger('id');
-        });
-
-        $this->assertFalse(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
-        $this->assertFalse(Schema::hasIndex('test', ['id'], 'primary'));
-
-        Schema::table('test', function (Blueprint $table) {
-            $table->bigIncrements('id')->generatedAs()->always()->primary()->change();
-        });
-
-        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
-        $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
-    }
-
     public function testAddingAutoIncrementColumn()
     {
         if ($this->driver === 'sqlite') {

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -131,6 +131,75 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertEquals(collect(Schema::getColumns('test'))->firstWhere('name', 'new_bar')['default'], $defaultBar);
     }
 
+    public function testCompoundPrimaryWithAutoIncrement()
+    {
+        if ($this->driver === 'sqlite') {
+            $this->markTestSkipped('Compound primary key with an auto increment column is not supported on SQLite.');
+        }
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->id();
+            $table->uuid();
+
+            $table->primary(['id', 'uuid']);
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['id', 'uuid'], 'primary'));
+    }
+
+    public function testModifyingAutoIncrementColumn()
+    {
+        Schema::create('test', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->bigIncrements('id')->change();
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
+    }
+
+    public function testModifyingColumnToAutoIncrementColumn()
+    {
+        if ($this->driver === 'sqlsrv') {
+            $this->markTestSkipped('Changing a column to auto increment is not supported on SQL Server.');
+        }
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->unsignedBigInteger('id');
+        });
+
+        $this->assertFalse(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertFalse(Schema::hasIndex('test', ['id'], 'primary'));
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->bigIncrements('id')->primary()->change();
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
+    }
+
+    public function testAddingAutoIncrementColumn()
+    {
+        Schema::create('test', function (Blueprint $table) {
+            $table->string('name');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->bigIncrements('id');
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
+    }
+
     public function testGetTables()
     {
         Schema::create('foo', function (Blueprint $table) {

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -150,6 +150,10 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testModifyingAutoIncrementColumn()
     {
+        if ($this->driver === 'sqlsrv') {
+            $this->markTestSkipped('Changing a primary column is not supported on SQL Server.');
+        }
+
         Schema::create('test', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -171,8 +171,8 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testModifyingColumnToAutoIncrementColumn()
     {
-        if ($this->driver === 'sqlsrv') {
-            $this->markTestSkipped('Changing a column to auto increment is not supported on SQL Server.');
+        if (in_array($this->driver,  ['pgsql', 'sqlsrv'])) {
+            $this->markTestSkipped('Changing a column to auto increment is not supported on PostgreSQL and SQL Server.');
         }
 
         Schema::create('test', function (Blueprint $table) {

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -192,7 +192,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testModifyingColumnToAutoIncrementColumnOnPgsql()
     {
-        if ($this->driver === 'pgsql') {
+        if ($this->driver !== 'pgsql') {
             $this->markTestSkipped('Test requires a PostgreSQL connection.');
         }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -171,7 +171,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testModifyingColumnToAutoIncrementColumn()
     {
-        if (in_array($this->driver,  ['pgsql', 'sqlsrv'])) {
+        if (in_array($this->driver, ['pgsql', 'sqlsrv'])) {
             $this->markTestSkipped('Changing a column to auto increment is not supported on PostgreSQL and SQL Server.');
         }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -190,6 +190,27 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
     }
 
+    public function testModifyingColumnToAutoIncrementColumnOnPgsql()
+    {
+        if ($this->driver === 'pgsql') {
+            $this->markTestSkipped('Test requires a PostgreSQL connection.');
+        }
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->unsignedBigInteger('id');
+        });
+
+        $this->assertFalse(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertFalse(Schema::hasIndex('test', ['id'], 'primary'));
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->bigIncrements('id')->generatedAs()->always()->primary()->change();
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['id'], 'primary'));
+    }
+
     public function testAddingAutoIncrementColumn()
     {
         if ($this->driver === 'sqlite') {

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -188,12 +188,16 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testAddingAutoIncrementColumn()
     {
+        if ($this->driver === 'sqlite') {
+            $this->markTestSkipped('Adding a primary column is not supported on SQLite.');
+        }
+
         Schema::create('test', function (Blueprint $table) {
             $table->string('name');
         });
 
         Schema::table('test', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->bigIncrements('id')->primary;
         });
 
         $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);


### PR DESCRIPTION
This PR fixes handling auto-increment columns on some edge cases:

## Create a compound primary with an auto-increment column
All databases except SQLite support creating a table with a compound/composite primary key with an auto-increment column:

```php
Schema::create('test', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->uuid('uuid');

    $table->primary(['id', 'uuid']);
});
```

## Modifying an auto-increment column
All databases except SQL Server support modifying an auto-increment/primary column:

```php
// Create
Schema::create('test', function (Blueprint $table) {
    $table->increments('id');
});

// Change
Schema::table('test', function (Blueprint $table) {
    $table->bigIncrements('id')->change();
});
```

## Changing a column to auto-increment
MySQL, MariaDB and SQLite support changing a regular column to an auto-increment column, but you must explicitly include `primary` modifier for this to work:

```php
// Create
Schema::create('test', function (Blueprint $table) {
    $table->unsignedBigInteger('id');
});

// Change
Schema::table('test', function (Blueprint $table) {
    $table->bigIncrements('id')->primary()->change();
});
```

## Upgrade Guide
We should add a note to docs:

The `change` method does not change indexes of a column. Therefore, you may use index modifiers explicitly to add/drop an index when modifying the column:

```php
$table->bigIncrements('id')->primary()->change();
$table->char('postal_code', 10)->unique(false)->change();
```
