### PR TITLE
[10.x] After commit callback throwing an exception causes transaction level to be incorrect

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -51,12 +51,6 @@ trait ManagesTransactions
                     $this->transactions,
                     max(0, $this->transactions - 1),
                 ];
-
-                $this->transactionsManager?->commit(
-                    $this->getName(),
-                    $levelBeingCommitted,
-                    $this->transactions
-                );
             } catch (Throwable $e) {
                 $this->handleCommitTransactionException(
                     $e, $currentAttempt, $attempts
@@ -64,6 +58,12 @@ trait ManagesTransactions
 
                 continue;
             }
+
+            $this->transactionsManager?->commit(
+                $this->getName(),
+                $levelBeingCommitted,
+                $this->transactions
+            );
 
             $this->fireConnectionEvent('committed');
 

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -41,16 +41,15 @@ trait ManagesTransactions
                 continue;
             }
 
+            $levelBeingCommitted = $this->transactions;
+
             try {
                 if ($this->transactions == 1) {
                     $this->fireConnectionEvent('committing');
                     $this->getPdo()->commit();
                 }
 
-                [$levelBeingCommitted, $this->transactions] = [
-                    $this->transactions,
-                    max(0, $this->transactions - 1),
-                ];
+                $this->transactions = max(0, $this->transactions - 1);
             } catch (Throwable $e) {
                 $this->handleCommitTransactionException(
                     $e, $currentAttempt, $attempts


### PR DESCRIPTION
Hey.

Whenever an `afterCommit` callback throws an exception inside of a `DB::transaction()` closure, it's caught by the `ManagesTransactions` trait and internal `->transactions` transaction level is decremented. In tests that use `DatabaseTransactions` trait this makes `DB::transactionLevel()` return 0, although the real transaction level (on the database side) is still 1.

```php
class SomeTest extends TestCase 
{
    use DatabaseTransactions;

    public function testSomething()
    {
        $this->assertSame(1, DB::transactionLevel());
    
        try {
            DB::transaction(function () {
                $this->assertSame(2, DB::transactionLevel());
            
                DB::afterCommit(fn () => throw new \RuntimeException());
            });
        } catch (\RuntimeException) {}
        
        // Currently fails
        $this->assertSame(1, DB::transactionLevel());
    }
}
```

This PR fixes this by running after commit callbacks outside of the try-catch, next to the "committing" event.