### PR TITLE
[11.x] Add support for installing Laravel passport on `install:api` artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -20,14 +20,15 @@ class ApiInstallCommand extends Command
      */
     protected $signature = 'install:api
                     {--composer=global : Absolute path to the Composer binary which should be used to install packages}
-                    {--force : Overwrite any existing API routes file}';
+                    {--force : Overwrite any existing API routes file}
+                    {--passport : Install Laravel Passport}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Create an API routes file and install Laravel Sanctum';
+    protected $description = 'Create an API routes file and install Laravel Sanctum or Laravel Passport';
 
     /**
      * Execute the console command.
@@ -36,7 +37,11 @@ class ApiInstallCommand extends Command
      */
     public function handle()
     {
-        $this->installSanctum();
+        if ($this->option('passport')) {
+            $this->installPassport();
+        } else {
+            $this->installSanctum();
+        }
 
         if (file_exists($apiRoutesPath = $this->laravel->basePath('routes/api.php')) &&
             ! $this->option('force')) {
@@ -46,14 +51,30 @@ class ApiInstallCommand extends Command
 
             copy(__DIR__.'/stubs/api-routes.stub', $apiRoutesPath);
 
+            if ($this->option('passport')) {
+                (new Filesystem)->replaceInFile(
+                    'auth:sanctum',
+                    'auth:api',
+                    $apiRoutesPath,
+                );
+            }
+
             $this->uncommentApiRoutesFile();
         }
 
-        if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', false)) {
-            $this->call('migrate');
-        }
+        if ($this->option('passport')) {
+            $this->call('passport:install', [
+                '--uuids' => $this->confirm('Would you like to use UUIDs for all client IDs?')
+            ]);
 
-        $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');
+            $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
+        } else {
+            if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', false)) {
+                $this->call('migrate');
+            }
+
+            $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');
+        }
     }
 
     /**
@@ -110,5 +131,17 @@ class ApiInstallCommand extends Command
                 'Laravel\\Sanctum\\SanctumServiceProvider',
             ]);
         }
+    }
+
+    /**
+     * Install Laravel Passport into the application.
+     *
+     * @return void
+     */
+    protected function installPassport()
+    {
+        $this->requireComposerPackages($this->option('composer'), [
+            'laravel/passport:^12.0',
+        ]);
     }
 }

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -21,7 +21,7 @@ class ApiInstallCommand extends Command
     protected $signature = 'install:api
                     {--composer=global : Absolute path to the Composer binary which should be used to install packages}
                     {--force : Overwrite any existing API routes file}
-                    {--passport : Install Laravel Passport}';
+                    {--passport : Install Laravel Passport instead of Laravel Sanctum}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -64,7 +64,7 @@ class ApiInstallCommand extends Command
 
         if ($this->option('passport')) {
             $this->call('passport:install', [
-                '--uuids' => $this->confirm('Would you like to use UUIDs for all client IDs?')
+                '--uuids' => $this->confirm('Would you like to use UUIDs for all client IDs?'),
             ]);
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');


### PR DESCRIPTION
As discussed on https://github.com/laravel/framework/pull/50315#issuecomment-1976781877

Related to laravel/passport#1724

This PR add support for installing Laravel Passport when running `install:api` on Laravel 11.x:

```shell
php artisan install:api --passport
```
