### PR TITLE
[10.x] Fix(Illuminate\Http\Client\Response.php): Fix doc block (remove redundant @param)

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -276,7 +276,6 @@ class Response implements ArrayAccess
     /**
      * Throw an exception if a server or client error occurred.
      *
-     * @param  \Closure|null  $callback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
@@ -300,7 +299,6 @@ class Response implements ArrayAccess
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
      * @param  \Closure|bool  $condition
-     * @param  \Closure|null  $throwCallback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException


### PR DESCRIPTION
In this PR, I've removed redundant `@param` tags from doc blocks, improving the clarity and accuracy of the documentation. 