### PR TITLE
[11.x] Checking for duplicate migration filenames

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -548,11 +548,12 @@ class Migrator
             static $uniqueNameCheck = [];
             $shortName = $this->getMigrationName($file);
             if (isset($uniqueNameCheck[$shortName])) {
-                $this->write(Error::class, "Duplicate migration filenames: " . $uniqueNameCheck[$shortName]);
-                $this->write(Error::class, "Duplicate migration filenames: " . $file);
+                $this->write(Error::class, "Duplicate migration filenames: ".$uniqueNameCheck[$shortName]);
+                $this->write(Error::class, "Duplicate migration filenames: ".$file);
                 exit;
             }
             $uniqueNameCheck[$shortName] = $file;
+
             return $shortName;
         })->sortBy(function ($file, $key) {
             return $key;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -548,8 +548,8 @@ class Migrator
             static $uniqueNameCheck = [];
             $shortName = $this->getMigrationName($file);
             if (isset($uniqueNameCheck[$shortName])) {
-                $this->write(Error::class, "Duplicate migration filenames: ".$uniqueNameCheck[$shortName]);
-                $this->write(Error::class, "Duplicate migration filenames: ".$file);
+                $this->write(Error::class, 'Duplicate migration filenames: '.$uniqueNameCheck[$shortName]);
+                $this->write(Error::class, 'Duplicate migration filenames: '.$file);
                 exit;
             }
             $uniqueNameCheck[$shortName] = $file;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -545,7 +545,15 @@ class Migrator
         return Collection::make($paths)->flatMap(function ($path) {
             return str_ends_with($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php');
         })->filter()->values()->keyBy(function ($file) {
-            return $this->getMigrationName($file);
+            static $uniqueNameCheck = [];
+            $shortName = $this->getMigrationName($file);
+            if (isset($uniqueNameCheck[$shortName])) {
+                $this->write(Error::class, "Duplicate migration filenames: " . $uniqueNameCheck[$shortName]);
+                $this->write(Error::class, "Duplicate migration filenames: " . $file);
+                exit;
+            }
+            $uniqueNameCheck[$shortName] = $file;
+            return $shortName;
         })->sortBy(function ($file, $key) {
             return $key;
         })->all();


### PR DESCRIPTION
Laravel allows use multiple directories for migration.

If the file names are the same, then Laravel will perform only one migration (which it will choose randomly), the second migration will not be performed. No errors or warnings are shown. There is a risk that migrations will be lost.

This pull request checks the names of migration files for uniqueness and does not allow migrations to run until all file names are unique.