### PR TITLE
[10.x] Truncate sqlite table name with prefix

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -387,7 +387,7 @@ class SQLiteGrammar extends Grammar
     public function compileTruncate(Builder $query)
     {
         return [
-            'delete from sqlite_sequence where name = ?' => [$query->from],
+            'delete from sqlite_sequence where name = ?' => [$this->getTablePrefix().$query->from],
             'delete from '.$this->wrapTable($query->from) => [],
         ];
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3592,6 +3592,23 @@ class DatabaseQueryBuilderTest extends TestCase
         ], $sqlite->compileTruncate($builder));
     }
 
+    public function testTruncateMethodWithPrefix()
+    {
+        $builder = $this->getBuilder();
+        $builder->getGrammar()->setTablePrefix('prefix_');
+        $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "prefix_users"', []);
+        $builder->from('users')->truncate();
+
+        $sqlite = new SQLiteGrammar;
+        $sqlite->setTablePrefix('prefix_');
+        $builder = $this->getBuilder();
+        $builder->from('users');
+        $this->assertEquals([
+            'delete from sqlite_sequence where name = ?' => ['prefix_users'],
+            'delete from "prefix_users"' => [],
+        ], $sqlite->compileTruncate($builder));
+    }
+
     public function testPreserveAddsClosureToArray()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
When truncating an SQLite table, it should reset the auto-increment value.

This PR fixes the failure to delete from `sqlite_sequence` when a table name is prefixed.

## Step to reproduce

```
Config::set('database.connections.sqlite.prefix', 'prefix_');

DB::table('users')->insert(
    [
        'name' => 'John Doe',
    ]
);

DB::table('users')->truncate();

DB::table('users')->insert(
    [
        'name' => 'John Doe',
    ]
);

$user = DB::table('users')->first();
```

### Expected behaviour

`$user->id` === 1

### Actual behaviour

`$user->id` === 2