### PR TITLE
[11.x] Improves broadcasting install

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -93,7 +93,7 @@ class BroadcastingInstallCommand extends Command
                 'channels: ',
                 $appBootstrapPath,
             );
-        }  elseif (str_contains($content, 'channels: ')) {
+        } elseif (str_contains($content, 'channels: ')) {
             return;
         } elseif (str_contains($content, 'commands: __DIR__.\'/../routes/console.php\',')) {
             (new Filesystem)->replaceInFile(

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -49,9 +49,9 @@ class BroadcastingInstallCommand extends Command
             $this->components->info("Published 'channels' route file.");
 
             copy(__DIR__.'/stubs/broadcasting-routes.stub', $broadcastingRoutesPath);
-
-            $this->uncommentChannelsRoutesFile();
         }
+
+        $this->uncommentChannelsRoutesFile();
 
         // Install bootstrapping...
         if (! file_exists($echoScriptPath = $this->laravel->resourcePath('js/echo.js'))) {
@@ -63,7 +63,7 @@ class BroadcastingInstallCommand extends Command
                 $bootstrapScriptPath
             );
 
-            if (! str_contains($bootstrapScript, 'echo.js')) {
+            if (! str_contains($bootstrapScript, './echo')) {
                 file_put_contents(
                     $bootstrapScriptPath,
                     trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL,
@@ -93,6 +93,8 @@ class BroadcastingInstallCommand extends Command
                 'channels: ',
                 $appBootstrapPath,
             );
+        }  elseif (str_contains($content, 'channels: ')) {
+            return;
         } elseif (str_contains($content, 'commands: __DIR__.\'/../routes/console.php\',')) {
             (new Filesystem)->replaceInFile(
                 'commands: __DIR__.\'/../routes/console.php\',',


### PR DESCRIPTION
This pull request makes the `install:broadcasting` better handling:

1. Situations where the channels file exists, but the route have not been uncommented.
2. The `echo` module have already being imported.