### PR TITLE
[10.x] Add namedTimestamps method to Blueprint class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1222,7 +1222,18 @@ class Blueprint
     {
         return $this->addColumn('timestampTz', $column, compact('precision'));
     }
+    /**
+     * Add nullable name creation and update timestamps to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function namedTimestamps($createdAtColumn, $updatedAtColumn, $precision = 0)
+    {
+        $this->timestamp($createdAtColumn, $precision)->nullable();
 
+        $this->timestamp($updatedAtColumn, $precision)->nullable();
+    }
     /**
      * Add nullable creation and update timestamps to the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1222,6 +1222,7 @@ class Blueprint
     {
         return $this->addColumn('timestampTz', $column, compact('precision'));
     }
+    
     /**
      * Add nullable named creation and update timestamps to the table.
      *
@@ -1236,6 +1237,7 @@ class Blueprint
 
         $this->timestamp($updatedAtColumn, $precision)->nullable();
     }
+    
     /**
      * Add nullable creation and update timestamps to the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1225,6 +1225,8 @@ class Blueprint
     /**
      * Add nullable named creation and update timestamps to the table.
      *
+     * @param  string  $createdAtColumn
+     * @param  string  $updatedAtColumn
      * @param  int|null  $precision
      * @return void
      */

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1223,7 +1223,7 @@ class Blueprint
         return $this->addColumn('timestampTz', $column, compact('precision'));
     }
     /**
-     * Add nullable name creation and update timestamps to the table.
+     * Add nullable named creation and update timestamps to the table.
      *
      * @param  int|null  $precision
      * @return void


### PR DESCRIPTION
I was trying to create tables with camelCase timestamp column names and found out that Laravel doesn't have a named timestamps helper. 

I have added the method with two parameters `$createdAtColumn` and `$updatedAtColumn`.

