### PR TITLE
[10.x] Fix DB::afterCommit() broken in tests using DatabaseTransactions

### DIFF
--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -83,7 +83,8 @@ class DatabaseTransactionsManager
         // shouldn't be any pending transactions, but going to clear them here anyways just
         // in case. This method could be refactored to receive a level in the future too.
         $this->pendingTransactions = $this->pendingTransactions->reject(
-            fn ($transaction) => $transaction->connection === $connection
+            fn ($transaction) => $transaction->connection === $connection &&
+                $transaction->level >= $levelBeingCommitted
         )->values();
 
         [$forThisConnection, $forOtherConnections] = $this->committedTransactions->partition(

--- a/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
+++ b/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
@@ -40,6 +40,8 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('foo', 2);
         $manager->commit('foo', 2, 1);
 
+        $this->assertCount(0, $manager->callbackApplicableTransactions());
+
         $manager->begin('foo', 2);
 
         $this->assertCount(1, $manager->callbackApplicableTransactions());

--- a/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
+++ b/tests/Foundation/Testing/DatabaseTransactionsManagerTest.php
@@ -31,6 +31,21 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertEquals(2, $manager->callbackApplicableTransactions()[0]->level);
     }
 
+    public function testCommittingDoesNotRemoveTheBasePendingTransaction()
+    {
+        $manager = new DatabaseTransactionsManager;
+
+        $manager->begin('foo', 1);
+
+        $manager->begin('foo', 2);
+        $manager->commit('foo', 2, 1);
+
+        $manager->begin('foo', 2);
+
+        $this->assertCount(1, $manager->callbackApplicableTransactions());
+        $this->assertEquals(2, $manager->callbackApplicableTransactions()[0]->level);
+    }
+
     public function testItExecutesCallbacksForTheSecondTransaction()
     {
         $testObject = new TestingDatabaseTransactionsManagerTestObject();


### PR DESCRIPTION
Closes #50066

Currently, committing the "root" transaction causes `DatabaseTransactionsManager` to remove all `$pendingTransactions`. This tells the `DatabaseTransactionsManager` that it's outside of the transaction and makes it immediately execute callbacks on calls to `DB::afterCommit()`:

```php
class Something {
	public function something(): void {
		// DatabaseTransactionsManager::$pendingTransactions->count() === 0
		
		DB::transaction(function () {
			// DatabaseTransactionsManager::$pendingTransactions->count() === 1
			
			// Not executed immediately
			DB::afterCommit(fn () => dump(123));
		});

		// DatabaseTransactionsManager::$pendingTransactions->count() === 0
		//
		// dump(123) executed at this point
		
		// Executed immediately because of $pendingTransactions->count() === 0
		DB::afterCommit(fn () => dump(456));
	}
}
```

Outside of tests, this works as expected. 

In tests that use `DatabaseTransactions` trait however, this causes an issue whenever you have a commit inside of your test:

```php
class SomeTest extends TestCase {
	use DatabaseTransactions;

	public function testSomething(): void
	{
		// DatabaseTransactionsManager::$pendingTransactions->count() === 1
		
		DB::transaction(function () {
			// DatabaseTransactionsManager::$pendingTransactions->count() === 2
			
			// This will only execute after the transaction commit, as expected
			DB::afterCommit(fn () => dump("after commit"));
		});
		
		// DatabaseTransactionsManager::$pendingTransactions->count() === 0
		//
		// Here the $pendingTransactions no longer contains the "root" transaction, 
		// causing subsequent `afterCommit()` calls to immediately execute:

		DB::transaction(function () {
			// DatabaseTransactionsManager::$pendingTransactions->count() === 1
			
			// Unlike the DB::afterCommit() a few lines above, this one is executed immediately,
			// without waiting for the transaction to commit, which is not expected
			DB::afterCommit(fn () => dd(123));
		});
	}
}
```

This PR fixes this by not letting `commit()` remove a pending transaction of a lower level than what's being committed. The result is that committing a nested transaction in tests leaves the root `$pendingTransactions` in place.

Please let me know if we need more tests or explanations for this. Feel free to make changes on the branch.