### PR TITLE
[11.x] Allow `install:broadcasting` to populate `echo.js` configuration either with or without Reverb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes for 11.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v11.0.0..11.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v11.0.0..master)
 
-## [v11.0.0 (2024-??-??)](https://github.com/laravel/framework/compare/v11.0.0...11.x)
+## [v11.0.0 (2024-??-??)](https://github.com/laravel/framework/compare/v11.0.0...master)
 
 Check the upgrade guide in the [Official Laravel Upgrade Documentation](https://laravel.com/docs/11.x/upgrade). Also you can see some release notes in the [Official Laravel Release Documentation](https://laravel.com/docs/11.x/releases).

--- a/bin/split.sh
+++ b/bin/split.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-CURRENT_BRANCH="11.x"
+CURRENT_BRANCH="master"
 
 function split()
 {

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -150,7 +150,7 @@ class BroadcastingInstallCommand extends Command
 
         return confirm('Would you like to install Laravel Reverb?', default: true);
     }
-  
+
     /**
      * Install and build Node dependencies.
      *

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Process;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\PhpExecutableFinder;
 
+use function Illuminate\Filesystem\join_paths;
 use function Laravel\Prompts\confirm;
 
 #[AsCommand(name: 'install:broadcasting')]
@@ -53,9 +54,11 @@ class BroadcastingInstallCommand extends Command
             $this->uncommentChannelsRoutesFile();
         }
 
+        $installReverb = $this->shouldInstallReverb();
+
         // Install bootstrapping...
         if (! file_exists($echoScriptPath = $this->laravel->resourcePath('js/echo.js'))) {
-            copy(__DIR__.'/stubs/echo-js.stub', $echoScriptPath);
+            copy(join_paths(__DIR__, 'stubs', $installReverb ? 'echo-js.stub' : 'echo.js.pusher.stub'), $echoScriptPath);
         }
 
         if (file_exists($bootstrapScriptPath = $this->laravel->resourcePath('js/bootstrap.js'))) {
@@ -71,7 +74,9 @@ class BroadcastingInstallCommand extends Command
             }
         }
 
-        $this->installReverb();
+        if ($installReverb) {
+            $this->performReverbInstallation();
+        }
     }
 
     /**
@@ -109,15 +114,9 @@ class BroadcastingInstallCommand extends Command
      *
      * @return void
      */
-    protected function installReverb()
+    protected function performReverbInstallation()
     {
         if (InstalledVersions::isInstalled('laravel/reverb')) {
-            return;
-        }
-
-        $install = confirm('Would you like to install Laravel Reverb?', default: true);
-
-        if (! $install) {
             return;
         }
 
@@ -134,5 +133,19 @@ class BroadcastingInstallCommand extends Command
         ]);
 
         $this->components->info('Reverb installed successfully.');
+    }
+
+    /**
+     * Determine if Reverb should be installed.
+     *
+     * @return bool
+     */
+    public function shouldInstallReverb()
+    {
+        if (InstalledVersions::isInstalled('laravel/reverb')) {
+            return true;
+        }
+
+        return confirm('Would you like to install Laravel Reverb?', default: true);
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/echo-js.pusher.stub
+++ b/src/Illuminate/Foundation/Console/stubs/echo-js.pusher.stub
@@ -1,0 +1,15 @@
+import Echo from 'laravel-echo';
+
+import Pusher from 'pusher-js';
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_PUSHER_APP_KEY,
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER ?? 'mt1',
+    wsHost: import.meta.env.VITE_PUSHER_HOST ? import.meta.env.VITE_PUSHER_HOST : `ws-${import.meta.env.VITE_PUSHER_APP_CLUSTER}.pusher.com`,
+    wsPort: import.meta.env.VITE_PUSHER_PORT ?? 80,
+    wssPort: import.meta.env.VITE_PUSHER_PORT ?? 443,
+    forceTLS: (import.meta.env.VITE_PUSHER_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});


### PR DESCRIPTION
fixes #50440
improvements from #50074