### PR TITLE
[11.x] Fix ObservedBy Attribute that did not take custom observables in account

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -30,16 +30,6 @@ trait HasEvents
     protected $observables = [];
 
     /**
-     * Boot the has event trait for a model.
-     *
-     * @return void
-     */
-    public static function bootHasEvents()
-    {
-        static::observe(static::resolveObserveAttributes());
-    }
-
-    /**
      * Resolve the observe class names from the attributes.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -312,6 +312,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 );
             }
         }
+
+        // register observers at the very end because observers registration may need
+        // some attributes initialized in model traits (typically observables)
+        static::observe(static::resolveObserveAttributes());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2010,6 +2010,17 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelWithObserveAttributeUsingArrayStub::flushEventListeners();
     }
 
+    public function testModelObserversCanBeAttachedToModelsWithObservableTraitUsingAttribute()
+    {
+        EloquentModelWithObserveAttributeAndObservableTraitStub::setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelWithObserveAttributeAndObservableTraitStub', EloquentTestObserverStub::class.'@creating');
+        $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelWithObserveAttributeAndObservableTraitStub', EloquentTestObserverStub::class.'@saved');
+        $events->shouldReceive('listen')->once()->with('eloquent.foo: Illuminate\Tests\Database\EloquentModelWithObserveAttributeAndObservableTraitStub', EloquentTestObserverStub::class.'@foo');
+        $events->shouldReceive('forget');
+        EloquentModelWithObserveAttributeAndObservableTraitStub::flushEventListeners();
+    }
+
     public function testThrowExceptionOnAttachingNotExistsModelObserverWithString()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -3036,6 +3047,11 @@ class EloquentTestObserverStub
     {
         //
     }
+
+    public function foo()
+    {
+        //
+    }
 }
 
 class EloquentTestAnotherObserverStub
@@ -3541,6 +3557,20 @@ class EloquentModelWithObserveAttributeStub extends EloquentModelStub
 class EloquentModelWithObserveAttributeUsingArrayStub extends EloquentModelStub
 {
     //
+}
+
+#[ObservedBy(EloquentTestObserverStub::class)]
+class EloquentModelWithObserveAttributeAndObservableTraitStub extends EloquentModelStub
+{
+    use ObservableTrait;
+}
+
+trait ObservableTrait
+{
+    public function initializeObservableTrait()
+    {
+        $this->addObservableEvents('foo');
+    }
 }
 
 class EloquentModelSavingEventStub


### PR DESCRIPTION
Hello laravel team ! 
I made this pull request to fix the issue described [here](https://github.com/laravel/framework/issues/50410)

### Bug description

When using PHP Attribute `ObservedBy` to observe my model (instead of register the observer in the `EventServiceProvider`), "custom" observables added through the `initialize{Trait}` using `addObservableEvents` are not taken in account.

(when I use `EventServiceProvider` to register the observer, it works well).

my investigation : 
When using `ObservedBy`, "custom" observables are not registered because when entering in `HasEvents::observe` for the first time, the Model is booting (and already tagged as booted in `Model::$booted`). And the instanciated model in `HasEvents::observe` line 67 (`$instance = new static;`) will not boot the model because it is already booting.

Conversely when we register the observer in `EventServiceProvider` we directly call `HasEvents::observe` and the previously mentioned `$instance = new static;` boot the model and can register "custom" observables.

### Steps To Reproduce

create a model that use `ObservedBy`
```PHP
#[ObservedBy([MyObserver::class])]
class MyModel extends Model
{
    use MyTrait;
    
    ...
}
```

create a trait that use `addObservableEvents`
```PHP
trait MyTrait
{
    public function initializeMyTrait()
    {
        $this->addObservableEvents('foo');
    }

    /**
     * to easily fire the event for debugging
     */
    public function fireFoo()
    {
        $this->fireModelEvent('foo');
    }
}
```
create the observer `MyObserver`
```PHP
class MyObserver
{
    public function foo(MyModel $myModel)
    {
        var_dump('triggered foo');
    }
}
```
finally call `fireFoo`
```PHP
$myModel = new MyModel();

$myModel->fireFoo(); // doesn't call MyObserver::foo
```

### Solution found 

Do not make the trait `HasEvents` bootable by removing `bootHasEvents`.
And just call `HasEvents::observe` at the very end of `bootTraits` method.
This way all stuff that need to be initialized will be initialized before the model instantiation in the method `HasEvents::observe`
