### PR TITLE
[10.x] Set wrapped job properties

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -621,7 +621,7 @@ class Dispatcher implements DispatcherContract
             ? (isset($arguments[0]) ? $listener->viaConnection($arguments[0]) : $listener->viaConnection())
             : $listener->connection ?? null);
 
-        $queue = method_exists($listener, 'viaQueue')
+        $job->queue = $queue = method_exists($listener, 'viaQueue')
             ? (isset($arguments[0]) ? $listener->viaQueue($arguments[0]) : $listener->viaQueue())
             : $listener->queue ?? null;
 
@@ -630,8 +630,8 @@ class Dispatcher implements DispatcherContract
             : $listener->delay ?? null;
 
         is_null($delay)
-            ? $connection->pushOn($queue, $job)
-            : $connection->laterOn($queue, $delay, $job);
+            ? $connection->pushOn($job->queue, $job)
+            : $connection->laterOn($job->queue, $delay, $job);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/pulse/issues/305

When a **queued** event listener has a custom `$queue` property or the `viaQueue` method defined, e.g.:

```php
<?php

namespace App\Listeners;

use App\Events\MyEvent;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\InteractsWithQueue;

class MyListener implements ShouldQueue
{
    use InteractsWithQueue;

    public $queue = 'custom_queue';

    public function handle(object $event): void
    {
        //
    }
}
```

the listener will be wrapped in the `CallQueuedListener` class when dispatched.

When listening to the `JobQueued` event it is not possible to retrieve the queue value from the original listener:

```php
Event::listen(function (JobQueued $event) {
    assert($event->job instanceof CallQueuedListener); // ✅

    assert($event->job->queue === 'custom_queue'); // ❌
});
```

<img width="782" alt="Screenshot 2024-02-13 at 11 28 41 am" src="https://github.com/laravel/framework/assets/24803032/aecc8c37-0081-4f63-8a5d-fec752c807e6">


This PR fixes this by setting the `$queue` property on the `CallQueuedListener` to match the value of the listener.

Although it would be possible to manually redo all this work...

https://github.com/laravel/framework/blob/52305ed8a857b4e0e729c68455d60a608d1a75d3/src/Illuminate/Events/Dispatcher.php#L624-L626

I would expect that the queue be available and also be set in the payload like any other dispatched job.

This change does mean that the serialized `CallQueuedListener` payload put on the queue does now contain the correct `queue` value. Previously it would always be `null`.

<img width="307" alt="Screenshot 2024-02-13 at 11 15 17 am" src="https://github.com/laravel/framework/assets/24803032/45ee786f-df5a-4405-883d-f2550e4c1752">

## Notes

I could see value in also setting the `connection` and `delay` on the `CallQueuedListener` class so that it matches the listener, but as I don't specifically need this for the fix I have not included it.