### PR TITLE
[10.x] Fixes `Illuminate\Support\Str::fromBase64()` return type

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1551,7 +1551,7 @@ class Str
      *
      * @param  string  $string
      * @param  bool  $strict
-     * @return void
+     * @return string
      */
     public static function fromBase64($string, $strict = false)
     {


### PR DESCRIPTION
```base64_decode``` returns a string