### PR TITLE
[11.x] Fix version constraints for illuminate/process

### DIFF
--- a/src/Illuminate/Process/composer.json
+++ b/src/Illuminate/Process/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/collections": "^10.0",
-        "illuminate/contracts": "^10.0",
-        "illuminate/macroable": "^10.0",
-        "illuminate/support": "^10.0",
+        "php": "^8.2",
+        "illuminate/collections": "^11.0",
+        "illuminate/contracts": "^11.0",
+        "illuminate/macroable": "^11.0",
+        "illuminate/support": "^11.0",
         "symfony/process": "^7.0"
     },
     "autoload": {
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "10.x-dev"
+            "dev-master": "11.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
The `11.x` branch of `illuminate/process` still requires Laravel 10.