### PR TITLE
[11.x] Add `softDelete` option to Observer command

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -102,9 +102,15 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->option('model')
-            ? $this->resolveStubPath('/stubs/observer.stub')
-            : $this->resolveStubPath('/stubs/observer.plain.stub');
+        if ($this->option('model') && $this->option('softDelete')) {
+            $this->resolveStubPath('/stubs/observer.soft-delete.stub');
+        }
+
+        if ($this->option('model')) {
+            $this->resolveStubPath('/stubs/observer.stub');
+        }
+
+        return $this->resolveStubPath('/stubs/observer.plain.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -102,12 +102,12 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        if ($this->option('model') && $this->option('softDelete')) {
-            $this->resolveStubPath('/stubs/observer.soft-delete.stub');
+        if ($this->hasOption('model') && $this->option('softDelete')) {
+            return $this->resolveStubPath('/stubs/observer.soft-delete.stub');
         }
 
-        if ($this->option('model')) {
-            $this->resolveStubPath('/stubs/observer.stub');
+        if ($this->hasOption('model')) {
+            return $this->resolveStubPath('/stubs/observer.stub');
         }
 
         return $this->resolveStubPath('/stubs/observer.plain.stub');

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -147,6 +147,7 @@ class ObserverMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the observer already exists'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to'],
+            ['softDelete', 'sd', InputOption::VALUE_NONE, 'Create observer with soft deletes events'],
         ];
     }
 

--- a/src/Illuminate/Foundation/Console/stubs/observer.soft-delete.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.soft-delete.stub
@@ -1,0 +1,56 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+
+class {{ class }}
+{
+    /**
+     * Handle the {{ model }} "created" event.
+     */
+    public function created({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "updated" event.
+     */
+    public function updated({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "deleted" event.
+     */
+    public function deleted({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "trashed" event.
+     */
+    public function softDeleted({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "restored" event.
+     */
+    public function restored({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "force deleted" event.
+     */
+    public function forceDeleted({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -29,20 +29,4 @@ class {{ class }}
     {
         //
     }
-
-    /**
-     * Handle the {{ model }} "restored" event.
-     */
-    public function restored({{ model }} ${{ modelVariable }}): void
-    {
-        //
-    }
-
-    /**
-     * Handle the {{ model }} "force deleted" event.
-     */
-    public function forceDeleted({{ model }} ${{ modelVariable }}): void
-    {
-        //
-    }
 }

--- a/tests/Integration/Generators/ObserverMakeCommandTest.php
+++ b/tests/Integration/Generators/ObserverMakeCommandTest.php
@@ -33,4 +33,22 @@ class ObserverMakeCommandTest extends TestCase
             'public function deleted(Foo $foo)',
         ], 'app/Observers/FooObserver.php');
     }
+
+    public function testItCanGenerateObserverFileWithModelWithSoftDelete()
+    {
+        $this->artisan('make:observer', ['name' => 'FooObserver', '--model' => 'Foo', '--softDelete' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Observers;',
+            'use App\Models\Foo;',
+            'class FooObserver',
+            'public function created(Foo $foo)',
+            'public function updated(Foo $foo)',
+            'public function deleted(Foo $foo)',
+            'public function softDeleted(Foo $foo)',
+            'public function restored(Foo $foo)',
+            'public function forceDeleted(Foo $foo)',
+        ], 'app/Observers/FooObserver.php');
+    }
 }

--- a/tests/Integration/Generators/ObserverMakeCommandTest.php
+++ b/tests/Integration/Generators/ObserverMakeCommandTest.php
@@ -31,8 +31,6 @@ class ObserverMakeCommandTest extends TestCase
             'public function created(Foo $foo)',
             'public function updated(Foo $foo)',
             'public function deleted(Foo $foo)',
-            'public function restored(Foo $foo)',
-            'public function forceDeleted(Foo $foo)',
         ], 'app/Observers/FooObserver.php');
     }
 }


### PR DESCRIPTION
When creating an observer with the `model` option, the generated observer would look like this:

```php
<?php

namespace App\Observers;

use App\Models\Bar;

class BarObserver
{
    /**
     * Handle the Bar "created" event.
     */
    public function created(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "updated" event.
     */
    public function updated(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "deleted" event.
     */
    public function deleted(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "restored" event.
     */
    public function restored(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "force deleted" event.
     */
    public function forceDeleted(Bar $bar): void
    {
        //
    }
}
```

But in most cases, we don't need to have `restored` and `forceDeleted` functions and we delete these after generating the observer class because not all models use soft delete.

In this PR, I added a new option called "--softDelete" to create observers with soft delete events.

```bash
php artisan make:observer BarObserver --softDelete 
```

And the observer generated like this:

```php
<?php

namespace App\Observers;

use App\Models\Bar;

class BarObserver
{
    /**
     * Handle the Bar "created" event.
     */
    public function created(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "updated" event.
     */
    public function updated(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "deleted" event.
     */
    public function deleted(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "trashed" event.
     */
    public function softDeleted(Bar $bar): void
    {
        //
    } 
    
    /**
     * Handle the Bar "restored" event.
     */
    public function restored(Bar $bar): void
    {
        //
    }

    /**
     * Handle the Bar "force deleted" event.
     */
    public function forceDeleted(Bar $bar): void
    {
        //
    }
}
```

If you create observers without the `--softDelete` option, the observers have `created`, `updated` and `deleted` events.

- [x] Tests