### PR TITLE
[11.x] Remove `getDefaultNamespace` function in EnumMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -49,17 +49,6 @@ class EnumMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the default namespace for the class.
-     *
-     * @param  string  $rootNamespace
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace;
-    }
-
-    /**
      * Build the class with the given name.
      *
      * @param  string  $name


### PR DESCRIPTION
There is no need to have this method in the EnumMakeCommand (Parent class)