### PR TITLE
[11.x] Fix: Removed TTY mode to resolve Windows compatibility issue 

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -176,7 +176,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         if ($command->run()->failed()) {
-            $this->components->warn("Node dependencies installation couldn't complete. Please run the following commands manually: \n\n" . implode(" && ", $commands));
+            $this->components->warn("Node dependency installation failed. Please run the following commands manually: \n\n" . implode(" && ", $commands));
         } else {
             $this->components->info("Node dependencies installed successfully.");
         }

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -175,7 +175,7 @@ class BroadcastingInstallCommand extends Command
             $command->tty(true);
         }
 
-        if($command->run()->failed()) {
+        if ($command->run()->failed()) {
             $this->components->warn("Node dependencies installation couldn't complete. Please run the following commands manually: \n\n" . implode(" && ", $commands));
         } else {
             $this->components->info("Node dependencies installed successfully.");

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -171,7 +171,7 @@ class BroadcastingInstallCommand extends Command
         $command = Process::command(implode(' && ', $commands))
                         ->path(base_path());
 
-        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+        if (! windows_os()) {
             $command->tty(true);
         }
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -168,9 +168,17 @@ class BroadcastingInstallCommand extends Command
             ];
         }
 
-        Process::command(implode(' && ', $commands))
-            ->path(base_path())
-            ->tty(true)
-            ->run();
+        $command = Process::command(implode(' && ', $commands))
+                        ->path(base_path());
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+            $command->tty(true);
+        }
+
+        if($command->run()->failed()) {
+            $this->components->warn("Node dependencies installation couldn't complete. Please run the following commands manually: \n\n" . implode(" && ", $commands));
+        } else {
+            $this->components->info("Node dependencies installed successfully.");
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
+++ b/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
@@ -4,3 +4,4 @@
  * allow your team to quickly build robust real-time web applications.
  */
 
+import './echo';

--- a/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
+++ b/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
@@ -4,4 +4,3 @@
  * allow your team to quickly build robust real-time web applications.
  */
 
-import './echo.js';

--- a/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
+++ b/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
@@ -4,4 +4,4 @@
  * allow your team to quickly build robust real-time web applications.
  */
 
-import './echo';
+import './echo.js';


### PR DESCRIPTION
Error: RuntimeException - TTY mode is not supported on Windows platform.

![Screenshot 2024-03-13 063237](https://github.com/laravel/framework/assets/81873266/03a64017-727b-4810-88c4-4444ebe9a3f0)

### Description
This PR addresses a compatibility issue on Windows platforms where TTY mode is not supported. The issue arises in the installNodeDependencies() function, where TTY mode is set unnecessarily. This setting triggers a Symfony\Component\Process\Exception\RuntimeException due to unsupported TTY mode on Windows.

### Changes Made

- Removed unnecessary TTY mode from Symfony Process configuration.
- Conditionally set the TTY mode based on the operating system, ensuring compatibility with both Windows and non-Windows platforms.
- Improved error handling and user feedback in case of failed command execution.
