### PR TITLE
[10.x] Fix an error when $query->from is of type Illuminate\Database\Query\Expression

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -394,7 +394,7 @@ class Builder implements BuilderContract
             $this->getConnection()->getDatabaseName()) {
             $databaseName = $query->getConnection()->getDatabaseName();
 
-            if (! str_starts_with($query->from, $databaseName) && ! str_contains($query->from, '.')) {
+            if (is_string($query->from) && ! str_starts_with($query->from, $databaseName) && ! str_contains($query->from, '.')) {
                 $query->from($databaseName.'.'.$query->from);
             }
         }


### PR DESCRIPTION
When passing a subquery referencing a different database to joinSub(), the prependDatabaseNameIfCrossDatabaseQuery() method would rewrite the "from" clause of the subquery. However, if $query->from is not a string but an Illuminate\Database\Query\Expression, the following error occurs:

TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, Illuminate\Database\Query\Expression given

To address this issue, I made modifications to prevent the replacement process when $query->from is an Illuminate\Database\Query\Expression instead of a string.
