### PR TITLE
[10.x] Adds `mirror` method to Collection classes

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1678,6 +1678,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Create a collection by using this collection for keys as well as values.
+     *
+     * @return static<TValue, TValue>
+     */
+    public function mirror()
+    {
+        return new static(array_combine($this->items, $this->items));
+    }
+
+    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator<TKey, TValue>

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1154,6 +1154,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function pad($size, $value);
 
     /**
+     * Create a collection by using this collection for keys as well as values.
+     *
+     * @return static<TValue, TValue>
+     */
+    public function mirror();
+
+    /**
      * Get the values iterator.
      *
      * @return \Traversable<TKey, TValue>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1685,6 +1685,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Create a collection by using this collection for keys as well as values.
+     *
+     * @return static<TValue, TValue>
+     */
+    public function mirror()
+    {
+        return $this->passthru('mirror', []);
+    }
+
+    /**
      * Get the values iterator.
      *
      * @return \Traversable<TKey, TValue>

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -629,6 +629,16 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Create a collection by using this collection for keys as well as values.
+     *
+     * @return \Illuminate\Support\Collection<mixed, mixed>
+     */
+    public function mirror()
+    {
+        return $this->toBase()->mirror();
+    }
+
+    /**
      * Get an array with the values of a given key.
      *
      * @param  string|array<array-key, string>  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4158,6 +4158,17 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMirror($collection)
+    {
+        $c = new $collection(['value', 'value2']);
+        $c = $c->mirror();
+
+        $this->assertEquals(['value' => 'value', 'value2' => 'value2'], $c->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testGettingMaxItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);


### PR DESCRIPTION
This PR introduces a new Collection method, which simplifies copying collection values to its keys.

# Problem:
There is no fluent way to combine collections values with its values as keys.

Beforehand, we'd use some helper method to allow us to access the collection as a variable, providing the collection itself to the `combine` method:
```php
$collection = collect(['value_1', 'value_2'])->whenNotEmpty(fn (Collection $collection) => $collection->combine($collection));
```

# Solution:
```php
$collection = collect(['value_1', 'value_2'])->mirror();
```

The resulting collection contains an array where keys match their respective values.