### PR TITLE
[10.x] Added Str::dotify() helper method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -43,6 +43,13 @@ class Str
      * @var array
      */
     protected static $studlyCache = [];
+    
+    /**
+     * The cache of dotified words.
+     *
+     * @var array
+     */
+    protected static $dotifyCache = [];
 
     /**
      * The callback that should be used to generate UUIDs.
@@ -1832,6 +1839,30 @@ class Str
 
         return $ulid;
     }
+    
+    /**
+     * Converts an array notation string to its dot notation equivalent.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function dotify($value)
+    {
+        if (isset(static::$dotifyCache[$value])) {
+            return static::$dotifyCache[$value];
+        }
+        
+        $value = str_replace([ "'", '"' ], '', $value);
+        $value = str_replace('][', '.', $value);
+        $value = str_replace('[', '.', $value);
+        
+        static::$dotifyCache[$value] = trim(
+            rtrim($value, ']'),
+            '.'
+        );
+        
+        return static::$dotifyCache[$value];
+    }
 
     /**
      * Remove all strings from the casing caches.
@@ -1843,5 +1874,6 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
+        static::$dotifyCache = [];
     }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1384,6 +1384,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::fromBase64(base64_encode('foo')));
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
+    
+    public function testDotify()
+    {
+        $this->assertEquals('foo', Str::dotify('foo'));
+        $this->assertEquals('foo', Str::dotify('foo[]'));
+        $this->assertEquals('foo', Str::dotify('foo[][]'));
+        $this->assertEquals('foo', Str::dotify('foo[""]'));
+        $this->assertEquals('foo', Str::dotify('foo['));
+        $this->assertEquals('foo', Str::dotify('foo]'));
+        
+        $this->assertEquals('foo.*', Str::dotify('foo[*]'));
+        $this->assertEquals('foo.0', Str::dotify('foo[0]'));
+        $this->assertEquals('foo.bar', Str::dotify('foo[bar]'));
+        $this->assertEquals('foo.bar.baz', Str::dotify('foo[bar][baz]'));
+        $this->assertEquals('foo.bar.baz', Str::dotify('foo[\'bar\']["baz"]'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This helper function makes easy to convert to a notation like `foo[bar][baz]` (array notation) to `foo.bar.baz` (dot notation) without having to process an array and flatten it to retrieve a dot variant of just a position.

A use case may be this: when working with array in forms, `old()` helper function supports only array with dot notation while the input name must be given with array notation, using this helper function we could write a code like this (for example, in a Blade component):

```blade
@props([
    'name' => 'foo[bar][baz]'
])

<x-text-input :value="old(Str::dotify($name))" :name="$name" />
```

It works with numeric arrays and quoted indexed as well.