### PR TITLE
[11.x] Change phpdoc for typed config getters

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -102,7 +102,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified integer configuration value.
      *
      * @param  string  $key
-     * @param  int  $default
+     * @param  (\Closure():(int|null))|int|null  $default
      * @return int
      */
     public function integer(string $key, $default = null): int

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -82,7 +82,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified string configuration value.
      *
      * @param  string  $key
-     * @param  string  $default
+     * @param  (\Closure():(string|null))|string|null  $default
      * @return string
      */
     public function string(string $key, $default = null): string

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -142,7 +142,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified boolean configuration value.
      *
      * @param  string  $key
-     * @param  bool  $default
+     * @param  (\Closure():(bool|null))|bool|null  $default
      * @return bool
      */
     public function boolean(string $key, $default = null): bool

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -122,7 +122,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified float configuration value.
      *
      * @param  string  $key
-     * @param  float  $default
+     * @param  (\Closure():(float|null))|float|null  $default
      * @return float
      */
     public function float(string $key, $default = null): float

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -82,7 +82,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified string configuration value.
      *
      * @param  string  $key
-     * @param  mixed  $default
+     * @param  string  $default
      * @return string
      */
     public function string(string $key, $default = null): string
@@ -102,7 +102,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified integer configuration value.
      *
      * @param  string  $key
-     * @param  mixed  $default
+     * @param  int  $default
      * @return int
      */
     public function integer(string $key, $default = null): int
@@ -122,7 +122,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified float configuration value.
      *
      * @param  string  $key
-     * @param  mixed  $default
+     * @param  float  $default
      * @return float
      */
     public function float(string $key, $default = null): float
@@ -142,7 +142,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified boolean configuration value.
      *
      * @param  string  $key
-     * @param  mixed  $default
+     * @param  bool  $default
      * @return bool
      */
     public function boolean(string $key, $default = null): bool
@@ -162,7 +162,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified array configuration value.
      *
      * @param  string  $key
-     * @param  mixed  $default
+     * @param  array<array-key, mixed>  $default
      * @return array<array-key, mixed>
      */
     public function array(string $key, $default = null): array

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -162,7 +162,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified array configuration value.
      *
      * @param  string  $key
-     * @param  array<array-key, mixed>  $default
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
      * @return array<array-key, mixed>
      */
     public function array(string $key, $default = null): array


### PR DESCRIPTION
Follow up from #50140 

You can only provide the correct typed parameter, otherwise it will always throw an `InvalidArgumentException`

Since this is for Laravel 11, you could also add a php type instead of phpdoc.