### PR TITLE
[11.x] Add priority config to configuration middleware

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -214,8 +214,8 @@ class ApplicationBuilder
             $kernel->setMiddlewareGroups($middleware->getMiddlewareGroups());
             $kernel->setMiddlewareAliases($middleware->getMiddlewareAliases());
 
-            if ($priorities = $middleware->getMiddlewarePriorities()) {
-                $kernel->setMiddlewarePriorities($priorities);
+            if ($priorities = $middleware->getMiddlewarePriority()) {
+                $kernel->setMiddlewarePriority($priorities);
             }
         });
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -213,6 +213,10 @@ class ApplicationBuilder
             $kernel->setGlobalMiddleware($middleware->getGlobalMiddleware());
             $kernel->setMiddlewareGroups($middleware->getMiddlewareGroups());
             $kernel->setMiddlewareAliases($middleware->getMiddlewareAliases());
+
+            if ($priorities = $middleware->getMiddlewarePriorities()) {
+                $kernel->setMiddlewarePriorities($priorities);
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -153,6 +153,13 @@ class Middleware
     protected $customAliases = [];
 
     /**
+     * The custom middleware priorities.
+     *
+     * @var array
+     */
+    protected $customPriorities = [];
+
+    /**
      * Prepend middleware to the application's global middleware stack.
      *
      * @param  array|string  $middleware
@@ -656,5 +663,28 @@ class Middleware
                 : \Illuminate\Routing\Middleware\ThrottleRequests::class,
             'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         ];
+    }
+
+    /**
+     * Define the priority-sorted list of middleware.
+     *
+     * @param  array  $priorities
+     * @return $this
+     */
+    public function priority(array $priorities)
+    {
+        $this->customPriorities = $priorities;
+
+        return $this;
+    }
+
+    /**
+     * Get the priority-sorted list of middleware.
+     *
+     * @return array
+     */
+    public function getMiddlewarePriorities()
+    {
+        return $this->customPriorities;
     }
 }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -153,11 +153,11 @@ class Middleware
     protected $customAliases = [];
 
     /**
-     * The custom middleware priorities.
+     * The custom middleware priority definition.
      *
      * @var array
      */
-    protected $customPriorities = [];
+    protected $priority = [];
 
     /**
      * Prepend middleware to the application's global middleware stack.
@@ -666,25 +666,25 @@ class Middleware
     }
 
     /**
-     * Define the priority-sorted list of middleware.
+     * Define the middleware priority for the application.
      *
-     * @param  array  $priorities
+     * @param  array  $priority
      * @return $this
      */
-    public function priority(array $priorities)
+    public function priority(array $priority)
     {
-        $this->customPriorities = $priorities;
+        $this->priority = $priority;
 
         return $this;
     }
 
     /**
-     * Get the priority-sorted list of middleware.
+     * Get the middleware priority for the application.
      *
      * @return array
      */
-    public function getMiddlewarePriorities()
+    public function getMiddlewarePriority()
     {
-        return $this->customPriorities;
+        return $this->priority;
     }
 }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -404,6 +404,19 @@ class Middleware
     }
 
     /**
+     * Define the middleware priority for the application.
+     *
+     * @param  array  $priority
+     * @return $this
+     */
+    public function priority(array $priority)
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
      * Get the global middleware.
      *
      * @return array
@@ -663,19 +676,6 @@ class Middleware
                 : \Illuminate\Routing\Middleware\ThrottleRequests::class,
             'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         ];
-    }
-
-    /**
-     * Define the middleware priority for the application.
-     *
-     * @param  array  $priority
-     * @return $this
-     */
-    public function priority(array $priority)
-    {
-        $this->priority = $priority;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -597,14 +597,14 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Set the application's middleware priorities.
+     * Set the application's middleware priority.
      *
-     * @param  array  $priorities
+     * @param  array  $priority
      * @return $this
      */
-    public function setMiddlewarePriorities(array $priorities)
+    public function setMiddlewarePriority(array $priority)
     {
-        $this->middlewarePriority = $priorities;
+        $this->middlewarePriority = $priority;
 
         $this->syncMiddlewareToRouter();
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -597,6 +597,21 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Set the application's middleware priorities.
+     *
+     * @param  array  $priorities
+     * @return $this
+     */
+    public function setMiddlewarePriorities(array $priorities)
+    {
+        $this->middlewarePriority = $priorities;
+
+        $this->syncMiddlewareToRouter();
+
+        return $this;
+    }
+
+    /**
      * Get the Laravel application instance.
      *
      * @return \Illuminate\Contracts\Foundation\Application


### PR DESCRIPTION
After this pull request is merged, user can define middleware priority in app.php

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withMiddleware(function (Middleware $middleware) {
        $middleware->priority([
            \App\Http\Middleware\ExampleMiddleware::class,
            \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
            \Illuminate\Cookie\Middleware\EncryptCookies::class,
            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
            \Illuminate\Session\Middleware\StartSession::class,
            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
            \Illuminate\Routing\Middleware\ThrottleRequests::class,
            \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
            \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions::class,
            \Illuminate\Routing\Middleware\SubstituteBindings::class,
            \Illuminate\Auth\Middleware\Authorize::class
        ]);
    })
    ->create();
```