### PR TITLE
[11.x] Allows to disable `vendor:publish` updating migrations date

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -410,6 +410,6 @@ class VendorPublishCommand extends Command
      */
     public static function flushState()
     {
-        static::$updateMigrationDate = true;
+        static::$updateMigrationsDate = true;
     }
 }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -394,7 +394,7 @@ class VendorPublishCommand extends Command
     }
 
     /**
-     * Intructs the command to not update the dates on migrations when publishing.
+     * Intruct the command to not update the dates on migrations when publishing.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -69,6 +69,13 @@ class VendorPublishCommand extends Command
     protected $description = 'Publish any publishable assets from vendor packages';
 
     /**
+     * Indicates if the migrations date should be updated.
+     *
+     * @var bool
+     */
+    protected static $updateMigrationsDate = true;
+
+    /**
      * Create a new command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -341,6 +348,10 @@ class VendorPublishCommand extends Command
      */
     protected function ensureMigrationNameIsUpToDate($from, $to)
     {
+        if (static::$updateMigrationsDate === false) {
+            return $to;
+        }
+
         $from = realpath($from);
 
         foreach (ServiceProvider::publishableMigrationPaths() as $path) {
@@ -380,5 +391,25 @@ class VendorPublishCommand extends Command
             $from,
             $to,
         ));
+    }
+
+    /**
+     * Intructs the command to not update the migrations date on publish.
+     *
+     * @return void
+     */
+    public static function dontUpdateMigrationsDate()
+    {
+        static::$updateMigrationsDate = false;
+    }
+
+    /**
+     * Flush the global state of the command.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$updateMigrationDate = true;
     }
 }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -69,7 +69,7 @@ class VendorPublishCommand extends Command
     protected $description = 'Publish any publishable assets from vendor packages';
 
     /**
-     * Indicates if the migrations date should be updated.
+     * Indicates if migration dates should be updated while publishing.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -73,7 +73,7 @@ class VendorPublishCommand extends Command
      *
      * @var bool
      */
-    protected static $updateMigrationsDate = true;
+    protected static $updateMigrationDates = true;
 
     /**
      * Create a new command instance.
@@ -348,7 +348,7 @@ class VendorPublishCommand extends Command
      */
     protected function ensureMigrationNameIsUpToDate($from, $to)
     {
-        if (static::$updateMigrationsDate === false) {
+        if (static::$updateMigrationDates === false) {
             return $to;
         }
 
@@ -394,22 +394,12 @@ class VendorPublishCommand extends Command
     }
 
     /**
-     * Intructs the command to not update the migrations date on publish.
+     * Intructs the command to not update the dates on migrations when publishing.
      *
      * @return void
      */
-    public static function dontUpdateMigrationsDate()
+    public static function dontUpdateMigrationDates()
     {
-        static::$updateMigrationsDate = false;
-    }
-
-    /**
-     * Flush the global state of the command.
-     *
-     * @return void
-     */
-    public static function flushState()
-    {
-        static::$updateMigrationsDate = true;
+        static::$updateMigrationDates = false;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
-use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
@@ -177,7 +176,6 @@ trait InteractsWithTestCaseLifecycle
         TrustProxies::flushState();
         TrustHosts::flushState();
         ValidateCsrfToken::flushState();
-        VendorPublishCommand::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
@@ -176,6 +177,7 @@ trait InteractsWithTestCaseLifecycle
         TrustProxies::flushState();
         TrustHosts::flushState();
         ValidateCsrfToken::flushState();
+        VendorPublishCommand::flushState();
 
         if ($this->callbackException) {
             throw $this->callbackException;


### PR DESCRIPTION
Allows statically disable `vendor:publish` of updating migrations date.