### PR TITLE
[10.x] Add database upsertions

### DIFF
--- a/src/Illuminate/Database/Console/Upsertions/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/BaseCommand.php
@@ -118,7 +118,6 @@ abstract class BaseCommand extends Command
      * Render the initial select for all upsert files.
      *
      * @param  bool  $shouldShowSelect
-     *
      * @return void
      */
     private function selectAllUpserts($shouldShowSelect = true)

--- a/src/Illuminate/Database/Console/Upsertions/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/BaseCommand.php
@@ -43,7 +43,7 @@ abstract class BaseCommand extends Command
     }
 
     /**
-     * Initialize the command flow
+     * Initialize the command flow.
      *
      * @return void
      */
@@ -57,7 +57,7 @@ abstract class BaseCommand extends Command
     }
 
     /**
-     * Render the initial selecting functionality
+     * Render the initial selecting functionality.
      *
      * @return void
      */
@@ -83,7 +83,7 @@ abstract class BaseCommand extends Command
     }
 
     /**
-     * Render the multisearch to select which upsert files to run
+     * Render the multisearch to select which upsert files to run.
      *
      * @return void
      */
@@ -115,7 +115,7 @@ abstract class BaseCommand extends Command
     }
 
     /**
-     * Render the initial select for all upsert files
+     * Render the initial select for all upsert files.
      *
      * @param  bool  $shouldShowSelect
      *
@@ -163,7 +163,7 @@ abstract class BaseCommand extends Command
     }
 
     /**
-     * Render the found upsert files table and a select to run upserts
+     * Render the found upsert files table and a select to run upserts.
      *
      * @return void
      */

--- a/src/Illuminate/Database/Console/Upsertions/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/BaseCommand.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Illuminate\Database\Console\Upsertions;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multisearch;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\table;
+
+abstract class BaseCommand extends Command
+{
+    /**
+     * The upsertion resposity.
+     *
+     * @var Illuminate\Database\Console\Upsertions\UpsertionRepository
+     */
+    protected $repository;
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Create a new base upsertion command instance.
+     *
+     * @param  Illuminate\Database\Console\Upsertions\UpsertionRepository  $upsertionRepository
+     * @param  Illuminate\Filesystem\Filesystem  $filesystem
+     * @return void
+     */
+    public function __construct(UpsertionRepository $upsertionRepository, Filesystem $filesystem)
+    {
+        parent::__construct();
+
+        $this->repository = $upsertionRepository;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Initialize the command flow
+     *
+     * @return void
+     */
+    public function initializeCommandFlow()
+    {
+        if ($this->option('all')) {
+            $this->selectAllUpserts(false);
+        } else {
+            $this->selectFunctionality();
+        }
+    }
+
+    /**
+     * Render the initial selecting functionality
+     *
+     * @return void
+     */
+    private function selectFunctionality()
+    {
+        $functionality = select(
+            label: 'What do you want to do?',
+            options: [
+                'all' => 'Upsert all found files',
+                'selected' => 'Upsert only selected files',
+            ]
+        );
+
+        switch ($functionality) {
+            case 'selected':
+                $this->selectUpserts();
+
+                break;
+            case 'all':
+                $this->selectAllUpserts();
+                break;
+        }
+    }
+
+    /**
+     * Render the multisearch to select which upsert files to run
+     *
+     * @return void
+     */
+    private function selectUpserts()
+    {
+        $allUpserters = $this->repository->foundUpsertions;
+        $foundUpserterCount = count($allUpserters);
+
+        if ($foundUpserterCount < 1) {
+            return;
+        }
+
+        $files = $this->repository->getClassNames($allUpserters);
+
+        $selectedFilePaths = multisearch(
+            label: 'Search for the files you want to upsert.',
+            placeholder: 'E.g. UpsertUserPermissions.php',
+            options: fn (string $value) => strlen($value) > 0
+                ? $files
+                : [],
+            scroll: 10,
+            required: 'You must select at least one file.',
+            hint: 'Use space bar to select options. Use enter to continue'
+        );
+
+        $filesToUpsert = $this->repository->getFilesByPath($selectedFilePaths);
+        $this->repository->filesToUpsert = $filesToUpsert;
+        $this->runUpsertions();
+    }
+
+    /**
+     * Render the initial select for all upsert files
+     *
+     * @param  bool  $shouldShowSelect
+     *
+     * @return void
+     */
+    private function selectAllUpserts($shouldShowSelect = true)
+    {
+        $allUpserters = $this->repository->foundUpsertions;
+        $foundUpserterCount = count($allUpserters);
+
+        if ($foundUpserterCount < 1) {
+            return;
+        }
+
+        $this->repository->filesToUpsert = $allUpserters;
+        $files = $this->repository->getClassNames($allUpserters);
+
+        intro("Found {$foundUpserterCount} upsert files");
+
+        if ($shouldShowSelect) {
+            $shouldStart = select(
+                label: 'Would you like to upsert these files?',
+                options: [
+                    'Yes',
+                    'No',
+                    'Show me which files',
+                ],
+                default: 'No'
+            );
+
+            switch ($shouldStart) {
+                case 'Yes':
+                    $this->runUpsertions();
+
+                    break;
+                case 'No':
+                    break;
+                case 'Show me which files':
+                    $this->showUpsertFiles($files);
+                    break;
+            }
+        } else {
+            $this->runUpsertions();
+        }
+    }
+
+    /**
+     * Render the found upsert files table and a select to run upserts
+     *
+     * @return void
+     */
+    private function showUpsertFiles($files)
+    {
+        info('I\'ve found these upserters');
+
+        $tableArr = array_map(function ($file) {
+            return [$file];
+        }, $files);
+
+        table(
+            ['Upserter Name'],
+            $tableArr
+        );
+
+        $shouldStart = select(
+            label: 'Would you like to upsert these files?',
+            options: [
+                'Yes',
+                'No',
+            ],
+            default: 'Yes'
+        );
+
+        switch ($shouldStart) {
+            case 'Yes':
+                $this->runUpsertions();
+
+                break;
+            case 'No':
+                break;
+        }
+    }
+
+    /**
+     * The abstract function to run upsert files.
+     *
+     * @return void
+     */
+    abstract public function runUpsertions();
+}

--- a/src/Illuminate/Database/Console/Upsertions/UpsertCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Database\Console\Upsertions;
+
+use function Laravel\Prompts\outro;
+use function Laravel\Prompts\progress;
+
+#[AsCommand(name: 'upsert')]
+class UpsertCommand extends BaseCommand
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'upsert
+                {--all : Run all upsert files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Make sure essential seeders have been executed after something has updated';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->initializeCommandFlow();
+    }
+
+    /**
+     * Run all found upsertion files
+     *
+     * @return void
+     */
+    public function runUpsertions()
+    {
+        $files = $this->repository->filesToUpsert;
+        $count = count($files);
+        $skippedCount = 0;
+
+        /** @var Progress<TSteps> */
+        $progress = progress(
+            label: 'Running upserters',
+            steps: $files,
+        );
+
+        $progress->start();
+
+        foreach ($files as $file) {
+            $className = $file->getRelativePathname();
+            $progress->hint("Running upserter: {$className}");
+            $upserter = include $file->getRealPath();
+
+            if (! $upserter->shouldRun()) {
+                $progress->advance();
+                $skippedCount++;
+
+                continue;
+            }
+
+            $upserter->run();
+            $progress->advance();
+        }
+
+        $progress->finish();
+
+        $finishedStr = "Finished running {$count} upserters";
+        $skippedStr = "skipped {$skippedCount} upserters";
+
+        $outroStr = $skippedCount > 0
+            ? $finishedStr.', '.$skippedStr
+            : $finishedStr;
+
+        outro($outroStr);
+    }
+}

--- a/src/Illuminate/Database/Console/Upsertions/UpsertCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertCommand.php
@@ -34,7 +34,7 @@ class UpsertCommand extends BaseCommand
     }
 
     /**
-     * Run all found upsertion files
+     * Run all found upsertion files.
      *
      * @return void
      */

--- a/src/Illuminate/Database/Console/Upsertions/UpsertCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Upsertions;
 
 use function Laravel\Prompts\outro;
 use function Laravel\Prompts\progress;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'upsert')]
 class UpsertCommand extends BaseCommand

--- a/src/Illuminate/Database/Console/Upsertions/UpsertionMakeCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertionMakeCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Database\Console\Upsertions;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Upsertions\UpsertionCreator;
+
+use function Laravel\Prompts\outro;
+use function Laravel\Prompts\text;
+
+#[AsCommand(name: 'make:upsertion')]
+class UpsertionMakeCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'make:upsertion';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new upsertion file';
+
+    /**
+     * The upsertion creator instance.
+     *
+     * @var \Illuminate\Database\Upsertions\UpsertionCreator
+     */
+    protected $creator;
+
+    /**
+     * Create a new make upsertion command instance.
+     *
+     * @param  \Illuminate\Database\Upsertions\UpsertionCreator  $upsertionCreator
+     * @return void
+     */
+    public function __construct(UpsertionCreator $upsertionCreator)
+    {
+        parent::__construct();
+
+        $this->creator = $upsertionCreator;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $name = text(
+            label: 'Enter the name of the new upsertion',
+            placeholder: 'E.g. UpsertUserPermissions',
+            required: true,
+            validate: fn (string $value) => match (true) {
+                strlen($value) < 3 => 'The name must be at least 3 characters.',
+                strlen($value) > 50 => 'The name must not exceed 50 characters.',
+                $this->creator->ensureUpsertionDoesntAlreadyExist($value) => "A {$value} upsertion already exists.",
+                default => null
+            }
+        );
+
+        $isDone = $this->createUpsertion($name);
+
+        if ($isDone) {
+            outro("Upsertion {$name} has successfully been created.");
+        }
+    }
+
+    /**
+     * Create a new upsertion.
+     *
+     * @return string
+     */
+    private function createUpsertion($name)
+    {
+        return $this->creator->create($name);
+    }
+}

--- a/src/Illuminate/Database/Console/Upsertions/UpsertionMakeCommand.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertionMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Upsertions;
 
 use Illuminate\Console\Command;
 use Illuminate\Database\Upsertions\UpsertionCreator;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\outro;
 use function Laravel\Prompts\text;

--- a/src/Illuminate/Database/Console/Upsertions/UpsertionRepository.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertionRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Database\Console\Upsertions;
+
+use Symfony\Component\Finder\Finder;
+
+class UpsertionRepository
+{
+    /**
+     * The found upserter files inside the configured directory
+     *
+     * @var SplFileInfo[]
+     */
+    public $foundUpsertions = [];
+
+    /**
+     * The selected files to upsert
+     *
+     * @var SplFileInfo[]
+     */
+    public $filesToUpsert = [];
+
+    /**
+     * Create a new upsertion repository instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        foreach ((new Finder)->in(database_path('/upsertions'))->files() as $file) {
+            $this->foundUpsertions[] = $file;
+        }
+    }
+
+    /**
+     * Get the classnames of files as an associative array
+     *
+     * @param  SplFileInfo[]  $files
+     * @return array
+     */
+    public function getClassNames($files)
+    {
+        $classNames = [];
+
+        foreach ($files as $file) {
+            $className = str_replace('.php', '', $file->getRelativePathname());
+            $classNames[$file->getPathName()] = $className;
+        }
+
+        return $classNames;
+    }
+
+    /**
+     * Get files by path
+     *
+     * @param  string[]  $filePaths
+     * @return SplFileInfo[]
+     */
+    public function getFilesByPath($filePaths)
+    {
+        $files = [];
+
+        foreach ((new Finder)->in(database_path('/upsertions'))->files() as $file) {
+            if (in_array($file->getPathname(), $filePaths)) {
+                $files[] = $file;
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/Illuminate/Database/Console/Upsertions/UpsertionRepository.php
+++ b/src/Illuminate/Database/Console/Upsertions/UpsertionRepository.php
@@ -7,14 +7,14 @@ use Symfony\Component\Finder\Finder;
 class UpsertionRepository
 {
     /**
-     * The found upserter files inside the configured directory
+     * The found upserter files inside the configured directory.
      *
      * @var SplFileInfo[]
      */
     public $foundUpsertions = [];
 
     /**
-     * The selected files to upsert
+     * The selected files to upsert.
      *
      * @var SplFileInfo[]
      */
@@ -33,7 +33,7 @@ class UpsertionRepository
     }
 
     /**
-     * Get the classnames of files as an associative array
+     * Get the classnames of files as an associative array.
      *
      * @param  SplFileInfo[]  $files
      * @return array
@@ -51,7 +51,7 @@ class UpsertionRepository
     }
 
     /**
-     * Get files by path
+     * Get files by path.
      *
      * @param  string[]  $filePaths
      * @return SplFileInfo[]

--- a/src/Illuminate/Database/UpsertionServiceProvider.php
+++ b/src/Illuminate/Database/UpsertionServiceProvider.php
@@ -62,7 +62,7 @@ class UpsertionServiceProvider extends ServiceProvider implements DeferrableProv
     {
         $path = database_path('/upsertions');
 
-        if (!is_dir($path)) {
+        if (! is_dir($path)) {
             File::makeDirectory($path);
         }
     }

--- a/src/Illuminate/Database/UpsertionServiceProvider.php
+++ b/src/Illuminate/Database/UpsertionServiceProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Database;
+
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Database\Console\Upsertions\UpsertCommand;
+use Illuminate\Database\Console\Upsertions\UpsertionMakeCommand;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+
+class UpsertionServiceProvider extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * The commands to be registered.
+     *
+     * @var array
+     */
+    protected $commands = [
+        'UpsertionMake' => UpsertionMakeCommand::class,
+        'Upsert' => UpsertCommand::class,
+    ];
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerCommands($this->commands);
+
+        $this->createUpsertionsDirectory();
+    }
+
+
+    /**
+     * Register the given commands.
+     *
+     * @param  array  $commands
+     * @return void
+     */
+    protected function registerCommands(array $commands)
+    {
+        foreach ($commands as $commandName => $command) {
+            $method = "register{$commandName}Command";
+
+            if (method_exists($this, $method)) {
+                $this->{$method}();
+            } else {
+                $this->app->singleton($command);
+            }
+        }
+
+        $this->commands(array_values($commands));
+    }
+
+    /**
+     * Create the Upsertions directory
+     *
+     * @return void
+     */
+    protected function createUpsertionsDirectory()
+    {
+        $path = database_path('/upsertions');
+
+        if (!is_dir($path)) {
+            File::makeDirectory($path);
+        }
+    }
+}

--- a/src/Illuminate/Database/UpsertionServiceProvider.php
+++ b/src/Illuminate/Database/UpsertionServiceProvider.php
@@ -32,7 +32,6 @@ class UpsertionServiceProvider extends ServiceProvider implements DeferrableProv
         $this->createUpsertionsDirectory();
     }
 
-
     /**
      * Register the given commands.
      *
@@ -55,7 +54,7 @@ class UpsertionServiceProvider extends ServiceProvider implements DeferrableProv
     }
 
     /**
-     * Create the Upsertions directory
+     * Create the upsertions directory.
      *
      * @return void
      */

--- a/src/Illuminate/Database/Upsertions/Upsertion.php
+++ b/src/Illuminate/Database/Upsertions/Upsertion.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database\Upsertions;
+
+abstract class Upsertion
+{
+    abstract public function shouldRun(): bool;
+
+    abstract public function run(): void;
+}

--- a/src/Illuminate/Database/Upsertions/UpsertionCreator.php
+++ b/src/Illuminate/Database/Upsertions/UpsertionCreator.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Illuminate\Database\Upsertions;
+
+use Illuminate\Filesystem\Filesystem;
+
+class UpsertionCreator
+{
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Create a new upsertion creator instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $filesystem
+     * @return void
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Create a new upsertion.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function create($name)
+    {
+        $stub = $this->getStub();
+
+        $path = $this->getPath($name);
+
+        $this->filesystem->ensureDirectoryExists(dirname($path));
+
+        $this->filesystem->put($path, $stub);
+
+        return $path;
+    }
+
+    /**
+     * Get the upsertion stub file.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        $stub = "{$this->stubPath()}/upsertion.stub";
+
+        return $this->filesystem->get($stub);
+    }
+
+    /**
+     * Get the stubs folder path.
+     *
+     * @return string
+     */
+    public function stubPath()
+    {
+        return __DIR__.'/stubs';
+    }
+
+    /**
+     * Ensure that an upsertion with the given name doesn't already exist.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function ensureUpsertionDoesntAlreadyExist($name)
+    {
+        return $this->filesystem->exists("{$this->getUpsertionsPath()}/{$name}.php");
+    }
+
+    /**
+     * Get the full path to the upsertion.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return "{$this->getUpsertionsPath()}/{$name}.php";
+    }
+
+    /**
+     * Get the upsertions folder path
+     *
+     * @return string
+     */
+    protected function getUpsertionsPath()
+    {
+        return database_path('/upsertions');
+    }
+}

--- a/src/Illuminate/Database/Upsertions/UpsertionCreator.php
+++ b/src/Illuminate/Database/Upsertions/UpsertionCreator.php
@@ -88,7 +88,7 @@ class UpsertionCreator
     }
 
     /**
-     * Get the upsertions folder path
+     * Get the upsertions folder path.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Upsertions/stubs/upsertion.stub
+++ b/src/Illuminate/Database/Upsertions/stubs/upsertion.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Upsertions\Upsertion;
+
+return new class extends Upsertion
+{
+    /**
+     * The condition to run the upsertion.
+     */
+    public function shouldRun(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Running the upsertion.
+     */
+    public function run(): void
+    {
+        //
+    }
+};

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -26,6 +26,8 @@ use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\ShowCommand;
 use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
+use Illuminate\Database\Console\Upsertions\UpsertCommand;
+use Illuminate\Database\Console\Upsertions\UpsertionMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
@@ -208,6 +210,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'TestMake' => TestMakeCommand::class,
         'VendorPublish' => VendorPublishCommand::class,
         'ViewMake' => ViewMakeCommand::class,
+        'UpsertionMake' => UpsertionMakeCommand::class,
+        'Upsert' => UpsertCommand::class,
     ];
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -26,8 +26,6 @@ use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\ShowCommand;
 use Illuminate\Database\Console\ShowModelCommand;
 use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
-use Illuminate\Database\Console\Upsertions\UpsertCommand;
-use Illuminate\Database\Console\Upsertions\UpsertionMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
@@ -210,8 +208,6 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'TestMake' => TestMakeCommand::class,
         'VendorPublish' => VendorPublishCommand::class,
         'ViewMake' => ViewMakeCommand::class,
-        'UpsertionMake' => UpsertionMakeCommand::class,
-        'Upsert' => UpsertCommand::class,
     ];
 
     /**


### PR DESCRIPTION
This pull request adds new functionalities to generate and run database upsertions. Two new commands make:upsertion and upsert will generate and run upsertions respectively.

The reasoning behind this is to have a nice way to manage upserting data with conditions, instead of having to e.g make jobs for each upsertion. The commands use Laravel\Prompts for a nice user experience, to run all upsertions instantly, bypassing the prompts, you can add the argument --all.