### PR TITLE
[11.x] Improved translation for displaying the count of errors in the validation message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -96,7 +96,7 @@ class ValidationException extends Exception
         if ($count = count($messages)) {
             $pluralized = $count === 1 ? 'error' : 'errors';
 
-            $message .= ' '.$validator->getTranslator()->get("(and :count more $pluralized)", compact('count'));
+            $message .= ' '.$validator->getTranslator()->choice("(and :count more $pluralized)", $count, compact('count'));
         }
 
         return $message;

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -42,6 +42,74 @@ class ValidationExceptionTest extends TestCase
         $this->assertSame('validation.required (and 2 more errors)', $exception->getMessage());
     }
 
+    public function testExceptionTranslatedSummarizesTwoErrors()
+    {
+        $translator = $this->getTranslator('uk', [
+            '*' => [
+                '*' => [
+                    'uk' => [
+                        '(and :count more error)' => '(та ще :count помилка)',
+                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                    ],
+                ],
+            ],
+        ]);
+
+        $exception = $this->getException([], [
+            'foo' => 'required',
+            'bar' => 'required',
+        ], $translator);
+
+        $this->assertSame('validation.required (та ще 1 помилка)', $exception->getMessage());
+    }
+
+    public function testExceptionTranslatedSummarizesThreeOrMoreErrors()
+    {
+        $translator = $this->getTranslator('uk', [
+            '*' => [
+                '*' => [
+                    'uk' => [
+                        '(and :count more error)' => '(та ще :count помилка)',
+                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                    ],
+                ],
+            ],
+        ]);
+
+        $exception = $this->getException([], [
+            'foo' => 'required',
+            'bar' => 'required',
+            'baz' => 'required',
+        ], $translator);
+
+        $this->assertSame('validation.required (та ще 2 помилки)', $exception->getMessage());
+    }
+
+    public function testExceptionTranslatedSummarizesFiveOrMoreErrors()
+    {
+        $translator = $this->getTranslator('uk', [
+            '*' => [
+                '*' => [
+                    'uk' => [
+                        '(and :count more error)' => '(та ще :count помилка)',
+                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                    ],
+                ],
+            ],
+        ]);
+
+        $exception = $this->getException([], [
+            'foo' => 'required',
+            'bar' => 'required',
+            'baz' => 'required',
+            'baq' => 'required',
+            'baw' => 'required',
+            'bae' => 'required',
+        ], $translator);
+
+        $this->assertSame('validation.required (та ще 5 помилок)', $exception->getMessage());
+    }
+
     public function testExceptionErrorZeroErrors()
     {
         $exception = $this->getException([], []);
@@ -96,17 +164,26 @@ class ValidationExceptionTest extends TestCase
         $this->assertEquals(ValidationException::class, $exception);
     }
 
-    protected function getException($data = [], $rules = [])
+    protected function getException($data = [], $rules = [], $translator = null)
     {
-        $validator = $this->getValidator($data, $rules);
+        $validator = $this->getValidator($data, $rules, $translator);
 
         return new ValidationException($validator);
     }
 
-    protected function getValidator($data = [], $rules = [])
+    protected function getValidator($data = [], $rules = [], $translator = null)
     {
-        $translator = new Translator(new ArrayLoader, 'en');
+        $translator ??= $this->getTranslator();
 
         return new Validator($translator, $data, $rules);
+    }
+
+    protected function getTranslator($locale = 'en', $loaded = [])
+    {
+        $translator ??= new Translator(new ArrayLoader, $locale);
+
+        $translator->setLoaded($loaded);
+
+        return $translator;
     }
 }


### PR DESCRIPTION
The https://github.com/laravel/framework/pull/50546 (this is a fix for https://github.com/laravel/framework/issues/50534) solved the problem of message translation. I now propose to consider improving the translation of plurals.

In English, the plural will always be "plural", but in other languages, such as Ukrainian, Russian and many others, the plural has two forms.

For example:
| Count | English | Russian | Ukrainian |
|:---:|:---:|:---:|:---:|
| 1 | error | ошибка | помилка |
| 2 | errors | ошибки | помилки |
| 5 | errors | ошибок | помилок |

It turns out that now, even with the translation, there will be an incorrect definition of the plural form. For example, "и ещё 4 ошибок". There is a grammatical error here and it is correct to write "и ещё 4 ошибки".

Thus, we come to the point where we can not only bring back the old functionality I added earlier, but also improve it. What do you think about that?

```jsonc
// uk.json
{
    "(and :count more error)": "(та ще :count помилка)"
    "(and :count more errors)": "(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)"
}
```
In this way, the current structure of phrase formation will be preserved, and it will also make it possible to do grammatically correct translations into different languages with multiple forms of plurals.