### PR TITLE
[11.x] Remove cached config file in testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Throwable;
@@ -29,6 +30,10 @@ abstract class TestCase extends BaseTestCase
     public function createApplication()
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
+
+        if ($app->configurationIsCached()) {
+            (new Filesystem())->delete($app->getCachedConfigPath());
+        }
 
         $app->make(Kernel::class)->bootstrap();
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -31,7 +31,7 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        if ($app->configurationIsCached() && !$app->runningUnitTests()) {
+        if ($app->configurationIsCached() && ! $app->runningUnitTests()) {
             (new Filesystem())->delete($app->getCachedConfigPath());
 
             $this->refreshApplication();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -31,8 +31,10 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        if ($app->configurationIsCached()) {
+        if ($app->configurationIsCached() && !$app->runningUnitTests()) {
             (new Filesystem())->delete($app->getCachedConfigPath());
+
+            $this->refreshApplication();
         }
 
         $app->make(Kernel::class)->bootstrap();


### PR DESCRIPTION
Accouring to https://github.com/laravel/ideas/issues/1955, In your local environment, if you run `php artisan config:cache` before running phpunit tests, tests will be running under local rather than testing environment. So chances are your local database will be cleared. 
In this pr, this scenario is checked and if it happens, the cached config file is deleted