### PR TITLE
[10.x] Prevent throw exception when cannot extract port from line

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -254,20 +254,14 @@ class ServeCommand extends Command
                 $this->newLine();
 
                 $this->serverRunningHasBeenDisplayed = true;
-            } elseif (str($line)->contains(' Accepted')) {
-                $requestPort = $this->getRequestPortFromLine($line);
-
+            } elseif (str($line)->contains(' Accepted') && $requestPort = $this->getRequestPortFromLine($line)) {
                 $this->requestsPool[$requestPort] = [
                     $this->getDateFromLine($line),
                     false,
                 ];
-            } elseif (str($line)->contains([' [200]: GET '])) {
-                $requestPort = $this->getRequestPortFromLine($line);
-
+            } elseif (str($line)->contains([' [200]: GET ']) && $requestPort = $this->getRequestPortFromLine($line)) {
                 $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
-            } elseif (str($line)->contains(' Closing')) {
-                $requestPort = $this->getRequestPortFromLine($line);
-
+            } elseif (str($line)->contains(' Closing') && $requestPort = $this->getRequestPortFromLine($line)) {
                 if (empty($this->requestsPool[$requestPort])) {
                     return;
                 }
@@ -329,13 +323,13 @@ class ServeCommand extends Command
      * Get the request port from the given PHP server output.
      *
      * @param  string  $line
-     * @return int
+     * @return int|null
      */
     protected function getRequestPortFromLine($line)
     {
         preg_match('/:(\d+)\s(?:(?:\w+$)|(?:\[.*))/', $line, $matches);
 
-        return (int) $matches[1];
+        return isset($matches[1]) ? (int) $matches[1] : null;
     }
 
     /**


### PR DESCRIPTION
according to https://github.com/laravel/framework/issues/49927, when logging to stderr, certain strings will cause issues.

In handleProcessOutput of ServeCommand.php, the output is matched against certain strings. If these strings are found, additional logic is performed.

If strings that match the criteria are logged, it is possible that the strings are not what is expected, and will cause an exception

This pr solves this problem by checking that if it cannot extract the port from the line it does not enter the condition.