### PR TITLE
[11.x] Add route_path helper

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -385,6 +385,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->instance('path.database', $this->databasePath());
         $this->instance('path.public', $this->publicPath());
         $this->instance('path.resources', $this->resourcePath());
+        $this->instance('path.routes', $this->routePath());
         $this->instance('path.storage', $this->storagePath());
 
         $this->useBootstrapPath(value(function () {
@@ -616,6 +617,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function resourcePath($path = '')
     {
         return $this->joinPaths($this->basePath('resources'), $path);
+    }
+
+    /**
+     * Get the path to the routes directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function routePath($path = '')
+    {
+        return $this->joinPaths($this->basePath('routes'), $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -812,6 +812,19 @@ if (! function_exists('route')) {
     }
 }
 
+if (! function_exists('route_path')) {
+    /**
+     * Get the path to the routes folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function route_path($path = '')
+    {
+        return app()->routePath($path);
+    }
+}
+
 if (! function_exists('secure_asset')) {
     /**
      * Generate an asset path for the application.


### PR DESCRIPTION
Added helper that allows us to get the path of routes instead of using `__DIR__`. I think it would be more concise and inline with laravel style.

And then in app bootstrap file we can use this:

```php
->withRouting(
    web: route_path('web.php'),
    commands: route_path('console.php'),
    health: '/up',
)
```