### PR TITLE
[10.x] Fix LazyCollection::get() to return the default value when the key is null

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -522,7 +522,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function get($key, $default = null)
     {
         if (is_null($key)) {
-            return;
+            return value($default);
         }
 
         foreach ($this as $outerKey => $outerValue) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5524,6 +5524,7 @@ class SupportCollectionTest extends TestCase
     public function testGetWithDefaultValue($collection)
     {
         $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $this->assertEquals('34', $data->get(null, 34));
         $this->assertEquals('34', $data->get('age', 34));
     }
 
@@ -5533,10 +5534,8 @@ class SupportCollectionTest extends TestCase
     public function testGetWithCallbackAsDefaultValue($collection)
     {
         $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
-        $result = $data->get('email', function () {
-            return 'taylor@example.com';
-        });
-        $this->assertEquals('taylor@example.com', $result);
+        $this->assertSame('taylor@example.com', $data->get(null, fn () => 'taylor@example.com'));
+        $this->assertSame('taylor@example.com', $data->get('email', fn () => 'taylor@example.com'));
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug in LazyCollection::get() to return the default value when the key is null.