### PR TITLE
[10.x] Fix HasOneOrMany SQL bug when parent key not present

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -82,8 +82,11 @@ abstract class HasOneOrMany extends Relation
     {
         if (static::$constraints) {
             $query = $this->getRelationQuery();
+            $parentKey = $this->getParentKey();
 
-            $query->where($this->foreignKey, '=', $this->getParentKey());
+            if (! is_null($parentKey)) {
+                $query->where($this->foreignKey, '=', $parentKey);
+            }
 
             $query->whereNotNull($this->foreignKey);
         }


### PR DESCRIPTION
## Description 
When an Eloquent model is instantiated (and not retrieved from the database), accessing `hasMany` or `hasOne` relations result in SQL generated that doesn't make any sense, due to the parent key being null ie;
```
select * from `books` where `books`.`user_id` is null and `books`.`user_id` is not null
```
As you can see because user_id is null, the query becomes `user_id is null and user_id is not null`. This PR changes this behavior so that the generated query becomes:
```
select * from `books` where `books`.`user_id` is not null
```
which also from a logical perspective makes more sense than not returning any rows at all. 

In addition to that, warnings are generated by this SQL, which you can see in an explain;
```
mysql> explain select * from books where books.user_id is null and books.user_id is not null;
+----+-------------+-------+------------+------+---------------+------+---------+------+------+----------+------------------+
| id | select_type | table | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra            |
+----+-------------+-------+------------+------+---------------+------+---------+------+------+----------+------------------+
|  1 | SIMPLE      | NULL  | NULL       | NULL | NULL          | NULL | NULL    | NULL | NULL |     NULL | Impossible WHERE |
+----+-------------+-------+------------+------+---------------+------+---------+------+------+----------+------------------+
1 row in set, 1 warning (0.00 sec)
```
I think as a framework we should not be generating SQL that does not make sense and gives a warning.

## Discussion
Looking back through the PRs and issues I can see similar problems being referenced, but with different solutions.
For example #43948 which then references #8033
Also #36905  
But I want to stress that this PR is different, as it does not remove the `IS NULL` check, the focus is on removing the parent key check on freshly instantiated models. The behavior of models retrieved from the database is completely unchanged, which appears to be what those PRs are aiming to change.

Also, this is not a theoretical problem, a real world example I can give, and the reason why I stumbled across this issue in the first place, was because I noticed when using Filament I was unable to sort by a column that had a `->latestOfMany()`. After digging into it further I realized it's because the inner most query has this SQL which always returns no rows.

## Examples
```
   public function latestBook(): HasOne
    {
        return $this->hasOne(Book::class)->latestOfMany();
    }

    public function books(): HasMany
    {
        return $this->hasMany(Book::class);
    }
```
Example queries:
```
         // no change in behavior because parent key is set
         $user = User::find(1);
         dd($user->books()->toRawSql());
         // select * from `books` where `books`.`user_id` = 1 and `books`.`user_id` is not null
         
        // previous behavior (returns 0 results, generates warning)         
        $user = new User();
        dd($user->books()->toRawSql());
        // select * from `books` where `books`.`user_id` is null and `books`.`user_id` is not null

         // new behavior (returns all books where a user_id is set)
        $user = new User();
        dd($user->books()->toRawSql());
        // select * from `books` where `books`.`user_id` is not null
        
         // old behavior (returns no books, generates warning)
        $user = new User();
        dd(($user->latestBook())->toRawSql());
        // select `books`.* from `books` inner join (select MAX(`books`.`id`) as `id_aggregate`, `books`.`user_id` from `books` where `books`.`user_id` is null and `books`.`user_id` is not null group by `books`.`user_id`) as `latestOfMany` on `latestOfMany`.`id_aggregate` = `books`.`id` and `latestOfMany`.`user_id` = `books`.`user_id` where `books`.`user_id` is null and `books`.`user_id` is not null
        
        // new behavior (returns the latest book of all users, generates no warning, allows sorting of joined columns)
        $user = new User();
        dd(($user->latestBook())->toRawSql());
        // select `books`.* from `books` inner join (select MAX(`books`.`id`) as `id_aggregate`, `books`.`user_id` from `books` where `books`.`user_id` is not null group by `books`.`user_id`) as `latestOfMany` on `latestOfMany`.`id_aggregate` = `books`.`id` and `latestOfMany`.`user_id` = `books`.`user_id` where `books`.`user_id` is not null
        
```

If we agree that this is more logical and desirable behavior, but we do not want to risk merging it into `10.x` would you be open to merging it into `11.x`? Thanks for your time.

Also, any extra eyes on this to be sure I am not overlooking something is appreciated. I think the overall impact should be low as this changes only newly instantiated models and does not modify behavior of existing models.