### PR TITLE
[11.x] Allows to exclude URIs in PreventRequestsDuringMaintenance middleware

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -645,7 +645,6 @@ class Middleware
         return $this;
     }
 
-
     /**
      * Indicate that Sanctum's frontend state middleware should be enabled.
      *

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -8,6 +8,7 @@ use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Http\Middleware\TrustHosts;
@@ -630,6 +631,20 @@ class Middleware
 
         return $this;
     }
+
+    /**
+     * Configure the middleware to prevent requests during maintenance.
+     *
+     * @param  array<int, string>  $except
+     * @return $this
+     */
+    public function preventRequestsDuringMaintenance(array $except = [])
+    {
+        PreventRequestsDuringMaintenance::except($except);
+
+        return $this;
+    }
+
 
     /**
      * Indicate that Sanctum's frontend state middleware should be enabled.

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -633,7 +633,7 @@ class Middleware
     }
 
     /**
-     * Configure the middleware to prevent requests during maintenance.
+     * Configure the middleware that prevents requests during maintenance mode.
      *
      * @param  array<int, string>  $except
      * @return $this

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -172,4 +172,14 @@ class PreventRequestsDuringMaintenance
             array_merge(static::$neverPrevent, Arr::wrap($uris))
         ));
     }
+
+    /**
+     * Flush the state of the middleware.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$neverPrevent = [];
+    }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -28,7 +28,6 @@ class PreventRequestsDuringMaintenance
      */
     protected static $neverPrevent = [];
 
-
     /**
      * Create a new middleware instance.
      *

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
 use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PreventRequestsDuringMaintenance
@@ -19,6 +20,14 @@ class PreventRequestsDuringMaintenance
      * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
+
+    /**
+     * The URIs that should be accessible during maintenance.
+     *
+     * @var array
+     */
+    protected static $neverPrevent = [];
+
 
     /**
      * Create a new middleware instance.
@@ -140,5 +149,28 @@ class PreventRequestsDuringMaintenance
         }
 
         return $headers;
+    }
+
+    /**
+     * Get the URIs that should be excluded.
+     *
+     * @return array
+     */
+    public function getExcludedPaths()
+    {
+        return array_merge($this->except, static::$neverPrevent);
+    }
+
+    /**
+     * Indicate that the given URIs should always be accessible.
+     *
+     * @param  array|string  $uris
+     * @return void
+     */
+    public static function except($uris)
+    {
+        static::$neverPrevent = array_values(array_unique(
+            array_merge(static::$neverPrevent, Arr::wrap($uris))
+        ));
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -211,13 +211,13 @@ class VerifyCsrfToken
     /**
      * Indicate that the given URIs should be excluded from CSRF verification.
      *
-     * @param  array|string  $paths
+     * @param  array|string  $uris
      * @return void
      */
-    public static function except($paths)
+    public static function except($uris)
     {
         static::$neverVerify = array_values(array_unique(
-            array_merge(static::$neverVerify, Arr::wrap($paths))
+            array_merge(static::$neverVerify, Arr::wrap($uris))
         ));
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -168,6 +169,7 @@ trait InteractsWithTestCaseLifecycle
         EncryptCookies::flushState();
         HandleExceptions::flushState();
         Once::flush();
+        PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
         Sleep::fake(false);

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -31,6 +31,7 @@ class MiddlewareTest extends TestCase
         Container::setInstance(null);
         ConvertEmptyStringsToNull::flushState();
         EncryptCookies::flushState();
+        PreventRequestsDuringMaintenance::flushState();
         TrimStrings::flushState();
         TrustProxies::flushState();
     }
@@ -258,6 +259,7 @@ class MiddlewareTest extends TestCase
     public function testPreventRequestsDuringMaintenance()
     {
         $configuration = new Middleware();
+
         $mode = Mockery::mock(MaintenanceMode::class);
         $mode->shouldReceive('active')->andReturn(true);
         $mode->shouldReceive('date')->andReturn([]);


### PR DESCRIPTION
I think that with the new way of middleware configuration we lost the ability to allow access to defined URIs during maintenance. I bring it back with this PR.