### PR TITLE
[11.x] Remove duplicated assertion in SupportArrTest

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -922,11 +922,6 @@ class SupportArrTest extends TestCase
         $input = range('a', 'z');
 
         $this->assertFalse(
-            Arr::shuffle($input) === Arr::shuffle($input) && Arr::shuffle($input) === Arr::shuffle($input),
-            "The shuffles produced the same output each time, which shouldn't happen."
-        );
-
-        $this->assertFalse(
             Arr::shuffle($input) === $input && Arr::shuffle($input) === $input,
             "The shuffles were unshuffled each time, which shouldn't happen."
         );


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

On my search for something else, I stumbled upon #49769 and noted that an assertion added there was present in both test methods (`testShuffleProducesDifferentShuffles` and `testShuffleActuallyShuffles`), which seems like an unintended duplicate to me.