### PR TITLE
[10.x] Add color into MailMessage action method

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -64,6 +64,13 @@ class SimpleMessage
     public $actionUrl;
 
     /**
+     * The color of the action button.
+     *
+     * @var string
+     */
+    public $actionColor;
+
+    /**
      * The name of the mailer that should send the notification.
      *
      * @var string
@@ -247,12 +254,14 @@ class SimpleMessage
      *
      * @param  string  $text
      * @param  string  $url
+     * @param  string|null  $color
      * @return $this
      */
-    public function action($text, $url)
+    public function action($text, $url, $color = null)
     {
         $this->actionText = $text;
         $this->actionUrl = $url;
+        $this->actionColor = $color;
 
         return $this;
     }
@@ -286,6 +295,7 @@ class SimpleMessage
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,
             'actionUrl' => $this->actionUrl,
+            'actionColor' => $this->actionColor,
             'displayableActionUrl' => str_replace(['mailto:', 'tel:'], '', $this->actionUrl ?? ''),
         ];
     }

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -19,7 +19,7 @@
 {{-- Action Button --}}
 @isset($actionText)
 <?php
-    $color = match ($level) {
+    $color = $actionColor ?? match ($level) {
         'success', 'error' => $level,
         default => 'primary',
     };


### PR DESCRIPTION
### This Pull Request introduces a third parameter to the `action` method of `MailMessage`, allowing developers to customize the color of the action button as desired.
 
## example of usage.

```php

(new MailMessage)
    ->subject('example subject')
    ->greeting('Hello!')
    ->level('success')
    ->action('view more', 'https://examople.com/success','primary');
```

With the introduction of the third parameter in the `action` method, we now have the ability to customize the color of the action button. Previously, if the level was set to 'success', the button color would default to green. However, with this change, we can override the default color. For instance, we can set the button color to blue (primary) by passing it as the third parameter.

example 2.

By default, three colors are supported: blue, green, and red. Previously, even if we added a new color in `resources\views\html\themes\default.css`, there was no way to utilize it in notifications or `MailMessage`. However, with this update, if we add a new color class like `button-warning` (yellow), we can now use it by passing it as the third parameter to the `action` method.

```css
.button-yellow,
.button-warning {
    background-color: #f6e05e;
    border-bottom: 8px solid #f6e05e;
    border-left: 18px solid #f6e05e;
    border-right: 18px solid #f6e05e;
    border-top: 8px solid #f6e05e;
}
```

```php

(new MailMessage)
    ->subject('example subject')
    ->greeting('Hello!')
    ->level('success')
    ->action('view more', 'https://examople.com/success','yellow');
```

![image](https://github.com/laravel/framework/assets/53343069/ad4b006b-3614-4fc8-90c8-ed188bb8c1df)

