### PR TITLE
[10.x] Introduce new `Arr::take()` helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -232,7 +232,7 @@ class Arr
      * @param  int  $limit
      * @return array
      */
-    public static function limit($array, $limit)
+    public static function take($array, $limit)
     {
         if ($limit < 0) {
             return array_slice($array, $limit, abs($limit));

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -226,6 +226,22 @@ class Arr
     }
 
     /**
+     * Take the first or last {$limit} items from an array.
+     *
+     * @param  array  $array
+     * @param  int  $limit
+     * @return array
+     */
+    public static function limit($array, $limit)
+    {
+        if ($limit < 0) {
+            return array_slice($array, $limit, abs($limit));
+        }
+
+        return array_slice($array, 0, $limit);
+    }
+
+    /**
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  iterable  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1261,16 +1261,16 @@ class SupportArrTest extends TestCase
         ], Arr::prependKeysWith($array, 'test.'));
     }
 
-    public function testLimit()
+    public function testTake()
     {
         $array = [1, 2, 3, 4, 5, 6];
 
         $this->assertEquals([
             1, 2, 3,
-        ], Arr::limit($array, 3));
+        ], Arr::take($array, 3));
 
         $this->assertEquals([
             4, 5, 6,
-        ], Arr::limit($array, -3));
+        ], Arr::take($array, -3));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1260,4 +1260,17 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testLimit()
+    {
+        $array = [1, 2, 3, 4, 5, 6];
+
+        $this->assertEquals([
+            1, 2, 3,
+        ], Arr::limit($array, 3));
+
+        $this->assertEquals([
+            4, 5, 6,
+        ], Arr::limit($array, -3));
+    }
 }


### PR DESCRIPTION
I reached for this today and could have sworn that it existed, but turns out that it's only a `Collection` method. I think it makes sense as an `Arr` helper too, since it reads a lot nicer than the underlying `array_slice()` syntax.
