### PR TITLE
Mark config options for smart merge

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -92,7 +92,7 @@ class LoadConfiguration
 
         if (isset($base[$name])) {
             $config = array_merge($base[$name], $config);
-            if ($option = $this->smartMergeOption($name) && isset($config[$option])) {
+            if (($option = $this->smartMergeOption($name)) && isset($config[$option])) {
                 $config[$option] = array_merge($base[$name][$option], $config[$option]);
             }
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -92,8 +92,11 @@ class LoadConfiguration
 
         if (isset($base[$name])) {
             $config = array_merge($base[$name], $config);
-            if (($option = $this->smartMergeOption($name)) && isset($config[$option])) {
-                $config[$option] = array_merge($base[$name][$option], $config[$option]);
+
+            foreach ($this->mergeableOptions($name) as $option) {
+                if (isset($config[$option])) {
+                    $config[$option] = array_merge($base[$name][$option], $config[$option]);
+                }
             }
 
             unset($base[$name]);
@@ -105,23 +108,22 @@ class LoadConfiguration
     }
 
     /**
-     * Return the option within the configuration file
-     * which allows another level of merging.
+     * Get the options within the configuration file that should be merged again.
      *
      * @param  string  $name
-     * @return string|null
+     * @return array
      */
-    protected function smartMergeOption($name)
+    protected function mergeableOptions($name)
     {
         return [
-            'broadcasting' => 'connections',
-            'cache' => 'stores',
-            'database' => 'connections',
-            'filesystems' => 'disks',
-            'logging' => 'channels',
-            'mail' => 'mailers',
-            'queue' => 'connections',
-        ][$name] ?? null;
+            'broadcasting' => ['connections'],
+            'cache' => ['stores'],
+            'database' => ['connections'],
+            'filesystems' => ['disks'],
+            'logging' => ['channels'],
+            'mail' => ['mailers'],
+            'queue' => ['connections'],
+        ][$name] ?? [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -92,6 +92,9 @@ class LoadConfiguration
 
         if (isset($base[$name])) {
             $config = array_merge($base[$name], $config);
+            if ($option = $this->smartMergeOption($name) && isset($config[$option])) {
+                $config[$option] = array_merge($base[$name][$option], $config[$option]);
+            }
 
             unset($base[$name]);
         }
@@ -99,6 +102,26 @@ class LoadConfiguration
         $repository->set($name, $config);
 
         return $base;
+    }
+
+    /**
+     * Return the option within the configuration file
+     * which allows another level of merging.
+     *
+     * @param  string  $name
+     * @return string|null
+     */
+    protected function smartMergeOption($name)
+    {
+        return [
+            'broadcasting' => 'connections',
+            'cache' => 'stores',
+            'database' => 'connections',
+            'filesystems' => 'disks',
+            'logging' => 'channels',
+            'mail' => 'mailers',
+            'queue' => 'connections',
+        ][$name] ?? null;
     }
 
     /**


### PR DESCRIPTION
This is a proof of concept that would allow "smart merging" of configuration options. Right now Laravel 11 "shallow" merges application config with the frame defaults. However, many config files like database, filesystems, mail, etc have a "main" option which is nested. This PR creates a registry of those "main" options and does an additional merge for them.

This would allow developers to further slim their configuration files while reducing the possibility of removing a core configuration option. For example, only customizing `mysql` database driver, while still using `sqlite` for testing. Or adding additional `disks`, but still using the default `local` or `s3` disks.