### PR TITLE
[10.x] Enhance malformed request handling

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -42,6 +42,7 @@ use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -490,7 +491,7 @@ class Handler implements ExceptionHandlerContract
             ),
             $e instanceof AuthorizationException && ! $e->hasStatus() => new AccessDeniedHttpException($e->getMessage(), $e),
             $e instanceof TokenMismatchException => new HttpException(419, $e->getMessage(), $e),
-            $e instanceof SuspiciousOperationException => new NotFoundHttpException('Bad hostname provided.', $e),
+            $e instanceof SuspiciousOperationException => new BadRequestHttpException('Bad request.', $e),
             $e instanceof RecordsNotFoundException => new NotFoundHttpException('Not found.', $e),
             default => $e,
         };

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -38,7 +38,7 @@ use Psr\Log\LogLevel;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
-use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -116,7 +116,7 @@ class Handler implements ExceptionHandlerContract
         ModelNotFoundException::class,
         MultipleRecordsFoundException::class,
         RecordsNotFoundException::class,
-        SuspiciousOperationException::class,
+        RequestExceptionInterface::class,
         TokenMismatchException::class,
         ValidationException::class,
     ];
@@ -491,7 +491,7 @@ class Handler implements ExceptionHandlerContract
             ),
             $e instanceof AuthorizationException && ! $e->hasStatus() => new AccessDeniedHttpException($e->getMessage(), $e),
             $e instanceof TokenMismatchException => new HttpException(419, $e->getMessage(), $e),
-            $e instanceof SuspiciousOperationException => new BadRequestHttpException('Bad request.', $e),
+            $e instanceof RequestExceptionInterface => new BadRequestHttpException('Bad request.', $e),
             $e instanceof RecordsNotFoundException => new NotFoundHttpException('Not found.', $e),
             default => $e,
         };

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -313,15 +313,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertEquals($argumentExpected, $argumentActual);
     }
 
-    public function testSuspiciousOperationReturns404WithoutReporting()
+    public function testSuspiciousOperationReturns400WithoutReporting()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
         $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
 
         $response = $this->handler->render($this->request, new SuspiciousOperationException('Invalid method override "__CONSTRUCT"'));
 
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertStringContainsString('"message": "Bad hostname provided."', $response->getContent());
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertStringContainsString('"message": "Bad request."', $response->getContent());
 
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -123,6 +123,21 @@ class ExceptionHandlerTest extends TestCase
             ]);
     }
 
+    public function testItReturns400CodeOnMalformedRequests()
+    {
+        // HTTP request...
+        $this->post('test-route', ['_method' => '__construct'])
+            ->assertStatus(400)
+            ->assertSeeText('Bad Request'); // see https://github.com/symfony/symfony/blob/1d439995eb6d780531b97094ff5fa43e345fc42e/src/Symfony/Component/ErrorHandler/Resources/views/error.html.php#L12
+
+        // JSON request...
+        $this->postJson('test-route', ['_method' => '__construct'])
+            ->assertStatus(400)
+            ->assertExactJson([
+                'message' => 'Bad request.',
+            ]);
+    }
+
     /**
      * @dataProvider exitCodesProvider
      */


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Solves #50466.

This PR aims to have better handling of malformed requests; in particular those which throw exceptions when certain methods on the request are called, like `getMethod` with content as described in issue mentioned above.

To Do:
- [x] Add and/or adjust tests to verify general behavior
- [x] Add test for behavior as specified in #50466
- [x] Decide on whether or not to broaden matching to [`RequestExceptionInterface`](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpFoundation/Exception/RequestExceptionInterface.php)
- [ ] Gather feedback on the approach of this PR

Implementation notes:
- I've broadened matching from just `SuspiciousOperationException` to [`RequestExceptionInterface`](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/HttpFoundation/Exception/RequestExceptionInterface.php), given that Symfony recommends this per documentation in this interface. This is a separate that can be removed if wanted, however it seems more accurate and should generally not make any difference for valid requests. No additional tests have been added for other possible exceptions as part of this broadening; this can be part of a follow-up issue/MR.
- Due to `CompiledRouteCollection` using a copy of the `Request` instance in the scope of the `match` method (due to `requestWithoutTrailingSlash` call), the `getMethod` call is never called on the 'original' request within the route handling and thus causes an exception when `isMethod('HEAD')` is performed in the scope of preparing the error response. This is once again caught by the exception handler and then correctly rendered on the second attempt. Albeit technically a little ugly, this is probably not worth addressing further as the outcome is correct and these types of requests should be extremly rare anyways.
- The existing `Bad hostname provided` message seems to be based on [this line](https://github.com/symfony/symfony/blob/6ae74d38e3d20d0ffcc66c7c3d28767fab76bdfb/src/Symfony/Component/HttpFoundation/Request.php#L1087), but given that the exception also happens on incorrect method values (see test), a generic message seems to be more appropriate.