### PR TITLE
Add symmetrical convenience method

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -501,6 +501,17 @@ class Middleware
     }
 
     /**
+     * Configure where users are redirected by the authentication middleware.
+     *
+     * @param  callable|string  $redirect
+     * @return $this
+     */
+    public function redirectUsersTo(callable|string $redirect)
+    {
+        return $this->redirectTo(users: $redirect);
+    }
+
+    /**
      * Configure where users are redirected by the authentication and guest middleware.
      *
      * @param  callable|string  $guests


### PR DESCRIPTION
Since a `redirectGuestsTo` convenience method exists, I felt a `redirectUsersTo` convenience method should also exist. Especially since `users` is the second optional argument, as this would avoid using named parameters when it's the only redirect a user sets.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
