### PR TITLE
[11.x] Adding Like Operation to Laravel Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1263,7 +1263,7 @@ class Builder implements BuilderContract
      * @param  $value
      * @param  $boolean
      * @param  $not
-     * @return  $this|Builder
+     * @return $this
      */
     public function whereStartsWith($column, $value, $boolean = 'and', $not = false)
     {
@@ -1277,7 +1277,7 @@ class Builder implements BuilderContract
      *
      * @param  $column
      * @param  $value
-     * @return  $this|Builder
+     * @return $this
      */
     public function orWhereStartsWith($column, $value)
     {
@@ -1290,7 +1290,7 @@ class Builder implements BuilderContract
      * @param  $column
      * @param  $value
      * @param  $boolean
-     * @return $this|Builder
+     * @return $this
      */
     public function whereNotStartsWith($column, $value, $boolean = 'and')
     {
@@ -1300,9 +1300,9 @@ class Builder implements BuilderContract
     /**
      * Add an or where NOT LIKE 'expression%' statement to the query.
      *
-     * @param $column
-     * @param $value
-     * @return $this|Builder
+     * @param  $column
+     * @param  $value
+     * @return $this
      */
     public function orWhereNotStartsWith($column, $value)
     {
@@ -1316,7 +1316,7 @@ class Builder implements BuilderContract
      * @param  $value
      * @param  $boolean
      * @param  $not
-     * @return $this|Builder
+     * @return $this
      */
     public function whereEndsWith($column, $value, $boolean = 'and', $not = false)
     {
@@ -1330,7 +1330,7 @@ class Builder implements BuilderContract
      *
      * @param  $column
      * @param  $value
-     * @return $this|Builder
+     * @return $this
      */
     public function orWhereEndsWith($column, $value)
     {
@@ -1343,7 +1343,7 @@ class Builder implements BuilderContract
      * @param  $column
      * @param  $value
      * @param  $boolean
-     * @return  $this|Builder
+     * @return $this
      */
     public function whereNotEndsWith($column, $value, $boolean = 'and')
     {
@@ -1355,7 +1355,7 @@ class Builder implements BuilderContract
      *
      * @param  $column
      * @param  $value
-     * @return  $this|Builder
+     * @return $this
      */
     public function orWhereNotEndsWith($column, $value)
     {
@@ -1369,7 +1369,7 @@ class Builder implements BuilderContract
      * @param  $value
      * @param  $boolean
      * @param  $not
-     * @return  $this|Builder
+     * @return $this
      */
     public function whereContains($column, $value, $boolean = 'and', $not = false)
     {
@@ -1383,20 +1383,20 @@ class Builder implements BuilderContract
      *
      * @param  $column
      * @param  $value
-     * @return  void
+     * @return $this
      */
     public function orWhereContains($column, $value)
     {
-        $this->whereContains($column, $value, 'or');
+        return $this->whereContains($column, $value, 'or');
     }
 
     /**
      * Add a where NOT LIKE '%expression%' statement to the query.
      *
-     * @param $column
-     * @param $value
-     * @param $boolean
-     * @return $this|Builder
+     * @param  $column
+     * @param  $value
+     * @param  $boolean
+     * @return $this
      */
     public function whereNotContains($column, $value, $boolean = 'and')
     {
@@ -1408,7 +1408,7 @@ class Builder implements BuilderContract
      *
      * @param  $column
      * @param  $value
-     * @return  $this|Builder
+     * @return $this
      */
     public function orWhereNotContains($column, $value)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1257,6 +1257,165 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where LIKE 'expression%' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @param  $boolean
+     * @param  $not
+     * @return  $this|Builder
+     */
+    public function whereStartsWith($column, $value, $boolean = 'and', $not = false)
+    {
+        return $not === false
+            ? $this->where($column, 'LIKE', "{$value}%", $boolean)
+            : $this->where($column, 'NOT LIKE', "{$value}%", $boolean);
+    }
+
+    /**
+     * Add an or where LIKE 'expression%' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @return  $this|Builder
+     */
+    public function orWhereStartsWith($column, $value)
+    {
+        return $this->whereStartsWith($column, $value, 'or');
+    }
+
+    /**
+     * Add a where NOT LIKE 'expression%' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @param  $boolean
+     * @return $this|Builder
+     */
+    public function whereNotStartsWith($column, $value, $boolean = 'and')
+    {
+        return $this->whereStartsWith($column, $value, $boolean, true);
+    }
+
+    /**
+     * Add an or where NOT LIKE 'expression%' statement to the query.
+     *
+     * @param $column
+     * @param $value
+     * @return $this|Builder
+     */
+    public function orWhereNotStartsWith($column, $value)
+    {
+        return $this->whereNotStartsWith($column, $value, 'or');
+    }
+
+    /**
+     * Add a where LIKE '%expression' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @param  $boolean
+     * @param  $not
+     * @return $this|Builder
+     */
+    public function whereEndsWith($column, $value, $boolean = 'and', $not = false)
+    {
+        return $not === false
+            ? $this->where($column, 'LIKE', "%{$value}", $boolean)
+            : $this->where($column, 'NOT LIKE', "%{$value}", $boolean);
+    }
+
+    /**
+     * Add an or where LIKE '%expression' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @return $this|Builder
+     */
+    public function orWhereEndsWith($column, $value)
+    {
+        return $this->whereEndsWith($column, $value, 'or');
+    }
+
+    /**
+     *  Add a where NOT LIKE '%expression' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @param  $boolean
+     * @return  $this|Builder
+     */
+    public function whereNotEndsWith($column, $value, $boolean = 'and')
+    {
+        return $this->whereEndsWith($column, $value, $boolean, true);
+    }
+
+    /**
+     * Add an or where NOT LIKE '%expression' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @return  $this|Builder
+     */
+    public function orWhereNotEndsWith($column, $value)
+    {
+        return $this->whereNotEndsWith($column, $value, 'or');
+    }
+
+    /**
+     * Add a where LIKE '%expression%' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @param  $boolean
+     * @param  $not
+     * @return  $this|Builder
+     */
+    public function whereContains($column, $value, $boolean = 'and', $not = false)
+    {
+        return $not === false
+            ? $this->where($column, 'LIKE', "%{$value}%", $boolean)
+            : $this->where($column, 'NOT LIKE', "%{$value}%", $boolean);
+    }
+
+    /**
+     * Add an or where LIKE '%expression%' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @return  void
+     */
+    public function orWhereContains($column, $value)
+    {
+        $this->whereContains($column, $value, 'or');
+    }
+
+    /**
+     * Add a where NOT LIKE '%expression%' statement to the query.
+     *
+     * @param $column
+     * @param $value
+     * @param $boolean
+     * @return $this|Builder
+     */
+    public function whereNotContains($column, $value, $boolean = 'and')
+    {
+        return $this->whereContains($column, $value, $boolean, true);
+    }
+
+    /**
+     * Add an OR where NOT LIKE '%expression%' statement to the query.
+     *
+     * @param  $column
+     * @param  $value
+     * @return  $this|Builder
+     */
+    public function orWhereNotContains($column, $value)
+    {
+        return $this->whereNotContains($column, $value, 'or');
+    }
+
+    /**
      * Add a where between statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1259,10 +1259,10 @@ class Builder implements BuilderContract
     /**
      * Add a where LIKE 'expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
-     * @param  $boolean
-     * @param  $not
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereStartsWith($column, $value, $boolean = 'and', $not = false)
@@ -1275,8 +1275,8 @@ class Builder implements BuilderContract
     /**
      * Add an or where LIKE 'expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
+     * @param  string  $column
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereStartsWith($column, $value)
@@ -1287,9 +1287,9 @@ class Builder implements BuilderContract
     /**
      * Add a where NOT LIKE 'expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
-     * @param  $boolean
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNotStartsWith($column, $value, $boolean = 'and')
@@ -1300,8 +1300,8 @@ class Builder implements BuilderContract
     /**
      * Add an or where NOT LIKE 'expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
+     * @param  string  $column
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereNotStartsWith($column, $value)
@@ -1312,10 +1312,10 @@ class Builder implements BuilderContract
     /**
      * Add a where LIKE '%expression' statement to the query.
      *
-     * @param  $column
-     * @param  $value
-     * @param  $boolean
-     * @param  $not
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereEndsWith($column, $value, $boolean = 'and', $not = false)
@@ -1328,8 +1328,8 @@ class Builder implements BuilderContract
     /**
      * Add an or where LIKE '%expression' statement to the query.
      *
-     * @param  $column
-     * @param  $value
+     * @param  string  $column
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereEndsWith($column, $value)
@@ -1340,9 +1340,9 @@ class Builder implements BuilderContract
     /**
      *  Add a where NOT LIKE '%expression' statement to the query.
      *
-     * @param  $column
-     * @param  $value
-     * @param  $boolean
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNotEndsWith($column, $value, $boolean = 'and')
@@ -1353,8 +1353,8 @@ class Builder implements BuilderContract
     /**
      * Add an or where NOT LIKE '%expression' statement to the query.
      *
-     * @param  $column
-     * @param  $value
+     * @param  string  $column
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereNotEndsWith($column, $value)
@@ -1365,10 +1365,10 @@ class Builder implements BuilderContract
     /**
      * Add a where LIKE '%expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
-     * @param  $boolean
-     * @param  $not
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereContains($column, $value, $boolean = 'and', $not = false)
@@ -1381,8 +1381,8 @@ class Builder implements BuilderContract
     /**
      * Add an or where LIKE '%expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
+     * @param  string  $column
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereContains($column, $value)
@@ -1393,9 +1393,9 @@ class Builder implements BuilderContract
     /**
      * Add a where NOT LIKE '%expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
-     * @param  $boolean
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNotContains($column, $value, $boolean = 'and')
@@ -1406,8 +1406,8 @@ class Builder implements BuilderContract
     /**
      * Add an OR where NOT LIKE '%expression%' statement to the query.
      *
-     * @param  $column
-     * @param  $value
+     * @param  string  $column
+     * @param  mixed  $value
      * @return $this
      */
     public function orWhereNotContains($column, $value)

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -922,6 +922,120 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
+    public function testWhereStartsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereStartsWith('name', 'foo');
+        $this->assertSame('select * from "users" where "name" LIKE ?', $builder->toSql());
+        $this->assertEquals(['foo%'], $builder->getBindings());
+    }
+
+    public function testWhereNotStartsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotStartsWith('name', 'foo');
+        $this->assertSame('select * from "users" where "name" NOT LIKE ?', $builder->toSql());
+        $this->assertEquals(['foo%'], $builder->getBindings());
+    }
+
+    public function testOrWhereStartsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereStartsWith('name', 'foo')
+            ->orWhereStartsWith('last_name', 'bar');
+
+        $this->assertSame('select * from "users" where "name" LIKE ? or "last_name" LIKE ?', $builder->toSql());
+        $this->assertEquals(['foo%', 'bar%'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotStartsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereStartsWith('name', 'foo')
+            ->orWhereNotStartsWith('last_name', 'bar');
+
+        $this->assertSame('select * from "users" where "name" LIKE ? or "last_name" NOT LIKE ?', $builder->toSql());
+        $this->assertEquals(['foo%', 'bar%'], $builder->getBindings());
+    }
+
+    public function testWhereEndsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereEndsWith('name', 'foo');
+        $this->assertSame('select * from "users" where "name" LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo'], $builder->getBindings());
+    }
+
+    public function testWhereNotEndsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotEndsWith('name', 'foo');
+        $this->assertSame('select * from "users" where "name" NOT LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo'], $builder->getBindings());
+    }
+
+    public function testOrWhereEndsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereEndsWith('name', 'foo')
+            ->orWhereEndsWith('last_name', 'bar');
+
+        $this->assertSame('select * from "users" where "name" LIKE ? or "last_name" LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo', '%bar'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotEndsWith(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereEndsWith('name', 'foo')
+            ->orWhereNotEndsWith('last_name', 'bar');
+
+        $this->assertSame('select * from "users" where "name" LIKE ? or "last_name" NOT LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo', '%bar'], $builder->getBindings());
+    }
+
+    public function testWhereContains(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereContains('name', 'foo');
+        $this->assertSame('select * from "users" where "name" LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo%'], $builder->getBindings());
+    }
+
+    public function testWhereNotContains(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotContains('name', 'foo');
+        $this->assertSame('select * from "users" where "name" NOT LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo%'], $builder->getBindings());
+    }
+
+    public function testOrWhereContains(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereContains('name', 'foo')
+            ->orWhereContains('last_name', 'bar');
+
+        $this->assertSame('select * from "users" where "name" LIKE ? or "last_name" LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo%', '%bar%'], $builder->getBindings());
+    }
+
+    public function testOrWhereNotContains(): void
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereContains('name', 'foo')
+            ->orWhereNotContains('last_name', 'bar');
+
+        $this->assertSame('select * from "users" where "name" LIKE ? or "last_name" NOT LIKE ?', $builder->toSql());
+        $this->assertEquals(['%foo%', '%bar%'], $builder->getBindings());
+    }
+
     public function testRawWheres()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -922,7 +922,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
-    public function testWhereStartsWith(): void
+    public function testWhereStartsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereStartsWith('name', 'foo');
@@ -930,7 +930,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo%'], $builder->getBindings());
     }
 
-    public function testWhereNotStartsWith(): void
+    public function testWhereNotStartsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotStartsWith('name', 'foo');
@@ -938,7 +938,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo%'], $builder->getBindings());
     }
 
-    public function testOrWhereStartsWith(): void
+    public function testOrWhereStartsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')
@@ -949,7 +949,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo%', 'bar%'], $builder->getBindings());
     }
 
-    public function testOrWhereNotStartsWith(): void
+    public function testOrWhereNotStartsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')
@@ -960,7 +960,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo%', 'bar%'], $builder->getBindings());
     }
 
-    public function testWhereEndsWith(): void
+    public function testWhereEndsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereEndsWith('name', 'foo');
@@ -968,7 +968,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo'], $builder->getBindings());
     }
 
-    public function testWhereNotEndsWith(): void
+    public function testWhereNotEndsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotEndsWith('name', 'foo');
@@ -976,7 +976,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo'], $builder->getBindings());
     }
 
-    public function testOrWhereEndsWith(): void
+    public function testOrWhereEndsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')
@@ -987,7 +987,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo', '%bar'], $builder->getBindings());
     }
 
-    public function testOrWhereNotEndsWith(): void
+    public function testOrWhereNotEndsWith()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')
@@ -998,7 +998,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo', '%bar'], $builder->getBindings());
     }
 
-    public function testWhereContains(): void
+    public function testWhereContains()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereContains('name', 'foo');
@@ -1006,7 +1006,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo%'], $builder->getBindings());
     }
 
-    public function testWhereNotContains(): void
+    public function testWhereNotContains()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotContains('name', 'foo');
@@ -1014,7 +1014,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo%'], $builder->getBindings());
     }
 
-    public function testOrWhereContains(): void
+    public function testOrWhereContains()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')
@@ -1025,7 +1025,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%foo%', '%bar%'], $builder->getBindings());
     }
 
-    public function testOrWhereNotContains(): void
+    public function testOrWhereNotContains()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')


### PR DESCRIPTION
I am pleased to submit a new Pull Request that adds the ability to perform a Like operation to the Query Builder. These changes enhance the querying capabilities in Laravel and facilitate more complex search operations.

PR Details:

Added the like method to the Query Builder for executing Like operations in queries.

Now, the following features have been added to the Query Builder:

- `whereStartsWith`
- `whereNotStartsWith`
- `orWhereStartsWith`
- `orWhereNotStartsWith`
- `whereEndsWith`
- `whereNotEndsWith`
- `orWhereEndsWith`
- `orWhereNotEndsWith`
- `whereContains`
- `whereNotContains`
- `orWhereContains`
- `orWhereNotContains`


```php
 $query = DB::table('users')
        ->whereStartsWith('first_name','Taylor')
        ->orWhereEndsWith('username','Laravel')
        ->get();

```

Tests for these features have also been added.

Please review this PR and provide any feedback or necessary adjustments. I am ready for any changes or improvements.

Thank you for your time and attention.

Best regards,
Sayyed Abdollah Mahmoudzadeh