### PR TITLE
[11.x] Add facade config to configuration middleware

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -10,6 +10,13 @@ use Illuminate\Support\Facades\Facade;
 class RegisterFacades
 {
     /**
+     * The facades that should be merged before registration.
+     *
+     * @var array
+     */
+    protected static $merge = [];
+
+    /**
      * Bootstrap the given application.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -17,6 +24,11 @@ class RegisterFacades
      */
     public function bootstrap(Application $app)
     {
+        if (! $app->bound('config_loaded_from_cache') ||
+            $app->make('config_loaded_from_cache') === false) {
+            $this->mergeAdditionalFacades($app);
+        }
+
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication($app);
@@ -25,5 +37,34 @@ class RegisterFacades
             $app->make('config')->get('app.aliases', []),
             $app->make(PackageManifest::class)->aliases()
         ))->register();
+    }
+
+    /**
+     * Merge the additional configured facades into the configuration.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    protected function mergeAdditionalFacades(Application $app)
+    {
+        $app->make('config')->set(
+            'app.aliases',
+            array_merge(
+                $app->make('config')->get('app.aliases'),
+                static::$merge,
+            ),
+        );
+    }
+
+    /**
+     * Merge the given facades into the facade configuration before registration.
+     *
+     * @param  array $facades
+     * @return void
+     */
+    public static function merge(array $facades)
+    {
+        static::$merge = array_filter(array_unique(
+            $facades
+        ));
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -58,7 +58,7 @@ class RegisterFacades
     /**
      * Merge the given facades into the facade configuration before registration.
      *
-     * @param  array $facades
+     * @param  array  $facades
      * @return void
      */
     public static function merge(array $facades)

--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -64,7 +64,17 @@ class RegisterFacades
     public static function merge(array $facades)
     {
         static::$merge = array_filter(array_unique(
-            $facades
+            array_merge(static::$merge, $facades)
         ));
+    }
+
+    /**
+     * Flush the bootstrapper's global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$merge = [];
     }
 }

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Events\DiagnosingHealth;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as AppEventServiceProvider;
@@ -67,6 +68,19 @@ class ApplicationBuilder
                 ? $this->app->getBootstrapProvidersPath()
                 : null
         );
+
+        return $this;
+    }
+
+    /**
+     * Register additional facades.
+     *
+     * @param  array  $facades
+     * @return $this
+     */
+    public function withFacades(array $facades = [])
+    {
+        RegisterFacades::merge($facades);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
@@ -159,6 +160,7 @@ trait InteractsWithTestCaseLifecycle
         Once::flush();
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
+        RegisterFacades::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();
 


### PR DESCRIPTION
Once this PR is merged, we can  define facade in app.php like provider.

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withFacades([
        'Example' => ExampleClass::class
    ])
    ->create();
```
