### PR TITLE
[10.x] Add test for the "empty strings in `Str::apa()`" fix

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -98,6 +98,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('To Kill a Mockingbird', Str::apa('To Kill A Mockingbird'));
 
         $this->assertSame('', Str::apa(''));
+        $this->assertSame('   ', Str::apa('   '));
     }
 
     public function testStringWithoutWordsDoesntProduceError()


### PR DESCRIPTION
Test for the recent fix: https://github.com/laravel/framework/pull/50335