### PR TITLE
[11.x] Fix undefined key "mysql" in DbCommand

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -130,7 +130,7 @@ class DbCommand extends Command
     public function getCommand(array $connection)
     {
         return [
-            'mysql' => 'mysql', 
+            'mysql' => 'mysql',
             'mariadb' => 'mysql',
             'pgsql' => 'psql',
             'sqlite' => 'sqlite3',

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -130,7 +130,8 @@ class DbCommand extends Command
     public function getCommand(array $connection)
     {
         return [
-            'mysql', 'mariadb' => 'mysql',
+            'mysql' => 'mysql', 
+            'mariadb' => 'mysql',
             'pgsql' => 'psql',
             'sqlite' => 'sqlite3',
             'sqlsrv' => 'sqlcmd',


### PR DESCRIPTION
This PR fixes an undefined array key when you use the MySQL connection in the `DbCommand` (`php artisan db --connection=mysql`). Assuming the `mysql` connection's `driver` is also set to `mysql`.

This was introduced in #50146.
