### PR TITLE
[10.x] Add collect method to Config Repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -183,13 +183,10 @@ class Repository implements ArrayAccess, ConfigContract
 
     /**
      * Get the specified configuration value as a Collection.
-     * 
-     * @template TKey of array-key
-     * @template TValue
      *
      * @param  array|string  $key
      * @param  mixed  $default
-     * @return \Illuminate\Support\Collection<TKey, TValue>
+     * @return \Illuminate\Support\Collection
      */
     public function collect($key, $default = null): Collection
     {

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -5,6 +5,7 @@ namespace Illuminate\Config;
 use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 
 class Repository implements ArrayAccess, ConfigContract
@@ -178,5 +179,20 @@ class Repository implements ArrayAccess, ConfigContract
     public function offsetUnset($key): void
     {
         $this->set($key, null);
+    }
+
+    /**
+     * Get the specified configuration value as a Collection.
+     * 
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array|string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Collection<TKey, TValue>
+     */
+    public function collect($key, $default = null): Collection
+    {
+        return collect($this->get($key, $default));
     }
 }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -269,7 +269,7 @@ class RepositoryTest extends TestCase
             collect($this->repository->collect('this-key-does-not-exist', 'default')),
             $this->repository->collect('this-key-does-not-exist', 'default')
         );
-        
+
         $this->assertTrue($this->repository->collect('this-key-does-not-exist')->isEmpty());
 
         $this->assertEquals(

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -252,4 +252,29 @@ class RepositoryTest extends TestCase
 
         $this->assertSame('macroable', $this->repository->foo());
     }
+
+    public function testCollect()
+    {
+        $this->assertEquals(
+            collect($this->repository->get('foo')),
+            $this->repository->collect('foo')
+        );
+
+        $this->assertEquals(
+            collect($this->repository->get('associate')),
+            $this->repository->collect('associate')
+        );
+
+        $this->assertEquals(
+            collect($this->repository->collect('this-key-does-not-exist', 'default')),
+            $this->repository->collect('this-key-does-not-exist', 'default')
+        );
+        
+        $this->assertTrue($this->repository->collect('this-key-does-not-exist')->isEmpty());
+
+        $this->assertEquals(
+            collect($this->repository->get(['foo', 'bar'])),
+            $this->repository->collect(['foo', 'bar'])
+        );
+    }
 }


### PR DESCRIPTION
This PR just gives the possibility to access config as collections instead of arrays.

```php
// Before
collect(config()->get('database.connections'));

// After
config()->collect('database.connections');
```
