### PR TITLE
[10.x] Adds PHPUnit 11 as conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,8 @@
     "conflict": {
         "carbonphp/carbon-doctrine-types": ">=3.0",
         "doctrine/dbal": ">=4.0",
-        "tightenco/collect": "<5.5.33"
+        "tightenco/collect": "<5.5.33",
+        "phpunit/phpunit": ">=11.0.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Laravel 10 does not support PHPUnit 11, so this pull request adds PHPUnit 11 as conflict.