### PR TITLE
[10.x] Fix for attributes being escaped on Dynamic Blade Components

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -262,7 +262,7 @@ class ComponentTagCompiler
 <?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag && $constructor = (new ReflectionClass('.$class.'::class))->getConstructor()): ?>
 <?php $attributes = $attributes->except(collect($constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php $component->withAttributes(['.$this->attributesToStringWithExistingComponentData($attributes->all(), $escapeAttributes = $class !== DynamicComponent::class).']); ?>';
+<?php $component->withAttributes(['.$this->attributesToStringWithExistingComponentData($attributes->all(), $escapeAttributes = $class !== DynamicComponent::class && ! is_subclass_of($class, DynamicComponent::class)).']); ?>';
     }
 
     /**


### PR DESCRIPTION
I understand this is an edge case, but I'm extending the `DynamicComponent` class as I needed some helper methods there:

```php
use Illuminate\View\DynamicComponent;

class CustomComponent extends DynamicComponent
{
    // custom helper methods...
}
```

Since v10.48, it fails to pass attributes. This code snippet results in `Argument #1 ($name) must be of type string, null given`:

```blade
<x-custom-component :component="$componentName" :name="$name" />
```

The attributes are filtered out in `attributesToStringWithExistingComponentData()` (see #50403), except for Dynamic Components. However, it only checks for the exact class name, not for subclasses of `DynamicComponent`. This PR fixes that.