### PR TITLE
[11.x] Use a generic message for ValidationException

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -91,15 +91,11 @@ class ValidationException extends Exception
             return 'The given data was invalid.';
         }
 
-        $message = array_shift($messages);
+        $amount = count($messages);
 
-        if ($additional = count($messages)) {
-            $pluralized = $additional === 1 ? 'error' : 'errors';
+        $pluralized = $amount === 1 ? 'was one error' : "were {$amount} errors";
 
-            $message .= " (and {$additional} more {$pluralized})";
-        }
-
-        return $message;
+        return "There {$pluralized} with the given data.";
     }
 
     /**

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -544,7 +544,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The nested.0.name field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'nested' => [
                     [
@@ -580,7 +580,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The nested.0.name field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'nested' => [
                     [
@@ -611,7 +611,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The nested.0.name field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'nested' => [
                     [
@@ -642,7 +642,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The nested.0.name field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'nested' => [
                     [
@@ -690,7 +690,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The escaped.dot field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'escaped.dot' => [
                     'The escaped.dot field is required.',
@@ -720,7 +720,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The escaped.dot field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'escaped.dot' => [
                     'The escaped.dot field is required.',
@@ -745,7 +745,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The escaped.dot field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'escaped.dot' => [
                     'The escaped.dot field is required.',
@@ -770,7 +770,7 @@ class PrecognitionTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertExactJson([
-            'message' => 'The escaped.dot field is required.',
+            'message' => 'There was one error with the given data.',
             'errors' => [
                 'escaped.dot' => [
                     'The escaped.dot field is required.',

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -21,14 +21,14 @@ class ValidationExceptionTest extends TestCase
     {
         $exception = $this->getException([], ['foo' => 'required']);
 
-        $this->assertSame('validation.required', $exception->getMessage());
+        $this->assertSame('There was one error with the given data.', $exception->getMessage());
     }
 
     public function testExceptionSummarizesTwoErrors()
     {
         $exception = $this->getException([], ['foo' => 'required', 'bar' => 'required']);
 
-        $this->assertSame('validation.required (and 1 more error)', $exception->getMessage());
+        $this->assertSame('There were 2 errors with the given data.', $exception->getMessage());
     }
 
     public function testExceptionSummarizesThreeOrMoreErrors()
@@ -39,7 +39,7 @@ class ValidationExceptionTest extends TestCase
             'baz' => 'required',
         ]);
 
-        $this->assertSame('validation.required (and 2 more errors)', $exception->getMessage());
+        $this->assertSame('There were 3 errors with the given data.', $exception->getMessage());
     }
 
     public function testExceptionErrorZeroErrors()


### PR DESCRIPTION
This PR partially reverts https://github.com/laravel/framework/pull/35524 without any breaking changes. 

Since this message is not something that ever should reach an end user, these should also never be translated. Because we're pulling messages from the error bag of the validator, part of the message was translated, while the other one we computed wasn't. The original intent of https://github.com/laravel/framework/pull/35524 of showing the first error message was good but it's at the same time weird to just show the first error message and not the other potential ones. Since the error messages are user-facing and the exception message developer facing, we've decided to move this exception message back to a generic one. Also to prevent issues like https://github.com/laravel/framework/issues/50534.