### PR TITLE
[11.x] Introduce new `make:enum` command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:enum')]
+class EnumMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:enum';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new enum';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Enum';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('string') || $this->option('int')) {
+            return __DIR__.'/stubs/enum.backed.stub';
+        }
+
+        return __DIR__.'/stubs/enum.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\\Enums';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        if ($this->option('string') || $this->option('int')) {
+            return str_replace(
+                ['{{ type }}'],
+                $this->option('string') ? 'string' : 'int',
+                parent::buildClass($name)
+            );
+        }
+
+        return parent::buildClass($name);
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['string', 's', InputOption::VALUE_NONE, 'Generate a string backed enum.'],
+            ['int', 'i', InputOption::VALUE_NONE, 'Generate an int backed enum.'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the enum even if the enum already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -4,7 +4,11 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\select;
 
 #[AsCommand(name: 'make:enum')]
 class EnumMakeCommand extends GeneratorCommand
@@ -52,7 +56,7 @@ class EnumMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\\Enums';
+        return $rootNamespace;
     }
 
     /**
@@ -77,6 +81,30 @@ class EnumMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $type = select('Which type of enum would you like?', [
+            'pure' => 'Pure enum',
+            'string' => 'Backed enum (String)',
+            'int' => 'Backed enum (Integer)',
+        ]);
+
+        if ($type !== 'pure') {
+            $input->setOption($type, true);
+        }
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array
@@ -85,7 +113,7 @@ class EnumMakeCommand extends GeneratorCommand
     {
         return [
             ['string', 's', InputOption::VALUE_NONE, 'Generate a string backed enum.'],
-            ['int', 'i', InputOption::VALUE_NONE, 'Generate an int backed enum.'],
+            ['int', 'i', InputOption::VALUE_NONE, 'Generate an integer backed enum.'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the enum even if the enum already exists'],
         ];
     }

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -43,6 +43,8 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/class.stub' => 'class.stub',
             __DIR__.'/stubs/class.invokable.stub' => 'class.invokable.stub',
             __DIR__.'/stubs/console.stub' => 'console.stub',
+            __DIR__.'/stubs/enum.stub' => 'enum.stub',
+            __DIR__.'/stubs/enum.backed.stub' => 'enum.backed.stub',
             __DIR__.'/stubs/event.stub' => 'event.stub',
             __DIR__.'/stubs/job.queued.stub' => 'job.queued.stub',
             __DIR__.'/stubs/job.stub' => 'job.stub',

--- a/src/Illuminate/Foundation/Console/stubs/enum.backed.stub
+++ b/src/Illuminate/Foundation/Console/stubs/enum.backed.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+enum {{ class }}: {{ type }}
+{
+    //
+}

--- a/src/Illuminate/Foundation/Console/stubs/enum.stub
+++ b/src/Illuminate/Foundation/Console/stubs/enum.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+enum {{ class }}
+{
+    //
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -43,6 +43,7 @@ use Illuminate\Foundation\Console\ConfigShowCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
+use Illuminate\Foundation\Console\EnumMakeCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\EnvironmentDecryptCommand;
 use Illuminate\Foundation\Console\EnvironmentEncryptCommand;
@@ -188,6 +189,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConsoleMake' => ConsoleMakeCommand::class,
         'ControllerMake' => ControllerMakeCommand::class,
         'Docs' => DocsCommand::class,
+        'EnumMake' => EnumMakeCommand::class,
         'EventGenerate' => EventGenerateCommand::class,
         'EventMake' => EventMakeCommand::class,
         'ExceptionMake' => ExceptionMakeCommand::class,
@@ -413,6 +415,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(ControllerMakeCommand::class, function ($app) {
             return new ControllerMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEnumMakeCommand()
+    {
+        $this->app->singleton(EnumMakeCommand::class, function ($app) {
+            return new EnumMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
There have been a couple of other attempts to do this that were closed, but this one is correctly targeting 11.x (master) and is a bit more generic (options for `string` and `int` backed enums, as well as unit enums).

Wasn't sure on the stub naming convention, seems to be a mix of kebab case and period-separated names.

This command is designed to live alongside the new `make:class` and `make:interface` commands found in 11.x.