### PR TITLE
[10.x] Add Arr::mapSpread helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -643,7 +643,7 @@ class Arr
      * @param  callable(mixed...): TMapSpreadValue  $callback
      * @return array<TKey, TMapSpreadValue>
      */
-    public function mapSpread(array $array, callable $callback)
+    public static function mapSpread(array $array, callable $callback)
     {
         return static::map($array, function ($chunk, $key) use ($callback) {
             $chunk[] = $key;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -635,6 +635,23 @@ class Arr
     }
 
     /**
+     * Run a map over each nested chunk of items.
+     *
+     * @template TMapSpreadValue
+     *
+     * @param  callable(mixed...): TMapSpreadValue  $callback
+     * @return array<TKey, TMapSpreadValue>
+     */
+    public function mapSpread(callable $callback)
+    {
+        return static::map(function ($chunk, $key) use ($callback) {
+            $chunk[] = $key;
+
+            return $callback(...$chunk);
+        });
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -638,6 +638,7 @@ class Arr
      * Run a map over each nested chunk of items.
      *
      * @template TMapSpreadValue
+     *
      * @param  array  $array
      * @param  callable(mixed...): TMapSpreadValue  $callback
      * @return array<TKey, TMapSpreadValue>

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -638,13 +638,13 @@ class Arr
      * Run a map over each nested chunk of items.
      *
      * @template TMapSpreadValue
-     *
+     * @param  array  $array
      * @param  callable(mixed...): TMapSpreadValue  $callback
      * @return array<TKey, TMapSpreadValue>
      */
-    public function mapSpread(callable $callback)
+    public function mapSpread(array $array, callable $callback)
     {
-        return static::map(function ($chunk, $key) use ($callback) {
+        return static::map($array, function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -733,6 +733,27 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
 
+    public function testMapSpread()
+    {
+        $c = [[1, 'a'], [2, 'b']];
+
+        $result = Arr::mapSpread(function ($number, $character) {
+            return "{$number}-{$character}";
+        });
+        $this->assertEquals(['1-a', '2-b'], $result);
+
+        $result = Arr::mapSpread(function ($number, $character, $key) {
+            return "{$number}-{$character}-{$key}";
+        });
+        $this->assertEquals(['1-a-0', '2-b-1'], $result);
+
+        $c = [[1, 'a'], [2, 'b']];
+        $result = Arr::mapSpread(function ($number, $character, $key) {
+            return "{$number}-{$character}-{$key}";
+        });
+        $this->assertEquals(['1-a-0', '2-b-1'], $result);
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -746,12 +746,6 @@ class SupportArrTest extends TestCase
             return "{$number}-{$character}-{$key}";
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
-
-        $c = [[1, 'a'], [2, 'b']];
-        $result = Arr::mapSpread($c, function ($number, $character, $key) {
-            return "{$number}-{$character}-{$key}";
-        });
-        $this->assertEquals(['1-a-0', '2-b-1'], $result);
     }
 
     public function testPrepend()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -737,18 +737,18 @@ class SupportArrTest extends TestCase
     {
         $c = [[1, 'a'], [2, 'b']];
 
-        $result = Arr::mapSpread(function ($number, $character) {
+        $result = Arr::mapSpread($c, function ($number, $character) {
             return "{$number}-{$character}";
         });
         $this->assertEquals(['1-a', '2-b'], $result);
 
-        $result = Arr::mapSpread(function ($number, $character, $key) {
+        $result = Arr::mapSpread($c, function ($number, $character, $key) {
             return "{$number}-{$character}-{$key}";
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
 
         $c = [[1, 'a'], [2, 'b']];
-        $result = Arr::mapSpread(function ($number, $character, $key) {
+        $result = Arr::mapSpread($c, function ($number, $character, $key) {
             return "{$number}-{$character}-{$key}";
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result);


### PR DESCRIPTION
This PR simply adds an already well-known `Collection` function `$collection->mapSpread()` to the Array helper:

```php
Arr::mapSpread($data, fn ($first, $second) => $first.$second)
```

The underlaying logic is *completely* the same as the already provided Collection function, the point of this PR is to allow for this often used array manipulation without the overhead of creating a Collection instance first.