### PR TITLE
[11.x] Enhancing Middleware Configuration

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -342,6 +342,18 @@ class Middleware
      */
     protected function modifyGroup(string $group, array|string $append, array|string $prepend, array|string $remove, array $replace)
     {
+        $aliases = [];
+
+        if($append && !isset($append[0])){
+            $aliases = array_merge($aliases,($append));
+            $append = array_values($append);
+        }
+
+        if($prepend && !isset($prepend[0])){
+            $aliases = array_merge($aliases,($prepend));
+            $prepend = array_values($prepend);
+        }
+
         if (! empty($append)) {
             $this->appendToGroup($group, $append);
         }
@@ -359,6 +371,8 @@ class Middleware
                 $this->replaceInGroup($group, $search, $replace);
             }
         }
+
+        $this->alias($aliases);
 
         return $this;
     }
@@ -384,7 +398,7 @@ class Middleware
      */
     public function alias(array $aliases)
     {
-        $this->customAliases = $aliases;
+        $this->customAliases = array_merge($this->customAliases, $aliases);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -344,13 +344,13 @@ class Middleware
     {
         $aliases = [];
 
-        if($append && !isset($append[0])){
-            $aliases = array_merge($aliases,($append));
+        if ($append && ! isset($append[0])) {
+            $aliases = array_merge($aliases, $append);
             $append = array_values($append);
         }
 
-        if($prepend && !isset($prepend[0])){
-            $aliases = array_merge($aliases,($prepend));
+        if ($prepend && ! isset($prepend[0])) {
+            $aliases = array_merge($aliases, $prepend);
             $prepend = array_values($prepend);
         }
 


### PR DESCRIPTION
This pull request enhances the Middleware class by introducing the ability to register middleware and their aliases simultaneously using the web() and api() methods. Users can now conveniently specify middleware aliases alongside middleware classes, streamlining the registration process. Additionally, the existing method of defining middleware and its alias separately remains fully functional.

**Benefits:**

- Simplifies middleware registration by allowing users to specify aliases in addition to middleware classes in a single method call.
- Enhances code readability and maintainability by consolidating related configuration tasks into one place.
- Provides flexibility for developers to choose between the old and new registration methods, ensuring backward compatibility without breaking existing features.

**Example Usage:**

```
// old way
$middleware->web([
    TestMiddleware::class
]);

//new way
$middleware->web([
    'test' => TestMiddleware::class
]);

$middleware->api([
    'test' => TestMiddleware::class
]);
```
