### PR TITLE
[10.x] Fix the issue of `$wrap` collection resource attribute 💼

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -82,6 +82,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+
+            if (property_exists(static::class, 'wrap')) {
+                $collection::$wrap = static::$wrap;
+            }
         });
     }
 

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -82,10 +82,6 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
-
-            if (property_exists(static::class, 'wrap')) {
-                $collection::$wrap = static::$wrap;
-            }
         });
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -106,6 +106,10 @@ class ResourceResponse implements Responsable
      */
     protected function wrapper()
     {
+        if ($this->resource instanceof AnonymousResourceCollection) {
+            return $this->resource->collects::$wrap;
+        }
+        
         return get_class($this->resource)::$wrap;
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -109,7 +109,7 @@ class ResourceResponse implements Responsable
         if ($this->resource instanceof AnonymousResourceCollection) {
             return $this->resource->collects::$wrap;
         }
-        
+
         return get_class($this->resource)::$wrap;
     }
 

--- a/tests/Integration/Http/Fixtures/PostResourceWithWrap.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithWrap.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithWrap extends PostResource
+{
+    public static $wrap = 'posts';
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -148,7 +148,7 @@ class ResourceTest extends TestCase
     public function testResourceCollectionThatHaveWrap()
     {
         Route::get('/', function () {
-            return PostResourceWithWrap::collect(collect([new Post([
+            return PostResourceWithWrap::collection(collect([new Post([
                 'id' => 5,
                 'title' => 'Test Title',
             ])]));

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -145,29 +145,6 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function testResourceCollectionThatHaveWrap()
-    {
-        Route::get('/', function () {
-            return new PostResourceWithWrap(new Post([
-                'id' => 5,
-                'title' => 'Test Title',
-            ]));
-        });
-
-        $response = $this->withoutExceptionHandling()->get(
-            '/', ['Accept' => 'application/json']
-        );
-
-        $response->assertStatus(200);
-
-        $response->assertJson([
-            'posts' => [
-                'id' => 5,
-                'title' => 'Test Title',
-            ],
-        ]);
-    }
-
     public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {
@@ -1757,5 +1734,33 @@ class ResourceTest extends TestCase
             ->get('/', ['Accept' => 'application/json'])
             ->assertStatus(200)
             ->assertExactJson($expectedJson);
+    }
+
+    // This method must be at the end of the file because the method intends to
+    // change the wrapper key from "data" to "posts" and this makes all the previous
+    // test methods fail.
+    public function testResourceCollectionThatHaveWrap()
+    {
+        Route::get('/', function () {
+            return PostResourceWithWrap::collection(collect([new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ])]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'posts' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ]
+            ],
+        ]);
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1759,7 +1759,7 @@ class ResourceTest extends TestCase
                 [
                     'id' => 5,
                     'title' => 'Test Title',
-                ]
+                ],
             ],
         ]);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -148,10 +148,10 @@ class ResourceTest extends TestCase
     public function testResourceCollectionThatHaveWrap()
     {
         Route::get('/', function () {
-            return PostResourceWithWrap::collection(collect([new Post([
+            return new PostResourceWithWrap(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
-            ])]));
+            ]));
         });
 
         $response = $this->withoutExceptionHandling()->get(
@@ -162,10 +162,8 @@ class ResourceTest extends TestCase
 
         $response->assertJson([
             'posts' => [
-                [
-                    'id' => 5,
-                    'title' => 'Test Title',
-                ],
+                'id' => 5,
+                'title' => 'Test Title',
             ],
         ]);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -145,6 +145,31 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function testResourceCollectionThatHaveWrap()
+    {
+        Route::get('/', function () {
+            return PostResourceWithWrap::collection(collect([new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ])]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'posts' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ],
+            ],
+        ]);
+    }
+
     public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {
@@ -1734,33 +1759,5 @@ class ResourceTest extends TestCase
             ->get('/', ['Accept' => 'application/json'])
             ->assertStatus(200)
             ->assertExactJson($expectedJson);
-    }
-
-    // This method must be at the end of the file because the method intends to
-    // change the wrapper key from "data" to "posts" and this makes all the previous
-    // test methods fail.
-    public function testResourceCollectionThatHaveWrap()
-    {
-        Route::get('/', function () {
-            return PostResourceWithWrap::collection(collect([new Post([
-                'id' => 5,
-                'title' => 'Test Title',
-            ])]));
-        });
-
-        $response = $this->withoutExceptionHandling()->get(
-            '/', ['Accept' => 'application/json']
-        );
-
-        $response->assertStatus(200);
-
-        $response->assertJson([
-            'posts' => [
-                [
-                    'id' => 5,
-                    'title' => 'Test Title',
-                ],
-            ],
-        ]);
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -39,6 +39,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelations
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipCounts;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithoutWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
@@ -141,6 +142,31 @@ class ResourceTest extends TestCase
         $response->assertJson([
             'id' => 5,
             'title' => 'Test Title',
+        ]);
+    }
+
+    public function testResourceCollectionThatHaveWrap()
+    {
+        Route::get('/', function () {
+            return PostResourceWithWrap::collect(collect([new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ])]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'posts' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ],
+            ],
         ]);
     }
 


### PR DESCRIPTION
## In The Old Pull Request Version

I intended to use the **Data Wrapping** feature but, there was a glitch in the response where the wrapper was not affected by whatever changes in the `$wrap` attribute when I used the `collection` method, so, I debugged the code and found out that Laravel not accessing this attribute inside that method therefore, I did it and the response was correct back! 🎉

## In The New Pull Request Version

Mr. **Taylor Otwell** told me to update the code to access that attribute anonymously to fade away any issue in the future so, I worked on the code again and resolved the issue. Moreover, I found the new way is more efficient and works without restrictions! 🥳

> [!NOTE]
> In the old version, I was forced to put the testing method at the end of the file because when I changed the `$wrap` attribute value affected the successor testing methods and the wrapper value changed from `data` to `posts` and made them fail **(This the restriction that I mean in the new version)**.