### PR TITLE
[10.x] Add Model `except` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1890,6 +1890,19 @@ trait HasAttributes
     }
 
     /**
+     * Get a subset of the model's attributes that aren't in the given array.
+     *
+     * @param  array|string  $attributes
+     * @return array
+     */
+    public function except($attributes)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        return Arr::except($this->getAttributes(), $attributes);
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -486,6 +486,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testExcept()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'Taylor';
+        $model->last_name = 'Otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['first_name' => 'Taylor', 'last_name' => 'Otwell'], $model->except('project'));
+        $this->assertEquals(['project' => 'laravel'], $model->except('first_name', 'last_name'));
+        $this->assertEquals([], $model->except(['first_name', 'last_name', 'project']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
The `except()` method provides a convenient way to retrieve a subset of the model's attributes that are not present in the given array.