### PR TITLE
[11.x] New command key:rotate to utilize new app key rotate features

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -114,12 +114,26 @@ class KeyGenerateCommand extends Command
     /**
      * Get a regex pattern that will match env APP_KEY with any random key.
      *
+     * @param  string $key
      * @return string
      */
-    protected function keyReplacementPattern()
+    protected function keyReplacementPattern($key = 'app.key')
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $configValue = $this->laravel['config'][$key];
+        $stringValue = is_array($configValue)
+            ? implode(',', $configValue)
+            : $configValue;
 
-        return "/^APP_KEY{$escaped}/m";
+        $escaped = preg_quote('='.$stringValue, '/');
+
+        return "/^{$this->enviornmentKeyName($key)}{$escaped}/m";
+    }
+
+    /**
+     * Get string formated as enviornment key style
+     */
+    protected function enviornmentKeyName($key)
+    {
+        return strtoupper(str_replace('.', '_', $key));
     }
 }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -114,7 +114,7 @@ class KeyGenerateCommand extends Command
     /**
      * Get a regex pattern that will match env APP_KEY with any random key.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return string
      */
     protected function keyReplacementPattern($key = 'app.key')
@@ -130,7 +130,7 @@ class KeyGenerateCommand extends Command
     }
 
     /**
-     * Get string formated as enviornment key style
+     * Get string formated as enviornment key style.
      */
     protected function enviornmentKeyName($key)
     {

--- a/src/Illuminate/Foundation/Console/KeyRotateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyRotateCommand.php
@@ -38,7 +38,7 @@ class KeyRotateCommand extends KeyGenerateCommand
 
         $keys = [
             'app.key' => $key,
-            'app.previous_keys' => $previousKeys
+            'app.previous_keys' => $previousKeys,
         ];
 
         if ($this->option('show')) {
@@ -51,7 +51,7 @@ class KeyRotateCommand extends KeyGenerateCommand
 
         $this->laravel['config']['app.key'] = $key;
         $this->laravel['config']['app.previous_keys'] = $previousKeys;
-    
+
         $this->components->info('Appliction key successfully rotated');
     }
 

--- a/src/Illuminate/Foundation/Console/KeyRotateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyRotateCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Illuminate\Foundation\Console\KeyGenerateCommand;
+
+#[AsCommand(name: 'key:rotate')]
+class KeyRotateCommand extends KeyGenerateCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'key:rotate
+                    {--show : Display the key instead of modifying files}
+                    {--force : Force the operation to run when in production}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rotate the application key.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $key = $this->generateRandomKey();
+
+        $previousKeys = $this->laravel['config']['app.previous_keys'];
+        $previousKeys[] = $this->laravel['config']['app.key'];
+
+        $keys = [
+            'app.key' => $key,
+            'app.previous_keys' => $previousKeys
+        ];
+
+        if ($this->option('show')) {
+            $this->line('<comment>'.$key.'</comment>');
+        }
+
+        if (! $this->setKeysInEnviornmentFile($keys)) {
+            return;
+        }
+
+        $this->laravel['config']['app.key'] = $key;
+        $this->laravel['config']['app.previous_keys'] = $previousKeys;
+    
+        $this->components->info('Appliction key successfully rotated');
+    }
+
+    protected function setKeysInEnviornmentFile($keys)
+    {
+        $input = file_get_contents($this->laravel->environmentFilePath());
+
+        foreach ($keys as $key => $value) {
+            try {
+                $input = $this->prepareEnviornmentInputWith($key, $value, $input);
+            } catch (\Exception $e) {
+                $this->error($e->getMessage());
+                
+                return false;
+            }
+
+            $this->laravel['config'][$key] = $value;
+        }
+
+        file_put_contents($this->laravel->environmentFilePath(), $input);
+
+        return true;
+    }
+
+    protected function prepareEnviornmentInputWith($key, $value, $input)
+    {
+        $keyName = $this->enviornmentKeyName($key);
+
+        $keyValue = is_array($value)
+            ? implode(',', $value)
+            : $value;
+
+        $replaced = preg_replace(
+            $this->keyReplacementPattern($key),
+            $keyName.'='.$keyValue,
+            $input
+        );
+
+        if ($replaced === $input || $replaced === null) {
+            throw new \Exception("Unable to set key {$keyName}, No {$keyName} found in the .env file");
+        }
+
+        return $replaced;
+    }
+}

--- a/tests/Foundation/Console/KeyRotateCommandTest.php
+++ b/tests/Foundation/Console/KeyRotateCommandTest.php
@@ -27,7 +27,7 @@ class KeyRotateCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        File::delete(__DIR__.'/.env');
+        File::delete(__DIR__.DIRECTORY_SEPARATOR.'.env');
 
         parent::tearDown();
     }
@@ -38,7 +38,7 @@ class KeyRotateCommandTest extends TestCase
         $originalPreviousKeys = ['old-key-1', 'old-key-2'];
 
         File::put(
-            __DIR__.'/.env',
+            __DIR__.DIRECTORY_SEPARATOR.'.env',
             "APP_KEY=".$currentKey."\nAPP_PREVIOUS_KEYS=".implode(',', $originalPreviousKeys)
         );
         

--- a/tests/Foundation/Console/KeyRotateCommandTest.php
+++ b/tests/Foundation/Console/KeyRotateCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Console\KeyRotateCommand;
+use Illuminate\Foundation\Testing\TestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
+
+class KeyRotateCommandTest extends TestCase
+{
+    use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->useEnvironmentPath(__DIR__);
+
+        /** @var ConsoleKernel $kernel */
+        $kernel = $this->app->make(Kernel::class);
+        $kernel->registerCommand(new KeyRotateCommand);
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete(__DIR__.'/.env');
+
+        parent::tearDown();
+    }
+
+    public function test_command_rotates_keys()
+    {
+        $currentKey = 'key-1';
+        $originalPreviousKeys = ['old-key-1', 'old-key-2'];
+
+        File::put(
+            __DIR__.'/.env',
+            "APP_KEY=".$currentKey."\nAPP_PREVIOUS_KEYS=".implode(',', $originalPreviousKeys)
+        );
+        
+        Config::set('app.key', $currentKey);
+        Config::set('app.previous_keys', $originalPreviousKeys);
+
+        $this->artisan('key:rotate');
+
+        $expectedPreviousKeys = array_merge($originalPreviousKeys, [
+           $currentKey
+        ]);
+
+        $this->assertEquals($expectedPreviousKeys, Config::get('app.previous_keys'));
+        $this->assertNotEquals($currentKey, Config::get('app.key'));
+    }
+}


### PR DESCRIPTION
I saw the Laracon EU talk and was inspired to write this because it can be used in scheduled commands, etc.



**What is this PR?**
This PR is creating a new artisan command ```key:rotate``` based on the ```key:generate``` command.

This would provide an easy and automated way to rotate the APP_KEY (putting it into APP_PREVIOUS_KEYS and then adding a new APP_KEY) instead of manually doing it.

**Breaking changes**
None that I know of.

I did make some changes that the class extended from with just default parameter values so it doesn't break ```key:generate```

___

In this case, it might be better to put common functionality into a trait perhaps?