### PR TITLE
[10.x] Http helper for tests so postXml is possible

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -401,6 +401,7 @@ trait MakesHttpRequests
     {
         $headers = array_merge($headers, ['Content-Type' => 'text/xml;charset=utf-8']);
         $server = $this->transformHeadersToServerVars($headers);
+        
         return $this->call('POST', $uri, [], [], [], $server, $xmlBody);
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -390,6 +390,21 @@ trait MakesHttpRequests
     }
 
     /**
+     * Visit the given URI with a POST request, expecting an XML response.
+     *
+     * @param  string  $uri
+     * @param  string  $xmlBody
+     * @param  array  $headers
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function postXml($uri, $xmlBody, array $headers = [])
+    {
+        $headers = $this->transformHeadersToServerVars(array_merge($this->defaultHeaders,$headers,['Content-Type' => 'text/xml;charset=utf-8']));
+        $server = $this->transformHeadersToServerVars($headers);
+        return $this->call('POST', $uri, [], [], [], $server, $xmlBody);
+    }
+
+    /**
      * Visit the given URI with a PUT request.
      *
      * @param  string  $uri

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -399,7 +399,7 @@ trait MakesHttpRequests
      */
     public function postXml($uri, $xmlBody, array $headers = [])
     {
-        $headers = $this->transformHeadersToServerVars(array_merge($this->defaultHeaders,$headers,['Content-Type' => 'text/xml;charset=utf-8']));
+        $headers = array_merge($headers, ['Content-Type' => 'text/xml;charset=utf-8']);
         $server = $this->transformHeadersToServerVars($headers);
         return $this->call('POST', $uri, [], [], [], $server, $xmlBody);
     }


### PR DESCRIPTION
Right now it is very difficult to make an HTTP request in a test with XML data as the body. With this method it is now possible, quite similar to postJson() helper.
