### PR TITLE
[10.x] Add support for setting app currency

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -18,6 +18,13 @@ class Number
     protected static $locale = 'en';
 
     /**
+     * The current default currency.
+     *
+     * @var string
+     */
+    protected static $currency = 'USD';
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -115,13 +122,13 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = 'USD', ?string $locale = null)
+    public static function currency(int|float $number, ?string $in = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
 
-        return $formatter->formatCurrency($number, $in);
+        return $formatter->formatCurrency($number, $in ?? static::$currency);
     }
 
     /**
@@ -257,6 +264,33 @@ class Number
     public static function useLocale(string $locale)
     {
         static::$locale = $locale;
+    }
+
+    /**
+     * Execute the given callback using the given currency.
+     *
+     * @param  string  $currency
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function withCurrency(string $currency, callable $callback)
+    {
+        $previousCurrency = static::$currency;
+
+        static::useCurrency($currency);
+
+        return tap($callback(), fn () => static::useCurrency($previousCurrency));
+    }
+
+    /**
+     * Set the default currency.
+     *
+     * @param  string  $currency
+     * @return void
+     */
+    public static function useCurrency(string $currency)
+    {
+        static::$currency = $currency;
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -154,6 +154,19 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
     }
 
+    public function testToCurrencyWithAppCurrency()
+    {
+        $this->needsIntlExtension();
+
+        $this->assertSame('$10.00', Number::currency(10));
+
+        Number::useCurrency('EUR');
+
+        $this->assertSame('€10.00', Number::currency(10));
+
+        Number::useCurrency('USD');
+    }
+
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::fileSize(0));


### PR DESCRIPTION
This pull request allows for setting a default currency to be used. The usage equals the behaviour of the 'locale' methods and is as follows:

```php
use Illuminate\Support\Number;
use Illuminate\Support\ServiceProvider;
 
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        // set default app currency
        Number::useCurrency('EUR');
    }
}
```
Now the currency helper method can be used without providing an explicit currency:

```php
use Illuminate\Support\Number;

Number::currency(10); // €10.00
```

This won't break backwards compatibility because the former default setting 'USD' is set internally as fallback.
