### PR TITLE
[10.x] Allow usage of class string syntax for withGlobalScope

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -163,11 +163,15 @@ class Builder implements BuilderContract
      * Register a new global scope.
      *
      * @param  string  $identifier
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|null  $scope
      * @return $this
      */
-    public function withGlobalScope($identifier, $scope)
+    public function withGlobalScope($identifier, $scope = null)
     {
+        if (is_null($scope) && class_exists($identifier) && is_subclass_of($identifier, Scope::class)) {
+            $scope = new $identifier;
+        }
+        
         $this->scopes[$identifier] = $scope;
 
         if (method_exists($scope, 'extend')) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -19,6 +19,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -170,6 +171,10 @@ class Builder implements BuilderContract
     {
         if (is_null($scope) && class_exists($identifier) && is_subclass_of($identifier, Scope::class)) {
             $scope = new $identifier;
+        }
+
+        if (is_null($scope)) {
+            throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope or identifier must be a class name of a class extending '.Scope::class);
         }
 
         $this->scopes[$identifier] = $scope;
@@ -917,7 +922,7 @@ class Builder implements BuilderContract
      * @param  \Closure|int|null  $total
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -166,6 +166,8 @@ class Builder implements BuilderContract
      * @param  string  $identifier
      * @param  \Illuminate\Database\Eloquent\Scope|\Closure|null  $scope
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function withGlobalScope($identifier, $scope = null)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -171,7 +171,7 @@ class Builder implements BuilderContract
         if (is_null($scope) && class_exists($identifier) && is_subclass_of($identifier, Scope::class)) {
             $scope = new $identifier;
         }
-        
+
         $this->scopes[$identifier] = $scope;
 
         if (method_exists($scope, 'extend')) {

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -52,6 +52,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
+    public function testQueryGlobalScopeIsApplied()
+    {
+        $model = new EloquentQueryGlobalScopesTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testGlobalScopeInAttributeIsApplied()
     {
         $model = new EloquentGlobalScopeInAttributeTestModel;
@@ -224,6 +232,16 @@ class EloquentClassNameGlobalScopesTestModel extends Model
         static::addGlobalScope(ActiveScope::class);
 
         parent::boot();
+    }
+}
+
+class EloquentQueryGlobalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public function newQuery()
+    {
+        return parent::newQuery()->withGlobalScope(ActiveScope::class);
     }
 }
 


### PR DESCRIPTION
Since the static addGlobalScope offers a convenient way to use class string syntax, this shall also be possible when using withGlobalScope on the query builder.