### PR TITLE
[11.x] Removes need to publish queue config in order to configure database queue connection

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -37,6 +37,7 @@ return [
         'database' => [
             'driver' => 'database',
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
+            'connection' => env('DB_QUEUE_CONNECTION', null),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => env('DB_QUEUE_RETRY_AFTER', 90),
             'after_commit' => false,

--- a/config/queue.php
+++ b/config/queue.php
@@ -36,8 +36,8 @@ return [
 
         'database' => [
             'driver' => 'database',
-            'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'connection' => env('DB_QUEUE_CONNECTION', null),
+            'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => env('DB_QUEUE_RETRY_AFTER', 90),
             'after_commit' => false,


### PR DESCRIPTION
Since the configs will no longer be published by default. And database queue is the new quickstart default.

Following the same practice as found in the cache and session config.

This PR contains just one line added to `config/queue.php`
```diff
+'connection' => env('DB_QUEUE_CONNECTION', null),
```

### Quick links for reference:

#### `DatabaseQueue` creation
https://github.com/laravel/framework/blob/b9c541a765cc3ebdf963a3d59f2cd16b6c2e6786/src/Illuminate/Queue/Connectors/DatabaseConnector.php#L37

### Cache config
https://github.com/laravel/framework/blob/b9c541a765cc3ebdf963a3d59f2cd16b6c2e6786/config/cache.php#L48

### Session config
https://github.com/laravel/framework/blob/b9c541a765cc3ebdf963a3d59f2cd16b6c2e6786/config/session.php#L76