### PR TITLE
[11.x] Remove redundant returns from void methods

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -95,7 +95,7 @@ class Builder
      */
     public static function morphUsingUuids()
     {
-        return static::defaultMorphKeyType('uuid');
+        static::defaultMorphKeyType('uuid');
     }
 
     /**
@@ -105,7 +105,7 @@ class Builder
      */
     public static function morphUsingUlids()
     {
-        return static::defaultMorphKeyType('ulid');
+        static::defaultMorphKeyType('ulid');
     }
 
     /**

--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -41,7 +41,7 @@ class Hub implements HubContract
      */
     public function defaults(Closure $callback)
     {
-        return $this->pipeline('default', $callback);
+        $this->pipeline('default', $callback);
     }
 
     /**

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -39,9 +39,7 @@ trait InteractsWithQueue
      */
     public function delete()
     {
-        if ($this->job) {
-            return $this->job->delete();
-        }
+        $this->job?->delete();
     }
 
     /**
@@ -57,9 +55,7 @@ trait InteractsWithQueue
         }
 
         if ($exception instanceof Throwable || is_null($exception)) {
-            if ($this->job) {
-                return $this->job->fail($exception);
-            }
+            $this->job?->fail($exception);
         } else {
             throw new InvalidArgumentException('The fail method requires a string or an instance of Throwable.');
         }
@@ -77,9 +73,7 @@ trait InteractsWithQueue
             ? $this->secondsUntil($delay)
             : $delay;
 
-        if ($this->job) {
-            return $this->job->release($delay);
-        }
+        $this->job?->release($delay);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -190,7 +190,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function extend($driver, Closure $resolver)
     {
-        return $this->addConnector($driver, $resolver);
+        $this->addConnector($driver, $resolver);
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -87,7 +87,7 @@ abstract class Connection
      */
     public function subscribe($channels, Closure $callback)
     {
-        return $this->createSubscription($channels, $callback, __FUNCTION__);
+        $this->createSubscription($channels, $callback, __FUNCTION__);
     }
 
     /**
@@ -99,7 +99,7 @@ abstract class Connection
      */
     public function psubscribe($channels, Closure $callback)
     {
-        return $this->createSubscription($channels, $callback, __FUNCTION__);
+        $this->createSubscription($channels, $callback, __FUNCTION__);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -68,7 +68,7 @@ class Queue extends Facade
      */
     public static function popUsing($workerName, $callback)
     {
-        return Worker::popUsing($workerName, $callback);
+        Worker::popUsing($workerName, $callback);
     }
 
     /**

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -211,7 +211,7 @@ class Lottery
      */
     public static function fix($sequence, $whenMissing = null)
     {
-        return static::forceResultWithSequence($sequence, $whenMissing);
+        static::forceResultWithSequence($sequence, $whenMissing);
     }
 
     /**

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -400,7 +400,7 @@ class Sleep
      */
     public static function assertNeverSlept()
     {
-        return static::assertSleptTimes(0);
+        static::assertSleptTimes(0);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -93,7 +93,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     public function assertSentOnDemandTimes($notification, $times = 1)
     {
-        return $this->assertSentToTimes(new AnonymousNotifiable, $notification, $times);
+        $this->assertSentToTimes(new AnonymousNotifiable, $notification, $times);
     }
 
     /**


### PR DESCRIPTION
Removed unnecessary return statements from methods with void return type.