### PR TITLE
[10.x] refactor(ServiceProvider.php): Simplify callBootingCallbacks, callBootedCallbacks methods

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -97,12 +97,8 @@ abstract class ServiceProvider
      */
     public function callBootingCallbacks()
     {
-        $index = 0;
-
-        while ($index < count($this->bootingCallbacks)) {
-            $this->app->call($this->bootingCallbacks[$index]);
-
-            $index++;
+        foreach ($this->bootingCallbacks as $callback) {
+            $this->app->call($callback);
         }
     }
 
@@ -113,12 +109,8 @@ abstract class ServiceProvider
      */
     public function callBootedCallbacks()
     {
-        $index = 0;
-
-        while ($index < count($this->bootedCallbacks)) {
-            $this->app->call($this->bootedCallbacks[$index]);
-
-            $index++;
+        foreach ($this->bootedCallbacks as $callback) {
+            $this->app->call($callback);
         }
     }
 


### PR DESCRIPTION
This PR simplifies the `callBootedCallbacks` and `callBootingCallbacks`  methods by replacing the while loop with a more concise and readable foreach loop. This change improves code clarity and maintainability.

#### Before

```php

$index = 0;

while ($index < count($this->bootingCallbacks)) {
   $this->app->call($this->bootingCallbacks[$index]);

   $index++;
 }
```

#### After

```php

foreach ($this->bootingCallbacks as $callback) {
    $this->app->call($callback);
 }
```

In the new implementation, there's no need for the $index variable, and calculating the array count in each iteration is eliminated for better performance. The code is now more concise and efficient.