### PR TITLE
[11.x] Fix crash when configuration directory is non-existing

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -139,6 +139,10 @@ class LoadConfiguration
 
         $configPath = realpath($app->configPath());
 
+        if (! $configPath) {
+            return [];
+        }
+
         foreach (Finder::create()->files()->name('*.php')->in($configPath) as $file) {
             $directory = $this->getNestedDirectory($file, $configPath);
 


### PR DESCRIPTION
Since the Laravel configuration files are no longer necessarily needed in the skeleton, some may want to delete the configuration directory entirely.

When the configuration directory is omitted, Laravel crashes using the following error:
<img width="1685" alt="image" src="https://github.com/laravel/framework/assets/16333228/b854de90-c994-4035-a4f4-11bfbbfc955d">

The error occurs because `$configPath = realpath($app->configPath());` returns`false`, this triggers a Exception because `false` is not a directory that can be found.

This PR solves this problem where the configuration directory can be omitted without crash.