### PR TITLE
[11.x] Fixes install:broadcasting command

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -176,7 +176,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         $this->requireComposerPackages($this->option('composer'), [
-            'laravel/reverb:dev-fix/reverb-install',
+            'laravel/reverb:@beta',
         ]);
 
         $php = (new PhpExecutableFinder())->find(false) ?: 'php';

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -188,7 +188,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         $command = Process::command(implode(' && ', $commands))
-            ->path(base_path());
+                        ->path(base_path());
 
         if (! windows_os()) {
             $command->tty(true);

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -49,7 +49,6 @@ class BroadcastingInstallCommand extends Command
         }
 
         $this->uncommentChannelsRoutesFile();
-        $this->updateBroadcastingConfiguration();
         $this->enableBroadcastServiceProvider();
 
         // Install bootstrapping...
@@ -101,43 +100,6 @@ class BroadcastingInstallCommand extends Command
                 $appBootstrapPath,
             );
         }
-    }
-
-    /**
-     * Update the broadcasting.php configuration file.
-     *
-     * @return void
-     */
-    protected function updateBroadcastingConfiguration()
-    {
-        if ($this->laravel->config->has('broadcasting.connections.reverb')) {
-            return;
-        }
-
-        (new Filesystem)->replaceInFile(
-            "'connections' => [\n",
-            <<<'CONFIG'
-            'connections' => [
-
-                    'reverb' => [
-                        'driver' => 'reverb',
-                        'key' => env('REVERB_APP_KEY'),
-                        'secret' => env('REVERB_APP_SECRET'),
-                        'app_id' => env('REVERB_APP_ID'),
-                        'options' => [
-                            'host' => env('REVERB_HOST'),
-                            'port' => env('REVERB_PORT', 443),
-                            'scheme' => env('REVERB_SCHEME', 'https'),
-                            'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
-                        ],
-                        'client_options' => [
-                            // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
-                        ],
-                    ],
-
-            CONFIG,
-            app()->configPath('broadcasting.php')
-        );
     }
 
     /**


### PR DESCRIPTION
This PR updates the `install:broadcasting` process to lways attempt to enable the `BroadcastServiceProvider` in `app.php`

This combined with the changes in the `reverb:install command (https://github.com/laravel/reverb/pull/84) will resolve installation issues for apps migrating from Laravel 10 to Laravel 11.

