### PR TITLE
[10.x] Fixes return type "never"

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -171,7 +171,7 @@ trait ResponseTrait
     /**
      * Throws the response in a HttpResponseException instance.
      *
-     * @return void
+     * @return never
      *
      * @throws \Illuminate\Http\Exceptions\HttpResponseException
      */


### PR DESCRIPTION
This only changes the return type of the method to the correct one (`never`).

This would also fix some static analysis to correctly assert that the method never returns.