### PR TITLE
[10.x] DB command: add sqlcmd -C flag when 'trust_server_certificate' is set

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -192,6 +192,7 @@ class DbCommand extends Command
             'password' => ['-P', $connection['password']],
             'host' => ['-S', 'tcp:'.$connection['host']
                         .($connection['port'] ? ','.$connection['port'] : ''), ],
+            'trust_server_certificate' => ['-C'],
         ], $connection));
     }
 


### PR DESCRIPTION
Currently `artisan db` command does not set -C flag in any way. 
There is config value in `config/database.php` for sqlsrv that is used for same reason in `SqlServerConnector`.