### PR TITLE
[11.x] Add typed getters to session store

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
 use SessionHandlerInterface;
 use stdClass;
+use TypeError;
 
 class Store implements Session
 {
@@ -305,6 +306,106 @@ class Store implements Session
     public function get($key, $default = null)
     {
         return Arr::get($this->attributes, $key, $default);
+    }
+
+    /**
+     * Get the specified string session value.
+     *
+     * @param  string  $key
+     * @param string|(callable():(string|null))|null $default
+     * @return string
+     */
+    public function string(string $key, string|callable|null $default = null): string
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_string($value)) {
+            throw new TypeError(
+                sprintf('Session value for key [%s] must be a string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer session value.
+     *
+     * @param  string  $key
+     * @param (callable():(int|null))|int|null $default
+     * @return int
+     */
+    public function integer(string $key, callable|int|null $default = null): int
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_int($value)) {
+            throw new TypeError(
+                sprintf('Session value for key [%s] must be an integer, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified float session value.
+     *
+     * @param  string  $key
+     * @param (callable():(float|null))|float|null $default
+     * @return float
+     */
+    public function float(string $key, callable|float|null $default = null): float
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_float($value)) {
+            throw new TypeError(
+                sprintf('Session value for key [%s] must be a float, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified boolean session value.
+     *
+     * @param  string  $key
+     * @param (callable():(bool|null))|bool|null $default
+     * @return bool
+     */
+    public function boolean(string $key, callable|bool|null $default = null): bool
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_bool($value)) {
+            throw new TypeError(
+                sprintf('Session value for key [%s] must be a boolean, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified array session value.
+     *
+     * @param  string  $key
+     * @param (callable():(array<array-key, mixed>|null))|array<array-key, mixed>|null $default
+     * @return array<array-key, mixed>
+     */
+    public function array(string $key, array|callable|null $default = null): array
+    {
+        $value = $this->get($key, $default);
+
+        if (! is_array($value)) {
+            throw new TypeError(
+                sprintf('Session value for key [%s] must be an array, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -71,15 +71,18 @@ class SessionStoreTest extends TestCase
         $this->assertTypeError(fn () => $session->integer('integer'), 'integer');
         $this->assertTypeError(fn () => $session->array('array'), 'array');
         $this->assertTypeError(fn () => $session->boolean('boolean'), 'boolean');
-        $this->assertTypeError(fn () => $session->flloat('float'), 'float');
+        $this->assertTypeError(fn () => $session->float('float'), 'float');
         $this->assertTypeError(fn () => $session->string('string'), 'string');
     }
 
     private function assertTypeError(callable $callback, string $expectedType): void
     {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessageMatches("/(.*) must be (.*) $expectedType/");
-        $callback();
+        try {
+            $callback();
+            $this->fail("Expected TypeError for $expectedType type.");
+        } catch (\TypeError $e) {
+            $this->assertMatchesRegularExpression("/Session value for key \[(.*)\] must be (.*) {$expectedType}, (.*) given./", $e->getMessage());
+        }
     }
 
     public function testSessionMigration()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi :smile:

I previously submitted a PR #50140 for typed configuration getters that have been approved and then enhanced by  #50287.

I tried to make the same features for the session store as I believe it can help to have static analysis. Not sure though the way I wrote the tests.

Let me know if any changes needed (and also I didn't find a pint or lint command)

EDIT: Tests for type errors are not correct, changing to draft
