### PR TITLE
[11.x] Allow "safe" objects to be used by Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -151,10 +151,10 @@ class Builder implements BuilderContract
     /**
      * Create and return an un-saved model instance.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function make(array $attributes = [])
+    public function make($attributes = [])
     {
         return $this->newModelInstance($attributes);
     }
@@ -1017,10 +1017,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function create(array $attributes = [])
+    public function create($attributes = [])
     {
         return tap($this->newModelInstance($attributes), function ($instance) {
             $instance->save();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1008,13 +1008,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database within a transaction.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      *
      * @throws \Throwable
      */
-    public function updateOrFail(array $attributes = [], array $options = [])
+    public function updateOrFail($attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;
@@ -1026,11 +1026,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database without raising any events.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function updateQuietly(array $attributes = [], array $options = [])
+    public function updateQuietly($attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1273,12 +1273,12 @@ class BelongsToMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $joining
      * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [], array $joining = [], $touch = true)
+    public function create($attributes = [], array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -46,10 +46,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create and return an un-saved instance of the related model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function make(array $attributes = [])
+    public function make($attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
@@ -331,10 +331,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [])
+    public function create($attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
@@ -346,10 +346,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model without raising any events to the parent model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function createQuietly(array $attributes = [])
+    public function createQuietly($attributes = [])
     {
         return Model::withoutEvents(fn () => $this->create($attributes));
     }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -166,7 +166,6 @@ class EloquentModelTest extends DatabaseTestCase
         };
 
         $this->expectException(\Illuminate\Database\QueryException::class);
-        $this->expectExceptionMessage('table actions has no column named unknown');
 
         $model->newInstance()->create(new ValidatedInput([
             'label' => 'test',

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Support\ValidatedInput;
 
 class EloquentModelTest extends DatabaseTestCase
 {
@@ -125,6 +126,52 @@ class EloquentModelTest extends DatabaseTestCase
             'end' => '2024-01-01 00:00:00',
             'analyze' => true,
         ]);
+    }
+
+    public function testCreateModelWithSafeObject()
+    {
+        Schema::create('actions', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+        });
+
+        $model = new class extends Model
+        {
+            protected $table = 'actions';
+            protected $fillable = [];
+            public $timestamps = false;
+        };
+
+        $model->newInstance()->create(new ValidatedInput([
+            'label' => 'test',
+        ]));
+
+        $this->assertDatabaseHas('actions', [
+            'label' => 'test',
+        ]);
+    }
+
+    public function testCreateModelWithSafeObjectThrowsExceptionForUnknownColumn()
+    {
+        Schema::create('actions', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+        });
+
+        $model = new class extends Model
+        {
+            protected $table = 'actions';
+            protected $fillable = [];
+            public $timestamps = false;
+        };
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('table actions has no column named unknown');
+
+        $model->newInstance()->create(new ValidatedInput([
+            'label' => 'test',
+            'unknown' => 'column',
+        ]));
     }
 }
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Support\ValidatedInput;
 
 class EloquentUpdateTest extends DatabaseTestCase
 {
@@ -44,6 +45,19 @@ class EloquentUpdateTest extends DatabaseTestCase
         TestUpdateModel1::where('title', 'Ms.')->delete();
 
         $this->assertCount(0, TestUpdateModel1::all());
+    }
+
+    public function testUpdateAllowsSafeObject()
+    {
+        $model = TestUpdateModel2::create([
+            'name' => Str::random(),
+        ]);
+
+        $model->update(new ValidatedInput(['job' => 'Developer']));
+
+        $model->refresh();
+
+        $this->assertSame('Developer', $model->job);
     }
 
     public function testUpdateWithLimitsAndOrders()


### PR DESCRIPTION
Alright, I know this PR might be a bit scary as it changes some Eloquent methods. But bear with me as these changes are mostly superficial with really only a few lines of new code. Nonetheless, I have targeted `master` as some are "breaking".

The goal of this PR is to address a long-standing papercut I feel exists around mass assignment. Laravel makes it very easy to validate user input. This validation even provides first-class objects which are "safe". However, these objects still need to be downcast to an array to send to Eloquent.

```php
Post::create($request->safe()->all());
```

It would be wonderful if I could pass this "safe" object directly to Eloquent.

```php
Post::create($request->safe());
```

That addresses one aspect.

The other aspect is I still need to set `fillable`/`guarded` in my model to allow this data to be assigned. But, by passing this "safe" object, Eloquent can check the argument type (`ValidatedInput`) and effectively "force fill" the model. Thus avoiding any mass assignment errors and alleviating the papercut.

If this PR were merged, you would never need to set `fillable` or `guarded` on your models again. So long as you passed your model a "safe" object or set attributes directly, you could avoid the mass assignment dance.

### Breaking Changes
The code change itself is not breaking, only addative. However, the removal of the `array` type hint from public methods is. For that reason this PR targets Laravel 11.

### Disclaimer
This is a _sharp knife_. If a developer choses to pass Eloquent a "safe" object, they are telling the framework to "trust this data". No different than developers who bypass mass assignment currently by completely unguarding their models. It's important to remember this is opt-in. No existing behavior is changing. You may continue to pass an array with mass assignment.

In the end, this may not be _the_ solution. But it is _a_ solution. One I hope might at least get some ideas flowing around the future of mass assignment.