### PR TITLE
[10.x] Add getQualifiedTableName Method to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1870,11 +1870,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $connection = $this->getConnectionName();
         $table = $this->getTable();
 
-        if ($connection) {
-            return $connection . '.' . $table;
-        }
-
-        return $table;
+        return $connection ? "{$connection}.{$table}" : $table;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1861,6 +1861,23 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Get the fully qualified table name for the model.
+     *
+     * @return string
+     */
+    public function getQualifiedTableName()
+    {
+        $connection = $this->getConnectionName();
+        $table = $this->getTable();
+
+        if ($connection) {
+            return $connection . '.' . $table;
+        }
+
+        return $table;
+    }
+
+    /**
      * Set the table associated with the model.
      *
      * @param  string  $table

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -30,6 +30,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = m::mock(Connection::class);
+
+        $this->connection->shouldReceive('getName')->andReturn('test_connection');
     }
 
     protected function tearDown(): void
@@ -351,6 +353,21 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertEquals($this->table, $this->getTable(ProductStub::class));
         $this->assertEquals($this->table, $this->getTable(new ProductStub));
         $this->assertEquals($this->table, $this->getTable($this->table));
+    }
+
+    public function testGetQualifiedTableNameFromModel()
+    {
+        $expectedTableNameWithConnection = 'test_connection.' . $this->table;
+
+        $model = new ProductStub;
+        $model->setConnection('test_connection');
+
+        $this->assertEquals($expectedTableNameWithConnection, $model->getQualifiedTableName());
+
+        $defaultModel = new ProductStub;
+
+        $expectedDefaultTableName = $defaultModel->getTable();
+        $this->assertEquals($expectedDefaultTableName, $defaultModel->getQualifiedTableName());
     }
 
     public function testGetTableCustomizedDeletedAtColumnName()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -357,7 +357,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     public function testGetQualifiedTableNameFromModel()
     {
-        $expectedTableNameWithConnection = 'test_connection.' . $this->table;
+        $expectedTableNameWithConnection = 'test_connection.'.$this->table;
 
         $model = new ProductStub;
         $model->setConnection('test_connection');


### PR DESCRIPTION
This PR introduces a new method,`getQualifiedTableName`, to the `Illuminate\Database\Eloquent\Model` class. This method aims to simplify the process of referencing fully qualified table names (including the connection name, when applicable) in multi-database setups. It concatenates the connection name and the table name. This is especially useful when performing joins across multiple connections.

The `getQualifiedTableName` method checks if the model's connection name is set; if so, it returns the connection name and table name concatenated with a dot (.). If no connection name is set, it returns just the table name, preserving the expected behavior for models using the default database connection.