### PR TITLE
[11.x] Add column type for native UUID

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1305,6 +1305,17 @@ class Blueprint
     }
 
     /**
+     * Create a new native UUID column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function nativeUuid($column = 'uuid')
+    {
+        return $this->addColumn('nativeUuid', $column);
+    }
+
+    /**
      * Create a new ULID column on the table.
      *
      * @param  string  $column
@@ -1330,17 +1341,6 @@ class Blueprint
             'name' => $column,
             'length' => $length,
         ]));
-    }
-
-    /**
-     * Create a new native UUID column on the table.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Database\Schema\ColumnDefinition
-     */
-    public function nativeUuid($column = 'uuid')
-    {
-        return $this->addColumn('nativeUuid', $column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1333,6 +1333,17 @@ class Blueprint
     }
 
     /**
+     * Create a new native UUID column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function nativeUuid($column = 'uuid')
+    {
+        return $this->addColumn('nativeUuid', $column);
+    }
+
+    /**
      * Create a new IP address column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -210,6 +210,17 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Create the column definition for a native uuid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeNativeUuid(Fluent $column)
+    {
+        throw new RuntimeException('This database driver does not support the native UUID type.');
+    }
+
+    /**
      * Create the column definition for a generated, computed column type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -55,6 +55,17 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Create the column definition for a uuid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeUuid(Fluent $column)
+    {
+        return 'uuid';
+    }
+
+    /**
      * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -55,6 +55,17 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
+     * Create the column definition for a native uuid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeNativeUuid(Fluent $column)
+    {
+        return 'uuid';
+    }
+
+    /**
      * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -55,17 +55,6 @@ class MariaDbGrammar extends MySqlGrammar
     }
 
     /**
-     * Create the column definition for a uuid type.
-     *
-     * @param  \Illuminate\Support\Fluent  $column
-     * @return string
-     */
-    protected function typeUuid(Fluent $column)
-    {
-        return 'uuid';
-    }
-
-    /**
      * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -996,6 +996,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a native uuid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeNativeUuid(Fluent $column)
+    {
+        return $this->typeUuid($column);
+    }
+
+    /**
      * Create the column definition for an IP address type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -889,6 +889,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a native uuid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeNativeUuid(Fluent $column)
+    {
+        return $this->typeUuid($column);
+    }
+
+    /**
      * Create the column definition for an IP address type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -57,7 +57,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table `users` (`id` char(36) not null, primary key (`id`))', $statements[0]);
+        $this->assertSame('create table `users` (`id` uuid not null, primary key (`id`))', $statements[0]);
     }
 
     public function testAutoIncrementStartingValue()
@@ -1090,7 +1090,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` uuid not null', $statements[0]);
     }
 
     public function testAddingUuidDefaultsColumnName()
@@ -1100,7 +1100,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `uuid` char(36) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `uuid` uuid not null', $statements[0]);
     }
 
     public function testAddingForeignUuid()
@@ -1116,7 +1116,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
-            'alter table `users` add `foo` char(36) not null, add `company_id` char(36) not null, add `laravel_idea_id` char(36) not null, add `team_id` char(36) not null, add `team_column_id` char(36) not null',
+            'alter table `users` add `foo` uuid not null, add `company_id` uuid not null, add `laravel_idea_id` uuid not null, add `team_id` uuid not null, add `team_column_id` uuid not null',
             'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
             'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
             'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -1124,6 +1124,16 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingNativeUuid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->nativeUuid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` uuid not null', $statements[0]);
+    }
+
     public function testAddingIpAddress()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -57,7 +57,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table `users` (`id` uuid not null, primary key (`id`))', $statements[0]);
+        $this->assertSame('create table `users` (`id` char(36) not null, primary key (`id`))', $statements[0]);
     }
 
     public function testAutoIncrementStartingValue()
@@ -1090,7 +1090,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` uuid not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
     }
 
     public function testAddingUuidDefaultsColumnName()
@@ -1100,7 +1100,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `uuid` uuid not null', $statements[0]);
+        $this->assertSame('alter table `users` add `uuid` char(36) not null', $statements[0]);
     }
 
     public function testAddingForeignUuid()
@@ -1116,7 +1116,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
         $this->assertSame([
-            'alter table `users` add `foo` uuid not null, add `company_id` uuid not null, add `laravel_idea_id` uuid not null, add `team_id` uuid not null, add `team_column_id` uuid not null',
+            'alter table `users` add `foo` char(36) not null, add `company_id` char(36) not null, add `laravel_idea_id` char(36) not null, add `team_id` char(36) not null, add `team_column_id` char(36) not null',
             'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
             'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
             'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
@@ -1122,6 +1123,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
             'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
             'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
         ], $statements);
+    }
+
+    public function testAddingNativeUuid()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database driver does not support the native UUID type.');
+
+        $blueprint = new Blueprint('users');
+        $blueprint->nativeUuid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingIpAddress()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -923,6 +923,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingNativeUuid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->nativeUuid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" uuid not null', $statements[0]);
+    }
+
     public function testAddingGeneratedAs()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -742,6 +742,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingNativeUuid()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database driver does not support the native UUID type.');
+
+        $blueprint = new Blueprint('users');
+        $blueprint->nativeUuid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
     public function testAddingIpAddress()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -783,6 +783,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingNativeUuid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->nativeUuid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" uniqueidentifier not null', $statements[0]);
+    }
+
     public function testAddingIpAddress()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
With the new dedicated driver, MariaDB users can now benefit from the [native column type](https://mariadb.com/kb/en/uuid-data-type/) for UUIDs (Laravel uses `char(36)` at the moment).

This would be a breaking change for existing applications, but since the driver is new, users have to consciously switch to it and will be made aware of this change. They should convert their existing UUID columns to the native type. I'll document it in the upgrade guide.
