### PR TITLE
[10.x] Allow component slots to be empty, even if they have an html comment or line break

### DIFF
--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -64,7 +64,7 @@ class ComponentSlot implements Htmlable
      */
     public function isEmpty()
     {
-        return $this->contents === '';
+        return trim(preg_replace('/<!--([\s\S]*?)-->/', '', $this->contents)) === '';
     }
 
     /**

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -27,7 +27,6 @@ class ComponentSlot implements Htmlable
      */
     protected $sanitizerResolver;
 
-
     /**
      * Create a new slot instance.
      *
@@ -42,7 +41,7 @@ class ComponentSlot implements Htmlable
         $this->withAttributes($attributes);
 
         // default sanitizer, return the input as it is
-        $this->sanitizerResolver = fn($input) => $input;
+        $this->sanitizerResolver = fn ($input) => $input;
     }
 
     /**
@@ -76,13 +75,13 @@ class ComponentSlot implements Htmlable
      */
     public function sanitize(null|string|callable $callable = null)
     {
-        if (is_string($callable) && !function_exists($callable)) {
+        if (is_string($callable) && ! function_exists($callable)) {
             throw new \InvalidArgumentException("Callable does not exist.");
         }
 
         $this->sanitizerResolver =
             $callable ??
-            fn($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", "", $input)); // replace everything between <!-- and --> with empty string
+            fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input)); // replace everything between <!-- and --> with empty string
 
         return $this;
     }
@@ -97,7 +96,7 @@ class ComponentSlot implements Htmlable
     public function isEmpty()
     {
         return filter_var($this->contents, FILTER_CALLBACK, [
-          "options" => $this->sanitizerResolver
+            'options' => $this->sanitizerResolver
         ]) === '';
     }
 

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -76,7 +76,7 @@ class ComponentSlot implements Htmlable
     public function sanitize(null|string|callable $callable = null)
     {
         if (is_string($callable) && ! function_exists($callable)) {
-            throw new \InvalidArgumentException("Callable does not exist.");
+            throw new \InvalidArgumentException('Callable does not exist.');
         }
 
         $this->sanitizerResolver =
@@ -96,7 +96,7 @@ class ComponentSlot implements Htmlable
     public function isEmpty()
     {
         return filter_var($this->contents, FILTER_CALLBACK, [
-            'options' => $this->sanitizerResolver
+            'options' => $this->sanitizerResolver,
         ]) === '';
     }
 

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -60,10 +60,13 @@ class ComponentSlot implements Htmlable
     /**
      * Determine if the slot is empty.
      *
+     * HTML comments and whitespace will be trimmed out.
+     *
      * @return bool
      */
     public function isEmpty()
     {
+        // replace everything between <!-- and --> with empty string
         return trim(preg_replace('/<!--([\s\S]*?)-->/', '', $this->contents)) === '';
     }
 

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -307,7 +307,8 @@ class ComponentTest extends TestCase
         $this->assertNotSame($this->viewFactory, $getFactory($inline));
     }
 
-    public function testComponentSlotIsEmpty() {
+    public function testComponentSlotIsEmpty()
+    {
         $slot = new ComponentSlot;
 
         $anotherSlot = new ComponentSlot('<!-- test -->');

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -311,7 +311,13 @@ class ComponentTest extends TestCase
     {
         $slot = new ComponentSlot;
 
-        $anotherSlot = new ComponentSlot('<!-- test -->');
+        $this->assertTrue((bool) $slot->isEmpty());
+    }
+
+    public function testComponentSlotSanitizer()
+    {
+        // default sanitizer should remove all html tags
+        $slot = new ComponentSlot('<!-- test -->');
 
         $linebreakingSlot = new ComponentSlot("\n  \t");
 
@@ -320,13 +326,14 @@ class ComponentTest extends TestCase
         <img border="0" src="pic_trulli.jpg" alt="Trulli">
         -->');
 
-        $this->assertTrue((bool) $slot->isEmpty());
+        $whitespaceSlot = new ComponentSlot("\t  \n  \t  \n  \t");
 
-        $this->assertTrue((bool) $anotherSlot->isEmpty());
+        $this->assertTrue((bool) $slot->sanitize()->isEmpty());
+        $this->assertTrue((bool) $linebreakingSlot->sanitize()->isEmpty());
+        $this->assertTrue((bool) $moreComplexSlot->sanitize()->isEmpty());
 
-        $this->assertTrue((bool) $linebreakingSlot->isEmpty());
-
-        $this->assertTrue((bool) $moreComplexSlot->isEmpty());
+        $this->assertTrue((bool) (clone $whitespaceSlot)->sanitize('trim')->isEmpty());
+        $this->assertTrue((bool) $whitespaceSlot->isNotEmpty());
     }
 
     public function testComponentSlotIsNotEmpty()
@@ -342,9 +349,9 @@ class ComponentTest extends TestCase
 
         $this->assertTrue((bool) $slot->isNotEmpty());
 
-        $this->assertTrue((bool) $anotherSlot->isNotEmpty());
+        $this->assertTrue((bool) $anotherSlot->sanitize()->isNotEmpty());
 
-        $this->assertTrue((bool) $moreComplexSlot->isNotEmpty());
+        $this->assertTrue((bool) $moreComplexSlot->sanitize()->isNotEmpty());
     }
 }
 

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
+use Illuminate\View\ComponentSlot;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
 use Mockery as m;
@@ -304,6 +305,45 @@ class ComponentTest extends TestCase
 
         Component::forgetFactory();
         $this->assertNotSame($this->viewFactory, $getFactory($inline));
+    }
+
+    public function testComponentSlotIsEmpty() {
+        $slot = new ComponentSlot;
+
+        $anotherSlot = new ComponentSlot('<!-- test -->');
+
+        $linebreakingSlot = new ComponentSlot("\n  \t");
+
+        $moreComplexSlot = new ComponentSlot('<!--
+        <p>Look at this cool image:</p>
+        <img border="0" src="pic_trulli.jpg" alt="Trulli">
+        -->');
+
+        $this->assertTrue((bool) $slot->isEmpty());
+
+        $this->assertTrue((bool) $anotherSlot->isEmpty());
+
+        $this->assertTrue((bool) $linebreakingSlot->isEmpty());
+
+        $this->assertTrue((bool) $moreComplexSlot->isEmpty());
+    }
+
+    public function testComponentSlotIsNotEmpty()
+    {
+        $slot = new ComponentSlot('test');
+
+        $anotherSlot = new ComponentSlot('test<!-- test -->');
+
+        $moreComplexSlot = new ComponentSlot('t<!--
+        <p>Look at this cool image:</p>
+        <img border="0" src="pic_trulli.jpg" alt="Trulli">
+        -->est');
+
+        $this->assertTrue((bool) $slot->isNotEmpty());
+
+        $this->assertTrue((bool) $anotherSlot->isNotEmpty());
+
+        $this->assertTrue((bool) $moreComplexSlot->isNotEmpty());
     }
 }
 


### PR DESCRIPTION
This PR addresses and solves an issue with [Livewire V3 morph markers](https://livewire.laravel.com/docs/morphing#injecting-morph-markers).

Since Livewire is injecting `morph markers`, we cannot safely ask if a slot is empty or not. The same happens if we add a linebreak or nonprintable characters like whitespaces or tabs. The slot is not empty and should be rendered.

From a technical point of view, the slot is not empty, the blade compiler must render this.
But from a 'what should happen in the template' point of view, the slot might be empty, and the HTML should contain something that occurs in the other condition.

here is an example. Given is a component `table.blade.php`

```blade
01    <table>
02    @if($slot->isNotEmpty())
03        {{ $slot }}
04    @else
05        <tr><td>{{ __('No Results') }}</td></tr>
06    @endif
07    </table>
```

In the view, we use this `<x-table />` and do a loop. The `@foreach()` is an empty result set; I expect that we see `No Results.`

another blade file
```blade
01    <x-table>
02    <!-- start loop -->
03    @foreach([] as $value)
04        <tr><td>{{ $value }}</td></tr>
05    @endforeach
06    <!-- end loop -->
07    </x-table>
```

The slot content starts with `<!--` in line 2 and ends with `-->` in line 6. If the loop is empty, our slot content is `<!-- start loop --><!-- end loop -->`. Should we render it, or is the slot empty? 

The Filament package has a [is_slot_empty helper](https://github.com/filamentphp/filament/blob/fda8417925366209bacad9844278f1d28c00c703/packages/support/src/helpers.php#L114-L134), which addresses this issue.

Shouldn't we bring this into the Framework to make slots a bit more intelligent?
