### PR TITLE
[11.x] Enable Str::markdown() security controls by default

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -639,6 +639,12 @@ class Str
      */
     public static function markdown($string, array $options = [])
     {
+        $options = array_merge([
+            'html_input' => 'escape',
+            'allow_unsafe_links' => false,
+            'max_nesting_level' => 50,
+        ], $options);
+
         $converter = new GithubFlavoredMarkdownConverter($options);
 
         return (string) $converter->convert($string);
@@ -653,6 +659,12 @@ class Str
      */
     public static function inlineMarkdown($string, array $options = [])
     {
+        $options = array_merge([
+            'html_input' => 'escape',
+            'allow_unsafe_links' => false,
+            'max_nesting_level' => 50,
+        ], $options);
+
         $environment = new Environment($options);
 
         $environment->addExtension(new GithubFlavoredMarkdownExtension());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1114,6 +1114,54 @@ class SupportStrTest extends TestCase
         $this->assertSame("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", Str::inlineMarkdown('[**Laravel**](https://laravel.com)'));
     }
 
+    public function testRawHTMLEscapedInMarkdownByDefault()
+    {
+        $this->assertSame(
+            "&lt;script&gt;alert('Hello World!');&lt;/script&gt;\n",
+            Str::markdown("<script>alert('Hello World!');</script>")
+        );
+
+        $this->assertSame(
+            "&lt;img src=x onerror='alert(\"Hello World!\")'&gt;\n",
+            Str::markdown("<img src=x onerror='alert(\"Hello World!\")'>")
+        );
+
+        $this->assertSame(
+            "&lt;script&gt;alert('Hello World!');&lt;/script&gt;\n",
+            Str::inlineMarkdown("<script>alert('Hello World!');</script>")
+        );
+
+        $this->assertSame(
+            "&lt;img src=x onerror='alert(\"Hello World!\")'&gt;\n",
+            Str::inlineMarkdown("<img src=x onerror='alert(\"Hello World!\")'>")
+        );
+    }
+
+    public function testOverrideMarkdownOptions()
+    {
+        // <script> tags are always blocked with the GithubFlavoredMarkdownConverter
+        $this->assertSame(
+            "&lt;script>alert('Hello World!');&lt;/script>\n",
+            Str::markdown("<script>alert('Hello World!');</script>", ['html_input' => 'allow'])
+        );
+
+        $this->assertSame(
+            "<img src=x onerror='alert(\"Hello World!\")'>\n",
+            Str::markdown("<img src=x onerror='alert(\"Hello World!\")'>", ['html_input' => 'allow'])
+        );
+
+        // <script> tags are always blocked with the GithubFlavoredMarkdownConverter
+        $this->assertSame(
+            "&lt;script>alert('Hello World!');&lt;/script>\n",
+            Str::inlineMarkdown("<script>alert('Hello World!');</script>", ['html_input' => 'allow'])
+        );
+
+        $this->assertSame(
+            "<img src=x onerror='alert(\"Hello World!\")'>\n",
+            Str::inlineMarkdown("<img src=x onerror='alert(\"Hello World!\")'>", ['html_input' => 'allow'])
+        );
+    }
+
     public function testRepeat()
     {
         $this->assertSame('aaaaa', Str::repeat('a', 5));


### PR DESCRIPTION
The [Commonmark parser](https://commonmark.thephpleague.com/) Laravel uses for `Str::markdown()` allows inline HTML and unsafe links by default. This is a major security risk as it exposes any sites which accepts and blindly renders user-inputted markdown to Cross-Site Scripting (XSS) attacks. In the same way that Blade recommends and defaults to using `{{ ... }}` for escaped output, the `Str::markdown()` should be secure by default.

This issue is made worse by the use of `GithubFlavoredMarkdownConverter` within the Markdown parser, as it strips out a limited number of tags with `DisallowedRawHtmlExtension`  (`<title>`, `<textarea>`, `<style>`, `<xmp>`, `<iframe>`, `<noembed>`, `<noframes>`, `<script>` & `<plaintext>`), while still allowing other inline HTML.

For example:

```
<script>alert('Hello World!');</script> <img src=x onerror='alert("Hello World!")'>
```

Is parsed into:
```
&lt;script>alert('Hello World!');&lt;/script> <img src=x onerror='alert("Hello World!")'>\n
```

The `<script>` tag is escaped, but the XSS within the `<img>` is completely ignored. 
My concern is that devs will check a `<script>` tag, see it's escaped, and assume the output is safe - when it's really not.


This change sets the following options by default:

```
[
    'html_input' => 'escape',
    'allow_unsafe_links' => false,
    'max_nesting_level' => 50,
]
```

These are recommended by the package Security page: https://commonmark.thephpleague.com/2.4/security/

They can all be overridden if developers wish to accept the risks and allow inline HTML:

```
Str::markdown($string, [
    'html_input' => 'allow',
    'allow_unsafe_links' => true,
    'max_nesting_level' => PHP_INT_MAX,
]);
```

This is a breaking change, but should be easy to explain in the upgrade guide. Devs who need inline HTML can simply override the options, and those who don't will get XSS protection.