### PR TITLE
Fix typehint for ResetPassword::toMailUsing()

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -25,7 +25,7 @@ class ResetPassword extends Notification
     /**
      * The callback that should be used to build the mail message.
      *
-     * @var (\Closure(mixed, string): \Illuminate\Notifications\Messages\MailMessage)|null
+     * @var (\Closure(mixed, string): \Illuminate\Notifications\Messages\MailMessage|\Illuminate\Contracts\Mail\Mailable)|null
      */
     public static $toMailCallback;
 
@@ -114,7 +114,7 @@ class ResetPassword extends Notification
     /**
      * Set a callback that should be used when building the notification mail message.
      *
-     * @param  \Closure(mixed, string): \Illuminate\Notifications\Messages\MailMessage  $callback
+     * @param  \Closure(mixed, string): (\Illuminate\Notifications\Messages\MailMessage|\Illuminate\Contracts\Mail\Mailable)  $callback
      * @return void
      */
     public static function toMailUsing($callback)


### PR DESCRIPTION
The type hint the `$callback` parameter in `ResetPassword::toMailUsing()` seems to be too narrow - it declares that the Closure must return an instance of `MailMessage` and nothing else. However an instance of `Mailable` is perfectly acceptable in this case as it goes through `MailChannel::send()` which has a special case for `$message instanceof Mailable`.

This triggers the following error eg. in phpstan:
```
Parameter #1 $callback of static method Illuminate\Auth\Notifications\ResetPassword::toMailUsing() expects Closure(mixed, string): Illuminate\Notifications\Messages\MailMessage, Closure(mixed, mixed): App\Mail\ResetPassword given.
```

I believe the type hint should be corrected to include `Mailable` as an acceptable Closure return type.