### PR TITLE
[11.x] Add typed getters for configuration

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
+use Webmozart\Assert\Assert;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -178,5 +179,63 @@ class Repository implements ArrayAccess, ConfigContract
     public function offsetUnset($key): void
     {
         $this->set($key, null);
+    }
+
+    public function string(string $key): string
+    {
+        $value = $this->get($key);
+
+        Assert::string($value, message: sprintf(
+            "Configuration value for key [%s] must be a string, %s given.", $key, gettype($value))
+        );
+
+        return $value;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function array(string $key): array
+    {
+        $value = $this->get($key);
+
+        Assert::isArray($value, message: sprintf(
+            "Configuration value for key [%s] must be an array, %s given.", $key, gettype($value))
+        );
+
+        return $value;
+    }
+
+    public function boolean(string $key): bool
+    {
+        $value = $this->get($key);
+
+        Assert::boolean($value, message: sprintf(
+            "Configuration value for key [%s] must be a boolean, %s given.", $key, gettype($value))
+        );
+
+        return $value;
+    }
+
+    public function integer(string $key): int
+    {
+        $value = $this->get($key);
+
+        Assert::integer($value, message: sprintf(
+            "Configuration value for key [%s] must be an integer, %s given.", $key, gettype($value))
+        );
+
+        return $value;
+    }
+
+    public function float(string $key): float
+    {
+        $value = $this->get($key);
+
+        Assert::float($value, message: sprintf(
+            "Configuration value for key [%s] must be a float, %s given.", $key, gettype($value))
+        );
+
+        return $value;
     }
 }

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -185,9 +185,11 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        Assert::string($value, message: sprintf(
-            "Configuration value for key [%s] must be a string, %s given.", $key, gettype($value))
-        );
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException(
+                sprintf("Configuration value for key [%s] must be a string, %s given.", $key, gettype($value))
+            );
+        }
 
         return $value;
     }
@@ -199,9 +201,11 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        Assert::isArray($value, message: sprintf(
-            "Configuration value for key [%s] must be an array, %s given.", $key, gettype($value))
-        );
+        if (!is_array($value)) {
+            throw new \InvalidArgumentException(
+                sprintf("Configuration value for key [%s] must be an array, %s given.", $key, gettype($value))
+            );
+        }
 
         return $value;
     }
@@ -210,9 +214,11 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        Assert::boolean($value, message: sprintf(
-            "Configuration value for key [%s] must be a boolean, %s given.", $key, gettype($value))
-        );
+        if(!is_bool($value)) {
+            throw new \InvalidArgumentException(
+                sprintf("Configuration value for key [%s] must be a boolean, %s given.", $key, gettype($value))
+            );
+        }
 
         return $value;
     }
@@ -221,9 +227,11 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        Assert::integer($value, message: sprintf(
-            "Configuration value for key [%s] must be an integer, %s given.", $key, gettype($value))
-        );
+        if (!is_int($value)) {
+            throw new \InvalidArgumentException(
+                sprintf("Configuration value for key [%s] must be an integer, %s given.", $key, gettype($value))
+            );
+        }
 
         return $value;
     }
@@ -232,9 +240,11 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        Assert::float($value, message: sprintf(
-            "Configuration value for key [%s] must be a float, %s given.", $key, gettype($value))
-        );
+        if (!is_float($value)) {
+            throw new \InvalidArgumentException(
+                sprintf("Configuration value for key [%s] must be a float, %s given.", $key, gettype($value))
+            );
+        }
 
         return $value;
     }

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -88,7 +89,7 @@ class Repository implements ArrayAccess, ConfigContract
         $value = $this->get($key);
 
         if (! is_string($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Configuration value for key [%s] must be a string, %s given.', $key, gettype($value))
             );
         }
@@ -107,7 +108,7 @@ class Repository implements ArrayAccess, ConfigContract
         $value = $this->get($key);
 
         if (! is_int($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Configuration value for key [%s] must be an integer, %s given.', $key, gettype($value))
             );
         }
@@ -126,7 +127,7 @@ class Repository implements ArrayAccess, ConfigContract
         $value = $this->get($key);
 
         if (! is_float($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Configuration value for key [%s] must be a float, %s given.', $key, gettype($value))
             );
         }
@@ -145,7 +146,7 @@ class Repository implements ArrayAccess, ConfigContract
         $value = $this->get($key);
 
         if (! is_bool($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Configuration value for key [%s] must be a boolean, %s given.', $key, gettype($value))
             );
         }
@@ -164,7 +165,7 @@ class Repository implements ArrayAccess, ConfigContract
         $value = $this->get($key);
 
         if (! is_array($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Configuration value for key [%s] must be an array, %s given.', $key, gettype($value))
             );
         }

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -180,7 +180,6 @@ class Repository implements ArrayAccess, ConfigContract
         $this->set($key, null);
     }
 
-
     /**
      * Get the specified configuration value typed as a string.
      * If the value isn't a string it should throw an exception.
@@ -221,7 +220,6 @@ class Repository implements ArrayAccess, ConfigContract
         return $value;
     }
 
-
     /**
      * Get the specified configuration value typed as a boolean.
      * If the value isn't a boolean it should throw an exception.
@@ -261,7 +259,6 @@ class Repository implements ArrayAccess, ConfigContract
 
         return $value;
     }
-
 
     /**
      * Get the specified configuration value typed as a float.

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -78,6 +78,101 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified string configuration value.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    public function string(string $key): string
+    {
+        $value = $this->get($key);
+
+        if (! is_string($value)) {
+            throw new \InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer configuration value.
+     *
+     * @param  string  $key
+     * @return int
+     */
+    public function integer(string $key): int
+    {
+        $value = $this->get($key);
+
+        if (! is_int($value)) {
+            throw new \InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an integer, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified float configuration value.
+     *
+     * @param  string  $key
+     * @return float
+     */
+    public function float(string $key): float
+    {
+        $value = $this->get($key);
+
+        if (! is_float($value)) {
+            throw new \InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a float, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified boolean configuration value.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function boolean(string $key): bool
+    {
+        $value = $this->get($key);
+
+        if (! is_bool($value)) {
+            throw new \InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a boolean, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified array configuration value.
+     *
+     * @param  string  $key
+     * @return array<array-key, mixed>
+     */
+    public function array(string $key): array
+    {
+        $value = $this->get($key);
+
+        if (! is_array($value)) {
+            throw new \InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an array, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Set a given configuration value.
      *
      * @param  array|string  $key
@@ -178,105 +273,5 @@ class Repository implements ArrayAccess, ConfigContract
     public function offsetUnset($key): void
     {
         $this->set($key, null);
-    }
-
-    /**
-     * Get the specified configuration value typed as a string.
-     * If the value isn't a string it should throw an exception.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    public function string(string $key): string
-    {
-        $value = $this->get($key);
-
-        if (! is_string($value)) {
-            throw new \InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a string, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified configuration value typed as an array.
-     * If the value isn't an array it should throw an exception.
-     *
-     * @param  string  $key
-     * @return array<array-key, mixed>
-     */
-    public function array(string $key): array
-    {
-        $value = $this->get($key);
-
-        if (! is_array($value)) {
-            throw new \InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an array, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified configuration value typed as a boolean.
-     * If the value isn't a boolean it should throw an exception.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function boolean(string $key): bool
-    {
-        $value = $this->get($key);
-
-        if (! is_bool($value)) {
-            throw new \InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a boolean, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified configuration value typed as an integer.
-     * If the value isn't an integer it should throw an exception.
-     *
-     * @param  string  $key
-     * @return int
-     */
-    public function integer(string $key): int
-    {
-        $value = $this->get($key);
-
-        if (! is_int($value)) {
-            throw new \InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an integer, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified configuration value typed as a float.
-     * If the value isn't a float it should throw an exception.
-     *
-     * @param  string  $key
-     * @return float
-     */
-    public function float(string $key): float
-    {
-        $value = $this->get($key);
-
-        if (! is_float($value)) {
-            throw new \InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a float, %s given.', $key, gettype($value))
-            );
-        }
-
-        return $value;
     }
 }

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,7 +6,6 @@ use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
-use Webmozart\Assert\Assert;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -185,9 +184,9 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             throw new \InvalidArgumentException(
-                sprintf("Configuration value for key [%s] must be a string, %s given.", $key, gettype($value))
+                sprintf('Configuration value for key [%s] must be a string, %s given.', $key, gettype($value))
             );
         }
 
@@ -201,9 +200,9 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             throw new \InvalidArgumentException(
-                sprintf("Configuration value for key [%s] must be an array, %s given.", $key, gettype($value))
+                sprintf('Configuration value for key [%s] must be an array, %s given.', $key, gettype($value))
             );
         }
 
@@ -214,9 +213,9 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        if(!is_bool($value)) {
+        if (! is_bool($value)) {
             throw new \InvalidArgumentException(
-                sprintf("Configuration value for key [%s] must be a boolean, %s given.", $key, gettype($value))
+                sprintf('Configuration value for key [%s] must be a boolean, %s given.', $key, gettype($value))
             );
         }
 
@@ -227,9 +226,9 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        if (!is_int($value)) {
+        if (! is_int($value)) {
             throw new \InvalidArgumentException(
-                sprintf("Configuration value for key [%s] must be an integer, %s given.", $key, gettype($value))
+                sprintf('Configuration value for key [%s] must be an integer, %s given.', $key, gettype($value))
             );
         }
 
@@ -240,9 +239,9 @@ class Repository implements ArrayAccess, ConfigContract
     {
         $value = $this->get($key);
 
-        if (!is_float($value)) {
+        if (! is_float($value)) {
             throw new \InvalidArgumentException(
-                sprintf("Configuration value for key [%s] must be a float, %s given.", $key, gettype($value))
+                sprintf('Configuration value for key [%s] must be a float, %s given.', $key, gettype($value))
             );
         }
 

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -82,11 +82,12 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified string configuration value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return string
      */
-    public function string(string $key): string
+    public function string(string $key, $default = null): string
     {
-        $value = $this->get($key);
+        $value = $this->get($key, $default);
 
         if (! is_string($value)) {
             throw new InvalidArgumentException(
@@ -101,11 +102,12 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified integer configuration value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return int
      */
-    public function integer(string $key): int
+    public function integer(string $key, $default = null): int
     {
-        $value = $this->get($key);
+        $value = $this->get($key, $default);
 
         if (! is_int($value)) {
             throw new InvalidArgumentException(
@@ -120,11 +122,12 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified float configuration value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return float
      */
-    public function float(string $key): float
+    public function float(string $key, $default = null): float
     {
-        $value = $this->get($key);
+        $value = $this->get($key, $default);
 
         if (! is_float($value)) {
             throw new InvalidArgumentException(
@@ -139,11 +142,12 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified boolean configuration value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return bool
      */
-    public function boolean(string $key): bool
+    public function boolean(string $key, $default = null): bool
     {
-        $value = $this->get($key);
+        $value = $this->get($key, $default);
 
         if (! is_bool($value)) {
             throw new InvalidArgumentException(
@@ -158,11 +162,12 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified array configuration value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return array<array-key, mixed>
      */
-    public function array(string $key): array
+    public function array(string $key, $default = null): array
     {
-        $value = $this->get($key);
+        $value = $this->get($key, $default);
 
         if (! is_array($value)) {
             throw new InvalidArgumentException(

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -180,6 +180,14 @@ class Repository implements ArrayAccess, ConfigContract
         $this->set($key, null);
     }
 
+
+    /**
+     * Get the specified configuration value typed as a string.
+     * If the value isn't a string it should throw an exception.
+     *
+     * @param  string  $key
+     * @return string
+     */
     public function string(string $key): string
     {
         $value = $this->get($key);
@@ -194,6 +202,10 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified configuration value typed as an array.
+     * If the value isn't an array it should throw an exception.
+     *
+     * @param  string  $key
      * @return array<array-key, mixed>
      */
     public function array(string $key): array
@@ -209,6 +221,14 @@ class Repository implements ArrayAccess, ConfigContract
         return $value;
     }
 
+
+    /**
+     * Get the specified configuration value typed as a boolean.
+     * If the value isn't a boolean it should throw an exception.
+     *
+     * @param  string  $key
+     * @return bool
+     */
     public function boolean(string $key): bool
     {
         $value = $this->get($key);
@@ -222,6 +242,13 @@ class Repository implements ArrayAccess, ConfigContract
         return $value;
     }
 
+    /**
+     * Get the specified configuration value typed as an integer.
+     * If the value isn't an integer it should throw an exception.
+     *
+     * @param  string  $key
+     * @return int
+     */
     public function integer(string $key): int
     {
         $value = $this->get($key);
@@ -235,6 +262,14 @@ class Repository implements ArrayAccess, ConfigContract
         return $value;
     }
 
+
+    /**
+     * Get the specified configuration value typed as a float.
+     * If the value isn't a float it should throw an exception.
+     *
+     * @param  string  $key
+     * @return float
+     */
     public function float(string $key): float
     {
         $value = $this->get($key);

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -54,34 +54,4 @@ interface Repository
      * @return void
      */
     public function push($key, $value);
-
-    /**
-     * Get the specified configuration value typed as a string.
-     * If the value isn't a string it should throw an exception.
-     */
-    public function string(string $key): string;
-
-    /**
-     * Get the specified configuration value typed as an array.
-     * If the value isn't an array it should throw an exception.
-     */
-    public function array(string $key): array;
-
-    /**
-     * Get the specified configuration value typed as an integer.
-     * If the value isn't an integer it should throw an exception.
-     */
-    public function integer(string $key): int;
-
-    /**
-     * Get the specified configuration value typed as a boolean.
-     * If the value isn't a boolean it should throw an exception.
-     */
-    public function boolean(string $key): bool;
-
-    /**
-     * Get the specified configuration value typed as a float.
-     * If the value isn't a float it should throw an exception.
-     */
-    public function float(string $key): float;
 }

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -54,4 +54,34 @@ interface Repository
      * @return void
      */
     public function push($key, $value);
+
+    /**
+     * Get the specified configuration value typed as a string.
+     * If the value isn't a string it should throw an exception.
+     */
+    public function string(string $key): string;
+
+    /**
+     * Get the specified configuration value typed as an array.
+     * If the value isn't an array it should throw an exception.
+     */
+    public function array(string $key): array;
+
+    /**
+     * Get the specified configuration value typed as an integer.
+     * If the value isn't an integer it should throw an exception.
+     */
+    public function integer(string $key): int;
+
+    /**
+     * Get the specified configuration value typed as a boolean.
+     * If the value isn't a boolean it should throw an exception.
+     */
+    public function boolean(string $key): bool;
+
+    /**
+     * Get the specified configuration value typed as a float.
+     * If the value isn't a float it should throw an exception.
+     */
+    public function float(string $key): float;
 }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
 use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
 
 class RepositoryTest extends TestCase
 {
@@ -25,6 +26,8 @@ class RepositoryTest extends TestCase
             'baz' => 'bat',
             'null' => null,
             'boolean' => true,
+            'integer' => 1,
+            'float' => 1.1,
             'associate' => [
                 'x' => 'xxx',
                 'y' => 'yyy',
@@ -251,5 +254,80 @@ class RepositoryTest extends TestCase
         });
 
         $this->assertSame('macroable', $this->repository->foo());
+    }
+
+    public function testItGetsAsString(): void
+    {
+        $this->assertSame(
+            $this->repository->string('a.b'), 'c'
+        );
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonStringValueAsString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[a\] must be a string, (.*) given.#');
+
+        $this->repository->string('a');
+    }
+
+    public function testItGetsAsArray(): void
+    {
+        $this->assertSame(
+            $this->repository->array('array'), ['aaa', 'zzz']
+        );
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonArrayValueAsArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an array, (.*) given.#');
+
+        $this->repository->array('a.b');
+    }
+
+    public function testItGetsAsBoolean(): void
+    {
+        $this->assertTrue(
+            $this->repository->boolean('boolean')
+        );
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonBooleanValueAsBoolean(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be a boolean, (.*) given.#');
+
+        $this->repository->boolean('a.b');
+    }
+
+    public function testItGetsAsInteger(): void
+    {
+        $this->assertSame(
+            $this->repository->integer('integer'), 1
+        );
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonIntegerValueAsInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an integer, (.*) given.#');
+
+        $this->repository->integer('a.b');
+    }
+
+    public function testItGetsAsFloat(): void
+    {
+        $this->assertSame(
+            $this->repository->float('float'), 1.1
+        );
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonFloatValueAsFloat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[a.b\] must be a float, (.*) given.#');
+
+        $this->repository->float('a.b');
     }
 }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Webmozart\Assert\InvalidArgumentException;
 
 class RepositoryTest extends TestCase
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi

I've been struggling sometimes with Laravel and Larastan on high levels (8 & 9 mostly). Indeed, the configuration helper `config` give values as `mixed` which requires annotation or assertion each time it is used to satisfy static analysis. It gives this kind of errors:
```
Parameter #1 $config of method Class::method() expects array, mixed given.
```

I think it can be great to have, like the `Request` object, typed getters, like `->string($key);`, `->integer($key);` etc.

This would make it much more easier to satisfy static analysis. Only array might be complaining sometimes.