### PR TITLE
[11.x] `afterQuery` hook

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -901,7 +901,7 @@ class Builder implements BuilderContract
             $model = $this->newModelInstance()->newFromBuilder($record);
 
             return $this->applyAfterQueryCallbacks($this->newModelInstance()->newCollection([$model]))->first();
-        });
+        })->reject(fn ($item) => is_null($item));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -731,9 +731,9 @@ class Builder implements BuilderContract
             $models = $builder->eagerLoadRelations($models);
         }
 
-        $models = $builder->getModel()->newCollection($models);
-
-        return $this->applyAfterQueryCallbacks($models);
+        return $this->applyAfterQueryCallbacks(
+            $builder->getModel()->newCollection($models)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -898,7 +898,11 @@ class Builder implements BuilderContract
     public function cursor()
     {
         return $this->applyScopes()->query->cursor()->map(function ($record) {
-            return $this->newModelInstance()->newFromBuilder($record);
+            $model = $this->newModelInstance()->newFromBuilder($record);
+
+            $this->applyAfterQueryCallbacks($this->newModelInstance()->newCollection([$model]));
+
+            return $model;
         });
     }
 
@@ -938,9 +942,13 @@ class Builder implements BuilderContract
             return $results;
         }
 
-        return $results->map(function ($value) use ($column) {
+        $results = $results->map(function ($value) use ($column) {
             return $this->model->newFromBuilder([$column => $value])->{$column};
         });
+
+        $this->applyAfterQueryCallbacks($results);
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -715,32 +715,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Register a closure to be invoked after the query is executed.
-     *
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function afterQuery(Closure $callback)
-    {
-        $this->afterQueryCallbacks[] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Invoke the "after query" modification callbacks.
-     *
-     * @param  mixed  $result
-     * @return void
-     */
-    public function applyAfterQueryCallbacks($result)
-    {
-        foreach ($this->afterQueryCallbacks as $afterQueryCallback) {
-            $afterQueryCallback($result);
-        }
-    }
-
-    /**
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
@@ -759,9 +733,7 @@ class Builder implements BuilderContract
 
         $models = $builder->getModel()->newCollection($models);
 
-        $this->applyAfterQueryCallbacks($models);
-
-        return $models;
+        return $this->applyAfterQueryCallbacks($models);
     }
 
     /**
@@ -888,6 +860,34 @@ class Builder implements BuilderContract
     protected function isNestedUnder($relation, $name)
     {
         return str_contains($name, '.') && str_starts_with($name, $relation.'.');
+    }
+
+    /**
+     * Register a closure to be invoked after the query is executed.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function afterQuery(Closure $callback)
+    {
+        $this->afterQueryCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Invoke the "after query" modification callbacks.
+     *
+     * @param  mixed  $result
+     * @return mixed
+     */
+    public function applyAfterQueryCallbacks($result)
+    {
+        foreach ($this->afterQueryCallbacks as $afterQueryCallback) {
+            $result = $afterQueryCallback($result) ?: $result;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -730,7 +730,7 @@ class Builder implements BuilderContract
     /**
      * Invoke the "after query" modification callbacks.
      *
-     * @param  mixed $result
+     * @param  mixed  $result
      * @return void
      */
     public function applyAfterQueryCallbacks($result)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -900,9 +900,7 @@ class Builder implements BuilderContract
         return $this->applyScopes()->query->cursor()->map(function ($record) {
             $model = $this->newModelInstance()->newFromBuilder($record);
 
-            $this->applyAfterQueryCallbacks($this->newModelInstance()->newCollection([$model]));
-
-            return $model;
+            return $this->applyAfterQueryCallbacks($this->newModelInstance()->newCollection([$model]))->first();
         });
     }
 
@@ -942,13 +940,11 @@ class Builder implements BuilderContract
             return $results;
         }
 
-        $results = $results->map(function ($value) use ($column) {
-            return $this->model->newFromBuilder([$column => $value])->{$column};
-        });
-
-        $this->applyAfterQueryCallbacks($results);
-
-        return $results;
+        return $this->applyAfterQueryCallbacks(
+            $results->map(function ($value) use ($column) {
+                return $this->model->newFromBuilder([$column => $value])->{$column};
+            })
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -901,7 +901,7 @@ class Builder implements BuilderContract
             $model = $this->newModelInstance()->newFromBuilder($record);
 
             return $this->applyAfterQueryCallbacks($this->newModelInstance()->newCollection([$model]))->first();
-        })->reject(fn ($item) => is_null($item));
+        })->reject(fn ($model) => is_null($model));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -20,7 +20,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
-use Laravel\SerializableClosure\Support\ReflectionClosure;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -732,7 +731,6 @@ class Builder implements BuilderContract
      * Invoke the "after query" modification callbacks.
      *
      * @param  mixed $result
-     *
      * @return void
      */
     public function applyAfterQueryCallbacks($result)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -883,7 +883,11 @@ class BelongsToMany extends Relation
             $models = $builder->eagerLoadRelations($models);
         }
 
-        return $this->related->newCollection($models);
+        $models = $this->related->newCollection($models);
+
+        $this->query->applyAfterQueryCallbacks($models);
+
+        return $models;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -885,9 +885,7 @@ class BelongsToMany extends Relation
 
         $models = $this->related->newCollection($models);
 
-        $this->query->applyAfterQueryCallbacks($models);
-
-        return $models;
+        return $this->query->applyAfterQueryCallbacks($models);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -883,9 +883,9 @@ class BelongsToMany extends Relation
             $models = $builder->eagerLoadRelations($models);
         }
 
-        $models = $this->related->newCollection($models);
-
-        return $this->query->applyAfterQueryCallbacks($models);
+        return $this->query->applyAfterQueryCallbacks(
+            $this->related->newCollection($models)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -505,9 +505,9 @@ class HasManyThrough extends Relation
             $models = $builder->eagerLoadRelations($models);
         }
 
-        $models = $this->related->newCollection($models);
-
-        return $this->query->applyAfterQueryCallbacks($models);
+        return $this->query->applyAfterQueryCallbacks(
+            $this->related->newCollection($models)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -505,7 +505,11 @@ class HasManyThrough extends Relation
             $models = $builder->eagerLoadRelations($models);
         }
 
-        return $this->related->newCollection($models);
+        $models = $this->related->newCollection($models);
+
+        $this->query->applyAfterQueryCallbacks($models);
+
+        return $models;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -507,9 +507,7 @@ class HasManyThrough extends Relation
 
         $models = $this->related->newCollection($models);
 
-        $this->query->applyAfterQueryCallbacks($models);
-
-        return $models;
+        return $this->query->applyAfterQueryCallbacks($models);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2704,6 +2704,34 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Register a closure to be invoked after the query is executed.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function afterQuery(Closure $callback)
+    {
+        $this->afterQueryCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Invoke the "after query" modification callbacks.
+     *
+     * @param  mixed  $result
+     * @return mixed
+     */
+    public function applyAfterQueryCallbacks($result)
+    {
+        foreach ($this->afterQueryCallbacks as $afterQueryCallback) {
+            $result = $afterQueryCallback($result) ?: $result;
+        }
+
+        return $result;
+    }
+
+    /**
      * Get the SQL representation of the query.
      *
      * @return string
@@ -2806,32 +2834,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Register a closure to be invoked after the query is executed.
-     *
-     * @param  \Closure  $callback
-     * @return $this
-     */
-    public function afterQuery(Closure $callback)
-    {
-        $this->afterQueryCallbacks[] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Invoke the "after query" modification callbacks.
-     *
-     * @param  mixed  $result
-     * @return void
-     */
-    public function applyAfterQueryCallbacks($result)
-    {
-        foreach ($this->afterQueryCallbacks as $afterQueryCallback) {
-            $afterQueryCallback($result);
-        }
-    }
-
-    /**
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
@@ -2843,11 +2845,9 @@ class Builder implements BuilderContract
             return $this->processor->processSelect($this, $this->runSelect());
         }));
 
-        $items = isset($this->groupLimit) ? $this->withoutGroupLimitKeys($items) : $items;
-
-        $this->applyAfterQueryCallbacks($items);
-
-        return $items;
+        return $this->applyAfterQueryCallbacks(
+            isset($this->groupLimit) ? $this->withoutGroupLimitKeys($items) : $items
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2821,7 +2821,7 @@ class Builder implements BuilderContract
     /**
      * Invoke the "after query" modification callbacks.
      *
-     * @param  mixed $result
+     * @param  mixed  $result
      * @return void
      */
     public function applyAfterQueryCallbacks($result)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3081,7 +3081,7 @@ class Builder implements BuilderContract
             );
         }))->map(function ($item) {
             return $this->applyAfterQueryCallbacks(collect([$item]))->first();
-        });
+        })->reject(fn ($item) => is_null($item));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -26,7 +26,6 @@ use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
-use Laravel\SerializableClosure\Support\ReflectionClosure;
 use LogicException;
 use RuntimeException;
 
@@ -2823,7 +2822,6 @@ class Builder implements BuilderContract
      * Invoke the "after query" modification callbacks.
      *
      * @param  mixed $result
-     *
      * @return void
      */
     public function applyAfterQueryCallbacks($result)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3079,8 +3079,8 @@ class Builder implements BuilderContract
             yield from $this->connection->cursor(
                 $this->toSql(), $this->getBindings(), ! $this->useWritePdo
             );
-        }))->each(function ($item) {
-            $this->applyAfterQueryCallbacks(collect([$item]));
+        }))->map(function ($item) {
+            return $this->applyAfterQueryCallbacks(collect([$item]))->first();
         });
     }
 
@@ -3130,13 +3130,11 @@ class Builder implements BuilderContract
 
         $key = $this->stripTableForPluck($key);
 
-        $results = is_array($queryResult[0])
+        return $this->applyAfterQueryCallbacks(
+            is_array($queryResult[0])
                     ? $this->pluckFromArrayColumn($queryResult, $column, $key)
-                    : $this->pluckFromObjectColumn($queryResult, $column, $key);
-
-        $this->applyAfterQueryCallbacks($results);
-
-        return $results;
+                    : $this->pluckFromObjectColumn($queryResult, $column, $key)
+        );
     }
 
     /**

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class AfterQueryTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->string('address');
+        });
+    }
+
+    public function testAfterQueryOnEloquentBuilder()
+    {
+        UserAfterQueryTest::create([
+            'name' => 'test-name-1',
+            'email' => 'test-email-1',
+            'address' => 'test-address-1',
+        ]);
+        UserAfterQueryTest::create([
+            'name' => 'test-name-2',
+            'email' => 'test-email-2',
+            'address' => 'test-address-2',
+        ]);
+
+        $afterQueryIds = collect();
+
+        $users = UserAfterQueryTest::query()
+            ->afterQuery(function (Collection $users) use ($afterQueryIds) {
+                $afterQueryIds->push(...$users->pluck('id')->all());
+
+                foreach ($users as $user) {
+                    $this->assertInstanceOf(UserAfterQueryTest::class, $user);
+                }
+            })
+            ->get();
+
+        $this->assertCount(2, $users);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
+    }
+
+    public function testAfterQueryOnBaseBuilder()
+    {
+        UserAfterQueryTest::create([
+            'name' => 'test-name-1',
+            'email' => 'test-email-1',
+            'address' => 'test-address-1',
+        ]);
+        UserAfterQueryTest::create([
+            'name' => 'test-name-2',
+            'email' => 'test-email-2',
+            'address' => 'test-address-2',
+        ]);
+
+        $afterQueryIds = collect();
+
+        $users = UserAfterQueryTest::query()
+            ->toBase()
+            ->afterQuery(function (Collection $users) use ($afterQueryIds) {
+                $afterQueryIds->push(...$users->pluck('id')->all());
+
+                foreach ($users as $user) {
+                    $this->assertNotInstanceOf(UserAfterQueryTest::class, $user);
+                }
+            })
+            ->get();
+
+        $this->assertCount(2, $users);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
+    }
+}
+
+class UserAfterQueryTest extends Model
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -76,6 +76,35 @@ class AfterQueryTest extends DatabaseTestCase
         $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
     }
 
+    public function testAfterQueryOnEloquentBuilderCanAlterReturnedResult()
+    {
+        AfterQueryUser::create();
+        AfterQueryUser::create();
+
+        $users = AfterQueryUser::query()
+            ->afterQuery(function () {
+                return collect(['foo', 'bar']);
+            })
+            ->get();
+
+        $this->assertEquals(collect(['foo', 'bar']), $users);
+    }
+
+    public function testAfterQueryOnBaseBuilderCanAlterReturnedResult()
+    {
+        AfterQueryUser::create();
+        AfterQueryUser::create();
+
+        $users = AfterQueryUser::query()
+            ->toBase()
+            ->afterQuery(function () {
+                return collect(['foo', 'bar']);
+            })
+            ->get();
+
+        $this->assertEquals(collect(['foo', 'bar']), $users);
+    }
+
     public function testAfterQueryOnEloquentCursor()
     {
         AfterQueryUser::create();

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -240,6 +240,14 @@ class AfterQueryTest extends DatabaseTestCase
 
         $this->assertEquals(collect(['foo', 'bar']), $users->collect());
 
+        $users = AfterQueryUser::query()
+            ->afterQuery(function ($users) use ($firstUser) {
+                return $users->where('id', '!=', $firstUser->id);
+            })
+            ->cursor();
+
+        $this->assertEquals([$secondUser->id], $users->collect()->pluck('id')->all());
+
         $firstPost = AfterQueryPost::create();
         $secondPost = AfterQueryPost::create();
 
@@ -300,6 +308,15 @@ class AfterQueryTest extends DatabaseTestCase
             ->cursor();
 
         $this->assertEquals(collect(['foo', 'bar']), $users->collect());
+
+        $users = AfterQueryUser::query()
+            ->toBase()
+            ->afterQuery(function ($users) use ($firstUser) {
+                return $users->where('id', '!=', $firstUser->id);
+            })
+            ->cursor();
+
+        $this->assertEquals([$secondUser->id], $users->collect()->pluck('id')->all());
 
         $firstPost = AfterQueryPost::create();
         $secondPost = AfterQueryPost::create();

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -13,33 +13,39 @@ class AfterQueryTest extends DatabaseTestCase
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
-            $table->string('email');
-            $table->string('address');
+            $table->integer('team_id')->nullable();
+        });
+
+        Schema::create('teams', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('owner_id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('users_posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('post_id');
+            $table->timestamps();
         });
     }
 
     public function testAfterQueryOnEloquentBuilder()
     {
-        UserAfterQueryTest::create([
-            'name' => 'test-name-1',
-            'email' => 'test-email-1',
-            'address' => 'test-address-1',
-        ]);
-        UserAfterQueryTest::create([
-            'name' => 'test-name-2',
-            'email' => 'test-email-2',
-            'address' => 'test-address-2',
-        ]);
+        AfterQueryUser::create();
+        AfterQueryUser::create();
 
         $afterQueryIds = collect();
 
-        $users = UserAfterQueryTest::query()
+        $users = AfterQueryUser::query()
             ->afterQuery(function (Collection $users) use ($afterQueryIds) {
                 $afterQueryIds->push(...$users->pluck('id')->all());
 
                 foreach ($users as $user) {
-                    $this->assertInstanceOf(UserAfterQueryTest::class, $user);
+                    $this->assertInstanceOf(AfterQueryUser::class, $user);
                 }
             })
             ->get();
@@ -50,26 +56,18 @@ class AfterQueryTest extends DatabaseTestCase
 
     public function testAfterQueryOnBaseBuilder()
     {
-        UserAfterQueryTest::create([
-            'name' => 'test-name-1',
-            'email' => 'test-email-1',
-            'address' => 'test-address-1',
-        ]);
-        UserAfterQueryTest::create([
-            'name' => 'test-name-2',
-            'email' => 'test-email-2',
-            'address' => 'test-address-2',
-        ]);
+        AfterQueryUser::create();
+        AfterQueryUser::create();
 
         $afterQueryIds = collect();
 
-        $users = UserAfterQueryTest::query()
+        $users = AfterQueryUser::query()
             ->toBase()
             ->afterQuery(function (Collection $users) use ($afterQueryIds) {
                 $afterQueryIds->push(...$users->pluck('id')->all());
 
                 foreach ($users as $user) {
-                    $this->assertNotInstanceOf(UserAfterQueryTest::class, $user);
+                    $this->assertNotInstanceOf(AfterQueryUser::class, $user);
                 }
             })
             ->get();
@@ -77,11 +75,89 @@ class AfterQueryTest extends DatabaseTestCase
         $this->assertCount(2, $users);
         $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
     }
+
+    public function testAfterQueryHookOnBelongsToManyRelationship()
+    {
+        $user = AfterQueryUser::create();
+        $firstPost = AfterQueryPost::create();
+        $secondPost = AfterQueryPost::create();
+
+        $user->posts()->attach($firstPost);
+        $user->posts()->attach($secondPost);
+
+        $afterQueryIds = collect();
+
+        $posts = $user->posts()
+            ->afterQuery(function (Collection $posts) use ($afterQueryIds) {
+                $afterQueryIds->push(...$posts->pluck('id')->all());
+
+                foreach ($posts as $post) {
+                    $this->assertInstanceOf(AfterQueryPost::class, $post);
+                }
+            })
+            ->get();
+
+        $this->assertCount(2, $posts);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $posts->pluck('id')->toArray());
+    }
+
+    public function testAfterQueryHookOnHasManyThroughRelationship()
+    {
+        $user = AfterQueryUser::create();
+        $team = AfterQueryTeam::create(['owner_id' => $user->id]);
+
+        AfterQueryUser::create(['team_id' => $team->id]);
+        AfterQueryUser::create(['team_id' => $team->id]);
+
+        $afterQueryIds = collect();
+
+        $teamMates = $user->teamMates()
+            ->afterQuery(function (Collection $teamMates) use ($afterQueryIds) {
+                $afterQueryIds->push(...$teamMates->pluck('id')->all());
+
+                foreach ($teamMates as $teamMate) {
+                    $this->assertInstanceOf(AfterQueryUser::class, $teamMate);
+                }
+            })
+            ->get();
+
+        $this->assertCount(2, $teamMates);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $teamMates->pluck('id')->toArray());
+    }
 }
 
-class UserAfterQueryTest extends Model
+class AfterQueryUser extends Model
 {
     protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function teamMates()
+    {
+        return $this->hasManyThrough(self::class, AfterQueryTeam::class, 'owner_id', 'team_id');
+    }
+
+    public function posts()
+    {
+        return $this->belongsToMany(AfterQueryPost::class, 'users_posts', 'user_id', 'post_id')->withTimestamps();
+    }
+}
+
+class AfterQueryTeam extends Model
+{
+    protected $table = 'teams';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function members()
+    {
+        return $this->hasMany(AfterQueryUser::class, 'team_id');
+    }
+}
+
+class AfterQueryPost extends Model
+{
+    protected $table = 'posts';
     protected $guarded = [];
     public $timestamps = false;
 }

--- a/tests/Integration/Database/AfterQueryTest.php
+++ b/tests/Integration/Database/AfterQueryTest.php
@@ -76,6 +76,92 @@ class AfterQueryTest extends DatabaseTestCase
         $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
     }
 
+    public function testAfterQueryOnEloquentCursor()
+    {
+        AfterQueryUser::create();
+        AfterQueryUser::create();
+
+        $afterQueryIds = collect();
+
+        $users = AfterQueryUser::query()
+            ->afterQuery(function (Collection $users) use ($afterQueryIds) {
+                $afterQueryIds->push(...$users->pluck('id')->all());
+
+                foreach ($users as $user) {
+                    $this->assertInstanceOf(AfterQueryUser::class, $user);
+                }
+            })
+            ->cursor();
+
+        $this->assertCount(2, $users);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
+    }
+
+    public function testAfterQueryOnBaseBuilderCursor()
+    {
+        AfterQueryUser::create();
+        AfterQueryUser::create();
+
+        $afterQueryIds = collect();
+
+        $users = AfterQueryUser::query()
+            ->toBase()
+            ->afterQuery(function (Collection $users) use ($afterQueryIds) {
+                $afterQueryIds->push(...$users->pluck('id')->all());
+
+                foreach ($users as $user) {
+                    $this->assertNotInstanceOf(AfterQueryUser::class, $user);
+                }
+            })
+            ->cursor();
+
+        $this->assertCount(2, $users);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $users->pluck('id')->toArray());
+    }
+
+    public function testAfterQueryOnEloquentPluck()
+    {
+        AfterQueryUser::create();
+        AfterQueryUser::create();
+
+        $afterQueryIds = collect();
+
+        $userIds = AfterQueryUser::query()
+            ->afterQuery(function (Collection $userIds) use ($afterQueryIds) {
+                $afterQueryIds->push(...$userIds->all());
+
+                foreach ($userIds as $userId) {
+                    $this->assertIsInt($userId);
+                }
+            })
+            ->pluck('id');
+
+        $this->assertCount(2, $userIds);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $userIds->toArray());
+    }
+
+    public function testAfterQueryOnBaseBuilderPluck()
+    {
+        AfterQueryUser::create();
+        AfterQueryUser::create();
+
+        $afterQueryIds = collect();
+
+        $userIds = AfterQueryUser::query()
+            ->toBase()
+            ->afterQuery(function (Collection $userIds) use ($afterQueryIds) {
+                $afterQueryIds->push(...$userIds->all());
+
+                foreach ($userIds as $userId) {
+                    $this->assertIsInt($userId);
+                }
+            })
+            ->pluck('id');
+
+        $this->assertCount(2, $userIds);
+        $this->assertEqualsCanonicalizing($afterQueryIds->toArray(), $userIds->toArray());
+    }
+
     public function testAfterQueryHookOnBelongsToManyRelationship()
     {
         $user = AfterQueryUser::create();


### PR DESCRIPTION
### Explanation

Query scopes (or custom query builder methods) can be used to add constraints to a query, but in my projects, I use them a lot to hide (complex) code to add extra data to every queried model. Most of the time that code can completely live inside a scope, but there are some cases where some extra code needs to be executed after running the query. That extra code currently needs to live outside of the scope. That also means you have to remember to add that extra code after every query that uses that scope. Would it not be nice if we could keep that code in the scope itself? That is what this PR makes possible by adding an `afterQuery` method.

```php
$query->afterQuery(function ($models) {
    // Make changes to the queried models ...
});
```

### Use cases

#### Set attributes or relations in certain situations

Let's say that you have a `withIsFavorite()` scope that queries a boolean attribute on every model based on the authenticated user. But if there is no authenticated user, then that boolean should just be false on every model. Using the `afterQuery()` method, you can easily set that attribute on every model if there is no authenticated user.

```php
// Before

public function scopeWithIsFavoriteOf($query, ?User $user = null) : void
{
    if ($user === null) {
        return $query;
    }

    $query->addSelect([
        // 'is_favorite' => some query ...
    ]);
}

$products = Product::withIsFavoriteOf(auth()->user())->get();

if (auth()->user() === null) {
    $products->each->setAttribute('is_favorite', false);
}
```

```php
// After

public function scopeWithIsFavoriteOf($query, ?User $user = null) : void
{
    if ($user === null) {
        $query->afterQuery(fn ($products) => $products->each->setAttribute('is_favorite', false));

        return;
    }

    $query->addSelect([
        // 'is_favorite' => some query ...
    ]);
}

Product::withIsFavoriteOf(auth()->user())->get();
```

The example above could probably be done inside a query as well, but in the next example that would not be possible. Let's say we want to load the event booking of the authenticated user on every event, but if there is no authenticated user, we want to set the relation to `null`. We can easily achieve this with the `afterQuery()` method

```php
// Before

public function scopeWithBookingOf($query, ?User $user = null) : void
{
    if ($user === null) {
        return $query;
    }

    $query->with([
        'booking' => function ($query) use ($user) {
            // ...
        }
    ]);
}

$events = Event::withBookingOf(auth()->user())->get();

if (auth()->user() === null) {
    $events->each->setRelation('booking', null);
}
```

```php
// After

public function scopeWithBookingOf($query, ?User $user = null) : void
{
    if ($user === null) {
        $query->afterQuery(fn ($users) => $users->each->setRelation('booking', null));

        return;
    }

    $query->with([
        'booking' => function ($query) use ($user) {
            // ...
        }
    ]);
}

Event::withBookingOf(auth()->user())->get();
```

#### Make changes to data after it has been queried

Another example is when you load some extra data / some special relationshp in your query, but when the models are hydrated, you need to make some changes to the models and their releationships. Again, the `afterQuery()` makes it possible to keep that code together.

```php
// Before

public function scopewithExtraData($query) : void
{
    $query->with('someRelation');
}

$models = Model::withExtraData()->get()->each(function ($model) {
    // making some changes to models and the loaded relation ...
});
```

```php
// After

public function scopewithExtraData($query) : void
{
    $query->with('someRelation')->afterQuery(function (Collection $models) {
        $models->each(function ($model) {
            // making some changes to models and the loaded relation ...
        });
    });
}

Model::withExtraData()->get();
```

#### Only load data on the queried models instead of querying that data immediately

Another use case is where you want to load some data through a subselect on a paginated query, but you only want to do that after you have fetched the models of the current page to keep the pagination query performant. You could achieve this by creating a custom eloquent collection class for that model and adding that code to a method in that custom collection class, but that is a lot of extra code and an extra class that you might not need for anything else. The `afterQuery()` method makes that a lot simpler.

```php
// Before

class UserCollection extends Collection
{
    public function loadHeadySubselectData()
    {
        // run a heavy query to get dat of selected users ...
    }
}

User::query()->paginate()->getCollection()-> loadHeadySubselectData();
```

```php
// After

public function scopewithHeadySubselectData($query)
{
    $query->afterQuery(function ($users) {
        // run a heavy query on those $users ...
    })
}

User::withHeadySubselectData()->paginate();
```