### PR TITLE
fix: phpstan issue - right side of || always false

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumArrayObject.php
@@ -30,7 +30,7 @@ class AsEnumArrayObject implements Castable
 
             public function get($model, $key, $value, $attributes)
             {
-                if (! isset($attributes[$key]) || is_null($attributes[$key])) {
+                if (! isset($attributes[$key])) {
                     return;
                 }
 

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -30,7 +30,7 @@ class AsEnumCollection implements Castable
 
             public function get($model, $key, $value, $attributes)
             {
-                if (! isset($attributes[$key]) || is_null($attributes[$key])) {
+                if (! isset($attributes[$key])) {
                     return;
                 }
 


### PR DESCRIPTION
*isset* already checks if the value is null (and phpstan complains about that).

> In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

No real benefit to anybody, it doesn't break any existing feature since the condition that should be removed was always false, won't make building web applications easier. I just noticed that minor issue, hence my pr.
