### PR TITLE
[11.x] Allow sending mail synchronously even for queued mailables

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -38,4 +38,14 @@ interface Mailer
      * @return \Illuminate\Mail\SentMessage|null
      */
     public function send($view, array $data = [], $callback = null);
+
+    /**
+     * Send a new message synchronously using a view.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $mailable
+     * @param  array  $data
+     * @param  \Closure|string|null  $callback
+     * @return \Illuminate\Mail\SentMessage|null
+     */
+    public function sendNow($mailable, array $data = [], $callback = null);
 }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -358,6 +358,23 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
+     * Send a new message synchronously using a view.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
+     * @param  array  $data
+     * @param  \Closure|string|null  $callback
+     * @return \Illuminate\Mail\SentMessage|null
+     */
+    public function sendNow($mailable, array $data = [], $callback = null)
+    {
+        if ($mailable instanceof MailableContract) {
+            return $mailable->mailer($this->name)->send($this);
+        }
+
+        return $this->send($mailable, $data, $callback);
+    }
+
+    /**
      * Parse the given view name or array.
      *
      * @param  \Closure|array|string  $view

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -125,6 +125,17 @@ class PendingMail
     }
 
     /**
+     * Send a new mailable message instance synchronously.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @return \Illuminate\Mail\SentMessage|null
+     */
+    public function sendNow(MailableContract $mailable)
+    {
+        return $this->mailer->sendNow($this->fill($mailable));
+    }
+
+    /**
      * Push the given mailable onto the queue.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static \Illuminate\Mail\SentMessage|null plain(string $view, array $data, mixed $callback)
  * @method static string render(string|array $view, array $data = [])
  * @method static \Illuminate\Mail\SentMessage|null send(\Illuminate\Contracts\Mail\Mailable|string|array $view, array $data = [], \Closure|string|null $callback = null)
+ * @method static \Illuminate\Mail\SentMessage|null sendNow(\Illuminate\Contracts\Mail\Mailable|string|array $mailable, array $data = [], \Closure|string|null $callback = null)
  * @method static mixed queue(\Illuminate\Contracts\Mail\Mailable|string|array $view, string|null $queue = null)
  * @method static mixed onQueue(string $queue, \Illuminate\Contracts\Mail\Mailable $view)
  * @method static mixed queueOn(string $queue, \Illuminate\Contracts\Mail\Mailable $view)

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -422,9 +422,22 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  array  $data
      * @param  \Closure|string|null  $callback
-     * @return void
+     * @return mixed|void
      */
     public function send($view, array $data = [], $callback = null)
+    {
+        return $this->sendMail($view, $view instanceof ShouldQueue, $data);
+    }
+
+    /**
+     * Send a new message using a view.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
+     * @param  bool  $shouldSync
+     * @param  array  $data
+     * @return mixed|void
+     */
+    protected function sendMail($view, $shouldSync, array $data = [])
     {
         if (! $view instanceof Mailable) {
             return;
@@ -432,13 +445,26 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
 
         $view->mailer($this->currentMailer);
 
-        if ($view instanceof ShouldQueue) {
+        if ($shouldSync) {
             return $this->queue($view, $data);
         }
 
         $this->currentMailer = null;
 
         $this->mailables[] = $view;
+    }
+
+    /**
+     * Send a new message synchronously using a view.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $mailable
+     * @param  array  $data
+     * @param  \Closure|string|null  $callback
+     * @return void
+     */
+    public function sendNow($mailable, array $data = [], $callback = null)
+    {
+        return $this->sendMail($mailable, false);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -30,6 +30,17 @@ class PendingMailFake extends PendingMail
     }
 
     /**
+     * Send a new mailable message instance synchronously.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @return void
+     */
+    public function sendNow(Mailable $mailable)
+    {
+        $this->mailer->sendNow($this->fill($mailable));
+    }
+
+    /**
      * Push the given mailable onto the queue.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable


### PR DESCRIPTION
Reopening #50001 with docblocks.

Sometimes you may need to send a mailable synchronously even though the mailable implements `ShouldQueue`.  For example if you need to do some cleanup after the email was sent out. 
In our use case, we have many mailables that extend our base mailable. The parent implements `ShouldQueue`, but for one email we need to do some cleanup after the email is sent. We could use listeners, but it feels a bit heavy handed to set up a listener on all emails just for one or 2 lines of code that will only run in a very limited amount of cases.

This PR introduces a `sendNow` method which will send mail out  synchronously.

```php
Mail::to('user@example.com')->sendNow(new MyMailable());
```

This mimics the functionality of queued jobs which have a `dispatchSync` method which will dispatch a job synchronously even though it implements `ShouldQueue`.

