### PR TITLE
[10.x] Use InteractsWithQueue in Batchable trait

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -4,11 +4,14 @@ namespace Illuminate\Bus;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Container\Container;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\BatchFake;
 
 trait Batchable
 {
+    use InteractsWithQueue;
+
     /**
      * The batch ID (if applicable).
      *

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -183,8 +183,7 @@ class CallQueuedHandler
     {
         $uses = class_uses_recursive($command);
 
-        if (! in_array(Batchable::class, $uses) ||
-            ! in_array(InteractsWithQueue::class, $uses)) {
+        if (! in_array(Batchable::class, $uses)) {
             return;
         }
 


### PR DESCRIPTION
Batchable success is only recorded when the `InteractsWithQueue` trait has been used and because without the success being recorded tha batch will always remain open and possibly block other jobs if they are chained with the batch it is better to use the `InteractsWithQueue` trait in the `Batchable` trait itself to prevent misuse/bugs.

Solves #50057 