### PR TITLE
[10.x] Fix breaking changes in after validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -255,7 +255,7 @@ trait ValidatesAttributes
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
             $comparedValue = $this->getValue($parameters[0]);
 
-            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
+            if (! is_null($comparedValue) && ! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
                 return false;
             }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -255,11 +255,15 @@ trait ValidatesAttributes
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
             $comparedValue = $this->getValue($parameters[0]);
 
-            if (! is_null($comparedValue) && ! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
+            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
                 return false;
             }
 
             $date = $this->getDateTimestamp($comparedValue);
+
+            if (is_null($date)) {
+                return true;
+            }
         }
 
         return $this->compare($this->getDateTimestamp($value), $date, $operator);

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -255,11 +255,7 @@ trait ValidatesAttributes
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
             $comparedValue = $this->getValue($parameters[0]);
 
-            if (is_null($comparedValue)) {
-                return true;
-            }
-
-            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
+            if (! is_null($comparedValue) && ! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
                 return false;
             }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -255,16 +255,15 @@ trait ValidatesAttributes
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
             $comparedValue = $this->getValue($parameters[0]);
 
-            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
-                return false;
-            }
-
             if (is_null($comparedValue)) {
                 return true;
             }
 
-            $date = $this->getDateTimestamp($comparedValue);
+            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
+                return false;
+            }
 
+            $date = $this->getDateTimestamp($comparedValue);
         }
 
         return $this->compare($this->getDateTimestamp($value), $date, $operator);

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -259,11 +259,12 @@ trait ValidatesAttributes
                 return false;
             }
 
-            $date = $this->getDateTimestamp($comparedValue);
-
-            if (is_null($date)) {
+            if (is_null($comparedValue)) {
                 return true;
             }
+
+            $date = $this->getDateTimestamp($comparedValue);
+
         }
 
         return $this->compare($this->getDateTimestamp($value), $date, $operator);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5991,6 +5991,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
+        $v = new Validator($trans, ['dates' => [['x' => '2024-02-02 12:00:00', 'y' => '2024-02-02 14:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5994,11 +5994,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         // with start_at,ends_at it passes
-        $v = new Validator($trans, ['dates' => [['start_at' => '1970-01-01 01:00:00', 'ends_at' => '1970-01-01 02:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
+        $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
 
         // with x,y it faiils (looks weird)
-        $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
+        $v = new Validator($trans, ['dates' => [['x' => '2024-02-02 12:00:00', 'y' => '2024-02-02 12:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5992,9 +5992,6 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['dates' => [['x' => '2024-02-02 12:00:00', 'y' => '2024-02-02 12:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
-        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5990,9 +5990,6 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => null, 'y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
-        $this->assertTrue($v->passes());
-
         $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5986,6 +5986,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date','y' => 'nullable|date|after:x']);
+        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5989,6 +5989,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date','y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ["dates" => [["x" => "1970-01-01 01:00:00","y" => "1970-01-01 02:00:00"]]], ['dates.*.x' => 'date','dates.*.y' => 'date|after:x']);
+        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5987,10 +5987,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date','y' => 'nullable|date|after:x']);
+        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ["dates" => [["x" => "1970-01-01 01:00:00","y" => "1970-01-01 02:00:00"]]], ['dates.*.x' => 'date','dates.*.y' => 'date|after:x']);
+        $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date','dates.*.y' => 'date|after:x']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5987,17 +5987,15 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
+        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => null, 'y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
-        // with start_at,ends_at it passes
         $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
 
-        // with x,y it faiils (looks weird)
         $v = new Validator($trans, ['dates' => [['x' => '2024-02-02 12:00:00', 'y' => '2024-02-02 12:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
         $this->assertTrue($v->passes());
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5991,7 +5991,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
-        $v = new Validator($trans, ['dates' => [['x' => '2024-02-02 12:00:00', 'y' => '2024-02-02 14:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
+        $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 14:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5990,7 +5990,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date','dates.*.y' => 'date|after:x']);
+        $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5990,8 +5990,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
+        // with start_at,ends_at it passes
+        $v = new Validator($trans, ['dates' => [['start_at' => '1970-01-01 01:00:00', 'ends_at' => '1970-01-01 02:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
+        $this->assertTrue($v->passes());
+
+        // with x,y it faiils (looks weird)
         $v = new Validator($trans, ['dates' => [['x' => '1970-01-01 01:00:00', 'y' => '1970-01-01 02:00:00']]], ['dates.*.x' => 'date', 'dates.*.y' => 'date|after:x']);
-        $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 14:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5992,6 +5992,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['date_end' => '2021-09-17 13:28:47'], ['date_start' => 'nullable|date', 'date_end' => 'nullable|date|after_or_equal:date_start']);
+        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5987,7 +5987,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
+        $v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => null, 'y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
         $this->assertTrue($v->passes());
 
         // with start_at,ends_at it passes


### PR DESCRIPTION
I had a [PR #49871](https://github.com/laravel/framework/pull/49871) to fix [Issue #49863](https://github.com/laravel/framework/issues/49863) but from this https://github.com/laravel/framework/pull/49871#issuecomment-1921544394 conversation it looks breaking change. also solving [Issue #49955](https://github.com/laravel/framework/issues/49955) 

if it is a breaking change then this PR will solve it. added tests for it too. 

```php
$v = new Validator($trans, ['y' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
$this->assertTrue($v->passes());

$v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
$this->assertTrue($v->passes());

$v = new Validator($trans, ['date_end' => '2021-09-17 13:28:47'], ['date_start' => 'nullable|date', 'date_end' => 'nullable|date|after_or_equal:date_start']);
$this->assertTrue($v->passes());
```

>[!NOTE]
> last 2 tests were not passing with `x`, `y` at place of `starts_at` or `date_start` and `ends_at` or `date_end`
> even if I revert my previous  [PR #49871](https://github.com/laravel/framework/pull/49871) changes.
> we can look into that later