### PR TITLE
[11.x] Fixes installation of passport

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -64,9 +64,12 @@ class ApiInstallCommand extends Command
         }
 
         if ($this->option('passport')) {
-            $this->call('passport:install', [
-                '--uuids' => $this->confirm('Would you like to use UUIDs for all client IDs?'),
-            ]);
+            Process::run(array_filter([
+                (new PhpExecutableFinder())->find(false) ?: 'php',
+                defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+                'passport:install',
+                $this->confirm('Would you like to use UUIDs for all client IDs?') ? '--uuids' : null,
+            ]));
 
             $this->components->info('API scaffolding installed. Please add the [Laravel\Passport\HasApiTokens] trait to your User model.');
         } else {


### PR DESCRIPTION
This pull request fixes the `install:api --passport` Artisan command.

This pull request fixes the installation of passport, as the `$this->call` can't be called on commands that are not yet be loaded by Laravel. On that case, the `$this->call('passport:install')` would only work if passport was already installed on Vendor.