### PR TITLE
[11.x] Allow withRouting with just pages, health and then callback

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -127,7 +127,7 @@ class ApplicationBuilder
         string $apiPrefix = 'api',
         ?callable $then = null)
     {
-        if (is_null($using) && (is_string($web) || is_string($api))) {
+        if (is_null($using) && (is_string($web) || is_string($api) || is_string($pages) || is_string($health)) || is_callable($then)) {
             $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $then);
         }
 


### PR DESCRIPTION
This update allows the use of `withRouting` with only health endpoint set up like this:

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        health: '/up',
    );
```

Right now, such setup throws an error:
```
Fatal error: Uncaught TypeError: Illuminate\Foundation\Support\Providers\RouteServiceProvider::loadRoutesUsing(): Argument #1 ($routesCallback) must be of type Closure, null given
```

**Why the error?**
`withRouting` method is only checking for the presence of web and api routes to determine if a new routing callback should be created. It skips that in case only the health route is provided and flops when ` AppRouteServiceProvider::loadRoutesUsing($using);` is called with an empty default value. 


**What's the actual use-case?**
I ran into this as I'm using my own `RouteServiceProvider` to specify routes separately for each domain of the application. With that approach, the only route I wanted in the bootstrap file was the health endpoint. 


**Why include the `$pages` and `$then`?**
I'd assume there might be similar scenarios where someone wants to specify only one or two named parameters from all that are offered:

```php
public function withRouting(?Closure $using = null,
        ?string $web = null,
        ?string $api = null,
        ?string $commands = null,
        ?string $channels = null,
        ?string $pages = null,
        ?string $health = null,
        string $apiPrefix = 'api',
        ?callable $then = null)
{
...
}
```

 IMO, the expectation is that it would work even if web or API routes are not defined. 

