### PR TITLE
[10.x] Add `toBase64()` and `fromBase64()` methods to Stringable and Str classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1536,7 +1536,7 @@ class Str
     }
 
     /**
-     * Base64 encode the string.
+     * Convert the given string to Base64 encoding.
      *
      * @param  string  $string
      * @return string
@@ -1547,7 +1547,7 @@ class Str
     }
 
     /**
-     * Decode the string from base64.
+     * Decode the given Base64 encoded string.
      *
      * @param  string  $string
      * @param  bool  $strict

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1550,7 +1550,7 @@ class Str
      * Decode the string from base64.
      *
      * @param  string  $string
-     * @param  boolean  $strict
+     * @param  bool  $strict
      * @return void
      */
     public static function fromBase64($string, $strict = false)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1536,6 +1536,29 @@ class Str
     }
 
     /**
+     * Base64 encode the string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function toBase64($string): string
+    {
+        return base64_encode($string);
+    }
+
+    /**
+     * Decode the string from base64.
+     *
+     * @param  string  $string
+     * @param  boolean  $strict
+     * @return void
+     */
+    public static function fromBase64($string, $strict = false)
+    {
+        return base64_decode($string, $strict);
+    }
+
+    /**
      * Make a string's first character lowercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1259,7 +1259,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Decode the string from base64.
      *
-     * @param bool $strict
+     * @param  bool  $strict
      * @return void
      */
     public function fromBase64($strict = false)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1247,6 +1247,27 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Base64 encode the string.
+     *
+     * @return void
+     */
+    public function toBase64()
+    {
+        return new static(base64_encode($this->value));
+    }
+
+    /**
+     * Decode the string from base64.
+     *
+     * @param boolean $strict
+     * @return void
+     */
+    public function fromBase64($strict = false)
+    {
+        return new static(base64_decode($this->value, $strict));
+    }
+
+    /**
      * Dump the string.
      *
      * @return $this

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1247,7 +1247,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Base64 encode the string.
+     * Convert the string to Base64 encoding.
      *
      * @return void
      */
@@ -1257,7 +1257,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
-     * Decode the string from base64.
+     * Decode the Base64 encoded string.
      *
      * @param  bool  $strict
      * @return void

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1259,7 +1259,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Decode the string from base64.
      *
-     * @param boolean $strict
+     * @param bool $strict
      * @return void
      */
     public function fromBase64($strict = false)

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1370,6 +1370,18 @@ class SupportStrTest extends TestCase
             Str::of(Str::password())->contains(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
         );
     }
+
+    public function testToBase64()
+    {
+        $this->assertSame(base64_encode('foo'), Str::toBase64('foo'));
+        $this->assertSame(base64_encode('foobar'), Str::toBase64('foobar'));
+    }
+
+    public function testFromBase64()
+    {
+        $this->assertSame('foo', Str::fromBase64(base64_encode('foo')));
+        $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1305,15 +1305,15 @@ class SupportStringableTest extends TestCase
 
     public function testToBase64()
     {
-        $this->assertSame(base64_encode('foo'), $this->stringable('foo')->toBase64());
-        $this->assertSame(base64_encode('foobar'), $this->stringable('foobar')->toBase64());
-        $this->assertSame(base64_encode('foobarbaz'), $this->stringable('foobarbaz')->toBase64());
+        $this->assertSame(base64_encode('foo'), (string) $this->stringable('foo')->toBase64());
+        $this->assertSame(base64_encode('foobar'), (string) $this->stringable('foobar')->toBase64());
+        $this->assertSame(base64_encode('foobarbaz'), (string) $this->stringable('foobarbaz')->toBase64());
     }
 
     public function testFromBase64()
     {
-        $this->assertSame('foo', $this->stringable(base64_encode('foo'))->fromBase64());
-        $this->assertSame('foobar', $this->stringable(base64_encode('foobar'))->fromBase64());
-        $this->assertSame('foobarbaz', $this->stringable(base64_encode('foobarbaz'))->fromBase64());
+        $this->assertSame('foo', (string) $this->stringable(base64_encode('foo'))->fromBase64());
+        $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64());
+        $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1313,7 +1313,7 @@ class SupportStringableTest extends TestCase
     public function testFromBase64()
     {
         $this->assertSame('foo', (string) $this->stringable(base64_encode('foo'))->fromBase64());
-        $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64());
+        $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1302,4 +1302,18 @@ class SupportStringableTest extends TestCase
         $this->assertTrue(isset($str[2]));
         $this->assertFalse(isset($str[10]));
     }
+
+    public function testToBase64()
+    {
+        $this->assertSame(base64_encode('foo'), $this->stringable('foo')->toBase64());
+        $this->assertSame(base64_encode('foobar'), $this->stringable('foobar')->toBase64());
+        $this->assertSame(base64_encode('foobarbaz'), $this->stringable('foobarbaz')->toBase64());
+    }
+
+    public function testFromBase64()
+    {
+        $this->assertSame('foo', $this->stringable(base64_encode('foo'))->fromBase64());
+        $this->assertSame('foobar', $this->stringable(base64_encode('foobar'))->fromBase64());
+        $this->assertSame('foobarbaz', $this->stringable(base64_encode('foobarbaz'))->fromBase64());
+    }
 }


### PR DESCRIPTION
This PR adds two very simply methods to the Stringable and Str classes:

* toBase64()
* fromBase64()

I recently needed to inspect a JWT token in a guard and the Stringable class had every other built in function I needed except when it came to base64. Base64 has enough use in things such as JWT to files transmitted over the web. These simple helper methods make it easy to work with inside the context of a Stringable object similar to how Laravel supports `upper` and `lower`.

Example usage:

```php
// Decoding a JWT token
$decodedJwt = collect(explode('.', $jwt))
    ->map(function (string $value) {
        $value = (string) Str::of($value)->fromBase64()->replace('_', '/')->replace('-', '+');
        return json_decode($value, true) ?? [];
    })
    ->reject(fn ($value) => empty($value))
    ->mapWithKeys(fn ($array) => $array)
    ->toArray();
    
// Simple encoding
return Str::toBase64('foobar');
```