### PR TITLE
[11.x] Hides `event:generate` Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -24,6 +24,13 @@ class EventGenerateCommand extends Command
     protected $description = 'Generate the missing events and listeners based on registration';
 
     /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = true;
+
+    /**
      * Execute the console command.
      *
      * @return void


### PR DESCRIPTION
This command no longer makes sense on L11 skeletons.