### PR TITLE
[11.x] Add magical enum feature

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/enum.backed.stub
+++ b/src/Illuminate/Foundation/Console/stubs/enum.backed.stub
@@ -2,7 +2,11 @@
 
 namespace {{ namespace }};
 
+use Illuminate\Support\Traits\MagicalEnum;
+
 enum {{ class }}: {{ type }}
 {
+    use MagicalEnum;
+
     //
 }

--- a/src/Illuminate/Foundation/Console/stubs/enum.stub
+++ b/src/Illuminate/Foundation/Console/stubs/enum.stub
@@ -2,7 +2,11 @@
 
 namespace {{ namespace }};
 
+use Illuminate\Support\Traits\MagicalEnum;
+
 enum {{ class }}
 {
+    use MagicalEnum;
+
     //
 }

--- a/src/Illuminate/Support/Traits/MagicalEnum.php
+++ b/src/Illuminate/Support/Traits/MagicalEnum.php
@@ -155,7 +155,7 @@ trait MagicalEnum
      *
      * @return array
      */
-    public static function reverseArray(): array
+    public static function toReverseArray(): array
     {
         self::ensureEnum();
 

--- a/src/Illuminate/Support/Traits/MagicalEnum.php
+++ b/src/Illuminate/Support/Traits/MagicalEnum.php
@@ -40,7 +40,6 @@ trait MagicalEnum
         return (new \ReflectionEnum(self::class))->isBacked();
     }
 
-
     /**
      *  Retrieves the enumeration type (int,string).
      *
@@ -54,9 +53,9 @@ trait MagicalEnum
     }
 
     /**
-     * Checks if the enumeration type implements a specified interface
+     * Checks if the enumeration type implements a specified interface.
      *
-     * @param string $interfaceName
+     * @param  string  $interfaceName
      * @return bool
      */
     public static function isImplementsInterface(string $interfaceName): bool
@@ -67,9 +66,9 @@ trait MagicalEnum
     }
 
     /**
-     * Checks if a specified trait is used in the current enum
+     * Checks if a specified trait is used in the current enum.
      *
-     * @param string $traitName
+     * @param  string  $traitName
      * @return bool
      */
     public static function isTraitUsed(string $traitName): bool
@@ -103,11 +102,10 @@ trait MagicalEnum
             : [];
     }
 
-
     /**
      * Checks if the enumeration type has a specific case by name.
      *
-     * @param string $name
+     * @param  string  $name
      * @return bool
      */
     public static function hasCase(string $name): bool
@@ -120,7 +118,7 @@ trait MagicalEnum
     /**
      * Validates a value for an enumeration type.
      *
-     * @param string|int $value
+     * @param  string|int  $value
      * @return bool
      */
     public static function isValidEnumValue(string|int $value): bool

--- a/src/Illuminate/Support/Traits/MagicalEnum.php
+++ b/src/Illuminate/Support/Traits/MagicalEnum.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use BadMethodCallException;
+
+trait MagicalEnum
+{
+    /**
+     * Checks if the class represents an enumeration type.
+     *
+     * @return bool
+     */
+    public static function isEnum(): bool
+    {
+        return enum_exists(self::class);
+    }
+
+    /**
+     * Counts the number of cases in the enumeration type.
+     *
+     * @return int
+     */
+    public static function count(): int
+    {
+        self::ensureEnum();
+
+        return count(self::cases());
+    }
+
+    /**
+     * Checks if the enumeration type is backed by a specific backing type.
+     *
+     * @return bool
+     */
+    public static function isBackedEnum(): bool
+    {
+        self::ensureEnum();
+
+        return (new \ReflectionEnum(self::class))->isBacked();
+    }
+
+
+    /**
+     *  Retrieves the enumeration type (int,string).
+     *
+     * @return string|null
+     */
+    public static function getBackingType(): ?string
+    {
+        self::ensureEnum();
+
+        return (new \ReflectionEnum(self::class))->getBackingType()?->getName();
+    }
+
+    /**
+     * Checks if the enumeration type implements a specified interface
+     *
+     * @param string $interfaceName
+     * @return bool
+     */
+    public static function isImplementsInterface(string $interfaceName): bool
+    {
+        self::ensureEnum();
+
+        return is_a(self::class, $interfaceName, true);
+    }
+
+    /**
+     * Checks if a specified trait is used in the current enum
+     *
+     * @param string $traitName
+     * @return bool
+     */
+    public static function isTraitUsed(string $traitName): bool
+    {
+        return in_array($traitName, class_uses(self::class), true);
+    }
+
+    /**
+     * Retrieves an array of names representing the cases of the enumeration.
+     *
+     * @return array
+     */
+    public static function names(): array
+    {
+        self::ensureEnum();
+
+        return array_column(self::cases(), 'name');
+    }
+
+    /**
+     * Retrieves an array of values representing the cases of the enumeration.
+     *
+     * @return array
+     */
+    public static function values(): array
+    {
+        self::ensureEnum();
+
+        return self::isBackedEnum()
+            ? array_column(self::cases(), 'value')
+            : [];
+    }
+
+
+    /**
+     * Checks if the enumeration type has a specific case by name.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public static function hasCase(string $name): bool
+    {
+        self::ensureEnum();
+
+        return (new \ReflectionEnum(self::class))->hasCase($name);
+    }
+
+    /**
+     * Validates a value for an enumeration type.
+     *
+     * @param string $value
+     * @return bool
+     */
+    public static function isValidEnumValue(string $value): bool
+    {
+        self::ensureEnum();
+
+        if (self::isBackedEnum() === true) {
+            return self::tryFrom($value) !== null;
+        }
+
+        return in_array($value, self::names(), true);
+    }
+
+    /**
+     * Converts the enumeration type to an associative array.
+     *
+     * @return array
+     */
+    public static function toArray(): array
+    {
+        self::ensureEnum();
+
+        if (self::isBackedEnum() === false) {
+            return self::names();
+        }
+
+        return array_column(self::cases(), 'value', 'name');
+    }
+
+    /**
+     * Generates an associative array mapping case values to their corresponding names in the enumeration type.
+     *
+     * @return array
+     */
+    public static function reverseArray(): array
+    {
+        self::ensureEnum();
+
+        if (self::isBackedEnum() === false) {
+            return self::names();
+        }
+
+        return array_column(self::cases(), 'name', 'value');
+    }
+
+    private static function ensureEnum(): void
+    {
+        if (self::isEnum() === false) {
+            throw new BadMethodCallException('This method should only be called within an enumeration.');
+        }
+    }
+}

--- a/src/Illuminate/Support/Traits/MagicalEnum.php
+++ b/src/Illuminate/Support/Traits/MagicalEnum.php
@@ -120,10 +120,10 @@ trait MagicalEnum
     /**
      * Validates a value for an enumeration type.
      *
-     * @param string $value
+     * @param string|int $value
      * @return bool
      */
-    public static function isValidEnumValue(string $value): bool
+    public static function isValidEnumValue(string|int $value): bool
     {
         self::ensureEnum();
 
@@ -131,7 +131,7 @@ trait MagicalEnum
             return self::tryFrom($value) !== null;
         }
 
-        return in_array($value, self::names(), true);
+        return false;
     }
 
     /**

--- a/tests/Support/Fixtures/EnumInterface.php
+++ b/tests/Support/Fixtures/EnumInterface.php
@@ -4,5 +4,4 @@ namespace Illuminate\Tests\Support\Fixtures;
 
 interface EnumInterface
 {
-
 }

--- a/tests/Support/Fixtures/EnumInterface.php
+++ b/tests/Support/Fixtures/EnumInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+interface EnumInterface
+{
+
+}

--- a/tests/Support/Fixtures/ExampleTrait.php
+++ b/tests/Support/Fixtures/ExampleTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+trait ExampleTrait
+{
+
+}

--- a/tests/Support/Fixtures/ExampleTrait.php
+++ b/tests/Support/Fixtures/ExampleTrait.php
@@ -4,5 +4,4 @@ namespace Illuminate\Tests\Support\Fixtures;
 
 trait ExampleTrait
 {
-
 }

--- a/tests/Support/Fixtures/IntBackedMagicalEnum.php
+++ b/tests/Support/Fixtures/IntBackedMagicalEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+use Illuminate\Support\Traits\MagicalEnum;
+
+enum IntBackedMagicalEnum: int implements EnumInterface
+{
+    use MagicalEnum, ExampleTrait;
+
+    case ONE = 1;
+    case TOW = 2;
+    case THREE = 3;
+}

--- a/tests/Support/Fixtures/MagicalUnitEnum.php
+++ b/tests/Support/Fixtures/MagicalUnitEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+use Illuminate\Support\Traits\MagicalEnum;
+
+enum MagicalUnitEnum
+{
+    use MagicalEnum;
+
+    case A;
+    case B;
+    case C;
+    case D;
+}

--- a/tests/Support/Fixtures/StringBackedMagicalEnum.php
+++ b/tests/Support/Fixtures/StringBackedMagicalEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+use Illuminate\Support\Traits\MagicalEnum;
+
+enum StringBackedMagicalEnum: string
+{
+    use MagicalEnum;
+
+    case Taylor = 'Otwell';
+    case Laravel = 'Framework';
+}

--- a/tests/Support/SupportMagicalEnumTest.php
+++ b/tests/Support/SupportMagicalEnumTest.php
@@ -123,9 +123,9 @@ class SupportMagicalEnumTest extends TestCase
 
     public function testReverseArray(): void
     {
-        $this->assertEquals([1 => 'ONE', 2 => 'TOW', 3 => 'THREE'], IntBackedMagicalEnum::reverseArray());
-        $this->assertEquals(['Otwell' => 'Taylor', 'Framework' => 'Laravel'], stringBackedMagicalEnum::reverseArray());
-        $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::reverseArray());
+        $this->assertEquals([1 => 'ONE', 2 => 'TOW', 3 => 'THREE'], IntBackedMagicalEnum::toReverseArray());
+        $this->assertEquals(['Otwell' => 'Taylor', 'Framework' => 'Laravel'], stringBackedMagicalEnum::toReverseArray());
+        $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::toReverseArray());
 
         $this->expectException(BadMethodCallException::class);
         $instance = new class {

--- a/tests/Support/SupportMagicalEnumTest.php
+++ b/tests/Support/SupportMagicalEnumTest.php
@@ -156,6 +156,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertTrue(StringBackedMagicalEnum::isValidEnumValue('Framework'));
         $this->assertFalse(StringBackedMagicalEnum::isValidEnumValue('Forge'));
 
+        $this->assertFalse(MagicalUnitEnum::isValidEnumValue('A'));
+
         $this->expectException(BadMethodCallException::class);
         $instance = new class {
             use MagicalEnum;

--- a/tests/Support/SupportMagicalEnumTest.php
+++ b/tests/Support/SupportMagicalEnumTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\TestCase;
 
 class SupportMagicalEnumTest extends TestCase
 {
-
     public function testIsEnum(): void
     {
         $this->assertTrue(IntBackedMagicalEnum::isEnum());
@@ -21,7 +20,8 @@ class SupportMagicalEnumTest extends TestCase
 
     public function testIsEnumWhenTraitAddToClass(): void
     {
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 
@@ -34,7 +34,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertFalse(MagicalUnitEnum::isBackedEnum());
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 
@@ -54,7 +55,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertNull(MagicalUnitEnum::getBackingType());
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 
@@ -72,7 +74,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertTrue(IntBackedMagicalEnum::isTraitUsed(ExampleTrait::class));
         $this->assertFalse(StringBackedMagicalEnum::isTraitUsed(ExampleTrait::class));
 
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum, ExampleTrait;
         };
 
@@ -86,7 +89,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::names());
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 
@@ -101,7 +105,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertEquals([], MagicalUnitEnum::values());
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
         $this->assertNotEquals(['A', 'B', 'C', 'D'], $instance::names());
@@ -114,7 +119,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::toArray());
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 
@@ -128,7 +134,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::toReverseArray());
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 
@@ -147,7 +154,6 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertFalse(MagicalUnitEnum::hasCase('Z'));
     }
 
-
     public function testIsValidEnumValue(): void
     {
         $this->assertTrue(IntBackedMagicalEnum::isValidEnumValue(2));
@@ -159,7 +165,8 @@ class SupportMagicalEnumTest extends TestCase
         $this->assertFalse(MagicalUnitEnum::isValidEnumValue('A'));
 
         $this->expectException(BadMethodCallException::class);
-        $instance = new class {
+        $instance = new class
+        {
             use MagicalEnum;
         };
 

--- a/tests/Support/SupportMagicalEnumTest.php
+++ b/tests/Support/SupportMagicalEnumTest.php
@@ -11,8 +11,6 @@ use Illuminate\Tests\Support\Fixtures\MagicalUnitEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedMagicalEnum;
 use PHPUnit\Framework\TestCase;
 
-include_once 'Enums.php';
-
 class SupportMagicalEnumTest extends TestCase
 {
 

--- a/tests/Support/SupportMagicalEnumTest.php
+++ b/tests/Support/SupportMagicalEnumTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use BadMethodCallException;
+use Illuminate\Support\Traits\MagicalEnum;
+use Illuminate\Tests\Support\Fixtures\EnumInterface;
+use Illuminate\Tests\Support\Fixtures\ExampleTrait;
+use Illuminate\Tests\Support\Fixtures\IntBackedMagicalEnum;
+use Illuminate\Tests\Support\Fixtures\MagicalUnitEnum;
+use Illuminate\Tests\Support\Fixtures\StringBackedMagicalEnum;
+use PHPUnit\Framework\TestCase;
+
+include_once 'Enums.php';
+
+class SupportMagicalEnumTest extends TestCase
+{
+
+    public function testIsEnum(): void
+    {
+        $this->assertTrue(IntBackedMagicalEnum::isEnum());
+    }
+
+    public function testIsEnumWhenTraitAddToClass(): void
+    {
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $this->assertFalse($instance::isEnum());
+    }
+
+    public function testIsBackedEnum(): void
+    {
+        $this->assertTrue(IntBackedMagicalEnum::isBackedEnum());
+        $this->assertFalse(MagicalUnitEnum::isBackedEnum());
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $instance::isBackedEnum();
+    }
+
+    public function testCount(): void
+    {
+        $this->assertEquals(3, IntBackedMagicalEnum::count());
+        $this->assertEquals(4, MagicalUnitEnum::count());
+    }
+
+    public function testGetBackingType(): void
+    {
+        $this->assertEquals('int', IntBackedMagicalEnum::getBackingType());
+        $this->assertEquals('string', stringBackedMagicalEnum::getBackingType());
+        $this->assertNull(MagicalUnitEnum::getBackingType());
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $instance::getBackingType();
+    }
+
+    public function testIsImplementsInterface(): void
+    {
+        $this->assertTrue(IntBackedMagicalEnum::isImplementsInterface(EnumInterface::class));
+        $this->assertFalse(MagicalUnitEnum::isImplementsInterface(EnumInterface::class));
+    }
+
+    public function testIsTraitUsed(): void
+    {
+        $this->assertTrue(IntBackedMagicalEnum::isTraitUsed(ExampleTrait::class));
+        $this->assertFalse(StringBackedMagicalEnum::isTraitUsed(ExampleTrait::class));
+
+        $instance = new class {
+            use MagicalEnum, ExampleTrait;
+        };
+
+        $this->assertTrue($instance::isTraitUsed(ExampleTrait::class));
+    }
+
+    public function testNames(): void
+    {
+        $this->assertEquals(['ONE', 'TOW', 'THREE'], IntBackedMagicalEnum::names());
+        $this->assertEquals(['Taylor', 'Laravel'], stringBackedMagicalEnum::names());
+        $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::names());
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $this->assertNotEquals(['ONE', 'TOW', 'THREE'], $instance::names());
+    }
+
+    public function testValues(): void
+    {
+        $this->assertEquals([1, 2, 3], IntBackedMagicalEnum::values());
+        $this->assertEquals(['Otwell', 'Framework'], stringBackedMagicalEnum::values());
+
+        $this->assertEquals([], MagicalUnitEnum::values());
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+        $this->assertNotEquals(['A', 'B', 'C', 'D'], $instance::names());
+    }
+
+    public function testToArray(): void
+    {
+        $this->assertEquals(['ONE' => 1, 'TOW' => 2, 'THREE' => 3], IntBackedMagicalEnum::toArray());
+        $this->assertEquals(['Taylor' => 'Otwell', 'Laravel' => 'Framework'], stringBackedMagicalEnum::toArray());
+        $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::toArray());
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $this->assertNotEquals(['A', 'B', 'C'], $instance::names());
+    }
+
+    public function testReverseArray(): void
+    {
+        $this->assertEquals([1 => 'ONE', 2 => 'TOW', 3 => 'THREE'], IntBackedMagicalEnum::reverseArray());
+        $this->assertEquals(['Otwell' => 'Taylor', 'Framework' => 'Laravel'], stringBackedMagicalEnum::reverseArray());
+        $this->assertEquals(['A', 'B', 'C', 'D'], MagicalUnitEnum::reverseArray());
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $this->assertNotEquals(['A', 'B', 'C'], $instance::names());
+    }
+
+    public function testHasCase(): void
+    {
+        $this->assertTrue(IntBackedMagicalEnum::hasCase('ONE'));
+        $this->assertFalse(IntBackedMagicalEnum::hasCase('FOUR'));
+
+        $this->assertTrue(StringBackedMagicalEnum::hasCase('Taylor'));
+        $this->assertFalse(StringBackedMagicalEnum::hasCase('DotNetCore'));
+
+        $this->assertTrue(MagicalUnitEnum::hasCase('A'));
+        $this->assertFalse(MagicalUnitEnum::hasCase('Z'));
+    }
+
+
+    public function testIsValidEnumValue(): void
+    {
+        $this->assertTrue(IntBackedMagicalEnum::isValidEnumValue(2));
+        $this->assertFalse(IntBackedMagicalEnum::isValidEnumValue(100));
+
+        $this->assertTrue(StringBackedMagicalEnum::isValidEnumValue('Framework'));
+        $this->assertFalse(StringBackedMagicalEnum::isValidEnumValue('Forge'));
+
+        $this->expectException(BadMethodCallException::class);
+        $instance = new class {
+            use MagicalEnum;
+        };
+
+        $this->assertTrue($instance::isValidEnumValue(2));
+    }
+}


### PR DESCRIPTION
In this PR, a Trait named `MagicalEnum` has been added to `Illuminate\Support\Traits`, providing attractive and practical features for working with enums.

```php

enum MagicalUnitEnum
{
    use MagicalEnum;

    case Laravel;
    case Livewire;
    case Nova;
    case Horizon;
}

enum StringBackedMagicalEnum: string
{
    use MagicalEnum;

    case Taylor = 'Otwell';
    case Laravel = 'Framework';
}

enum IntBackedMagicalEnum: int implements EnumerationInterface
{
    use MagicalEnum, ExampleTrait;

    case ONE = 1;
    case TOW = 2;
    case THREE = 3;
}

```

### names() , values()

```php
StringBackedMagicalEnum::names() ; // [ 'Taylor' , 'Laravel' ]
StringBackedMagicalEnum::values(); // [ 'Otwell' , 'Framework' ]

MagicalUnitEnum::names(); // [ 'Laravel' , 'Livewire' , 'Nova' , 'Horizon' ]

// Unit enums only have names and do not have any values, unlike BackedEnums
MagicalUnitEnum::values(); // [] 
```

### count()

```php

StringBackedMagicalEnum::count(); // 2
IntBackedMagicalEnum::count(); // 3
MagicalUnitEnum::count(); // 4

```

### hasCase() , isValidEnumValue()

```php
StringBackedMagicalEnum::hasCase('Taylor'); // true
StringBackedMagicalEnum::hasCase('Mahmoudzadeh'); // false

StringBackedMagicalEnum::isValidEnumValue('Otwell'); // true
IntBackedMagicalEnum::isValidEnumValue(100); // false

MagicalEnum::hasCase('Laravel'); // true
MagicalEnum::hasCase('CodeIgnitor'); // false
MagicalEnum::hasCase('Wordpress'); // false

// Unit enums only have names and do not have any values, unlike BackedEnums
MagicalEnum::isValidEnumValue('Laravel'); // false

```

## toArray() , toReverseArray()

```php
StringBackedMagicalEnum::toArray(); // [ 'Taylor' => 'Otwell' , 'Laravel' => 'Framework'  ]
StringBackedMagicalEnum::toReverseArray(); // [ 'Otwell' => 'Taylor' , 'Framework' => 'Laravel' ]

IntBackedMagicalEnum::toArray(); // [ 'ONE' => 1 , 'TOW' => 2 , 'THREE' => 3]
IntBackedMagicalEnum::toReverseArray(); // [ 1  =>  'ONE' ,  2 => 'TOW' , 3 => 'THREE' ] 


// note: In Unit Enums, toArray and toReverseArray methods are identical.
MagicalUnitEnum::toArray(); // [ 'Laravel', 'Livewire', 'Nova', 'Horizon']
MagicalUnitEnum::toReverseArray(); // [ 'Laravel', 'Livewire', 'Nova', 'Horizon']
```


### isBackedEnum()

```php
MagicalUnitEnum::isBackedEnum();  // false
StringBackedMagicalEnum::isBackedEnum(); // true
```

### getBackingType()

```php

StringBackedMagicalEnum::getBackingType(); // 'string'
IntBackedMagicalEnum::getBackingType(); // 'int'
MagicalUnitEnum::getBackingType(); // null

```

### isImplementsInterface() , isTraitUsed()

```php
IntBackedMagicalEnum::isImplementsInterface(EnumerationInterface::class); // true
IntBackedMagicalEnum::isTraitUsed(ExampleTrait::class); // true
```

### make:enum
In Laravel 11, a new command, make:enum, has been introduced. In this feature, two stub files (enum.backed.stub, enum.stub) have been edited, and this trait has been added to enums.


### Testing
In this feature, I have added tests for all methods of the trait.

### Documentation
I'll send a separate PR to update the doc, if this PR is merged.


Thank you!