### PR TITLE
[11.x] add feature create many items for Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1028,6 +1028,22 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Save many new models and return the collection of instances.
+     *
+     * @param  array $arrayOfArrays
+     * @return \Illuminate\Support\Collection
+     */
+    public function createMany(array $arrayOfArrays) {
+        $items = collect();
+
+        foreach ($arrayOfArrays as $attributes){
+            $items->push($this->create($attributes));
+        }
+
+        return $items;
+    }
+
+    /**
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes


### PR DESCRIPTION
**Add feature Create many items for Eloquent.** 
Example:
 `$users = \App\Models\User::createMany([ ` <br>`
        [` <br>`
            "email" => "moemengaballa5@gmail.com",` <br>`
            "name" => "moemen gaballa",` <br>`
            "password" => bcrypt("12345678")` <br>`
        ], [` <br>`
            "email" => "moemengaballa5@mailinator.com",` <br>`
            "name" => "moemen",` <br>`
            "password" => bcrypt("12345678")` <br>`
        ]` <br>`
    ]);`

* return collection of users

