### PR TITLE
[11.x] Prompts to install Reverb when enabling broadcasting

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Composer\InstalledVersions;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Process;
@@ -108,14 +109,18 @@ class BroadcastingInstallCommand extends Command
      */
     protected function installReverb()
     {
+        if (InstalledVersions::isInstalled('laravel/reverb')) {
+            return;
+        }
+
         $install = confirm('Would you like to install Laravel Reverb?', default: true);
 
-        if(! $install) {
+        if (! $install) {
             return;
         }
 
         $this->requireComposerPackages($this->option('composer'), [
-            'laravel/reverb:@dev',
+            'laravel/reverb:@beta',
         ]);
 
         $php = (new PhpExecutableFinder())->find(false) ?: 'php';

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -103,7 +103,7 @@ class BroadcastingInstallCommand extends Command
     }
 
     /**
-     * Install Laravel Reverb into the application.
+     * Install Laravel Reverb into the application if desired.
      *
      * @return void
      */


### PR DESCRIPTION
This PR updates the `install:broadcasting` command to prompt users whether they would like to install Reverb if it is not already installed after broadcasting has been enabled.

When requested, Reverb will be installed via composer and the `reverb:install` command will be invoked which publishes the config, adds the relevant variables to the `.env` file and configures the broadcast connection. At this point, the `install:broadcasting` will have already created `channels.php` so the Reverb installer won't attempt to install it again.
