### PR TITLE
[10.x] Ensure lazy-loading for trashed morphTo relations works

### DIFF
--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -95,6 +95,21 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertTrue($action[1]->relationLoaded('target'));
         $this->assertInstanceOf(User::class, $action[1]->getRelation('target'));
     }
+
+    public function testMorphWithTrashedRelationLazyLoading()
+    {
+        $deletedUser = User::forceCreate(['deleted_at' => now()]);
+
+        $action = new Action;
+        $action->target()->associate($deletedUser)->save();
+
+        // model is already set via associate and not retrieved from the database
+        $this->assertInstanceOf(User::class, $action->target);
+
+        $action->unsetRelation('target');
+
+        $this->assertInstanceOf(User::class, $action->target);
+    }
 }
 
 class Action extends Model


### PR DESCRIPTION
Since #50124 its no longer possible to lazy-load **trashed** `morphTo` relations.

Once the `Conditionable` trait is removed from the [Relation](https://github.com/DarkGhostHunter/framework/blob/ed378e06b82101666f6606597255a2c765be5ab4/src/Illuminate/Database/Eloquent/Relations/Relation.php) class all works fine.

This PR covers this scenario with a test.