### PR TITLE
[10.x] Fix optional charset and collation when creating database

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -43,6 +43,16 @@ class MySqlGrammar extends Grammar
      */
     public function compileCreateDatabase($name, $connection)
     {
+        $charset = $connection->getConfig('charset');
+        $collation = $connection->getConfig('collation');
+
+        if (!$charset || !$collation) {
+            return sprintf(
+                'create database %s',
+                $this->wrapValue($name),
+            );
+        }
+
         return sprintf(
             'create database %s default character set %s default collate %s',
             $this->wrapValue($name),

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -56,8 +56,8 @@ class MySqlGrammar extends Grammar
         return sprintf(
             'create database %s default character set %s default collate %s',
             $this->wrapValue($name),
-            $this->wrapValue($connection->getConfig('charset')),
-            $this->wrapValue($connection->getConfig('collation')),
+            $this->wrapValue($charset),
+            $this->wrapValue($collation),
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -46,7 +46,7 @@ class MySqlGrammar extends Grammar
         $charset = $connection->getConfig('charset');
         $collation = $connection->getConfig('collation');
 
-        if (!$charset || !$collation) {
+        if (! $charset || ! $collation) {
             return sprintf(
                 'create database %s',
                 $this->wrapValue($name),


### PR DESCRIPTION
It is permitted to set the `charset` and `collation` to `null` in the database config, which will use the MySQL server defaults without sending a `SET` while setting up the connection. However, the `MySqlGrammar` grammar incorrectly assumes these are set. I propose we allow the server to choose if there's no explicit config.