### PR TITLE
[10.x] Add Lateral Join to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -587,6 +587,39 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a lateral join clause to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  string  $as
+     * @param  string  $type
+     * @return $this
+     */
+    public function joinLateral($query, string $as, string $type = 'inner'): static
+    {
+        [$query, $bindings] = $this->createSub($query);
+
+        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+
+        $this->addBinding($bindings, 'join');
+
+        $this->joins[] = $this->newJoinLateralClause($this, $type, new Expression($expression));
+
+        return $this;
+    }
+
+    /**
+     * Add a lateral left join to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
+     * @param  string  $as
+     * @return $this
+     */
+    public function leftJoinLateral($query, string $as): static
+    {
+        return $this->joinLateral($query, $as, 'left');
+    }
+
+    /**
      * Add a left join to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
@@ -723,6 +756,19 @@ class Builder implements BuilderContract
     protected function newJoinClause(self $parentQuery, $type, $table)
     {
         return new JoinClause($parentQuery, $type, $table);
+    }
+
+    /**
+     * Get a new join lateral clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $parentQuery
+     * @param  string  $type
+     * @param  string  $table
+     * @return \Illuminate\Database\Query\JoinLateralClause
+     */
+    protected function newJoinLateralClause(self $parentQuery, $type, $table)
+    {
+        return new JoinLateralClause($parentQuery, $type, $table);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -594,7 +594,7 @@ class Builder implements BuilderContract
      * @param  string  $type
      * @return $this
      */
-    public function joinLateral($query, string $as, string $type = 'inner'): static
+    public function joinLateral($query, string $as, string $type = 'inner')
     {
         [$query, $bindings] = $this->createSub($query);
 
@@ -614,7 +614,7 @@ class Builder implements BuilderContract
      * @param  string  $as
      * @return $this
      */
-    public function leftJoinLateral($query, string $as): static
+    public function leftJoinLateral($query, string $as)
     {
         return $this->joinLateral($query, $as, 'left');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Database\Query\JoinLateralClause;
 use Illuminate\Support\Arr;
 use RuntimeException;
 
@@ -182,8 +183,26 @@ class Grammar extends BaseGrammar
 
             $tableAndNestedJoins = is_null($join->joins) ? $table : '('.$table.$nestedJoins.')';
 
+            if ($join instanceof JoinLateralClause) {
+                return $this->compileJoinLateral($join, $tableAndNestedJoins);
+            }
+
             return trim("{$join->type} join {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        throw new RuntimeException('This database engine does not support lateral joins.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinLateralClause;
 use Illuminate\Support\Str;
 
 class MySqlGrammar extends Grammar
@@ -231,6 +232,18 @@ class MySqlGrammar extends Grammar
 
             return $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        return trim("{$join->type} join lateral {$expression} on true");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -235,18 +235,6 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile a "lateral join" clause.
-     *
-     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
-     * @param  string  $expression
-     * @return string
-     */
-    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
-    {
-        return trim("{$join->type} join lateral {$expression} on true");
-    }
-
-    /**
      * Compile an "upsert" statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -278,6 +266,18 @@ class MySqlGrammar extends Grammar
         })->implode(', ');
 
         return $sql.$columns;
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        return trim("{$join->type} join lateral {$expression} on true");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinLateralClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -383,6 +384,18 @@ class PostgresGrammar extends Grammar
 
             return $this->wrap($column).' = '.$this->parameter($value);
         })->implode(', ');
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        return trim("{$join->type} join lateral {$expression} on true");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -387,18 +387,6 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Compile a "lateral join" clause.
-     *
-     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
-     * @param  string  $expression
-     * @return string
-     */
-    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
-    {
-        return trim("{$join->type} join lateral {$expression} on true");
-    }
-
-    /**
      * Compile an "upsert" statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -420,6 +408,18 @@ class PostgresGrammar extends Grammar
         })->implode(', ');
 
         return $sql.$columns;
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        return trim("{$join->type} join lateral {$expression} on true");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -388,20 +388,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile a "lateral join" clause.
-     *
-     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
-     * @param  string  $expression
-     * @return string
-     */
-    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
-    {
-        $type = $join->type == 'left' ? 'outer' : 'cross';
-
-        return trim("{$type} apply {$expression}");
-    }
-
-    /**
      * Compile an "upsert" statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -457,6 +443,20 @@ class SqlServerGrammar extends Grammar
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))
         );
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        $type = $join->type == 'left' ? 'outer' : 'cross';
+
+        return trim("{$type} apply {$expression}");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinLateralClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -384,6 +385,20 @@ class SqlServerGrammar extends Grammar
         $joins = $this->compileJoins($query, $query->joins);
 
         return "update {$alias} set {$columns} from {$table} {$joins} {$where}";
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        $type = $join->type == 'left' ? 'outer' : 'cross';
+
+        return trim("{$type} apply {$expression}");
     }
 
     /**

--- a/src/Illuminate/Database/Query/JoinLateralClause.php
+++ b/src/Illuminate/Database/Query/JoinLateralClause.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+class JoinLateralClause extends JoinClause
+{
+    //
+}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2526,6 +2526,117 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->rightJoinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
+    public function testJoinLateral()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->joinLateral('select * from `contacts` where `contracts`.`user_id` = `users`.`id`', 'sub');
+        $this->assertSame('select * from `users` inner join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id`) as `sub` on true', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->joinLateral(function ($q) {
+            $q->from('contacts')->whereColumn('contracts.user_id', 'users.id');
+        }, 'sub');
+        $this->assertSame('select * from `users` inner join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id`) as `sub` on true', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $sub = $this->getMySqlBuilder();
+        $sub->getConnection()->shouldReceive('getDatabaseName');
+        $eloquentBuilder = new EloquentBuilder($sub->from('contacts')->whereColumn('contracts.user_id', 'users.id'));
+        $builder->from('users')->joinLateral($eloquentBuilder, 'sub');
+        $this->assertSame('select * from `users` inner join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id`) as `sub` on true', $builder->toSql());
+
+        $sub1 = $this->getMySqlBuilder();
+        $sub1->getConnection()->shouldReceive('getDatabaseName');
+        $sub1 = $sub1->from('contacts')->whereColumn('contracts.user_id', 'users.id')->where('name', 'foo');
+
+        $sub2 = $this->getMySqlBuilder();
+        $sub2->getConnection()->shouldReceive('getDatabaseName');
+        $sub2 = $sub2->from('contacts')->whereColumn('contracts.user_id', 'users.id')->where('name', 'bar');
+
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->joinLateral($sub1, 'sub1')->joinLateral($sub2, 'sub2');
+
+        $expected = 'select * from `users` ';
+        $expected .= 'inner join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id` and `name` = ?) as `sub1` on true ';
+        $expected .= 'inner join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id` and `name` = ?) as `sub2` on true';
+
+        $this->assertEquals($expected, $builder->toSql());
+        $this->assertEquals(['foo', 'bar'], $builder->getRawBindings()['join']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getMySqlBuilder();
+        $builder->from('users')->joinLateral(['foo'], 'sub');
+    }
+
+    public function testJoinLateralSQLite()
+    {
+        $this->expectException(RuntimeException::class);
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->joinLateral(function ($q) {
+            $q->from('contacts')->whereColumn('contracts.user_id', 'users.id');
+        }, 'sub')->toSql();
+    }
+
+    public function testJoinLateralPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->joinLateral(function ($q) {
+            $q->from('contacts')->whereColumn('contracts.user_id', 'users.id');
+        }, 'sub');
+        $this->assertSame('select * from "users" inner join lateral (select * from "contacts" where "contracts"."user_id" = "users"."id") as "sub" on true', $builder->toSql());
+    }
+
+    public function testJoinLateralSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->joinLateral(function ($q) {
+            $q->from('contacts')->whereColumn('contracts.user_id', 'users.id');
+        }, 'sub');
+        $this->assertSame('select * from [users] cross apply (select * from [contacts] where [contracts].[user_id] = [users].[id]) as [sub]', $builder->toSql());
+    }
+
+    public function testJoinLateralWithPrefix()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->getGrammar()->setTablePrefix('prefix_');
+        $builder->from('users')->joinLateral('select * from `contacts` where `contracts`.`user_id` = `users`.`id`', 'sub');
+        $this->assertSame('select * from `prefix_users` inner join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id`) as `prefix_sub` on true', $builder->toSql());
+    }
+
+    public function testLeftJoinLateral()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+
+        $sub = $this->getMySqlBuilder();
+        $sub->getConnection()->shouldReceive('getDatabaseName');
+
+        $builder->from('users')->leftJoinLateral($sub->from('contacts')->whereColumn('contracts.user_id', 'users.id'), 'sub');
+        $this->assertSame('select * from `users` left join lateral (select * from `contacts` where `contracts`.`user_id` = `users`.`id`) as `sub` on true', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->leftJoinLateral(['foo'], 'sub');
+    }
+
+    public function testLeftJoinLateralSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('users')->leftJoinLateral(function ($q) {
+            $q->from('contacts')->whereColumn('contracts.user_id', 'users.id');
+        }, 'sub');
+        $this->assertSame('select * from [users] outer apply (select * from [contacts] where [contracts].[user_id] = [users].[id]) as [sub]', $builder->toSql());
+    }
+
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();

--- a/tests/Integration/Database/MySql/JoinLateralTest.php
+++ b/tests/Integration/Database/MySql/JoinLateralTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * @requires extension pdo_mysql
+ * @requires OS Linux|Darwin
+ */
+class JoinLateralTest extends MySqlTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('name');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title');
+            $table->integer('rating');
+            $table->unsignedBigInteger('user_id');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('posts');
+        Schema::drop('users');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->checkMySqlVersion();
+
+        DB::table('users')->insert([
+            ['name' => Str::random()],
+            ['name' => Str::random()],
+        ]);
+
+        DB::table('posts')->insert([
+            ['title' => Str::random(), 'rating' => 1, 'user_id' => 1],
+            ['title' => Str::random(), 'rating' => 3, 'user_id' => 1],
+            ['title' => Str::random(), 'rating' => 7, 'user_id' => 1],
+        ]);
+    }
+
+    protected function checkMySqlVersion()
+    {
+        $mySqlVersion = DB::select('select version()')[0]->{'version()'} ?? '';
+
+        if (strpos($mySqlVersion, 'Maria') !== false) {
+            $this->markTestSkipped('Lateral joins are not supported on MariaDB'.__CLASS__);
+        } elseif ((float) $mySqlVersion < '8.0.14') {
+            $this->markTestSkipped('Lateral joins are not supported on MySQL < 8.0.14'.__CLASS__);
+        }
+    }
+
+    public function testJoinLateral()
+    {
+        $subquery = DB::table('posts')
+            ->select('title as best_post_title', 'rating as best_post_rating')
+            ->whereColumn('user_id', 'users.id')
+            ->orderBy('rating', 'desc')
+            ->limit(2);
+
+        $userWithPosts = DB::table('users')
+            ->where('id', 1)
+            ->joinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(2, $userWithPosts);
+        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
+        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+
+        $userWithoutPosts = DB::table('users')
+            ->where('id', 2)
+            ->joinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(0, $userWithoutPosts);
+    }
+
+    public function testLeftJoinLateral()
+    {
+        $subquery = DB::table('posts')
+            ->select('title as best_post_title', 'rating as best_post_rating')
+            ->whereColumn('user_id', 'users.id')
+            ->orderBy('rating', 'desc')
+            ->limit(2);
+
+        $userWithPosts = DB::table('users')
+            ->where('id', 1)
+            ->leftJoinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(2, $userWithPosts);
+        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
+        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+
+        $userWithoutPosts = DB::table('users')
+            ->where('id', 2)
+            ->leftJoinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(1, $userWithoutPosts);
+        $this->assertNull($userWithoutPosts[0]->best_post_title);
+        $this->assertNull($userWithoutPosts[0]->best_post_rating);
+    }
+}

--- a/tests/Integration/Database/Postgres/JoinLateralTest.php
+++ b/tests/Integration/Database/Postgres/JoinLateralTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * @requires extension pdo_pgsql
+ * @requires OS Linux|Darwin
+ */
+class JoinLateralTest extends PostgresTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('name');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title');
+            $table->integer('rating');
+            $table->unsignedBigInteger('user_id');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('posts');
+        Schema::drop('users');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('users')->insert([
+            ['name' => Str::random()],
+            ['name' => Str::random()],
+        ]);
+
+        DB::table('posts')->insert([
+            ['title' => Str::random(), 'rating' => 1, 'user_id' => 1],
+            ['title' => Str::random(), 'rating' => 3, 'user_id' => 1],
+            ['title' => Str::random(), 'rating' => 7, 'user_id' => 1],
+        ]);
+    }
+
+    public function testJoinLateral()
+    {
+        $subquery = DB::table('posts')
+            ->select('title as best_post_title', 'rating as best_post_rating')
+            ->whereColumn('user_id', 'users.id')
+            ->orderBy('rating', 'desc')
+            ->limit(2);
+
+        $userWithPosts = DB::table('users')
+            ->where('id', 1)
+            ->joinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(2, $userWithPosts);
+        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
+        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+
+        $userWithoutPosts = DB::table('users')
+            ->where('id', 2)
+            ->joinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(0, $userWithoutPosts);
+    }
+
+    public function testLeftJoinLateral()
+    {
+        $subquery = DB::table('posts')
+            ->select('title as best_post_title', 'rating as best_post_rating')
+            ->whereColumn('user_id', 'users.id')
+            ->orderBy('rating', 'desc')
+            ->limit(2);
+
+        $userWithPosts = DB::table('users')
+            ->where('id', 1)
+            ->leftJoinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(2, $userWithPosts);
+        $this->assertEquals(7, $userWithPosts[0]->best_post_rating);
+        $this->assertEquals(3, $userWithPosts[1]->best_post_rating);
+
+        $userWithoutPosts = DB::table('users')
+            ->where('id', 2)
+            ->leftJoinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(1, $userWithoutPosts);
+        $this->assertNull($userWithoutPosts[0]->best_post_title);
+        $this->assertNull($userWithoutPosts[0]->best_post_rating);
+    }
+}

--- a/tests/Integration/Database/SqlServer/JoinLateralTest.php
+++ b/tests/Integration/Database/SqlServer/JoinLateralTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SqlServer;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class JoinLateralTest extends SqlServerTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('name');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title');
+            $table->integer('rating');
+            $table->unsignedBigInteger('user_id');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('posts');
+        Schema::drop('users');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('users')->insert([
+            ['name' => Str::random()],
+            ['name' => Str::random()],
+        ]);
+
+        DB::table('posts')->insert([
+            ['title' => Str::random(), 'rating' => 1, 'user_id' => 1],
+            ['title' => Str::random(), 'rating' => 3, 'user_id' => 1],
+            ['title' => Str::random(), 'rating' => 7, 'user_id' => 1],
+        ]);
+    }
+
+    public function testJoinLateral()
+    {
+        $subquery = DB::table('posts')
+            ->select('title as best_post_title', 'rating as best_post_rating')
+            ->whereColumn('user_id', 'users.id')
+            ->orderBy('rating', 'desc')
+            ->limit(2);
+
+        $userWithPosts = DB::table('users')
+            ->where('id', 1)
+            ->joinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(2, $userWithPosts);
+        $this->assertEquals(7, (int) $userWithPosts[0]->best_post_rating);
+        $this->assertEquals(3, (int) $userWithPosts[1]->best_post_rating);
+
+        $userWithoutPosts = DB::table('users')
+            ->where('id', 2)
+            ->joinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(0, $userWithoutPosts);
+    }
+
+    public function testLeftJoinLateral()
+    {
+        $subquery = DB::table('posts')
+            ->select('title as best_post_title', 'rating as best_post_rating')
+            ->whereColumn('user_id', 'users.id')
+            ->orderBy('rating', 'desc')
+            ->limit(2);
+
+        $userWithPosts = DB::table('users')
+            ->where('id', 1)
+            ->leftJoinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(2, $userWithPosts);
+        $this->assertEquals(7, (int) $userWithPosts[0]->best_post_rating);
+        $this->assertEquals(3, (int) $userWithPosts[1]->best_post_rating);
+
+        $userWithoutPosts = DB::table('users')
+            ->where('id', 2)
+            ->leftJoinLateral($subquery, 'best_post')
+            ->get();
+
+        $this->assertCount(1, $userWithoutPosts);
+        $this->assertNull($userWithoutPosts[0]->best_post_title);
+        $this->assertNull($userWithoutPosts[0]->best_post_rating);
+    }
+}


### PR DESCRIPTION
This PR adds lateral join methods to the query builder. I have based the methods and tests upon `joinSub` as the behaviour is somewhat similar.

Lateral joins have been supported in PostgreSQL for a long time (since 9.3), and are also supported in MySQL since 8.0.14.

The lateral joins are a bit similar to a subquery join, as the right-hand table is expressed as a subquery. However the right-hand expression is executed for every row, which opens up for new use cases. It is particularly useful for joining in the top 'N' rows related to the main query. In example: 

```sql
select * from "users" 
join lateral (
    select * from "contacts" 
    where "contracts"."user_id" = "users"."id"
    order by "contracts"."value" desc
    limit 5
) as "sub" 
    on true
``` 
