### PR TITLE
[10.x] Add support for SI and IEC binary prefixes to Number::fileSize function

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -130,14 +130,21 @@ class Number
      * @param  int|float  $bytes
      * @param  int  $precision
      * @param  int|null  $maxPrecision
+     * @param  bool $useSiUnits
      * @return string
      */
-    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
+    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, ?bool $useSiUnits = false)
     {
-        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-
-        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
-            $bytes /= 1024;
+        if ($useSiUnits) {
+            $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+            $divisor = 1000;
+        } else {
+            $units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+            $divisor = 1024;
+        }
+        
+        for ($i = 0; ($bytes / $divisor) > 0.9 && ($i < count($units) - 1); $i++) {
+            $bytes /= $divisor;
         }
 
         return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision), $units[$i]);

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -130,7 +130,7 @@ class Number
      * @param  int|float  $bytes
      * @param  int  $precision
      * @param  int|null  $maxPrecision
-     * @param  bool $useSiUnits
+     * @param  bool  $useSiUnits
      * @return string
      */
     public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, ?bool $useSiUnits = false)
@@ -142,7 +142,7 @@ class Number
             $units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
             $divisor = 1024;
         }
-        
+
         for ($i = 0; ($bytes / $divisor) > 0.9 && ($i < count($units) - 1); $i++) {
             $bytes /= $divisor;
         }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -159,18 +159,34 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0 B', Number::fileSize(0));
         $this->assertSame('0.00 B', Number::fileSize(0, precision: 2));
         $this->assertSame('1 B', Number::fileSize(1));
-        $this->assertSame('1 KB', Number::fileSize(1024));
-        $this->assertSame('2 KB', Number::fileSize(2048));
-        $this->assertSame('2.00 KB', Number::fileSize(2048, precision: 2));
-        $this->assertSame('1.23 KB', Number::fileSize(1264, precision: 2));
-        $this->assertSame('1.234 KB', Number::fileSize(1264.12345, maxPrecision: 3));
-        $this->assertSame('1.234 KB', Number::fileSize(1264, 3));
-        $this->assertSame('5 GB', Number::fileSize(1024 * 1024 * 1024 * 5));
-        $this->assertSame('10 TB', Number::fileSize((1024 ** 4) * 10));
-        $this->assertSame('10 PB', Number::fileSize((1024 ** 5) * 10));
-        $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
-        $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
-        $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+        $this->assertSame('1 KiB', Number::fileSize(1024));
+        $this->assertSame('2 KiB', Number::fileSize(2048));
+        $this->assertSame('2.00 KiB', Number::fileSize(2048, precision: 2));
+        $this->assertSame('1.23 KiB', Number::fileSize(1264, precision: 2));
+        $this->assertSame('1.234 KiB', Number::fileSize(1264.12345, maxPrecision: 3));
+        $this->assertSame('1.234 KiB', Number::fileSize(1264, 3));
+        $this->assertSame('5 GiB', Number::fileSize(1024 * 1024 * 1024 * 5));
+        $this->assertSame('10 TiB', Number::fileSize((1024 ** 4) * 10));
+        $this->assertSame('10 PiB', Number::fileSize((1024 ** 5) * 10));
+        $this->assertSame('1 ZiB', Number::fileSize(1024 ** 7));
+        $this->assertSame('1 YiB', Number::fileSize(1024 ** 8));
+        $this->assertSame('1,024 YiB', Number::fileSize(1024 ** 9));
+
+        $this->assertSame('0 B', Number::fileSize(0, useSiUnits: true));
+        $this->assertSame('0.00 B', Number::fileSize(0, precision: 2, useSiUnits: true));
+        $this->assertSame('1 B', Number::fileSize(1, useSiUnits: true));
+        $this->assertSame('1 KB', Number::fileSize(1000, useSiUnits: true));
+        $this->assertSame('2 KB', Number::fileSize(2000, useSiUnits: true));
+        $this->assertSame('2.05 KB', Number::fileSize(2048, precision: 2, useSiUnits: true));
+        $this->assertSame('1.26 KB', Number::fileSize(1264, precision: 2, useSiUnits: true));
+        $this->assertSame('1.264 KB', Number::fileSize(1264.12345, maxPrecision: 3, useSiUnits: true));
+        $this->assertSame('1.264 KB', Number::fileSize(1264, 3, useSiUnits: true));
+        $this->assertSame('5 GB', Number::fileSize(1000 * 1000 * 1000 * 5, useSiUnits: true));
+        $this->assertSame('10 TB', Number::fileSize((1000 ** 4) * 10, useSiUnits: true));
+        $this->assertSame('10 PB', Number::fileSize((1000 ** 5) * 10, useSiUnits: true));
+        $this->assertSame('1 ZB', Number::fileSize(1000 ** 7, useSiUnits: true));
+        $this->assertSame('1 YB', Number::fileSize(1000 ** 8, useSiUnits: true));
+        $this->assertSame('1,238 YB', Number::fileSize(1024 ** 9, useSiUnits: true));
     }
 
     public function testClamp()


### PR DESCRIPTION
The current `Number::fileSize` function uses SI prefixes (KB, MB, GB...) but is dividing by 1024 instead of 1000.
The IEC defined a standard (in 2009) to help differentiate decimal prefixes from binary prefixes.

This PR fixes and adds support to the `fileSize()` function for SI and IEC binary prefixes.

The new boolean `$useSiUnits` argument has a default of `false` to avoid breaking numerical changes, but will change the units from...

KB -> KiB
MB -> MiB
GB -> GiB
...etc

I'm happy for the default to be `true` to retain the original units and for the numbers to reflect the correct values, but given files are in a binary world, I feel using the IEC units are a more appropriate default.

References:
- [Wikipedia - Binary_prefix](https://en.wikipedia.org/wiki/Binary_prefix)
- [Wikipedia - IEC-80000](https://en.wikipedia.org/wiki/ISO/IEC_80000#Units_of_the_ISO_and_IEC_80000_series)
