### PR TITLE
[10.x] Remove regex case insensitivity modifier in UUID detection to speed it up slightly

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -542,7 +542,7 @@ class Str
             return false;
         }
 
-        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
+        return preg_match('/^[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}$/D', $value) > 0;
     }
 
     /**


### PR DESCRIPTION
Generally speaking, in any platform, case insensitive regex matching is slower than the sensitive one:

* https://stackoverflow.com/questions/32010/is-regex-case-insensitivity-slower
* https://stackoverflow.com/questions/56908328/regex-case-insensitive-search-performance-i-vs-enumeration
* https://stackoverflow.com/questions/13819635/why-is-grep-ignore-case-50-times-slower
* etc...

I’d suggest to turn the case insensitivity flag off in UUID matching and enumerate `[a-fA-F]` characters explicitly.

The speed up (measured in a billion iterations) is about 5 % when the match is successful and about 5-10 % with the unsuccessful one.