### PR TITLE
[10.x] Add POSIX compliant cleanup to artisan serve

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -89,18 +89,6 @@ class ServeCommand extends Command
 
         $process = $this->startProcess($hasEnvironment);
 
-        if (function_exists('pcntl_signal')) {
-            $cleanup = function ($signo) use ($process) {
-                if ($process->isRunning()) {
-                    $process->stop(10, $signo);
-                }
-                exit;
-            };
-            pcntl_signal(SIGINT, $cleanup);
-            pcntl_signal(SIGTERM, $cleanup);
-            pcntl_signal(SIGHUP, $cleanup);
-        }
-
         while ($process->isRunning()) {
             if ($hasEnvironment) {
                 clearstatcache(false, $environmentFile);
@@ -151,6 +139,18 @@ class ServeCommand extends Command
 
             return in_array($key, static::$passthroughVariables) ? [$key => $value] : [$key => false];
         })->all());
+
+        if (function_exists('pcntl_signal')) {
+            $cleanup = function ($signo) use ($process) {
+                if ($process->isRunning()) {
+                    $process->stop(10, $signo);
+                }
+                exit;
+            };
+            pcntl_signal(SIGINT, $cleanup);
+            pcntl_signal(SIGTERM, $cleanup);
+            pcntl_signal(SIGHUP, $cleanup);
+        }
 
         $process->start($this->handleProcessOutput());
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -89,6 +89,18 @@ class ServeCommand extends Command
 
         $process = $this->startProcess($hasEnvironment);
 
+        if (function_exists('pcntl_signal')) {
+            $cleanup = function ($signo) use ($process) {
+                if ($process->isRunning()) {
+                    $process->stop(10, $signo);
+                }
+                exit();
+            };
+            pcntl_signal(SIGINT, $cleanup);
+            pcntl_signal(SIGTERM, $cleanup);
+            pcntl_signal(SIGHUP, $cleanup);
+        }
+        
         while ($process->isRunning()) {
             if ($hasEnvironment) {
                 clearstatcache(false, $environmentFile);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -94,13 +94,13 @@ class ServeCommand extends Command
                 if ($process->isRunning()) {
                     $process->stop(10, $signo);
                 }
-                exit();
+                exit;
             };
             pcntl_signal(SIGINT, $cleanup);
             pcntl_signal(SIGTERM, $cleanup);
             pcntl_signal(SIGHUP, $cleanup);
         }
-        
+
         while ($process->isRunning()) {
             if ($hasEnvironment) {
                 clearstatcache(false, $environmentFile);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -140,10 +140,11 @@ class ServeCommand extends Command
             return in_array($key, static::$passthroughVariables) ? [$key => $value] : [$key => false];
         })->all());
 
-        $this->trap([SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT], function ($signo) use ($process) {
+        $this->trap([SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2, SIGQUIT], function ($signal) use ($process) {
             if ($process->isRunning()) {
-                $process->stop(10, $signo);
+                $process->stop(10, $signal);
             }
+
             exit;
         });
 


### PR DESCRIPTION
Fixes #49941

### Description

When running `php artisan serve` it creates a subprocess for the server, but it seems to simply forward all it's input to the subprocess which is only listening for Ctrl + C on the keyboard to close itself which in turn exits the parent, this is is not POSIX compliant

As such when we kill the `php artisan serve` command it doesn't do any cleanup itself and the subprocess keeps running

### Steps To Reproduce

1. Run `php artisan serve`
2. Open a second terminal
3. Run `ps aux` and get the pid of `php artisan serve`
![image](https://github.com/laravel/framework/assets/6115458/299af716-1e25-4abe-aa6e-3535257ca6e5)
4. Run `kill -SIGTINT $the_pid` which should be equivalent to a Ctrl + C signal
5. Check `ps aux` and notice that the main process is gone but the subprocess is still there
![image](https://github.com/laravel/framework/assets/6115458/e68bfdcb-e9ba-4850-8f4f-7ec36c094d0d)

This is a big problem when spawning `php artisan serve` from within another program, because programs should only use signals to kill their offsprings


With this PR if pcntl is enabled (it's optional but recommended in composer) any termination signal will trigger the cleanup of the subprocess