### PR TITLE
[10.x] Allow sync with carbon to be set from fake method

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -319,15 +319,16 @@ class Sleep
      * Stay awake and capture any attempts to sleep.
      *
      * @param  bool  $value
+     * @param  bool  $syncWithCarbon
      * @return void
      */
-    public static function fake($value = true)
+    public static function fake($value = true, $syncWithCarbon = false)
     {
         static::$fake = $value;
 
         static::$sequence = [];
         static::$fakeSleepCallbacks = [];
-        static::$syncWithCarbon = false;
+        static::$syncWithCarbon = $syncWithCarbon;
     }
 
     /**

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -597,11 +597,11 @@ class SleepTest extends TestCase
 
     #[TestWith([
         'syncWithCarbon' => true,
-        'datetime' => '2000-01-01 00:05:03'
+        'datetime' => '2000-01-01 00:05:03',
     ])]
     #[TestWith([
         'syncWithCarbon' => false,
-        'datetime' => '2000-01-01 00:00:00'
+        'datetime' => '2000-01-01 00:00:00',
     ])]
     public function testFakeCanSetSyncWithCarbon(bool $syncWithCarbon, string $datetime)
     {

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Sleep;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -592,5 +593,41 @@ class SleepTest extends TestCase
             Sleep::for(303)->seconds(),
         ]);
         $this->assertSame('2000-01-01 00:05:03', Date::now()->toDateTimeString());
+    }
+
+    #[TestWith([
+        'syncWithCarbon' => true,
+        'datetime' => '2000-01-01 00:05:03'
+    ])]
+    #[TestWith([
+        'syncWithCarbon' => false,
+        'datetime' => '2000-01-01 00:00:00'
+    ])]
+    public function testFakeCanSetSyncWithCarbon(bool $syncWithCarbon, string $datetime)
+    {
+        Carbon::setTestNow('2000-01-01 00:00:00');
+        Sleep::fake(syncWithCarbon: $syncWithCarbon);
+
+        Sleep::for(5)->minutes()
+            ->and(3)->seconds();
+
+        Sleep::assertSequence([
+            Sleep::for(303)->seconds(),
+        ]);
+        $this->assertSame($datetime, Date::now()->toDateTimeString());
+    }
+
+    public function testFakeDoesNotNeedToSyncWithCarbon()
+    {
+        Carbon::setTestNow('2000-01-01 00:00:00');
+        Sleep::fake();
+
+        Sleep::for(5)->minutes()
+            ->and(3)->seconds();
+
+        Sleep::assertSequence([
+            Sleep::for(303)->seconds(),
+        ]);
+        $this->assertSame('2000-01-01 00:00:00', Date::now()->toDateTimeString());
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As mentioned in #50392 to @timacdonald  this is my proposal for allowing the `syncWithCarbon` value to be set from the `fake` method. 
