### PR TITLE
[11.x] Check for password before storing hash in session

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -44,7 +44,7 @@ class AuthenticateSession implements AuthenticatesSessions
      */
     public function handle($request, Closure $next)
     {
-        if (! $request->hasSession() || ! $request->user()) {
+        if (! $request->hasSession() || ! $request->user() || ! $request->user()->getAuthPassword()) {
             return $next($request);
         }
 


### PR DESCRIPTION
Fixes #50497

The `\Illuminate\Session\Middleware\AuthenticateSession` middleware is designed to log out other user sessions when their password has changed. 

It shouldn't be used when there is no password on the user record, however it used to fail silently in 10.x and earlier. Since 11.x expects a password, it now fails on apps without a password and this middleware enabled. This checks for a password and if none set, ignores the rest of the checks to prevent errors in a backwards compatible way.

Ideally this middleware shouldn't be enabled on these sites - so the alternative is to instruct devs to disable this middleware on affected apps and document this in the Upgrade guide.
