### PR TITLE
[10.x] Add `upsertUsing` method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1207,6 +1207,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an "upsert" statement using a subquery into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $columns
+     * @param  string  $sql
+     * @param  array  $uniqueBy
+     * @param  array  $update
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)
+    {
+        throw new RuntimeException('This database engine does not support upserts.');
+    }
+
+    /**
      * Prepare the bindings for an update statement.
      *
      * @param  array  $bindings

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1210,7 +1210,6 @@ class Grammar extends BaseGrammar
      * Compile an "upsert" statement using a subquery into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $values
      * @param  array  $columns
      * @param  string  $sql
      * @param  array  $uniqueBy

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -411,6 +411,31 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement using a subquery into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @param  string  $sql
+     * @param  array  $uniqueBy
+     * @param  array  $update
+     * @return string
+     */
+    public function compileUpsertUsing(Builder $query, array $columns, string $sql, array $uniqueBy, array $update)
+    {
+        $sql = $this->compileInsertUsing($query, $columns, $sql);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect($update)->map(function ($value, $key) {
+            return is_numeric($key)
+                ? $this->wrap($value).' = '.$this->wrap('excluded').'.'.$this->wrap($value)
+                : $this->wrap($key).' = '.$this->parameter($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Compile a "lateral join" clause.
      *
      * @param  \Illuminate\Database\Query\JoinLateralClause  $join

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -286,8 +286,8 @@ class SQLiteGrammar extends Grammar
         // To avoid potential parser ambiguity, when an INSERT statement to which UPSERT
         // is attached takes its values from a SELECT statement, the SELECT statement
         // should always include a WHERE clause, even if that's just "WHERE true".
-        if (! Str::contains($sql, ' where ')) {
-            $fromClausePosition = strpos($sql, ' from ');
+        if (! Str::contains($sql, ' where ', true)) {
+            $fromClausePosition = strpos(mb_strtolower($sql), ' from ');
             $afterFromTablePosition = strpos($sql, ' ', $fromClausePosition + strlen(' from '));
 
             if ($afterFromTablePosition === false) {

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -285,15 +285,15 @@ class SQLiteGrammar extends Grammar
     {
         $sql = $this->compileInsertUsing($query, $columns, $sql);
 
-        $sql .= ' on conflict (' . $this->columnize($uniqueBy) . ') do update set ';
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
 
         $columns = collect($update)->map(function ($value, $key) {
             return is_numeric($key)
-                ? $this->wrap($value) . ' = ' . $this->wrap('excluded') . '.' . $this->wrap($value)
-                : $this->wrap($key) . ' = ' . $this->parameter($value);
+                ? $this->wrap($value).' = '.$this->wrap('excluded').'.'.$this->wrap($value)
+                : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
-        return $sql . $columns;
+        return $sql.$columns;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -288,7 +288,7 @@ class SQLiteGrammar extends Grammar
         // should always include a WHERE clause, event if it is just "WHERE true".
         if (! Str::contains($sql, 'where')) {
             $fromClausePosition = strpos($sql, 'from');
-            $afterFromTablePosition = strpos($sql, ' ',  $fromClausePosition + strlen('from '));
+            $afterFromTablePosition = strpos($sql, ' ', $fromClausePosition + strlen('from '));
 
             if ($afterFromTablePosition === false) {
                 $afterFromTablePosition = strlen($sql);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -286,9 +286,9 @@ class SQLiteGrammar extends Grammar
         // To avoid potential parser ambiguity, when an INSERT statement to which UPSERT
         // is attached takes its values from a SELECT statement, the SELECT statement
         // should always include a WHERE clause, even if that's just "WHERE true".
-        if (! Str::contains($sql, 'where')) {
-            $fromClausePosition = strpos($sql, 'from');
-            $afterFromTablePosition = strpos($sql, ' ', $fromClausePosition + strlen('from '));
+        if (! Str::contains($sql, ' where ')) {
+            $fromClausePosition = strpos($sql, ' from ');
+            $afterFromTablePosition = strpos($sql, ' ', $fromClausePosition + strlen(' from '));
 
             if ($afterFromTablePosition === false) {
                 $afterFromTablePosition = strlen($sql);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -285,7 +285,7 @@ class SQLiteGrammar extends Grammar
     {
         // To avoid potential parser ambiguity, when an INSERT statement to which UPSERT
         // is attached takes its values from a SELECT statement, the SELECT statement
-        // should always include a WHERE clause, event if it is just "WHERE true".
+        // should always include a WHERE clause, even if that's just "WHERE true".
         if (! Str::contains($sql, 'where')) {
             $fromClausePosition = strpos($sql, 'from');
             $afterFromTablePosition = strpos($sql, ' ', $fromClausePosition + strlen('from '));

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -463,7 +463,7 @@ class SqlServerGrammar extends Grammar
             $compiledSql .= 'when matched then update set '.$update.' ';
         }
 
-        $compiledSql .= 'when not matched then insert ('.$columns.') values ('.$columns .');';
+        $compiledSql .= 'when not matched then insert ('.$columns.') values ('.$columns.');';
 
         return $compiledSql;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3365,7 +3365,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()
             ->shouldReceive('getDatabaseName')->andReturn('test')
-            ->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") select "column1", "column2" from "table2" on conflict ("email") do update set "name" = "excluded"."name"', [])->andReturn(1);
+            ->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") select "column1", "column2" from "table2" where true on conflict ("email") do update set "name" = "excluded"."name"', [])->andReturn(1);
         $result = $builder->from('users')->upsertUsing(['email', 'name'], function (Builder $query) {
             $query->select(['column1', 'column2'])->from('table2');
         }, 'email', ['name']);
@@ -3374,7 +3374,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()
             ->shouldReceive('getDatabaseName')->andReturn('test')
-            ->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") select "column1", "column2" from "table2" on conflict ("email") do update set "name" = ?', ['New name'])->andReturn(1);
+            ->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") select "column1", "column2" from "table2" where true on conflict ("email") do update set "name" = ?', ['New name'])->andReturn(1);
         $result = $builder->from('users')->upsertUsing(['email', 'name'], function (Builder $query) {
             $query->select(['column1', 'column2'])->from('table2');
         }, 'email', ['name' => 'New name']);
@@ -3383,7 +3383,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()
             ->shouldReceive('getDatabaseName')->andReturn('test')
-            ->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") select "column1", "column2" from "table2" on conflict ("email") do update set "name" = concat("name", \' 2\')', [])->andReturn(1);
+            ->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") select "column1", "column2" from "table2" where true on conflict ("email") do update set "name" = concat("name", \' 2\')', [])->andReturn(1);
         $result = $builder->from('users')->upsertUsing(['email', 'name'], function (Builder $query) {
             $query->select(['column1', 'column2'])->from('table2');
         }, 'email', ['name' => new Raw('concat("name", \' 2\')')]);


### PR DESCRIPTION
Currently we have `upsert` method for operations where we want to insert new records and update existing ones based on some unique identifier. `upsert`, similarly to `insert`, uses provided array of values to insert and update the table.

To insert using a subquery as source of data instead of an array we have `insertUsing` method. So, in a similar fashion, `upsertUsing` method that this PR is adding, uses a subquery as source of data to perform "upsert".

I can get something like this for my projects using macros, but I thought that it could be useful to others, hence this PR.

There are no breaking changes, only new functionality.

If there's something to improve before this PR can be accepted, please let me know and I'll make the changes.

Cheers!