### PR TITLE
Adds a check for the existence of the `routes` directory before api installation

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -50,6 +50,10 @@ class ApiInstallCommand extends Command
         } else {
             $this->components->info('Published API routes file.');
 
+            $routesDir = $this->laravel->basePath('routes');
+            if (! file_exists($routesDir)) {
+                mkdir($routesDir);
+            }
             copy(__DIR__.'/stubs/api-routes.stub', $apiRoutesPath);
 
             if ($this->option('passport')) {


### PR DESCRIPTION
[Solves this issue](https://github.com/laravel/framework/issues/50586)

When installing breeze with the api option, stubs copying is interrupted if the "routes" directory does not exist. This PR checks for the `routes` directory before copying stubs and creates it if it has been deleted.