### PR TITLE
Revert commit 30324cf

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -7,7 +7,7 @@ trait GuardsAttributes
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<int, string>
+     * @var array<string>
      */
     protected $fillable = [];
 


### PR DESCRIPTION
The `fillable` property is a list, not a map, as evident by how it is used in both `Model` and `GuardsAttributes`. As such, typing it as a map is incorrect.

This fixes v10.46.0 causing any typed `$fillable` property to no longer have a valid type.

laravel/laravel PR to correct the types of the default `User` model: laravel/laravel#6353