### PR TITLE
[11.x] Add short connect timeout to default db connectors

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -21,6 +21,7 @@ class Connector
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
         PDO::ATTR_STRINGIFY_FETCHES => false,
+        PDO::ATTR_TIMEOUT => 5,
         PDO::ATTR_EMULATE_PREPARES => false,
     ];
 

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -19,6 +19,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
         PDO::ATTR_STRINGIFY_FETCHES => false,
+        PDO::ATTR_TIMEOUT => 5,
     ];
 
     /**

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -17,6 +17,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
         PDO::ATTR_STRINGIFY_FETCHES => false,
+        PDO::ATTR_TIMEOUT => 5,
     ];
 
     /**


### PR DESCRIPTION
The default database connect timeout are about 15 and 30 seconds (from various sources). As with http, it can be useful to fail early since it is a connect operation.

This PR sets the default timeout to 5. As comparison, https' default to 10s connect timeout
https://github.com/laravel/framework/blob/988206bcacf79829bda66af4a016778e4b4d762a/src/Illuminate/Http/Client/PendingRequest.php#L232-L236