### PR TITLE
[11.x] Remove unsued import for 'Once' class

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -18,7 +18,6 @@ use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Once;
 use Illuminate\Support\ServiceProvider;
 use Laravel\SerializableClosure\SerializableClosure;
 


### PR DESCRIPTION
Flushing 'Once' in the `QueueServiceProvider` was removed but the import is still there. (From this PR: https://github.com/laravel/framework/pull/49744)

In this PR, I've removed the unused import. 