### PR TITLE
[11.x] Update Broadcasting Install Command With Bun Support

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -163,6 +163,11 @@ class BroadcastingInstallCommand extends Command
                 'yarn add --dev laravel-echo pusher-js',
                 'yarn run build',
             ];
+        } elseif (file_exists(base_path('bun.lockb'))) {
+            $commands = [
+                'bun add --dev laravel-echo pusher-js',
+                'bun run build',
+            ];
         } else {
             $commands = [
                 'npm install --save-dev laravel-echo pusher-js',


### PR DESCRIPTION
This is a simple pull request to add support for https://bun.sh. More and more Laravel developers have moved away from `mix` and `npm` to `Vite` and `bun` such as myself. I did not see any tests needing adjustments for this addition.
