### PR TITLE
[11.x]  Added notifiable connection property to specify database connection for notifications

### DIFF
--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -11,7 +11,7 @@ trait HasDatabaseNotifications
      */
     public function notifications()
     {
-        return $this->morphMany(DatabaseNotification::class, 'notifiable')->latest();
+        return $this->setConnection($this->getNotifiableConnectionName())->morphMany(DatabaseNotification::class, 'notifiable')->latest();
     }
 
     /**
@@ -32,5 +32,16 @@ trait HasDatabaseNotifications
     public function unreadNotifications()
     {
         return $this->notifications()->unread();
+    }
+
+    /**
+     * Get updatable notifiable connection property
+     *
+     * @return string
+     */
+
+    public function getNotifiableConnectionName()
+    {
+        return $this->notifiableConnection ?: $this->connection;
     }
 }

--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -11,7 +11,9 @@ trait HasDatabaseNotifications
      */
     public function notifications()
     {
-        return $this->setConnection($this->getNotifiableConnectionName())->morphMany(DatabaseNotification::class, 'notifiable')->latest();
+        return $this->setConnection($this->getNotifiableConnectionName())
+                    ->morphMany(DatabaseNotification::class, 'notifiable')
+                    ->latest();
     }
 
     /**

--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -37,7 +37,7 @@ trait HasDatabaseNotifications
     }
 
     /**
-     * Get updatable notifiable connection property
+     * Get updatable notifiable connection property.
      *
      * @return string
      */

--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -39,7 +39,6 @@ trait HasDatabaseNotifications
      *
      * @return string
      */
-
     public function getNotifiableConnectionName()
     {
         return $this->notifiableConnection ?: $this->connection;


### PR DESCRIPTION
**Description:**

This pull request addresses the issue where Laravel's notification system does not behave as expected when dealing with models stored in secondary or legacy databases (introduced at issue #50564). Currently, notifications attempt to store themselves using the database connection of the notifiable model, even if it's not the primary Laravel connection.

To solve this problem, this pull request introduces a new `$notifiableConnection` property to the Illuminate\Notifications\Notifiable trait. This property allows developers to specify the database connection to be used for notifications, overriding the connection specified in the notifiable model as new feature for 11.x

**Usage:**

```
class Teacher extends Model
{
    use Notifiable;

    protected $connection = 'secondary-connection';

    protected $notifiableConnection = 'primary-connection';
}
```

**Testing:**

- Integration tests have been conducted to verify the behavior of notifications across different database connections.

**Any feedback or suggestions for improvement are welcome.**