### PR TITLE
[10.x] Fix breaking changes in before validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -255,7 +255,7 @@ trait ValidatesAttributes
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
             $secondValue = $this->getValue($parameters[0]);
 
-            if (! is_string($secondValue) && ! is_numeric($secondValue) && ! $secondValue instanceof DateTimeInterface) {
+            if (! is_null($secondValue) && ! is_string($secondValue) && ! is_numeric($secondValue) && ! $secondValue instanceof DateTimeInterface) {
                 return false;
             }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -253,7 +253,13 @@ trait ValidatesAttributes
         }
 
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
-            $date = $this->getDateTimestamp($this->getValue($parameters[0]));
+            $secondValue = $this->getValue($parameters[0]);
+
+            if (! is_string($secondValue) && ! is_numeric($secondValue) && ! $secondValue instanceof DateTimeInterface) {
+                return false;
+            }
+
+            $date = $this->getDateTimestamp($secondValue);
         }
 
         return $this->compare($this->getDateTimestamp($value), $date, $operator);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5980,6 +5980,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '0001-01-01T00:00'], ['x' => 'after:1970-01-01']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|after:x']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
+        $this->assertTrue($v->fails());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5989,9 +5989,6 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|before:x']);
-        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5986,6 +5986,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|before:x']);
+        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()


### PR DESCRIPTION
I had a [PR #49871](https://github.com/laravel/framework/pull/49871) to fix [Issue #49863](https://github.com/laravel/framework/issues/49863) but from this https://github.com/laravel/framework/pull/49871#issuecomment-1921544394 conversation it looks breaking change.

if it is a breaking change then this PR will solve it. added tests for it too. 

```php
$v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
$this->assertTrue($v->passes());

$v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|before:x']);
$this->assertTrue($v->passes());
```