### PR TITLE
Fix race condition with withoutOverlapping in Console tasks

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -88,17 +88,14 @@ abstract class Lock implements LockContract
      */
     public function get($callback = null)
     {
-        $result = $this->acquire();
-
-        if ($result && is_callable($callback)) {
-            try {
+        // If a callable is passed, only check whether the lock is available.
+        if (is_callable($callback)) {
+            $owner = $this->getCurrentOwner();
+            if (empty($owner) || $owner === $this->owner()) {
                 return $callback();
-            } finally {
-                $this->release();
             }
         }
-
-        return $result;
+        return $this->acquire();
     }
 
     /**


### PR DESCRIPTION
Changes the logic of the `Lock::get` method so that if a callable is passed, it simply checks whether the lock is available instead of actually acquiring it, this resolves the race condition reported in https://github.com/laravel/framework/issues/50330

Existing behaviour is preserved, as previously the lock was acquired then immediately released if a callable was passed.
