### PR TITLE
[11.x] Add `whereConcat` method to the query builder to improve interoperability between MySQL and SQLite

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2176,6 +2176,21 @@ class Builder implements BuilderContract
         return $this->whereAny($columns, $operator, $value, 'or');
     }
 
+    public function whereConcat($columns, $operator = '=', $value = null, $boolean = 'and')
+    {
+        $type = 'Concat';
+        
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+        
+        $this->wheres[] = compact('type','columns','operator', 'value', 'boolean');
+
+        $this->addBinding($value, 'where');
+
+        return $this;
+    }
+
     /**
      * Add a "group by" clause to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2178,7 +2178,7 @@ class Builder implements BuilderContract
 
     /**
      * Add an "where concat" clause to the query.
-     * 
+     *
      * @param  string[]  $columns
      * @param  string  $operator
      * @param  mixed  $value
@@ -2193,7 +2193,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
         
-        $this->wheres[] = compact('type','columns','operator', 'value', 'boolean');
+        $this->wheres[] = compact('type', 'columns', 'operator', 'value', 'boolean');
 
         $this->addBinding($value, 'where');
 
@@ -2202,7 +2202,7 @@ class Builder implements BuilderContract
 
     /**
      * Add an "or where concat" clause to the query.
-     * 
+     *
      * @param  string[]  $columns
      * @param  string  $operator
      * @param  mixed  $value

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2188,11 +2188,11 @@ class Builder implements BuilderContract
     public function whereConcat($columns, $operator = '=', $value = null, $boolean = 'and')
     {
         $type = 'Concat';
-        
+
         [$value, $operator] = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
         );
-        
+
         $this->wheres[] = compact('type', 'columns', 'operator', 'value', 'boolean');
 
         $this->addBinding($value, 'where');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2201,6 +2201,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an "or where concat" clause to the query.
+     * 
+     * @param  string[]  $columns
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereConcat($columns, $operator = '=', $value = null)
+    {
+        return $this->whereConcat($columns, $operator, $value, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|\Illuminate\Contracts\Database\Query\Expression|string  ...$groups

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2176,6 +2176,15 @@ class Builder implements BuilderContract
         return $this->whereAny($columns, $operator, $value, 'or');
     }
 
+    /**
+     * Add an "where concat" clause to the query.
+     * 
+     * @param  string[]  $columns
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
     public function whereConcat($columns, $operator = '=', $value = null, $boolean = 'and')
     {
         $type = 'Concat';

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -17,16 +17,17 @@ class MySqlGrammar extends Grammar
 
     /**
      * Add a "where concat" clause to the query.
-     * 
-     * @param Builder $query
-     * @param array $where
-     * @return string
+     *
+     * @param  Builder  $query
+     * @param  array  $where
+     * @return  string
      */
     protected function whereConcat(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
         $operator = $where['operator'];
         $columns = collect($where['columns'])->map(fn ($column) => Str::of($column)->trim()->isEmpty() ? '" "' : $this->wrap($column))->implode(', ');
+        
         return "concat({$columns}) {$operator} {$value}";
     }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -15,6 +15,14 @@ class MySqlGrammar extends Grammar
      */
     protected $operators = ['sounds like'];
 
+    protected function whereConcat(Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+        $operator = $where['operator'];
+        $columns = collect($where['columns'])->map(fn ($column) => Str::of($column)->trim()->isEmpty() ? '" "' : $this->wrap($column))->implode(', ');
+        return "concat({$columns}) {$operator} {$value}";
+    }
+
     /**
      * Add a "where null" clause to the query.
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -15,6 +15,13 @@ class MySqlGrammar extends Grammar
      */
     protected $operators = ['sounds like'];
 
+    /**
+     * Add a "where concat" clause to the query.
+     * 
+     * @param Builder $query
+     * @param array $where
+     * @return string
+     */
     protected function whereConcat(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -20,14 +20,14 @@ class MySqlGrammar extends Grammar
      *
      * @param  Builder  $query
      * @param  array  $where
-     * @return  string
+     * @return string
      */
     protected function whereConcat(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
         $operator = $where['operator'];
         $columns = collect($where['columns'])->map(fn ($column) => Str::of($column)->trim()->isEmpty() ? '" "' : $this->wrap($column))->implode(', ');
-        
+
         return "concat({$columns}) {$operator} {$value}";
     }
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -47,14 +47,14 @@ class SQLiteGrammar extends Grammar
      *
      * @param  Builder  $query
      * @param  array  $where
-     * @return  string
+     * @return string
      */
     protected function whereConcat(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
         $operator = $where['operator'];
         $columns = collect($where['columns'])->map(fn ($column) => Str::of($column)->trim()->isEmpty() ? "' '" : $this->wrap($column))->implode(' || ');
-        
+
         return "{$columns} {$operator} {$value}";
     }
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -42,6 +42,13 @@ class SQLiteGrammar extends Grammar
         return 'select * from ('.$sql.')';
     }
 
+    /**
+     * Add a "where concat" clause to the query.
+     * 
+     * @param Builder $query
+     * @param array $where
+     * @return string
+     */
     protected function whereConcat(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -44,16 +44,17 @@ class SQLiteGrammar extends Grammar
 
     /**
      * Add a "where concat" clause to the query.
-     * 
-     * @param Builder $query
-     * @param array $where
-     * @return string
+     *
+     * @param  Builder  $query
+     * @param  array  $where
+     * @return  string
      */
     protected function whereConcat(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
         $operator = $where['operator'];
         $columns = collect($where['columns'])->map(fn ($column) => Str::of($column)->trim()->isEmpty() ? "' '" : $this->wrap($column))->implode(' || ');
+        
         return "{$columns} {$operator} {$value}";
     }
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -42,6 +42,14 @@ class SQLiteGrammar extends Grammar
         return 'select * from ('.$sql.')';
     }
 
+    protected function whereConcat(Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+        $operator = $where['operator'];
+        $columns = collect($where['columns'])->map(fn ($column) => Str::of($column)->trim()->isEmpty() ? "' '" : $this->wrap($column))->implode(' || ');
+        return "{$columns} {$operator} {$value}";
+    }
+
     /**
      * Compile a "where date" clause.
      *

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1261,6 +1261,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Otwell%'], $builder->getBindings());
     }
 
+    public function testOrWhereConcat()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereConcat(['first_name', ' ', 'last_name'], 'like', '%Taylor%')->orWhereConcat(['first_name', ' ', 'last_name'], 'like', '%Otwell%');
+        $this->assertSame('select * from `users` where concat(`first_name`, " ", `last_name`) like ? or concat(`first_name`, " ", `last_name`) like ?', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereConcat(['first_name', ' ', 'last_name'], 'like', '%Taylor%')->orWhereConcat(['first_name', ' ', 'last_name'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" || \' \' || "last_name" like ? or "first_name" || \' \' || "last_name" like ?', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%'], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1248,6 +1248,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
+    public function testWhereConcat()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereConcat(['first_name', ' ', 'last_name'], 'like', '%Otwell%');
+        $this->assertSame('select * from `users` where concat(`first_name`, " ", `last_name`) like ?', $builder->toSql());
+        $this->assertEquals(['%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereConcat(['first_name', ' ', 'last_name'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" || \' \' || "last_name" like ?', $builder->toSql());
+        $this->assertEquals(['%Otwell%'], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Hi, this is my first PR, so if something is wrong, let me know.
As explained in [this discussion](https://github.com/laravel/framework/discussions/50596), I thought it would be nice to have a way to concatenate two columns and do an `where` in MySQL, SQLite, etc.

```php
User::query()->whereConcat(['first_name', 'last_name'], 'like', '%Otwell%')...
```

This means that when we are using MySQL the query will be something like this...
```sql
select * from `users` where concat(`first_name`, `last_name`) like "%Otwell%"
```
and when are using SQLite the query will be...
```sql
select * from "users" where "first_name" || "last_name" like "%Otwell%"
```

This new feature would be very helpful now with laravel 11 that [improves the performance of the tests](https://laravel.com/docs/11.x/releases#database-performance) using :memory: SQLite but when in our application we use MySQL or others.

I was not sure if it would be welcome for laravel 11. For that reason for the moment this PR only contains the grammer for MySQL and SQLite.

Thanks.