### PR TITLE
[10.x] MySQL Grammar and Blueprint binary column fix

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1334,6 +1334,17 @@ class Blueprint
     }
 
     /**
+     * Create a new blob column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function blob($column)
+    {
+        return $this->addColumn('blob', $column);
+    }
+
+    /**
      * Create a new UUID column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1022,6 +1022,17 @@ class MySqlGrammar extends Grammar
      */
     protected function typeBinary(Fluent $column)
     {
+        return 'binary';
+    }
+
+    /**
+     * Create the column definition for a blob type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeBlob(Fluent $column)
+    {
         return 'blob';
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1090,6 +1090,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` binary not null', $statements[0]);
+    }
+
+    public function testAddingBlob()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->blob('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
     }
 


### PR DESCRIPTION
The [Blueprint](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Schema/Blueprint.php) class has a ```binary``` method that creates a blob column in your database. 

I added a method called ```blob``` that creates a **blob** field in the database, and I did modify the ```binary``` method to create a **binary** field instead. 

I've also modified the ```typeBinary``` method in the [MySQLGrammar](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php) class so it returns **'binary'** instead of **'blob'** and added a ```typeBlob``` method that returns **'blob'**

As a finishing touch I've modified the ```testAddingBinary``` in [DatabaseMySqlSchemaGrammarTest.php](https://github.com/laravel/framework/blob/10.x/tests/Database/DatabaseMySqlSchemaGrammarTest.php) and added the ```testAddingBinary``` methods to ensure the quality.