### PR TITLE
[10.x] Cast translator key to string

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -141,6 +141,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
         $locale = $locale ?: $this->locale;
+        $key = (string) $key;
 
         // For JSON translations, there is only one file per locale, so we will simply load
         // that file and then we will be ready to check the array for the key. These are


### PR DESCRIPTION
(See also: https://github.com/laravel/framework/pull/50281)

Fixes this example when a stringable class gets translated:

```php
$stringable = new Illuminate\View\AppendableAttributeValue('Hello');
__("$stringable"); // works fine
__($stringable);   // throws an error
```