### PR TITLE
[11.x] Fix Rule::exists: Use correct table name on global models

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -59,7 +59,7 @@ trait DatabaseRule
      */
     public function resolveTableName($table)
     {
-        if (! str_contains($table, '\\') || ! class_exists($table)) {
+        if (! class_exists($table)) {
             return $table;
         }
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Illuminate\Tests\Validation {
-
     use Illuminate\Database\Capsule\Manager as DB;
     use Illuminate\Database\Eloquent\Model as Eloquent;
     use Illuminate\Translation\ArrayLoader;
@@ -347,7 +346,6 @@ namespace Illuminate\Tests\Validation {
 }
 
 namespace {
-
     use Illuminate\Database\Eloquent\Model as Eloquent;
 
     class GlobalModelNamespace extends Eloquent

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -1,342 +1,357 @@
 <?php
 
-namespace Illuminate\Tests\Validation;
+namespace Illuminate\Tests\Validation {
 
-use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Translation\ArrayLoader;
-use Illuminate\Translation\Translator;
-use Illuminate\Validation\DatabasePresenceVerifier;
-use Illuminate\Validation\Rules\Exists;
-use Illuminate\Validation\Validator;
-use PHPUnit\Framework\TestCase;
+    use Illuminate\Database\Capsule\Manager as DB;
+    use Illuminate\Database\Eloquent\Model as Eloquent;
+    use Illuminate\Translation\ArrayLoader;
+    use Illuminate\Translation\Translator;
+    use Illuminate\Validation\DatabasePresenceVerifier;
+    use Illuminate\Validation\Rules\Exists;
+    use Illuminate\Validation\Validator;
+    use PHPUnit\Framework\TestCase;
 
-class ValidationExistsRuleTest extends TestCase
-{
-    /**
-     * Setup the database schema.
-     *
-     * @return void
-     */
-    protected function setUp(): void
+    class ValidationExistsRuleTest extends TestCase
     {
-        $db = new DB;
+        /**
+         * Setup the database schema.
+         *
+         * @return void
+         */
+        protected function setUp(): void
+        {
+            $db = new DB;
 
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
+            $db->addConnection([
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+            ]);
 
-        $db->bootEloquent();
-        $db->setAsGlobal();
+            $db->bootEloquent();
+            $db->setAsGlobal();
 
-        $this->createSchema();
-    }
+            $this->createSchema();
+        }
 
-    public function testItCorrectlyFormatsAStringVersionOfTheRule()
-    {
-        $rule = new Exists('table');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:table,NULL,foo,"bar"', (string) $rule);
+        public function testItCorrectlyFormatsAStringVersionOfTheRule()
+        {
+            $rule = new Exists('table');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:table,NULL,foo,"bar"', (string) $rule);
 
-        $rule = new Exists(User::class);
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:users,NULL,foo,"bar"', (string) $rule);
+            $rule = new Exists(User::class);
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:users,NULL,foo,"bar"', (string) $rule);
 
-        $rule = new Exists(UserWithPrefixedTable::class);
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:'.UserWithPrefixedTable::class.',NULL,foo,"bar"', (string) $rule);
+            $rule = new Exists(UserWithPrefixedTable::class);
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:'.UserWithPrefixedTable::class.',NULL,foo,"bar"', (string) $rule);
 
-        $rule = new Exists('table', 'column');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
+            $rule = new Exists('table', 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
 
-        $rule = new Exists(User::class, 'column');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
+            $rule = new Exists(User::class, 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
 
-        $rule = new Exists(UserWithConnection::class, 'column');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:mysql.users,column,foo,"bar"', (string) $rule);
+            $rule = new Exists(UserWithConnection::class, 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:mysql.users,column,foo,"bar"', (string) $rule);
 
-        $rule = new Exists('Illuminate\Tests\Validation\User', 'column');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
+            $rule = new Exists('Illuminate\Tests\Validation\User', 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
 
-        $rule = new Exists(NoTableNameModel::class, 'column');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:no_table_name_models,column,foo,"bar"', (string) $rule);
+            $rule = new Exists(NoTableNameModel::class, 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:no_table_name_models,column,foo,"bar"', (string) $rule);
 
-        $rule = new Exists(ClassWithRequiredConstructorParameters::class, 'column');
-        $rule->where('foo', 'bar');
-        $this->assertSame('exists:'.ClassWithRequiredConstructorParameters::class.',column,foo,"bar"', (string) $rule);
-    }
+            $rule = new Exists(ClassWithRequiredConstructorParameters::class, 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:'.ClassWithRequiredConstructorParameters::class.',column,foo,"bar"', (string) $rule);
 
-    public function testItChoosesValidRecordsUsingWhereInRule()
-    {
-        $rule = new Exists('users', 'id');
-        $rule->whereIn('type', ['foo', 'bar']);
+            $rule = new Exists(\GlobalModelNamespace::class, 'column');
+            $rule->where('foo', 'bar');
+            $this->assertSame('exists:global_model_namespace_test,column,foo,"bar"', (string) $rule);
+        }
 
-        User::create(['id' => '1', 'type' => 'foo']);
-        User::create(['id' => '2', 'type' => 'bar']);
-        User::create(['id' => '3', 'type' => 'baz']);
-        User::create(['id' => '4', 'type' => 'other']);
+        public function testItChoosesValidRecordsUsingWhereInRule()
+        {
+            $rule = new Exists('users', 'id');
+            $rule->whereIn('type', ['foo', 'bar']);
 
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [], ['id' => $rule]);
-        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+            User::create(['id' => '1', 'type' => 'foo']);
+            User::create(['id' => '2', 'type' => 'bar']);
+            User::create(['id' => '3', 'type' => 'baz']);
+            User::create(['id' => '4', 'type' => 'other']);
 
-        $v->setData(['id' => 1]);
-        $this->assertTrue($v->passes());
-        $v->setData(['id' => 2]);
-        $this->assertTrue($v->passes());
-        $v->setData(['id' => 3]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 4]);
-        $this->assertFalse($v->passes());
+            $trans = $this->getIlluminateArrayTranslator();
+            $v = new Validator($trans, [], ['id' => $rule]);
+            $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
 
-        // array values
-        $v->setData(['id' => [1, 2]]);
-        $this->assertTrue($v->passes());
-        $v->setData(['id' => [3, 4]]);
-        $this->assertFalse($v->passes());
-    }
+            $v->setData(['id' => 1]);
+            $this->assertTrue($v->passes());
+            $v->setData(['id' => 2]);
+            $this->assertTrue($v->passes());
+            $v->setData(['id' => 3]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 4]);
+            $this->assertFalse($v->passes());
 
-    public function testItChoosesValidRecordsUsingWhereNotInRule()
-    {
-        $rule = new Exists('users', 'id');
-        $rule->whereNotIn('type', ['foo', 'bar']);
+            // array values
+            $v->setData(['id' => [1, 2]]);
+            $this->assertTrue($v->passes());
+            $v->setData(['id' => [3, 4]]);
+            $this->assertFalse($v->passes());
+        }
 
-        User::create(['id' => '1', 'type' => 'foo']);
-        User::create(['id' => '2', 'type' => 'bar']);
-        User::create(['id' => '3', 'type' => 'baz']);
-        User::create(['id' => '4', 'type' => 'other']);
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [], ['id' => $rule]);
-        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
-
-        $v->setData(['id' => 1]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 2]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 3]);
-        $this->assertTrue($v->passes());
-        $v->setData(['id' => 4]);
-        $this->assertTrue($v->passes());
-
-        // array values
-        $v->setData(['id' => [1, 2]]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => [3, 4]]);
-        $this->assertTrue($v->passes());
-    }
-
-    public function testItChoosesValidRecordsUsingConditionalModifiers()
-    {
-        $rule = new Exists('users', 'id');
-        $rule->when(true, function ($rule) {
+        public function testItChoosesValidRecordsUsingWhereNotInRule()
+        {
+            $rule = new Exists('users', 'id');
             $rule->whereNotIn('type', ['foo', 'bar']);
-        });
-        $rule->unless(true, function ($rule) {
-            $rule->whereNotIn('type', ['baz', 'other']);
-        });
 
-        User::create(['id' => '1', 'type' => 'foo']);
-        User::create(['id' => '2', 'type' => 'bar']);
-        User::create(['id' => '3', 'type' => 'baz']);
-        User::create(['id' => '4', 'type' => 'other']);
+            User::create(['id' => '1', 'type' => 'foo']);
+            User::create(['id' => '2', 'type' => 'bar']);
+            User::create(['id' => '3', 'type' => 'baz']);
+            User::create(['id' => '4', 'type' => 'other']);
 
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [], ['id' => $rule]);
-        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+            $trans = $this->getIlluminateArrayTranslator();
+            $v = new Validator($trans, [], ['id' => $rule]);
+            $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
 
-        $v->setData(['id' => 1]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 2]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 3]);
-        $this->assertTrue($v->passes());
-        $v->setData(['id' => 4]);
-        $this->assertTrue($v->passes());
+            $v->setData(['id' => 1]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 2]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 3]);
+            $this->assertTrue($v->passes());
+            $v->setData(['id' => 4]);
+            $this->assertTrue($v->passes());
 
-        // array values
-        $v->setData(['id' => [1, 2]]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => [3, 4]]);
-        $this->assertTrue($v->passes());
-    }
+            // array values
+            $v->setData(['id' => [1, 2]]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => [3, 4]]);
+            $this->assertTrue($v->passes());
+        }
 
-    public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether()
-    {
-        $rule = new Exists('users', 'id');
-        $rule->whereIn('type', ['foo', 'bar', 'baz'])->whereNotIn('type', ['foo', 'bar']);
+        public function testItChoosesValidRecordsUsingConditionalModifiers()
+        {
+            $rule = new Exists('users', 'id');
+            $rule->when(true, function ($rule) {
+                $rule->whereNotIn('type', ['foo', 'bar']);
+            });
+            $rule->unless(true, function ($rule) {
+                $rule->whereNotIn('type', ['baz', 'other']);
+            });
 
-        User::create(['id' => '1', 'type' => 'foo']);
-        User::create(['id' => '2', 'type' => 'bar']);
-        User::create(['id' => '3', 'type' => 'baz']);
-        User::create(['id' => '4', 'type' => 'other']);
-        User::create(['id' => '5', 'type' => 'baz']);
+            User::create(['id' => '1', 'type' => 'foo']);
+            User::create(['id' => '2', 'type' => 'bar']);
+            User::create(['id' => '3', 'type' => 'baz']);
+            User::create(['id' => '4', 'type' => 'other']);
 
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [], ['id' => $rule]);
-        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+            $trans = $this->getIlluminateArrayTranslator();
+            $v = new Validator($trans, [], ['id' => $rule]);
+            $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
 
-        $v->setData(['id' => 1]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 2]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 3]);
-        $this->assertTrue($v->passes());
-        $v->setData(['id' => 4]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => 5]);
-        $this->assertTrue($v->passes());
+            $v->setData(['id' => 1]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 2]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 3]);
+            $this->assertTrue($v->passes());
+            $v->setData(['id' => 4]);
+            $this->assertTrue($v->passes());
 
-        // array values
-        $v->setData(['id' => [1, 2, 4]]);
-        $this->assertFalse($v->passes());
-        $v->setData(['id' => [3, 5]]);
-        $this->assertTrue($v->passes());
-    }
+            // array values
+            $v->setData(['id' => [1, 2]]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => [3, 4]]);
+            $this->assertTrue($v->passes());
+        }
 
-    public function testItChoosesValidRecordsUsingWhereNotRule()
-    {
-        $rule = new Exists('users', 'id');
+        public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether()
+        {
+            $rule = new Exists('users', 'id');
+            $rule->whereIn('type', ['foo', 'bar', 'baz'])->whereNotIn('type', ['foo', 'bar']);
 
-        $rule->whereNot('type', 'baz');
+            User::create(['id' => '1', 'type' => 'foo']);
+            User::create(['id' => '2', 'type' => 'bar']);
+            User::create(['id' => '3', 'type' => 'baz']);
+            User::create(['id' => '4', 'type' => 'other']);
+            User::create(['id' => '5', 'type' => 'baz']);
 
-        User::create(['id' => '1', 'type' => 'foo']);
-        User::create(['id' => '2', 'type' => 'bar']);
-        User::create(['id' => '3', 'type' => 'baz']);
-        User::create(['id' => '4', 'type' => 'other']);
-        User::create(['id' => '5', 'type' => 'baz']);
+            $trans = $this->getIlluminateArrayTranslator();
+            $v = new Validator($trans, [], ['id' => $rule]);
+            $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
 
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [], ['id' => $rule]);
-        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+            $v->setData(['id' => 1]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 2]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 3]);
+            $this->assertTrue($v->passes());
+            $v->setData(['id' => 4]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => 5]);
+            $this->assertTrue($v->passes());
 
-        $v->setData(['id' => 3]);
-        $this->assertFalse($v->passes());
+            // array values
+            $v->setData(['id' => [1, 2, 4]]);
+            $this->assertFalse($v->passes());
+            $v->setData(['id' => [3, 5]]);
+            $this->assertTrue($v->passes());
+        }
 
-        $v->setData(['id' => 4]);
-        $this->assertTrue($v->passes());
-    }
+        public function testItChoosesValidRecordsUsingWhereNotRule()
+        {
+            $rule = new Exists('users', 'id');
 
-    public function testItIgnoresSoftDeletes()
-    {
-        $rule = new Exists('table');
-        $rule->withoutTrashed();
-        $this->assertSame('exists:table,NULL,deleted_at,"NULL"', (string) $rule);
+            $rule->whereNot('type', 'baz');
 
-        $rule = new Exists('table');
-        $rule->withoutTrashed('softdeleted_at');
-        $this->assertSame('exists:table,NULL,softdeleted_at,"NULL"', (string) $rule);
-    }
+            User::create(['id' => '1', 'type' => 'foo']);
+            User::create(['id' => '2', 'type' => 'bar']);
+            User::create(['id' => '3', 'type' => 'baz']);
+            User::create(['id' => '4', 'type' => 'other']);
+            User::create(['id' => '5', 'type' => 'baz']);
 
-    public function testItOnlyTrashedSoftDeletes()
-    {
-        $rule = new Exists('table');
-        $rule->onlyTrashed();
-        $this->assertSame('exists:table,NULL,deleted_at,"NOT_NULL"', (string) $rule);
+            $trans = $this->getIlluminateArrayTranslator();
+            $v = new Validator($trans, [], ['id' => $rule]);
+            $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
 
-        $rule = new Exists('table');
-        $rule->onlyTrashed('softdeleted_at');
-        $this->assertSame('exists:table,NULL,softdeleted_at,"NOT_NULL"', (string) $rule);
-    }
+            $v->setData(['id' => 3]);
+            $this->assertFalse($v->passes());
 
-    protected function createSchema()
-    {
-        $this->schema('default')->create('users', function ($table) {
-            $table->unsignedInteger('id');
-            $table->string('type');
-        });
+            $v->setData(['id' => 4]);
+            $this->assertTrue($v->passes());
+        }
+
+        public function testItIgnoresSoftDeletes()
+        {
+            $rule = new Exists('table');
+            $rule->withoutTrashed();
+            $this->assertSame('exists:table,NULL,deleted_at,"NULL"', (string) $rule);
+
+            $rule = new Exists('table');
+            $rule->withoutTrashed('softdeleted_at');
+            $this->assertSame('exists:table,NULL,softdeleted_at,"NULL"', (string) $rule);
+        }
+
+        public function testItOnlyTrashedSoftDeletes()
+        {
+            $rule = new Exists('table');
+            $rule->onlyTrashed();
+            $this->assertSame('exists:table,NULL,deleted_at,"NOT_NULL"', (string) $rule);
+
+            $rule = new Exists('table');
+            $rule->onlyTrashed('softdeleted_at');
+            $this->assertSame('exists:table,NULL,softdeleted_at,"NOT_NULL"', (string) $rule);
+        }
+
+        protected function createSchema()
+        {
+            $this->schema('default')->create('users', function ($table) {
+                $table->unsignedInteger('id');
+                $table->string('type');
+            });
+        }
+
+        /**
+         * Get a schema builder instance.
+         *
+         * @return \Illuminate\Database\Schema\Builder
+         */
+        protected function schema($connection = 'default')
+        {
+            return $this->connection($connection)->getSchemaBuilder();
+        }
+
+        /**
+         * Get a database connection instance.
+         *
+         * @return \Illuminate\Database\Connection
+         */
+        protected function connection($connection = 'default')
+        {
+            return $this->getConnectionResolver()->connection($connection);
+        }
+
+        /**
+         * Get connection resolver.
+         *
+         * @return \Illuminate\Database\ConnectionResolverInterface
+         */
+        protected function getConnectionResolver()
+        {
+            return Eloquent::getConnectionResolver();
+        }
+
+        /**
+         * Tear down the database schema.
+         *
+         * @return void
+         */
+        protected function tearDown(): void
+        {
+            $this->schema('default')->drop('users');
+        }
+
+        public function getIlluminateArrayTranslator()
+        {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        }
     }
 
     /**
-     * Get a schema builder instance.
-     *
-     * @return \Illuminate\Database\Schema\Builder
+     * Eloquent Models.
      */
-    protected function schema($connection = 'default')
+    class User extends Eloquent
     {
-        return $this->connection($connection)->getSchemaBuilder();
+        protected $table = 'users';
+        protected $guarded = [];
+        public $timestamps = false;
     }
 
-    /**
-     * Get a database connection instance.
-     *
-     * @return \Illuminate\Database\Connection
-     */
-    protected function connection($connection = 'default')
+    class UserWithPrefixedTable extends Eloquent
     {
-        return $this->getConnectionResolver()->connection($connection);
+        protected $table = 'public.users';
+        protected $guarded = [];
+        public $timestamps = false;
     }
 
-    /**
-     * Get connection resolver.
-     *
-     * @return \Illuminate\Database\ConnectionResolverInterface
-     */
-    protected function getConnectionResolver()
+    class UserWithConnection extends User
     {
-        return Eloquent::getConnectionResolver();
+        protected $connection = 'mysql';
     }
 
-    /**
-     * Tear down the database schema.
-     *
-     * @return void
-     */
-    protected function tearDown(): void
+    class NoTableNameModel extends Eloquent
     {
-        $this->schema('default')->drop('users');
+        protected $guarded = [];
+        public $timestamps = false;
     }
 
-    public function getIlluminateArrayTranslator()
+    class ClassWithRequiredConstructorParameters
     {
-        return new Translator(
-            new ArrayLoader, 'en'
-        );
+        private $bar;
+        private $baz;
+
+        public function __construct($bar, $baz)
+        {
+            $this->bar = $bar;
+            $this->baz = $baz;
+        }
     }
 }
 
-/**
- * Eloquent Models.
- */
-class User extends Eloquent
-{
-    protected $table = 'users';
-    protected $guarded = [];
-    public $timestamps = false;
-}
+namespace {
 
-class UserWithPrefixedTable extends Eloquent
-{
-    protected $table = 'public.users';
-    protected $guarded = [];
-    public $timestamps = false;
-}
+    use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class UserWithConnection extends User
-{
-    protected $connection = 'mysql';
-}
-
-class NoTableNameModel extends Eloquent
-{
-    protected $guarded = [];
-    public $timestamps = false;
-}
-
-class ClassWithRequiredConstructorParameters
-{
-    private $bar;
-    private $baz;
-
-    public function __construct($bar, $baz)
+    class GlobalModelNamespace extends Eloquent
     {
-        $this->bar = $bar;
-        $this->baz = $baz;
+        protected $table = 'global_model_namespace_test';
     }
 }


### PR DESCRIPTION
I was working on a FormRequest's rule section at my company (using Laravel 9.x) when I tried using a normal `Rule::exists(SomeModel::class, 'some_column')->withoutTrashed()->where('another_column', 1)` but the rule was failing because it tried using `database_name.SomeModel` instead of the correct `$table` value for `SomeModel`.

I did check the source code and it does have `! str_contains($table, '\\')` at the beginning of a check. I tried looking for any logic about why if it does not have `\\` it should be used directly (when we do have a `! class_exists($table)` after this check) but I did not find anything.

So, I followed these steps to accomplish the desired outcome:
1. Removed the previous logic mentioned from `src/Illuminate/Validation/Rules/DatabaseRule.php`
2. Run all the tests in `tests/Validation/ValidationExistsRuleTest.php` and all of them passed
3. Added that logic back
4. Added my new case inside the first test case
5. Ran all the tests again and my case failed (as expected)
6. Removed the first check again (main logic breaking the desired result)
7. Ran all the tests again and they all passed

I did have to do something super ugly I have never done, declare the whole test file inside a namespace (with `{ }`), because I had to declare a test model on the global namespace and I didn't want to add it on the main structure of the repository, nor inside `test` folder and declare a new namespace on the composer file (`psr-4` for `autoload-dev`).

Do let me know if there is a better way of declaring this global namespace (`\`) test model class for this specific test.