### PR TITLE
[10.x] Update Vite.php

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Exception;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -652,7 +652,9 @@ class Vite implements Htmlable
      */
     protected function hotAsset($asset)
     {
-        return rtrim(file_get_contents($this->hotFile())).'/'.$asset;
+        $hotURL = parse_url(file_get_contents($this->hotFile()));
+        $hotURLNew = str_replace('//' . $hotURL['host'], '//' . app(Request::class)->getHost(), file_get_contents($this->hotFile()));
+        return rtrim($hotURLNew) . '/' . $asset;
     }
 
     /**


### PR DESCRIPTION
Fixed automatic replacement of domain names accessed by clients for vite hot


When http://127.0.0.1:8000, the vite resource address is: http://127.0.0.1:5173/resources/js/app.js
When http://localhost:8000, the vite resource address is: http://localhost:5173/resources/js/app.js
When http://192.168.75.130:8000, the vite resource address is: http://192.168.75.130:5173/resources/js/app.js

Used for client testing in different environments, including docker and virtual machine LAN developers, very convenient

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
