### PR TITLE
[10.x] Fix infinite loop when global scopes query contains aggregates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -630,8 +630,8 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($name);
 
             if ($function) {
-                if ($this->getGrammar()->isExpression($column)) {
-                    $aggregateColumn = $this->getGrammar()->getValue($column);
+                if ($this->getQuery()->getGrammar()->isExpression($column)) {
+                    $aggregateColumn = $this->getQuery()->getGrammar()->getValue($column);
                 } else {
                     $hashedColumn = $this->getRelationHashedColumn($column, $relation);
 
@@ -642,7 +642,7 @@ trait QueriesRelationships
 
                 $expression = $function === 'exists' ? $aggregateColumn : sprintf('%s(%s)', $function, $aggregateColumn);
             } else {
-                $expression = $this->getGrammar()->getValue($column);
+                $expression = $this->getQuery()->getGrammar()->getValue($column);
             }
 
             // Here, we will grab the relationship sub-query and prepare to add it to the main query
@@ -671,7 +671,7 @@ trait QueriesRelationships
             // the query builder. Then, we will return the builder instance back to the developer
             // for further constraint chaining that needs to take place on the query as needed.
             $alias ??= Str::snake(
-                preg_replace('/[^[:alnum:][:space:]_]/u', '', "$name $function {$this->getGrammar()->getValue($column)}")
+                preg_replace('/[^[:alnum:][:space:]_]/u', '', "$name $function {$this->getQuery()->getGrammar()->getValue($column)}")
             );
 
             if ($function === 'exists') {


### PR DESCRIPTION
Attempt to fix #49968.

>TLDR: We can't call `$this->getGrammar()` directly because this causes an infinite loop.

Pinging @tpetry here because this is related to #49912. I'm not sure how to test this TBH, so I'd appreciate your input here. 

Calling `$this->getGrammar()` will redirect the call (passthru) from `\Illuminate\Database\Eloquent\Builder` to the base `Illuminate\Database\Query\Builder`. When doing this, we add a call to `->applyScopes()`:

https://github.com/laravel/framework/blob/4f7802dfc9993cb57cf69615491ce1a7eb2e9529/src/Illuminate/Database/Eloquent/Builder.php#L1760

This will cause laravel to call the scopes we have defined, and, since we are using a `count` aggregate, we'll end up in the  `withAggregate` method defined on line  606 of `Illuminate\Database\Eloquent\Concerns\QueriesRelationships` trait. Now, since we are calling `$this->getGrammar()` directly, we'll start the process of forwarding the call to the base query builder and calling `->applyScopes` all over again, which will cause an infinite loop.


I hope I was clear enough, but help to explain in the comments if need be.