### PR TITLE
FIx for "empty" strings passed to Str::apa()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1298,7 +1298,7 @@ class Str
      */
     public static function apa($value)
     {
-        if ($value === '') {
+        if (trim($value) === '') {
             return $value;
         }
 


### PR DESCRIPTION
```
Illuminate\Support\Str::apa('   ')
````
Is throwing an exception. This (hopefully) fixes this edge case.

