### PR TITLE
[10.x] Adds command to re-encrypt table columns

### DIFF
--- a/src/Illuminate/Foundation/Console/ReEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/ReEncryptCommand.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use function array_flip;
+use function array_keys;
+use function array_merge;
+use function array_pad;
+use function array_values;
+use function base64_decode;
+use function explode;
+use function str_split;
+
+#[AsCommand(name: 'crypt:re-encrypt')]
+class ReEncryptCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'crypt:re-encrypt
+                    {targets : The table name and columns to re-encrypt, like "users:private,notes"}
+                    {key : The new key to use for re-encryption.}
+                    {cipher? : The encryption algorithm for re-encryption.}
+                    {--old-key : The old key used to encrypt the original values.}
+                    {--old-cipher : The old cipher used to encrypt the original values.}
+                    {--connection : The database connection name to use.}
+                    {--id=id : The column ID to use for lazy chunking.}
+                    {--skip-failed : Whether re-encryption should skip any decryption errors.}
+                    {--chunk=1000 : The amount of items per chunk to process.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Re-encrypts a model encrypted columns with a new encryption key';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info('Using "...'.substr($this->argument('key'), -6).'" key to re-encryption');
+        $this->newLine();
+
+        $originalEncrypter = $this->makeEncrypter(
+            $this->option('old-key') ?: $this->laravel->make('config')->get('app.key'),
+            $this->option('old-cipher')
+        );
+
+        $newEncrypter = $this->makeEncrypter(
+            $this->argument('key'),
+            $this->argument('cipher')
+        );
+
+        [$table, $columns, $id] = $this->parseOptions();
+
+        $query = $this->laravel->make('db')->connection($this->option('connection'))->table($table);
+
+        $this->withProgressBar(
+            $this->rows($query, $columns, $id),
+            function (object $row) use ($originalEncrypter, $newEncrypter, $id, $columns, $query) {
+                $data = [];
+
+                foreach ($columns as $column) {
+                    if (is_null($row->{$column})) {
+                        continue;
+                    }
+
+                    try {
+                        $data[$column] = $originalEncrypter->decrypt($row->{$column}, false);
+                    } catch (DecryptException $exception) {
+                        if ($this->option('skip-failed')) {
+                            continue;
+                        }
+
+                        throw $exception;
+                    }
+
+                    $data[$column] = $newEncrypter->encrypt($data[$column], false);
+                }
+
+                $query->where($id, $row->{$id})->update($data);
+            }
+        );
+    }
+
+    /**
+     * Create a new encrypter instance.
+     *
+     * @return \Illuminate\Encryption\Encrypter
+     */
+    protected function makeEncrypter($key, $cipher)
+    {
+        if (Str::startsWith($key, $prefix = 'base64:')) {
+            $key = Str::after($key, $prefix);
+        }
+
+        return new Encrypter(
+            base64_decode($key),
+            $cipher ?: $this->laravel->make('config')->get('app.cipher')
+        );
+    }
+
+    /**
+     * Parse the options of the command.
+     *
+     * @return array{table: string, columns: string[], id: string}
+     */
+    protected function parseOptions()
+    {
+        [$table, $columns] = array_pad(explode(':', trim($this->argument('targets')), 2), 2, null);
+
+        $columns = explode(',', $columns);
+
+        return [$table, $columns, $this->option('id')];
+    }
+
+    /**
+     * Create a lazy query for the target model
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string[]  $columns
+     * @param  string  $id
+     * @return \Illuminate\Support\LazyCollection<object>
+     */
+    protected function rows($query, $columns, $id)
+    {
+        return $query
+            ->select([$id, ...$columns])
+            ->lazyById($this->option('chunk'), $id);
+    }
+
+    /**
+     * Re-encrypts the model attribute with a new encryption key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  EncrypterContract  $encrypter
+     * @param  array<string,int>  $encryptables
+     * @return void
+     */
+    protected function reEncryptModelValues($model, $encrypter, $encryptables)
+    {
+        foreach ($encryptables as $name => $value) {
+            try {
+                $encryptables[$name] = $model->getAttribute($name);
+            } catch (DecryptException $exception) {
+                if ($this->argument('skip-failed')) {
+                    continue;
+                }
+
+                throw $exception;
+            }
+        }
+    }
+
+    /**
+     * Get the model casts that should be encrypted.
+     *
+     * @return string[]
+     */
+    protected function encryptables()
+    {
+        return array_keys(
+            array_filter($this->newModel()->getCasts(), function ($cast) {
+                if (is_object($cast) || class_exists($cast)) {
+                    $cast = class_basename($cast);
+                }
+
+                return Str::startsWith($cast, ['AsEncrypted', 'encrypted']);
+            })
+        );
+    }
+
+    /**
+     * Create a new Eloquent Model instance.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function newModel()
+    {
+        $model = trim($this->argument('model'));
+
+        if (!class_exists($model) && is_dir(app_path('Models'))) {
+            $model = Str::start($model, $this->laravel->getNamespace().'\Models\\');
+        }
+
+        return new $model;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ReEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/ReEncryptCommand.php
@@ -73,7 +73,7 @@ class ReEncryptCommand extends Command
                 $data = [];
 
                 foreach ($columns as $column) {
-                    if (is_null($row->{$column})) {
+                    if (!is_string($row->{$column})) {
                         continue;
                     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -61,6 +61,7 @@ use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
+use Illuminate\Foundation\Console\ReEncryptCommand;
 use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
@@ -197,6 +198,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueFailedTable' => FailedTableCommand::class,
         'QueueTable' => TableCommand::class,
         'QueueBatchesTable' => BatchesTableCommand::class,
+        'ReEncrypt' => ReEncryptCommand::class,
         'RequestMake' => RequestMakeCommand::class,
         'ResourceMake' => ResourceMakeCommand::class,
         'RuleMake' => RuleMakeCommand::class,

--- a/tests/Integration/Console/ReEncryptionCommandTest.php
+++ b/tests/Integration/Console/ReEncryptionCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
+use Illuminate\Database\Eloquent\Casts\Json;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
+use function base64_decode;
+use function base64_encode;
+use function json_encode;
+use function random_bytes;
+
+class ReEncryptionCommandTest extends TestCase
+{
+    protected $appKey = '/JEsDQCLbuXaUjd/nz/cDcsoczyLX929uYxGuwIzEYs=';
+    protected $newKey = 'A/XpDmqaahaIw7mmsJSg33NMVzsb1Bnj+7MYT4KmxhI=';
+    protected $cipher = 'AES-256-CBC';
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']['database.default'] = 'testing';
+        $app['config']['app.key'] = 'base64:' . $this->appKey;
+        $app['config']['app.cipher'] = $this->cipher;
+    }
+
+    protected function setUp(): void
+    {
+        $this->afterApplicationCreated(function () {
+            Schema::create('test_models', function (Blueprint $table) {
+                $table->id();
+                $table->text('foo');
+                $table->text('bar');
+                $table->text('baz');
+                $table->text('qux');
+                $table->text('fred')->nullable();
+            });
+
+            $encrypter = new Encrypter(base64_decode($this->appKey), $this->cipher);
+
+            DB::table('test_models')->insert([
+                'foo' => $encrypter->encrypt('foo', false),
+                'bar' => $encrypter->encrypt(json_encode(['bar']), false),
+                'baz' => 'verbatim',
+                'qux' => $encrypter->encrypt(Json::encode(new Collection(['qux'])), false),
+            ]);
+        });
+
+        parent::setUp();
+    }
+
+    public function testReEncryptsModel()
+    {
+        $this->artisan('crypt:re-encrypt', [
+            'targets' => 'test_models:foo,bar,qux,fred',
+            'key' => $this->newKey,
+        ])
+            ->expectsOutput('Using "...KmxhI=" key to re-encryption')
+            ->assertExitCode(0);
+
+        $encrypter = new Encrypter(base64_decode($this->newKey), $this->cipher);
+
+        $row = DB::table('test_models')->where('id', 1)->first();
+
+        $this->assertSame('foo', $encrypter->decrypt($row->foo, false));
+        $this->assertSame('["bar"]', $encrypter->decrypt($row->bar, false));
+        $this->assertSame('verbatim', $row->baz);
+        $this->assertEquals(new Collection(['qux']), $encrypter->decrypt($row->qux, false));
+    }
+
+    public function testSkipsIfFailedDecryption()
+    {
+        $this->artisan('crypt:re-encrypt', [
+            'targets' => 'test_models:foo,bar,baz,qux,fred',
+            'key' => $this->newKey,
+            '--skip-failed' => true
+        ])
+            ->assertExitCode(0);
+
+        $encrypter = new Encrypter(base64_decode($this->newKey), $this->cipher);
+
+        $row = DB::table('test_models')->where('id', 1)->first();
+
+        $this->assertSame('foo', $encrypter->decrypt($row->foo, false));
+        $this->assertSame('["bar"]', $encrypter->decrypt($row->bar, false));
+        $this->assertSame('verbatim', $row->baz);
+        $this->assertEquals(new Collection(['qux']), $encrypter->decrypt($row->qux, false));
+    }
+}


### PR DESCRIPTION
# What?

This PR introduces a command to automatically re-encrypt table columns **before** a key rotation. The only requirement is to have a primary key. 

## Why?

It takes the problem away from the developer **before** a [key rotation on the app](https://laravel.com/docs/10.x/eloquent-mutators#key-rotation), which is sometimes a destructive operation. 

Before this, the developer had to create a custom command with hard-coded tables and columns to re-encrypt, plus the whole logic.

## How?

By default, it only needs the "targets" (`table:column,column...`) and the new key to re-encrypt the data. It assumes the data is already encrypted using the application key and cipher.  

```shell
php artisan crypt:re-encrypt \ 
    users:notes,credit-card-number \
    base64:AdXpDmqaahaIw7mmsJSg33NMVzsb1Bnj+7MYT4KmxhI=
```

The command will show the last 6 characters of the key to avoid mistakenly using the same app key or other unwanted key.

    Using "...KmxhI=" key to re-encryption

It supports using a custom key and cypher to _decrypt_ the data before re-encryption, in case rows has been previously encrypted with another key.

```shell
php artisan crypt:re-encrypt \
    users:notes,credit-card-number \
    AdXpDmqaahaIw7mmsJSg33NMVzsb1Bnj+7MYT4KmxhI= \
    --old-key yJEsDQCLbuXaUjdrnzTcDcsoczyLX929uYxGuwIzEYs= \
    --old-cipher AES-256-CBC
```

Because sometimes the command or the database may fail for any reason, the re-encryption may stop mid-progress. To avoid leaving the table unusable, the `--skip-failed` will actually skip any column that cannot be decrypted, leaving it as-is.

```shell
php artisan crypt:re-encrypt \
    users:notes,credit-card-number \
    AdXpDmqaahaIw7mmsJSg33NMVzsb1Bnj+7MYT4KmxhI= \
    --skip-failed
```

> [!WARNING]
> 
> This was done because the inability to flag a row as "re-encrypted", as the column to flag wouldn't exist. It's _easier_ to just proceed and, if the decryption fails because the key is different, continue with the next row. 

The operation is done using `lazyById` to avoid memory problems on large rows and/or payloads. The connection, chunk size, and ID are configurable.

```shell
php artisan crypt:re-encrypt \
    users:notes,credit-card-number \
    AdXpDmqaahaIw7mmsJSg33NMVzsb1Bnj+7MYT4KmxhI= \
    --connection=pgsql
    --chunk=100
    --id=uuid
```