### PR TITLE
[11.x] Setup providers only from one of providers.php or app.php

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
@@ -14,13 +14,6 @@ class RegisterProviders
     protected static $merge = [];
 
     /**
-     * The path to the bootstrap provider configuration file.
-     *
-     * @var string|null
-     */
-    protected static $bootstrapProviderPath;
-
-    /**
      * Bootstrap the given application.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -43,23 +36,11 @@ class RegisterProviders
      */
     protected function mergeAdditionalProviders(Application $app)
     {
-        if (static::$bootstrapProviderPath &&
-            file_exists(static::$bootstrapProviderPath)) {
-            $packageProviders = require static::$bootstrapProviderPath;
-
-            foreach ($packageProviders as $index => $provider) {
-                if (! class_exists($provider)) {
-                    unset($packageProviders[$index]);
-                }
-            }
-        }
-
         $app->make('config')->set(
             'app.providers',
             array_merge(
                 $app->make('config')->get('app.providers'),
                 static::$merge,
-                array_values($packageProviders ?? []),
             ),
         );
     }
@@ -68,13 +49,10 @@ class RegisterProviders
      * Merge the given providers into the provider configuration before registration.
      *
      * @param  array  $providers
-     * @param  string|null  $bootstrapProviderPath
      * @return void
      */
-    public static function merge(array $providers, ?string $bootstrapProviderPath = null)
+    public static function merge(array $providers)
     {
-        static::$bootstrapProviderPath = $bootstrapProviderPath;
-
         static::$merge = array_values(array_filter(array_unique(
             array_merge(static::$merge, $providers)
         )));
@@ -87,8 +65,6 @@ class RegisterProviders
      */
     public static function flushState()
     {
-        static::$bootstrapProviderPath = null;
-
         static::$merge = [];
     }
 }

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -56,17 +56,15 @@ class ApplicationBuilder
      * Register additional service providers.
      *
      * @param  array  $providers
-     * @param  bool  $withBootstrapProviders
      * @return $this
      */
-    public function withProviders(array $providers = [], bool $withBootstrapProviders = true)
+    public function withProviders(array $providers = [])
     {
-        RegisterProviders::merge(
-            $providers,
-            $withBootstrapProviders
-                ? $this->app->getBootstrapProvidersPath()
-                : null
-        );
+        if (empty($providers) && is_file($bootstrapProviderPath = $this->app->getBootstrapProvidersPath())) {
+            $providers = require $bootstrapProviderPath;
+        }
+
+        RegisterProviders::merge(array_filter($providers, fn($provider) => class_exists($provider)));
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -64,7 +64,7 @@ class ApplicationBuilder
             $providers = require $bootstrapProviderPath;
         }
 
-        RegisterProviders::merge(array_filter($providers, fn($provider) => class_exists($provider)));
+        RegisterProviders::merge(array_filter($providers, fn ($provider) => class_exists($provider)));
 
         return $this;
     }


### PR DESCRIPTION
I'm not sure, but I think adding `bootstrap/providers.php` in Laravel 11 is because of the possibility of automatic registration through the `make:provider` command, however, I think it would be less complicated if it didn't exist and all the config were done through the `app.php`. But if it exists, the ability to set providers from both `providers.php` and `app.php `is not needed and it is better for the user to use only one of these. In this case, there will be less complexity and if an array of providers is passed in `app.php`, `providers.php` will no longer be used.