### PR TITLE
[11.x]  ctype_lower deprecation warning

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1409,7 +1409,7 @@ class Str
             return static::$snakeCache[$key][$delimiter];
         }
 
-        if (! ctype_lower($value)) {
+        if (! ctype_lower((string) $value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
             $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));


### PR DESCRIPTION
Noticed I was getting some deprecation warning `ctype_lower(): Argument of type int will be interpreted as string in the future` and it seemed mostly for the validation factory but a few other places.

https://www.php.net/manual/en/function.ctype-lower.php

```
As of PHP 8.1.0, passing a non-string argument is deprecated. In the future, the argument will be interpreted as a string instead of an ASCII codepoint. Depending on the intended behavior, the argument should either be cast to [string](https://www.php.net/manual/en/language.types.string.php) or an explicit call to [chr()](https://www.php.net/manual/en/function.chr.php) should be made.
```