### PR TITLE
Add Number::trim()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -241,7 +241,7 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public function trim(int|float $number, int $precision = 2, ?int $maxPrecision = null, ?string $locale = null)
+    public static function trim(int|float $number, int $precision = 2, ?int $maxPrecision = null, ?string $locale = null)
     {
         $formatter = new NumberFormatter($locale, NumberFormatter::PATTERN_DECIMAL);
         $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
@@ -249,10 +249,10 @@ class Number
         $parts = explode('.', (string) $number);
         $currentPrecision = strlen($parts[1]);
 
-        if (!is_null($maxPrecision)) {
+        if ( !is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS,
                 min($currentPrecision, $maxPrecision));
-        } elseif (!is_null($precision)) {
+        } elseif ( !is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, min($currentPrecision, $precision));
         }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -233,6 +233,33 @@ class Number
     }
 
     /**
+     * Trim the number of decimal places to not exceed the precision.
+     *
+     * @param  int|float  $number
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @param  string|null  $locale
+     * @return string|false
+     */
+    public function trim(int|float $number, int $precision = 2, ?int $maxPrecision = null, ?string $locale = null)
+    {
+        $formatter = new NumberFormatter($locale, NumberFormatter::PATTERN_DECIMAL);
+        $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
+
+        $parts = explode('.', (string) $number);
+        $currentPrecision = strlen($parts[1]);
+
+        if (!is_null($maxPrecision)) {
+            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS,
+                min($currentPrecision, $maxPrecision));
+        } elseif (!is_null($precision)) {
+            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, min($currentPrecision, $precision));
+        }
+
+        return $formatter->format($number);
+    }
+
+    /**
      * Execute the given callback using the given locale.
      *
      * @param  string  $locale

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -237,12 +237,12 @@ class Number
      *
      * @param  int|float  $number
      * @param  int  $maxDecimals
-     *
      * @return float
      */
     public static function trim(int|float $number, int $maxDecimals)
     {
         $divisor = pow(10, $maxDecimals);
+
         return floor($number * $divisor) / $divisor;
     }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -236,27 +236,14 @@ class Number
      * Trim the number of decimal places to not exceed the precision.
      *
      * @param  int|float  $number
-     * @param  int  $precision
-     * @param  int|null  $maxPrecision
-     * @param  string|null  $locale
-     * @return string|false
+     * @param  int  $maxDecimals
+     *
+     * @return float
      */
-    public static function trim(int|float $number, int $precision, ?int $maxPrecision = null, ?string $locale = null)
+    public static function trim(int|float $number, int $maxDecimals)
     {
-        $formatter = new NumberFormatter($locale, NumberFormatter::PATTERN_DECIMAL);
-        $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
-
-        $parts = explode('.', (string) $number);
-        $currentPrecision = strlen($parts[1]);
-
-        if (! is_null($maxPrecision)) {
-            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS,
-                min($currentPrecision, $maxPrecision));
-        } else {
-            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, min($currentPrecision, $precision));
-        }
-
-        return $formatter->format($number);
+        $divisor = pow(10, $maxDecimals);
+        return floor($number * $divisor) / $divisor;
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -249,7 +249,7 @@ class Number
         $parts = explode('.', (string) $number);
         $currentPrecision = strlen($parts[1]);
 
-        if ( !is_null($maxPrecision)) {
+        if (! is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS,
                 min($currentPrecision, $maxPrecision));
         } else {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -241,7 +241,7 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function trim(int|float $number, int $precision = 2, ?int $maxPrecision = null, ?string $locale = null)
+    public static function trim(int|float $number, int $precision, ?int $maxPrecision = null, ?string $locale = null)
     {
         $formatter = new NumberFormatter($locale, NumberFormatter::PATTERN_DECIMAL);
         $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
@@ -252,7 +252,7 @@ class Number
         if ( !is_null($maxPrecision)) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS,
                 min($currentPrecision, $maxPrecision));
-        } elseif ( !is_null($precision)) {
+        } else {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, min($currentPrecision, $precision));
         }
 

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -182,6 +182,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1, Number::clamp(-10, 1, 5));
     }
 
+    public function testTrim()
+    {
+        $this->assertSame(0.12, Number::trim(0.123456789));
+        $this->assertSame(0.1234, Number::trim(0.123456789, 4));
+        $this->assertSame(0.123456, Number::trim(0.123456789, 6));
+        $this->assertSame(0.123456789, Number::trim(0.123456789, 12));
+    }
+
     public function testToHuman()
     {
         $this->assertSame('1', Number::forHumans(1));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -184,7 +184,7 @@ class SupportNumberTest extends TestCase
 
     public function testTrim()
     {
-        $this->assertSame(0.12, Number::trim(0.123456789));
+        $this->assertSame(0.12, Number::trim(0.123456789, 2));
         $this->assertSame(0.1234, Number::trim(0.123456789, 4));
         $this->assertSame(0.123456, Number::trim(0.123456789, 6));
         $this->assertSame(0.123456789, Number::trim(0.123456789, 12));


### PR DESCRIPTION
# Overview
This PR extends the Number class to introduce a trim method, that trims the number of decimal places not to exceed the precision.


### Number::format() rounds decimals by default (may actually be a bug :shrug:)
```php
# Compare
  Number::trim(number: 0.123456789, precision: 3)  // 0.123
  Number::format(number: 0.123456789, precision: 3)  // 0.124 --> this was rounded
  
  Number::trim(number: 0.123456789, precision: 6)  // 0.123456
  Number::format(number: 0.123456789, precision: 6)  // 0.123457 --> also rounded
```  
### It does not pad/extend the number beyond what was passed, which is why its called trim  
```php
  # Will not pad/extend the number beyond what was passed, which is why its called trim
  Number::trim(number: 0.123, precision: 6) // 0.123
```

## Why is this change important?

This pull request introduces a new feature to our number formatting logic which addresses a subtle issue with how we currently handle decimal number precision. The current implementation of `Number::format()` method rounds off the last digit during the formatting operation. While this serves its purpose in some cases, there are specific scenarios where this may unintentionally alter the value that was to be preserved exactly as it is.

This new method, trim, primarily works by reducing the number of decimal places to a specified precision, if provided. Unlike `Number::format()`, this doesn't round off decimals; instead, it trims the extra decimals without modifying the overall value.
This new feature is particularly crucial in contexts where precise value representation matters, such as in the field of **finance**. 

By simply trimming the excess decimal places, we ensure the original value doesn't experience unnecessary data alteration.
Furthermore, this inclusion is especially important in maintaining data integrity when storing float or decimal types in a database, as different databases have varying size limitations on these data types.

## Potential Alternate Method Names

Personally, I'm not fully satisfied with the method name as I feel it's close but doesn't quite accurately convey its use, so here are some other equally not as great options to consider, in alphabetical order:

| Alternative  | Why I Like/Dislike |
| ------------- | ------------- |
| `Number::clip()`  | conveys loss of data well and is easy to remember, grows on me more and more each time I see it |
| `Number::decimal()`  | This may be a fine alternative, but doesn't directly convey the trimming of decimal places |
| `Number::decimalLimit()` or  `Number::limitDecimals()`  | Accurate and self explanatory  |
| `Number::decimalMax()` or `Number::maxDecimals()`  | Accurate and self explanatory  |
| `Number::limit()` | Seems more like an upper bound or `max()` and would likely be confused with `clamp()`|
| `Number::limitDecimalPlaces()` | Unsightly, but most descriptive lol |
| `Number::places()` | May need clarity but also grows on me more and more each time I see it, however, I feel like this suggests that it should pad with zeros to reach the given length if its too short |
| `Number::trimDecimals()` | Less unsightly, yet highly descriptive  |
| `Number::truncate()` | Might confuse someone into thinking it may limit the integer portion of the float as well |
| `Number::shorten()` | same as above |


## Thanks for Considering

This new feature should align with current features, so I do think the framework will benefit from its inclusion. Please consider it for merging. Thanks.
