### PR TITLE
[10.x] Add missing `putFile` to `Filesystem` contract

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -53,6 +53,16 @@ interface Filesystem
     public function put($path, $contents, $options = []);
 
     /**
+     * Store the uploaded file on the disk.
+     *
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $path
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|array|null  $file
+     * @param  mixed  $options
+     * @return string|false
+     */
+    public function putFile($path, $file, $options = []);
+
+    /**
      * Write a new file using a stream.
      *
      * @param  string  $path


### PR DESCRIPTION
Hey,

```
Storage::disk('custom')->putFile(
    'custom',
    new File("/tmp/{$filename}"),
    "{$client->id}_{$client->name}/{$filename}"
);
```

Since `disk` method returns` \Illuminate\Contracts\Filesystem\Filesystem` Intellisense is yelling at me for using `putFile` because the contract is missing it. Copied the method header from: https://github.com/laravel/framework/blob/f7c57c47f677b3fcfa1c70c6c3c51d0f90866d31/src/Illuminate/Filesystem/FilesystemAdapter.php#L388

Are there any implications for adding this method to the contract?