### PR TITLE
[11.x] Fix docblock in FakeInvokedProcess.php

### DIFF
--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -290,7 +290,7 @@ class FakeInvokedProcess implements InvokedProcessContract
     /**
      * Set the general output handler for the fake invoked process.
      *
-     * @param  callable|null  $output
+     * @param  callable|null  $outputHandler
      * @return $this
      */
     public function withOutputHandler(?callable $outputHandler)


### PR DESCRIPTION
In this PR, a doc block related to the method `withOutputHandler` has been updated, where the parameter name in the doc block did not match the input parameter of the method.