### PR TITLE
[10.x] Add `asXml()` method to `Http` facade

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -295,6 +295,16 @@ class PendingRequest
     }
 
     /**
+     * Indicate the request contains XML.
+     *
+     * @return $this
+     */
+    public function asXml()
+    {
+        return $this->bodyFormat('xml')->contentType('text/xml');
+    }
+
+    /**
      * Attach a file to the request.
      *
      * @param  string|array  $name
@@ -790,7 +800,7 @@ class PendingRequest
      * Issue a POST request to the given URL.
      *
      * @param  string  $url
-     * @param  array  $data
+     * @param  array|string  $data
      * @return \Illuminate\Http\Client\Response
      */
     public function post(string $url, $data = [])
@@ -818,7 +828,7 @@ class PendingRequest
      * Issue a PUT request to the given URL.
      *
      * @param  string  $url
-     * @param  array  $data
+     * @param  array|string  $data
      * @return \Illuminate\Http\Client\Response
      */
     public function put(string $url, $data = [])
@@ -832,7 +842,7 @@ class PendingRequest
      * Issue a DELETE request to the given URL.
      *
      * @param  string  $url
-     * @param  array  $data
+     * @param  array|string  $data
      * @return \Illuminate\Http\Client\Response
      */
     public function delete(string $url, $data = [])
@@ -958,6 +968,10 @@ class PendingRequest
                 $options[$this->bodyFormat] = $this->parseMultipartBodyFormat($options[$this->bodyFormat]);
             } elseif ($this->bodyFormat === 'body') {
                 $options[$this->bodyFormat] = $this->pendingBody;
+            } elseif ($this->bodyFormat === 'xml') {
+                $options['body'] = $options['xml'];
+                unset($options['xml']);
+                $this->bodyFormat('body');
             }
 
             if (is_array($options[$this->bodyFormat])) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -438,7 +438,7 @@ class HttpClientTest extends TestCase
 
     public function testCanSendXml()
     {
-        $xml = <<<XML
+        $xml = <<<'XML'
         <?xml version="1.0" encoding="utf-8"?>
         <user>
             <name>Taylor</name>
@@ -450,7 +450,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->asXml()->post('http://foo.com/xml', $xml);
 
-        $this->factory->assertSent(function (Request $request) use($xml) {
+        $this->factory->assertSent(function (Request $request) use ($xml) {
             return $request->url() === 'http://foo.com/xml' &&
                    $request->hasHeader('Content-Type', 'text/xml') &&
                    $request->body() === $xml;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -436,6 +436,27 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSendXml()
+    {
+        $xml = <<<XML
+        <?xml version="1.0" encoding="utf-8"?>
+        <mock_data>
+            <foo>foo</foo>
+            <bar>bar</bar>
+        </mock_data>
+        XML;
+
+        $this->factory->fake();
+
+        $this->factory->asXml()->post('http://foo.com/xml', $xml);
+
+        $this->factory->assertSent(function (Request $request) use($xml) {
+            return $request->url() === 'http://foo.com/xml' &&
+                   $request->hasHeader('Content-Type', 'text/xml') &&
+                   $request->body() === $xml;
+        });
+    }
+
     public function testCanSendArrayableFormData()
     {
         $this->factory->fake();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -440,10 +440,10 @@ class HttpClientTest extends TestCase
     {
         $xml = <<<XML
         <?xml version="1.0" encoding="utf-8"?>
-        <mock_data>
-            <foo>foo</foo>
-            <bar>bar</bar>
-        </mock_data>
+        <user>
+            <name>Taylor</name>
+            <title>Laravel Developer</title>
+        </user>
         XML;
 
         $this->factory->fake();


### PR DESCRIPTION
For SOAP requests, a method `asXml()` on `PendingRequest` class, as there are `asJson()` and `asForm()` would simplify things.

It's already possible to do:
```php
Http::send('POST', 'https://foo.com', [
  'body' => $xml,
  'headers' => [ 'Content-Type' => 'text/xml' ],
]);
```
But it's way too verbose.

And it's also possible to do:
```php
Http::withBody($xml, 'text/xml')->post('https://foo.com');
```
But still it has to pass the content type for it.

Having an interface like:
```php
Http::asXml()->post('https://foo.com', $xml);
```
Would make it simpler and would be more intuitive, since this is the way to do for JSON and Forms.

The implementation makes two changes in the code:

1. Creates the `asXml` method

```php
/**
 * Indicate the request contains XML.
 *
 * @return $this
 */
public function asXml()
{
    return $this->bodyFormat('xml')->contentType('text/xml');
}
```
2. Alters the `parseHttpOptions` method to handle XML body

```php
protected function parseHttpOptions(array $options)
{
  if (isset($options[$this->bodyFormat])) {
    if ($this->bodyFormat === 'multipart') {
      $options[$this->bodyFormat] = $this->parseMultipartBodyFormat($options[$this->bodyFormat]);
    } elseif ($this->bodyFormat === 'body') {
      $options[$this->bodyFormat] = $this->pendingBody;
+   } elseif ($this->bodyFormat === 'xml') {
+     $options['body'] = $options['xml'];
+     unset($options['xml']);
+     $this->bodyFormat('body');
+   }

    if (is_array($options[$this->bodyFormat])) {
      $options[$this->bodyFormat] = array_merge(
        $options[$this->bodyFormat], $this->pendingFiles
      );
    }
  } else {
    $options[$this->bodyFormat] = $this->pendingBody;
  }

  return collect($options)->map(function ($value, $key) {
    if ($key === 'json' && $value instanceof JsonSerializable) {
      return $value;
    }

    return $value instanceof Arrayable ? $value->toArray() : $value;
  })->all();
}
```

That addition on `parseHttpOptions`  is because it was the only way I could think of to correctly place the xml body on it's place. Another two approaches were thought of, but wouldn't work:

1. If `asXml` set `$this->formatBody` as `'body'` it wouldn't have `$this->pendingBody` set, since the body is only passed on `post` call.
2. To pass the xml body on `asXml` method as parameter, calling `withBody` inside, but that would break the interface pattern, since `asJson` as `asForm` methods don't take the body.

So the only solution I could think of was to alter `parseHttpOptions` to handle `$this->formatBody === 'xml'`.

The usage case can be found in the test case. Hope it contributes to the framework.