### PR TITLE
[11.x] Adds overwrite empty string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -781,7 +781,7 @@ class Str
      */
     public static function overwriteEmpty($value, $overwrite = '-')
     {
-        if (is_string($value) && static::squish($value) === '') {
+        if (is_string($value) && blank($value)) {
             return $overwrite;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -773,6 +773,26 @@ class Str
     }
 
     /**
+     * Overwrite empty value with a desired string
+     *
+     * @param  mixed  $value
+     * @param  mixed  $overwrite
+     * @return mixed
+     */
+    public static function overwriteEmpty($value, $overwrite = '-')
+    {
+        if (is_string($value) && static::squish($value) === '') {
+            return $overwrite;
+        }
+
+        if (is_null($value)) {
+            return $overwrite;
+        }
+
+        return $value;
+    }
+
+    /**
      * Pad both sides of a string with another.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -519,6 +519,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Overwrite empty string with a desired string
+     *
+     * @param  mixed  $overwrite
+     * @return static
+     */
+    public function overwriteEmpty($overwrite = '-')
+    {
+        return new static(Str::overwriteEmpty($this->value, $overwrite));
+    }
+
+    /**
      * Pad both sides of the string with another.
      *
      * @param  int  $length

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -578,6 +578,19 @@ class SupportStrTest extends TestCase
         $this->assertSame($arrayExpected, Str::numbers($arrayValue));
     }
 
+    public function testOverwriteEmpty()
+    {
+        $this->assertSame('-', Str::overwriteEmpty(''));
+        $this->assertSame('-', Str::overwriteEmpty('        ', '-'));
+        $this->assertSame('-', Str::overwriteEmpty('     ' . PHP_EOL .   '   ', '-'));
+        $this->assertSame('N/A', Str::overwriteEmpty(PHP_EOL, 'N/A'));
+        $this->assertSame(0, Str::overwriteEmpty(null, 0));
+
+        $this->assertSame('0', Str::overwriteEmpty('0', 'N/A'));
+        $this->assertSame(0, Str::overwriteEmpty(0, '-'));
+        $this->assertSame([], Str::overwriteEmpty([], '-'));
+    }
+
     public function testRandom()
     {
         $this->assertEquals(16, strlen(Str::random()));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1280,6 +1280,17 @@ class SupportStringableTest extends TestCase
         $this->assertSame('5551234567', (string) $this->stringable('(555) 123-4567')->numbers());
     }
 
+    public function testOverwriteEmpty()
+    {
+        $this->assertSame('-', $this->stringable('' )->overwriteEmpty()->toString());
+        $this->assertSame('-', $this->stringable('        ')->overwriteEmpty('-')->toString());
+        $this->assertSame('N/A', $this->stringable(PHP_EOL)->overwriteEmpty('N/A')->toString());
+        $this->assertSame(0, $this->stringable(null)->overwriteEmpty(0)->toInteger());
+
+        $this->assertSame('0', $this->stringable('0')->overwriteEmpty('N/A')->toString());
+        $this->assertSame(0, $this->stringable(0)->overwriteEmpty('-')->toInteger());
+    }
+
     public function testToDate()
     {
         $current = Carbon::create(2020, 1, 1, 16, 30, 25);


### PR DESCRIPTION
Nullable or empty string fields in a database table are common occurrences. However, we typically don't want to display those empty spaces in our Blade templates.

Consider a User table with a nullable field last_name. If this field is empty, when we display it in Blade as `{{$user->last_name}}` the expected result is:

**first name: lakshan
last name:**

But ideally, we want something like this:

**first name: lakshan
last name: N/A**

This situation is common in many projects. While there are multiple solutions, using a ternary operator like` {{$user->last_name ?: 'N/A'}} `can be cumbersome. Additionally, if our  value contains only empty spaces or new lines ...etc., we probably don't want to display them to the user. In such cases, we would need to use more complex logic in our Blade files.

To solve this issue more efficiently, the following feature comes in handy:

last name: `{{Str::overwriteEmpty($user->last_name)}}`

Although the default value is a hyphen, you can use any desired symbol like so:

last name: `{{Str::overwriteEmpty($user->last_name, 'N/A')}}`  

This would result in:

**last name: N/A** 



