### PR TITLE
[10.x] Simplify how providers are registered in Illuminate\Foundation\Application

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -757,12 +757,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function registerConfiguredProviders()
     {
         $providers = Collection::make($this->make('config')->get('app.providers'))
-                        ->partition(fn ($provider) => str_starts_with($provider, 'Illuminate\\'));
+            ->merge($this->make(PackageManifest::class)->providers())
+            ->toArray();
 
-        $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);
-
-        (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load($providers->collapse()->toArray());
+        (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))->load($providers);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# Description
There are 2 actions that seem to happen which happen for no reason. See the current flow: 

- The providers array is first split into App and Service providers
```php
^ Illuminate\Support\Collection^ {
  #items: array:2 [
    0 => Illuminate\Support\Collection^ {
      #items: array:22 [
        0 => "Illuminate\Auth\AuthServiceProvider"
        1 => "Illuminate\Broadcasting\BroadcastServiceProvider"
        2 => "Illuminate\Bus\BusServiceProvider"
        3 => "Illuminate\Cache\CacheServiceProvider"
        4 => "Illuminate\Foundation\Providers\ConsoleSupportServiceProvider"
        5 => "Illuminate\Cookie\CookieServiceProvider"
        6 => "Illuminate\Database\DatabaseServiceProvider"
        7 => "Illuminate\Encryption\EncryptionServiceProvider"
        8 => "Illuminate\Filesystem\FilesystemServiceProvider"
        9 => "Illuminate\Foundation\Providers\FoundationServiceProvider"
        10 => "Illuminate\Hashing\HashServiceProvider"
        11 => "Illuminate\Mail\MailServiceProvider"
        12 => "Illuminate\Notifications\NotificationServiceProvider"
        13 => "Illuminate\Pagination\PaginationServiceProvider"
        14 => "Illuminate\Pipeline\PipelineServiceProvider"
        15 => "Illuminate\Queue\QueueServiceProvider"
        16 => "Illuminate\Redis\RedisServiceProvider"
        17 => "Illuminate\Auth\Passwords\PasswordResetServiceProvider"
        18 => "Illuminate\Session\SessionServiceProvider"
        19 => "Illuminate\Translation\TranslationServiceProvider"
        20 => "Illuminate\Validation\ValidationServiceProvider"
        21 => "Illuminate\View\ViewServiceProvider"
      ]
      #escapeWhenCastingToString: false
    }
    1 => Illuminate\Support\Collection^ {
      #items: array:5 [
        23 => "App\Providers\AppServiceProvider"
        24 => "App\Providers\AuthServiceProvider"
        25 => "App\Providers\BroadcastServiceProvider"
        26 => "App\Providers\EventServiceProvider"
        27 => "App\Providers\RouteServiceProvider"
      ]
      #escapeWhenCastingToString: false
    }
  ]
  #escapeWhenCastingToString: false
}
```
- Package providers are added to them 
```php
^ Illuminate\Support\Collection^ {
  #items: array:3 [
    0 => Illuminate\Support\Collection^ {
      #items: array:22 [
        0 => "Illuminate\Auth\AuthServiceProvider"
        1 => "Illuminate\Broadcasting\BroadcastServiceProvider"
        2 => "Illuminate\Bus\BusServiceProvider"
        3 => "Illuminate\Cache\CacheServiceProvider"
        4 => "Illuminate\Foundation\Providers\ConsoleSupportServiceProvider"
        5 => "Illuminate\Cookie\CookieServiceProvider"
        6 => "Illuminate\Database\DatabaseServiceProvider"
        7 => "Illuminate\Encryption\EncryptionServiceProvider"
        8 => "Illuminate\Filesystem\FilesystemServiceProvider"
        9 => "Illuminate\Foundation\Providers\FoundationServiceProvider"
        10 => "Illuminate\Hashing\HashServiceProvider"
        11 => "Illuminate\Mail\MailServiceProvider"
        12 => "Illuminate\Notifications\NotificationServiceProvider"
        13 => "Illuminate\Pagination\PaginationServiceProvider"
        14 => "Illuminate\Pipeline\PipelineServiceProvider"
        15 => "Illuminate\Queue\QueueServiceProvider"
        16 => "Illuminate\Redis\RedisServiceProvider"
        17 => "Illuminate\Auth\Passwords\PasswordResetServiceProvider"
        18 => "Illuminate\Session\SessionServiceProvider"
        19 => "Illuminate\Translation\TranslationServiceProvider"
        20 => "Illuminate\Validation\ValidationServiceProvider"
        21 => "Illuminate\View\ViewServiceProvider"
      ]
      #escapeWhenCastingToString: false
    }
    1 => array:13 [
      0 => "BeyondCode\LaravelWebSockets\WebSocketsServiceProvider"
      1 => "Enlightn\Enlightn\EnlightnServiceProvider"
      2 => "Facade\Ignition\IgnitionServiceProvider"
      3 => "Fideloper\Proxy\TrustedProxyServiceProvider"
      4 => "Fruitcake\Cors\CorsServiceProvider"
      5 => "Laravel\Horizon\HorizonServiceProvider"
      6 => "Laravel\Sail\SailServiceProvider"
      7 => "Laravel\Telescope\TelescopeServiceProvider"
      8 => "Laravel\Tinker\TinkerServiceProvider"
      9 => "Maatwebsite\Excel\ExcelServiceProvider"
      10 => "Carbon\Laravel\ServiceProvider"
      11 => "NunoMaduro\Collision\Adapters\Laravel\CollisionServiceProvider"
      12 => "SqlsrvErrAvoid\SqlsrvErrAvoidServiceProvider"
    ]
    2 => Illuminate\Support\Collection^ {
      #items: array:5 [
        23 => "App\Providers\AppServiceProvider"
        24 => "App\Providers\AuthServiceProvider"
        25 => "App\Providers\BroadcastServiceProvider"
        26 => "App\Providers\EventServiceProvider"
        27 => "App\Providers\RouteServiceProvider"
      ]
      #escapeWhenCastingToString: false
    }
  ]
  #escapeWhenCastingToString: false
}
```
- The entire array is collapsed
```php
 array:43 [
    0 => "Illuminate\Auth\AuthServiceProvider"
    1 => "Illuminate\Broadcasting\BroadcastServiceProvider"
    2 => "Illuminate\Bus\BusServiceProvider"
    3 => "Illuminate\Cache\CacheServiceProvider"
    4 => "Illuminate\Foundation\Providers\ConsoleSupportServiceProvider"
    5 => "Illuminate\Cookie\CookieServiceProvider"
    6 => "Illuminate\Database\DatabaseServiceProvider"
    7 => "Illuminate\Encryption\EncryptionServiceProvider"
    8 => "Illuminate\Filesystem\FilesystemServiceProvider"
    9 => "Illuminate\Foundation\Providers\FoundationServiceProvider"
    10 => "Illuminate\Hashing\HashServiceProvider"
    11 => "Illuminate\Mail\MailServiceProvider"
    12 => "Illuminate\Notifications\NotificationServiceProvider"
    13 => "Illuminate\Pagination\PaginationServiceProvider"
    14 => "Illuminate\Pipeline\PipelineServiceProvider"
    15 => "Illuminate\Queue\QueueServiceProvider"
    16 => "Illuminate\Redis\RedisServiceProvider"
    17 => "Illuminate\Auth\Passwords\PasswordResetServiceProvider"
    18 => "Illuminate\Session\SessionServiceProvider"
    19 => "Illuminate\Translation\TranslationServiceProvider"
    20 => "Illuminate\Validation\ValidationServiceProvider"
    21 => "Illuminate\View\ViewServiceProvider"
    23 => "App\Providers\AppServiceProvider"
    24 => "App\Providers\AuthServiceProvider"
    25 => "App\Providers\BroadcastServiceProvider"
    26 => "App\Providers\EventServiceProvider"
    27 => "App\Providers\RouteServiceProvider"
    30 => "BeyondCode\LaravelWebSockets\WebSocketsServiceProvider"
    31 => "Enlightn\Enlightn\EnlightnServiceProvider"
    32 => "Facade\Ignition\IgnitionServiceProvider"
    33 => "Fideloper\Proxy\TrustedProxyServiceProvider"
    34 => "Fruitcake\Cors\CorsServiceProvider"
    35 => "Laravel\Horizon\HorizonServiceProvider"
    36 => "Laravel\Sail\SailServiceProvider"
    37 => "Laravel\Telescope\TelescopeServiceProvider"
    38 => "Laravel\Tinker\TinkerServiceProvider"
    39 => "Maatwebsite\Excel\ExcelServiceProvider"
    40 => "Carbon\Laravel\ServiceProvider"
    41 => "NunoMaduro\Collision\Adapters\Laravel\CollisionServiceProvider"
    42 => "SqlsrvErrAvoid\SqlsrvErrAvoidServiceProvider"
  ]
```
 
Instead of doing it in multiple steps, we can simplify the syntax by simply not splitting them anymore and merging them at the beginning. 

Therefore, instead of doing a `split`, `splice` and `collapse` we can simplify merge and convert it to an `array`:

```php
$providers = Collection::make($this->make('config')->get('app.providers'))
    ->merge($this->make(PackageManifest::class)->providers())
    ->toArray();
```

Which results in the same outcome. 
