### PR TITLE
[10.x] Update Facade::$app to nullable

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -18,7 +18,7 @@ abstract class Facade
     /**
      * The application instance being facaded.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application|null
      */
     protected static $app;
 
@@ -317,7 +317,7 @@ abstract class Facade
     /**
      * Get the application instance behind the facade.
      *
-     * @return \Illuminate\Contracts\Foundation\Application
+     * @return \Illuminate\Contracts\Foundation\Application|null
      */
     public static function getFacadeApplication()
     {
@@ -327,7 +327,7 @@ abstract class Facade
     /**
      * Set the application instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application|null  $app
      * @return void
      */
     public static function setFacadeApplication($app)


### PR DESCRIPTION
`Facade::$app` can be _null_.
There are already some nullability checks within the same class (see `swap()` or `resolveFacadeInstance()`).

Making it explicit in the PHP blocks allows us to avoid errors with static analysis tools like PHPStan:
```
Parameter #1 $app of static method Illuminate\Support\Facades\Facade::setFacadeApplication() expects Illuminate\Contracts\Foundation\Application, null given.
```