### PR TITLE
[10.x] Fix in appendExceptionToException method exception type check

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1651,8 +1651,7 @@ class TestResponse implements ArrayAccess
      */
     protected function appendExceptionToException($exceptionToAppend, $exception)
     {
-        $exceptionMessage = $exceptionToAppend->getMessage();
-
+        $exceptionMessage = is_string($exceptionToAppend) ? $exceptionToAppend : $exceptionToAppend->getMessage();
         $exceptionToAppend = (string) $exceptionToAppend;
 
         $message = <<<"EOF"

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1652,6 +1652,7 @@ class TestResponse implements ArrayAccess
     protected function appendExceptionToException($exceptionToAppend, $exception)
     {
         $exceptionMessage = is_string($exceptionToAppend) ? $exceptionToAppend : $exceptionToAppend->getMessage();
+
         $exceptionToAppend = (string) $exceptionToAppend;
 
         $message = <<<"EOF"


### PR DESCRIPTION
While testing, there can be an error, with some 3d party requests/code (RabbitMQ connect, wss conect, gRPC connect, etc.), that doesn't hande correctly.

Without this fix, any errors related to such tests, showing in console like - `Error: Call to a member function getMessage() on string on vendor/laravel/framework/src/Illuminate/Testing/TestResponse.php:1654`