### PR TITLE
[10.x] Ability to add custom filename for inline embed email

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -333,9 +333,11 @@ class Message
      * Embed a file in the message and get the CID.
      *
      * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
+     * @param  string|null  $name custom filename when $file is a string path
+     *
      * @return string
      */
-    public function embed($file)
+    public function embed($file, $name = null)
     {
         if ($file instanceof Attachable) {
             $file = $file->toMailAttachment();
@@ -362,7 +364,7 @@ class Message
             );
         }
 
-        $cid = Str::random(10);
+        $cid = $name ?? Str::random(10);
 
         $this->message->addPart(
             (new DataPart(new File($file), $cid))->asInline()

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -182,7 +182,8 @@ class MailMessageTest extends TestCase
 
         $cid = $this->message->embed($path, 'laravel.jpg');
 
-        $this->assertStringStartsWith('cid:', $cid);
+        $this->assertSame('cid:laravel.jpg', $cid);
+        
         $name = 'laravel.jpg';
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
         $headers = $attachment->getPreparedHeaders()->toArray();

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -176,6 +176,24 @@ class MailMessageTest extends TestCase
         unlink($path);
     }
 
+    public function testEmbedPathWithCustomName()
+    {
+        file_put_contents($path = __DIR__.'/foo.jpg', 'bar');
+
+        $cid = $this->message->embed($path, 'laravel.jpg');
+
+        $this->assertStringStartsWith('cid:', $cid);
+        $name = Str::after($cid, 'cid:');
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('bar', $attachment->getBody());
+        $this->assertSame("Content-Type: image/jpeg; name={$name}", $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame("Content-Disposition: inline; name={$name}; filename={$name}", $headers[2]);
+
+        unlink($path);
+    }
+
     public function testDataEmbed()
     {
         $cid = $this->message->embedData('bar', 'foo.jpg', 'image/png');

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -183,7 +183,7 @@ class MailMessageTest extends TestCase
         $cid = $this->message->embed($path, 'laravel.jpg');
 
         $this->assertStringStartsWith('cid:', $cid);
-        $name = Str::after($cid, 'cid:');
+        $name = 'laravel.jpg';
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
         $headers = $attachment->getPreparedHeaders()->toArray();
         $this->assertSame('bar', $attachment->getBody());

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -183,7 +183,7 @@ class MailMessageTest extends TestCase
         $cid = $this->message->embed($path, 'laravel.jpg');
 
         $this->assertSame('cid:laravel.jpg', $cid);
-        
+
         $name = 'laravel.jpg';
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
         $headers = $attachment->getPreparedHeaders()->toArray();


### PR DESCRIPTION
Hi team,

This PR adds the `$name` param for the email inline embedding. This shouldn't introduce any breaking changes.

![image](https://github.com/laravel/framework/assets/23478115/5e58b1b1-defe-46cb-aae8-ef5253fe7fd5)


Would really helpful to add inline file with the desired filename instead of random when using `string` path.

### Alternatively solution

We can use the `Attachment::fromPath('foo')->as('bar.jpg')`, however it'd get long and kinda ugly in the blade template 🤔 

Cheers!