### PR TITLE
[10.x] Stringable - let `exactly` be case insensitive

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -235,15 +235,32 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Alias for the `exactly` function.
+     *
+     * @param  \Illuminate\Support\Stringable|string  $value
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public function equals($value, $ignoreCase = false)
+    {
+        return $this->exactly($value, $ignoreCase);
+    }
+
+    /**
      * Determine if the string is an exact match with the given value.
      *
      * @param  \Illuminate\Support\Stringable|string  $value
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public function exactly($value)
+    public function exactly($value, $ignoreCase = false)
     {
         if ($value instanceof Stringable) {
             $value = $value->toString();
+        }
+
+        if ($ignoreCase) {
+            return strtolower($this->value) === strtolower($value);
         }
 
         return $this->value === $value;

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -260,7 +260,7 @@ class Stringable implements JsonSerializable, ArrayAccess
         }
 
         if ($ignoreCase) {
-            return strtolower($this->value) === strtolower($value);
+            return mb_strtolower($this->value) === mb_strtolower($value);
         }
 
         return $this->value === $value;


### PR DESCRIPTION
Let's enhance the `Stringable` `exactly` function to ignore string casing.

I propose adding a second optional boolean parameter, allowing users to decide whether the equality comparison should ignore casing. The default will be `false`, maintaining the original behavior. Now, users can check it without manually changing string cases before doing the check.

Before 🤷
```php
$str1 = str('hi');
$str2 = str('HI');
$shouldIgnoreCase = true;

$str1->when($shouldIgnoreCase, function (Stringable $str) {
    return $str->lower();
})->exactly(
    $str2->when($shouldIgnoreCase, function (Stringable $str) {
        return $str->lower();
    })
); // true
```

Now 🚀
```php
$str1 = str('hi');
$str2 = str('HI');
$shouldIgnoreCase = true;

$str1->equals($str2, $shouldIgnoreCase); // true
```

> Why I'm using `equals`? It's a clear alias for `exactly`. This aligns with common practices in other languages, enhancing readability for programmers checking string equality. 

Reasons to add this changes:
- Simplifies string comparison without manual casing.
- Addresses method limitations, now supporting case-insensitive comparison.
- "Equals" serves as a clear alias, aligning with common naming conventions in other languages/frameworks.