### PR TITLE
[11.x] Fix Octane health up defined check

### DIFF
--- a/src/Illuminate/Foundation/resources/health-up.blade.php
+++ b/src/Illuminate/Foundation/resources/health-up.blade.php
@@ -40,7 +40,7 @@
                         <p class="mt-2 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
                             HTTP request received.
 
-                            @if (defined(LARAVEL_START))
+                            @if (defined('LARAVEL_START'))
                                 Response successfully rendered in {{ round((microtime(true) - LARAVEL_START) * 1000) }}ms.
                             @endif
                         </p>


### PR DESCRIPTION
This PR fixes the missing quotes for the `defined` condition in health up (added for Octane).

Fixes https://github.com/laravel/octane/issues/836

Original PR: https://github.com/laravel/framework/pull/50012
