### PR TITLE
[11.x] Unserialize collection with relations

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -78,7 +78,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collection = $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->get();
+        )->useWritePdo()->get()->load($value->relations ?? []);
 
         if (is_a($value->class, Pivot::class, true) ||
             in_array(AsPivot::class, class_uses($value->class))) {


### PR DESCRIPTION
I am not sure if this is like this for purpose or not, but collection is serialized with relations, but the relations are not retrieved when collection is restored.