### PR TITLE
[10.x] Add getTable in migration stubs 

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -7,11 +7,19 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * Get table name.
+     */
+    public function getTable(): string
+    {
+        return '{{ table }}';
+    }
+
+    /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create($this->getTable(), function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });
@@ -22,6 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('{{ table }}');
+        Schema::dropIfExists($this->getTable());
     }
 };

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -7,11 +7,19 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * Get table name.
+     */
+    public function getTable(): string
+    {
+        return '{{ table }}';
+    }
+
+    /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table($this->getTable(), function (Blueprint $table) {
             //
         });
     }
@@ -21,7 +29,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table($this->getTable(), function (Blueprint $table) {
             //
         });
     }

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -12,7 +12,9 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foos\', function (Blueprint $table) {',
+            'function getTable()',
+            'return \'foos\'',
+            'Schema::table($this->getTable(), function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -24,7 +26,9 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foobar\', function (Blueprint $table) {',
+            'function getTable()',
+            'return \'foobar\'',
+            'Schema::table($this->getTable(), function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -36,8 +40,10 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'foos\');',
+            'function getTable()',
+            'return \'foos\'',
+            'Schema::create($this->getTable(), function (Blueprint $table) {',
+            'Schema::dropIfExists($this->getTable());',
         ], 'create_foos_table.php');
     }
 
@@ -49,8 +55,10 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foobar\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'foobar\');',
+            'function getTable()',
+            'return \'foobar\'',
+            'Schema::create($this->getTable(), function (Blueprint $table) {',
+            'Schema::dropIfExists($this->getTable());',
         ], 'foos_table.php');
     }
 }

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -117,8 +117,10 @@ class ModelMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
-            'Schema::dropIfExists(\'foos\');',
+            'function getTable()',
+            'return \'foos\'',
+            'Schema::create($this->getTable(), function (Blueprint $table) {',
+            'Schema::dropIfExists($this->getTable());',
         ], 'create_foos_table.php');
 
         $this->assertFilenameNotExists('app/Http/Controllers/FooController.php');


### PR DESCRIPTION
During development, it sometimes happens that you change the name of a table,making the mistake of only updating the up method.

I simply added a getTable method.