### PR TITLE
[10.x] Add empty object JSON serialize support for array object castable attributes

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/ArrayObjectCastable.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/ArrayObjectCastable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface ArrayObjectCastable extends Castable
+{
+}

--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Eloquent\Casts;
 
 use ArrayObject as BaseArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
-use JsonSerializable;
 
 /**
  * @template TKey of array-key
@@ -12,7 +11,7 @@ use JsonSerializable;
  *
  * @extends  \ArrayObject<TKey, TItem>
  */
-class ArrayObject extends BaseArrayObject implements Arrayable, JsonSerializable
+class ArrayObject extends BaseArrayObject implements Arrayable
 {
     /**
      * Get a collection containing the underlying array.
@@ -30,16 +29,6 @@ class ArrayObject extends BaseArrayObject implements Arrayable, JsonSerializable
      * @return array
      */
     public function toArray()
-    {
-        return $this->getArrayCopy();
-    }
-
-    /**
-     * Get the array that should be JSON serialized.
-     *
-     * @return array
-     */
-    public function jsonSerialize(): array
     {
         return $this->getArrayCopy();
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Casts;
 
-use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\ArrayObjectCastable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
-class AsArrayObject implements Castable
+class AsArrayObject implements ArrayObjectCastable
 {
     /**
      * Get the caster class to use when casting from / to this cast target.
@@ -30,7 +30,7 @@ class AsArrayObject implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => Json::encode($value)];
+                return [$key => Json::encode(is_array($value) ? new ArrayObject($value) : $value)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Database\Eloquent\Casts;
 
-use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\ArrayObjectCastable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Facades\Crypt;
 
-class AsEncryptedArrayObject implements Castable
+class AsEncryptedArrayObject implements ArrayObjectCastable
 {
     /**
      * Get the caster class to use when casting from / to this cast target.
@@ -30,7 +30,7 @@ class AsEncryptedArrayObject implements Castable
             public function set($model, $key, $value, $attributes)
             {
                 if (! is_null($value)) {
-                    return [$key => Crypt::encryptString(Json::encode($value))];
+                    return [$key => Crypt::encryptString(Json::encode(is_array($value) ? new ArrayObject($value) : $value))];
                 }
 
                 return null;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -10,6 +10,7 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Illuminate\Contracts\Database\Eloquent\ArrayObjectCastable;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
@@ -1583,6 +1584,25 @@ trait HasAttributes
     protected function isEncryptedCastable($key)
     {
         return $this->hasCast($key, ['encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
+    }
+
+    /**
+     * Determine whether a value is array object castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isArrayObjectCastable($key)
+    {
+        $casts = $this->getCasts();
+
+        if (! array_key_exists($key, $casts)) {
+            return false;
+        }
+
+        $castType = $this->parseCasterClass($casts[$key]);
+
+        return class_exists($castType) && is_subclass_of($castType, ArrayObjectCastable::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
+use ArrayObject;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -1662,7 +1663,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function jsonSerialize(): mixed
     {
-        return $this->toArray();
+        $attributes = $this->toArray();
+
+        foreach (array_keys($this->getCasts()) as $key) {
+            if ($this->isArrayObjectCastable($key) && is_array($attributes[$key] ?? null)) {
+                $attributes[$key] = new ArrayObject($attributes[$key]);
+            }
+        }
+
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
Eloquent uses an override of PHP's `ArrayObject `to handle the casting of model attributes using the `AsArrayObject`.
When I try to JSON serialize an empty array with `ArrayObject`, it serializes it as an empty array instead of an object.

```php
$var = ['array' => [], 'object' => new \ArrayObject()];
json_encode($var) // {"array":[],"object":{}}

$var = ['array' => [], 'object' => new \Illuminate\Database\Eloquent\Casts\ArrayObject()];
json_encode($var) // {"array":[],"object":[]}
```

This PR adds support to serialize empty objects as JSON objects instead of arrays.

Closes #50264 