### PR TITLE
[11.x] Implement Key Rotation Functionality in KeyGenerateCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -119,7 +119,7 @@ class KeyGenerateCommand extends Command
     /**
      * Rotates application keys in the Laravel environment file.
      *
-     * @param $currentKey
+     * @param  $currentKey
      * @return void
      */
     protected function rotateExistingKeysWith($currentKey)


### PR DESCRIPTION
This pull request introduces the ability to rotate application keys in the Laravel environment file. The `--rotate` option has been added to the `key:generate` command. When this option is used, the current application key is added to a list of previous keys stored in the `APP_PREVIOUS_KEYS` environment variable, and a new application key is generated.

This feature is inspired because of @taylorotwell [Laracon EU 2024 presentation](https://www.youtube.com/watch?v=0g7HqfsCX4Y&t=3137s). 
We can now pass `--rotate` on the `key:generate` command.