### PR TITLE
[11.x ] feat(helper): `with` supports more callbacks

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -462,8 +462,8 @@ if (! function_exists('with')) {
      * @template TReturn
      *
      * @param  TValue  $value
-     * @param  (callable(TValue): (TReturn))|null  $callbacks
-     * @return ($callback is null ? TValue : TReturn)
+     * @param  array<callable(TValue): (TReturn)>  $callbacks
+     * @return ($callbacks is empty ? TValue : TReturn)
      */
     function with($value, ...$callbacks)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -487,6 +487,7 @@ if (! function_exists('with')) {
                 $value = $callback($value);
             }
         }
+
         return $value;
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -469,4 +469,24 @@ if (! function_exists('with')) {
     {
         return is_null($callback) ? $value : $callback($value);
     }
+
+    /**
+     * Return the given value, optionally passed through the callbacks.
+     *
+     * @template TValue
+     * @template TReturn
+     *
+     * @param TValue $value
+     * @param (callable(TValue): (TReturn)) $callbacks
+     * @return ($callbacks is empty ? TValue : TReturn)
+     */
+    function chain($value, ...$callbacks)
+    {
+        foreach ($callbacks as $callback) {
+            if (is_callable($callback)) {
+                $value = $callback($value);
+            }
+        }
+        return $value;
+    }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -463,7 +463,7 @@ if (! function_exists('with')) {
      *
      * @param  TValue  $value
      * @param  array<callable(TValue): (TReturn)>  $callbacks
-     * @return ($callbacks is empty ? TValue : TReturn)
+     * @return TReturn
      */
     function with($value, ...$callbacks)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -460,9 +460,10 @@ if (! function_exists('with')) {
      *
      * @template TValue
      * @template TReturn
+     * @template TCallback of callable(TValue): (TReturn)
      *
      * @param  TValue  $value
-     * @param  array<callable(TValue): (TReturn)>  $callbacks
+     * @param  TCallback  ...$callbacks
      * @return TReturn
      */
     function with($value, ...$callbacks)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -476,8 +476,8 @@ if (! function_exists('with')) {
      * @template TValue
      * @template TReturn
      *
-     * @param TValue $value
-     * @param (callable(TValue): (TReturn)) $callbacks
+     * @param  TValue  $value
+     * @param  (callable(TValue): (TReturn))  $callbacks
      * @return ($callbacks is empty ? TValue : TReturn)
      */
     function chain($value, ...$callbacks)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -462,25 +462,10 @@ if (! function_exists('with')) {
      * @template TReturn
      *
      * @param  TValue  $value
-     * @param  (callable(TValue): (TReturn))|null  $callback
+     * @param  (callable(TValue): (TReturn))|null  $callbacks
      * @return ($callback is null ? TValue : TReturn)
      */
-    function with($value, callable $callback = null)
-    {
-        return is_null($callback) ? $value : $callback($value);
-    }
-
-    /**
-     * Return the given value, optionally passed through the callbacks.
-     *
-     * @template TValue
-     * @template TReturn
-     *
-     * @param  TValue  $value
-     * @param  (callable(TValue): (TReturn))  $callbacks
-     * @return ($callbacks is empty ? TValue : TReturn)
-     */
-    function chain($value, ...$callbacks)
+    function with($value, ...$callbacks)
     {
         foreach ($callbacks as $callback) {
             if (is_callable($callback)) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1041,6 +1041,22 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
+    public function testChain()
+    {
+        $this->assertEquals(10, chain(10));
+
+        $this->assertEquals(10, chain(5, function ($five) {
+            return $five + 5;
+        }, function ($ten) {
+            return $ten * 2;
+        }, new class {
+            public function __invoke($twenty): int
+            {
+                return $twenty * 3;
+            }
+        }, fn ($sixty) => $sixty / 6));
+    }
+
     public function testAppendConfig()
     {
         $this->assertSame([10000 => 'name', 10001 => 'family'], append_config([1 => 'name', 2 => 'family']));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1039,13 +1039,8 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(10, with(5, function ($five) {
             return $five + 5;
         }));
-    }
 
-    public function testChain()
-    {
-        $this->assertEquals(10, chain(10));
-
-        $this->assertEquals(10, chain(5, function ($five) {
+        $this->assertEquals(10, with(5, function ($five) {
             return $five + 5;
         }, function ($ten) {
             return $ten * 2;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1049,7 +1049,8 @@ class SupportHelpersTest extends TestCase
             return $five + 5;
         }, function ($ten) {
             return $ten * 2;
-        }, new class {
+        }, new class
+        {
             public function __invoke($twenty): int
             {
                 return $twenty * 3;


### PR DESCRIPTION
```php
<?php

$value = chain(10);
// output: 10

$value = chain(5, function ($five) {
    return $five + 5;
}, function ($ten) {
    return $ten * 2;
}, new class {
    public function __invoke($twenty): int
    {
        return $twenty * 3;
    }
}, fn ($sixty) => $sixty / 6);
// output: 10
```