### PR TITLE
Fix DATABASE_URL parsing in ConfigurationUrlParser->getDatabase()

### DIFF
--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -90,14 +90,30 @@ class ConfigurationUrlParser
     /**
      * Get the database name from the URL.
      *
-     * @param  array  $url
+     * @param array $url
      * @return string|null
      */
     protected function getDatabase($url)
     {
         $path = $url['path'] ?? null;
 
-        return $path && $path !== '/' ? substr($path, 1) : null;
+        $pairs = explode(';', $path);
+
+        $databaseName = null;
+
+        // Iterate over each pair
+        foreach ($pairs as $pair) {
+            // Split the pair into key and value
+            list($key, $value) = explode('=', $pair, 2); // Limit to 2 elements to ensure it splits only on the first '='
+
+            // Check if the key matches 'Database', case-insensitively
+            if (strcasecmp($key, 'Database') === 0) {
+                $databaseName = $value;
+                break; // Stop the loop once we've found the database name
+            }
+        }
+
+        return $databaseName;
     }
 
     /**


### PR DESCRIPTION
Not sure how this ever worked.

Maybe it used to recieve `$url['path'] => '=database_name`' from `DB_DATABASE=database_name` in `.env`. So chopping off the first character ('=') would work. But that's now how it works today.

Connecting to the database without setting the DATABASE_URL, and using the array syntax from `config/database.php` still works.

Found in: https://github.com/laravel/docs/pull/9459