### PR TITLE
[11.x] Add support for non-primary auto-increment column

### DIFF
--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -365,7 +365,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+        $this->assertSame('alter table `users` add unique `bar` (`foo`)', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -375,7 +375,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
+        $this->assertSame('alter table `users` add index `baz` (`foo`, `bar`)', $statements[0]);
     }
 
     public function testAddingIndexWithAlgorithm()
@@ -395,7 +395,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add fulltext `users_body_fulltext`(`body`)', $statements[0]);
+        $this->assertSame('alter table `users` add fulltext `users_body_fulltext` (`body`)', $statements[0]);
     }
 
     public function testAddingSpatialIndex()
@@ -405,7 +405,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
+        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex` (`coordinates`)', $statements[0]);
     }
 
     public function testAddingFluentSpatialIndex()
@@ -415,7 +415,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
+        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex` (`coordinates`)', $statements[1]);
     }
 
     public function testAddingRawIndex()
@@ -425,7 +425,48 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add index `raw_index`((function(column)))', $statements[0]);
+        $this->assertSame('alter table `users` add index `raw_index` ((function(column)))', $statements[0]);
+    }
+
+    public function testAddingIndexesOnCreate()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->integer('col1');
+        $blueprint->integer('col2');
+        $blueprint->integer('col3');
+        $blueprint->string('col4');
+        $blueprint->geometry('col5');
+        $blueprint->primary('col1');
+        $blueprint->unique('col2');
+        $blueprint->index('col3');
+        $blueprint->fullText('col4');
+        $blueprint->spatialIndex('col5');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertEquals(['create table `users` (`col1` int not null, `col2` int not null, `col3` int not null, `col4` varchar(255) not null, `col5` geometry not null, index `users_col3_index` (`col3`), fulltext `users_col4_fulltext` (`col4`), spatial index `users_col5_spatialindex` (`col5`), primary key (`col1`), unique `users_col2_unique` (`col2`))'], $statements);
+    }
+
+    public function testFluentAddingIndexesOnCreate()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->integer('col1')->primary();
+        $blueprint->integer('col2')->unique();
+        $blueprint->integer('col3')->index();
+        $blueprint->string('col4')->fulltext();
+        $blueprint->geometry('col5')->spatialIndex();
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertEquals(['create table `users` (`col1` int not null, `col2` int not null, `col3` int not null, `col4` varchar(255) not null, `col5` geometry not null, index `users_col3_index` (`col3`), fulltext `users_col4_fulltext` (`col4`), spatial index `users_col5_spatialindex` (`col5`), primary key (`col1`), unique `users_col2_unique` (`col2`))'], $statements);
     }
 
     public function testAddingForeignKey()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -278,7 +278,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) not null, add `commentable_id` bigint unsigned not null',
-            'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
+            'alter table `comments` add index `comments_commentable_type_commentable_id_index` (`commentable_type`, `commentable_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -294,7 +294,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) null, add `commentable_id` bigint unsigned null',
-            'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
+            'alter table `comments` add index `comments_commentable_type_commentable_id_index` (`commentable_type`, `commentable_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -312,7 +312,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) not null, add `commentable_id` char(36) not null',
-            'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
+            'alter table `comments` add index `comments_commentable_type_commentable_id_index` (`commentable_type`, `commentable_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -330,7 +330,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) null, add `commentable_id` char(36) null',
-            'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
+            'alter table `comments` add index `comments_commentable_type_commentable_id_index` (`commentable_type`, `commentable_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -348,7 +348,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) not null, add `commentable_id` char(26) not null',
-            'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
+            'alter table `comments` add index `comments_commentable_type_commentable_id_index` (`commentable_type`, `commentable_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -366,7 +366,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) null, add `commentable_id` char(26) null',
-            'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
+            'alter table `comments` add index `comments_commentable_type_commentable_id_index` (`commentable_type`, `commentable_id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 

--- a/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBlueprintTest.php
@@ -406,7 +406,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $expected = [
             'alter table `users` modify `name` varchar(255) null',
-            'alter table `users` add unique `users_name_unique`(`name`)',
+            'alter table `users` add unique `users_name_unique` (`name`)',
         ];
 
         $this->assertEquals($expected, $queries);
@@ -470,7 +470,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $expected = [
             'alter table `users` modify `name` varchar(255) null',
-            'alter table `users` add unique `index1`(`name`)',
+            'alter table `users` add unique `index1` (`name`)',
         ];
 
         $this->assertEquals($expected, $queries);

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -148,6 +148,23 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertTrue(Schema::hasIndex('test', ['id', 'uuid'], 'primary'));
     }
 
+    public function testNonPrimaryAutoIncrementColumn()
+    {
+        if ($this->driver === 'sqlite') {
+            $this->markTestSkipped('non-primary auto-increment column is not supported on SQLite.');
+        }
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->uuid()->primary();
+            $table->id()->unique();
+        });
+
+        $this->assertTrue(collect(Schema::getColumns('test'))->firstWhere('name', 'id')['auto_increment']);
+        $this->assertTrue(Schema::hasIndex('test', ['uuid'], 'primary'));
+        $this->assertTrue(Schema::hasIndex('test', ['id'], 'unique'));
+        $this->assertTrue(Schema::hasIndex('test', 'test_id_unique', 'unique'));
+    }
+
     public function testModifyingAutoIncrementColumn()
     {
         if ($this->driver === 'sqlsrv') {


### PR DESCRIPTION
In addition to #49925, all databases except SQLite support creating a table with a non-primary auto-increment column. This wasn't supported on Laravel for MySQL and MariaDB, as MySQL needs an auto-increment column to be defined as key (i.e have index), so after this PR you can:

```php
Schema::create('test', function (Blueprint $table) {
    $table->uuid()->primary();
    $table->bigIncrements('code')->index();
});

// create table `test` (`uuid` char(36) not null, `code` bigint unsigned not null auto_increment, index `users_id_index` (`code`), primary key (`uuid`))
```

or using unique index like this:

```php
Schema::create('test', function (Blueprint $table) {
    $table->uuid()->primary();
    $table->bigIncrements('code')->unique();
});

// create table `test` (`uuid` char(36) not null, `code` bigint unsigned not null auto_increment, primary key (`uuid`), unique `users_id_unique` (`code`))
```

PS 1: The order of compiling indexes is based on [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/create-table.html#:~:text=create_definition%3A%20%7B%0A%20%20%20%20col_name,%7C%20check_constraint_definition%0A%7D).
PS 2: No upgrade guide entry is needed for this as everything works as before.

