### PR TITLE
[10.x] Update mockery conflict to just disallow the broken version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
     "conflict": {
         "carbonphp/carbon-doctrine-types": ">=3.0",
         "doctrine/dbal": ">=4.0",
-        "mockery/mockery": ">=1.6.8",
+        "mockery/mockery": "1.6.8",
         "tightenco/collect": "<5.5.33",
         "phpunit/phpunit": ">=11.0.0"
     },


### PR DESCRIPTION
The break in 1.6.8 was fixed in 1.6.9.