### PR TITLE
[10.x] Fixes `ShouldBeUnique` behavior for missing models

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -70,6 +70,10 @@ class UniqueLock
                     ? $job->uniqueId()
                     : ($job->uniqueId ?? '');
 
-        return 'laravel_unique_job:'.get_class($job).$uniqueId;
+        $jobName = property_exists($job, 'jobName')
+                   ? $job->jobName
+                   : get_class($job);
+
+        return 'laravel_unique_job:'.$jobName.$uniqueId;
     }
 }

--- a/src/Illuminate/Queue/UniqueHandler.php
+++ b/src/Illuminate/Queue/UniqueHandler.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+
+/**
+ * A helper class to manage the unique ID and cache instance for a job
+ * base on the data of the job itself.
+ */
+class UniqueHandler
+{
+    /**
+     * Original job name.
+     *
+     * @var string
+     */
+    public $jobName;
+
+    /**
+     * The unique ID for the job.
+     *
+     * @var string|null
+     */
+    public $uniqueId = null;
+
+    /**
+     * Cache connection name for the job.
+     *
+     * @var string|null
+     */
+    protected $uniqueVia = null;
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * Create a new handler instance.
+     *
+     * @param  object  $job
+     */
+    public function __construct(object $job)
+    {
+        $this->jobName = get_class($job);
+
+        if (method_exists($job, 'uniqueId')) {
+            $this->uniqueId = $job->uniqueId();
+        } elseif (isset($job->uniqueId)) {
+            $this->uniqueId = $job->uniqueId;
+        }
+
+        if (method_exists($job, 'uniqueVia')) {
+            $this->uniqueVia = $job->uniqueVia()->getName();
+        }
+    }
+
+    /**
+     * Creates a new instance if the job should be unique.
+     *
+     * @param  object  $job
+     * @return \Illuminate\Queue\UniqueHandler|null
+     */
+    public static function forJob(object $job)
+    {
+        if (
+            $job instanceof ShouldBeUnique ||
+            $job instanceof ShouldBeUniqueUntilProcessing
+        ) {
+            return new static($job);
+        }
+
+        return null;
+    }
+
+    /**
+     * Sets the container instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return \Illuminate\Queue\UpdateHandler
+     */
+    public function withContainer(Container $container)
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+
+    /**
+     * Returns the cache instance for the job.
+     *
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    protected function getCacheStore()
+    {
+        return $this->container->make(CacheFactory::class)
+                               ->store($this->uniqueVia);
+    }
+
+    /**
+     * Releases the lock for the job.
+     *
+     * @return void
+     */
+    public function release()
+    {
+        (new UniqueLock($this->getCacheStore()))->release($this);
+    }
+}


### PR DESCRIPTION
This PR is a follow-up on #49890 and tries to fix the issue by using a memo object that stores the information required to manage the unique lock (uniqueId and the name of the uniqueVia storage if present).

**EDIT: A detailed explanation.**

The unique job lock mechanism relies on the attributes and methods of the job class. However, these methods are not necessarily deterministic. For example, they might produce different outcomes or errors when called on the same object, especially if dependent objects have changed or no longer exist.

Additionally, if the job incorporates the `Illuminate\Queue\SerializesModels` trait and fails to unserialize due to a missing model, the unserialization process is interrupted by an `Illuminate\Database\Eloquent\ModelNotFoundException`.

Due to these factors, it may become impossible to retrieve the necessary information for managing the unique lock in the queue worker.

This scenario creates a special case where the job's failure to unserialize prevents the worker from releasing the lock, potentially causing a complete deadlock for that particular job class.

To resolve this issue, this pull request introduces a memo object `Illuminate\Queue\UniqueHandler`. This object gathers all essential information from the job object beforehand, which can later be used to manage the unique lock w/o relying on the command instance. This approach effectively separates the job lock information from the job object itself and guarantees that both the dispatcher and the worker are working with the same unique lock.