### PR TITLE
[11.x] Simplifies routes file

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/api-routes.stub
+++ b/src/Illuminate/Foundation/Console/stubs/api-routes.stub
@@ -1,9 +1,8 @@
 <?php
 
-use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
-})->middleware(Authenticate::using('sanctum'));
+})->middleware('auth:sanctum');


### PR DESCRIPTION
This pull request simplifies routes file by using the "auth:sanctum" alias instead of an import + `Authenticate::using('sanctum')` code.