### PR TITLE
Fix the issue of `$wrap` collection resource attribute 💼

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -82,6 +82,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+
+            if (property_exists(static::class, 'wrap')) {
+                $collection::$wrap = static::$wrap;
+            }
         });
     }
 

--- a/tests/Integration/Http/Fixtures/PostResourceWithWrap.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithWrap.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithWrap extends PostResource
+{
+    public static $wrap = 'posts';
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -148,7 +148,7 @@ class ResourceTest extends TestCase
     public function testResourceCollectionThatHaveWrap()
     {
         Route::get('/', function () {
-            return PostResourceWithWrap::collect(collect([new Post([
+            return PostResourceWithWrap::collection(collect([new Post([
                 'id' => 5,
                 'title' => 'Test Title',
             ])]));

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -39,6 +39,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelations
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipCounts;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithoutWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
@@ -141,6 +142,31 @@ class ResourceTest extends TestCase
         $response->assertJson([
             'id' => 5,
             'title' => 'Test Title',
+        ]);
+    }
+
+    public function testResourceCollectionThatHaveWrap()
+    {
+        Route::get('/', function () {
+            return PostResourceWithWrap::collect(collect([new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ])]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'posts' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ],
+            ],
         ]);
     }
 


### PR DESCRIPTION
I intended to use the **Data Wrapping** feature but, there was a glitch in the response where the wrapper was not affected by whatever changes in the `$wrap` attribute, so, I debugged the code and found out that Laravel accessing this attribute via `Illuminate\Http\Resources\Json\AnonymousResourceCollection` not the `JsonResource` class that I use therefore, I resolved the issue via using the public `collects` attribute and the response was correct back! 🎉