### PR TITLE
fix: incomplete type for Builder::from property

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -98,7 +98,7 @@ class Builder implements BuilderContract
     /**
      * The table which the query is targeting.
      *
-     * @var string|\Illuminate\Database\Query\Expression
+     * @var \Illuminate\Database\Query\Expression|string
      */
     public $from;
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -98,7 +98,7 @@ class Builder implements BuilderContract
     /**
      * The table which the query is targeting.
      *
-     * @var string
+     * @var string|\Illuminate\Database\Query\Expression
      */
     public $from;
 


### PR DESCRIPTION
Hi,

I fixed an incorrect type in `Illuminate\Database\Builder`. PHPStan is showing a warning when I'm checking the `from` property of my Builder is an Expression.

You can see here that it can be an expression: 

https://github.com/laravel/framework/blob/6c27ca43dbcfd232813ca5aba8ad3c80405ba9b1/src/Illuminate/Database/Query/Builder.php#L335