### PR TITLE
[10.x] Add `whereAll` and `whereAny` methods to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2110,19 +2110,16 @@ class Builder implements BuilderContract
      */
     public function whereMultiple($columns, $operator = null, $value = null, $columnsBoolean = 'or', $boolean = 'and')
     {
-        if (
-            func_num_args() > 2 && func_num_args() < 5
+        $isOperatorMissing = func_num_args() === 3
             && in_array($value, ['and', 'or'])
-            && $this->invalidOperator($operator)
-        ) {
-            $columnsBoolean = $value;
+            && $this->invalidOperator($operator);
 
-            // Set the value to null to prepare the value and the operator successfully.
-            $value = null;
+        if ($isOperatorMissing) {
+            $columnsBoolean = $value;
         }
 
         [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() > 2 && func_num_args() < 5
+            $value, $operator, func_num_args() === 2 || $isOperatorMissing
         );
 
         $value = $this->flattenValue($value);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2172,8 +2172,6 @@ class Builder implements BuilderContract
             $value, $operator, empty($value) && $this->invalidOperator($operator)
         );
 
-        $value = $this->flattenValue($value);
-
         $this->whereNested(function ($query) use ($columns, $operator, $value, $columnsBoolean) {
             foreach ($columns as $column) {
                 $query->where($column, $operator, $value, $columnsBoolean);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2096,8 +2096,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "where" clause to the query for each passed column with the same value
-     * to check if all passed columns match the value.
+     * Add a "where" clause to the query for multiple columns with "and" conditions between them.
      *
      * @param  string[]  $columns
      * @param  mixed  $operator
@@ -2121,8 +2120,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where" clause to the query for each passed column with the same value
-     * to check if all passed columns match the value.
+     * Add an "or where" clause to the query for multiple columns with "and" conditions between them.
      *
      * @param  string[]  $columns
      * @param  string  $operator
@@ -2135,8 +2133,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "where" clause to the query for each passed column with the same value
-     * to check if any of passed columns matches the value.
+     * Add an "where" clause to the query for multiple columns with "or" conditions between them.
      *
      * @param  string[]  $columns
      * @param  string  $operator
@@ -2160,8 +2157,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where" clause to the query for each passed column with the same value
-     * to check if any of passed columns matches the value.
+     * Add an "or where" clause to the query for multiple columns with "or" conditions between them.
      *
      * @param  string[]  $columns
      * @param  string  $operator

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2107,7 +2107,17 @@ class Builder implements BuilderContract
      */
     public function whereAll($columns, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereMultiple($columns, $operator, $value, 'and', $boolean);
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+
+        $this->whereNested(function ($query) use ($columns, $operator, $value) {
+            foreach ($columns as $column) {
+                $query->where($column, $operator, $value, 'and');
+            }
+        }, $boolean);
+
+        return $this;
     }
 
     /**
@@ -2136,7 +2146,17 @@ class Builder implements BuilderContract
      */
     public function whereAny($columns, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereMultiple($columns, $operator, $value, 'or', $boolean);
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+
+        $this->whereNested(function ($query) use ($columns, $operator, $value) {
+            foreach ($columns as $column) {
+                $query->where($column, $operator, $value, 'or');
+            }
+        }, $boolean);
+
+        return $this;
     }
 
     /**
@@ -2151,51 +2171,6 @@ class Builder implements BuilderContract
     public function orWhereAny($columns, $operator = null, $value = null)
     {
         return $this->whereAny($columns, $operator, $value, 'or');
-    }
-
-    /**
-     * Add a "where" clause to the query for each passed column with the same value.
-     *
-     * @param  string[]  $columns
-     * @param  string  $operator
-     * @param  mixed  $value
-     * @param  string  $columnsBoolean  Boolean type between columns
-     *                                  (column1 = 'foo' or column2 = 'foo')
-     *                                  or
-     *                                  (column1 = 'bar' and column2 = 'bar')
-     * @param  string  $boolean
-     * @return $this
-     */
-    private function whereMultiple($columns, $operator = null, $value = null, $columnsBoolean = 'and', $boolean = 'and')
-    {
-        [$value, $operator] = $this->prepareValueAndOperator(
-            $value, $operator, empty($value) && $this->invalidOperator($operator)
-        );
-
-        $this->whereNested(function ($query) use ($columns, $operator, $value, $columnsBoolean) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, $columnsBoolean);
-            }
-        }, $boolean);
-
-        return $this;
-    }
-
-    /**
-     * Add an "or where" clause to the query for each passed column with the same value.
-     *
-     * @param  string[]  $columns
-     * @param  string  $operator
-     * @param  array  $value
-     * @param  string  $columnsBoolean  Boolean type between columns
-     *                                  (column1 = 'foo' or column2 = 'foo')
-     *                                  or
-     *                                  (column1 = 'bar' and column2 = 'bar')
-     * @return $this
-     */
-    public function orWhereMultiple($columns, $operator = null, $value = null, $columnsBoolean = 'or')
-    {
-        return $this->whereMultiple($columns, $operator, $value, $columnsBoolean, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2101,10 +2101,10 @@ class Builder implements BuilderContract
      * @param  string[]  $columns
      * @param  string  $operator
      * @param  array  $value
-     * @param  string  $columnsBoolean Boolean type between columns
-     *                                 (column1 = 'foo' or column2 = 'foo')
-     *                                 or
-     *                                 (column1 = 'bar' and column2 = 'bar')
+     * @param  string  $columnsBoolean  Boolean type between columns
+     *                                  (column1 = 'foo' or column2 = 'foo')
+     *                                  or
+     *                                  (column1 = 'bar' and column2 = 'bar')
      * @param  string  $boolean
      * @return $this
      */
@@ -2142,10 +2142,10 @@ class Builder implements BuilderContract
      * @param  string[]  $columns
      * @param  string  $operator
      * @param  array  $value
-     * @param  string  $columnsBoolean Boolean type between columns
-     *                                 (column1 = 'foo' or column2 = 'foo')
-     *                                 or
-     *                                 (column1 = 'bar' and column2 = 'bar')
+     * @param  string  $columnsBoolean  Boolean type between columns
+     *                                  (column1 = 'foo' or column2 = 'foo')
+     *                                  or
+     *                                  (column1 = 'bar' and column2 = 'bar')
      * @return $this
      */
     public function orWhereMultiple($columns, $operator = null, $value = null, $columnsBoolean = 'or')

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1185,6 +1185,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['Car Plane'], $builder->getBindings());
     }
 
+    public function testWhereMultiple()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'LIKE','%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" like "%Otwell%" or "email" like "%Otwell%")');
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1189,7 +1189,22 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'LIKE','%Otwell%');
-        $this->assertSame('select * from "users" where ("last_name" like "%Otwell%" or "email" like "%Otwell%")', $builder->toSql());
+        $this->assertSame('select * from "users" where ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'%Otwell%', 'and');
+        $this->assertSame('select * from "users" where ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'NOT LIKE', '%Otwell%', 'and');
+        $this->assertSame('select * from "users" where ("last_name" NOT LIKE ? and "email" NOT LIKE ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1189,7 +1189,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'LIKE','%Otwell%');
-        $this->assertSame('select * from "users" where ("last_name" like "%Otwell%" or "email" like "%Otwell%")');
+        $this->assertSame('select * from "users" where ("last_name" like "%Otwell%" or "email" like "%Otwell%")', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1198,6 +1198,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
+    public function testOrWhereAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereAll(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
     public function testWhereAny()
     {
         $builder = $this->getBuilder();
@@ -1209,6 +1227,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereAny(['last_name', 'email'], '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testOrWhereAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereAny(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("last_name" = ? or "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
     public function testUnions()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1188,7 +1188,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testWhereMultiple()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'LIKE','%Otwell%');
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'like','%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" like ? or "email" like ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
 
@@ -1203,8 +1203,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'NOT LIKE', '%Otwell%', 'and');
-        $this->assertSame('select * from "users" where ("last_name" NOT LIKE ? and "email" NOT LIKE ?)', $builder->toSql());
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'not like', '%Otwell%', 'and');
+        $this->assertSame('select * from "users" where ("last_name" not like ? and "email" not like ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1188,22 +1188,22 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testWhereMultiple()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'like','%Otwell%');
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'like', '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" like ? or "email" like ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'%Otwell%');
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'%Otwell%', 'and');
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], '%Otwell%', 'and');
         $this->assertSame('select * from "users" where ("last_name" = ? and "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'],'not like', '%Otwell%', 'and');
+        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'not like', '%Otwell%', 'and');
         $this->assertSame('select * from "users" where ("last_name" not like ? and "email" not like ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1185,26 +1185,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['Car Plane'], $builder->getBindings());
     }
 
-    public function testWhereMultiple()
+    public function testWhereAll()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'like', '%Otwell%');
-        $this->assertSame('select * from "users" where ("last_name" like ? or "email" like ?)', $builder->toSql());
-        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], '%Otwell%');
-        $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
-        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], '%Otwell%', 'and');
+        $builder->select('*')->from('users')->whereAll(['last_name', 'email'], '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" = ? and "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->whereMultiple(['last_name', 'email'], 'not like', '%Otwell%', 'and');
+        $builder->select('*')->from('users')->whereAll(['last_name', 'email'], 'not like', '%Otwell%');
         $this->assertSame('select * from "users" where ("last_name" not like ? and "email" not like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testWhereAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where ("last_name" = ? or "email" = ?)', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 


### PR DESCRIPTION
Hi,

Sometimes I need to make a search input on some pages where one value is compared with multiple columns. For example, an admin needs to able to search users by first name, last name, email or phone. Usually I wrap `orWhere` in another `where` as a closure:
```
$search = '%Otwell%';

User::query()
      ->where(function ($query) use ($search) {
          $query
              ->where('first_name', 'LIKE', $search)
              ->orWhere('last_name', 'LIKE', $search)
              ->orWhere('email', 'LIKE', $search)
              ->orWhere('phone', 'LIKE', $search);
      })
      ...
```

We can create a scope 'search' or something, but it's anyway a lot of `where` in `where`, so I always wanted something like that:
```
$search = '%Otwell%';

User::query()
      ->whereMultiple([
          'first_name',
          'last_name',
          'email',
          'phone'
      ], 'LIKE', $search)
      ...
```

The method has these params:
```
whereMultiple($columns, $operator = null, $value = null, $columnsBoolean = 'or', $boolean = 'and')
```

`$columnsBoolean` is the boolean type between passed columns: 
```
// $columnsBoolean = 'or'
where (column_1 = 'text' or column_2 = 'text' or column_3 = 'text')

// $columnsBoolean = 'and'
where (column_1 = 'text' and column_2 = 'text' and column_3 = 'text')
```

The method creates a closure and `where` for each passed column with `or` or `and`. It looks like:
```
select * from "users" where (
  "first_name" like "%Otwell%" 
  or "last_name" like "%Otwell%" 
  or "email" like "%Otwell%"
  or "phone" like "%Otwell%"
)
```

I haven't found something similar, except putting an array in `where`, but this is not the same. I hope I didn't miss the same functionality. If I did, please let me know

It's my first PR, so if something is wrong or you just have any questions, let me know 

Thanks,
Alex

## Updates

`whereMultiple` has been split into `whereAll` and `whereAny`.

### whereAll

Creates a nested query that uses the same operator and value for each column passed in, where **ALL columns** must match the value and operator.

Params:
```
whereAll($columns, $operator = null, $value = null, $boolean = 'and')
```

Usage:
```
$search = 'test';

User::whereAll([
  'first_name',
  'last_name',
  'email',
], 'LIKE', "%$search%")
...
```

All columns has the same operator `LIKE` and the same value `"%test%"`, and they have `AND` between each column:
```
SELECT * FROM "users" WHERE (
  "first_name" LIKE "%test%" 
  AND "last_name" LIKE "%test%" 
  AND "email" LIKE "%test%"
)
```

### whereAny

Creates a nested query that uses the same operator and value for each column passed in, where **ANY of the columns** must match the value and operator.

Params:
```
whereAll($columns, $operator = null, $value = null, $boolean = 'and')
```

Usage:
```
$search = 'test';

User::whereAny([
  'first_name',
  'last_name',
  'email',
], 'LIKE', "%$search%")
...
```

All columns has the same operator `LIKE` and the same value `"%test%"`, and they have `OR` between each column:
```
SELECT * FROM "users" WHERE (
  "first_name" LIKE "%test%" 
  OR "last_name" LIKE "%test%" 
  OR "email" LIKE "%test%"
)
```