### PR TITLE
[11.x] Health check endpoint should return JSON for API requests

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -193,7 +193,7 @@ class ApplicationBuilder
 
                     if (request()->isJson()) {
                         return response()->json([
-                            'status' => true
+                            'status' => true,
                         ]);
                     }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -191,6 +191,12 @@ class ApplicationBuilder
                 Route::middleware('web')->get($health, function () {
                     Event::dispatch(new DiagnosingHealth);
 
+                    if (request()->isJson()) {
+                        return response()->json([
+                            'status' => true
+                        ]);
+                    }
+
                     return View::file(__DIR__.'/../resources/health-up.blade.php');
                 });
             }

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -17,7 +17,7 @@ class RouteServiceProviderHealthTest extends TestCase
     {
         return Application::configure(static::applicationBasePath())
             ->withRouting(
-                web: __DIR__.'/fixtures/web.php',
+                web: __DIR__ . '/fixtures/web.php',
                 health: '/up',
             )->create();
     }
@@ -30,5 +30,10 @@ class RouteServiceProviderHealthTest extends TestCase
     public function test_it_can_load_health_page()
     {
         $this->get('/up')->assertOk();
+    }
+
+    public function test_it_returns_json_response_for_api()
+    {
+        $this->getJson('/up')->assertOk()->assertJson(['status' => true]);
     }
 }

--- a/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
+++ b/tests/Integration/Foundation/Support/Providers/RouteServiceProviderHealthTest.php
@@ -17,7 +17,7 @@ class RouteServiceProviderHealthTest extends TestCase
     {
         return Application::configure(static::applicationBasePath())
             ->withRouting(
-                web: __DIR__ . '/fixtures/web.php',
+                web: __DIR__.'/fixtures/web.php',
                 health: '/up',
             )->create();
     }


### PR DESCRIPTION
When we build RESTful APIs or Microservices using Laravel, it would be better if we get the `health` status as JSON response instead of HTML. 

In this PR, I've modified the `health` endpoint response to add a check for API requests. 

If there are any better suggestions for the format of the JSON or if we need to add more data to the response, I'll update the PR accordingly. 
