### PR TITLE
Add string type to translator get() and choice() functions' key parameter

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -12,7 +12,7 @@ interface Translator
      * @param  string|null  $locale
      * @return mixed
      */
-    public function get($key, array $replace = [], $locale = null);
+    public function get(string $key, array $replace = [], $locale = null);
 
     /**
      * Get a translation according to an integer value.
@@ -23,7 +23,7 @@ interface Translator
      * @param  string|null  $locale
      * @return string
      */
-    public function choice($key, $number, array $replace = [], $locale = null);
+    public function choice(string $key, $number, array $replace = [], $locale = null);
 
     /**
      * Get the default locale being used.

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -188,7 +188,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string|null  $locale
      * @return string
      */
-    public function choice($key, $number, array $replace = [], $locale = null)
+    public function choice(string $key, $number, array $replace = [], $locale = null)
     {
         $line = $this->get(
             $key, $replace, $locale = $this->localeForChoice($locale)

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -138,7 +138,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  bool  $fallback
      * @return string|array
      */
-    public function get($key, array $replace = [], $locale = null, $fallback = true)
+    public function get(string $key, array $replace = [], $locale = null, $fallback = true)
     {
         $locale = $locale ?: $this->locale;
 


### PR DESCRIPTION
You currently cannot pass a stringable object to the translator, as it will not automatically stringify it and instead throw an `Illegal offset type` error.

A quick and dirty way to reproduce this error in base Laravel would be something like:

```php
$stringable = new Illuminate\View\AppendableAttributeValue('Hello');
__("$stringable"); // works fine
__($stringable);   // throws an error
```

By adding the `string` type to the parameter, this will always automatically get stringified, allowing the second line to also work.