### PR TITLE
[10.x] Release job after timeout

### DIFF
--- a/src/Illuminate/Queue/Events/JobReleasedAfterTimeOut.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterTimeOut.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobReleasedAfterTimeOut
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->job = $job;
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -233,7 +233,7 @@ class Worker
                 } finally {
                     if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
                         $job->release($this->calculateBackoff($job, $options));
-        
+
                         $this->events->dispatch(new JobReleasedAfterTimeOut(
                             $job->getConnectionName(), $job
                         ));


### PR DESCRIPTION
Currently, when the job occurred timeout, the process is killed and the next attempt is made after the `retry_after` value instead of `backoff`.
After merging this pr, like other exceptions, if a timeout has occurred, the job can be released and try after backoff value.