### PR TITLE
[11.x] Aligning Migration Stub File Style with Modern PHP Coding Standards

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * The database connection that should be used by the migration.

--- a/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * The database connection that should be used by the migration.

--- a/tests/Database/migrations/connection_configured/2022_02_21_120000_create_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_120000_create_jobs_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/tests/Database/migrations/connection_configured/2022_02_21_120000_create_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_120000_create_jobs_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.

--- a/tests/Integration/Generators/CacheTableCommandTest.php
+++ b/tests/Integration/Generators/CacheTableCommandTest.php
@@ -12,7 +12,7 @@ class CacheTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'cache\', function (Blueprint $table) {',
             'Schema::create(\'cache_locks\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'cache\');',

--- a/tests/Integration/Generators/CacheTableCommandTest.php
+++ b/tests/Integration/Generators/CacheTableCommandTest.php
@@ -12,7 +12,7 @@ class CacheTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'cache\', function (Blueprint $table) {',
             'Schema::create(\'cache_locks\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'cache\');',

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -11,7 +11,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::table(\'foos\', function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
@@ -23,7 +23,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::table(\'foobar\', function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
@@ -35,7 +35,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'foos\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');
@@ -48,7 +48,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'foobar\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'foobar\');',
         ], 'foos_table.php');

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -11,7 +11,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::table(\'foos\', function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
@@ -23,7 +23,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::table(\'foobar\', function (Blueprint $table) {',
         ], 'add_bar_to_foos_table.php');
     }
@@ -35,7 +35,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'foos\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');
@@ -48,7 +48,7 @@ class MigrateMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'foobar\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'foobar\');',
         ], 'foos_table.php');

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -116,7 +116,7 @@ class ModelMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'foos\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -116,7 +116,7 @@ class ModelMakeCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'foos\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');

--- a/tests/Integration/Generators/NotificationTableCommandTest.php
+++ b/tests/Integration/Generators/NotificationTableCommandTest.php
@@ -12,7 +12,7 @@ class NotificationTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'notifications\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'notifications\');',
         ], 'create_notifications_table.php');

--- a/tests/Integration/Generators/NotificationTableCommandTest.php
+++ b/tests/Integration/Generators/NotificationTableCommandTest.php
@@ -12,7 +12,7 @@ class NotificationTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'notifications\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'notifications\');',
         ], 'create_notifications_table.php');

--- a/tests/Integration/Generators/QueueBatchesTableCommandTest.php
+++ b/tests/Integration/Generators/QueueBatchesTableCommandTest.php
@@ -12,7 +12,7 @@ class QueueBatchesTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'job_batches\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'job_batches\');',
         ], 'create_job_batches_table.php');

--- a/tests/Integration/Generators/QueueBatchesTableCommandTest.php
+++ b/tests/Integration/Generators/QueueBatchesTableCommandTest.php
@@ -12,7 +12,7 @@ class QueueBatchesTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'job_batches\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'job_batches\');',
         ], 'create_job_batches_table.php');

--- a/tests/Integration/Generators/QueueFailedTableCommandTest.php
+++ b/tests/Integration/Generators/QueueFailedTableCommandTest.php
@@ -12,7 +12,7 @@ class QueueFailedTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'failed_jobs\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'failed_jobs\');',
         ], 'create_failed_jobs_table.php');

--- a/tests/Integration/Generators/QueueFailedTableCommandTest.php
+++ b/tests/Integration/Generators/QueueFailedTableCommandTest.php
@@ -12,7 +12,7 @@ class QueueFailedTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'failed_jobs\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'failed_jobs\');',
         ], 'create_failed_jobs_table.php');

--- a/tests/Integration/Generators/QueueTableCommandTest.php
+++ b/tests/Integration/Generators/QueueTableCommandTest.php
@@ -12,7 +12,7 @@ class QueueTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'jobs\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'jobs\');',
         ], 'create_jobs_table.php');

--- a/tests/Integration/Generators/QueueTableCommandTest.php
+++ b/tests/Integration/Generators/QueueTableCommandTest.php
@@ -12,7 +12,7 @@ class QueueTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'jobs\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'jobs\');',
         ], 'create_jobs_table.php');

--- a/tests/Integration/Generators/SessionTableCommandTest.php
+++ b/tests/Integration/Generators/SessionTableCommandTest.php
@@ -12,7 +12,7 @@ class SessionTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class extends Migration',
+            'return new class () extends Migration',
             'Schema::create(\'sessions\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'sessions\');',
         ], 'create_sessions_table.php');

--- a/tests/Integration/Generators/SessionTableCommandTest.php
+++ b/tests/Integration/Generators/SessionTableCommandTest.php
@@ -12,7 +12,7 @@ class SessionTableCommandTest extends TestCase
 
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
-            'return new class () extends Migration',
+            'return new class() extends Migration',
             'Schema::create(\'sessions\', function (Blueprint $table) {',
             'Schema::dropIfExists(\'sessions\');',
         ], 'create_sessions_table.php');

--- a/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+return new class () extends Migration
 {
     /**
      * Run the migrations.

--- a/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
+return new class() extends Migration
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
Summary
This pull request updates the Laravel migration file stub syntax from return new class extends Migration {} to return new class () extends Migration {}, aligning with modern PHP coding standards.

Details
Implementing this change promotes adherence to several standard style rules, including PHP CS Fixer's new_with_parentheses, PSR-12, PHP-FIG Extended Recommendations (PER) Coding Style, and Symfony Coding Standards. This syntax adjustment is not only a matter of code clarity and consistency but also reflects a broader perspective that frameworks should support widely used coding standards, especially those applied by popular tools like PHP CS Fixer. By aligning the Laravel stubs with these standards, we ensure that the framework's codebase is immediately compatible and does not require additional interventions when developers apply these tools to their projects. This initiative demonstrates Laravel's commitment to developer experience and code quality, acknowledging the significance of following widely adopted rules that enhance the maintainability and readability of code.

References
PHP CS Fixer new_with_parentheses Rule: [PHP CS Fixer Documentation](https://cs.symfony.com/doc/rules/operator/new_with_parentheses.html)
PER Coding Style: [PHP-FIG Extended Recommendations](https://www.php-fig.org/per/coding-style/)

Embracing these standards within Laravel's default stubs helps streamline development workflows, ensuring that generated migration files are immediately in sync with best practices, thereby enhancing the overall developer experience and code quality across the ecosystem.

Thank you for considering this enhancement.