### PR TITLE
[10.x] Add `Conditionable` in enum rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -5,10 +5,13 @@ namespace Illuminate\Validation\Rules;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 use TypeError;
 
 class Enum implements Rule, ValidatorAwareRule
 {
+    use Conditionable;
+
     /**
      * The type of the enum.
      *


### PR DESCRIPTION
This PR adds `Conditionable` trait to Enum rule.

How to use:

```php
Rule::enum(PostStatus::class)
    ->when(
        auth()->user()->is_admin,
        fn ($rule) => $rule->only([PostStatus::APPROVED]),
        fn ($rule) => $rule->only([PostStatus::PADDING]),
    );
```
