### PR TITLE
[v11] Spark is not a framework dependency, middleware does not exist

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -736,7 +736,6 @@ class Middleware
             'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
             'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
             'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
-            'subscribed' => \Spark\Http\Middleware\VerifyBillableIsSubscribed::class,
             'throttle' => $this->throttleWithRedis
                 ? \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class
                 : \Illuminate\Routing\Middleware\ThrottleRequests::class,


### PR DESCRIPTION
I was bugged with https://github.com/laravel/framework/issues/50298

I think closing the issue was an overlook, as I still think this does not belong here. 

I should have created the PR at first to better illustrate the issue, sorry for that 🙏 

Cheers