### PR TITLE
[10.x] Fix error handlings in Hashers to conform to PHP 8.x specifications.

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -60,13 +60,13 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     public function make($value, array $options = [])
     {
-        $hash = @password_hash($value, $this->algorithm(), [
-            'memory_cost' => $this->memory($options),
-            'time_cost' => $this->time($options),
-            'threads' => $this->threads($options),
-        ]);
-
-        if (! is_string($hash)) {
+        try {
+            $hash = @password_hash($value, $this->algorithm(), [
+                'memory_cost' => $this->memory($options),
+                'time_cost' => $this->time($options),
+                'threads' => $this->threads($options),
+            ]);
+        } catch (\ValueError) {
             throw new RuntimeException('Argon2 hashing not supported.');
         }
 

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -44,11 +44,11 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      */
     public function make($value, array $options = [])
     {
-        $hash = password_hash($value, PASSWORD_BCRYPT, [
-            'cost' => $this->cost($options),
-        ]);
-
-        if ($hash === false) {
+        try {
+            $hash = @password_hash($value, PASSWORD_BCRYPT, [
+                'cost' => $this->cost($options),
+            ]);
+        } catch (\ValueError) {
             throw new RuntimeException('Bcrypt hashing not supported.');
         }
 


### PR DESCRIPTION
This PR fixes error handlings in hashing methods to conform to PHP 8.x specifications.

In PHP 8.x, password_hash() always returns a hashed string and throws a ValueError if hashing fails, while until PHP 7.x it returned false on failure. (cf. changelog in https://www.php.net/manual/en/function.password-hash.php)

Currently Hashers check **if password_hash() returns false**, with the intention of throwing a RuntimeException when hashing fails. Since Laravel 10 (or 11) supports PHP 8.1 or later, I have modified the code to throw a RuntimeException **when a ValueError is thrown**.