### PR TITLE
[11.x] Fix Octane health up issue

### DIFF
--- a/src/Illuminate/Foundation/resources/health-up.blade.php
+++ b/src/Illuminate/Foundation/resources/health-up.blade.php
@@ -38,7 +38,11 @@
                         <h2 class="text-xl font-semibold text-gray-900">Application up</h2>
 
                         <p class="mt-2 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
-                            HTTP request received. Response successfully rendered in {{ round((microtime(true) - LARAVEL_START) * 1000) }}ms.
+                            HTTP request received.
+
+                            @if (defined(LARAVEL_START))
+                                Response successfully rendered in {{ round((microtime(true) - LARAVEL_START) * 1000) }}ms.
+                            @endif
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes https://github.com/laravel/octane/issues/836

This PR fixes an issue where the constant `LARAVEL_START` isn't available in each Octane request since it's only defined one-time at boot time and not sub sequential for each further request.