### PR TITLE
[11.x] Use available `getPath()` instead of using `app_path()` to detect if base controller exists

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -127,7 +127,7 @@ class ControllerMakeCommand extends GeneratorCommand
             $replace['abort(404);'] = '//';
         }
 
-        $baseControllerExists = file_exists(app_path('Http/Controllers/Controller.php'));
+        $baseControllerExists = file_exists($this->getPath("{$rootNamespace}Http\Controllers\Controller"));
 
         if ($baseControllerExists) {
             $replace["use {$controllerNamespace}\Controller;\n"] = '';

--- a/tests/Integration/Generators/ControllerMakeCommandTest.php
+++ b/tests/Integration/Generators/ControllerMakeCommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Generators;
 class ControllerMakeCommandTest extends TestCase
 {
     protected $files = [
+        'app/Http/Controllers/Controller.php',
         'app/Http/Controllers/FooController.php',
         'app/Models/Bar.php',
         'app/Models/Foo.php',
@@ -23,7 +24,31 @@ class ControllerMakeCommandTest extends TestCase
         ], 'app/Http/Controllers/FooController.php');
 
         $this->assertFileNotContains([
+            'class FooController extends Controller',
             'public function __invoke(Request $request)',
+        ], 'app/Http/Controllers/FooController.php');
+
+        $this->assertFilenameNotExists('tests/Feature/Http/Controllers/FooControllerTest.php');
+    }
+
+    public function testItCanGenerateControllerFileWhenBaseControllerExists()
+    {
+        $this->artisan('make:controller', ['name' => 'Controller'])
+            ->assertExitCode(0);
+
+        $this->artisan('make:controller', ['name' => 'FooController'])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Http\Controllers;',
+            'use Illuminate\Http\Request;',
+            'class Controller',
+        ], 'app/Http/Controllers/Controller.php');
+
+        $this->assertFileContains([
+            'namespace App\Http\Controllers;',
+            'use Illuminate\Http\Request;',
+            'class FooController extends Controller',
         ], 'app/Http/Controllers/FooController.php');
 
         $this->assertFilenameNotExists('tests/Feature/Http/Controllers/FooControllerTest.php');


### PR DESCRIPTION

This would be useful for custom packages generator on top of Laravel's default `make:controller`

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
