### PR TITLE
[11.x] Fluhses the state of `VerifyCsrfToken`

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -230,4 +230,14 @@ class VerifyCsrfToken
     {
         return EncryptCookies::serialized('XSRF-TOKEN');
     }
+
+    /**
+     * Flush the state of the middleware.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$neverVerify = [];
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
@@ -174,6 +175,7 @@ trait InteractsWithTestCaseLifecycle
         TrimStrings::flushState();
         TrustProxies::flushState();
         TrustHosts::flushState();
+        ValidateCsrfToken::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;


### PR DESCRIPTION
While working on https://github.com/laravel/framework/pull/50127, I've noticed that we forgot to flush this particular middleware.