### PR TITLE
[10.x] Fix Process::fake() never matching multi-line commands

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -348,7 +348,7 @@ class PendingProcess
     protected function fakeFor(string $command)
     {
         return collect($this->fakeHandlers)
-                ->first(fn ($handler, $pattern) => Str::is($pattern, $command));
+                ->first(fn ($handler, $pattern) => $pattern === '*' || Str::is($pattern, $command));
     }
 
     /**

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -148,6 +148,26 @@ class ProcessTest extends TestCase
         $this->assertTrue($result->successful());
     }
 
+    public function testBasicProcessFakeWithMultiLineCommand()
+    {
+        $factory = new Factory;
+
+        $factory->preventStrayProcesses();
+
+        $factory->fake([
+            '*' => 'The output',
+        ]);
+
+        $result = $factory->run(<<<'COMMAND'
+        git clone --depth 1 \
+              --single-branch \
+              --branch main \
+              git://some-url .
+        COMMAND);
+
+        $this->assertSame(0, $result->exitCode());
+    }
+
     public function testProcessFakeExitCodes()
     {
         $factory = new Factory;


### PR DESCRIPTION
It is currently impossible to use patterns with `Process::fake()` to match a multi-line command. For example:

```php
$result = Process::run(<<<BASH
git clone --depth 1 \
      --single-branch \
      --branch main \
      git://some-url .
BASH);
```

```php
Process::preventStrayProcesses();

Process::fake(['*' => 'faked output']);
```

The test above will always throw an "Attempted process without a matching fake" exception. This is because the pattern is matched using `Str::is()`, and `Str::is()` always returns false for multi-line strings (the regex it uses doesn't have the `m` option). 

This PR is only a partial fix, using any pattern that isn't `*` (like `git clone*` for example) still won't work if the command has multiple lines. 

I'm not sure what the best approach for a proper fix is. I assume modifying `Str::is()` isn't an option.

I know it isn't ideal that this PR isn't a proper fix, but this change at least makes it possible to test multi-line commands. I'm currently resorting to monkey patching the `PendingProcess` file in the vendor directory. I could re-write my commands to not be multi-line, but some of them are pretty long so I'd rather not do that.

Related issue: https://github.com/laravel/framework/issues/50158
