### PR TITLE
[10.x] Add method to check if model has an attribute loaded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -479,6 +479,17 @@ trait HasAttributes
     }
 
     /**
+     * Determine if the model has the given attribute loaded
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function hasAttribute($key)
+    {
+        return array_key_exists($key, $this->attributes);
+    }
+
+    /**
      * Get a plain attribute (not a relationship).
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -479,9 +479,9 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the model has the given attribute loaded
+     * Determine if the model has the given attribute loaded.
      *
-     * @param string $key
+     * @param  string $key
      * @return boolean
      */
     public function hasAttribute($key)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2763,6 +2763,14 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
+    public function testHasAttribute()
+    {
+        $model = new EloquentModelStub(['id' => 1]);
+
+        $this->assertTrue($model->hasAttribute('id'));
+        $this->assertFalse($model->hasAttribute('name'));
+    }
+
     public function testGetOriginalCastsAttributes()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
Currently if we want to check if a model has an attribute loaded from the DB or when it's created we would have to do
```php
array_key_exists('some_key', $model->getAttributes())
```

With this new method we can simply do:

```php
$model->hasAttribute('some_key')
```