### PR TITLE
[10.x] Fix appended accessors from overwriting existing value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -211,7 +211,9 @@ trait HasAttributes
         // as these attributes are not really in the attributes array, but are run
         // when we need to array or JSON the model for convenience to the coder.
         foreach ($this->getArrayableAppends() as $key) {
-            $attributes[$key] = $this->mutateAttributeForArray($key, null);
+            if (! array_key_exists($key, $attributes)) {
+                $attributes[$key] = $this->mutateAttributeForArray($key, null);
+            }
         }
 
         return $attributes;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2039,18 +2039,28 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('camelCased', $model->camelCased);
         $this->assertSame('StudlyCased', $model->StudlyCased);
 
-        $this->assertEquals(['is_admin', 'camelCased', 'StudlyCased'], $model->getAppends());
+        $this->assertEquals(['is_admin', 'camelCased', 'StudlyCased', 'name'], $model->getAppends());
 
         $this->assertTrue($model->hasAppended('is_admin'));
         $this->assertTrue($model->hasAppended('camelCased'));
         $this->assertTrue($model->hasAppended('StudlyCased'));
         $this->assertFalse($model->hasAppended('not_appended'));
 
-        $model->setHidden(['is_admin', 'camelCased', 'StudlyCased']);
+        $model->setHidden(['is_admin', 'camelCased', 'StudlyCased', 'name']);
         $this->assertEquals([], $model->toArray());
 
         $model->setVisible([]);
         $this->assertEquals([], $model->toArray());
+    }
+
+    public function testAppendingOfAccessors()
+    {
+        $model = new EloquentModelAppendsStub;
+
+        $model->setRawAttributes(['name' => 'taylor otwell']);
+
+        $this->assertSame('Taylor Otwell', $model->name);
+        $this->assertSame('Taylor Otwell', $model->toArray()['name']);
     }
 
     public function testGetMutatedAttributes()
@@ -3136,7 +3146,7 @@ class EloquentModelBootingTestStub extends Model
 
 class EloquentModelAppendsStub extends Model
 {
-    protected $appends = ['is_admin', 'camelCased', 'StudlyCased'];
+    protected $appends = ['is_admin', 'camelCased', 'StudlyCased', 'name'];
 
     public function getIsAdminAttribute()
     {
@@ -3151,6 +3161,11 @@ class EloquentModelAppendsStub extends Model
     public function getStudlyCasedAttribute()
     {
         return 'StudlyCased';
+    }
+
+    protected function name(): Attribute
+    {
+        return Attribute::get(fn ($value) => ucwords($value));
     }
 }
 


### PR DESCRIPTION
Hello!

First off, I understand that this is not the intended use case, but the below scenario did occur and resulted in a very elusive bug to track down.

Definitions:
- Accessor: an attribute that transforms an Eloquent database value when it is accessed
- Computed attribute: an extra attribute on the model that is not backed by a database value


### Problem
A developer mistakenly added an accessor to the `$appends` array not knowing that the accessor already transforms the database value when the model is cast to an array. However, this resulted in an elusive bug where the attribute in question came through as `null` on the front end.

#### Example
To take the example given in the docs, say you have a `User` model that uses an accessor to modify the database value when the `first_name` attribute is accessed. A developer mistakenly adds the accessor to the `$appends` array:

```php
class User extends Model
{
    protected $appends = ['first_name'];

    protected function firstName(): Attribute
    {
        return Attribute::get(fn ($value) => ucfirst($value));
    }
}
// ...
$user->toArray()['first_name'] // ''
```
The result is that the `first_name` in the array will be empty even when the user has a `first_name` in the database!

What happens is that the accessor is called (with the correct `$value`) when adding the database property to the array, then the accessor is called *again* (with a `$value = null`) when processing all of the appended computed properties which overwrites the correct value.

### Solution
Obviously, the correct fix is for the above problem is to remove the accessor from the appends array. However, I decided to improve the developer experience to keep this from biting someone else in the future.

The easy solution implemented in this PR is to simply avoid overwriting any attribute that already exists:

```diff
        // Here we will grab all of the appended, calculated attributes to this model
        // as these attributes are not really in the attributes array, but are run
        // when we need to array or JSON the model for convenience to the coder.
        // We null-coalesce here in case the developer has appended an accessor.
        foreach ($this->getArrayableAppends() as $key) {
-            $attributes[$key] = $this->mutateAttributeForArray($key, null);
+            if (! array_key_exists($key, $attributes)) {
+                $attributes[$key] = $this->mutateAttributeForArray($key, null);
+            }
        }
```


The docs should also probably be updated to make this more clear that the `$appends` array is only for **computed properties**.


Thanks!