### PR TITLE
[11.x] fix: Add missing InvalidArgumentException import to Database/Schema/SqlServerBuilder

### DIFF
--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Database\Schema;
+
 use InvalidArgumentException;
 
 class SqlServerBuilder extends Builder

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Database\Schema;
+use InvalidArgumentException;
 
 class SqlServerBuilder extends Builder
 {


### PR DESCRIPTION
- Ensured `InvalidArgumentException` is recognized in SqlServerBuilde, mirroring PostgresBuilder.php's approach.

This commit corrects the oversight of not including `use InvalidArgumentException;` in SqlServerBuilder, aligning exception handling with PostgresBuilder's strategy.