### PR TITLE
[10.x] Fix for sortByDesc ignoring multiple attributes

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1490,6 +1490,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
+        if (is_array($callback) && ! is_callable($callback)) {
+            foreach ($callback as $index => $key) {
+                $comparison = Arr::wrap($key);
+                $comparison[1] = 'desc';
+                $callback[$index] = $comparison;
+            }
+        }
+
         return $this->sortBy($callback, $options, true);
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1493,7 +1493,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         if (is_array($callback) && ! is_callable($callback)) {
             foreach ($callback as $index => $key) {
                 $comparison = Arr::wrap($key);
+
                 $comparison[1] = 'desc';
+
                 $callback[$index] = $comparison;
             }
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2036,14 +2036,6 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['name' => 'taylor'], ['name' => 'dayle']], array_values($data->all()));
     }
 
-    #[DataProvider('collectionClassProvider')]
-    public function testSortByStringDesc($collection)
-    {
-        $data = new $collection([['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]);
-        $data = $data->sortByDesc(['id']);
-        $this->assertEquals([['id' => 2, 'name' => 'bar'], ['id' => 1, 'name' => 'foo']], array_values($data->all()));
-    }
-
     /**
      * @dataProvider collectionClassProvider
      */
@@ -2053,6 +2045,21 @@ class SupportCollectionTest extends TestCase
         $data = $data->sortBy([['sort', 'asc']]);
 
         $this->assertEquals([['sort' => 1], ['sort' => 2]], array_values($data->all()));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testSortByCallableStringDesc($collection)
+    {
+        $data = new $collection([['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]);
+        $data = $data->sortByDesc(['id']);
+        $this->assertEquals([['id' => 2, 'name' => 'bar'], ['id' => 1, 'name' => 'foo']], array_values($data->all()));
+
+        $data = new $collection([['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar'], ['id' => 2, 'name' => 'baz']]);
+        $data = $data->sortByDesc(['id']);
+        $this->assertEquals([['id' => 2, 'name' => 'bar'], ['id' => 2, 'name' => 'baz'], ['id' => 1, 'name' => 'foo']], array_values($data->all()));
+
+        $data = $data->sortByDesc(['id', 'name']);
+        $this->assertEquals([['id' => 2, 'name' => 'baz'], ['id' => 2, 'name' => 'bar'], ['id' => 1, 'name' => 'foo']], array_values($data->all()));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2036,6 +2036,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['name' => 'taylor'], ['name' => 'dayle']], array_values($data->all()));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testSortByStringDesc($collection)
+    {
+        $data = new $collection([['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]);
+        $data = $data->sortByDesc(['id']);
+        $this->assertEquals([['id' => 2, 'name' => 'bar'], ['id' => 1, 'name' => 'foo']], array_values($data->all()));
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
When calling `sortByDesc()` on a collection, it should match the signature of the `sortBy()` method. 

The `sortBy()` method accepts an array of attributes to sort a collection in 2 different formats: 

1. `[['attribute1', 'asc|desc'], ['attribute2', 'asc|desc']]`
2. `['attribute1', 'attribute2']` which is then transformed to `[['attribute1', 'asc'], ['attribute2', 'asc']]` in the `sortByMany()` method.

Essentially, when you pass in an array as the first parameter, you need to be explicit about sorting direction, or it will sort in ascending order. Also, when you pass array as the first parameter, it ignores the `$descending` flag in the `sortBy()` method.

Currently, the `sortByDesc()` method just calls `sortBy()` and sets the `$descending` flag to true. So when you pass in an array as the first parameter, if you are not specific, it sorts in ascending order.

This PR resolves this issue by converting the array to the more descriptive format and forcing it to sort in descending order.