### PR TITLE
[10.x] Pass Herd specific env variables to "artisan serve"

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -57,10 +57,10 @@ class ServeCommand extends Command
      */
     public static $passthroughVariables = [
         'APP_ENV',
-        'IGNITION_LOCAL_SITES_PATH',
         'HERD_PHP_81_INI_SCAN_DIR',
         'HERD_PHP_82_INI_SCAN_DIR',
         'HERD_PHP_83_INI_SCAN_DIR',
+        'IGNITION_LOCAL_SITES_PATH',
         'LARAVEL_SAIL',
         'PATH',
         'PHP_CLI_SERVER_WORKERS',

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -58,6 +58,9 @@ class ServeCommand extends Command
     public static $passthroughVariables = [
         'APP_ENV',
         'IGNITION_LOCAL_SITES_PATH',
+        'HERD_PHP_81_INI_SCAN_DIR',
+        'HERD_PHP_82_INI_SCAN_DIR',
+        'HERD_PHP_83_INI_SCAN_DIR',
         'LARAVEL_SAIL',
         'PATH',
         'PHP_CLI_SERVER_WORKERS',


### PR DESCRIPTION
When a user has Laravel Herd installed, running `php artisan serve` does not use the correct php.ini files.
Laravel Herd reads the PHP-specific ini file from a custom environment variable, which needs to be passed through to the PHP process that gets spawned in the `ServeCommand`.

Related Laravel Herd issue: https://github.com/beyondcode/herd-community/issues/397