### PR TITLE
[10.x] Add `assertStatusNot` method

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -151,6 +151,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has not the given status code.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    public function assertStatusNot($status)
+    {
+        $message = $this->statusMessageWithDetails($status, $actual = $this->getStatusCode());
+
+        PHPUnit::assertNotSame($status, $actual, $message);
+
+        return $this;
+    }
+
+    /**
      * Get an assertion message for a status assertion containing extra details when available.
      *
      * @param  string|int  $expected


### PR DESCRIPTION
Sometimes, it’s useful to have an assertion that the response code is not the same as the given one.