### PR TITLE
[11.x] Fix count for paginated queries with a union and an orderBy clause

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -233,3 +233,48 @@ jobs:
           DB_DATABASE: master
           DB_USERNAME: SA
           DB_PASSWORD: Forge123
+  mssql_2022:
+    runs-on: ubuntu-20.04
+
+    services:
+      sqlsrv:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: Forge123
+        ports:
+          - 1433:1433
+
+    strategy:
+      fail-fast: true
+
+    name: SQL Server 2022
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: sqlsrv
+          DB_DATABASE: master
+          DB_USERNAME: SA
+          DB_PASSWORD: Forge123

--- a/config/database.php
+++ b/config/database.php
@@ -106,7 +106,7 @@ return [
             'prefix' => '',
             'prefix_indexes' => true,
             // 'encrypt' => env('DB_ENCRYPT', 'yes'),
-            // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
+            'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
         ],
 
     ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,12 +16,7 @@
         <ini name="date.timezone" value="UTC" />
         <ini name="intl.default_locale" value="C.UTF-8" />
         <ini name="memory_limit" value="2048M" />
-        <env name="DB_CONNECTION" value="sqlsrv" />
-        <env name="DB_HOST" value="127.0.0.1" />
-        <env name="DB_PORT" value="1433" />
-        <env name="DB_USERNAME" value="SA" />
-        <env name="DB_PASSWORD" value="Forge123" />
-        <env name="DB_TRUST_SERVER_CERTIFICATE" value="true" />
+        <env name="DB_CONNECTION" value="testing" />
         <!--
         <env name="REDIS_HOST" value="127.0.0.1" />
         <env name="REDIS_PORT" value="6379" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,12 @@
         <ini name="date.timezone" value="UTC" />
         <ini name="intl.default_locale" value="C.UTF-8" />
         <ini name="memory_limit" value="2048M" />
-        <env name="DB_CONNECTION" value="testing" />
+        <env name="DB_CONNECTION" value="sqlsrv" />
+        <env name="DB_HOST" value="127.0.0.1" />
+        <env name="DB_PORT" value="1433" />
+        <env name="DB_USERNAME" value="SA" />
+        <env name="DB_PASSWORD" value="Forge123" />
+        <env name="DB_TRUST_SERVER_CERTIFICATE" value="true" />
         <!--
         <env name="REDIS_HOST" value="127.0.0.1" />
         <env name="REDIS_PORT" value="6379" />

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3070,10 +3070,12 @@ class Builder implements BuilderContract
                 ->get()->all();
         }
 
-        $without = $this->unions ? ['orders', 'limit', 'offset'] : ['columns', 'orders', 'limit', 'offset'];
+        $without = $this->unions
+            ? ['orders', 'unionOrders', 'limit', 'unionLimit', 'offset', 'unionOffset']
+            : ['columns', 'orders', 'limit', 'offset'];
 
         return $this->cloneWithout($without)
-                    ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
+                    ->cloneWithoutBindings($this->unions ? ['order', 'unionOrder'] : ['select', 'order'])
                     ->setAggregate('count', $this->withoutSelectAliases($columns))
                     ->get()->all();
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3071,11 +3071,11 @@ class Builder implements BuilderContract
         }
 
         $without = $this->unions
-            ? ['orders', 'unionOrders', 'limit', 'unionLimit', 'offset', 'unionOffset']
+            ? ['orders', , 'limit', 'unionLimit', 'offset', 'unionOffset']
             : ['columns', 'orders', 'limit', 'offset'];
 
         return $this->cloneWithout($without)
-                    ->cloneWithoutBindings($this->unions ? ['order', 'unionOrder'] : ['select', 'order'])
+                    ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
                     ->setAggregate('count', $this->withoutSelectAliases($columns))
                     ->get()->all();
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3071,7 +3071,7 @@ class Builder implements BuilderContract
         }
 
         $without = $this->unions
-            ? ['orders', , 'limit', 'unionLimit', 'offset', 'unionOffset']
+            ? ['orders', 'limit', 'unionLimit', 'offset', 'unionOffset']
             : ['columns', 'orders', 'limit', 'offset'];
 
         return $this->cloneWithout($without)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3071,11 +3071,11 @@ class Builder implements BuilderContract
         }
 
         $without = $this->unions
-            ? ['orders', 'limit', 'unionLimit', 'offset', 'unionOffset']
+            ? ['orders', 'unionOrders', 'limit', 'unionLimit', 'offset', 'unionOffset']
             : ['columns', 'orders', 'limit', 'offset'];
 
         return $this->cloneWithout($without)
-                    ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
+                    ->cloneWithoutBindings($this->unions ? ['order', 'unionOrder'] : ['select', 'order'])
                     ->setAggregate('count', $this->withoutSelectAliases($columns))
                     ->get()->all();
     }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -311,8 +311,7 @@ class SqlServerGrammar extends Grammar
         }
 
         if (empty($query->orders) && empty($query->unionOrders)) {
-            // Limits do not work when there is no order by in the query.
-            return '';
+            $query->orders[] = ['sql' => '(SELECT 0)'];
         }
 
         $sql = '';

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -71,13 +71,6 @@ class SqlServerGrammar extends Grammar
 
         $select = $query->distinct ? 'select distinct ' : 'select ';
 
-        // If there is a limit on the query, but not an offset, we will add the top
-        // clause to the query, which serves as a "limit" type clause within the
-        // SQL Server system similar to the limit keywords available in MySQL.
-        if (is_numeric($query->limit) && $query->limit > 0 && $query->offset <= 0) {
-            $select .= 'top '.((int) $query->limit).' ';
-        }
-
         return $select.$this->columnize($columns);
     }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -71,6 +71,13 @@ class SqlServerGrammar extends Grammar
 
         $select = $query->distinct ? 'select distinct ' : 'select ';
 
+        // If there is a limit on the query, but not an order, we will add the top
+        // clause to the query, which serves as a "limit" type clause within the
+        // SQL Server system similar to the limit keywords available in MySQL.
+        if (is_numeric($query->limit) && $query->limit > 0 && empty($query->orders)) {
+            $select .= 'top '.((int) $query->limit).' ';
+        }
+
         return $select.$this->columnize($columns);
     }
 
@@ -300,6 +307,11 @@ class SqlServerGrammar extends Grammar
         $limit = (int) $limit;
 
         if (! $limit) {
+            return '';
+        }
+
+        if (empty($query->orders) && empty($query->unionOrders)) {
+            // Limits do not work when there is no order by in the query.
             return '';
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -71,13 +71,6 @@ class SqlServerGrammar extends Grammar
 
         $select = $query->distinct ? 'select distinct ' : 'select ';
 
-        // If there is a limit on the query, but not an order, we will add the top
-        // clause to the query, which serves as a "limit" type clause within the
-        // SQL Server system similar to the limit keywords available in MySQL.
-        if (is_numeric($query->limit) && $query->limit > 0 && empty($query->orders)) {
-            $select .= 'top '.((int) $query->limit).' ';
-        }
-
         return $select.$this->columnize($columns);
     }
 
@@ -310,11 +303,12 @@ class SqlServerGrammar extends Grammar
             return '';
         }
 
+        $sql = '';
+
         if (empty($query->orders) && empty($query->unionOrders)) {
-            $query->orders[] = ['sql' => '(SELECT 0)'];
+            $sql .= 'order by (SELECT 0) ';
         }
 
-        $sql = '';
 
         if (! $query->offset > 0) {
             $sql .= 'offset 0 rows ';

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -306,11 +306,19 @@ class SqlServerGrammar extends Grammar
     {
         $limit = (int) $limit;
 
-        if ($limit && $query->offset > 0) {
-            return "fetch next {$limit} rows only";
+        if (! $limit) {
+            return '';
         }
 
-        return '';
+        $sql = '';
+
+        if (! $query->offset > 0) {
+            $sql .= 'offset 0 rows ';
+        }
+
+        $sql .= "fetch next {$limit} rows only";
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -309,7 +309,6 @@ class SqlServerGrammar extends Grammar
             $sql .= 'order by (SELECT 0) ';
         }
 
-
         if (! $query->offset > 0) {
             $sql .= 'offset 0 rows ';
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2874,7 +2874,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerExists()
     {
         $builder = $this->getSqlServerBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select 1 [exists] from [users] order by (SELECT 0) offset 0 rows fetch 1 rows only', [], true)->andReturn([['exists' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select 1 [exists] from [users] order by (SELECT 0) offset 0 rows fetch next 1 rows only', [], true)->andReturn([['exists' => 1]]);
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);
     }
@@ -4197,7 +4197,7 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take(10);
-        $this->assertSame('select top 10 * from [users]', $builder->toSql());
+        $this->assertSame('select * from [users] order by (SELECT 0) offset 0 rows fetch next 10 rows only', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->orderBy('email', 'desc');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2038,23 +2038,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([4], $builder->getBindings());
     }
 
-    public function testGetCountForPaginationWithUnionAllAndBindings()
-    {
-        $builder = $this->getBuilder();
-        $builder->from('users')->selectSub(function ($q) {
-            $q->select('body')->from('posts')->where('id', 4);
-        }, 'post')->unionAll();
-
-        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
-            return $results;
-        });
-
-        $count = $builder->getCountForPagination();
-        $this->assertEquals(1, $count);
-        $this->assertEquals([4], $builder->getBindings());
-    }
-
     public function testGetCountForPaginationWithColumnAliases()
     {
         $builder = $this->getBuilder();
@@ -4227,26 +4210,6 @@ SQL;
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');
         $this->assertSame('select * from [users] order by [email] desc offset 11 rows fetch next 10 rows only', $builder->toSql());
-
-        $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users');
-        $builder2 = $this->getSqlServerBuilder();
-        $builder2->select('*')->from('users');
-        $builder->unionAll($builder2);
-
-        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
-        $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
-        $builder->shouldReceive('forPage')->once()->with(1, 2)->andReturnSelf();
-        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
-                'select * from "foobar" where ("test" > ?) order by "test" asc limit 17',
-                $builder->toSql());
-            $this->assertEquals(['bar'], $builder->bindings['where']);
-
-            return $results;
-        });
-
-        $result = $builder->paginate(2);
 
         $builder = $this->getSqlServerBuilder();
         $subQuery = function ($query) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2874,7 +2874,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerExists()
     {
         $builder = $this->getSqlServerBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select top 1 1 [exists] from [users]', [], true)->andReturn([['exists' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select 1 [exists] from [users] order by (SELECT 0) offset 0 rows fetch 1 rows only', [], true)->andReturn([['exists' => 1]]);
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4214,7 +4214,7 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take(10);
-        $this->assertSame('select * from [users] offset 0 rows fetch next 10 rows only', $builder->toSql());
+        $this->assertSame('select top 10 * from [users]', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->orderBy('email', 'desc');

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -96,6 +96,17 @@ class EloquentPaginateTest extends DatabaseTestCase
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }
+
+    public function testPaginationWithUnion()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            Post::create(['title' => 'Hello world']);
+            Post::create(['title' => 'Goodbye world']);
+        }
+
+        $result = Post::query()->unionAll(Post::query())->orderBy('title', 'desc')->paginate(1);
+        $this->assertEquals(1, $result->count());
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
When calling the `paginate()` function on a query that:

- uses a union
- contains an orderBy
- uses SQL Server

```php
$firstQuery = FirstModel::query();
$secondQuery = FirstModel::query();

$firstQuery->unionAll($secondQuery)->orderBy('date')->paginate(10);
```

We get the following error:
`SQLSTATE[42000]: [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified. `

We see that the `orderBy` clause is not removed as it should when the ` runPaginationCountQuery()` is called.
The orderBy clause is set in the `unionOrders` property of the query and not on the `orders` property.

This is done in the Builder `orderBy` method here: https://github.com/laravel/framework/blob/08acc925f1ec8e1c41a54774a36720f506c5b5a8/src/Illuminate/Database/Query/Builder.php#L2450

```php
$this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
            'column' => $column,
            'direction' => $direction,
        ];
```

This PR removes the unionOrders, unionLimit and unionOffset properties from the query and the bindings.