### PR TITLE
Fix the issue of `$wrap` attribute 💼

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -106,7 +106,7 @@ class ResourceResponse implements Responsable
      */
     protected function wrapper()
     {
-        return get_class($this->resource)::$wrap;
+        return $this->resource->collects::$wrap;
     }
 
     /**


### PR DESCRIPTION
I intended to use the **Data Wrapping** feature but, there was a glitch in the response where the wrapper was not affected by whatever changes in the `$wrap` attribute, so, I debugged the code and found out that Laravel accessing this attribute via `Illuminate\Http\Resources\Json\AnonymousResourceCollection` not the `JsonResource` class that I use therefore, I resolved the issue via using the public `collects` attribute and the response was correct back! 🎉