### PR TITLE
[11.x] Fix: import statement in echo-bootstrap-js.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
+++ b/src/Illuminate/Foundation/Console/stubs/echo-bootstrap-js.stub
@@ -4,4 +4,4 @@
  * allow your team to quickly build robust real-time web applications.
  */
 
-import './echo';
+import './echo.js';


### PR DESCRIPTION
**Problem:** Keeps appending import statement for `install:broadcasting` though it's already imported

![Screenshot 2024-03-13 213300](https://github.com/laravel/framework/assets/81873266/fbebdebd-f44e-4e5e-a928-1e4e7d020b9f)


**Description:**
This PR addresses an issue where the import statement in echo-bootstrap-js.stub is incorrect, leading to the checker always returning false when verifying the presence of the import statement.

**Changes:**

- Modified echo-bootstrap-js.stub to import `./echo.js` instead of `./echo`

**Reason for the Change:**
The import statement in the stub file was not correctly matching the filename, causing the checker to fail when verifying the presence of the import statement during the installation of broadcasting, leading to a bug of appending the import of echo.js to inifinite. By correcting the import statement to ./echo.js, the checker accurately detects the presence of the import statement, resolving the issue.