### PR TITLE
[10.x] Allow listening to multiple or all eloquent events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -228,6 +228,24 @@ trait HasEvents
     }
 
     /**
+     * Register events with the dispatcher.
+     *
+     * @param  array|string  $events
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback
+     * @return void
+     */
+    public static function listen($events, $callback)
+    {
+        if ($events === '*') {
+            $events = (new static)->getObservableEvents();
+        }
+
+        foreach (Arr::wrap($events) as $event) {
+            static::registerModelEvent($event, $callback);
+        }
+    }
+
+    /**
      * Register a retrieved model event with the dispatcher.
      *
      * @param  \Illuminate\Events\QueuedClosure|\Closure|string|array  $callback

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -166,6 +166,14 @@ class EventFakeTest extends TestCase
 
         Post::observe(new PostObserver);
 
+        Post::listen('*', function (){
+            // do something
+        });
+
+        Post::listen(['saved', 'deleted'], function (){
+            // do something
+        });
+
         (new Post)->save();
 
         Event::assertListening('event', 'listener');
@@ -177,6 +185,9 @@ class EventFakeTest extends TestCase
         Event::assertListening(NonImportantEvent::class, Closure::class);
         Event::assertListening('eloquent.saving: '.Post::class, PostObserver::class.'@saving');
         Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
+        Event::assertListening('eloquent.created: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.saved: '.Post::class, Closure::class);
+        Event::assertListening('eloquent.deleted: '.Post::class, Closure::class);
         Event::assertListening('event', InvokableEventSubscriber::class);
     }
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -166,11 +166,11 @@ class EventFakeTest extends TestCase
 
         Post::observe(new PostObserver);
 
-        Post::listen('*', function (){
+        Post::listen('*', function () {
             // do something
         });
 
-        Post::listen(['saved', 'deleted'], function (){
+        Post::listen(['saved', 'deleted'], function () {
             // do something
         });
 


### PR DESCRIPTION
Right now, if you want to perform the same action (e.g. clearing cache) for multiple eloquent events you have to do this:

```php
protected static function booted(): void
{
    static::created(function () {
        Cache::forget('users');
    });

    static::deleted(function () {
        Cache::forget('users');
    });
}
```

In the future you can simply do this:

```php
protected static function booted(): void
{
    static::listen(['created', 'deleted'], function () {
        Cache::forget('users');
    });
}
```

I have also added a way to listen to all/wildcard events:

```php
protected static function booted(): void
{
    static::listen('*', function () {
        // Do something
    });
}
```