### PR TITLE
[11.x] Add `ApplicationBuilder::flushState()` method

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -3,17 +3,26 @@
 namespace Illuminate\Foundation\Configuration;
 
 use Closure;
+use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Events\DiagnosingHealth;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as AppEventServiceProvider;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as AppRouteServiceProvider;
+use Illuminate\Queue\Queue;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Once;
+use Illuminate\Support\Sleep;
+use Illuminate\View\Component;
 use Laravel\Folio\Folio;
 
 class ApplicationBuilder
@@ -30,6 +39,27 @@ class ApplicationBuilder
      */
     public function __construct(protected Application $app)
     {
+    }
+
+    /**
+     * Flush the application's global state.
+     *
+     * @return void
+     */
+    public static function flushState(): void
+    {
+        AboutCommand::flushState();
+        Artisan::forgetBootstrappers();
+        Component::flushCache();
+        Component::forgetComponentsResolver();
+        Component::forgetFactory();
+        ConvertEmptyStringsToNull::flushState();
+        HandleExceptions::flushState();
+        Once::flush();
+        Queue::createPayloadUsing(null);
+        RegisterProviders::flushState();
+        Sleep::fake(false);
+        TrimStrings::flushState();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
+use Illuminate\Foundation\Configuration\ApplicationBuilder;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
@@ -242,18 +243,7 @@ abstract class TestCase extends BaseTestCase
         $this->originalExceptionHandler = null;
         $this->originalDeprecationHandler = null;
 
-        AboutCommand::flushState();
-        Artisan::forgetBootstrappers();
-        Component::flushCache();
-        Component::forgetComponentsResolver();
-        Component::forgetFactory();
-        ConvertEmptyStringsToNull::flushState();
-        HandleExceptions::flushState();
-        Once::flush();
-        Queue::createPayloadUsing(null);
-        RegisterProviders::flushState();
-        Sleep::fake(false);
-        TrimStrings::flushState();
+        ApplicationBuilder::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,24 +3,14 @@
 namespace Illuminate\Foundation\Testing;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Bootstrap\HandleExceptions;
-use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Configuration\ApplicationBuilder;
-use Illuminate\Foundation\Console\AboutCommand;
-use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
-use Illuminate\Foundation\Http\Middleware\TrimStrings;
-use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
-use Illuminate\Support\Once;
-use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
-use Illuminate\View\Component;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
 use PHPUnit\Framework\TestCase as BaseTestCase;


### PR DESCRIPTION
This allows it to be reused in package developments without having duplicate codes.