### PR TITLE
[11.x] Adds `Exceptions::shouldReturnJsonWhen`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -144,9 +144,9 @@ class Exceptions
      * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool  $callback
      * @return $this
      */
-    public function shouldReturnJsonWhen(callable $callback)
+    public function shouldRenderJsonWhen(callable $callback)
     {
-        $this->handler->shouldReturnJsonWhen($callback);
+        $this->handler->shouldRenderJsonWhen($callback);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -139,6 +139,16 @@ class Exceptions
     }
 
     /**
+     * Register the callable that determines if the exception handler response should be JSON.
+     */
+    public function shouldReturnJsonWhen(callable $callback)
+    {
+        $this->handler->shouldReturnJsonWhen($callback);
+
+        return $this;
+    }
+
+    /**
      * Indicate that the given exception class should not be ignored.
      *
      * @param  array<int, class-string<\Throwable>>|class-string<\Throwable>  $class

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -140,6 +140,9 @@ class Exceptions
 
     /**
      * Register the callable that determines if the exception handler response should be JSON.
+     *
+     * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool $callback
+     * @return $this
      */
     public function shouldReturnJsonWhen(callable $callback)
     {

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -141,7 +141,7 @@ class Exceptions
     /**
      * Register the callable that determines if the exception handler response should be JSON.
      *
-     * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool $callback
+     * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool  $callback
      * @return $this
      */
     public function shouldReturnJsonWhen(callable $callback)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -102,6 +102,13 @@ class Handler implements ExceptionHandlerContract
     protected $renderCallbacks = [];
 
     /**
+     * The callback that determines if the exception handler response should be JSON.
+     *
+     * @var callable|null
+     */
+    protected $shouldReturnJsonWhenCallback;
+
+    /**
      * The registered exception mappings.
      *
      * @var array<string, \Closure>
@@ -371,6 +378,19 @@ class Handler implements ExceptionHandlerContract
     public function shouldReport(Throwable $e)
     {
         return ! $this->shouldntReport($e);
+    }
+
+    /**
+     * Register the callable that determines if the exception handler response should be JSON.
+     *
+     * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool  $callback
+     * @return $this
+     */
+    public function shouldReturnJsonWhen($callback)
+    {
+        $this->shouldReturnJsonWhenCallback = $callback;
+
+        return $this;
     }
 
     /**
@@ -720,7 +740,9 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldReturnJson($request, Throwable $e)
     {
-        return $request->expectsJson();
+        return $this->shouldReturnJsonWhenCallback
+            ? call_user_func($this->shouldReturnJsonWhenCallback, $request, $e)
+            : $request->expectsJson();
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -106,7 +106,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @var callable|null
      */
-    protected $shouldReturnJsonWhenCallback;
+    protected $shouldRenderJsonWhenCallback;
 
     /**
      * The registered exception mappings.
@@ -727,8 +727,8 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldReturnJson($request, Throwable $e)
     {
-        return $this->shouldReturnJsonWhenCallback
-            ? call_user_func($this->shouldReturnJsonWhenCallback, $request, $e)
+        return $this->shouldRenderJsonWhenCallback
+            ? call_user_func($this->shouldRenderJsonWhenCallback, $request, $e)
             : $request->expectsJson();
     }
 
@@ -738,9 +738,9 @@ class Handler implements ExceptionHandlerContract
      * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool  $callback
      * @return $this
      */
-    public function shouldReturnJsonWhen($callback)
+    public function shouldRenderJsonWhen($callback)
     {
-        $this->shouldReturnJsonWhenCallback = $callback;
+        $this->shouldRenderJsonWhenCallback = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -381,19 +381,6 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Register the callable that determines if the exception handler response should be JSON.
-     *
-     * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool  $callback
-     * @return $this
-     */
-    public function shouldReturnJsonWhen($callback)
-    {
-        $this->shouldReturnJsonWhenCallback = $callback;
-
-        return $this;
-    }
-
-    /**
      * Determine if the exception is in the "do not report" list.
      *
      * @param  \Throwable  $e
@@ -743,6 +730,19 @@ class Handler implements ExceptionHandlerContract
         return $this->shouldReturnJsonWhenCallback
             ? call_user_func($this->shouldReturnJsonWhenCallback, $request, $e)
             : $request->expectsJson();
+    }
+
+    /**
+     * Register the callable that determines if the exception handler response should be JSON.
+     *
+     * @param  callable(\Illuminate\Http\Request $request, \Throwable): bool  $callback
+     * @return $this
+     */
+    public function shouldReturnJsonWhen($callback)
+    {
+        $this->shouldReturnJsonWhenCallback = $callback;
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/Configuration/ExceptionsTest.php
+++ b/tests/Foundation/Configuration/ExceptionsTest.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Tests\Foundation\Configuration;
 
+use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Exceptions\Handler;
+use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -35,5 +37,21 @@ class ExceptionsTest extends TestCase
         $this->assertContains(ModelNotFoundException::class, $handler->getDontReport());
         $exceptions->stopIgnoring([ModelNotFoundException::class]);
         $this->assertNotContains(ModelNotFoundException::class, $handler->getDontReport());
+    }
+
+    public function testShouldReturnJsonWhen()
+    {
+        $exceptions = new Exceptions(new Handler(new Container));
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
+        $this->assertFalse($shouldReturnJson);
+
+        $exceptions->shouldReturnJsonWhen(fn () => true);
+        $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
+        $this->assertTrue($shouldReturnJson);
+
+        $exceptions->shouldReturnJsonWhen(fn () => false);
+        $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
+        $this->assertFalse($shouldReturnJson);
     }
 }

--- a/tests/Foundation/Configuration/ExceptionsTest.php
+++ b/tests/Foundation/Configuration/ExceptionsTest.php
@@ -39,18 +39,18 @@ class ExceptionsTest extends TestCase
         $this->assertNotContains(ModelNotFoundException::class, $handler->getDontReport());
     }
 
-    public function testShouldReturnJsonWhen()
+    public function testShouldRenderJsonWhen()
     {
         $exceptions = new Exceptions(new Handler(new Container));
 
         $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
         $this->assertFalse($shouldReturnJson);
 
-        $exceptions->shouldReturnJsonWhen(fn () => true);
+        $exceptions->shouldRenderJsonWhen(fn () => true);
         $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
         $this->assertTrue($shouldReturnJson);
 
-        $exceptions->shouldReturnJsonWhen(fn () => false);
+        $exceptions->shouldRenderJsonWhen(fn () => false);
         $shouldReturnJson = (fn () => $this->shouldReturnJson(new Request, new Exception()))->call($exceptions->handler);
         $this->assertFalse($shouldReturnJson);
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -189,7 +189,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $request = $this->request;
 
-        $this->handler->shouldReturnJsonWhen(function ($r, $e) use ($request, $exception) {
+        $this->handler->shouldRenderJsonWhen(function ($r, $e) use ($request, $exception) {
             $this->assertSame($request, $r);
             $this->assertSame($exception, $e);
 
@@ -199,7 +199,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $shouldReturnJson = (fn () => $this->shouldReturnJson($request, $exception))->call($this->handler);
         $this->assertTrue($shouldReturnJson);
 
-        $this->handler->shouldReturnJsonWhen(function ($r, $e) use ($request, $exception) {
+        $this->handler->shouldRenderJsonWhen(function ($r, $e) use ($request, $exception) {
             $this->assertSame($request, $r);
             $this->assertSame($exception, $e);
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -166,6 +166,52 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new CustomException('Exception message'));
     }
 
+    public function testShouldReturnJson()
+    {
+        $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
+        $e = new Exception('My custom error message');
+
+        $request = $this->request;
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson($request, $e))->call($this->handler);
+        $this->assertTrue($shouldReturnJson);
+
+        $this->request->shouldReceive('expectsJson')->once()->andReturn(false);
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson($request, $e))->call($this->handler);
+        $this->assertFalse($shouldReturnJson);
+    }
+
+    public function testShouldReturnJsonWhen()
+    {
+        $this->request->shouldReceive('expectsJson')->never();
+        $exception = new Exception('My custom error message');
+
+        $request = $this->request;
+
+        $this->handler->shouldReturnJsonWhen(function ($r, $e) use ($request, $exception) {
+            $this->assertSame($request, $r);
+            $this->assertSame($exception, $e);
+
+            return true;
+        });
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson($request, $exception))->call($this->handler);
+        $this->assertTrue($shouldReturnJson);
+
+        $this->handler->shouldReturnJsonWhen(function ($r, $e) use ($request, $exception) {
+            $this->assertSame($request, $r);
+            $this->assertSame($exception, $e);
+
+            return false;
+        });
+
+        $shouldReturnJson = (fn () => $this->shouldReturnJson($request, $exception))->call($this->handler);
+        $this->assertFalse($shouldReturnJson);
+
+        $this->assertSame(6, Assert::getCount());
+    }
+
     public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);


### PR DESCRIPTION
This pull request adds `shouldReturnJsonWhen` to the Exceptions configuration class so people can configure when exceptions should be rendered as json or not:

```php
->withExceptions(function (Exceptions $exceptions) {
    $exceptions->shouldReturnJsonWhen(function (Request $request, Throwable $exception) {
        return true;
    });
})
```