### PR TITLE
[10.x] Allow for relation key to be an enum

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
+use BackedEnum;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -152,6 +153,9 @@ trait InteractsWithPivotTable
         return collect($records)->mapWithKeys(function ($attributes, $id) {
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
+            }
+            if ($id instanceof BackedEnum) {
+                $id = $id->value;
             }
 
             return [$id => $attributes];

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -154,6 +154,7 @@ trait InteractsWithPivotTable
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }
+
             if ($id instanceof BackedEnum) {
                 $id = $id->value;
             }


### PR DESCRIPTION
If a foring key is being cast to an enum calling ->sync() will cause a TypeError: Illegal offset type.

This resolves the issue by getting the value before using it as an array key.