### PR TITLE
[12.x] Switch Js::encode() to return HtmlString

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -75,7 +75,7 @@ class Js implements Htmlable, Stringable
             $data = $data->value;
         }
 
-        $json = static::encode($data, $flags, $depth);
+        $json = (string) static::encode($data, $flags, $depth);
 
         if (is_string($data)) {
             return "'".substr($json, 1, -1)."'";
@@ -90,21 +90,21 @@ class Js implements Htmlable, Stringable
      * @param  mixed  $data
      * @param  int  $flags
      * @param  int  $depth
-     * @return string
+     * @return \Illuminate\Contracts\Support\Htmlable
      *
      * @throws \JsonException
      */
-    public static function encode($data, $flags = 0, $depth = 512)
+    public static function encode($data, $flags = 0, $depth = 512): Htmlable
     {
         if ($data instanceof Jsonable) {
-            return $data->toJson($flags | static::REQUIRED_FLAGS);
+            return new HtmlString($data->toJson($flags | static::REQUIRED_FLAGS));
         }
 
         if ($data instanceof Arrayable && ! ($data instanceof JsonSerializable)) {
             $data = $data->toArray();
         }
 
-        return json_encode($data, $flags | static::REQUIRED_FLAGS, $depth);
+        return new HtmlString(json_encode($data, $flags | static::REQUIRED_FLAGS, $depth));
     }
 
     /**

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
 use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
@@ -129,5 +130,16 @@ class SupportJsTest extends TestCase
     {
         $this->assertSame('2', (string) Js::from(IntBackedEnum::TWO));
         $this->assertSame("'Hello world'", (string) Js::from(StringBackedEnum::HELLO_WORLD));
+    }
+
+    public function testEncode()
+    {
+        $json = Js::encode(['foo' => 'hello', 'bar' => 'world']);
+
+        $this->assertInstanceOf(HtmlString::class, $json);
+        $this->assertEquals(
+            '{"foo":"hello","bar":"world"}',
+            (string) $json
+        );
     }
 }


### PR DESCRIPTION
Since it missed 11 in https://github.com/laravel/framework/pull/49641, let's try again and get it into 12. 🤞

Updating the `Js::encode()` helper to return an instance of `HtmlString` rather than a raw string.

The primary reason is to support using the normal escaping Blade tags: `{{ Js::encode() }}`, rather than `{!! Js::encode() !}}`, when using this in Blade. This will then match the behaviour already possible with `Js::from()` which returns an instance of `Htmlable` and supports `{{ Js::from() }}`.

Since this is a breaking change, it will need to go into ~v11~ v12 - hence the `master` branch.

There are no downsides to this change, it may just require minor code updates - which should be trivial to identify and perform with a search for `Js::encode(`.

P.s. Is this the first PR into 12?