### PR TITLE
[10.x] Fix Accepting nullable Parameters, updated doc block, and null pointer exception handling in batchable trait

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -35,7 +35,7 @@ trait Batchable
         }
 
         if ($this->batchId) {
-            return Container::getInstance()->make(BatchRepository::class)->find($this->batchId);
+            return Container::getInstance()->make(BatchRepository::class)?->find($this->batchId);
         }
     }
 

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -98,7 +98,7 @@ trait Batchable
             $failedJobs,
             $failedJobIds,
             $options,
-            $createdAt ?? CarbonImmutable::now()->toImmutable(),
+            $createdAt ?? CarbonImmutable::now(),
             $cancelledAt,
             $finishedAt,
         );

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -74,7 +74,7 @@ trait Batchable
      * @param  int  $failedJobs
      * @param  array  $failedJobIds
      * @param  array  $options
-     * @param  \Carbon\CarbonImmutable  $createdAt
+     * @param  \Carbon\CarbonImmutable|null  $createdAt
      * @param  \Carbon\CarbonImmutable|null  $cancelledAt
      * @param  \Carbon\CarbonImmutable|null  $finishedAt
      * @return array{0: $this, 1: \Illuminate\Support\Testing\Fakes\BatchFake}
@@ -86,7 +86,7 @@ trait Batchable
                                   int $failedJobs = 0,
                                   array $failedJobIds = [],
                                   array $options = [],
-                                  CarbonImmutable $createdAt = null,
+                                  ?CarbonImmutable $createdAt = null,
                                   ?CarbonImmutable $cancelledAt = null,
                                   ?CarbonImmutable $finishedAt = null)
     {
@@ -98,7 +98,7 @@ trait Batchable
             $failedJobs,
             $failedJobIds,
             $options,
-            $createdAt ?? CarbonImmutable::now(),
+            $createdAt ?? CarbonImmutable::now()->toImmutable(),
             $cancelledAt,
             $finishedAt,
         );


### PR DESCRIPTION
This PR, in `batchable` trait :

- fix  accepting nullable Parameter (`withFakeBatch` method)
- fix doc block (`withFakeBatch` method)
- fix null pointer exception (`batch` method)


#### Fix Accepting Nullable Parameter in WithFakeBatch method

```php
// before
CarbonImmutable $createdAt = null

// after
?CarbonImmutable $createdAt = null
```

#### CarbonImmutable::now()->toImmutable()
Modified the `$createdAt` assignment to explicitly convert the result of `CarbonImmutable::now()` to `CarbonImmutable` using `toImmutable()`. This guarantees that the type of `$createdAt` aligns with the expected `CarbonImmutable` type in the new `BatchFake` class.

```php
$this->fakeBatch = new BatchFake(
   empty($id) ? (string) Str::uuid() : $id,
   $name,
   $totalJobs,
   $pendingJobs,
   $failedJobs,
   $failedJobIds,
   $options,
   $createdAt ?? CarbonImmutable::now()->toImmutable(),
   $cancelledAt,
   $finishedAt,
);
```

