### PR TITLE
[10.x] Add suport to streamed responses in APIResources

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -41,6 +41,17 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public $additional = [];
 
+
+    /**
+     * Set true if the resource should be streamed.
+     *
+     * @var boolean
+     */
+    public $stream = false;
+
+
+
+
     /**
      * The "data" wrapper that should be applied.
      *
@@ -57,6 +68,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function __construct($resource)
     {
         $this->resource = $resource;
+        $this->stream = method_exists($this, 'toStream');
     }
 
     /**
@@ -191,10 +203,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Customize the response for a request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\JsonResponse  $response
+     * @param  \Illuminate\Http\JsonResponse|\Symfony\Component\HttpFoundationStreamedJsonResponse  $response
      * @return void
      */
-    public function withResponse(Request $request, JsonResponse $response)
+    public function withResponse(Request $request, $response)
     {
         //
     }
@@ -241,6 +253,8 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toResponse($request)
     {
+        if ($this->stream)
+            return (new StreamedResourceResponse($this))->toResponse($request);
         return (new ResourceResponse($this))->toResponse($request);
     }
 

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\DelegatesToResource;
@@ -41,16 +40,12 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public $additional = [];
 
-
     /**
      * Set true if the resource should be streamed.
      *
-     * @var boolean
+     * @var bool
      */
     public $stream = false;
-
-
-
 
     /**
      * The "data" wrapper that should be applied.
@@ -253,8 +248,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toResponse($request)
     {
-        if ($this->stream)
+        if ($this->stream) {
             return (new StreamedResourceResponse($this))->toResponse($request);
+        }
+
         return (new ResourceResponse($this))->toResponse($request);
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -103,6 +103,19 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     }
 
     /**
+     * Transform the colection into a generator.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return Generator
+     */
+    public function toStream(Request $request)
+    {
+        foreach ($this->collection as $item) {
+            yield $this->filter($item->toArray($request));
+        }
+    }
+
+    /**
      * Create an HTTP response that represents the object.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -127,7 +140,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     {
         if ($this->preserveAllQueryParameters) {
             $this->resource->appends($request->query());
-        } elseif (! is_null($this->queryParameters)) {
+        } elseif (!is_null($this->queryParameters)) {
             $this->resource->appends($this->queryParameters);
         }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -140,7 +140,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     {
         if ($this->preserveAllQueryParameters) {
             $this->resource->appends($request->query());
-        } elseif (!is_null($this->queryParameters)) {
+        } elseif (! is_null($this->queryParameters)) {
             $this->resource->appends($this->queryParameters);
         }
 

--- a/src/Illuminate/Http/Resources/Json/StreamedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/StreamedResourceResponse.php
@@ -3,13 +3,10 @@
 namespace Illuminate\Http\Resources\Json;
 
 use Generator;
-use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 class StreamedResourceResponse extends ResourceResponse
 {
-
     /**
      * The underlying resource.
      *
@@ -36,7 +33,10 @@ class StreamedResourceResponse extends ResourceResponse
      */
     public function toResponse($request)
     {
-        if (!$this->resource->stream) return parent::toResponse($request);
+        if (! method_exists($this->resource, 'toStream')) {
+            return parent::toResponse($request);
+        }
+
         return tap(response()->streamJson(
             $this->wrap(
                 $this->resource->toStream($request),

--- a/src/Illuminate/Http/Resources/Json/StreamedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/StreamedResourceResponse.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Http\Resources\Json;
+
+use Generator;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class StreamedResourceResponse extends ResourceResponse
+{
+
+    /**
+     * The underlying resource.
+     *
+     * @var JsonResource
+     */
+    public $resource;
+
+    /**
+     * Create a new resource response.
+     *
+     * @param  JsonResource  $resource
+     * @return void
+     */
+    public function __construct($resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Create an Streamed HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function toResponse($request)
+    {
+        if (!$this->resource->stream) return parent::toResponse($request);
+        return tap(response()->streamJson(
+            $this->wrap(
+                $this->resource->toStream($request),
+                $this->resource->with($request),
+                $this->resource->additional
+            ),
+            $this->calculateStatus(),
+            [],
+            $this->resource->jsonOptions()
+        ), function ($response) use ($request) {
+            $response->original = $this->resource->resource;
+
+            $this->resource->withResponse($request, $response);
+        });
+    }
+
+    /**
+     * Wrap the given data if necessary.
+     *
+     * @param  \Illuminate\Support\Collection|array|Generator  $data
+     * @param  array  $with
+     * @param  array  $additional
+     * @return array
+     */
+    protected function wrap($data, $with = [], $additional = [])
+    {
+        if ($data instanceof Collection) {
+            $data = $data->all();
+        }
+
+        if ($data instanceof Generator) {
+            $data = [($this->wrapper() ?? 'data') => $data];
+        } elseif ($this->haveDefaultWrapperAndDataIsUnwrapped($data)) {
+            $data = [$this->wrapper() => $data];
+        } elseif ($this->haveAdditionalInformationAndDataIsUnwrapped($data, $with, $additional)) {
+            $data = [($this->wrapper() ?? 'data') => $data];
+        }
+
+        return array_merge_recursive($data, $with, $additional);
+    }
+}


### PR DESCRIPTION
Based on this discution #50242 and this pull request #49873:
> I was taking a look at pull request https://github.com/laravel/framework/pull/49873, and I identified a feature that would be very useful in the APIResources that already exist.
  I generally do the following in my controllers:

```php
public function index(IndexRequest $request)
    {
        $query = Client::with(['user', 'address']);

        return ClientResource::collection($query->get());
    }
```

> And in some entities it may take time to start transmitting data to the user.
  I believe it is plausible to add the StreamedResources functionality to the API Resources, especially in the static ::collection() function. I don't think it's a difficult addition.

And by coding a little in the library in a project I arrived at a good construction of a StreamedResource while still maintaining support for existing functionality.

I believe it would be a good addition to completely transform the APIResource to only return StreamedJsonResponses, as it would make it possible to use generators within Responses, like so:
```php
class ClientResource extends JsonResource
{
    /**
     * Transform the resource into an array.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return array
     */
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'address' => new AddressResource($this->address),
            'name' => $this->name,
            'email' => $this->email,
            'birthday' => $this->birthday,
            'contacts' => $this->yieldContacts(),
        ];
    }

    protected function yieldContacts(): Generator
    {
        foreach ($this->contacts()->cursor() as $contact) {
            yield new ContactResource($contact);
        }
    }
}
```

I think it needs a little more refinement before a APIResource only return StreamedJsonResponse. So in this pull request only add the possibility of returning streamed responses if the toStream() function is defined within the Resource class. And I also added the toStream() function to the AnonymousResourceCollection class, which I believe will not affect existing code and will even improve memory usage.

Tell me if it needs any change.
