### PR TITLE
Added setAbly() method for AblyBroadcaster

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -232,4 +232,15 @@ class AblyBroadcaster extends Broadcaster
     {
         return $this->ably;
     }
+
+    /**
+     * Set the underlying Ably SDK instance.
+     *
+     * @param  \Ably\AblyRest  $ably
+     * @return void
+     */
+    public function setAbly($ably)
+    {
+        $this->ably = $ably;
+    }
 }


### PR DESCRIPTION
Recently, I encountered an issue with multiple WebSocket connections using the Pusher driver. The problem arose because the broadcasting manager is registered as a singleton during the application boot. In my multitenant application, I needed these connections to be dynamic. The PusherBroadcaster has a `setPusher()` method, which helped to resolve the scenario. However, when working with the Ably driver, I faced the same issue because there was no corresponding setter method for Ably. Hence, the PR.
