### PR TITLE
[10.x] Add `before` to the `PendingBatch`

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Bus;
 
 use Closure;
-use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\Events\BatchDispatched;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
@@ -299,7 +298,7 @@ class PendingBatch
     /**
      * Stores the batch.
      *
-     * @param  BatchRepository $repository
+     * @param  BatchRepository  $repository
      * @return \Illuminate\Bus\Batch
      */
     protected function store($repository)

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -296,29 +296,6 @@ class PendingBatch
     }
 
     /**
-     * Stores the batch.
-     *
-     * @param  BatchRepository  $repository
-     * @return \Illuminate\Bus\Batch
-     */
-    protected function store($repository)
-    {
-        $batch = $repository->store($this);
-
-        collect($this->beforeCallbacks())->each(function ($handler) use ($batch) {
-            try {
-                return $handler($batch);
-            } catch (Throwable $e) {
-                if (function_exists('report')) {
-                    report($e);
-                }
-            }
-        });
-
-        return $batch;
-    }
-
-    /**
      * Dispatch the batch.
      *
      * @return \Illuminate\Bus\Batch
@@ -413,5 +390,28 @@ class PendingBatch
     public function dispatchUnless($boolean)
     {
         return ! value($boolean) ? $this->dispatch() : null;
+    }
+
+    /**
+     * Store the batch using the given repository.
+     *
+     * @param  \Illuminate\Bus\BatchRepository  $repository
+     * @return \Illuminate\Bus\Batch
+     */
+    protected function store($repository)
+    {
+        $batch = $repository->store($this);
+
+        collect($this->beforeCallbacks())->each(function ($handler) use ($batch) {
+            try {
+                return $handler($batch);
+            } catch (Throwable $e) {
+                if (function_exists('report')) {
+                    report($e);
+                }
+            }
+        });
+
+        return $batch;
     }
 }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Bus;
 
 use Closure;
+use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\Events\BatchDispatched;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
@@ -72,6 +73,31 @@ class PendingBatch
         }
 
         return $this;
+    }
+
+    /**
+     * Add a callback to be executed when the batch is stored.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function before($callback)
+    {
+        $this->options['before'][] = $callback instanceof Closure
+            ? new SerializableClosure($callback)
+            : $callback;
+
+        return $this;
+    }
+
+    /**
+     * Get the "before" callbacks that have been registered with the pending batch.
+     *
+     * @return array
+     */
+    public function beforeCallbacks()
+    {
+        return $this->options['before'] ?? [];
     }
 
     /**
@@ -271,6 +297,29 @@ class PendingBatch
     }
 
     /**
+     * Stores the batch.
+     *
+     * @param  BatchRepository $repository
+     * @return \Illuminate\Bus\Batch
+     */
+    protected function store($repository)
+    {
+        $batch = $repository->store($this);
+
+        collect($this->beforeCallbacks())->each(function ($handler) use ($batch) {
+            try {
+                return $handler($batch);
+            } catch (Throwable $e) {
+                if (function_exists('report')) {
+                    report($e);
+                }
+            }
+        });
+
+        return $batch;
+    }
+
+    /**
      * Dispatch the batch.
      *
      * @return \Illuminate\Bus\Batch
@@ -282,7 +331,7 @@ class PendingBatch
         $repository = $this->container->make(BatchRepository::class);
 
         try {
-            $batch = $repository->store($this);
+            $batch = $this->store($repository);
 
             $batch = $batch->add($this->jobs);
         } catch (Throwable $e) {
@@ -309,7 +358,7 @@ class PendingBatch
     {
         $repository = $this->container->make(BatchRepository::class);
 
-        $batch = $repository->store($this);
+        $batch = $this->store($repository);
 
         if ($batch) {
             $this->container->terminating(function () use ($batch) {


### PR DESCRIPTION
This PR adds a `before` method to the `PendingBatch`.

## Problem

In the case that we have this:

```php
$batch = Bus::batch($jobs)
    ->finally(fn ($batch) => Cache::forget($cacheKey))
    ->dispatch();

Cache::put($cacheKey, $batch->id);
```

In the case we are using a `redis` connection it works, is sets the cache key and cleans it up when it ends, but in the case we are using a `sync` connection is runs the `finally` callback first and only after it calls the `Cache::put`.

## Solution

```php
$batch = Bus::batch($jobs)
    ->before(fn ($batch) => Cache::put($cacheKey, $batch->id))
    ->finally(fn ($batch) => Cache::forget($cacheKey))
    ->dispatch();
```

With this approach, it will call the `before` callback when it stores the batch, so even with the `sync` queue it should work well.

Let me know what you think,
Francisco
