### PR TITLE
[11.x] remove return statement on method with return type void

### DIFF
--- a/src/Illuminate/Console/BufferedConsoleOutput.php
+++ b/src/Illuminate/Console/BufferedConsoleOutput.php
@@ -37,6 +37,6 @@ class BufferedConsoleOutput extends ConsoleOutput
             $this->buffer .= \PHP_EOL;
         }
 
-        return parent::doWrite($message, $newline);
+        parent::doWrite($message, $newline);
     }
 }


### PR DESCRIPTION
doWrite was given an explicit return type `void`, but was still returning void from doWrite. This PR corrects this.