### PR TITLE
[11.x] Fix(Router.php): use nullsafe operator in input method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1243,7 +1243,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function input($key, $default = null)
     {
-        return $this->current()->parameter($key, $default);
+        return $this->current()?->parameter($key, $default);
     }
 
     /**


### PR DESCRIPTION
This pull request updates the `input` method in the class to utilize the null-safe operator (in Router.php)


