### PR TITLE
[10.x] Remove error handlings of Hashers that will never be reached to conform to PHP 8.x specifications.

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -66,10 +66,6 @@ class ArgonHasher extends AbstractHasher implements HasherContract
             'threads' => $this->threads($options),
         ]);
 
-        if (! is_string($hash)) {
-            throw new RuntimeException('Argon2 hashing not supported.');
-        }
-
         return $hash;
     }
 

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -48,10 +48,6 @@ class BcryptHasher extends AbstractHasher implements HasherContract
             'cost' => $this->cost($options),
         ]);
 
-        if ($hash === false) {
-            throw new RuntimeException('Bcrypt hashing not supported.');
-        }
-
         return $hash;
     }
 


### PR DESCRIPTION
This PR removes redundant error handlings in hashing methods to conform to PHP 8.x specifications.

In PHP 8.x, password_hash() always returns a hashed string and throws a ValueError if hashing fails, while until PHP 7.x it returned false on failure. (cf. changelog in https://www.php.net/manual/en/function.password-hash.php)

Currently Hashers check if password_hash() returns false, with the intention of throwing a RuntimeException when hashing fails. Since Laravel 10 (or 11) supports PHP 8.1 or later, I have modified the code to remove that unreached handlings.

To avoid breaking changes, ValueError is not caught in this commit.