### PR TITLE
[11.x] Allows to comment `web` and `health` routes

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -85,10 +85,10 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Register the callback that will be used to load the application's routes.
      *
-     * @param  \Closure  $routesCallback
+     * @param  \Closure|null  $routesCallback
      * @return void
      */
-    public static function loadRoutesUsing(Closure $routesCallback)
+    public static function loadRoutesUsing(?Closure $routesCallback)
     {
         self::$alwaysLoadRoutesUsing = $routesCallback;
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/50531.

This pull request allows comment all HTTP routes (web, health) without having Laravel to throw: `TypeError: Illuminate\Foundation\Support\Providers\RouteServiceProvider::loadRoutesUsing(): Argument #1 ($routesCallback) must be of type Closure, null given`.

```php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        // web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        // health: '/up',
    )
```