### PR TITLE
HTTP client: Merge hardcoded query for GET requests when providing query as array

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -768,8 +768,11 @@ class PendingRequest
      */
     public function get(string $url, $query = null)
     {
+        $url_query = parse_url($url, PHP_URL_QUERY);
+        parse_str($url_query, $url_query);
+
         return $this->send('GET', $url, func_num_args() === 1 ? [] : [
-            'query' => $query,
+            'query' => array_merge($query, $url_query),
         ]);
     }
 


### PR DESCRIPTION
This PR makes the HTTP client respect any existing URL query string when you also provide queries as an array, when making GET requests.

Query parameters provided as array (not in URL) will have precedence.