### PR TITLE
[11.x] Improve MySQL connect init time by setting all our variables in a single shot

### DIFF
--- a/src/Illuminate/Database/Connectors/MariaDbConnector.php
+++ b/src/Illuminate/Database/Connectors/MariaDbConnector.php
@@ -7,14 +7,26 @@ use PDO;
 class MariaDbConnector extends MySqlConnector implements ConnectorInterface
 {
     /**
-     * Get the query to enable strict mode.
+     * Get the sql_mode value.
      *
      * @param  \PDO  $connection
      * @param  array  $config
-     * @return string
+     * @return string|null
      */
-    protected function strictMode(PDO $connection, $config)
+    protected function getSqlMode(PDO $connection, array $config)
     {
-        return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+        if (isset($config['modes'])) {
+            return implode(',', $config['modes']);
+        }
+
+        if (! isset($config['strict'])) {
+            return null;
+        }
+
+        if (! $config['strict']) {
+            return 'NO_ENGINE_SUBSTITUTION';
+        }
+
+        return 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
     }
 }

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -27,78 +27,52 @@ class MySqlConnector extends Connector implements ConnectorInterface
             $connection->exec("use `{$config['database']}`;");
         }
 
-        $this->configureIsolationLevel($connection, $config);
-
-        $this->configureEncoding($connection, $config);
-
-        // Next, we will check to see if a timezone has been specified in this config
-        // and if it has we will issue a statement to modify the timezone with the
-        // database. Setting this DB timezone is an optional configuration item.
-        $this->configureTimezone($connection, $config);
-
-        $this->setModes($connection, $config);
+        $this->configureConnection($connection, $config);
 
         return $connection;
     }
 
     /**
-     * Set the connection transaction isolation level.
+     * Configure the connection.
      *
      * @param  \PDO  $connection
      * @param  array  $config
      * @return void
      */
-    protected function configureIsolationLevel($connection, array $config)
+    protected function configureConnection(PDO $connection, array $config)
     {
-        if (! isset($config['isolation_level'])) {
-            return;
+        $statements = [];
+
+        // First, we set the transaction isolation level.
+        if (isset($config['isolation_level'])) {
+            $statements[] = sprintf('SESSION TRANSACTION ISOLATION LEVEL %s', $config['isolation_level']);
         }
 
-        $connection->prepare(
-            "SET SESSION TRANSACTION ISOLATION LEVEL {$config['isolation_level']}"
-        )->execute();
-    }
-
-    /**
-     * Set the connection character set and collation.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return void|\PDO
-     */
-    protected function configureEncoding($connection, array $config)
-    {
-        if (! isset($config['charset'])) {
-            return $connection;
+        // Now, we set the charset and possibly the collation.
+        if (isset($config['charset'])) {
+            if (isset($config['collation'])) {
+                $statements[] = sprintf("NAMES '%s' COLLATE '%s'", $config['charset'], $config['collation']);
+            } else {
+                $statements[] = sprintf("NAMES '%s'", $config['charset']);
+            }
         }
 
-        $connection->prepare(
-            "set names '{$config['charset']}'".$this->getCollation($config)
-        )->execute();
-    }
-
-    /**
-     * Get the collation for the configuration.
-     *
-     * @param  array  $config
-     * @return string
-     */
-    protected function getCollation(array $config)
-    {
-        return isset($config['collation']) ? " collate '{$config['collation']}'" : '';
-    }
-
-    /**
-     * Set the timezone on the connection.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return void
-     */
-    protected function configureTimezone($connection, array $config)
-    {
+        // Next, we will check to see if a timezone has been specified in this config
+        // and if it has we will issue a statement to modify the timezone with the
+        // database. Setting this DB timezone is an optional configuration item.
         if (isset($config['timezone'])) {
-            $connection->prepare('set time_zone="'.$config['timezone'].'"')->execute();
+            $statements[] = sprintf("time_zone='%s'", $config['timezone']);
+        }
+
+        // Next, we set the correct sql_mode mode according to the config.
+        $sqlMode = $this->getSqlMode($connection, $config);
+        if (null !== $sqlMode) {
+            $statements[] = sprintf("SESSION sql_mode='%s'", $sqlMode);
+        }
+
+        // Finally, execute a single SET command with all our statements.
+        if ([] !== $statements) {
+            $connection->exec(sprintf('SET %s;', implode(', ', $statements)));
         }
     }
 
@@ -155,54 +129,32 @@ class MySqlConnector extends Connector implements ConnectorInterface
     }
 
     /**
-     * Set the modes for the connection.
+     * Get the sql_mode value.
      *
      * @param  \PDO  $connection
      * @param  array  $config
-     * @return void
+     * @return string|null
      */
-    protected function setModes(PDO $connection, array $config)
+    protected function getSqlMode(PDO $connection, array $config)
     {
         if (isset($config['modes'])) {
-            $this->setCustomModes($connection, $config);
-        } elseif (isset($config['strict'])) {
-            if ($config['strict']) {
-                $connection->prepare($this->strictMode($connection, $config))->execute();
-            } else {
-                $connection->prepare("set session sql_mode='NO_ENGINE_SUBSTITUTION'")->execute();
-            }
+            return implode(',', $config['modes']);
         }
-    }
 
-    /**
-     * Set the custom modes on the connection.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return void
-     */
-    protected function setCustomModes(PDO $connection, array $config)
-    {
-        $modes = implode(',', $config['modes']);
+        if (! isset($config['strict'])) {
+            return null;
+        }
 
-        $connection->prepare("set session sql_mode='{$modes}'")->execute();
-    }
+        if (! $config['strict']) {
+            return 'NO_ENGINE_SUBSTITUTION';
+        }
 
-    /**
-     * Get the query to enable strict mode.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return string
-     */
-    protected function strictMode(PDO $connection, $config)
-    {
         $version = $config['version'] ?? $connection->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if (version_compare($version, '8.0.11') >= 0) {
-            return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+            return 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
         }
 
-        return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+        return 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
     }
 }

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -36,10 +36,8 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($statement);
-        $statement->shouldReceive('execute')->once();
-        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->once()->with('use `bar`;')->andReturn(true);
+        $connection->shouldReceive('exec')->once()->with("SET NAMES 'utf8' COLLATE 'utf8_unicode_ci';")->andReturn(true);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -63,11 +61,8 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($statement);
-        $connection->shouldReceive('prepare')->once()->with('SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ')->andReturn($statement);
-        $statement->shouldReceive('execute')->zeroOrMoreTimes();
-        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->once()->with('use `bar`;')->andReturn(true);
+        $connection->shouldReceive('exec')->once()->with("SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ, NAMES 'utf8' COLLATE 'utf8_unicode_ci';")->andReturn(true);
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);


### PR DESCRIPTION
The current code does multiple round-trips to set all the variables we need for our config, both because there are multiple commands to run, but also because it's using prepare, for many of them - each use of prepare and execute causes 3 round trips - one to prepare, one to execute, and one to close statement (on garbage collection of the statement in PHP land). The MySQL SET command supports setting multiple things in a comma separated fashion. Refactoring to do this enables us to just run one SET statement against the server. This can make a real difference in a cloud situation such as AWS Lambda talking to an RDS database where we have to go cross-AZ with low single digit ms latency, instead of sub-ms latency. This also reduces load on the DB (fewer statements to execute), so spinning up a bunch of Lambdas in a burst will be less of a burden.

---

In principal this optimization could be applied to other drivers, too, but I've not included any of that in this PR.