### PR TITLE
[11.x] Remove support for old SQLite versions

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -185,25 +185,6 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Compile a group limit clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return string
-     */
-    protected function compileGroupLimit(Builder $query)
-    {
-        $version = $query->getConnection()->getServerVersion();
-
-        if (version_compare($version, '3.25.0') >= 0) {
-            return parent::compileGroupLimit($query);
-        }
-
-        $query->groupLimit = null;
-
-        return $this->compileSelect($query);
-    }
-
-    /**
      * Compile an update statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
Laravel 11 requires SQLite 3.35.0 and so we can remove this legacy code for SQLite < 3.25.0.