### PR TITLE
 [11.x] Add neverAddHttpCookie in middleware configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes for 11.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v11.0.0..11.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v11.0.0..master)
 
-## [v11.0.0 (2024-??-??)](https://github.com/laravel/framework/compare/v11.0.0...11.x)
+## [v11.0.0 (2024-??-??)](https://github.com/laravel/framework/compare/v11.0.0...master)
 
 Check the upgrade guide in the [Official Laravel Upgrade Documentation](https://laravel.com/docs/11.x/upgrade). Also you can see some release notes in the [Official Laravel Release Documentation](https://laravel.com/docs/11.x/releases).

--- a/bin/split.sh
+++ b/bin/split.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-CURRENT_BRANCH="11.x"
+CURRENT_BRANCH="master"
 
 function split()
 {

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -552,6 +552,19 @@ class Middleware
     }
 
     /**
+     * Configure if we want to add the CSRF token to the http cookie.
+     *
+     * @param  bool  $status
+     * @return $this
+     */
+    public function neverAddHttpCookie(bool $status = true)
+    {
+        ValidateCsrfToken::neverAddHttpCookie($status);
+
+        return $this;
+    }
+
+    /**
      * Configure the URL signature validation middleware.
      *
      * @param  array  $except

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -42,6 +42,13 @@ class VerifyCsrfToken
     protected static $neverVerify = [];
 
     /**
+     * Indicates whether the XSRF-TOKEN cookie should never be set on the response globally.
+     *
+     * @var bool
+     */
+    protected static $neverAddHttpCookie = false;
+
+    /**
      * Indicates whether the XSRF-TOKEN cookie should be set on the response.
      *
      * @var bool
@@ -162,7 +169,7 @@ class VerifyCsrfToken
      */
     public function shouldAddXsrfTokenCookie()
     {
-        return $this->addHttpCookie;
+        return ! static::$neverAddHttpCookie && $this->addHttpCookie;
     }
 
     /**
@@ -222,6 +229,17 @@ class VerifyCsrfToken
     }
 
     /**
+     * Indicate that the CSRF token should not be added to the response cookies.
+     *
+     * @param  bool  $status
+     * @return void
+     */
+    public static function neverAddHttpCookie(bool $status = true)
+    {
+        static::$neverAddHttpCookie = $status;
+    }
+
+    /**
      * Determine if the cookie contents should be serialized.
      *
      * @return bool
@@ -239,5 +257,7 @@ class VerifyCsrfToken
     public static function flushState()
     {
         static::$neverVerify = [];
+
+        static::$neverAddHttpCookie = false;
     }
 }

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Http\Middleware\TrustHosts;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
@@ -279,5 +280,21 @@ class MiddlewareTest extends TestCase
 
         $configuration->preventRequestsDuringMaintenance(['metrics/*']);
         $this->assertTrue($method->invoke($middleware, $request));
+    }
+
+    public function testNeverAddHttpCookie()
+    {
+        $configuration = new Middleware();
+        $app = Mockery::mock(Application::class);
+        $encrypter = Mockery::mock(Encrypter::class);
+        $middleware = new ValidateCsrfToken($app, $encrypter);
+
+        $this->assertTrue($middleware->shouldAddXsrfTokenCookie());
+
+        $configuration->neverAddHttpCookie();
+        $this->assertFalse($middleware->shouldAddXsrfTokenCookie());
+
+        $configuration->neverAddHttpCookie(false);
+        $this->assertTrue($middleware->shouldAddXsrfTokenCookie());
     }
 }


### PR DESCRIPTION
This pull request adds `neverAddHttpCookie` in middleware configuration. This will allow us to exclude the XSRF Token cookie in the response.

Here is how to use it.
```php
// in bootstrap/app.php

    ->withMiddleware(function (Middleware $middleware) {
        $middleware->neverAddHttpCookie();
    })
```