### PR TITLE
[11.x] Add Support for After Hook Inside Policy Class

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -761,7 +761,11 @@ class Gate implements GateContract
 
             $method = $this->formatAbilityToMethod($ability);
 
-            return $this->callPolicyMethod($policy, $method, $user, $arguments);
+            $result = $this->callPolicyMethod($policy, $method, $user, $arguments);
+
+            return $this->callPolicyAfter(
+                $policy, $user, $ability, $result, $arguments
+            );
         };
     }
 
@@ -783,6 +787,25 @@ class Gate implements GateContract
         if ($this->canBeCalledWithUser($user, $policy, 'before')) {
             return $policy->before($user, $ability, ...$arguments);
         }
+    }
+
+    /**
+     * Call the "after" method on the given policy, if applicable.
+     *
+     * @param  mixed  $policy
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $ability
+     * @param  mixed  $result
+     * @param  array  $arguments
+     * @return mixed
+     */
+    protected function callPolicyAfter($policy, $user, $ability, $result, $arguments)
+    {
+        if (method_exists($policy, 'after') && $this->canBeCalledWithUser($user, $policy, 'after')) {
+            return $policy->after($user, $ability, $result, ...$arguments);
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Allows for an `after` method to be added on a policy class. This works just like the `before` method on the policy class. I felt like it was missing since `Gate::after` does exist.

This could be breaking if an `after` method already exists on the policy class.

My use-case for this would be something like the following.

```php
class UserPolicy
{
    public function after(User $user, $ability, $result)
    {
        return $result ? Response::allow() : Response::denyAsNotFound();
    }
    
    public function show(User $user, User $other): bool
    {
        return $user->id === $other->id;
    }
    
    public function update(User $user, User $other): bool
    {
        return $user->id === $other->id;
    }
}
```