### PR TITLE
[10.x] Number set Default Precision

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -18,6 +18,13 @@ class Number
     protected static $locale = 'en';
 
     /**
+     * The current default precision.
+     *
+     * @var int
+     */
+    protected static $precision = 0;
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -36,6 +43,8 @@ class Number
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
         } elseif (! is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+        } elseif (! is_float($number)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, static::$precision);
         }
 
         return $formatter->format($number);
@@ -92,7 +101,7 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function percentage(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
+    public static function percentage(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
@@ -101,7 +110,7 @@ class Number
         if (! is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
         } else {
-            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision ?? static::$precision);
         }
 
         return $formatter->format($number / 100);
@@ -132,7 +141,7 @@ class Number
      * @param  int|null  $maxPrecision
      * @return string
      */
-    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
+    public static function fileSize(int|float $bytes, ?int $precision = null, ?int $maxPrecision = null)
     {
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
@@ -140,7 +149,7 @@ class Number
             $bytes /= 1024;
         }
 
-        return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision), $units[$i]);
+        return sprintf('%s %s', static::format($bytes, $precision ?? static::$precision, $maxPrecision), $units[$i]);
     }
 
     /**
@@ -151,9 +160,9 @@ class Number
      * @param  int|null  $maxPrecision
      * @return bool|string
      */
-    public static function abbreviate(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function abbreviate(int|float $number, ?int $precision = null, ?int $maxPrecision = null)
     {
-        return static::forHumans($number, $precision, $maxPrecision, abbreviate: true);
+        return static::forHumans($number, $precision ?? static::$precision, $maxPrecision, abbreviate: true);
     }
 
     /**
@@ -165,9 +174,9 @@ class Number
      * @param  bool  $abbreviate
      * @return bool|string
      */
-    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
+    public static function forHumans(int|float $number, ?int $precision = null, ?int $maxPrecision = null, bool $abbreviate = false)
     {
-        return static::summarize($number, $precision, $maxPrecision, $abbreviate ? [
+        return static::summarize($number, $precision ?? static::$precision, $maxPrecision, $abbreviate ? [
             3 => 'K',
             6 => 'M',
             9 => 'B',
@@ -257,6 +266,17 @@ class Number
     public static function useLocale(string $locale)
     {
         static::$locale = $locale;
+    }
+
+    /**
+     * Set the default precision.
+     *
+     * @param  int  $precision
+     * @return void
+     */
+    public static function usePrecision(int $precision)
+    {
+        static::$precision = $precision;
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -64,6 +64,19 @@ class SupportNumberTest extends TestCase
         Number::useLocale('en');
     }
 
+    public function testFormatWithAppPrecision()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('100,000', Number::format(100000));
+
+        Number::usePrecision(2);
+
+        $this->assertSame('100,000.00', Number::format(100000));
+
+        Number::usePrecision(0);
+    }
+
     public function testSpellout()
     {
         $this->assertSame('ten', Number::spell(10));
@@ -124,6 +137,19 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4));
     }
 
+    public function testToPercentWithAppPrecision()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('100%', Number::percentage(100));
+
+        Number::usePrecision(2);
+
+        $this->assertSame('100.00%', Number::percentage(100));
+
+        Number::usePrecision(0);
+    }
+
     public function testToCurrency()
     {
         $this->needsIntlExtension();
@@ -171,6 +197,17 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
         $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+    }
+
+    public function testBytesToHumanWithAppPrecision()
+    {
+        $this->assertSame('2 KB', Number::fileSize(2048));
+
+        Number::usePrecision(2);
+
+        $this->assertSame('2.00 KB', Number::fileSize(2048));
+
+        Number::usePrecision(0);
     }
 
     public function testClamp()
@@ -238,6 +275,17 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
     }
 
+    public function testToHumanWithAppPrecision()
+    {
+        $this->assertSame('1 thousand', Number::forHumans(1000));
+
+        Number::usePrecision(2);
+
+        $this->assertSame('1.00 thousand', Number::forHumans(1000));
+
+        Number::usePrecision(0);
+    }
+
     public function testSummarize()
     {
         $this->assertSame('1', Number::abbreviate(1));
@@ -292,6 +340,17 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1.1T', Number::abbreviate(-1100000000000, maxPrecision: 1));
         $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
+    }
+
+    public function testSummarizeWithAppPrecision()
+    {
+        $this->assertSame('1K', Number::abbreviate(1000));
+
+        Number::usePrecision(2);
+
+        $this->assertSame('1.00K', Number::abbreviate(1000));
+
+        Number::usePrecision(0);
     }
 
     protected function needsIntlExtension()


### PR DESCRIPTION
While implementing the Number helper in a large application, I've found repeating myself repeating the precision parameter, for example `Number:format(123.45, precision: 2)`.

This PR introduces a `usePrecision` method which allows to set the default precision.
```php
Number::usePrecision(2);
```

After setting the default precision:

```php 
Number::format(100);        // 100.00
Number::percentage(100);    // 100.00%
Number::fileSize(2048);     // 2.00 KB
Number::forHumans(1000);    // 1.00 thousand
Number::abbreviate(1000);   // 1.00K
```