### PR TITLE
[10.x] Prevent cache command with closure to being written

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,7 @@
     },
     "autoload": {
         "files": [
+            "src/Illuminate/Console/functions.php",
             "src/Illuminate/Collections/helpers.php",
             "src/Illuminate/Events/functions.php",
             "src/Illuminate/Filesystem/functions.php",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -29,7 +29,10 @@
     "autoload": {
         "psr-4": {
             "Illuminate\\Console\\": ""
-        }
+        },
+        "files": [
+            "functions.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/src/Illuminate/Console/functions.php
+++ b/src/Illuminate/Console/functions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Exception;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+if (! function_exists('Illuminate\Console\checked_var_export')) {
+    /**
+     * Returns a parsable string representation of a variable.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    function checked_var_export($value)
+    {
+        $exported = var_export($value, true);
+
+        $process = new Process([
+            (new PhpExecutableFinder())->find(false) ?: 'php',
+            '-r',
+            "{$exported};",
+        ]);
+
+        if ($process->run()) {
+            throw new Exception('Unable to export file: Candidate file content cannot be parsed.');
+        }
+
+        return $exported;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -9,6 +9,8 @@ use LogicException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
+use function Illuminate\Console\checked_var_export;
+
 #[AsCommand(name: 'config:cache')]
 class ConfigCacheCommand extends Command
 {
@@ -62,7 +64,7 @@ class ConfigCacheCommand extends Command
         $configPath = $this->laravel->getCachedConfigPath();
 
         $this->files->put(
-            $configPath, '<?php return '.var_export($config, true).';'.PHP_EOL
+            $configPath, '<?php return '.checked_var_export($config).';'.PHP_EOL
         );
 
         try {

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Illuminate\Console\checked_var_export;
+
 #[AsCommand(name: 'event:cache')]
 class EventCacheCommand extends Command
 {
@@ -34,7 +36,7 @@ class EventCacheCommand extends Command
 
         file_put_contents(
             $this->laravel->getCachedEventsPath(),
-            '<?php return '.var_export($this->getEvents(), true).';'
+            '<?php return '.checked_var_export($this->getEvents()).';'
         );
 
         $this->components->info('Events cached successfully.');

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -8,6 +8,8 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function Illuminate\Console\checked_var_export;
+
 #[AsCommand(name: 'route:cache')]
 class RouteCacheCommand extends Command
 {
@@ -106,6 +108,6 @@ class RouteCacheCommand extends Command
     {
         $stub = $this->files->get(__DIR__.'/stubs/routes.stub');
 
-        return str_replace('{{routes}}', var_export($routes->compile(), true), $stub);
+        return str_replace('{{routes}}', checked_var_export($routes->compile()), $stub);
     }
 }

--- a/tests/Console/CheckedVarExportHelperTest.php
+++ b/tests/Console/CheckedVarExportHelperTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+use function Illuminate\Console\checked_var_export;
+
+class CheckedVarExportHelperTest extends TestCase
+{
+    public function testItCanExportVariable()
+    {
+        $this->assertSame(<<<'TEXT'
+        array (
+          0 => 'Laravel',
+        )
+        TEXT, checked_var_export(['Laravel']));
+    }
+
+    public function testExportThrowsOnClosure()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unable to export file: Candidate file content cannot be parsed.');
+        $this->expectExceptionCode(0);
+
+        checked_var_export([fn () => null]);
+    }
+}


### PR DESCRIPTION
When running caching commands that serializes closure, the generated file will contain empty php code of `Closure::__set_state`. Then on the subsequent cache clear command, the app will throw on parsing said file. The solution now is to manually remove the cached files (config, event, and route).

This PR will prevent the file being generated in the first place, by trying to execute the generated var_export before returning to the caller.
