### PR TITLE
[10.x] Remove redundant argument in `Repository.php`

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -177,6 +177,6 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function offsetUnset($key): void
     {
-        $this->set($key, null);
+        $this->set($key);
     }
 }


### PR DESCRIPTION
No need to add `null` as the second parameter, as the `set` method already defaults to `null`