### PR TITLE
[10.x] Arr::select not working when $keys is a string

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -516,9 +516,7 @@ class Arr
      */
     public static function select($array, $keys)
     {
-        if (is_string($keys)) {
-            $keys = [$keys];
-        }
+        $keys = static::wrap($keys);
         
         return static::map($array, function ($item) use ($keys) {
             $result = [];

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -516,6 +516,10 @@ class Arr
      */
     public static function select($array, $keys)
     {
+        if (is_string($keys)) {
+            $keys = [$keys];
+        }
+        
         return static::map($array, function ($item) use ($keys) {
             $result = [];
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1273,4 +1273,40 @@ class SupportArrTest extends TestCase
             4, 5, 6,
         ], Arr::take($array, -3));
     }
+
+    public function testSelect()
+    {
+        $array = [
+            [
+                'name' => 'Taylor',
+                'role' => 'Developer',
+                'age' => 1,
+            ],
+            [
+                'name' => 'Abigail',
+                'role' => 'Infrastructure',
+                'age' => 2,
+            ],
+        ];
+
+        $this->assertEquals([
+            [
+                'name' => 'Taylor',
+                'age' => 1,
+            ],
+            [
+                'name' => 'Abigail',
+                'age' => 2,
+            ],
+        ], Arr::select($array, ['name', 'age']));
+
+        $this->assertEquals([
+            [
+                'name' => 'Taylor',
+            ],
+            [
+                'name' => 'Abigail',
+            ],
+        ], Arr::select($array, 'name'));
+    }
 }


### PR DESCRIPTION
Adding a check about $keys as a string.

If it is a string, transform it into an array.

Function documentation says string is a valid type for $keys 

