### PR TITLE
[10.x] Allow apiResource and resource routes to specify middleware per action

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -152,9 +152,11 @@ class PendingResourceRegistration
         $middleware = Arr::wrap($middleware);
 
         foreach ($middleware as $key => $value) {
-            $middleware[$key] = is_array($value) && array_is_list($value)
-                ? $value
-                : (string) $value;
+            if (is_array($value) && array_is_list($value)) {
+                $middleware[$key] = array_map(fn($item) => (string) $item, $value);
+            } else {
+                $middleware[$key] = (string) $value;
+            }
         }
 
         $this->options['middleware'] = $middleware;

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -152,7 +152,9 @@ class PendingResourceRegistration
         $middleware = Arr::wrap($middleware);
 
         foreach ($middleware as $key => $value) {
-            $middleware[$key] = (string) $value;
+            $middleware[$key] = is_array($value) && array_is_list($value)
+                ? $value
+                : (string) $value;
         }
 
         $this->options['middleware'] = $middleware;

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -153,7 +153,7 @@ class PendingResourceRegistration
 
         foreach ($middleware as $key => $value) {
             if (is_array($value) && array_is_list($value)) {
-                $middleware[$key] = array_map(fn($item) => (string) $item, $value);
+                $middleware[$key] = array_map(fn ($item) => (string) $item, $value);
             } else {
                 $middleware[$key] = (string) $value;
             }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -620,7 +620,7 @@ class ResourceRegistrar
             $middlewaresIsArray = is_array($middlewares);
             $middlewaresIsList = $middlewaresIsArray && array_is_list($middlewares);
 
-            if ($middlewaresIsList || ! $middlewaresIsArray ) {
+            if ($middlewaresIsList || ! $middlewaresIsArray) {
                 $action['middleware'] = $middlewares;
             }
 

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -617,14 +617,16 @@ class ResourceRegistrar
 
         if (isset($options['middleware'])) {
             $middlewares = $options['middleware'];
-            $middlewaresIsList = is_array($middlewares) && array_is_list($middlewares);
+            $middlewaresIsArray = is_array($middlewares);
+            $middlewaresIsList = $middlewaresIsArray && array_is_list($middlewares);
 
-            if ($middlewaresIsList) {
+            if ($middlewaresIsList || !$middlewaresIsArray ) {
                 $action['middleware'] = $middlewares;
-            } elseif (!$middlewaresIsList && isset($middlewares[$method])) {
-                $action['middleware'] = $middlewares[$method];
             }
 
+            if (!$middlewaresIsList && isset($middlewares[$method])) {
+                $action['middleware'] = $middlewares[$method];
+            }
         }
 
         if (isset($options['excluded_middleware'])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -613,10 +613,18 @@ class ResourceRegistrar
     {
         $name = $this->getResourceRouteName($resource, $method, $options);
 
-        $action = ['as' => $name, 'uses' => $controller.'@'.$method];
+        $action = ['as' => $name, 'uses' => $controller . '@' . $method];
 
         if (isset($options['middleware'])) {
-            $action['middleware'] = $options['middleware'];
+            $middlewares = $options['middleware'];
+            $middlewaresIsList = is_array($middlewares) && array_is_list($middlewares);
+
+            if ($middlewaresIsList) {
+                $action['middleware'] = $middlewares;
+            } elseif (!$middlewaresIsList && isset($middlewares[$method])) {
+                $action['middleware'] = $middlewares[$method];
+            }
+
         }
 
         if (isset($options['excluded_middleware'])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -613,18 +613,18 @@ class ResourceRegistrar
     {
         $name = $this->getResourceRouteName($resource, $method, $options);
 
-        $action = ['as' => $name, 'uses' => $controller . '@' . $method];
+        $action = ['as' => $name, 'uses' => $controller.'@'.$method];
 
         if (isset($options['middleware'])) {
             $middlewares = $options['middleware'];
             $middlewaresIsArray = is_array($middlewares);
             $middlewaresIsList = $middlewaresIsArray && array_is_list($middlewares);
 
-            if ($middlewaresIsList || !$middlewaresIsArray ) {
+            if ($middlewaresIsList || ! $middlewaresIsArray ) {
                 $action['middleware'] = $middlewares;
             }
 
-            if (!$middlewaresIsList && isset($middlewares[$method])) {
+            if (! $middlewaresIsList && isset($middlewares[$method])) {
                 $action['middleware'] = $middlewares[$method];
             }
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -890,7 +890,6 @@ class RouteRegistrarTest extends TestCase
                      ])
                      ->withoutMiddleware('one');
 
-
         $this->seeResponse('deleted', Request::create('users/id', 'DELETE'));
 
         $routes = $this->router->getRoutes()->get();

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -875,6 +875,25 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
     }
 
+    public function testResourceWithMiddlewarePerAction()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->middleware([
+                        'index' => ['one', 'two'],
+                     ])
+                     ->withoutMiddleware('one');
+
+
+        $this->seeResponse('deleted', Request::create('users/id', 'DELETE'));
+
+        $routes = $this->router->getRoutes()->get();
+
+        $this->assertEquals(['one', 'two'], $routes[0]->middleware());
+        $this->assertEquals(['one'], $routes[0]->excludedMiddleware());
+        $this->assertEquals([], $routes[1]->middleware());
+        $this->assertEquals(['one'], $routes[1]->excludedMiddleware());
+    }
+
     public function testResourceWheres()
     {
         $wheres = [

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -886,7 +886,7 @@ class RouteRegistrarTest extends TestCase
         };
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->middleware([
-                        'index' => [$one , 'two'],
+                         'index' => [$one , 'two'],
                      ])
                      ->withoutMiddleware('one');
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -877,9 +877,16 @@ class RouteRegistrarTest extends TestCase
 
     public function testResourceWithMiddlewarePerAction()
     {
+        $one = new class implements Stringable
+        {
+            public function __toString()
+            {
+                return 'one';
+            }
+        };
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->middleware([
-                        'index' => ['one', 'two'],
+                        'index' => [$one , 'two'],
                      ])
                      ->withoutMiddleware('one');
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -886,7 +886,7 @@ class RouteRegistrarTest extends TestCase
         };
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->middleware([
-                         'index' => [$one , 'two'],
+                         'index' => [$one, 'two'],
                      ])
                      ->withoutMiddleware('one');
 


### PR DESCRIPTION
While working on my project I was trying to attach different middlewares to an api resource route and I noticed currently the framework only allows to apply the same middleware to all of the actions of the given route. The only current solution is to do it inside the controller constructor while with this PR devs will be able to specify the middleware they want to associate to each action in a resource route directly from the route definition.

```php
Route::resource('users', UserController::class)
    ->middleware([
        'index' => ['can:viewAny,'.User::class,'another_needed'],
        'store' => ['auth','can:create,'.User::class,'some other'],
        'show' => [ApiTokenRequired::class],
    ]);
```

It is backwards compatible with the other options of setting middleware