### PR TITLE
[11.x] Alternate implementation to allow "safe" objects to be used by Eloquent models (without breaking mass assignment protection)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -152,7 +152,7 @@ class Builder implements BuilderContract
     /**
      * Create and return an un-saved model instance.
      *
-     * @param  array|ValidatedInput $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function make(array|ValidatedInput $attributes = [])
@@ -1018,7 +1018,7 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance.
      *
-     * @param  array|ValidatedInput $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
     public function create(array|ValidatedInput $attributes = [])
@@ -1031,7 +1031,7 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance. Allow mass-assignment.
      *
-     * @param  array|ValidatedInput $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
     public function forceCreate(array|ValidatedInput $attributes)
@@ -1044,7 +1044,7 @@ class Builder implements BuilderContract
     /**
      * Save a new model instance with mass assignment without raising model events.
      *
-     * @param  array|ValidatedInput $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
     public function forceCreateQuietly(array|ValidatedInput $attributes = [])
@@ -1055,7 +1055,7 @@ class Builder implements BuilderContract
     /**
      * Update records in the database.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return int
      */
     public function update(array $values)
@@ -1066,7 +1066,7 @@ class Builder implements BuilderContract
     /**
      * Insert new records or update the existing ones.
      *
-     * @param  array $values
+     * @param  array  $values
      * @param  array|string  $uniqueBy
      * @param  array|null  $update
      * @return int

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -19,6 +19,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\ValidatedInput;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -151,10 +152,10 @@ class Builder implements BuilderContract
     /**
      * Create and return an un-saved model instance.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput $attributes
+     * @param  array|ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function make($attributes = [])
+    public function make(array|ValidatedInput $attributes = [])
     {
         return $this->newModelInstance($attributes);
     }
@@ -1017,10 +1018,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput $attributes
+     * @param  array|ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function create($attributes = [])
+    public function create(array|ValidatedInput $attributes = [])
     {
         return tap($this->newModelInstance($attributes), function ($instance) {
             $instance->save();
@@ -1030,10 +1031,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance. Allow mass-assignment.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput $attributes
+     * @param  array|ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function forceCreate($attributes)
+    public function forceCreate(array|ValidatedInput $attributes)
     {
         return $this->model->unguarded(function () use ($attributes) {
             return $this->newModelInstance()->create($attributes);
@@ -1043,10 +1044,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model instance with mass assignment without raising model events.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput $attributes
+     * @param  array|ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function forceCreateQuietly($attributes = [])
+    public function forceCreateQuietly(array|ValidatedInput $attributes = [])
     {
         return Model::withoutEvents(fn () => $this->forceCreate($attributes));
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -151,10 +151,10 @@ class Builder implements BuilderContract
     /**
      * Create and return an un-saved model instance.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function make(array $attributes = [])
+    public function make($attributes = [])
     {
         return $this->newModelInstance($attributes);
     }
@@ -1017,10 +1017,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function create(array $attributes = [])
+    public function create($attributes = [])
     {
         return tap($this->newModelInstance($attributes), function ($instance) {
             $instance->save();
@@ -1030,10 +1030,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model and return the instance. Allow mass-assignment.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function forceCreate(array $attributes)
+    public function forceCreate($attributes)
     {
         return $this->model->unguarded(function () use ($attributes) {
             return $this->newModelInstance()->create($attributes);
@@ -1043,10 +1043,10 @@ class Builder implements BuilderContract
     /**
      * Save a new model instance with mass assignment without raising model events.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function forceCreateQuietly(array $attributes = [])
+    public function forceCreateQuietly($attributes = [])
     {
         return Model::withoutEvents(fn () => $this->forceCreate($attributes));
     }
@@ -1054,7 +1054,7 @@ class Builder implements BuilderContract
     /**
      * Update records in the database.
      *
-     * @param  array  $values
+     * @param  array $values
      * @return int
      */
     public function update(array $values)
@@ -1065,7 +1065,7 @@ class Builder implements BuilderContract
     /**
      * Insert new records or update the existing ones.
      *
-     * @param  array  $values
+     * @param  array $values
      * @param  array|string  $uniqueBy
      * @param  array|null  $update
      * @return int

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -228,10 +228,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return void
      */
-    public function __construct(array $attributes = [])
+    public function __construct($attributes = [])
     {
         $this->bootIfNotBooted();
 
@@ -501,14 +501,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Fill the model with an array of attributes.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\MassAssignmentException
      */
-    public function fill(array $attributes)
+    public function fill($attributes)
     {
         $totallyGuarded = $this->totallyGuarded();
+
+        if ($attributes instanceof \Illuminate\Support\ValidatedInput) {
+            $attributes = $attributes->all();
+        }
 
         $fillable = $this->fillableFromArray($attributes);
 
@@ -551,10 +555,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Fill the model with an array of attributes. Force mass assignment.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return $this
      */
-    public function forceFill(array $attributes)
+    public function forceFill($attributes)
     {
         return static::unguarded(fn () => $this->fill($attributes));
     }
@@ -590,7 +594,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Create a new instance of the given model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  bool  $exists
      * @return static
      */
@@ -611,7 +615,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $model->mergeCasts($this->casts);
 
-        $model->fill((array) $attributes);
+        $model->fill($attributes);
 
         return $model;
     }
@@ -982,11 +986,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function update(array $attributes = [], array $options = [])
+    public function update($attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;
@@ -998,13 +1002,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database within a transaction.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      *
      * @throws \Throwable
      */
-    public function updateOrFail(array $attributes = [], array $options = [])
+    public function updateOrFail($attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;
@@ -1016,11 +1020,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database without raising any events.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function updateQuietly(array $attributes = [], array $options = [])
+    public function updateQuietly($attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\ValidatedInput;
 use JsonSerializable;
 use LogicException;
 use Stringable;
@@ -228,10 +229,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return void
      */
-    public function __construct($attributes = [])
+    public function __construct(array|ValidatedInput $attributes = [])
     {
         $this->bootIfNotBooted();
 
@@ -501,16 +502,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Fill the model with an array of attributes.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\MassAssignmentException
      */
-    public function fill($attributes)
+    public function fill(array|ValidatedInput $attributes)
     {
         $totallyGuarded = $this->totallyGuarded();
 
-        if ($attributes instanceof \Illuminate\Support\ValidatedInput) {
+        if ($attributes instanceof ValidatedInput) {
             $attributes = $attributes->all();
         }
 
@@ -555,10 +556,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Fill the model with an array of attributes. Force mass assignment.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return $this
      */
-    public function forceFill($attributes)
+    public function forceFill(array|ValidatedInput $attributes)
     {
         return static::unguarded(fn () => $this->fill($attributes));
     }
@@ -594,11 +595,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Create a new instance of the given model.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @param  bool  $exists
      * @return static
      */
-    public function newInstance($attributes = [], $exists = false)
+    public function newInstance(array|ValidatedInput $attributes = [], $exists = false)
     {
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
@@ -986,11 +987,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function update($attributes = [], array $options = [])
+    public function update(array|ValidatedInput $attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;
@@ -1002,13 +1003,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database within a transaction.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      *
      * @throws \Throwable
      */
-    public function updateOrFail($attributes = [], array $options = [])
+    public function updateOrFail(array|ValidatedInput $attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;
@@ -1020,11 +1021,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Update the model in the database without raising any events.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function updateQuietly($attributes = [], array $options = [])
+    public function updateQuietly(array|ValidatedInput $attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1273,12 +1273,12 @@ class BelongsToMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @param  array  $joining
      * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [], array $joining = [], $touch = true)
+    public function create($attributes = [], array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Str;
+use Illuminate\Support\ValidatedInput;
 use InvalidArgumentException;
 
 class BelongsToMany extends Relation
@@ -1273,12 +1274,12 @@ class BelongsToMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @param  array  $joining
      * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create($attributes = [], array $joining = [], $touch = true)
+    public function create(array|ValidatedInput $attributes = [], array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -46,10 +46,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create and return an un-saved instance of the related model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function make(array $attributes = [])
+    public function make($attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
@@ -331,10 +331,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [])
+    public function create($attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
@@ -346,10 +346,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model without raising any events to the parent model.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function createQuietly(array $attributes = [])
+    public function createQuietly($attributes = [])
     {
         return Model::withoutEvents(fn () => $this->create($attributes));
     }
@@ -357,10 +357,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model. Allow mass-assignment.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate(array $attributes = [])
+    public function forceCreate($attributes = [])
     {
         $attributes[$this->getForeignKeyName()] = $this->getParentKey();
 
@@ -370,10 +370,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model with mass assignment without raising model events.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreateQuietly(array $attributes = [])
+    public function forceCreateQuietly($attributes = [])
     {
         return Model::withoutEvents(fn () => $this->forceCreate($attributes));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\ValidatedInput;
 
 abstract class HasOneOrMany extends Relation
 {
@@ -46,10 +47,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create and return an un-saved instance of the related model.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function make($attributes = [])
+    public function make(array|ValidatedInput $attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
@@ -331,10 +332,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create($attributes = [])
+    public function create(array|ValidatedInput $attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
@@ -346,10 +347,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model without raising any events to the parent model.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function createQuietly($attributes = [])
+    public function createQuietly(array|ValidatedInput $attributes = [])
     {
         return Model::withoutEvents(fn () => $this->create($attributes));
     }
@@ -357,10 +358,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model. Allow mass-assignment.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate($attributes = [])
+    public function forceCreate(array|ValidatedInput $attributes = [])
     {
         $attributes[$this->getForeignKeyName()] = $this->getParentKey();
 
@@ -370,10 +371,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Create a new instance of the related model with mass assignment without raising model events.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreateQuietly($attributes = [])
+    public function forceCreateQuietly(array|ValidatedInput $attributes = [])
     {
         return Model::withoutEvents(fn () => $this->forceCreate($attributes));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -67,10 +67,10 @@ class MorphMany extends MorphOneOrMany
     /**
      * Create a new instance of the related model. Allow mass-assignment.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate(array $attributes = [])
+    public function forceCreate($attributes = [])
     {
         $attributes[$this->getMorphType()] = $this->morphClass;
 
@@ -80,10 +80,10 @@ class MorphMany extends MorphOneOrMany
     /**
      * Create a new instance of the related model with mass assignment without raising model events.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreateQuietly(array $attributes = [])
+    public function forceCreateQuietly($attributes = [])
     {
         return Model::withoutEvents(fn () => $this->forceCreate($attributes));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\ValidatedInput;
 
 class MorphMany extends MorphOneOrMany
 {
@@ -67,10 +68,10 @@ class MorphMany extends MorphOneOrMany
     /**
      * Create a new instance of the related model. Allow mass-assignment.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate($attributes = [])
+    public function forceCreate(array|ValidatedInput $attributes = [])
     {
         $attributes[$this->getMorphType()] = $this->morphClass;
 
@@ -80,10 +81,10 @@ class MorphMany extends MorphOneOrMany
     /**
      * Create a new instance of the related model with mass assignment without raising model events.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreateQuietly($attributes = [])
+    public function forceCreateQuietly(array|ValidatedInput $attributes = [])
     {
         return Model::withoutEvents(fn () => $this->forceCreate($attributes));
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -70,10 +70,10 @@ abstract class MorphOneOrMany extends HasOneOrMany
     /**
      * Create a new instance of the related model. Allow mass-assignment.
      *
-     * @param  array  $attributes
+     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate(array $attributes = [])
+    public function forceCreate($attributes = [])
     {
         $attributes[$this->getForeignKeyName()] = $this->getParentKey();
         $attributes[$this->getMorphType()] = $this->morphClass;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\ValidatedInput;
 
 abstract class MorphOneOrMany extends HasOneOrMany
 {
@@ -70,10 +71,10 @@ abstract class MorphOneOrMany extends HasOneOrMany
     /**
      * Create a new instance of the related model. Allow mass-assignment.
      *
-     * @param  array|\Illuminate\Support\ValidatedInput  $attributes
+     * @param  array|ValidatedInput  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate($attributes = [])
+    public function forceCreate(array|ValidatedInput $attributes = [])
     {
         $attributes[$this->getForeignKeyName()] = $this->getParentKey();
         $attributes[$this->getMorphType()] = $this->morphClass;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -44,6 +44,7 @@ use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Illuminate\Support\ValidatedInput;
 use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
@@ -622,6 +623,18 @@ class DatabaseEloquentModelTest extends TestCase
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::make(['name' => 'taylor']);
         $this->assertFalse($_SERVER['__eloquent.saved']);
+        $this->assertSame('taylor', $model->name);
+    }
+
+    public function testMakeMethodAllowsSafeObject()
+    {
+        $model = EloquentModelSaveStub::make(new ValidatedInput(['name' => 'taylor']));
+        $this->assertSame('taylor', $model->name);
+    }
+
+    public function testConstructorAllowsSafeObject()
+    {
+        $model = new EloquentModelSaveStub(new ValidatedInput(['name' => 'taylor']));
         $this->assertSame('taylor', $model->name);
     }
 
@@ -1430,6 +1443,14 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->fillable(['name', 'age']);
         $model->fill(['name' => 'foo', 'age' => 'bar']);
+        $this->assertSame('foo', $model->name);
+        $this->assertSame('bar', $model->age);
+    }
+
+    public function testFillingWithSafeObject()
+    {
+        $model = new EloquentModelStub;
+        $model->fill(new ValidatedInput(['name' => 'foo', 'age' => 'bar']));
         $this->assertSame('foo', $model->name);
         $this->assertSame('bar', $model->age);
     }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -161,13 +161,13 @@ class EloquentModelTest extends DatabaseTestCase
         $model = new class extends Model
         {
             protected $table = 'actions';
-            protected $fillable = ['label'];
+            protected $fillable = [];
             public $timestamps = false;
         };
 
         $this->expectException(\Illuminate\Database\QueryException::class);
 
-        $model->newInstance()->create(new ValidatedInput([
+        $model->newInstance()->forceCreate(new ValidatedInput([
             'label' => 'test',
             'unknown' => 'column',
         ]));

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Support\ValidatedInput;
 
 class EloquentUpdateTest extends DatabaseTestCase
 {
@@ -44,6 +45,19 @@ class EloquentUpdateTest extends DatabaseTestCase
         TestUpdateModel1::where('title', 'Ms.')->delete();
 
         $this->assertCount(0, TestUpdateModel1::all());
+    }
+
+    public function testUpdateAllowsSafeObject()
+    {
+        $model = TestUpdateModel2::create([
+            'name' => Str::random(),
+        ]);
+
+        $model->update(new ValidatedInput(['job' => 'Developer']));
+
+        $model->refresh();
+
+        $this->assertSame('Developer', $model->job);
     }
 
     public function testUpdateWithLimitsAndOrders()

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -53,11 +53,11 @@ class EloquentUpdateTest extends DatabaseTestCase
             'name' => Str::random(),
         ]);
 
-        $model->update(new ValidatedInput(['job' => 'Developer']));
+        $model->update(new ValidatedInput(['title' => 'Developer']));
 
         $model->refresh();
 
-        $this->assertSame('Developer', $model->job);
+        $this->assertSame('Developer', $model->title);
     }
 
     public function testUpdateWithLimitsAndOrders()

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -49,7 +49,7 @@ class EloquentUpdateTest extends DatabaseTestCase
 
     public function testUpdateAllowsSafeObject()
     {
-        $model = TestUpdateModel2::create([
+        $model = TestUpdateModel1::create([
             'name' => Str::random(),
         ]);
 


### PR DESCRIPTION
This is an alternative implementation of #50190 which will allow the `ValidatedInput` object to be passed in directly without forcing the user to first cast it to an array themselves without touching mass assignment protection.

In #50190 @jasonmccreary introduces this ability to pass in this object directly into eloquent. However in his implementation he makes the choice that because the input has been validated to disable mass assignment protection when the `ValidatedInput` object is passed in.

In his PR I commented that I felt that was too hidden and many users unless they dig into it are unlikely to realize that create/update/fill are implicitly changed to disable mass assignment protection based on the type of input used. As other commenters have also raised this same concern I have prepared this PR as an alternative implementation for Taylor to consider.

The first commit brings this to parity with #50190 at the current time, plus added this to the "force" methods as well. The second commit is more opinionated, adding back type hints with the union type. However, since I am unaware of whether Taylor would prefer union types or no types I left that as a separate commit which could easily be reverted.