### PR TITLE
[11.x] Add class_exists check for `Spark`'s `subscribed` default alias Middleware

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -747,7 +747,6 @@ class Middleware
             'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
             'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
             'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
-            'subscribed' => \Spark\Http\Middleware\VerifyBillableIsSubscribed::class,
             'throttle' => $this->throttleWithRedis
                 ? \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class
                 : \Illuminate\Routing\Middleware\ThrottleRequests::class,

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -737,7 +737,7 @@ class Middleware
      */
     protected function defaultAliases()
     {
-        return [
+        $aliases = [
             'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
             'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
             'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,
@@ -752,6 +752,12 @@ class Middleware
                 : \Illuminate\Routing\Middleware\ThrottleRequests::class,
             'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         ];
+
+        if (class_exists(\Spark\Http\Middleware\VerifyBillableIsSubscribed::class)) {
+            $aliases['subscribed'] = \Spark\Http\Middleware\VerifyBillableIsSubscribed::class;
+        }
+
+        return $aliases;
     }
 
     /**


### PR DESCRIPTION
#### Fix ReflectionException for Missing Spark Middleware in Laravel
This PR addresses an issue where Laravel was attempting to load the `Spark\Http\Middleware\VerifyBillableIsSubscribed` middleware, which does not exist by default in Laravel 11. The alias `subscribed` was mistakenly added to the default middleware aliases in `Middleware.php`, leading to a `ReflectionException` when the framework tried to resolve it. 

When Laravel attempts to utilize the `subscribed` middleware, it triggers a `ReflectionException` because the `Spark\Http\Middleware\VerifyBillableIsSubscribed` class does not exist. This error disrupts the functionality of applications running on Laravel 11 that rely on the default middleware stack.

The PR removes the `subscribed` alias from the `defaultAliases()` method in `Middleware.php`, preventing Laravel from attempting to load a non-existent middleware class. This change ensures that the application can run without encountering a fatal error due to the missing class.