### PR TITLE
[10.x] Ignore generated columns during replicating

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -72,6 +72,13 @@ trait HasAttributes
     protected $casts = [];
 
     /**
+     * The attributes that are generated.
+     *
+     * @var array
+     */
+    protected $generated = [];
+
+    /**
      * The attributes that have been cast using custom classes.
      *
      * @var array

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1723,6 +1723,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $this->getKeyName(),
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
+            ...$this->generated,
             ...$this->uniqueIds(),
         ]));
 


### PR DESCRIPTION
There is a problem during replicating the Model with generated columns. If you are in a strict mode MySQL you will see the error
_The value specified for generated column 'total' in table 'transactions' is not allowed_
In MySQL 5.7 you will get the error even in not strict mode.

Also, this will solve an issue from a few years ago https://github.com/laravel/framework/issues/25495

With my changes you can enter in your Model just like `$casts` and it will be applied to all replications.
`protected $generated = ['total'];`

So during `$transaction->replicate()` it will not cause errors. 

Of course, you can make like this `$transaction->replicate(['total'])` and it will work, but I think my way is more consistence. The solution that is already in the framework is more wide and you need to enter all your generated columns during each call.

P.S. This is my first contribution, so I would highly appreciate any feedback. Sorry for any mistakes.