### PR TITLE
[11.x] Created a `markdown` helper to utilise the `Illuminate\Mail\Markdown` class

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/footer.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/footer.blade.php
@@ -3,7 +3,7 @@
 <table class="footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
 <tr>
 <td class="content-cell" align="center">
-{{ Illuminate\Mail\Markdown::parse($slot) }}
+{{ markdown()->parse($slot) }}
 </td>
 </tr>
 </table>

--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -39,7 +39,7 @@ width: 100% !important;
 <!-- Body content -->
 <tr>
 <td class="content-cell">
-{{ Illuminate\Mail\Markdown::parse($slot) }}
+{{ markdown()->parse($slot) }}
 
 {{ $subcopy ?? '' }}
 </td>

--- a/src/Illuminate/Mail/resources/views/html/panel.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/panel.blade.php
@@ -4,7 +4,7 @@
 <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
 <tr>
 <td class="panel-item">
-{{ Illuminate\Mail\Markdown::parse($slot) }}
+{{ markdown()->parse($slot) }}
 </td>
 </tr>
 </table>

--- a/src/Illuminate/Mail/resources/views/html/subcopy.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/subcopy.blade.php
@@ -1,7 +1,7 @@
 <table class="subcopy" width="100%" cellpadding="0" cellspacing="0" role="presentation">
 <tr>
 <td>
-{{ Illuminate\Mail\Markdown::parse($slot) }}
+{{ markdown()->parse($slot) }}
 </td>
 </tr>
 </table>

--- a/src/Illuminate/Mail/resources/views/html/table.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/table.blade.php
@@ -1,3 +1,3 @@
 <div class="table">
-{{ Illuminate\Mail\Markdown::parse($slot) }}
+{{ markdown()->parse($slot) }}
 </div>

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,15 +1,17 @@
 <?php
 
-use Illuminate\Contracts\Support\DeferringDisplayableValue;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
-use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Str;
 use Illuminate\Support\Once;
+use Illuminate\Mail\Markdown;
+use Illuminate\Support\Sleep;
 use Illuminate\Support\Onceable;
 use Illuminate\Support\Optional;
-use Illuminate\Support\Sleep;
-use Illuminate\Support\Str;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Contracts\Support\DeferringDisplayableValue;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 
 if (! function_exists('append_config')) {
     /**
@@ -470,3 +472,28 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('markdown')) {
+    /**
+     * Create a new Markdown instance.
+     *
+     * @param ViewFactory|null $view
+     * @param array $options
+     * @return \Illuminate\Mail\Markdown|mixed
+     */
+    function markdown(?ViewFactory $view = null, array $options = [])
+    {
+        if (func_num_args() === 0) {
+            return new class
+            {
+                public function __call($method, $parameters)
+                {
+                    return Markdown::$method(...$parameters);
+                }
+            };
+        }
+
+        return new Markdown($view, $options);
+    }
+}
+


### PR DESCRIPTION
I have created a markdown helper function to reduce the utilisation of classes within the blade components.

- [x] Added a function to the helpers file that will use the Markdown class
- [x] Updated the mail blade components which utilises the Markdown class