### PR TITLE
[11.x] Fixing a missing translation error

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -88,7 +88,7 @@ class ValidationException extends Exception
         $messages = $validator->errors()->all();
 
         if (! count($messages) || ! is_string($messages[0])) {
-            return 'The given data was invalid.';
+            return __('The given data was invalid.');
         }
 
         $message = array_shift($messages);
@@ -96,7 +96,7 @@ class ValidationException extends Exception
         if ($additional = count($messages)) {
             $pluralized = $additional === 1 ? 'error' : 'errors';
 
-            $message .= " (and {$additional} more {$pluralized})";
+            $message .= __(" (and {$additional} more {$pluralized})");
         }
 
         return $message;


### PR DESCRIPTION
After upgrading from Laravel 10 to Laravel 11, validation error translation started working incorrectly.

Laravel 10:
```jsonc
[{
    "message": "Le champ compilation ID sélectionné est invalide. (et 3 erreurs en plus)",
    // ... below in the post it's all good. The only problem is with "message".
}]
```
Laravel 11:
```jsonc
[{
    "message": "Le champ compilation ID sélectionné est invalide. (and 3 more errors)",
    // ... below in the post it's all good. The only problem is with "message".
}].
```