### PR TITLE
[10.x] Format only one item instead of mapping for all

### DIFF
--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -55,9 +55,9 @@ class Inspiring
      */
     public static function quote()
     {
-        return static::quotes()
-            ->map(fn ($quote) => static::formatForConsole($quote))
-            ->random();
+        return static::formatForConsole(
+            static::quotes()->random()
+        );
     }
 
     /**


### PR DESCRIPTION
Since it's returning only one item, it's not necessary to map the format method for all the items. This change only applies the format method to the returning item.
 