### PR TITLE
[11.x] Fix validated method

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -577,7 +577,11 @@ class Validator implements ValidatorContract
      */
     public function validated()
     {
-        throw_if($this->invalid(), $this->exception, $this);
+        if (! $this->messages) {
+            $this->passes();
+        }
+
+        throw_if($this->messages->isNotEmpty(), $this->exception, $this);
 
         $results = [];
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -167,6 +167,35 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $v->validate());
     }
 
+    public function testValidatedThrowsOnFail()
+    {
+        $this->expectException(ValidationException::class);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
+
+        $v->validated();
+    }
+
+    public function testValidatedThrowsOnFailEvenAfterPassesCall()
+    {
+        $this->expectException(ValidationException::class);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
+
+        $v->passes();
+        $v->validated();
+    }
+
+    public function testValidatedDoesntThrowOnPass()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'required']);
+
+        $this->assertSame(['foo' => 'bar'], $v->validated());
+    }
+
     public function testHasFailedValidationRules()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
If we manually create a validator instance and use the `validated` or `safe` method without validating first, there is a chance that we will get incorrect data.

Below is an example.

```php
Route::post('/', function (Request $request) {
    $validator = Validator::make($request->all(), [
        'name' => ['required', 'string'],
        'address' => ['required', 'string'],
    ]);

    $data = $validator->safe()->all();

    dd($data);
});
```

There is no `passes` or `validate` method above, but still this somehow works as people expect, because the framework checks if there are any validation errors.

But this `validated` method has a little problem because the `invalid` method that the `validated` method uses only returns the data that people actually send.

For example, in the code above, you will still get data even if some bad guy doesn't send the `name` field at all.

This is more of a bug fix, but I'm sending this PR to `master` because if you already have potential bugs, this PR affects them.

Example.
```
Route::post('/', function (Request $request) {
    $validator = Validator::make($request->all(), [
        'name' => ['required', 'string'],
        'address' => ['required', 'string'],
        'field_people_never_send' => ['required', 'string'],   // This is  a bug.
    ]);

    $data = $validator->safe()->all();

    dd($data);
});
```