### PR TITLE
[10.x] Make the regex for the translation condition stricter

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -80,7 +80,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        if(preg_match('/'.$this->conditionRegex().'(?<value>.*)/sJ', $part, $matches) == false) {
+        if (preg_match('/'.$this->conditionRegex().'(?<value>.*)/sJ', $part, $matches) == false) {
             return null;
         }
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -48,7 +48,7 @@ class MessageSelector
     }
 
     /**
-     * The regex for the condition part of a segment
+     * The regex for the condition part of a segment.
      *
      * @return string
      */
@@ -80,7 +80,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        if(preg_match('/' . $this->conditionRegex() . '(?<value>.*)/sJ', $part, $matches) == false) {
+        if(preg_match('/'.$this->conditionRegex().'(?<value>.*)/sJ', $part, $matches) == false) {
             return null;
         }
 
@@ -111,7 +111,7 @@ class MessageSelector
     private function stripConditions($segments)
     {
         return collect($segments)
-            ->map(fn ($part) => preg_replace('/' . $this->conditionRegex() . '/J', '', $part))
+            ->map(fn ($part) => preg_replace('/'.$this->conditionRegex().'/J', '', $part))
             ->all();
     }
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -58,12 +58,31 @@ class TranslationMessageSelectorTest extends TestCase
             ['second', '{0}first|[1,3]second|[4,*]third', 1],
             ['third', '{0}first|[1,3]second|[4,*]third', 9],
 
+            ['first', '[1.1,1.3] first|[1.4,1.6] second|[1.7,1.9] third', 1.2],
+            ['second', '[1.1,1.3] first|[1.4,1.6] second|[1.7,1.9] third', 1.5],
+            ['third', '[1.1,1.3] first|[1.4,1.6] second|[1.7,1.9] third', 1.8],
+
+            ['first', '{-5,-1} first|{0,+5} second|{+6,10} third', -4],
+            ['second', '{-5,-1} first|{0,+5} second|{+6,10} third', 3],
+            ['third', '{-5,-1} first|{0,+5} second|{+6,10} third', 8],
+
             ['first', 'first|second|third', 1],
             ['second', 'first|second|third', 9],
             ['second', 'first|second|third', 0],
 
             ['first', '{0}  first | { 1 } second', 0],
             ['first', '[4,*]first | [1,3]second', 100],
+
+            ['third', '  [  0   ] It works with whitespaces | [ 1 ] second | [  2  ,  5  ] third', 4],
+            ['third', '  {  0   } It works with whitespaces | { 1 } second | {  2  ,  5  } third', 4],
+
+            ['{1] plural', '{0] singular|{1] plural|[2} It does not work with mismatching brackets', 2],
+
+            ['{3,4,5} plural', '{0,1,2} singular|{3,4,5} plural|{6,7,8} It does not work with 3 arguments', 6],
+            ['[3,4,5] plural', '[0,1,2] singular|[3,4,5] plural|[6,7,8] It does not work with 3 arguments', 6],
+
+            ['{a} singular', '{a} singular|{b} plural|{c} It does not work with words', 1],
+            ['[a] singular', '[a] singular|[b] plural|[c] It does not work with words', 1],
         ];
     }
 }


### PR DESCRIPTION
The current regex used for the translation conditions in choice allow for a lot of invalid formats.
It currently allows you to define conditions with a starting with a { and ending with ] or the other way around.
And it allows comparison of the count with text or other nonsense.
This PR makes the regex more strict by looking that the brace types match and by checking the condition exists of a number or a *
By ignoring the invalid formats of the condition, it should be more obvious when something is wrong with a translation.