### PR TITLE
[11.x] Allow `withMiddleware` without callback in ApplicationBuilder class

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -198,16 +198,18 @@ class ApplicationBuilder
     /**
      * Register the global middleware, middleware groups, and middleware aliases for the application.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @return $this
      */
-    public function withMiddleware(callable $callback)
+    public function withMiddleware(?callable $callback = null)
     {
         $this->app->afterResolving(HttpKernel::class, function ($kernel) use ($callback) {
             $middleware = (new Middleware)
                 ->redirectTo(fn () => route('login'));
 
-            $callback($middleware);
+            if (! is_null($callback)) {
+                $callback($middleware);
+            }
 
             $this->pageMiddleware = $middleware->getPageMiddleware();
             $kernel->setGlobalMiddleware($middleware->getGlobalMiddleware());


### PR DESCRIPTION
After this pull request is merged, the callback to load additional middleware using the new `withMiddleware` method can be omitted. The same is already possible for the `withExceptions` method.

Whenever people wish it, the following is now also possible without empty callbacks:
```php
<?php

use Illuminate\Foundation\Application;

return Application::configure(basePath: dirname(__DIR__))
    ->withProviders()
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )
    ->withMiddleware()
    ->withExceptions()
    ->create();
```