### PR TITLE
[10.x] Add requiredTimestamps method to Schema Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1250,6 +1250,19 @@ class Blueprint
     }
 
     /**
+     * Add required creation and update timestamps to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function requiredTimestamps($precision = 0)
+    {
+        $this->timestamp('created_at', $precision);
+
+        $this->timestamp('updated_at', $precision);
+    }
+
+    /**
      * Add creation and update timestampTz columns to the table.
      *
      * @param  int|null  $precision

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1073,6 +1073,24 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
     }
 
+    public function testAddingRequiredTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp not null, add `updated_at` timestamp not null', $statements[0]);
+    }
+
+    public function testAddingRequiredTimestampsWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null, add `updated_at` timestamp(1) not null', $statements[0]);
+    }
+
     public function testAddingRememberToken()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -863,6 +863,24 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
     }
 
+    public function testAddingRequiredTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null, add column "updated_at" timestamp(0) without time zone not null', $statements[0]);
+    }
+
+    public function testAddingRequiredTimestampsWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(1) without time zone not null, add column "updated_at" timestamp(1) without time zone not null', $statements[0]);
+    }
+
     public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -669,6 +669,30 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingRequiredTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertEquals([
+            'alter table "users" add column "created_at" datetime not null',
+            'alter table "users" add column "updated_at" datetime not null',
+        ], $statements);
+    }
+
+    public function testAddingRequiredTimestampsWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertEquals([
+            'alter table "users" add column "created_at" datetime not null',
+            'alter table "users" add column "updated_at" datetime not null',
+        ], $statements);
+    }
+
     public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -722,6 +722,24 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add "created_at" datetimeoffset null, "updated_at" datetimeoffset null', $statements[0]);
     }
 
+    public function testAddingRequiredTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "created_at" datetime not null, "updated_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingRequiredTimestampsWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->requiredTimestamps(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "created_at" datetime2(1) not null, "updated_at" datetime2(1) not null', $statements[0]);
+    }
+
     public function testAddingRememberToken()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This PR aims to add a helper method to the Schema builder and allows developers to choose how to use timestamps in their tables. 

Currently, you can use either `timestamps()` or `nullableTimestamps()` to create nullable timestamps; however, the ability to easily add required, non-nullable `created_at` and `updated_at` timestamps to a database table.

As this is additive and does not change the existing default behaviour of the `timestamps` method, no breaking change is introduced for users.

The change allows the following:
```php
Schema::create('users', function (Blueprint $table) {
  $table->ulid('id')->primary();
  ...
  $table->requiredTimestamps();
});
```