### PR TITLE
[10.x] Refactor(Illuminate\Foundation\Console): modify getNameInput method in ViewMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -77,9 +77,7 @@ class ViewMakeCommand extends GeneratorCommand
     {
         $name = trim($this->argument('name'));
 
-        $name = str_replace(['\\', '.'], '/', $this->argument('name'));
-
-        return $name;
+        return str_replace(['\\', '.'], '/', $name);
     }
 
     /**


### PR DESCRIPTION
#### before
```php
protected function getNameInput()
    {
        $name = trim($this->argument('name'));

        $name = str_replace(['\\', '.'], '/', $this->argument('name'));

        return $name;
    }
```

If we look at the above code, in the first line, we trim the input, but we no longer use `$name` afterward. Therefore, we can simplify this method and reduce it to two lines as per the following code.

```php
protected function getNameInput()
    {
        $name = trim($this->argument('name'));

        return str_replace(['\\', '.'], '/', $name);
    }
```