### PR TITLE
[10.x] Sleep syncing

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Support;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use DateInterval;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -21,7 +21,7 @@ class Sleep
     public static $fakeSleepCallbacks = [];
 
     /**
-     * Keep carbon's "now" in sync when sleeping.
+     * Keep Carbon's "now" in sync when sleeping.
      *
      * @var bool
      */

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -21,6 +21,13 @@ class Sleep
     public static $fakeSleepCallbacks = [];
 
     /**
+     * Keep carbon's "now" in sync when sleeping.
+     *
+     * @var bool
+     */
+    protected static $syncWithCarbon = false;
+
+    /**
      * The total duration to sleep.
      *
      * @var \Carbon\CarbonInterval
@@ -259,6 +266,10 @@ class Sleep
         if (static::$fake) {
             static::$sequence[] = $this->duration;
 
+            if (static::$syncWithCarbon) {
+                Carbon::setTestNow(Carbon::now()->add($this->duration));
+            }
+
             foreach (static::$fakeSleepCallbacks as $callback) {
                 $callback($this->duration);
             }
@@ -317,6 +328,7 @@ class Sleep
 
         static::$sequence = [];
         static::$fakeSleepCallbacks = [];
+        static::$syncWithCarbon = false;
     }
 
     /**
@@ -457,5 +469,15 @@ class Sleep
     public static function whenFakingSleep($callback)
     {
         static::$fakeSleepCallbacks[] = $callback;
+    }
+
+    /**
+     * Indicate that Carbon's "now" should be kept in sync when sleeping.
+     *
+     * @return void
+     */
+    public static function syncWithCarbon($value = true)
+    {
+        static::$syncWithCarbon = $value;
     }
 }

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Carbon\CarbonInterval;
 use Exception;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Sleep;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
@@ -562,5 +563,34 @@ class SleepTest extends TestCase
         Sleep::for(1)->millisecond();
 
         $this->assertTrue(true);
+    }
+
+    public function testItDoesNotSyncCarbon()
+    {
+        Carbon::setTestNow('2000-01-01 00:00:00');
+        Sleep::fake();
+
+        Sleep::for(5)->minutes()
+            ->and(3)->seconds();
+
+        Sleep::assertSequence([
+            Sleep::for(303)->seconds(),
+        ]);
+        $this->assertSame('2000-01-01 00:00:00', Date::now()->toDateTimeString());
+    }
+
+    public function testItCanSyncCarbon()
+    {
+        Carbon::setTestNow('2000-01-01 00:00:00');
+        Sleep::fake();
+        Sleep::syncWithCarbon();
+
+        Sleep::for(5)->minutes()
+            ->and(3)->seconds();
+
+        Sleep::assertSequence([
+            Sleep::for(303)->seconds(),
+        ]);
+        $this->assertSame('2000-01-01 00:05:03', Date::now()->toDateTimeString());
     }
 }


### PR DESCRIPTION
Adds a testing helper to keep carbon in sync when sleeping.

```php
// Test...
Sleep::fake();
Sleep::syncWithCarbon();

// Code...
$start = now();

Sleep::for(1)->second();

$start->diffForHumans(); // 1 second ago
```

Before you would commonly do the following...

```php
Carbon::fake();

Sleep::whenFakingSleep(function ($duration) {
    Carbon::setTestNow(now()->add($duration);
});
```

Docs: https://github.com/laravel/docs/pull/9462