### PR TITLE
[12.x] Unicode `Str::snake()` + edge case improvements

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1414,7 +1414,7 @@ class Str
         (?<!^) # don't match the beginning of a string
         (
             (?<=[^\p{Lu}])[\p{Lu}\p{M}]+(?=\p{M}?[^\p{Ll}]\p{M}?\p{L}) # string of upper-case (like an abbreviation)
-            | (?<=\p{Lu}{2})[\p{Lu}\p{M}](?=\p{M}?[^\p{Lu}]) # the final upper-case in a sequence
+            | (?<=\p{Lu}{2})[\p{Lu}\p{M}](?=\p{M}?\p{Ll}) # the final upper-case in a sequence
             | (?<=[^\p{Lu}])[\p{Lu}\p{M}](?=\p{M}?\p{Ll}) # first upper-case in a capitalized sequence
         )
         /ux

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1421,7 +1421,7 @@ class Str
         REGEXP;
 
         $value = preg_replace($pattern, ' $1', trim($value));
-        $value = preg_replace('/[^\p{L}]+/u', $delimiter, self::lower($value));
+        $value = preg_replace('/[^\p{L}0-9]+/u', $delimiter, self::lower($value));
 
         return static::$snakeCache[$key][$delimiter] = $value;
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1409,11 +1409,19 @@ class Str
             return static::$snakeCache[$key][$delimiter];
         }
 
-        if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', ucwords($value));
+        $pattern = <<<'REGEXP'
+        /
+        (?<!^) # don't match the beginning of a string
+        (
+            (?<=[^\p{Lu}])[\p{Lu}\p{M}]+(?=\p{M}?[^\p{Ll}]\p{M}?\p{L}) # string of upper-case (like an abbreviation)
+            | (?<=\p{Lu}{2})[\p{Lu}\p{M}](?=\p{M}?[^\p{Lu}]) # the final upper-case in a sequence
+            | (?<=[^\p{Lu}])[\p{Lu}\p{M}](?=\p{M}?\p{Ll}) # first upper-case in a capitalized sequence
+        )
+        /ux
+        REGEXP;
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
-        }
+        $value = preg_replace($pattern, ' $1', trim($value));
+        $value = preg_replace('/[^\p{L}]+/u', $delimiter, self::lower($value));
 
         return static::$snakeCache[$key][$delimiter] = $value;
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -749,7 +749,7 @@ class SupportStrTest extends TestCase
 
     public function testSnake()
     {
-        $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
+        $this->assertSame('laravel_php_framework', Str::snake('LaravelPHPFramework'));
         $this->assertSame('laravel_php_framework', Str::snake('LaravelPhpFramework'));
         $this->assertSame('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
         $this->assertSame('laravel_php_framework', Str::snake('Laravel Php Framework'));
@@ -760,10 +760,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
         // prevent breaking changes
-        $this->assertSame('foo-bar', Str::snake('foo-bar'));
-        $this->assertSame('foo-_bar', Str::snake('Foo-Bar'));
-        $this->assertSame('foo__bar', Str::snake('Foo_Bar'));
-        $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
+        $this->assertSame('foo_bar', Str::snake('foo-bar'));
+        $this->assertSame('foo_bar', Str::snake('Foo-Bar'));
+        $this->assertSame('foo_bar', Str::snake('Foo_Bar'));
+        $this->assertSame('żółta_łódka', Str::snake('ŻółtaŁódka'));
     }
 
     public function testSquish()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -759,10 +759,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
-        // prevent breaking changes
+        // changes in Laravel 12
         $this->assertSame('foo_bar', Str::snake('foo-bar'));
         $this->assertSame('foo_bar', Str::snake('Foo-Bar'));
         $this->assertSame('foo_bar', Str::snake('Foo_Bar'));
+        $this->assertSame('foo_bar', Str::snake('FOO BAR'));
         $this->assertSame('żółta_łódka', Str::snake('ŻółtaŁódka'));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -754,11 +754,17 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
         $this->assertSame('laravel_php_framework', Str::snake('Laravel Php Framework'));
         $this->assertSame('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
+
+        // ensure numbers are handled properly
+        $this->assertSame('foo_bar1', Str::snake('FooBar1'));
+        $this->assertSame('foobar1', Str::snake('Foobar1'));
+
         // ensure cache keys don't overlap
         $this->assertSame('laravel__php__framework', Str::snake('LaravelPhpFramework', '__'));
         $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+
         // changes in Laravel 12
         $this->assertSame('foo_bar', Str::snake('foo-bar'));
         $this->assertSame('foo_bar', Str::snake('Foo-Bar'));


### PR DESCRIPTION
Sadly, I bumped into this just after the Laravel 11 release, so I'm submitting against Laravel 12.

This PR adds better unicode support to `Str::snake()` as well as improving its handling of a few edge cases:

**Input String**|**Current Output**|**New Output**
:-----:|:-----:|:-----:
`LaravelPHPFramework`| `laravel_p_h_p_framework` |`laravel_php_framework`
`foo-bar`|         `foo-bar`         |`foo_bar`
`Foo-Bar`|        `foo-_bar`         |`foo_bar`
`Foo_Bar`|         `foo_bar`         |`foo_bar`
`FOO BAR`|       `f_o_o_b_a_r`       |`foo_bar`
`ŻółtaŁódka`|       `żółtałódka`        |`żółta_łódka`

The regular expression is a little intimidating, but most of the complexity comes from the fact that I'm using sequences like `\p{Lu}` instead of `[A-Z]` to make the expression unicode-safe, and I'm accounting for non-printed accent modifiers with `\p{M}`, which are used for things like umlauts in non-English languages.