### PR TITLE
[11.x] Set up APP_KEY rotation automatically with APP_PREVIOUS_KEYS when php artisan key:generate is run

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -96,7 +96,7 @@ class KeyGenerateCommand extends Command
     {
         $previousKeys = implode(',', $this->laravel['config']['app.previous_keys']);
 
-        $newPreviousKeys = $this->laravel['config']['app.key'] . ($previousKeys ? ",$previousKeys" : '');
+        $newPreviousKeys = $this->laravel['config']['app.key'].($previousKeys ? ",$previousKeys" : '');
 
         $replaced = preg_replace(
             $this->previousKeyAddPattern($previousKeys),


### PR DESCRIPTION
It will need a fix on .env.example into the Laravel project to add the APP_PREVIOUS_KEYS by default in .env

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
