### PR TITLE
[11.x] Prompts user to run migrations on `install:api` Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -51,7 +51,7 @@ class ApiInstallCommand extends Command
 
         if ($this->confirm('One new migration has been published. Would like to run pending migrations now?', false)) {
             $this->call('migrate');
-        };
+        }
 
         $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');
     }

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -49,7 +49,7 @@ class ApiInstallCommand extends Command
             $this->uncommentApiRoutesFile();
         }
 
-        if ($this->confirm('One new migration has been published. Would like to run pending migrations now?', false)) {
+        if ($this->confirm('One new migration has been published. Would you like to run the pending database migrations?', false)) {
             $this->call('migrate');
         }
 

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -49,7 +49,7 @@ class ApiInstallCommand extends Command
             $this->uncommentApiRoutesFile();
         }
 
-        if ($this->confirm('One new migration has been published. Would you like to run the pending database migrations?', false)) {
+        if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', false)) {
             $this->call('migrate');
         }
 

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -49,7 +49,11 @@ class ApiInstallCommand extends Command
             $this->uncommentApiRoutesFile();
         }
 
-        $this->components->info('API scaffolding installed. Please add the "Laravel\Sanctum\HasApiTokens" trait to your User model.');
+        if ($this->confirm('One new migration has been published. Would like to run pending migrations now?', false)) {
+            $this->call('migrate');
+        };
+
+        $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');
     }
 
     /**


### PR DESCRIPTION
This pull request prompts user to run migrations on `install:api` Artisan command:

<img width="1223" alt="Screenshot 2024-02-29 at 14 59 33" src="https://github.com/laravel/framework/assets/5457236/01932cd1-41dc-46eb-9097-01abb0929afb">
