### PR TITLE
[11.x] Add make:service Command to Laravel

### DIFF
--- a/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'make:service')]
-class ServiceMakeCommand  extends GeneratorCommand
+class ServiceMakeCommand extends GeneratorCommand
 {
     /**
      * The console command name.

--- a/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:service')]
+class ServiceMakeCommand  extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:service';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new service class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Service';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub(): string
+    {
+        return __DIR__.'/stubs/service.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions(): array
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the service even if the service already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/service.stub
+++ b/src/Illuminate/Foundation/Console/stubs/service.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+    //
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -75,6 +75,7 @@ use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ScopeMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Foundation\Console\ServiceMakeCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Foundation\Console\StorageUnlinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
@@ -217,6 +218,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'SeederMake' => SeederMakeCommand::class,
         'SessionTable' => SessionTableCommand::class,
         'Serve' => ServeCommand::class,
+        'ServiceMake' => ServiceMakeCommand::class,
         'StubPublish' => StubPublishCommand::class,
         'TestMake' => TestMakeCommand::class,
         'TraitMake' => TraitMakeCommand::class,
@@ -847,6 +849,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(SeedCommand::class, function ($app) {
             return new SeedCommand($app['db']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerServiceMakeCommand()
+    {
+        $this->app->singleton(ServiceMakeCommand::class, function ($app) {
+            return new ServiceMakeCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Generators/ServiceMakeCommandTest.php
+++ b/tests/Integration/Generators/ServiceMakeCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
-class ServiceMakeCommandTest  extends TestCase
+class ServiceMakeCommandTest extends TestCase
 {
     protected $files = [
         'app/FooService.php',

--- a/tests/Integration/Generators/ServiceMakeCommandTest.php
+++ b/tests/Integration/Generators/ServiceMakeCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Generators;
+
+class ServiceMakeCommandTest  extends TestCase
+{
+    protected $files = [
+        'app/FooService.php',
+    ];
+
+    public function testItCanGenerateServiceFile()
+    {
+        $this->artisan('make:service', ['name' => 'FooService'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App;',
+            'class FooService',
+        ], 'app/FooService.php');
+    }
+}


### PR DESCRIPTION
This PR  adds the `make:service` command to the Laravel framework. This new command allows developers to easily create and add new services to their projects. 

### Main changes include:

- Adding files related to the `make:service` command
- Adding corresponding tests

With Artisan now adorned with commands to create Traits, Interfaces, and Enums more elegantly than ever before, I believe that adding the ability to automatically generate services with the `make:service` command in Artisan would greatly improve the quality of our code and the testability of our logic.

Hopefully, this feature will be added to Artisan.

Thanks!