### PR TITLE
[11.x] Add symmetrical convenience method

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -501,6 +501,17 @@ class Middleware
     }
 
     /**
+     * Configure where users are redirected by the authentication middleware.
+     *
+     * @param  callable|string  $redirect
+     * @return $this
+     */
+    public function redirectUsersTo(callable|string $redirect)
+    {
+        return $this->redirectTo(users: $redirect);
+    }
+
+    /**
      * Configure where users are redirected by the authentication and guest middleware.
      *
      * @param  callable|string  $guests

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -490,7 +490,7 @@ class Middleware
     }
 
     /**
-     * Configure where guests are redirected by the authentication middleware.
+     * Configure where guests are redirected by the "auth" middleware.
      *
      * @param  callable|string  $redirect
      * @return $this
@@ -501,7 +501,7 @@ class Middleware
     }
 
     /**
-     * Configure where users are redirected by the authentication middleware.
+     * Configure where users are redirected by the "guest" middleware.
      *
      * @param  callable|string  $redirect
      * @return $this


### PR DESCRIPTION
Since a `redirectGuestsTo` convenience method exists, I felt a `redirectUsersTo` convenience method should also exist. Especially since `users` is the second optional argument, as this would avoid using named parameters when it's the only redirect a user sets.
