### PR TITLE
[11.x] Remove workaround for MariaDB integration tests

### DIFF
--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -32,10 +32,5 @@ abstract class DatabaseTestCase extends TestCase
         $connection = $app['config']->get('database.default');
 
         $this->driver = $app['config']->get("database.connections.$connection.driver");
-
-        // TODO: Adjust orchestra/testbench-core/laravel/config/database.php
-        if ($connection === 'mariadb') {
-            $this->driver = 'mariadb';
-        }
     }
 }


### PR DESCRIPTION
The workaround from #50146 is longer necessary after the Testbench config got adjusted (https://github.com/orchestral/testbench-core/pull/190).