### PR TITLE
[11.x] Adds `Enums` folder to `make:enum` command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -56,7 +56,7 @@ class EnumMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\\Enums';
+        return $rootNamespace.'\\Enums';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -49,6 +49,17 @@ class EnumMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\\Enums';
+    }
+
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -12,9 +12,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum StatusEnum',
-        ], 'app/StatusEnum.php');
+        ], 'app/Enums/StatusEnum.php');
     }
 
     public function testItCanGenerateEnumFileWithString()
@@ -23,9 +23,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum StringEnum: string',
-        ], 'app/StringEnum.php');
+        ], 'app/Enums/StringEnum.php');
     }
 
     public function testItCanGenerateEnumFileWithInt()
@@ -34,8 +34,8 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum IntEnum: int',
-        ], 'app/IntEnum.php');
+        ], 'app/Enums/IntEnum.php');
     }
 }


### PR DESCRIPTION
It is better to create enum classes in the Enums folder, like `Models`