### PR TITLE
[11.x] Adds `firstOrCreate` in Factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -297,6 +297,26 @@ abstract class Factory
     }
 
     /**
+     * Create a collection of models and persist them to the database if the attribute do not already exist in the database.
+     *
+     * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>|\Illuminate\Database\Eloquent\Model|TModel
+     */
+    public function firstOrCreate($attributes = [], ?Model $parent = null)
+    {
+        $model = $this->modelName();
+
+        $results = $model::where($attributes)->exists();
+
+        if ($results) {
+            return $model::where($attributes)->first();
+        }
+
+        return $this->create($attributes, $parent);
+    }
+
+    /**
      * Create a collection of models and persist them to the database without dispatching any model events.
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -307,7 +307,7 @@ abstract class Factory
     {
         $model = $this->modelName();
 
-        if(! is_null($result = $model::where($attributes)->first())) {
+        if (! is_null($result = $model::where($attributes)->first())) {
             return $result;
         }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -307,10 +307,8 @@ abstract class Factory
     {
         $model = $this->modelName();
 
-        $results = $model::where($attributes)->exists();
-
-        if ($results) {
-            return $model::where($attributes)->first();
+        if(! is_null($result = $model::where($attributes)->first())) {
+            return $result;
         }
 
         return $this->create($attributes, $parent);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -804,6 +804,13 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestUser::count());
     }
 
+    public function test_returns_first_instance_if_already_exists()
+    {
+        $user = FactoryTestUserFactory::new()->create();
+        $user2 = FactoryTestUserFactory::new()->firstOrCreate();
+        $this->assertSame($user->id, $user2->id);
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -811,6 +811,14 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame($user->id, $user2->id);
     }
 
+    public function test_returns_first_instance_if_already_exists_with_attributes()
+    {
+        $name = 'Taylor Otwell';
+        $user = FactoryTestUserFactory::new()->create(['name' => $name]);
+        $user2 = FactoryTestUserFactory::new()->firstOrCreate(['name' => $name]);
+        $this->assertSame($user->id, $user2->id);
+    }
+
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
This method `firstOrCreate()` in factory will return first instance of the model if already exists (with or without attributes).