### PR TITLE
[11.x] Add `redis` broadcaster configuration

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -69,6 +69,11 @@ return [
             'key' => env('ABLY_KEY'),
         ],
 
+        'redis' => [
+            'driver' => 'redis',
+            'connection' => 'default',
+        ],
+
         'log' => [
             'driver' => 'log',
         ],


### PR DESCRIPTION
Seems the configuration for the supported `redis` broadcaster is missing in 11 version.