### PR TITLE
[11.x] Add default empty config when creating repository within CacheManager

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -286,7 +286,7 @@ class CacheManager implements FactoryContract
      * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
-    public function repository(Store $store, array $config)
+    public function repository(Store $store, array $config = [])
     {
         return tap(new Repository($store, Arr::only($config, ['store'])), function ($repository) {
             $this->setEventDispatcher($repository);


### PR DESCRIPTION
This PR fix the following issue : https://github.com/laravel/framework/issues/50508