### PR TITLE
Update PHPDoc to allow raw expressions on the "having" method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2086,7 +2086,7 @@ class Builder implements BuilderContract
     /**
      * Add a "having" clause to the query.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string|int|float|null  $operator
      * @param  string|int|float|null  $value
      * @param  string  $boolean


### PR DESCRIPTION
The `$column` parameter type could only be a `\Closure` or a `string` according to the PHPDoc's `@param` tag, but raw expressions can be used.

For example, this code works:
```
DB::table('time_logs')
    ->select('user_id')
    ->groupBy('user_id')
    ->having(DB::raw("SUM(TIMESTAMPDIFF(SECOND, entrance, exit))"), '>=', 10)
    ->get()
```
But raises the warning `Expected parameter of type '\Closure|string', '\Illuminate\Contracts\Database\Query\Expression' provided`.

By simply adding the `\Illuminate\Contracts\Database\Query\Expression` type to the `$column`'s `@param` the warning goes away, and the code keeps working.

This change should be backwards-compatible to the best of my knowledge.