### PR TITLE
[10.x] Add strict option to hasColumns function

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -267,10 +267,15 @@ class Builder
      *
      * @param  string  $table
      * @param  array  $columns
+     * @param  bool  $strict
      * @return bool
      */
-    public function hasColumns($table, array $columns)
+    public function hasColumns($table, array $columns, bool $strict = false)
     {
+        if ($strict){
+            return $this->getColumnListing($table) === $columns;
+        }
+
         $tableColumns = array_map('strtolower', $this->getColumnListing($table));
 
         foreach ($columns as $column) {

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -17,7 +17,7 @@ namespace Illuminate\Support\Facades;
  * @method static array getViews()
  * @method static array getTypes()
  * @method static bool hasColumn(string $table, string $column)
- * @method static bool hasColumns(string $table, array $columns)
+ * @method static bool hasColumns(string $table, array $columns, bool $strict = false)
  * @method static void whenTableHasColumn(string $table, string $column, \Closure $callback)
  * @method static void whenTableDoesntHaveColumn(string $table, string $column, \Closure $callback)
  * @method static string getColumnType(string $table, string $column, bool $fullDefinition = false)

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -65,10 +65,15 @@ class DatabaseSchemaBuilderTest extends TestCase
         $grammar = m::mock(stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = m::mock(Builder::class.'[getColumnListing]', [$connection]);
-        $builder->shouldReceive('getColumnListing')->with('users')->twice()->andReturn(['id', 'firstname']);
+        $builder->shouldReceive('getColumnListing')->with('users')->times(6)->andReturn(['id', 'firstname']);
 
         $this->assertTrue($builder->hasColumns('users', ['id', 'firstname']));
         $this->assertFalse($builder->hasColumns('users', ['id', 'address']));
+
+        $this->assertTrue($builder->hasColumns('users',['id','firstname'],true));
+        $this->assertFalse($builder->hasColumns('users',['id'],true));
+        $this->assertFalse($builder->hasColumns('users',['firstname','id'],true));
+        $this->assertFalse($builder->hasColumns('users',['id','FirstName'],true));
     }
 
     public function testGetColumnTypeAddsPrefix()


### PR DESCRIPTION
I usually test my database schema using the `hasColumns` method and ensure all desired columns exist on my database. 

However, this method changes the column's name and does not check the order of columns. 

I've added a simple `strict` param that will check the columns against the given `columns` array that is passed to the `hasColumns` function.