### PR TITLE
[10.x] Fix conditionally loaded attributes

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -293,7 +293,7 @@ trait ConditionallyLoadsAttributes
 
         $attribute = (string) Str::of($relationship)->snake()->finish('_count');
 
-        if (! isset($this->resource->getAttributes()[$attribute])) {
+        if (! array_key_exists($attribute, $this->resource->getAttributes())) {
             return value($default);
         }
 
@@ -326,7 +326,7 @@ trait ConditionallyLoadsAttributes
 
         $attribute = (string) Str::of($relationship)->snake()->append('_')->append($aggregate)->append('_')->finish($column);
 
-        if (! isset($this->resource->getAttributes()[$attribute])) {
+        if (! array_key_exists($attribute, $this->resource->getAttributes())) {
             return value($default);
         }
 

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\MissingValue;
+use PHPUnit\Framework\TestCase;
+
+class JsonResourceTest extends TestCase
+{
+    public function testJsonResourceNullAttributes()
+    {
+        $model = new class extends Model {};
+
+        $model->setAttribute('relation_sum_column', null);
+        $model->setAttribute('relation_count', null);
+
+        $resource = new JsonResource($model);
+
+        $this->assertNotInstanceOf(MissingValue::class, $resource->whenAggregated('relation', 'column', 'sum'));
+        $this->assertNotInstanceOf(MissingValue::class, $resource->whenCounted('relation'));
+
+        $this->assertNull($resource->whenAggregated('relation', 'column', 'sum'));
+        $this->assertNull($resource->whenCounted('relation'));
+    }
+}


### PR DESCRIPTION
#49967

I got stuck on this for a bit of time and finally noticed that the issue is inside logic that checks aggregated attributes.

There is a case when aggregated attribute may be `null`: for example, when using `withSum`/`loadSum` on empty relationship. (I'm not sure if it is the same on mysql, but it is like this on pgsql)

Currently, the `isset` function is used to check the loading of aggregated/counted properties. In the case when `transactions_sum_credits` is `null`, `isset` will return `false` and `whenAggregated` will return `MissingValue`:

```php
// Controller
new UserResource(
    $request->user()
        ->loadCount('transactions') // 0
        ->loadSum('transactions', 'credits') // null
);

// Resource
$this->whenLoaded('transations_sum_credits') // MissingValue
```

I refactored all `isset` checks to use `array_key_exists` instead, as it feels like a more accurate way to check aggregated values in case they were not loaded.