### PR TITLE
Str helper conjunction method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -243,6 +243,34 @@ class Str
     }
 
     /**
+     * Get the "an" or "a" conjunction for the word that it precedes,
+     * or substute the conjunction into the string if a sprintf format string is provided.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function conjunction($string)
+    {
+        $vowelSounds = ['a', 'e', 'i', 'o', 'x'];
+
+        $makeConjunction = fn ($subsequentWord) => Str::startsWith(
+            Str::lower(trim($subsequentWord)),
+            $vowelSounds,
+        )
+            ? _('an')
+            : _('a');
+
+        if (Str::contains($string, '%s')) {
+            return sprintf(
+                $string,
+                $makeConjunction(Str::substr($string, Str::position($string, '%s') + 2)),
+            );
+        }
+
+        return $makeConjunction($string);
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -257,8 +257,8 @@ class Str
             Str::lower(trim($subsequentWord)),
             $vowelSounds,
         )
-            ? _('an')
-            : _('a');
+            ? 'an'
+            : 'a';
 
         if (Str::contains($string, '%s')) {
             return sprintf(

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1387,11 +1387,10 @@ class SupportStrTest extends TestCase
 
     public function testConjunction()
     {
-        $this->assertSame('a', Str::conjunction('machine'));
-        $this->assertSame('an', Str::conjunction('item'));
         $this->assertSame('List a machine', Str::conjunction('List %s machine'));
         $this->assertSame('List an item', Str::conjunction('List %s item'));
         $this->assertSame('book a  hotel', Str::conjunction('book %s  hotel'));
+        $this->assertSame('a git merge', Str::conjunction('%s git merge'));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1384,6 +1384,55 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::fromBase64(base64_encode('foo')));
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
+
+    public function testConjunction()
+    {
+        $this->assertSame('a', Str::conjunction('machine'));
+        $this->assertSame('an', Str::conjunction('item'));
+        $this->assertSame('List a machine', Str::conjunction('List %s machine'));
+        $this->assertSame('List an item', Str::conjunction('List %s item'));
+        $this->assertSame('book a  hotel', Str::conjunction('book %s  hotel'));
+    }
+
+    /**
+     * @dataProvider strConjunctionProvider
+     */
+    public function testConjunctionWord($word, $string)
+    {
+        $this->assertSame($word, Str::conjunction($string));
+    }
+
+    public static function strConjunctionProvider(): array
+    {
+        return [
+            ['an', 'appointment'],
+            ['an', 'espresso'],
+            ['an', 'igloo'],
+            ['an', 'ostrich'],
+            ['an', 'xray'],
+            ['a', 'book'],
+            ['a', 'candle'],
+            ['a', 'dog'],
+            ['a', 'fox'],
+            ['a', 'giraffe'],
+            ['a', 'hotel'],
+            ['a', 'jousting stick'],
+            ['a', 'kilo'],
+            ['a', 'laravel helper'],
+            ['a', 'milkshake'],
+            ['a', 'nose'],
+            ['a', 'pianno'],
+            ['a', 'quick'],
+            ['a', 'radio'],
+            ['a', 'slide'],
+            ['a', 'toaster'],
+            ['a', 'uniform'],
+            ['a', 'violin'],
+            ['a', 'whisky'],
+            ['a', 'yak shave'],
+            ['a', 'zoo'],
+        ];
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
Sometimes you'll want to construct text from a template string where the subject is variable.
e.g.

`Book a hotel` vs `Book an x-ray` where `hotel`/`x-ray` is only known at runtime.

This helper can determine if `a` or `an` is required.

```php
$subject = 'hotel';
Str::conjunction('Book %s ' . $subject); // Book a hotel
```

If you only require the conjunction back you can pass in the word that follows it without using a sprintf template string
```php
Str::conjunction('skeleton'); // a
```

## About acronyms and initializations
Terms such as `HTTP`, `MP4` or  `CEO` are tricky because if they are initializations you would pronounce each letter (CEO = C . E . O). This can affect what the conjunction would be. Because of this, this helper would not support text intended for acronyms or initializations. I belive these are less likely to need to be dynamically generated at runtime though.