### PR TITLE
[11.x] Allows to ignore`install:api` migration prompt

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -71,7 +71,7 @@ class ApiInstallCommand extends Command
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
         } else {
             if (! $this->option('ignore-migrate-prompt')) {
-                if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', false)) {
+                if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', true)) {
                     $this->call('migrate');
                 }
             }

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -21,7 +21,8 @@ class ApiInstallCommand extends Command
     protected $signature = 'install:api
                     {--composer=global : Absolute path to the Composer binary which should be used to install packages}
                     {--force : Overwrite any existing API routes file}
-                    {--passport : Install Laravel Passport instead of Laravel Sanctum}';
+                    {--passport : Install Laravel Passport instead of Laravel Sanctum}
+                    {--ignore-migrate-prompt : Ignore the prompt to run pending migrations}';
 
     /**
      * The console command description.
@@ -69,8 +70,10 @@ class ApiInstallCommand extends Command
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
         } else {
-            if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', false)) {
-                $this->call('migrate');
+            if (! $this->option('ignore-migrate-prompt')) {
+                if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', false)) {
+                    $this->call('migrate');
+                }
             }
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Sanctum\HasApiTokens] trait to your User model.');

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -22,7 +22,7 @@ class ApiInstallCommand extends Command
                     {--composer=global : Absolute path to the Composer binary which should be used to install packages}
                     {--force : Overwrite any existing API routes file}
                     {--passport : Install Laravel Passport instead of Laravel Sanctum}
-                    {--ignore-migrate-prompt : Ignore the prompt to run pending migrations}';
+                    {--without-migration-prompt : Do not prompt to run pending migrations}';
 
     /**
      * The console command description.
@@ -70,7 +70,7 @@ class ApiInstallCommand extends Command
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
         } else {
-            if (! $this->option('ignore-migrate-prompt')) {
+            if (! $this->option('without-migration-prompt')) {
                 if ($this->confirm('One new database migration has been published. Would you like to run all pending database migrations?', true)) {
                     $this->call('migrate');
                 }


### PR DESCRIPTION
Related to https://github.com/laravel/jetstream/pull/1447.