### PR TITLE
[10.x] Add lowercaseKeys and uppercaseKeys methods to Arr helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -936,4 +936,26 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Convert all keys in the given associative array to lowercase.
+     *
+     * @param array $array The input array.
+     * @return array The array with all keys converted to lowercase.
+     */
+    public static function lowercaseKeys(array $array): array
+    {
+        return array_change_key_case($array, CASE_LOWER);
+    }
+
+    /**
+     * Convert all keys in the given associative array to uppercase.
+     *
+     * @param array $array The input array.
+     * @return array The array with all keys converted to uppercase.
+     */
+    public static function uppercaseKeys(array $array): array
+    {
+        return array_change_key_case($array, CASE_UPPER);
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1309,4 +1309,42 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::select($array, 'name'));
     }
+
+    public function testLowercaseKeys()
+    {
+        $inputArray = [
+            'Name' => 'John',
+            'Age' => 25,
+            'City' => 'New York',
+        ];
+
+        $resultArray = Arr::lowercaseKeys($inputArray);
+
+        $expectedArray = [
+            'name' => 'John',
+            'age' => 25,
+            'city' => 'New York',
+        ];
+
+        $this->assertSame($expectedArray, $resultArray);
+    }
+
+    public function testUppercaseKeys()
+    {
+        $inputArray = [
+            'Name' => 'John',
+            'Age' => 25,
+            'City' => 'New York',
+        ];
+
+        $resultArray = Arr::uppercaseKeys($inputArray);
+
+        $expectedArray = [
+            'NAME' => 'John',
+            'AGE' => 25,
+            'CITY' => 'New York',
+        ];
+
+        $this->assertSame($expectedArray, $resultArray);
+    }
 }


### PR DESCRIPTION
This pull request introduces two new methods to the Arr helper in Laravel, namely lowercaseKeys and uppercaseKeys. These methods allow users to conveniently convert all keys in an associative array to lowercase or uppercase, providing a more versatile and user-friendly array manipulation utility.

**Changes** :
- Added `lowercaseKeys` method to convert array keys to lowercase.
- Added `uppercaseKeys` method to convert array keys to uppercase.

```php
// Convert keys to lowercase
$lowercasedArray = Arr::lowercaseKeys($originalArray);

// Convert keys to uppercase
$uppercasedArray = Arr::uppercaseKeys($originalArray);
```

These additions enhance the functionality of the Arr helper and provide users with a consistent way to handle array keys in different casing scenarios.

