### PR TITLE
[10.x] Launch committing event despite the current transaction level

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -42,8 +42,9 @@ trait ManagesTransactions
             }
 
             try {
+                $this->fireConnectionEvent('committing');
+
                 if ($this->transactions == 1) {
-                    $this->fireConnectionEvent('committing');
                     $this->getPdo()->commit();
                 }
 
@@ -198,8 +199,9 @@ trait ManagesTransactions
      */
     public function commit()
     {
+        $this->fireConnectionEvent('committing');
+
         if ($this->transactionLevel() == 1) {
-            $this->fireConnectionEvent('committing');
             $this->getPdo()->commit();
         }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -273,17 +273,6 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
-        $connection->commit();
-    }
-
-    public function testCommittingFiresEventsIfSet()
-    {
-        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
-        $connection = $this->getMockConnection(['getName', 'transactionLevel'], $pdo);
-        $connection->expects($this->any())->method('getName')->willReturn('name');
-        $connection->expects($this->any())->method('transactionLevel')->willReturn(1);
-        $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
         $connection->commit();


### PR DESCRIPTION
Currently the `TransactionCommitting` event is launched only when the top transaction is committed.

If you want to build custom logic around `TransactionCommitting` event you will encounter the an issue in tests when using `RefreshDatabaseTrait`. The event will not be triggered because the `RefreshDatabase` trait encapsulates the logic between a begin transaction and rollback. 

I.e.: 
These are the events fired by `Connection` [class](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Connection.php#L1074) when using `RefreshDatabase` trait
* beganTransaction   
* beganTransaction   
* committed   
* rollingBack   


In my case, I put a listener for `TransactionCommitting` in order to do some custom logic. In my manual test, my logic works ok, but in my automated tests with `RefreshDatabase` trait, fails due to the fact that the event is not fired.

With this fix the order of the events will be:
* beganTransaction   
* beganTransaction   
* committing   
* committed   
* rollingBack   
