### PR TITLE
[11.x] Adds `throwReportedExceptions`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -82,12 +82,12 @@ trait InteractsWithExceptionHandling
         property_exists($handler, 'throwReportedExceptions')
             ? $handler->throwReportedExceptions = $throwReportedExceptions
             : (fn () => $this->reportCallbacks = [
-                    new ReportableHandler(function (Throwable $e) use ($throwReportedExceptions) {
-                        if (collect($throwReportedExceptions)->contains(fn ($class) => $e instanceof $class)) {
-                            throw $e;
-                        }
-                    }), ...$this->reportCallbacks,
-                ])->call($handler);
+                new ReportableHandler(function (Throwable $e) use ($throwReportedExceptions) {
+                    if (collect($throwReportedExceptions)->contains(fn ($class) => $e instanceof $class)) {
+                        throw $e;
+                    }
+                }), ...$this->reportCallbacks,
+            ])->call($handler);
 
         return $this;
     }

--- a/tests/Foundation/Testing/Concerns/InteractsWithExceptionHandlingTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithExceptionHandlingTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing\Concerns;
+
+use Exception;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class InteractsWithExceptionHandlingTest extends TestCase
+{
+    public function testReportedExceptionsAreNotThrownByDefault()
+    {
+        report(new Exception('Test exception'));
+
+        $this->assertTrue(true);
+    }
+
+    public function testReportedExceptionsAreNotThrownByDefaultWithExceptionHandling()
+    {
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->get('/')->assertStatus(200);
+    }
+
+    public function testReportedExceptionsAreNotThrownByDefaultWithoutExceptionHandling()
+    {
+        $this->withoutExceptionHandling();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->get('/')->assertStatus(200);
+    }
+
+    public function testReportedExceptionsAreThrownWhenRequested()
+    {
+        $this->throwReportedExceptions();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        report(new Exception('Test exception'));
+    }
+
+    public function testReportedExceptionsAreThrownWhenRequestedWithExceptionHandling()
+    {
+        $this->throwReportedExceptions();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->get('/');
+    }
+
+    public function testReportedExceptionsAreThrownWhenRequestedWithoutExceptionHandling()
+    {
+        $this->withoutExceptionHandling()->throwReportedExceptions();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->get('/');
+    }
+
+    public function testReportedExceptionsAreThrownRegardlessOfTheCallingOrderOfWithoutExceptionHandling()
+    {
+        $this->throwReportedExceptions()
+            ->withoutExceptionHandling()
+            ->withExceptionHandling()
+            ->withoutExceptionHandling();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->get('/');
+    }
+
+    public function testReportedExceptionsAreThrownRegardlessOfTheCallingOrderOfWithExceptionHandling()
+    {
+        $this->throwReportedExceptions()
+            ->withoutExceptionHandling()
+            ->withExceptionHandling()
+            ->withoutExceptionHandling()
+            ->withExceptionHandling();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->get('/');
+    }
+}

--- a/tests/Foundation/Testing/Concerns/InteractsWithExceptionHandlingTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithExceptionHandlingTest.php
@@ -3,8 +3,12 @@
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
 use Exception;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Route;
+use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
+use Throwable;
 
 class InteractsWithExceptionHandlingTest extends TestCase
 {
@@ -106,5 +110,110 @@ class InteractsWithExceptionHandlingTest extends TestCase
         $this->expectExceptionMessage('Test exception');
 
         $this->get('/');
+    }
+
+    public function testOnlySpecifiedExceptionsAreThrown()
+    {
+        $this->throwReportedExceptions([InvalidArgumentException::class]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        report(new Exception('Test exception'));
+        report(new RuntimeException('Test exception'));
+        report(new InvalidArgumentException('Test exception'));
+    }
+
+    public function testOnlySpecifiedExceptionsAreThrownWithExceptionHandling()
+    {
+        $this->throwReportedExceptions([InvalidArgumentException::class]);
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+            report(new RuntimeException('Test exception'));
+            report(new InvalidArgumentException('Test exception'));
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->get('/');
+    }
+
+    public function testOnlySpecifiedExceptionsAreThrownWithoutExceptionHandling()
+    {
+        $this->withoutExceptionHandling()->throwReportedExceptions([InvalidArgumentException::class]);
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+            report(new RuntimeException('Test exception'));
+            report(new InvalidArgumentException('Test exception'));
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->get('/');
+    }
+
+    public function testReportedExceptionsAreThrowEvenWhenAppReportablesReturnFalse()
+    {
+        app(ExceptionHandler::class)->reportable(function (Throwable $e) {
+            return false;
+        });
+
+        $this->throwReportedExceptions();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        report(new Exception('Test exception'));
+    }
+
+    public function testReportedExceptionsAreThrowEvenWhenAppReportablesReturnFalseWithExceptionHandling()
+    {
+        app(ExceptionHandler::class)->reportable(function (Throwable $e) {
+            return false;
+        });
+
+        $this->throwReportedExceptions();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->get('/');
+    }
+
+    public function testReportedExceptionsAreThrowEvenWhenAppReportablesReturnFalseWithoutExceptionHandling()
+    {
+        app(ExceptionHandler::class)->reportable(function (Throwable $e) {
+            return false;
+        });
+
+        $this->withoutExceptionHandling()->throwReportedExceptions();
+
+        Route::get('/', function () {
+            report(new Exception('Test exception'));
+        });
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->get('/');
+    }
+
+    public function testAppReportablesAreLeftUntouched()
+    {
+        app(ExceptionHandler::class)->reportable(function (Throwable $e) {
+            throw new InvalidArgumentException($e->getMessage());
+        });
+
+        $this->throwReportedExceptions([RuntimeException::class]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('My exception message');
+
+        report(new Exception('My exception message'));
     }
 }

--- a/tests/Foundation/Testing/Concerns/InteractsWithExceptionHandlingTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithExceptionHandlingTest.php
@@ -81,7 +81,7 @@ class InteractsWithExceptionHandlingTest extends TestCase
             ->withoutExceptionHandling();
 
         Route::get('/', function () {
-            report(new Exception('Test exception'));
+            rescue(fn () => throw new Exception('Test exception'));
         });
 
         $this->expectException(Exception::class);
@@ -99,7 +99,7 @@ class InteractsWithExceptionHandlingTest extends TestCase
             ->withExceptionHandling();
 
         Route::get('/', function () {
-            report(new Exception('Test exception'));
+            rescue(fn () => throw new Exception('Test exception'));
         });
 
         $this->expectException(Exception::class);


### PR DESCRIPTION
Inspired by https://x.com/ganyicz/status/1767987824320512271?s=20, this pull request adds `throwReportedExceptions` to our testing component. Sometimes, we are silencing a few exceptions because we are in production. However, in testing, we probably want to catch those:

```php
<?php

Route::get('/reports/generate', function () {
    // Generate the report...

    rescue(function () {
        // Perform clean up... (but throws an exception) ❌
    });
});

it('before', function () {
    $this->get('/reports/generate'); // All good, even if clean up fails... 😢
});

it('after', function () {
    // Instructs Laravel to thrown exceptions within "rescue" or passed to "report" function...
    $this->throwReportedExceptions();

    $this->get('/reports/generate'); // Exception here... ❌ 😎
});
```

You can also only throw specific reported exceptions like so:

```php
test('example', function () {
        $this->throwReportedExceptions([InvalidArgumentException::class]);

        report(new Exception('Test exception'));
        report(new RuntimeException('Test exception'));
        report(new InvalidArgumentException('Test exception')); ❌ This one will make fail the test...
});
```

Finally, please be aware that `throwReportedExceptions` takes precedence on any application reportable that may return `false`:

```php
->withExceptions(function (Exceptions $exceptions) {
    $exceptions->reportable(function (Throwable $e) {
        if ($e instanceof InvalidArgumentException) {
             // report to xyz instead...

             return false;
        }
    });
})

test('example', function () {
        $this->throwReportedExceptions();
        
        report(new InvalidArgumentException('Test exception')); ❌ This one will still make the test fail
});
```