### PR TITLE
[11.x] Fix doc block: `@return static` has been modified to `@return void`

### DIFF
--- a/src/Illuminate/Database/Eloquent/InvalidCastException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidCastException.php
@@ -33,7 +33,7 @@ class InvalidCastException extends RuntimeException
      * @param  object  $model
      * @param  string  $column
      * @param  string  $castType
-     * @return static
+     * @return void
      */
     public function __construct($model, $column, $castType)
     {

--- a/src/Illuminate/Database/LazyLoadingViolationException.php
+++ b/src/Illuminate/Database/LazyLoadingViolationException.php
@@ -25,7 +25,7 @@ class LazyLoadingViolationException extends RuntimeException
      *
      * @param  object  $model
      * @param  string  $relation
-     * @return static
+     * @return void
      */
     public function __construct($model, $relation)
     {


### PR DESCRIPTION
In this PR, `@return static` has been modified to `@return void`

```php
/**
     * Create a new exception instance.
     *
     * @param  object  $model
     * @param  string  $column
     * @param  string  $castType
     * @return static
     */
    public function __construct($model, $column, $castType)
    {
        $class = get_class($model);

        parent::__construct("Call to undefined cast [{$castType}] on column [{$column}] in model [{$class}].");

        $this->model = $class;
        $this->column = $column;
        $this->castType = $castType;
    }
```


### Files Changed
- Illuminate\Database\Eloquent\InvalidCastException.php
- Illuminate\Database\LazyLoadingViolationException.php

Thanks!
