### PR TITLE
Make GuardsAttributes fillable property DocBlock more specific

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -7,7 +7,7 @@ trait GuardsAttributes
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [];
 


### PR DESCRIPTION
First of all, this is my first attempt at an Open Source contribution. Apologies if anything is sloppy / incorrect.

Starting from a clean project. Installing Larastan and [utilising strict mode](https://github.com/phpstan/phpstan-strict-rules) highlights the following issue:

```
Line   Models/User.php
20     PHPDoc type array<int, string> of property App\Models\User::$fillable is not the same as PHPDoc type array<string> of overridden property Illuminate\Database\Eloquent\Model::$fillable.
```

Specifically, this is caused by the `reportMaybesInPropertyPhpDocTypes` [rule](https://phpstan.org/config-reference#reportmaybesinpropertyphpdoctypes). My proposed fix is to make the `GuardsAttribute` `$fillable` property more specific, to remove the need to ignore / stub this error. If this plans to be merged, could possibly do with a wider conversation as to some of the other `array<string>` annotations elsewhere in the file?

Equally (and admittedly simpler), the User $fillable DocBlock could be made less specific - but I thought I'd start the conversation here as a higher specificity is presumably better.