### PR TITLE
[10.x] Extract method from checkForSpecificEnvironmentFile to improve clarity

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -41,7 +41,8 @@ class LoadEnvironmentVariables
     protected function checkForSpecificEnvironmentFile($app)
     {
         if ($app->runningInConsole() && ($envOption = $this->getEnvironmentOptionFromConsole())) {
-            $this->setEnvironmentFilePath($app, $app->environmentFile() . '.' . $envOption);
+            $this->setEnvironmentFilePath($app, $app->environmentFile().'.'.$envOption);
+
             return;
         }
 
@@ -57,15 +58,15 @@ class LoadEnvironmentVariables
     }
 
     /**
-    * Get the environment option from console input, if provided.
-    *
-    * @return string|null The environment option value if provided, null otherwise.
-    */
+     * Get the environment option from console input, if provided.
+     *
+     * @return string|null The environment option value if provided, null otherwise.
+     */
     protected function getEnvironmentOptionFromConsole()
     {
         $input = new ArgvInput;
 
-        if($input->hasParameterOption('--env')) {
+        if ($input->hasParameterOption('--env')) {
             return $input->getParameterOption('--env');
         }
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -61,7 +61,7 @@ class LoadEnvironmentVariables
     *
     * @return string|null The environment option value if provided, null otherwise.
     */
-    protected function getEnvironmentOptionsFromConsole()
+    protected function getEnvironmentOptionFromConsole()
     {
         $input = new ArgvInput;
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -40,9 +40,8 @@ class LoadEnvironmentVariables
      */
     protected function checkForSpecificEnvironmentFile($app)
     {
-        if ($app->runningInConsole() &&
-            ($input = new ArgvInput)->hasParameterOption('--env') &&
-            $this->setEnvironmentFilePath($app, $app->environmentFile().'.'.$input->getParameterOption('--env'))) {
+        if ($app->runningInConsole() && ($envOption = $this->getEnvironmentOptionFromConsole())) {
+            $this->setEnvironmentFilePath($app, $app->environmentFile() . '.' . $envOption);
             return;
         }
 
@@ -55,6 +54,22 @@ class LoadEnvironmentVariables
         $this->setEnvironmentFilePath(
             $app, $app->environmentFile().'.'.$environment
         );
+    }
+
+    /**
+    * Get the environment option from console input, if provided.
+    *
+    * @return string|null The environment option value if provided, null otherwise.
+    */
+    protected function getEnvironmentOptionsFromConsole()
+    {
+        $input = new ArgvInput;
+
+        if($input->hasParameterOption('--env')) {
+            return $input->getParameterOption('--env');
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Description
Improved the **checkForSpecificEnvironmentFile** method for better readability and maintainability.

### Changes Made
Simplified the if statement by adding the `getEnvironmentOptionFromConsole` method to directly retrieve the value of the `--env` option. 

Also removed the code execution from the `if` block for better **readability**.

I hope this adds to the work done [2 years ago](https://github.com/laravel/framework/commit/b88546cb137b80afe5b40b338f4d8a1a404c8dd5#diff-c98e65cab907362258f765fa2f4c61277a0e52a9205e2b6c9afc857f71ed32fe) on this code, as it can have improved clarity and readability 