### PR TITLE
[10.x] Fix warning and deprecation for Str::apa

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1298,6 +1298,10 @@ class Str
      */
     public static function apa($value)
     {
+        if ($value === '') {
+            return $value;
+        }
+
         $minorWords = [
             'and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an',
             'the', 'at', 'by', 'for', 'in', 'of', 'off', 'on', 'per', 'to', 'up', 'via',

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -96,6 +96,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('To Kill a Mockingbird', Str::apa('to kill a mockingbird'));
         $this->assertSame('To Kill a Mockingbird', Str::apa('TO KILL A MOCKINGBIRD'));
         $this->assertSame('To Kill a Mockingbird', Str::apa('To Kill A Mockingbird'));
+
+        $this->assertSame('', Str::apa(''));
     }
 
     public function testStringWithoutWordsDoesntProduceError()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/50112

```
WARNING  Undefined array key 0 in vendor/laravel/framework/src/Illuminate/Support/Str.php on line 1321.

DEPRECATED  mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/laravel/framework/src/Illuminate/Support/Str.php on line 1321.
```