### PR TITLE
[11.x] Fix an issue with missing controller class

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -127,7 +127,7 @@ class ControllerMakeCommand extends GeneratorCommand
             $replace['abort(404);'] = '//';
         }
 
-        $baseControllerExists = file_exists($rootNamespace.'Http\Controllers\Controller');
+        $baseControllerExists = file_exists(app_path('Http/Controllers/Controller.php'));
 
         if ($baseControllerExists) {
             $replace["use {$controllerNamespace}\Controller;\n"] = '';

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -127,7 +127,7 @@ class ControllerMakeCommand extends GeneratorCommand
             $replace['abort(404);'] = '//';
         }
 
-        $baseControllerExists = class_exists($rootNamespace.'Http\Controllers\Controller');
+        $baseControllerExists = file_exists($rootNamespace.'Http\Controllers\Controller');
 
         if ($baseControllerExists) {
             $replace["use {$controllerNamespace}\Controller;\n"] = '';


### PR DESCRIPTION
When you delete the base controller from a Laravel v11 project, the `make:controller` command will not work any longer. This is because Composer doesn't forgets about the namespace automatically. Using a `file_exists` check instead of a `class_exists` check is an easy way to remedy this.

Fixes https://github.com/laravel/framework/issues/50494