### PR TITLE
[10.x] Add string indent helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -412,6 +412,24 @@ class Str
     }
 
     /**
+     * Indent all non-empty lines in the string by the given amount of spaces.
+     * 
+     * @param  string  $value
+     * @param  int  $amount
+     * @return string
+     */
+    public static function indent(string $value, int $amount): string
+    {
+        $lines = explode(PHP_EOL, $value);
+
+        foreach ($lines as $key => $line) {
+            $lines[$key] = ($line === '') ? '' : str_repeat(' ', $amount).$line;
+        }
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1237,6 +1237,18 @@ class Stringable implements JsonSerializable, ArrayAccess
     }
 
     /**
+     * Indent all non-empty lines in the string by the given amount of spaces.
+     * 
+     * @param  int  $amount
+     * @return static
+     */
+    public function indent(int $amount): static
+    {
+        return new static(Str::indent($this->value, $amount));
+    }
+
+
+    /**
      * Convert the string into a `HtmlString` instance.
      *
      * @return \Illuminate\Support\HtmlString

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -436,6 +436,32 @@ class SupportStrTest extends TestCase
         $this->assertEquals('some: "json"', Str::unwrap('{some: "json"}', '{', '}'));
     }
 
+    public function testIndent()
+    {
+        $this->assertEquals('value', Str::indent('value', 0));
+        $this->assertEquals('    value', Str::indent('value', 4));
+
+        $this->assertEquals(
+            <<<HTML
+                <div>
+                    Foo
+
+                    Bar
+                </div>
+            HTML,
+            Str::indent(
+                <<<HTML
+                <div>
+                    Foo
+
+                    Bar
+                </div>
+                HTML,
+                4
+            ),
+        );
+    }
+
     public function testIs()
     {
         $this->assertTrue(Str::is('/', '/'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1184,6 +1184,33 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('some: "json"', $this->stringable('{some: "json"}')->unwrap('{', '}'));
     }
 
+    public function testIndent()
+    {
+        $this->assertEquals('value', $this->stringable('value')->indent(0));
+        $this->assertEquals('    value', $this->stringable('value')->indent(4));
+
+        $this->assertEquals(
+            <<<HTML
+                <div>
+                    Foo
+
+                    Bar
+                </div>
+            HTML,
+            $this
+                ->stringable(
+                    <<<HTML
+                    <div>
+                        Foo
+
+                        Bar
+                    </div>
+                    HTML,
+                )
+                ->indent(4),
+        );
+    }
+
     public function testToHtmlString()
     {
         $this->assertEquals(


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds an `indent()` helper method to the `Str` and `Stringable` support classes.

Indenting single-line strings is as easy as prepending spaces, but indenting multi-line strings requires a little more work. The new `indent()` method indents every line in the string with a given amount of spaces, and accounts for not indenting empty lines (as in really empty, since e.g. '0' still needs to be indented). It introduces a nice abstraction, since Laravel projects that need it often use it in multiple places.

Let me know if you want me to make any changes or a follow-up PR to the docs.
Thanks!