### PR TITLE
[11.x] Add `@delete` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -50,6 +50,16 @@ trait CompilesHelpers
     }
 
     /**
+     * Compile the delete method statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileDelete()
+    {
+        return "<?php echo method_field('delete'); ?>";
+    }
+
+    /**
      * Compile the "vite" statements into valid PHP.
      *
      * @param  string|null  $arguments

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -8,7 +8,7 @@ class BladeHelpersTest extends AbstractBladeTestCase
     {
         $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
-        $this->assertSame('<?php echo method_field(\'delete\'); ?>', $this->compiler->compileString("@delete"));
+        $this->assertSame('<?php echo method_field(\'delete\'); ?>', $this->compiler->compileString('@delete'));
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -8,6 +8,7 @@ class BladeHelpersTest extends AbstractBladeTestCase
     {
         $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
+        $this->assertSame('<?php echo method_field(\'delete\'); ?>', $this->compiler->compileString("@delete"));
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));


### PR DESCRIPTION
This pull request adds a new directive to Blade called `@delete`. With this directive, we can now set the method of a form to delete without having to write `@method('delete')`. This makes it simpler and more convenient to use.

```php
<form action="" method="POST">
       @csrf
       @delete

        ......
</form>
```
