### PR TITLE
[11.x] Removes unused Dumpable trait

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -22,7 +22,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
-use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -31,7 +30,7 @@ use RuntimeException;
 
 class Builder implements BuilderContract
 {
-    use BuildsQueries, Dumpable, ExplainsQueries, ForwardsCalls, Macroable {
+    use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }
 


### PR DESCRIPTION
When the `Dumpable` trait was added [here](https://github.com/laravel/framework/pull/47122/files#diff-2ed94a0ea151404a12f3c0d52ae9fb5742348578ec4a8ff79d079fa598ff145dL3883), you can see that the `dd()` method was removed. However, I noticed that it has been reintroduced (maybe when merging [10.x] to [11.x]). Consequently, for the `Builder` class, the trait is never used; its methods are being overridden by the local ones, which display the raw SQL and its bindings.