### PR TITLE
[10.x] Add support for casting bitmask as array of enum cases

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsBitmaskEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsBitmaskEnumArrayObject.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use BackedEnum;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+
+class AsBitmaskEnumArrayObject implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @template TEnum
+     *
+     * @param  array{class-string<TEnum>}  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Database\Eloquent\Casts\ArrayObject<array-key, TEnum>, iterable<TEnum>>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key]) || is_null($attributes[$key])) {
+                    return;
+                }
+
+                $enumClass = $this->arguments[0];
+
+                $reflectionClass = new ReflectionClass($enumClass);
+
+                $data = [];
+                foreach ($reflectionClass->getConstants() as $caseName => $caseValue) {
+                    if ($value & $caseValue->value) {
+                        $data[] = $caseValue->value;
+                    }
+                }
+
+                if (! is_array($data)) {
+                    return;
+                }
+
+                return new ArrayObject((new Collection($data))->map(function ($value) use ($enumClass) {
+                    return is_subclass_of($enumClass, BackedEnum::class)
+                        ? $enumClass::from($value)
+                        : constant($enumClass.'::'.$value);
+                })->toArray());
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if ($value === null) {
+                    return [$key => null];
+                }
+
+                $storable = 0;
+
+                foreach ($value as $enum) {
+                    $storable |= $this->getStorableEnumValue($enum);
+                }
+
+                return [$key => $storable];
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                return (new Collection($value->getArrayCopy()))->map(function ($enum) {
+                    return $this->getStorableEnumValue($enum);
+                })->toArray();
+            }
+
+            protected function getStorableEnumValue($enum)
+            {
+                if (is_string($enum) || is_int($enum)) {
+                    return $enum;
+                }
+
+                return $enum instanceof BackedEnum ? $enum->value : $enum->name;
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsBitmaskEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsBitmaskEnumCollection.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use BackedEnum;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+
+class AsBitmaskEnumCollection implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @template TEnum of \UnitEnum|\BackedEnum
+     *
+     * @param  array{class-string<TEnum>}  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, TEnum>, iterable<TEnum>>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key]) || is_null($attributes[$key])) {
+                    return;
+                }
+
+                $enumClass = $this->arguments[0];
+
+                $reflectionClass = new ReflectionClass($enumClass);
+
+                $data = [];
+                foreach ($reflectionClass->getConstants() as $caseName => $caseValue) {
+                    if ($value & $caseValue->value) {
+                        $data[] = $caseValue->value;
+                    }
+                }
+
+                if (! is_array($data)) {
+                    return;
+                }
+
+                return (new Collection($data))->map(function ($value) use ($enumClass) {
+                    return is_subclass_of($enumClass, BackedEnum::class)
+                        ? $enumClass::from($value)
+                        : constant($enumClass.'::'.$value);
+                });
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if ($value === null) {
+                    return [$key => null];
+                }
+
+                $storable = 0;
+
+                foreach ($value as $enum) {
+                    $storable |= $this->getStorableEnumValue($enum);
+                }
+
+                return [$key => $storable];
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                return (new Collection($value))->map(function ($enum) {
+                    return $this->getStorableEnumValue($enum);
+                })->toArray();
+            }
+
+            protected function getStorableEnumValue($enum)
+            {
+                if (is_string($enum) || is_int($enum)) {
+                    return $enum;
+                }
+
+                return $enum instanceof BackedEnum ? $enum->value : $enum->name;
+            }
+        };
+    }
+}

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Database\Eloquent\Casts\AsBitmaskEnumArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsBitmaskEnumCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -23,6 +25,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             $table->integer('integer_status')->nullable();
             $table->json('integer_status_collection')->nullable();
             $table->json('integer_status_array')->nullable();
+            $table->integer('bitmask_collection')->nullable();
+            $table->integer('bitmask_array')->nullable();
             $table->string('arrayable_status')->nullable();
         });
 
@@ -41,6 +45,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
+            'bitmask_collection' => 5,
+            'bitmask_array' => 5,
             'arrayable_status' => 'pending',
         ]);
 
@@ -52,6 +58,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals(IntegerStatus::pending, $model->integer_status);
         $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_collection->all());
         $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_array->toArray());
+        $this->assertEquals([IntegerBitmask::bitmask_value_one, IntegerBitmask::bitmask_value_four], $model->bitmask_collection->all());
+        $this->assertEquals([IntegerBitmask::bitmask_value_one, IntegerBitmask::bitmask_value_four], $model->bitmask_array->toArray());
         $this->assertEquals(ArrayableStatus::pending, $model->arrayable_status);
     }
 
@@ -64,6 +72,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => null,
             'integer_status_collection' => null,
             'integer_status_array' => null,
+            'bitmask_collection' => null,
+            'bitmask_array' => null,
             'arrayable_status' => null,
         ]);
 
@@ -75,6 +85,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals(null, $model->integer_status);
         $this->assertEquals(null, $model->integer_status_collection);
         $this->assertEquals(null, $model->integer_status_array);
+        $this->assertEquals(null, $model->bitmask_collection);
+        $this->assertEquals(null, $model->bitmask_array);
         $this->assertEquals(null, $model->arrayable_status);
     }
 
@@ -87,6 +99,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => IntegerStatus::pending,
             'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
             'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
+            'bitmask_collection' => [IntegerBitmask::bitmask_value_one, IntegerBitmask::bitmask_value_four],
+            'bitmask_array' => [IntegerBitmask::bitmask_value_one, IntegerBitmask::bitmask_value_four],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
@@ -97,6 +111,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_collection' => [1, 2],
             'integer_status_array' => [1, 2],
+            'bitmask_collection' => [1, 4],
+            'bitmask_array' => [1, 4],
             'arrayable_status' => [
                 'name' => 'pending',
                 'value' => 'pending',
@@ -114,6 +130,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => null,
             'integer_status_collection' => null,
             'integer_status_array' => null,
+            'bitmask_collection' => null,
+            'bitmask_array' => null,
             'arrayable_status' => null,
         ]);
 
@@ -124,6 +142,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => null,
             'integer_status_collection' => null,
             'integer_status_array' => null,
+            'bitmask_collection' => null,
+            'bitmask_array' => null,
             'arrayable_status' => null,
         ], $model->toArray());
     }
@@ -137,6 +157,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => IntegerStatus::pending,
             'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
             'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
+            'bitmask_collection' => [IntegerBitmask::bitmask_value_one, IntegerBitmask::bitmask_value_four],
+            'bitmask_array' => [IntegerBitmask::bitmask_value_one, IntegerBitmask::bitmask_value_four],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
@@ -150,6 +172,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
+            'bitmask_collection' => 5,
+            'bitmask_array' => 5,
             'arrayable_status' => 'pending',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
@@ -165,6 +189,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_collection' => [1, 2],
             'integer_status_array' => [1, 2],
+            'bitmask_collection' => [1, 4],
+            'bitmask_array' => [1, 4],
             'arrayable_status' => 'pending',
         ]);
 
@@ -178,6 +204,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_collection' => json_encode([1, 2]),
             'integer_status_array' => json_encode([1, 2]),
+            'bitmask_collection' => 5,
+            'bitmask_array' => 5,
             'arrayable_status' => 'pending',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
@@ -193,6 +221,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => null,
             'integer_status_collection' => null,
             'integer_status_array' => null,
+            'bitmask_collection' => null,
+            'bitmask_array' => null,
             'arrayable_status' => null,
         ]);
 
@@ -206,6 +236,8 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => null,
             'integer_status_collection' => null,
             'integer_status_array' => null,
+            'bitmask_collection' => null,
+            'bitmask_array' => null,
             'arrayable_status' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
@@ -304,6 +336,8 @@ class EloquentModelEnumCastingTestModel extends Model
         'integer_status' => IntegerStatus::class,
         'integer_status_collection' => AsEnumCollection::class.':'.IntegerStatus::class,
         'integer_status_array' => AsEnumArrayObject::class.':'.IntegerStatus::class,
+        'bitmask_collection' => AsBitmaskEnumCollection::class.':'.IntegerBitmask::class,
+        'bitmask_array' => AsBitmaskEnumArrayObject::class.':'.IntegerBitmask::class,
         'arrayable_status' => ArrayableStatus::class,
     ];
 }

--- a/tests/Integration/Database/Enums.php
+++ b/tests/Integration/Database/Enums.php
@@ -18,6 +18,14 @@ enum IntegerStatus: int
     case done = 2;
 }
 
+enum IntegerBitmask: int
+{
+    case bitmask_value_one = 1;
+    case bitmask_value_two = 2;
+    case bitmask_value_four = 4;
+    case bitmask_value_eight = 8;
+}
+
 enum ArrayableStatus: string implements Arrayable
 {
     case pending = 'pending';


### PR DESCRIPTION
Today I encountered an issue for which I needed to add several dozen boolean columns to the database. Instead, I decided to add a single integer column to store a bitmask and convert it to an array of Enum class values when needed.

Unfortunately, Laravel doesn't have native support for converting an array of Enum values to a bitmask and vice versa. So, I decided to try adding this capability based on existing code for converting Enum arrays to JSON format.

For example, I have an integer field `options` in which I want to store all available options of a House. I just need to pass an array of Enum class values there:

```php
enum HouseOptionsEnum: int
{
    case has_option_one = 1;
    case has_option_two = 2;
    case has_option_three = 4;
    case has_option_four = 8;
}

// ...

protected function casts(): array
{
    return [
        'options' => AsBitmaskEnumArrayObject::class.':'.HouseOptionsEnum::class,
    ];
}

// ...

/**
 * @property integer $options
 */
$house = House::query()->create([
    // ...
    'options' => [
        HouseOptionsEnum::has_option_one, // 1
        HouseOptionsEnum::has_option_three, // 4
        HouseOptionsEnum::has_option_four, // 8
    ],
    // ...
]);
```
The value `13` will be saved to the database. And when it is read from the database, it will be an array of Enum cases.

This PR will avoid an excessive increase in the number of fields in the table, make it easier to add new fields without the need to create them in the database, and easily retrieve information stored in fields of a similar type

Thanks!
