### PR TITLE
[10.x] Update return type

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -92,7 +92,7 @@ class TokenGuard implements Guard
     /**
      * Get the token for the current request.
      *
-     * @return string
+     * @return string|null
      */
     public function getTokenForRequest()
     {


### PR DESCRIPTION
Update return type for `getTokenForRequest` method.

For example bearerToken may return null

https://github.com/laravel/framework/blob/5f8684b3dde621a3fd6b523e9f48f232de38611c/src/Illuminate/Http/Concerns/InteractsWithInput.php#L50-L55

This will raise issue with phpstan when you come up with something like this:
`$token = auth()->getTokenForRequest() ?? '';`

