### PR TITLE
[10.x] Adds Tappable and Conditionable to Relation class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Traits\Macroable;
 
 abstract class Relation implements BuilderContract
 {
-    use ForwardsCalls, Conditionable, Macroable {
+    use ForwardsCalls, Conditionable, Tappable, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -10,12 +10,14 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Tappable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
 abstract class Relation implements BuilderContract
 {
-    use ForwardsCalls, Macroable {
+    use ForwardsCalls, Conditionable, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Traits\Macroable;
 
 abstract class Relation implements BuilderContract
 {
-    use ForwardsCalls, Conditionable, Tappable, Macroable {
+    use Conditionable, ForwardsCalls, Macroable, Tappable {
         Macroable::__call as macroCall;
     }
 


### PR DESCRIPTION
Fixes #50123

Since the `Relation` class forwards calls to the underlying Query instance, using `tap`, `when` and `unless` methods do not inherit the Relation methods.

For example, calling `wherePivot('is_cool', true)` after these methods will make the query set `WHERE "table"."pivot" = 'cool"` instead of using the `wherePivot()` method of the relation. This produces the Query instance to use its helpers disregarding anything else.

```php
$tag->posts()->when(true)->wherePivot('is_cool', true)->get();
```

```sql
// Before
SELECT * FROM "posts" INNER JOIN "post_tag" ... WHERE "post_tag"."pivot" = 'is_cool'

// After
SELECT * FROM "posts" INNER JOIN "post_tag" ... WHERE "post_tag"."is_cool" = 1
```

By adding these traits directly into the Relation class itself, it fixes that problem.

## Breaking changes?

None that is documented and could collision with this change.

The only edge case I can think of is someone receiving the `Builder` instance inside these methods callbacks, but that was deprecated in favor of the `BuilderContract`, so its a far stretch.

```php
use Illuminate\Database\Eloquent\Builder;
// use Illuminate\Contracts\Database\Eloquent\Builder; <-- Should be using this instead.

$tag->post()->when(true, function (Builder $query) {
    // ...
});
```