### PR TITLE
[11.x] Allowing the Publish of the Health Check View

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -191,6 +191,10 @@ class ApplicationBuilder
                 Route::middleware('web')->get($health, function () {
                     Event::dispatch(new DiagnosingHealth);
 
+                    if (file_exists(resource_path('views/health-up.blade.php'))) {
+                        return View::file(resource_path('views/health-up.blade.php'));
+                    }
+
                     return View::file(__DIR__.'/../resources/health-up.blade.php');
                 });
             }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -61,7 +61,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
 
             $this->publishes([
-                __DIR__.'/../resources/health-up.blade.php' => $this->app->resourcePath('views/'),
+                __DIR__.'/../resources/health-up.blade.php' => $this->app->resourcePath('views/health-up.blade.php'),
             ], 'laravel-health-up');
         }
     }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -59,6 +59,10 @@ class FoundationServiceProvider extends AggregateServiceProvider
             $this->publishes([
                 __DIR__.'/../Exceptions/views' => $this->app->resourcePath('views/errors/'),
             ], 'laravel-errors');
+
+            $this->publishes([
+                __DIR__.'/../resources/health-up.blade.php' => $this->app->resourcePath('views/'),
+            ], 'laravel-health-up');
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request aims to add the possibility of publishing the original health-up check view using the following command: 

```shel
php artisan vendor:publish --tag=laravel-health-up
```

When running this command, the original health-up view file will be copied to the `resources/view` path.

PS: If accepted, I'll send the PR for the docs.
