### PR TITLE
[11.x] Improved require password middleware to work with stateless authentication

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -102,4 +102,16 @@ trait Authenticatable
     {
         return $this->rememberTokenName;
     }
+
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return string
+     */
+    public function getUniqueIdentifierForUser()
+    {
+        $identifierValue = $this->getAuthIdentifier();
+        $className = class_basename($this::class);
+        return $className . "." . $identifierValue;
+    }
 }

--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -93,8 +93,9 @@ class RequirePassword
      */
     protected function shouldConfirmPassword($request, $passwordTimeoutSeconds = null)
     {
-        $confirmedAt = time() - $request->session()->get('auth.password_confirmed_at', 0);
-
+        $identifier = $request->user()->getUniqueIdentifierForUser();
+        $key = "auth.password_confirmed_at.$identifier";
+        $confirmedAt = time() - cache($key, 0);
         return $confirmedAt > ($passwordTimeoutSeconds ?? $this->passwordTimeout);
     }
 }


### PR DESCRIPTION
This pull request adjusts the mechanism used by the `Illuminate\Auth\Middleware\RequirePassword` to store users' password confirmation timeout.

The old mechanism used session storage, but this mechanism won't work with stateless authentication methods (e.g. Restful APIs) because we don't have sessions.

So, I thought about two possible scenarios to deal with this situation:

1. Store the timeout value inside the authenticatable users' tables (e.g. `users`) in some column called `password_confirmed_at`, but this approach has a performance impact since it requires hitting the database each time a request comes to a route that has this middleware. Another downside to this approach is the configuration that needs to be done each time a new auth provider is added, because a nullable `password_confirmed_at` column of type `timetstamp` must be defined inside the migration file.
2. Store the timeout value inside using cache, so I adopted this approach because cache access is faster than database access (even if the used cache driver is `file`), and because this approach works in a seamless way and doesn't require any configuration from on the developer side.

This pull request adds a new `getUniqueIdentifierForUser()` method inside the `Illuminate\Auth\Authenticatable` trait. The purpose of this method is to compose a unique identifier for the user for caching purposes by concatenating the model name and the value of the primary key, separated by a dot. This key will be used to read and write the confirmation timeout value from/into the cache storage. 
One might suggest that depending on the value of the primary key is sufficient, but it's not, because if you have multiple auth providers (e.g. `users` and `admins`) then it's possible that the value of the primary key may appear multiple times (e.g. `user_id` = 1 and `admin_id` = 1), causing one to overwrite the other inside the cache.

This pull request has breaking changes for the mentioned reasons. In the case of approval, other Laravel starter kits repositories will need to have pull requests to adopt these changes, and I'll definitely do that as well.
