### PR TITLE
[10.x] Fix database batch unserialize throwing when closure contains deleted/not found class

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -6,10 +6,10 @@ use Carbon\CarbonImmutable;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
+use Throwable;
 
 class DatabaseBatchRepository implements PrunableBatchRepository
 {
@@ -352,7 +352,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
 
         try {
             return unserialize($serialized);
-        } catch (ModelNotFoundException) {
+        } catch (Throwable) {
             return [];
         }
     }

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -352,7 +352,9 @@ class DatabaseBatchRepository implements PrunableBatchRepository
 
         try {
             return unserialize($serialized);
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            report($e);
+            
             return [];
         }
     }


### PR DESCRIPTION
This change catches all exceptions when unserializing the options on a database batch. 

If the options contained a serialize class that no longer exists then errors would be thrown. This breaks the Batches page in the UI.

Example of exception thrown:
```
exception: "ErrorException" 
file: "/home/benjamin/Development/saas-insights/vendor/laravel/serializable-closure/src/Serializers/Native.php"
line: 195
message: "Class \"App\\Actions\\TrialChecker\" not found"
```

Example of batch that causes this error
```
Bus::batch([])
    ->allowFailures()
    ->then(function () use ($customer) {
        TrialChecker::forCustomer($customer)->action();
    })
    ->dispatch();
```