### PR TITLE
[11.x] Improved exception message on 'ensure' method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -326,7 +326,7 @@ trait EnumeratesValues
     {
         $allowedTypes = is_array($type) ? $type : [$type];
 
-        return $this->each(function ($item) use ($allowedTypes) {
+        return $this->each(function ($item, $index) use ($allowedTypes) {
             $itemType = get_debug_type($item);
 
             foreach ($allowedTypes as $allowedType) {
@@ -336,7 +336,7 @@ trait EnumeratesValues
             }
 
             throw new UnexpectedValueException(
-                sprintf("Collection should only include [%s] items, but '%s' found.", implode(', ', $allowedTypes), $itemType)
+                sprintf("Collection should only include [%s] items, but '%s' found at position %d.", implode(', ', $allowedTypes), $itemType, $index)
             );
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5193,6 +5193,7 @@ class SupportCollectionTest extends TestCase
 
         $data = $collection::make([1, 2, 3, 'foo']);
         $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage("Collection should only include [int] items, but 'string' found at position 3.");
         $data->ensure('int');
     }
 
@@ -5204,6 +5205,7 @@ class SupportCollectionTest extends TestCase
 
         $data = $collection::make([new stdClass, new stdClass, new stdClass, $collection]);
         $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype($collection), 3));
         $data->ensure(stdClass::class);
     }
 
@@ -5213,8 +5215,10 @@ class SupportCollectionTest extends TestCase
         $data = $collection::make([new \Error, new \Error]);
         $data->ensure(\Throwable::class);
 
-        $data = $collection::make([new \Error, new \Error, new $collection]);
+        $wrongType = new $collection;
+        $data = $collection::make([new \Error, new \Error, $wrongType]);
         $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, get_class($wrongType), 2));
         $data->ensure(\Throwable::class);
     }
 
@@ -5224,8 +5228,10 @@ class SupportCollectionTest extends TestCase
         $data = $collection::make([new \Error, 123]);
         $data->ensure([\Throwable::class, 'int']);
 
-        $data = $collection::make([new \Error, new \Error, new $collection]);
+        $wrongType = new $collection;
+        $data = $collection::make([new \Error, new \Error, $wrongType]);
         $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), get_class($wrongType), 2));
         $data->ensure([\Throwable::class, 'int']);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR improves the returned message, when the `Collection::ensure` method throws an `UnexpectedValueException`.
For now on, we know what position (0-based index) the wrong value is.

```diff
- Collection should only include [stdClass] items, but 'string' found.
+ Collection should only include [stdClass] items, but 'string' found at position 3.
```