### PR TITLE
[11.x] Adds Enums folder to `make:enum` command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -49,6 +49,17 @@ class EnumMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Enums')) ? $rootNamespace.'\\Enums' : $rootNamespace;
+    }
+
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Integration\Generators;
 
-use Illuminate\Support\Facades\File;
 use Illuminate\Tests\Integration\Generators\TestCase;
 
 class EnumMakeCommandTest extends TestCase

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Integration\Generators;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Tests\Integration\Generators\TestCase;
 
 class EnumMakeCommandTest extends TestCase
@@ -37,5 +38,18 @@ class EnumMakeCommandTest extends TestCase
             'namespace App;',
             'enum IntEnum: int',
         ], 'app/IntEnum.php');
+    }
+
+    public function testItCanGenerateEnumFileInEnumsFolder()
+    {
+        File::makeDirectory(app_path() . '\\Enums', force: true);
+
+        $this->artisan('make:enum', ['name' => 'ImplicitEnum'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Enums;',
+            'enum ImplicitEnum',
+        ], 'app/Enums/ImplicitEnum.php');
     }
 }

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -42,7 +42,7 @@ class EnumMakeCommandTest extends TestCase
 
     public function testItCanGenerateEnumFileInEnumsFolder()
     {
-        File::makeDirectory(app_path() . '\\Enums', force: true);
+        File::makeDirectory(app_path().'\\Enums', force: true);
 
         $this->artisan('make:enum', ['name' => 'ImplicitEnum'])
             ->assertExitCode(0);
@@ -51,5 +51,7 @@ class EnumMakeCommandTest extends TestCase
             'namespace App\Enums;',
             'enum ImplicitEnum',
         ], 'app/Enums/ImplicitEnum.php');
+
+        File::deleteDirectory(app_path().'\\Enums');
     }
 }

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -39,19 +39,4 @@ class EnumMakeCommandTest extends TestCase
             'enum IntEnum: int',
         ], 'app/IntEnum.php');
     }
-
-    public function testItCanGenerateEnumFileInEnumsFolder()
-    {
-        File::makeDirectory(app_path().'\\Enums', force: true);
-
-        $this->artisan('make:enum', ['name' => 'ImplicitEnum'])
-            ->assertExitCode(0);
-
-        $this->assertFileContains([
-            'namespace App\Enums;',
-            'enum ImplicitEnum',
-        ], 'app/Enums/ImplicitEnum.php');
-
-        File::deleteDirectory(app_path().'\\Enums');
-    }
 }


### PR DESCRIPTION
https://github.com/laravel/framework/pull/50394

In our previous PR, we didn't include the option to create enums in the `Enums` folder or `App` folder. However, we have now added this feature! If someone would like to create an enum file in the `Enums` folder, they just need to create a folder named `Enums` :)
Like models