### PR TITLE
[10.x] Fix the phpdoc for replaceMatches in Str and Stringable helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1188,7 +1188,7 @@ class Str
     /**
      * Replace the patterns matching the given regular expression.
      *
-     * @param  string  $pattern
+     * @param  array|string  $pattern
      * @param  \Closure|string  $replace
      * @param  array|string  $subject
      * @param  int  $limit

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -720,7 +720,7 @@ class Stringable implements JsonSerializable, ArrayAccess
     /**
      * Replace the patterns matching the given regular expression.
      *
-     * @param  string  $pattern
+     * @param  array|string  $pattern
      * @param  \Closure|string  $replace
      * @param  int  $limit
      * @return static


### PR DESCRIPTION
This work aligns the type hinting of the `$pattern` parameter of the method `replaceMatches` in `Str` and `Stringable` classes, to match what the underneath php functions have:

```
// https://www.php.net/manual/en/function.preg-replace.php
preg_replace(
    string|array $pattern,
    string|array $replacement,
    string|array $subject,
    int $limit = -1,
    int &$count = null
): string|array|null

// https://www.php.net/manual/en/function.preg-replace-callback.php
preg_replace_callback(
    string|array $pattern,
    [callable](https://www.php.net/manual/en/language.types.callable.php) $callback,
    string|array $subject,
    int $limit = -1,
    int &$count = null,
    int $flags = 0
): string|array|null
```

