### PR TITLE
[11.x] Prompt to force queue workers in maintenance mode

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -16,6 +16,7 @@ use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Terminal;
 
+use function Laravel\Prompts\confirm;
 use function Termwind\terminal;
 
 #[AsCommand(name: 'queue:work')]
@@ -98,6 +99,10 @@ class WorkCommand extends Command
     {
         if ($this->downForMaintenance() && $this->option('once')) {
             return $this->worker->sleep($this->option('sleep'));
+        }
+
+        if($this->downForMaintenance() && !$this->option('force')) {
+            $this->components->warn("The application is in maintenance mode.");
         }
 
         // We'll listen to the processed and failed events so we can write information

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -101,8 +101,8 @@ class WorkCommand extends Command
             return $this->worker->sleep($this->option('sleep'));
         }
 
-        if($this->downForMaintenance() && ! $this->option('force')) {
-            $this->components->warn("The application is in maintenance mode.");
+        if ($this->downForMaintenance() && ! $this->option('force')) {
+            $this->components->warn('The application is in maintenance mode.');
 
             if (! confirm('Would you like to force the worker to run?', default: false)) {
                 return false;

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -101,8 +101,12 @@ class WorkCommand extends Command
             return $this->worker->sleep($this->option('sleep'));
         }
 
-        if($this->downForMaintenance() && !$this->option('force')) {
+        if($this->downForMaintenance() && ! $this->option('force')) {
             $this->components->warn("The application is in maintenance mode.");
+
+            if (confirm('Would you like to force the worker to run?', default: false)) {
+                $this->input->setOption('force', true);
+            }
         }
 
         // We'll listen to the processed and failed events so we can write information

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -104,9 +104,11 @@ class WorkCommand extends Command
         if($this->downForMaintenance() && ! $this->option('force')) {
             $this->components->warn("The application is in maintenance mode.");
 
-            if (confirm('Would you like to force the worker to run?', default: false)) {
-                $this->input->setOption('force', true);
+            if (! confirm('Would you like to force the worker to run?', default: false)) {
+                return false;
             }
+
+            $this->input->setOption('force', true);
         }
 
         // We'll listen to the processed and failed events so we can write information


### PR DESCRIPTION
With this, user will get prompt to enforce queue worker in maintenance mode.

**When Rejected**:

<img width="603" alt="image" src="https://github.com/laravel/framework/assets/30431426/8ee9a411-a9c6-4a41-80de-107a60b24c3e">

**On Accept**:

<img width="1582" alt="image" src="https://github.com/laravel/framework/assets/30431426/50bac13c-fd41-4c74-96c1-7d8fc0d826c8">
