### PR TITLE
[11.x] Add default empty config when creating repository within CacheManager

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -286,7 +286,7 @@ class CacheManager implements FactoryContract
      * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
-    public function repository(Store $store, array $config)
+    public function repository(Store $store, array $config = [])
     {
         return tap(new Repository($store, Arr::only($config, ['store'])), function ($repository) {
             $this->setEventDispatcher($repository);

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -75,7 +75,7 @@ class CacheManagerTest extends TestCase
         $this->assertFalse($app->bound(Dispatcher::class));
 
         $cacheManager = new CacheManager($app);
-        $repo = $cacheManager->repository($theStore = new NullStore, []);
+        $repo = $cacheManager->repository($theStore = new NullStore);
 
         $this->assertNull($repo->getEventDispatcher());
         $this->assertSame($theStore, $repo->getStore());
@@ -87,7 +87,7 @@ class CacheManagerTest extends TestCase
         $this->assertSame($theStore, $repo->getStore());
 
         $cacheManager = new CacheManager($app);
-        $repo = $cacheManager->repository(new NullStore, []);
+        $repo = $cacheManager->repository(new NullStore);
         // now that the $app has a Dispatcher, the newly born repository will also have one.
         $this->assertNotNull($repo->getEventDispatcher());
     }


### PR DESCRIPTION
This PR fix the following issue : https://github.com/laravel/framework/issues/50508