### PR TITLE
[10.x] Add `before` and `after` methods to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -480,6 +480,60 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the item before the specified key in the collection.
+     *
+     * @template TBeforeDefault
+     *
+     * @param  TKey|null  $key
+     * @param  TBeforeDefault|(\Closure(): TBeforeDefault)  $default
+     * @return TValue|TBeforeDefault
+     */
+    public function before($key, $default = null)
+    {
+        if (array_key_first($this->items) === $key) {
+            return value($default);
+        }
+
+        $prevItem = null;
+
+        foreach ($this->items as $k => $item) {
+            if ($k === $key) {
+                return $prevItem;
+            }
+
+            $prevItem = $item;
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Get the item after the specified key in the collection.
+     *
+     * @template TAfterDefault
+     *
+     * @param  TKey|null  $key
+     * @param  TAfterDefault|(\Closure(): TAfterDefault)  $default
+     * @return TValue|TAfterDefault
+     */
+    public function after($key, $default = null)
+    {
+        $found = false;
+
+        foreach ($this->items as $k => $item) {
+            if ($found) {
+                return $item;
+            }
+
+            if ($k === $key) {
+                $found = true;
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -535,6 +535,62 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the item before the specified key in the collection.
+     *
+     * @template TBeforeDefault
+     *
+     * @param  TKey|null  $key
+     * @param  TBeforeDefault|(\Closure(): TBeforeDefault)  $default
+     * @return TValue|TBeforeDefault
+     */
+    public function before($key, $default = null)
+    {
+        $iterator = $this->getIterator();
+
+        if ($iterator->key() === $key) {
+            return value($default);
+        }
+
+        $prevItem = null;
+
+        foreach ($iterator as $k => $item) {
+            if ($k === $key) {
+                return $prevItem;
+            }
+
+            $prevItem = $item;
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Get the item after the specified key in the collection.
+     *
+     * @template TAfterDefault
+     *
+     * @param  TKey|null  $key
+     * @param  TAfterDefault|(\Closure(): TAfterDefault)  $default
+     * @return TValue|TAfterDefault
+     */
+    public function after($key, $default = null)
+    {
+        $found = false;
+
+        foreach ($this as $k => $item) {
+            if ($found) {
+                return $item;
+            }
+
+            if ($k === $key) {
+                $found = true;
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5542,6 +5542,52 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testBefore($collection)
+    {
+        $collection = new $collection([
+            'mon' => 'Monday',
+            'tue' => 'Tuesday',
+            'wed' => 'Wednesday',
+        ]);
+
+        $this->assertNull($collection->before(null));
+        $this->assertNull($collection->before('not-exist'));
+        $this->assertNull($collection->before('mon'));
+
+        $this->assertSame('default', $collection->before('not-exist', 'default'));
+        $this->assertSame('default', $collection->before('not-exist', fn () => 'default'));
+        $this->assertSame('default', $collection->before('mon', 'default'));
+        $this->assertSame('default', $collection->before('mon', fn () => 'default'));
+
+        $this->assertSame('Monday', $collection->before('tue'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testAfter($collection)
+    {
+        $collection = new $collection([
+            'mon' => 'Monday',
+            'tue' => 'Tuesday',
+            'wed' => 'Wednesday',
+        ]);
+
+        $this->assertNull($collection->after(null));
+        $this->assertNull($collection->after('not-exist'));
+        $this->assertNull($collection->after('wed'));
+
+        $this->assertSame('default', $collection->after('not-exist', 'default'));
+        $this->assertSame('default', $collection->after('not-exist', fn () => 'default'));
+        $this->assertSame('default', $collection->after('wed', 'default'));
+        $this->assertSame('default', $collection->after('wed', fn () => 'default'));
+
+        $this->assertSame('Wednesday', $collection->after('tue'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhereNull($collection)
     {
         $data = new $collection([

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -449,6 +449,20 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testBeforeIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->before(4);
+        });
+    }
+
+    public function testAfterIsLazy()
+    {
+        $this->assertEnumerates(6, function ($collection) {
+            $collection->after(4);
+        });
+    }
+
     public function testGroupByIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
I recently needed a way to show users the item before and after the one they select from a collection.
These methods make it easier to navigate through the collection items, with a signature similar to the `get` method.

Example usage:
```php
$collection = collect([
    'mon' => 'Monday',
    'tue' => 'Tuesday',
    'wed' => 'Wednesday',
]);

echo $collection->before('tue');  // Output: Monday
echo $collection->after('tue');  // Output: Wednesday
```