### PR TITLE
[10.x] fix Validator::validated get nullable array

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -584,13 +584,14 @@ class Validator implements ValidatorContract
         $missingValue = new stdClass;
 
         foreach ($this->getRules() as $key => $rules) {
+            $value = data_get($this->getData(), $key, $missingValue);
+
             if ($this->excludeUnvalidatedArrayKeys &&
                 in_array('array', $rules) &&
+                null !== $value &&
                 ! empty(preg_grep('/^'.preg_quote($key, '/').'\.+/', array_keys($this->getRules())))) {
                 continue;
             }
-
-            $value = data_get($this->getData(), $key, $missingValue);
 
             if ($value !== $missingValue) {
                 Arr::set($results, $key, $value);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -588,7 +588,7 @@ class Validator implements ValidatorContract
 
             if ($this->excludeUnvalidatedArrayKeys &&
                 in_array('array', $rules) &&
-                null !== $value &&
+                $value !== null &&
                 ! empty(preg_grep('/^'.preg_quote($key, '/').'\.+/', array_keys($this->getRules())))) {
                 continue;
             }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -293,6 +293,28 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('validation.boolean', $v->messages()->get('b')[0]);
     }
 
+    public function testArrayNullableWithUnvalidatedArrayKeys()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [
+            'x' => null,
+        ], [
+            'x' => 'array|nullable',
+            'x.key' => 'string',
+        ]);
+        $this->assertTrue($v->passes());
+        $this->assertArrayHasKey('x', $v->validated());
+
+        $v = new Validator($trans, [
+            'x' => null,
+        ], [
+            'x' => 'array',
+            'x.key' => 'string',
+        ]);
+        $this->assertFalse($v->passes());
+    }
+
     public function testNullableMakesNoDifferenceIfImplicitRuleExists()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Since laravel >= 9.x, `Illuminate\Validation\Validator::validated` no longer allows to retrieve a `nullable|array` validation rule with a nested key.

To reproduce:

```php
use Illuminate\Support\Facades\Validator;

$validator = Validator::make(
    [
        'x' => null,
    ],
    [
        'x' => ['array', 'nullable'],
        'x.key' => ['string'],
    ],
);

dd($validator->validate()); // return [] instead of ["x" => null]
```

This PR fix `Illuminate\Validation\Validator::validated` to allowed nullable array.