### PR TITLE
[10.x] Simple validation unexpectedly triggers Lang::handleMissingKeysUsing

### DIFF
--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -83,4 +83,17 @@ class TranslatorTest extends TestCase
 
         $this->app['translator']->handleMissingKeysUsing(null);
     }
+
+    public function testValidatorDoesntTriggerMissingKeys(): void
+    {
+        $_SERVER['__missing_translation_key_locale'] = [];
+
+        $this->app['translator']->handleMissingKeysUsing(function ($key, $replacements, $locale): void {
+            $_SERVER['__missing_translation_key_locale'][] = $key;
+        });
+
+        $this->app['validator']->make(['foo' => 'bar'], ['baz' => 'required'])->passes();
+
+        $this->assertEquals([], $_SERVER['__missing_translation_key_locale']);
+    }
 }


### PR DESCRIPTION
This PR isn't intended to be merged in its current state, it is just adding a failing test highlighting that the `Lang::handleMissingKeysUsing` feature documented [here](https://laravel.com/docs/10.x/localization#handling-missing-translation-strings)...

```php
    Lang::handleMissingKeysUsing(function (string $key, array $replacements, string $locale) {
        info("Missing translation key [$key] detected.");
 
        return $key;
    });
```

...isn't as helpful as I hoped, because doing a simple validation similar to that in this PR can result in one or more of the following items logged:
* `Missing translation key [validation.custom.foo.required] detected`
* `Missing translation key [validation.attributes] detected.`
* `Missing translation key [validation.values.foo.] detected.`

You can probably work out that this is because to decide whether a lang key exists, the translator does the actual translation (resulting in `handleMissingKeysUsing` being fired), and then compares whether the translated string equals the key.

As many routes in every application will have validation, this means that the `handleMissingKeysUsing` feature isn't particularly useful as the logs just get absolutely spammed.

I'm not personally sure how to resolve this, if there's a quick fix someone can suggest I'm happy to push something up to this PR, but please let me know what you would like the next steps to be.

For now I've had to work around this in my application with the following:

```php
    Lang::handleMissingKeysUsing(function (string $key, array $replacements, string $locale) {
        if (str_starts_with($key, 'validation.custom.') ||
            str_starts_with($key, 'validation.values.') ||
            $key === 'validation.attributes'
        ) {
            return $key;
        }

        info("Missing translation key [$key] detected.");
 
        return $key;
    });
```
Which works, but feels a bit hacky and I'm assuming you guys would prefer this was just handled out of the box?