### PR TITLE
[11.x] Throw exception for unsupported lateral joins on MariaDB

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinLateralClause;
+use RuntimeException;
 
 class MariaDbGrammar extends MySqlGrammar
 {
@@ -15,5 +17,19 @@ class MariaDbGrammar extends MySqlGrammar
     public function useLegacyGroupLimit(Builder $query)
     {
         return false;
+    }
+
+    /**
+     * Compile a "lateral join" clause.
+     *
+     * @param  \Illuminate\Database\Query\JoinLateralClause  $join
+     * @param  string  $expression
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileJoinLateral(JoinLateralClause $join, string $expression): string
+    {
+        throw new RuntimeException('This database engine does not support lateral joins.');
     }
 }


### PR DESCRIPTION
MariaDB [does not yet support](https://jira.mariadb.org/browse/MDEV-19078) lateral joins and with the new driver, we can now throw a proper exception.