### PR TITLE
[11.x] Update trait and interfaces directory

### DIFF
--- a/src/Illuminate/Foundation/Console/InterfaceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/InterfaceMakeCommand.php
@@ -48,7 +48,7 @@ class InterfaceMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace;
+        return $rootNamespace.'\Interfaces';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -48,7 +48,7 @@ class TraitMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace;
+        return $rootNamespace.'\Traits';
     }
 
     /**


### PR DESCRIPTION
Using the commands `php artisan make:interface [InterfaceName]` and `php artisan make:trait [TraitName]`, the desired interface and trait are created within the app directory.

Even if the names of the interface and trait are identical, the second command won't execute and will return an error '[Interface/Trait] already exists'.

![image](https://github.com/laravel/framework/assets/74505328/c3cd93e4-62a4-4979-8148-5c239fe7c92f)

<hr />

With this pull request, the organization of these two items within the app directory is improved, allowing for faster development and access to the files.

