### PR TITLE
Add model method withRelations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -892,6 +892,17 @@ trait HasRelationships
         return $model->unsetRelations();
     }
 
+    public function withRelations(array $relations)
+    {
+        $model = $this->withoutRelations();
+
+        foreach ($relations as $relation) {
+            $model->setRelation($relation, $this->getRelation($relation));
+        }
+
+        return $model;
+    }
+
     /**
      * Unset all the loaded relations for the instance.
      *


### PR DESCRIPTION
This method allows you to keep the relationships you need. When you have a model which is dispatched in a job, you might only need 1 or 2 relationships and not all of them. This prevents a huge data feed in as example a job