### PR TITLE
[11.x] Use dedicated namespace for enums

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -49,6 +49,17 @@ class EnumMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Enums';
+    }
+
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name


### PR DESCRIPTION
Would love to see the EnumMakeCommand use a dedicated Enums directory by default. Using this as well for all my personal apps.