### PR TITLE
[10.x] Improved Handling of Empty Component Slots with HTML Comments or Line Breaks

### DIFF
--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -78,6 +78,36 @@ class ComponentSlot implements Htmlable
     }
 
     /**
+     * Determine if the slot is empty after being sanitized.
+     *
+     * @param  null|string|callable  $callable
+     * @return bool
+     */
+    public function sanitizedEmpty(null|string|callable $callable = null)
+    {
+        if (is_string($callable) && ! function_exists($callable)) {
+            throw new \InvalidArgumentException('Callable does not exist.');
+        }
+
+        $resolver =
+            $callable ??
+            fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input)); // replace everything between <!-- and --> with empty string
+
+        return filter_var($this->contents, FILTER_CALLBACK, ['options' => $resolver,]) === '';
+    }
+
+    /**
+     * Determine if the slot is not empty after being sanitized.
+     *
+     * @param  null|string|callable  $callable
+     * @return bool
+     */
+    public function sanitizedNotEmpty(null|string|callable $callable = null)
+    {
+        return ! $this->sanitizedEmpty($callable);
+    }
+
+    /**
      * Get the slot's HTML string.
      *
      * @return string

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -92,7 +92,7 @@ class ComponentSlot implements Htmlable
         $resolver =
             $callable ??
             fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input));
-            // replace everything between <!-- and --> with empty string
+        // replace everything between <!-- and --> with empty string
 
         return filter_var($this->contents, FILTER_CALLBACK, ['options' => $resolver]) === '';
     }

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View;
 
 use Illuminate\Contracts\Support\Htmlable;
+use InvalidArgumentException;
 
 class ComponentSlot implements Htmlable
 {
@@ -78,34 +79,22 @@ class ComponentSlot implements Htmlable
     }
 
     /**
-     * Determine if the slot is empty after being sanitized.
+     * Determine if the slot has non-comment content.
      *
-     * @param  null|string|callable  $callable
+     * @param  callable|string|null  $callable
      * @return bool
      */
-    public function sanitizedEmpty(null|string|callable $callable = null)
+    public function hasActualContent(callable|string|null $callable = null)
     {
         if (is_string($callable) && ! function_exists($callable)) {
-            throw new \InvalidArgumentException('Callable does not exist.');
+            throw new InvalidArgumentException('Callable does not exist.');
         }
 
-        $resolver =
-            $callable ??
-            fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input));
-        // replace everything between <!-- and --> with empty string
-
-        return filter_var($this->contents, FILTER_CALLBACK, ['options' => $resolver]) === '';
-    }
-
-    /**
-     * Determine if the slot is not empty after being sanitized.
-     *
-     * @param  null|string|callable  $callable
-     * @return bool
-     */
-    public function sanitizedNotEmpty(null|string|callable $callable = null)
-    {
-        return ! $this->sanitizedEmpty($callable);
+        return filter_var(
+            $this->contents,
+            FILTER_CALLBACK,
+            ['options' => $callable ?? fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input))]
+        ) !== '';
     }
 
     /**

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -91,9 +91,10 @@ class ComponentSlot implements Htmlable
 
         $resolver =
             $callable ??
-            fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input)); // replace everything between <!-- and --> with empty string
+            fn ($input) => trim(preg_replace("/<!--([\s\S]*?)-->/", '', $input));
+            // replace everything between <!-- and --> with empty string
 
-        return filter_var($this->contents, FILTER_CALLBACK, ['options' => $resolver,]) === '';
+        return filter_var($this->contents, FILTER_CALLBACK, ['options' => $resolver]) === '';
     }
 
     /**

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -326,9 +326,9 @@ class ComponentTest extends TestCase
         <img border="0" src="" alt="">
         -->');
 
-        $this->assertTrue((bool) $slot->sanitizedEmpty());
-        $this->assertTrue((bool) $linebreakingSlot->sanitizedEmpty('trim'));
-        $this->assertTrue((bool) $moreComplexSlot->sanitizedEmpty());
+        $this->assertFalse((bool) $slot->hasActualContent());
+        $this->assertFalse((bool) $linebreakingSlot->hasActualContent('trim'));
+        $this->assertFalse((bool) $moreComplexSlot->hasActualContent());
     }
 
     public function testComponentSlotSanitizedNotEmpty()
@@ -343,9 +343,9 @@ class ComponentTest extends TestCase
         <img border="0" src="" alt="">
         -->after');
 
-        $this->assertTrue((bool) $slot->sanitizedNotEmpty());
-        $this->assertTrue((bool) $linebreakingSlot->sanitizedNotEmpty('trim'));
-        $this->assertTrue((bool) $moreComplexSlot->sanitizedNotEmpty());
+        $this->assertTrue((bool) $slot->hasActualContent());
+        $this->assertTrue((bool) $linebreakingSlot->hasActualContent('trim'));
+        $this->assertTrue((bool) $moreComplexSlot->hasActualContent());
     }
 
     public function testComponentSlotIsNotEmpty()
@@ -359,11 +359,9 @@ class ComponentTest extends TestCase
         <img border="0" src="pic_trulli.jpg" alt="Trulli">
         -->est');
 
-        $this->assertTrue((bool) $slot->sanitizedNotEmpty());
-
-        $this->assertTrue((bool) $anotherSlot->sanitizedNotEmpty());
-
-        $this->assertTrue((bool) $moreComplexSlot->sanitizedNotEmpty());
+        $this->assertTrue((bool) $slot->hasActualContent());
+        $this->assertTrue((bool) $anotherSlot->hasActualContent());
+        $this->assertTrue((bool) $moreComplexSlot->hasActualContent());
     }
 }
 


### PR DESCRIPTION
This PR is an alternate implementation for the problem that PR #49935 addresses.

A short summary:

Since Livewire is injecting `morph markers`, we cannot safely ask if a slot is empty or not. The same happens if we add a linebreak or nonprintable characters like whitespaces or tabs. The slot is not empty and should be rendered.

This PR provide a new function `$slot->sanitizedEmpty()` and the counterpart `$slot->sanitizedNotEmpty()`


```blade
01    <table>
02    @if($slot-> sanitizedNotEmpty())
03        {{ $slot }}
04    @else
05        <tr><td>{{ __('No Results') }}</td></tr>
06    @endif
07    </table>
```


Please decide which one fits better in the framework.

Please note, the method is renamed into `hasActualContent()`
