### PR TITLE
Add isLocked() method to detect whether a lock has already been taken

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -154,6 +154,16 @@ abstract class Lock implements LockContract
     }
 
     /**
+     * Determine whether this lock has already been locked.
+     *
+     * @return bool
+     */
+    public function isLocked()
+    {
+        return false === (! $this->getCurrentOwner());
+    }
+
+    /**
      * Specify the number of milliseconds to sleep in between blocked lock acquisition attempts.
      *
      * @param  int  $milliseconds

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -200,6 +200,19 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($lock->acquire());
     }
 
+    public function testIsLocked()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $store = new ArrayStore;
+        $lock = $store->lock('foo', 10);
+
+        $this->assertFalse($lock->isLocked());
+        $lock->acquire();
+
+        $this->assertTrue($store->lock('foo', 10)->isLocked());
+    }
+
     public function testLockExpirationLowerBoundary()
     {
         Carbon::setTestNow(Carbon::now());


### PR DESCRIPTION
Add isLocked() method to detect whether a lock has already been taken.
This can be useful to detect if a lock has been taken by either self or other owners.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
