### PR TITLE
[10.x] Add ScopedBy attribute for models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/ScopedBy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class ScopedBy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array|string  $classes
+     * @return void
+     */
+    public function __construct(array|string $classes)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -3,12 +3,39 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use ReflectionClass;
 
 trait HasGlobalScopes
 {
+    /**
+     * Boot the has global scopes trait for a model.
+     *
+     * @return void
+     */
+    public static function bootHasGlobalScopes()
+    {
+        static::addGlobalScopes(static::resolveGlobalScopeAttributes());
+    }
+
+    /**
+     * Resolve the observe class names from the attributes.
+     *
+     * @return array
+     */
+    public static function resolveGlobalScopeAttributes()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+
+        return collect($reflectionClass->getAttributes(ScopedBy::class))
+            ->map(fn ($attribute) => $attribute->getArguments())
+            ->flatten()
+            ->all();
+    }
+
     /**
      * Register a new global scope on the model.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -22,7 +22,7 @@ trait HasGlobalScopes
     }
 
     /**
-     * Resolve the observe class names from the attributes.
+     * Resolve the global scope class names from the attributes.
      *
      * @return array
      */

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
@@ -46,6 +47,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     public function testClassNameGlobalScopeIsApplied()
     {
         $model = new EloquentClassNameGlobalScopesTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testGlobalScopeInAttributeIsApplied()
+    {
+        $model = new EloquentGlobalScopeInAttributeTestModel;
         $query = $model->newQuery();
         $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
         $this->assertEquals([1], $query->getBindings());
@@ -231,6 +240,12 @@ class EloquentGlobalScopesArrayTestModel extends Model
 
         parent::boot();
     }
+}
+
+#[ScopedBy(ActiveScope::class)]
+class EloquentGlobalScopeInAttributeTestModel extends Model
+{
+    protected $table = 'table';
 }
 
 class ActiveScope implements Scope


### PR DESCRIPTION
This PR is similar to [my previous PR](https://github.com/laravel/framework/pull/49843), but for global scopes. It adds an option to register global scopes via an attribute.

For example:
```php
#[ScopedBy(AncientScope::class)]
class User extends Model
{
    //
}
```

It's also possible to use an array of scope classes:
```php
#[ScopedBy([FirstScope::class, SecondScope::class])]
```

This makes it easier to see which global scopes are applied to a model rather than having to look through the boot method.