### PR TITLE
[11.x] The health route should be loaded even when there is a model binding at the root

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -171,6 +171,14 @@ class ApplicationBuilder
                 Route::middleware('api')->prefix($apiPrefix)->group($api);
             }
 
+            if (is_string($health)) {
+                Route::middleware('web')->get($health, function () {
+                    Event::dispatch(new DiagnosingHealth);
+
+                    return View::file(__DIR__.'/../resources/health-up.blade.php');
+                });
+            }
+
             if (is_string($web) && realpath($web) !== false) {
                 Route::middleware('web')->group($web);
             }
@@ -179,14 +187,6 @@ class ApplicationBuilder
                 realpath($pages) !== false &&
                 class_exists(Folio::class)) {
                 Folio::route($pages, middleware: $this->pageMiddleware);
-            }
-
-            if (is_string($health)) {
-                Route::middleware('web')->get($health, function () {
-                    Event::dispatch(new DiagnosingHealth);
-
-                    return View::file(__DIR__.'/../resources/health-up.blade.php');
-                });
             }
 
             if (is_callable($then)) {

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -32,4 +32,3 @@ class RouteServiceProviderHealthTest extends TestCase
         $this->get('/up')->assertOk();
     }
 }
-

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Support\Providers;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
+
+class RouteServiceProviderHealthTest extends TestCase
+{
+    /**
+     * Resolve application implementation.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    protected function resolveApplication()
+    {
+        return Application::configure(static::applicationBasePath())
+            ->withRouting(
+                web: __DIR__.'/fixtures/web.php',
+                health: '/up',
+            )->create();
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('app.key', Str::random(32));
+    }
+
+    public function test_it_can_load_health_page()
+    {
+        $this->get('/up')->assertOk();
+    }
+}
+

--- a/tests/Integration/Foundation/Support/Providers/fixtures/web.php
+++ b/tests/Integration/Foundation/Support/Providers/fixtures/web.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/{user}', fn () => response('', 404));


### PR DESCRIPTION
This PR makes sure the `health` endpoint loads even if there is a model binding on the root:

## Example

```php
// routes/web.php

use Illuminate\Support\Facades\Route;

Route::get('/{user}', fn () => response('', 404));
```

before this PR it will load the `/{user}` route before the `health`.