### PR TITLE
[10.x] Fix the cache cannot expire cache with `0` TTL

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -19,15 +19,13 @@ class RedisTaggedCache extends TaggedCache
         if ($ttl !== null) {
             $seconds = $this->getSeconds($ttl);
 
-            if ($seconds <= 0) {
-                return false;
+            if ($seconds > 0) {
+                $this->tags->addEntry(
+                    $this->itemKey($key),
+                    $seconds
+                );
             }
         }
-
-        $this->tags->addEntry(
-            $this->itemKey($key),
-            $seconds
-        );
 
         return parent::add($key, $value, $ttl);
     }
@@ -48,14 +46,12 @@ class RedisTaggedCache extends TaggedCache
 
         $seconds = $this->getSeconds($ttl);
 
-        if ($seconds <= 0) {
-            return false;
+        if ($seconds > 0) {
+            $this->tags->addEntry(
+                $this->itemKey($key),
+                $seconds
+            );
         }
-
-        $this->tags->addEntry(
-            $this->itemKey($key),
-            $seconds
-        );
 
         return parent::put($key, $value, $ttl);
     }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -76,6 +76,20 @@ class RedisStoreTest extends TestCase
         $this->assertNan(Cache::store('redis')->get('foo'));
     }
 
+    public function testItCanExpireWithZeroTTL()
+    {
+        Cache::store('redis')->clear();
+
+        $result = Cache::store('redis')->put('foo', 10,10);
+        $this->assertTrue($result);
+
+        $result = Cache::store('redis')->put('foo', 10,0);
+        $this->assertTrue($result);
+
+        $value = Cache::store('redis')->get('foo');
+        $this->assertNull($value);
+    }
+
     public function testTagsCanBeAccessed()
     {
         Cache::store('redis')->clear();
@@ -145,6 +159,9 @@ class RedisStoreTest extends TestCase
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['votes'])->add('person-1', 0, new DateTime('yesterday'));
+
+        $value = Cache::store('redis')->tags(['votes'])->get('person-1');
+        $this->assertNull($value);
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
         $this->assertEquals(0, count($keyCount));


### PR DESCRIPTION
This PR addresses PR #49864, which caused inconsistent cache behavior by not allowing caches to expire with a 0 TTL.