### PR TITLE
[10.x] Move ShouldBeUnique locking from PendingDispatch to Dispatcher

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -4,8 +4,10 @@ namespace Illuminate\Bus;
 
 use Closure;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Pipeline\Pipeline;
@@ -202,7 +204,16 @@ class Dispatcher implements QueueingDispatcher
      */
     protected function commandShouldBeQueued($command)
     {
-        return $command instanceof ShouldQueue;
+        if(!$command instanceof ShouldQueue) {
+            return false;
+        }
+
+        if ($command instanceof ShouldBeUnique) {
+            return (new UniqueLock(\Illuminate\Container\Container::getInstance()->make(Cache::class)))
+                ->acquire($command);
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -44,6 +44,21 @@ class UniqueLock
     }
 
     /**
+     * Check if the lock for the given job is already acquired.
+     *
+     * @param  mixed  $job
+     * @return bool
+     */
+    public function isAcquired($job)
+    {
+        $cache = method_exists($job, 'uniqueVia')
+                    ? $job->uniqueVia()
+                    : $this->cache;
+
+        return (bool) $cache->lock($this->getKey($job))->get();
+    }
+
+    /**
      * Release the lock for the given job.
      *
      * @param  mixed  $job

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -212,10 +212,6 @@ class Schedule
             throw new RuntimeException('Cache driver not available. Scheduling unique jobs not supported.');
         }
 
-        if (! (new UniqueLock(Container::getInstance()->make(Cache::class)))->acquire($job)) {
-            return;
-        }
-
         $this->getDispatcher()->dispatch(
             $job->onConnection($connection)->onQueue($queue)
         );

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -2,11 +2,7 @@
 
 namespace Illuminate\Foundation\Bus;
 
-use Illuminate\Bus\UniqueLock;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
-use Illuminate\Contracts\Cache\Repository as Cache;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 
 class PendingDispatch
 {
@@ -150,21 +146,6 @@ class PendingDispatch
     }
 
     /**
-     * Determine if the job should be dispatched.
-     *
-     * @return bool
-     */
-    protected function shouldDispatch()
-    {
-        if (! $this->job instanceof ShouldBeUnique) {
-            return true;
-        }
-
-        return (new UniqueLock(Container::getInstance()->make(Cache::class)))
-                    ->acquire($this->job);
-    }
-
-    /**
      * Dynamically proxy methods to the underlying job.
      *
      * @param  string  $method
@@ -185,9 +166,7 @@ class PendingDispatch
      */
     public function __destruct()
     {
-        if (! $this->shouldDispatch()) {
-            return;
-        } elseif ($this->afterResponse) {
+        if ($this->afterResponse) {
             app(Dispatcher::class)->dispatchAfterResponse($this->job);
         } else {
             app(Dispatcher::class)->dispatch($this->job);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When dispatching jobs through the dispatcher directly, the ShouldBeUnique logic isn't checked and the job won't be locked. This is strange undocumented behaviour imo and caused lots of bugs around our platform as we heavily rely on dependency injecting the Dispatcher class. I've seen other instances online where users also dispatch jobs directly on the Dispatcher and I feel like key logic like ShouldBeUnique should be implemented on this level as well as theres no added value to doing so on PendingDispatch level. This even feels kindof hacky to be implemented on PendingDispatch level.