### PR TITLE
[10.x] Add only and except methods to Enum validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -28,14 +28,14 @@ class Enum implements Rule, ValidatorAwareRule
      *
      * @var array
      */
-    private array $only = [];
+    protected array $only = [];
 
     /**
      * The cases that should be considered invalid.
      *
      * @var array
      */
-    private array $except = [];
+    protected array $except = [];
 
     /**
      * Create a new rule instance.
@@ -104,7 +104,7 @@ class Enum implements Rule, ValidatorAwareRule
      * @param  mixed  $value
      * @return bool
      */
-    private function isDesirable(mixed $value): bool
+    protected function isDesirable(mixed $value): bool
     {
         return match (true) {
             ! empty($this->only) => in_array(needle: $value, haystack: $this->only, strict: true),

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -98,6 +98,8 @@ class Enum implements Rule, ValidatorAwareRule
 
     /**
      * Set specific cases to be valid.
+     *
+     * @param UnitEnum[]|UnitEnum $enums
      */
     public function only(array|UnitEnum $enums): static
     {
@@ -108,6 +110,8 @@ class Enum implements Rule, ValidatorAwareRule
 
     /**
      * Set specific cases to be invalid.
+     *
+     * @param UnitEnum[]|UnitEnum $enums
      */
     public function except(array|UnitEnum $enums): static
     {

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -99,7 +99,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Set specific cases to be valid.
      *
-     * @param UnitEnum[]|UnitEnum $enums
+     * @param  UnitEnum[]|UnitEnum $enums
      */
     public function only(array|UnitEnum $enums): static
     {
@@ -111,7 +111,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Set specific cases to be invalid.
      *
-     * @param UnitEnum[]|UnitEnum $enums
+     * @param  UnitEnum[]|UnitEnum $enums
      */
     public function except(array|UnitEnum $enums): static
     {

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -104,7 +104,7 @@ class Enum implements Rule, ValidatorAwareRule
      * @param  mixed  $value
      * @return bool
      */
-    protected function isDesirable(mixed $value)
+    protected function isDesirable($value)
     {
         return match (true) {
             ! empty($this->only) => in_array(needle: $value, haystack: $this->only, strict: true),

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -78,8 +78,9 @@ class Enum implements Rule, ValidatorAwareRule
      * Specify the cases that should be considered valid.
      *
      * @param  \UnitEnum[]|\UnitEnum  $values
+     * @return $this
      */
-    public function only($values): static
+    public function only($values)
     {
         $this->only = Arr::wrap($values);
 
@@ -90,8 +91,9 @@ class Enum implements Rule, ValidatorAwareRule
      * Specify the cases that should be considered invalid.
      *
      * @param  \UnitEnum[]|\UnitEnum  $values
+     * @return $this
      */
-    public function except($values): static
+    public function except($values)
     {
         $this->except = Arr::wrap($values);
 

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -99,7 +99,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Set specific cases to be valid.
      *
-     * @param  UnitEnum[]|UnitEnum $enums
+     * @param  UnitEnum[]|UnitEnum  $enums
      */
     public function only(array|UnitEnum $enums): static
     {
@@ -111,7 +111,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Set specific cases to be invalid.
      *
-     * @param  UnitEnum[]|UnitEnum $enums
+     * @param  UnitEnum[]|UnitEnum  $enums
      */
     public function except(array|UnitEnum $enums): static
     {

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -28,14 +28,14 @@ class Enum implements Rule, ValidatorAwareRule
      *
      * @var array
      */
-    protected array $only = [];
+    protected $only = [];
 
     /**
      * The cases that should be considered invalid.
      *
      * @var array
      */
-    protected array $except = [];
+    protected $except = [];
 
     /**
      * Create a new rule instance.
@@ -104,7 +104,7 @@ class Enum implements Rule, ValidatorAwareRule
      * @param  mixed  $value
      * @return bool
      */
-    protected function isDesirable(mixed $value): bool
+    protected function isDesirable(mixed $value)
     {
         return match (true) {
             ! empty($this->only) => in_array(needle: $value, haystack: $this->only, strict: true),

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -120,7 +120,7 @@ class Enum implements Rule, ValidatorAwareRule
     {
         return match (true) {
             ! empty($this->only) => in_array(needle: $value, haystack: $this->only, strict: true),
-            ! empty($this->except) => !in_array(needle: $value, haystack: $this->except, strict: true),
+            ! empty($this->except) => ! in_array(needle: $value, haystack: $this->except, strict: true),
             default => true,
         };
     }

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -25,12 +25,12 @@ class Enum implements Rule, ValidatorAwareRule
     protected $validator;
 
     /**
-     * Cases considered as valid
+     * Cases considered as valid.
      */
     private array $only = [];
 
     /**
-     * Cases considered as invalid
+     * Cases considered as invalid.
      */
     private array $except = [];
 
@@ -97,7 +97,7 @@ class Enum implements Rule, ValidatorAwareRule
     }
 
     /**
-     * Set specific cases to be valid
+     * Set specific cases to be valid.
      */
     public function only(array|UnitEnum $enums): static
     {
@@ -107,7 +107,7 @@ class Enum implements Rule, ValidatorAwareRule
     }
 
     /**
-     * Set specific cases to be invalid
+     * Set specific cases to be invalid.
      */
     public function except(array|UnitEnum $enums): static
     {
@@ -119,8 +119,8 @@ class Enum implements Rule, ValidatorAwareRule
     private function isDesirable(mixed $value): bool
     {
         return match (true) {
-            !empty($this->only) => in_array(needle: $value, haystack: $this->only, strict: true),
-            !empty($this->except) => !in_array(needle: $value, haystack: $this->except, strict: true),
+            ! empty($this->only) => in_array(needle: $value, haystack: $this->only, strict: true),
+            ! empty($this->except) => !in_array(needle: $value, haystack: $this->except, strict: true),
             default => true,
         };
     }


### PR DESCRIPTION
## Description
Sometimes you don`t expect all enum cases to be valid. Particularly, it can be useful when talking about statuses.
### Scenarios
1. Users have applications. When they switch application status from `new` to `another one`, you likely want to let them change application status to any one except for `new`.
2. If the order has status `shipped`, you likely want it to be possible to change its status only to `cancelled`, `delivered`, `rejected` etc. but not to `pending`, `new`, `created` etc.
3. When creating some task/project manager like Jira, you may wish to restrict which status task can be changed to in particular step.
### Solution
Add `only()` and `except()` methods to Enum validation Rule. So now you can do the following:

`Rule::enum(OrderStatus::class)->only([OrderStatus::Cancelled, OrderStatus::Delivered]);
`

`Rule::enum(ApplicationStatus::class)->except(ApplicationStatus::New);
`

It might be really useful in combination with `when()` (e.g. for task/project manager):
```
[
        'task_status' => [
            Rule::when(
                $this->task->status === TaskStatus::ReadyToWork,
                fn () => Rule::enum(TaskStatus::class)->only(TaskStatus::InProgress),
            ),
            Rule::when(
                $this->task->status === TaskStatus::InProgress,
                fn () => Rule::enum(TaskStatus::class)->only([TaskStatus::PROpen, TaskStatus::ReadyToWork]),
            ),
            Rule::when(
                $this->task->status === TaskStatus::Reopened,
                fn () => Rule::enum(TaskStatus::class)->except([TaskStatus::PROpen, TaskStatus::Done]),
            ),
        ]
 ],
```

### Note
`only()` has higher order than `except()`, so the validation below would pass:
```
Validator::make(
            [
                'order_status' => OrderStatus::New,
            ],
            [
                'order_status' => Rule::enum(OrderStatus::class)->only(OrderStatus::New)->except(OrderStatus::New),
            ]
        );
```