### PR TITLE
[11.x] Add length to binary method

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1272,6 +1272,8 @@ class Blueprint
      * Create a new binary column on the table.
      *
      * @param  string  $column
+     * @param  int|null  $length
+     * @param  bool  $fixed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
     public function binary($column, $length = null, $fixed = false)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1274,9 +1274,9 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function binary($column)
+    public function binary($column, $length = null, $fixed = false)
     {
-        return $this->addColumn('binary', $column);
+        return $this->addColumn('binary', $column, compact('length', 'fixed'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -999,6 +999,10 @@ class MySqlGrammar extends Grammar
      */
     protected function typeBinary(Fluent $column)
     {
+        if ($column->length) {
+            return $column->fixed ? "binary({$column->length})" : "varbinary({$column->length})";
+        }
+
         return 'blob';
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -874,6 +874,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeBinary(Fluent $column)
     {
+        if ($column->length) {
+            return $column->fixed ? "binary({$column->length})" : "varbinary({$column->length})";
+        }
+
         return 'varbinary(max)';
     }
 


### PR DESCRIPTION
This PR adds support for `binary(n)` and `varbinary(n)` column types on databases that support this type (MySQL, MariaDB and SQL Server).

PS: No upgrade guide entry is needed.

## Usage

```php
Schema::binary('test', function (Blueprint $table) {
    $table->binary('blob_column'); // no change
    // `BLOB` on MySQL, MariaDB, and SQLite, `BYTEA` on PostgreSQL, `VARBINARY(MAX)` on SQL Server

    $table->binary('varbinary_column', length: 16);
    // `VARBINARY(16)` on MySQL, MariaDB, and SQL Server, `BLOB` on SQLite, `BYTEA` on PostgreSQL

    $table->binary('binary_column', length: 16, fixed: true);
    // `BINARY(16)` on MySQL, MariaDB, and SQL Server, `BLOB` on SQLite, `BYTEA` on PostgreSQL
});
```

| Syntax | MySQL / MariaDB | SQL Server | SQLite | PostgreSQL |
|--------|--------|--------|--------|--------|
| `binary('name')` | `BLOB` | `VARBINARY(MAX)` | `BLOB` |  `BYTEA` |
| `binary('name', length: 16)` | `VARBINARY(16)` | `VARBINARY(16)` | `BLOB` |  `BYTEA` |
| `binary('name', length: 16, fixed: true)` | `BINARY(16)` | `BINARY(16)` | `BLOB` |  `BYTEA` |