### PR TITLE
[10.x] Refactor helpers.php ( improvement code quality, more readability )

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -185,7 +185,7 @@ if (! function_exists('optional')) {
      *
      * @param  mixed  $value
      * @param  callable|null  $callback
-     * @return mixed
+     * @return mixed|null
      */
     function optional($value = null, callable $callback = null)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -91,8 +91,8 @@ if (! function_exists('class_uses_recursive')) {
 
         $results = [];
 
-        foreach (array_reverse(class_parents($class) ?: []) + [$class => $class] as $class) {
-            $results += trait_uses_recursive($class);
+        foreach (array_reverse(class_parents($class) ?: []) + [$class => $class] as $_class) {
+            $results += trait_uses_recursive($_class);
         }
 
         return array_unique($results);
@@ -362,12 +362,12 @@ if (! function_exists('trait_uses_recursive')) {
     /**
      * Returns all traits used by a trait and its traits.
      *
-     * @param  object|string  $trait
+     * @param  object|string  $currentTrait
      * @return array
      */
-    function trait_uses_recursive($trait)
+    function trait_uses_recursive($currentTrait)
     {
-        $traits = class_uses($trait) ?: [];
+        $traits = class_uses($currentTrait) ?: [];
 
         foreach ($traits as $trait) {
             $traits += trait_uses_recursive($trait);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -191,9 +191,13 @@ if (! function_exists('optional')) {
     {
         if (is_null($callback)) {
             return new Optional($value);
-        } elseif (! is_null($value)) {
+        }
+
+        if (! is_null($value)) {
             return $callback($value);
         }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
In this PR , I aim to enhance the code quality in the helpers.php file

```php
function trait_uses_recursive($trait)
    {
        $traits = class_uses($trait);

        foreach ($traits as $trait) {
            $traits += trait_uses_recursive($trait);
        }

        return $traits;
    }
```

Renamed the `trait_uses_recursive` parameter from `$trait` to `$currentTrait` for better readability and to avoid confusion with the variable used in the foreach loop.

### commit 2 : if-elseif convert to flatten if structure
```php

         // before
        if (is_null($callback)) {
            return new Optional($value);
        } elseif (! is_null($value)) {
            return $callback($value);
        }

        // after
        if (is_null($callback)) {
            return new Optional($value);
        }

        if (! is_null($value)) {
            return $callback($value);
        }

        return null;
```

Based on the written tests, if the value is equal to null, the output should be null.


