### PR TITLE
[11.x] Remove `all` option from config:publish

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -18,7 +18,6 @@ class ConfigPublishCommand extends Command
      */
     protected $signature = 'config:publish
                     {name? : The name of the configuration file to publish}
-                    {--all : Publish all configuration files}
                     {--force : Overwrite any existing configuration files}';
 
     /**
@@ -36,14 +35,6 @@ class ConfigPublishCommand extends Command
     public function handle()
     {
         $config = $this->getBaseConfigurationFiles();
-
-        if (is_null($this->argument('name')) && $this->option('all')) {
-            foreach ($config as $key => $file) {
-                $this->publish($key, $file, $this->laravel->configPath().'/'.$key.'.php');
-            }
-
-            return;
-        }
 
         $name = (string) (is_null($this->argument('name')) ? select(
             label: 'Which configuration file would you like to publish?',


### PR DESCRIPTION
Now that almost all config files are back, I think it makes sense to remove the `all` option from the config:publish command.
Besides, if we run `config:publish --all`, we get lots of errors like `ERROR The 'app' configuration file already exists.`.

If this PR is merged, we need to update Laravel installer and a documentation page, which I can do.
