### PR TITLE
[10.x] Fix date validation issues

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -253,9 +253,15 @@ trait ValidatesAttributes
         }
 
         if (is_null($date = $this->getDateTimestamp($parameters[0]))) {
+            $dateAttributes = explode(' ', $parameters[0]);
             $comparedValue = $this->getValue($parameters[0]);
 
-            if (! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
+            if (count($dateAttributes) > 1) {
+                $key = array_shift($dateAttributes);
+                $comparedValue = implode(' ', [$this->getValue($key), ...$dateAttributes]);
+            }
+
+            if (! is_null($comparedValue) && ! is_string($comparedValue) && ! is_numeric($comparedValue) && ! $comparedValue instanceof DateTimeInterface) {
                 return false;
             }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5986,6 +5986,21 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => ['a' => ['v' => 'c']], 'y' => 'invalid'], ['x' => 'date', 'y' => 'date|before:x']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '1970-01-01'], ['x' => 'nullable|date', 'y' => 'nullable|date|after:x']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['dates' => [['start_at' => '2024-02-02 12:00:00', 'ends_at' => '2024-02-02 12:00:00']]], ['dates.*.start_at' => 'date', 'dates.*.ends_at' => 'date|after:start_at']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['date_end' => '2021-09-17 13:28:47'], ['date_start' => 'nullable|date', 'date_end' => 'nullable|date|after_or_equal:date_start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['date_end' => '2024-01-05 00:00:01', 'date_start' => '2024-01-04 00:00:00'], ['date_start' => 'date', 'date_end' => 'date|after:date_start +1 day']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['date_end' => '2024-01-05 00:00:01', 'date_start' => '2024-01-04 00:00:00'], ['date_start' => 'date', 'date_end' => 'date|after:date_start +1day']);
+        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfterWithFormat()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5896,7 +5896,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testBeforeAndAfter2345()
+    public function testBeforeAndAfter()
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -6003,6 +6003,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['date_start' => '2024-01-04 00:00:00', 'date_end' => '2024-01-05 00:00:01'], ['date_start' => 'date|before:date_end -1 day', 'date_end' => 'date']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['date_start' => '2024-01-04 00:00:00', 'date_end' => '2024-01-05 00:00:01'], ['date_start' => 'date|before:date_end -1day', 'date_end' => 'date']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5896,7 +5896,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
-    public function testBeforeAndAfter()
+    public function testBeforeAndAfter2345()
     {
         date_default_timezone_set('UTC');
         $trans = $this->getIlluminateArrayTranslator();
@@ -6000,6 +6000,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['date_end' => '2024-01-05 00:00:01', 'date_start' => '2024-01-04 00:00:00'], ['date_start' => 'date', 'date_end' => 'date|after:date_start +1day']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['date_start' => '2024-01-04 00:00:00', 'date_end' => '2024-01-05 00:00:01'], ['date_start' => 'date|before:date_end -1 day', 'date_end' => 'date']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
Fixes #49955 
Fixes #49988

This is an alternative to #49956

In Laravel v10.42.0, we can validate that a date is `after` or `before` another one, adding/subtracting a given amount of minutes, hours, seconds:

```php
$data = [
    'dt1' => '2020-01-01',
    'dt2' => '2024-01-01',
];

Validator::make($data, [
    'dt1' => 'required|date',
    'dt2' => 'required|date|after:dt1 +1 day', //dt +1day also works
]);

```

PR #49871 broke this behavior and the nested after date validation.

I tried to fix both issues without reverting the original PR. Also added tests to make sure after and before are working as expected now.