### PR TITLE
[10.x] Use is_file instead of file_exists

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -24,7 +24,7 @@ class LoadConfiguration
         // First we will see if we have a cache configuration file. If we do, we'll load
         // the configuration items from that file so that it is very quick. Otherwise
         // we will need to spin through every configuration file and load them all.
-        if (file_exists($cached = $app->getCachedConfigPath())) {
+        if (is_file($cached = $app->getCachedConfigPath())) {
             $items = require $cached;
 
             $loadedFromCache = true;


### PR DESCRIPTION
like [this](https://github.com/laravel/framework/blob/67a0e4716ab3cbf92528a41a8515dfb8d8bbaa37/src/Illuminate/Foundation/Application.php#L1125) `is_file` is better function, because `file_exists` return true if config.php is directory