### PR TITLE
[10.x] Document that `null` is allowed for limit in query builders

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2464,7 +2464,7 @@ class Builder implements BuilderContract
     /**
      * Alias to set the "limit" value of the query.
      *
-     * @param  int  $value
+     * @param  int|null  $value
      * @return $this
      */
     public function take($value)
@@ -2475,7 +2475,7 @@ class Builder implements BuilderContract
     /**
      * Set the "limit" value of the query.
      *
-     * @param  int  $value
+     * @param  int|null  $value
      * @return $this
      */
     public function limit($value)


### PR DESCRIPTION
The implementation suggests that `null` is allowed here, but the doc comment does not.
This leads to PHPStan and other static analysis tools to report a false-positive when trying to reset a limit on a query builder by passing `null`.