### PR TITLE
[10.x] Remove use mysql database

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -23,10 +23,6 @@ class MySqlConnector extends Connector implements ConnectorInterface
         // connection's behavior, and some might be specified by the developers.
         $connection = $this->createConnection($dsn, $config, $options);
 
-        if (! empty($config['database'])) {
-            $connection->exec("use `{$config['database']}`;");
-        }
-
         $this->configureIsolationLevel($connection, $config);
 
         $this->configureEncoding($connection, $config);


### PR DESCRIPTION
> The DSN information of pdo already contains the information of the default database, so there is no need to emphasize it again.