### PR TITLE
[10.x] Fixes on nesting operations performed while applying scopes.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1454,9 +1454,9 @@ class Builder implements BuilderContract
         // Here we'll check if the given subset of where clauses contains any "or"
         // booleans and in this case create a nested where expression. That way
         // we don't add any unnecessary nesting thus keeping the query clean.
-        if ($whereBooleans->contains('or')) {
+        if ($whereBooleans->contains(fn ($logicalOperator) => str_contains($logicalOperator, 'or'))) {
             $query->wheres[] = $this->createNestedWhere(
-                $whereSlice, $whereBooleans->first()
+                $whereSlice, str_replace(' not', '', $whereBooleans->first())
             );
         } else {
             $query->wheres = array_merge($query->wheres, $whereSlice);


### PR DESCRIPTION
This pull request was initiated by the following issue : https://github.com/laravel/framework/issues/50078

In which is put forward a problem with nesting when scope are applied.

As a reminder, when a scope is applied, previously existing where clauses and scope where clauses can be grouped together (with parenthesis) depending on some criteria (it's done with `src/Illuminate/Database/Eloquent/Builder.php` ->`groupWhereSliceForScope` function).

From the code doing this operation what is happening is pretty obvious : 
- if the nesting happens, the first operator of the clauses that are going to be nested is used as operator for the whole groups (which allows for example that when a scope start with a `orWhere`, the whole scoped is `or`-ed with the rest of the query)
But if the first operator contains a negation, then the whole group is negated, which is what happens in the issue to which this PR is linked.
=> fixed it by removing negation of the operator applied on the group.

 - if the logical operator `or` appears as one of the where clause, then nesting occurs. But if only a `or not` appears, then nesting doesn't happens, which is inconsistent for the very reason the nesting happens on `or` clause : grouping if there is lower priority operator.
=> fixed by grouping if `or` is contained in any one of the potentially grouped where clauses, rather than one exactly matching `or.`

I put tests in local scopes because I thought it was simpler, but the problem occurs in exactly the same ways for local and global scopes.
 
If you ask me, I would use nested queries everytime there is multiple where clauses and always use `and` between pre-existing where clauses and scope, by the very meaning of the word scope. But I'm not here to fundamentally change the spirit, just fix the issue.

Thanks to anyone taking some time to give feedback about those fixes.

For information, here is what happens with the tests I added and before the fixes when performing those tests : 
```
public function testLocalScopeNestingDoesntDoubleFirstWhereClauseNegation()
    {
        $model = new EloquentLocalScopesTestModel;
        $query = $model
            ->newQuery()
            ->whereNot('firstWhere', true)
            ->orWhere('secondWhere', true)
            ->active();

        $this->assertSame('select * from "table" where (not "firstWhere" = ? or "secondWhere" = ?) and "active" = ?', $query->toSql());
        $this->assertEquals([true, true, true], $query->getBindings());
    }

    public function testLocalScopeNestingGroupsOrNotWhereClause()
    {
        $model = new EloquentLocalScopesTestModel;
        $query = $model
            ->newQuery()
            ->where('firstWhere', true)
            ->orWhereNot('secondWhere', true)
            ->active();

        $this->assertSame('select * from "table" where ("firstWhere" = ? or not "secondWhere" = ?) and "active" = ?', $query->toSql());
        $this->assertEquals([true, true, true], $query->getBindings());
    }
```

Results :

```1) Illuminate\Tests\Database\DatabaseEloquentLocalScopesTest::testLocalScopeNestingDoesntDoubleFirstWhereClauseNegation
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'select * from "table" where (not "firstWhere" = ? or "secondWhere" = ?) and "active" = ?'
+'select * from "table" where not (not "firstWhere" = ? or "secondWhere" = ?) and "active" = ?'

/home/archie/projects/laravel-framework/tests/Database/DatabaseEloquentLocalScopesTest.php:74

2) Illuminate\Tests\Database\DatabaseEloquentLocalScopesTest::testLocalScopeNestingGroupsOrNotWhereClause
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'select * from "table" where ("firstWhere" = ? or not "secondWhere" = ?) and "active" = ?'
+'select * from "table" where "firstWhere" = ? or not "secondWhere" = ? and "active" = ?'```

The unintuitive results speaks for themselves as far as I'm concerned.