### PR TITLE
[10.x] Allow an update query to have subqueries as values

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3416,10 +3416,20 @@ class Builder implements BuilderContract
     {
         $this->applyBeforeQueryCallbacks();
 
-        $sql = $this->grammar->compileUpdate($this, $values);
+        $values = collect($values)->map(function ($value) {
+            if (! $value instanceof Builder) {
+                return ['value' => $value, 'bindings' => [$value]];
+            }
+
+            [$query, $bindings] = $this->parseSub($value);
+
+            return ['value' => new Expression("({$query})"), 'bindings' => $bindings];
+        });
+
+        $sql = $this->grammar->compileUpdate($this, $values->map(fn ($value) => $value['value'])->all());
 
         return $this->connection->update($sql, $this->cleanBindings(
-            $this->grammar->prepareBindingsForUpdate($this->bindings, $values)
+            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->pluck('bindings')->flatten(1)->all())
         ));
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3418,7 +3418,7 @@ class Builder implements BuilderContract
 
         $values = collect($values)->map(function ($value) {
             if (! $value instanceof Builder) {
-                return ['value' => $value, 'bindings' => [$value]];
+                return ['value' => $value, 'bindings' => $value];
             }
 
             [$query, $bindings] = $this->parseSub($value);
@@ -3429,7 +3429,7 @@ class Builder implements BuilderContract
         $sql = $this->grammar->compileUpdate($this, $values->map(fn ($value) => $value['value'])->all());
 
         return $this->connection->update($sql, $this->cleanBindings(
-            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->pluck('bindings')->flatten(1)->all())
+            $this->grammar->prepareBindingsForUpdate($this->bindings, $values->map(fn ($value) => $value['bindings'])->all())
         ));
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3423,7 +3423,7 @@ class Builder implements BuilderContract
 
             [$query, $bindings] = $this->parseSub($value);
 
-            return ['value' => new Expression("({$query})"), 'bindings' => $bindings];
+            return ['value' => new Expression("({$query})"), 'bindings' => fn () => $bindings];
         });
 
         $sql = $this->grammar->compileUpdate($this, $values->map(fn ($value) => $value['value'])->all());

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1183,6 +1183,8 @@ class Grammar extends BaseGrammar
     {
         $cleanBindings = Arr::except($bindings, ['select', 'join']);
 
+        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
+
         return array_values(
             array_merge($bindings['join'], $values, Arr::flatten($cleanBindings))
         );

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3181,6 +3181,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpdateMethodWorksWithQueryAsValue()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "credits" = (select sum(credits) from "transactions" where "transactions"."user_id" = "users"."id" and "type" = ?) where "id" = ?', ['foo', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->update(['credits' => $this->getBuilder()->from('transactions')->selectRaw('sum(credits)')->whereColumn('transactions.user_id', 'users.id')->where('type', 'foo')]);
+
+        $this->assertEquals(1, $result);
+    }
+
     public function testUpdateOrInsertMethod()
     {
         $builder = m::mock(Builder::class.'[where,exists,insert]', [


### PR DESCRIPTION
When you want to execute an update-query where one of the values is another query, you have to do the following:
```php
DB::table('users')->update([
    'credits' => DB::raw(
		'(' .
		DB::table('transactions')
			->selectRaw('sum(credits)')
			->whereColumn('transactions.user_id', 'users.id')
			->toSql()
		. ')'
	)
]);
```
That is not very Laravel-like. When the subquery has bindings, then that workaround does not even work anymore.

This PR fixes that. If a query is provided as a value, then that query is correctly converted to SQL and the bindings are used correctly. With the change in this PR, you can now just do this:
```php
DB::table('users')->update([
    'credits' => DB::table('transactions')
		->selectRaw('sum(credits)')
		->whereColumn('transactions.user_id', 'users.id')
]);
```