### PR TITLE
[10.x] Add urlencode, urldecode, rawurlencode and rawurldecode methods to Stringable and Str classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1559,6 +1559,50 @@ class Str
     }
 
     /**
+     * URL-encodes the given string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function urlencode($string)
+    {
+        return urlencode($string);
+    }
+
+    /**
+     * Decodes the given URL-encoded string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function urldecode($string)
+    {
+        return urldecode($string);
+    }
+
+    /**
+     * URL-encode the given string according to RFC 3986.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function rawurlencode($string)
+    {
+        return rawurlencode($string);
+    }
+
+    /**
+     * Decode the given URL-encoded string according to RFC 3986.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function rawurldecode($string)
+    {
+        return rawurldecode($string);
+    }
+
+    /**
      * Make a string's first character lowercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1268,6 +1268,46 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * URL-encodes the string.
+     *
+     * @return static
+     */
+    public function urlencode()
+    {
+        return new static(urlencode($this->value));
+    }
+
+    /**
+     * Decodes URL-encoded string.
+     *
+     * @return static
+     */
+    public function urldecode()
+    {
+        return new static(urldecode($this->value));
+    }
+
+    /**
+     * URL-encode according to RFC 3986.
+     *
+     * @return static
+     */
+    public function rawurlencode()
+    {
+        return new static(rawurlencode($this->value));
+    }
+
+    /**
+     * Decode URL-encoded string according to RFC 3986.
+     *
+     * @return static
+     */
+    public function rawurldecode()
+    {
+        return new static(rawurldecode($this->value));
+    }
+
+    /**
      * Dump the string.
      *
      * @return $this

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1382,6 +1382,38 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::fromBase64(base64_encode('foo')));
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
+
+    public function testUrlEncode()
+    {
+        $this->assertSame('Laravel', Str::urlencode('Laravel'));
+        $this->assertSame('laravel+11', Str::urlencode('laravel 11'));
+        $this->assertSame('touch%C3%A9', Str::urlencode('touché'));
+        $this->assertSame('%E2%98%86', Str::urlencode('☆'));
+    }
+
+    public function testUrlDecode()
+    {
+        $this->assertSame('Laravel', Str::urldecode('Laravel'));
+        $this->assertSame('laravel 11', Str::urldecode('laravel+11'));
+        $this->assertSame('touché', Str::urldecode('touch%C3%A9'));
+        $this->assertSame('☆', Str::urldecode('%E2%98%86'));
+    }
+
+    public function testRawUrlEncode()
+    {
+        $this->assertSame('Laravel', Str::rawurlencode('Laravel'));
+        $this->assertSame('laravel%2011', Str::rawurlencode('laravel 11'));
+        $this->assertSame('touch%C3%A9', Str::rawurlencode('touché'));
+        $this->assertSame('%E2%98%86', Str::rawurlencode('☆'));
+    }
+
+    public function testRawUrlDecode()
+    {
+        $this->assertSame('Laravel', Str::rawurldecode('Laravel'));
+        $this->assertSame('laravel 11', Str::rawurldecode('laravel%2011'));
+        $this->assertSame('touché', Str::rawurldecode('touch%C3%A9'));
+        $this->assertSame('☆', Str::rawurldecode('%E2%98%86'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1316,4 +1316,36 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
+
+    public function testUrlEncode()
+    {
+        $this->assertSame('Laravel', (string) $this->stringable('Laravel')->urlencode());
+        $this->assertSame('laravel+11', (string) $this->stringable('laravel 11')->urlencode());
+        $this->assertSame('touch%C3%A9', (string) $this->stringable('touché')->urlencode());
+        $this->assertSame('%E2%98%86', (string) $this->stringable('☆')->urlencode());
+    }
+
+    public function testUrlDecode()
+    {
+        $this->assertSame('Laravel', (string) $this->stringable('Laravel')->urldecode());
+        $this->assertSame('laravel 11', (string) $this->stringable('laravel+11')->urldecode());
+        $this->assertSame('touché', (string) $this->stringable('touch%C3%A9')->urldecode());
+        $this->assertSame('☆', (string) $this->stringable('%E2%98%86')->urldecode());
+    }
+
+    public function testRawUrlEncode()
+    {
+        $this->assertSame('Laravel', (string) $this->stringable('Laravel')->rawurlencode());
+        $this->assertSame('laravel%2011', (string) $this->stringable('laravel 11')->rawurlencode());
+        $this->assertSame('touch%C3%A9', (string) $this->stringable('touché')->rawurlencode());
+        $this->assertSame('%E2%98%86', (string) $this->stringable('☆')->rawurlencode());
+    }
+
+    public function testRawUrlDecode()
+    {
+        $this->assertSame('Laravel', (string) $this->stringable('Laravel')->rawurldecode());
+        $this->assertSame('laravel 11', (string) $this->stringable('laravel%2011')->rawurldecode());
+        $this->assertSame('touché', (string) $this->stringable('touch%C3%A9')->rawurldecode());
+        $this->assertSame('☆', (string) $this->stringable('%E2%98%86')->rawurldecode());
+    }
 }


### PR DESCRIPTION
Following the recently merged #49984 PR, I think we also might need [`urlencode`](https://www.php.net/manual/en/function.urlencode.php), [`urldecode`](https://www.php.net/manual/en/function.urldecode.php), [`rawurlencode`](https://www.php.net/manual/en/function.rawurlencode.php) and [`rawurldecode`](https://www.php.net/manual/en/function.rawurldecode.php).

These methods are usually alongside tedious or error-prone string operations so they make sense to be added.