### PR TITLE
[11.x] Improves `trimStrings` in middleware configuration

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Configuration;
 
+use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
@@ -553,7 +554,11 @@ class Middleware
      */
     public function trimStrings(array $except = [])
     {
-        TrimStrings::except($except);
+        [$skipWhen, $except] = collect($except)->partition(fn ($value) => $value instanceof Closure);
+
+        $skipWhen->each(fn (Closure $callback) => TrimStrings::skipWhen($callback));
+
+        TrimStrings::except($except->all());
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -549,7 +549,7 @@ class Middleware
     /**
      * Configure the string trimming middleware.
      *
-     * @param  array  $except
+     * @param  array<int, (\Closure(\Illuminate\Http\Request): bool)|string>  $except
      * @return $this
      */
     public function trimStrings(array $except = [])

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -99,6 +99,8 @@ class TrimStrings extends TransformsRequest
      */
     public static function flushState()
     {
+        static::$neverTrim = [];
+
         static::$skipCallbacks = [];
     }
 }

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Configuration;
+
+use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class MiddlewareTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        TrimStrings::flushState();
+    }
+
+    public function testTrimStrings()
+    {
+        $configuration = new Middleware();
+        $middleware = new TrimStrings();
+
+        $configuration->trimStrings(except: [
+            'aaa',
+            fn (Request $request) => $request->has('skip-all'),
+        ]);
+
+        $symfonyRequest = new SymfonyRequest([
+            'aaa' => '  123  ',
+            'bbb' => '  456  ',
+            'ccc' => '  789  ',
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $request = $middleware->handle($request, fn (Request $request) => $request);
+
+        $this->assertSame('  123  ', $request->get('aaa'));
+        $this->assertSame('456', $request->get('bbb'));
+        $this->assertSame('789', $request->get('ccc'));
+
+        $symfonyRequest = new SymfonyRequest([
+            'aaa' => '  123  ',
+            'bbb' => '  456  ',
+            'ccc' => '  789  ',
+            'skip-all' => true,
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $request = $middleware->handle($request, fn (Request $request) => $request);
+
+        $this->assertSame('  123  ', $request->get('aaa'));
+        $this->assertSame('  456  ', $request->get('bbb'));
+        $this->assertSame('  789  ', $request->get('ccc'));
+    }
+}

--- a/types/Foundation/Configuration/Middleware.php
+++ b/types/Foundation/Configuration/Middleware.php
@@ -2,12 +2,9 @@
 
 use Illuminate\Foundation\Configuration\Middleware;
 
-use function PHPStan\Testing\assertType;
-
 $middleware = new Middleware();
 
 $middleware->trimStrings(except: [
     'aaa',
     fn ($request) => $request->has('skip-all'),
 ]);
-

--- a/types/Foundation/Configuration/Middleware.php
+++ b/types/Foundation/Configuration/Middleware.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Foundation\Configuration\Middleware;
+
+use function PHPStan\Testing\assertType;
+
+$middleware = new Middleware();
+
+$middleware->trimStrings(except: [
+    'aaa',
+    fn ($request) => $request->has('skip-all'),
+]);
+


### PR DESCRIPTION
This pull request improves `trimStrings` in middleware configuration, so we can provide callbacks and strings while calling `trimStrings()` on the middleware configuration on Laravel 11.

```php
$middleware->trimStrings([
    'password',
    fn (Request $request) => $request->is('admin/*'),
]);
```

This pull request also improves the `flushState` method by flushing the `neverTrim` static property.