### PR TITLE
[10.x] Incorrect return in `FileSystem.php`

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -347,7 +347,7 @@ class Filesystem
      *
      * @param  string  $target
      * @param  string  $link
-     * @return void
+     * @return bool|void
      */
     public function link($target, $link)
     {

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -347,7 +347,7 @@ class Filesystem
      *
      * @param  string  $target
      * @param  string  $link
-     * @return bool|void
+     * @return bool|null
      */
     public function link($target, $link)
     {


### PR DESCRIPTION
if the method is run on an operating system other than Windows, the symlink function is called and returns a boolean