### PR TITLE
[11.x] Add generics for Arr::first()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -181,11 +181,12 @@ class Arr
     /**
      * Return the first element in an array passing a given truth test.
      *
+     * @template TKey
      * @template TValue
      * @template TFirstDefault
      *
-     * @param  iterable<TValue>  $array
-     * @param  (callable(TValue): bool)|null  $callback
+     * @param  iterable<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): bool)|null  $callback
      * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -181,10 +181,13 @@ class Arr
     /**
      * Return the first element in an array passing a given truth test.
      *
-     * @param  iterable  $array
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
+     * @template TValue
+     * @template TFirstDefault
+     *
+     * @param  iterable<TValue>  $array
+     * @param  (callable(TValue): bool)|null  $callback
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
+     * @return TValue|TFirstDefault
      */
     public static function first($array, callable $callback = null, $default = null)
     {

--- a/types/Support/Arr.php
+++ b/types/Support/Arr.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Arr;
+
+use function PHPStan\Testing\assertType;
+
+$array = [new User];
+/** @var iterable<int, User> $iterable */
+$iterable = [];
+/** @var Traversable<int, User> $traversable */
+$traversable = [];
+
+assertType('User|null', Arr::first($array));
+assertType('User|null', Arr::first($array, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::first($array, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::first($array, null, function () {
+    return 'string';
+}));
+
+assertType('User|null', Arr::first($iterable));
+assertType('User|null', Arr::first($iterable, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::first($iterable, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::first($iterable, null, function () {
+    return 'string';
+}));
+
+assertType('User|null', Arr::first($traversable));
+assertType('User|null', Arr::first($traversable, function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', Arr::first($traversable, function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+assertType('string|User', Arr::first($traversable, null, function () {
+    return 'string';
+}));


### PR DESCRIPTION
I noticed PHPStan was not able to assert on `Arr::first()`. This however was possible in collection, so I just took some inspiration from there.

Reproduce:
```
$array = [new User];

\PHPStan\dumpType(Arr::first($array));
\PHPStan\dumpType(collect($array)->first());
```

Before:
```
Dumped type: mixed
Dumped type: App\Models\User|null
```

After:
```
Dumped type: App\Models\User|null
Dumped type: App\Models\User|null
```

This is greatly inspired by [Collections](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Collections/Collection.php#L396-L400) and [the types test](https://github.com/laravel/framework/blob/11.x/types/Support/Collection.php#L476-L489)