### PR TITLE
[11.x] Fix withRouting docblock type

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -129,7 +129,7 @@ class ApplicationBuilder
      * @param  string|null  $commands
      * @param  string|null  $channels
      * @param  string|null  $pages
-     * @param  string|null  $apiPrefix
+     * @param  string  $apiPrefix
      * @param  callable|null  $then
      * @return $this
      */


### PR DESCRIPTION
The docblock type definition for the `withRoute` is accepting `string|null` for api prefix, but It should only accept `string`


```php
    /**
     * Register the routing services for the application.
     *
     * @param  \Closure|null  $using
     * @param  string|null  $web
     * @param  string|null  $api
     * @param  string|null  $commands
     * @param  string|null  $channels
     * @param  string|null  $pages
     * @param  string|null  $apiPrefix <--- it should be string only
     * @param  callable|null  $then
     * @return $this
     */
    public function withRouting(?Closure $using = null,
        ?string $web = null,
        ?string $api = null,
        ?string $commands = null,
        ?string $channels = null,
        ?string $pages = null,
        ?string $health = null,
        string $apiPrefix = 'api',
        ?callable $then = null)
```  

It leads VSCode to show this kind of error:

<img width="539" alt="image" src="https://github.com/laravel/framework/assets/7565417/a1993918-c25c-435a-bbd6-2bd29d808058">
