### PR TITLE
[10.x] Added FQDN(fully qualified domain name) validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2633,7 +2633,7 @@ trait ValidatesAttributes
     /**
      * Register a binding with the container.
      *
-     * @param  string $attribute
+     * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2631,7 +2631,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Register a binding with the container.
+     * Validating a value to be FQDN (Fully Qualified Domain Name)
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2629,4 +2629,18 @@ trait ValidatesAttributes
 
         return $value;
     }
+
+    /**
+     * Register a binding with the container.
+     *
+     * @param  string $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFqdn($attribute, $value)
+    {
+        $pattern = '/^(?!:\/\/)(?=.{1,255}$)((.{1,63}\.){1,127}(?![0-9]*$)[a-z0-9-]+\.?)$/i';
+
+        return preg_match($pattern, $value);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2631,7 +2631,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validating a value to be FQDN (Fully Qualified Domain Name)
+     * Validating a value to be FQDN (Fully Qualified Domain Name).
      *
      * @param  string  $attribute
      * @param  mixed  $value


### PR DESCRIPTION
Just added FQDN ('fqdn') validation rule to the list of rules in src/Illuminate/Validation/Concerns/ValidatesAttributes.php

FQDN stands for Fully Qualified Domain Name. For example subdomain.domain.com or just domain.com
https://en.wikipedia.org/wiki/Fully_qualified_domain_name#:~:text=A%20fully%20qualified%20domain%20name,domain%20and%20the%20root%20zone.