### PR TITLE
[11.x] Add `webPrefix` support to the withRouting method

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -130,6 +130,7 @@ class ApplicationBuilder
      * @param  string|null  $channels
      * @param  string|null  $pages
      * @param  string|null  $apiPrefix
+     * @param  string|null  $webPrefix
      * @param  callable|null  $then
      * @return $this
      */
@@ -141,10 +142,11 @@ class ApplicationBuilder
         ?string $pages = null,
         ?string $health = null,
         string $apiPrefix = 'api',
+        string $webPrefix = '',
         ?callable $then = null)
     {
         if (is_null($using) && (is_string($web) || is_string($api) || is_string($pages) || is_string($health)) || is_callable($then)) {
-            $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $then);
+            $using = $this->buildRoutingCallback($web, $api, $pages, $health, $apiPrefix, $webPrefix, $then);
         }
 
         AppRouteServiceProvider::loadRoutesUsing($using);
@@ -172,6 +174,7 @@ class ApplicationBuilder
      * @param  string|null  $pages
      * @param  string|null  $health
      * @param  string  $apiPrefix
+     * @param  string  $webPrefix
      * @param  callable|null  $then
      * @return \Closure
      */
@@ -180,9 +183,10 @@ class ApplicationBuilder
         ?string $pages,
         ?string $health,
         string $apiPrefix,
+        string $webPrefix,
         ?callable $then)
     {
-        return function () use ($web, $api, $pages, $health, $apiPrefix, $then) {
+        return function () use ($web, $api, $pages, $health, $apiPrefix, $webPrefix, $then) {
             if (is_string($api) && realpath($api) !== false) {
                 Route::middleware('api')->prefix($apiPrefix)->group($api);
             }
@@ -196,7 +200,7 @@ class ApplicationBuilder
             }
 
             if (is_string($web) && realpath($web) !== false) {
-                Route::middleware('web')->group($web);
+                Route::middleware('web')->prefix($webPrefix)->group($web);
             }
 
             if (is_string($pages) &&


### PR DESCRIPTION
# Overview
This Pull Request proposes the addition of the `webPrefix` parameter to the `withRouting` method.

Similarly to the `apiPrefix` parameter, the `webPrefix` parameter allows the user to specify a prefix for the web routes, if needed.

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        api: __DIR__.'/../routes/api.php',
        apiPrefix: '',
        webPrefix: 'content',
    )
    ->withMiddleware(function (Middleware $middleware) {
        //
    })
    ->withExceptions(function (Exceptions $exceptions) {
        //
    })->create();
```

## Changes Proposed:
1. A new parameter named `$webPrefix` has been added to the `withRouting()` method signature.
2. The `buildRoutingCallback()` method has been modified to accept the `$webPrefix` parameter and use it to prefix web routes.
3. The documentation has been updated to reflect the new parameter and its usage.

## Why is this change important?
Laravel 11 currently provides a way to specify a prefix for API routes using the `apiPrefix` parameter. However, there is no '_fluent_' way to prefix the web routes. 

With this change, users will be able to specify a prefix for web routes if needed. This will avoid the manual addition of prefixes in the `web.php` file, which in my opinion, would not be the best way to handle this. 

By adding the `webPrefix` parameter, web routes can be prefixed in a similar way to API routes, resulting in more consistent code.

## Use Cases

### Case 1
When the user wants to group all web routes under a specific URL path, they can prefix the web routes with a specific string.

### Case 2
From my own case, I have a Laravel application that is used as an API subdomain. However, I do not use the `/api` prefix for the API routes. Instead, I leave it blank or use it with something else. Consider the URL like `api.example.com/users`.

Additionally, I serve a few web routes in my application, and all these routes are grouped under the `/content` prefix. So, if I wanted to serve a web route for a file called "my-file.pdf", the URL would be `api.example.com/content/my-file.pdf`.

By making these changes to my application, I can use the `/content` prefix for my web routes and organize it the same way as my API routes.

## Additional Context
As the `webPrefix` parameter in the `withRouting` method is set to blank (empty string), it shouldn't change or break any existing code.

Lastly, I believe that the `webPrefix` is less likely to be used, so it was set after the `apiPrefix` in the `withRouting` method signature.