### PR TITLE
[10.x] Added passing loaded relationship to value callback

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -266,15 +266,17 @@ trait ConditionallyLoadsAttributes
             return value($default);
         }
 
+        $loadedValue = $this->resource->{$relationship};
+
         if (func_num_args() === 1) {
-            return $this->resource->{$relationship};
+            return $loadedValue;
         }
 
-        if ($this->resource->{$relationship} === null) {
+        if ($loadedValue === null) {
             return;
         }
 
-        return value($value);
+        return value($value, $loadedValue);
     }
 
     /**


### PR DESCRIPTION
It allows use something like:
```php
'owners' => $this->whenLoaded('owners', ClientMemberResource::collection(...)),
'answer' => $this->whenLoaded('answer', AnswersResource::make(...)),
```
instead
```php
'owners' => $this->whenLoaded('owners', fn() => ClientMemberResource::collection($this->resource->owners)),
'answer' => $this->whenLoaded('answer', fn() => AnswersResource::make($this->resource->answer)),
```
