### PR TITLE
[10.x] Create new command EnumMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\{InputInterface, InputOption};
+
+#[AsCommand(name: 'make:enum')]
+class EnumMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:enum';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new enum class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Enum';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (parent::handle() === false && !$this->option('force')) {
+            return false;
+        }
+
+        if ($this->option('test')) {
+            $this->createTest();
+        }
+    }
+
+    /**
+     * Create a model factory for the model.
+     *
+     * @return void
+     */
+    protected function createTest()
+    {
+        $this->call('make:test', [
+            'name' => $this->qualifyClass($this->getNameInput()) . 'Test',
+            '--unit' => true,
+        ]);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/enum.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__ . $stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Enums')) ? $rootNamespace . '\\Enums' : $rootNamespace;
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/enum.stub
+++ b/src/Illuminate/Foundation/Console/stubs/enum.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace {{ namespace }};
+
+enum {{ class }}: string
+{
+
+}
+

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -47,6 +47,7 @@ use Illuminate\Foundation\Console\EventClearCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
+use Illuminate\Foundation\Console\EnumMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
@@ -125,6 +126,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Environment' => EnvironmentCommand::class,
         'EnvironmentDecrypt' => EnvironmentDecryptCommand::class,
         'EnvironmentEncrypt' => EnvironmentEncryptCommand::class,
+        'EnumMake' => EnumMakeCommand::class,
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,
@@ -391,6 +393,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(EventMakeCommand::class, function ($app) {
             return new EventMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEnumMakeCommand()
+    {
+        $this->app->singleton(EnumMakeCommand::class, function ($app) {
+            return new EnumMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Within the commands defined in the structure there is currently no option to create enums, whenever I create a new project I need to create a custom command to create enums, the same applies to external actions and services.

For example: when I need to create an action, I created a make:action command.
For an external service, for integrations with other products I generally use a make:service command.

In this case, I always need to create a new command to create enums, I believe that make:enum would be very useful for Laravel developers' daily lives.

php artisan make:enum

Att. Felipe Arnold.