### PR TITLE
[11.x] Use `nick-fields/retry` v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
           command: composer require guzzlehttp/psr7:^2.4 --no-interaction --no-update
 
       - name: Set PHPUnit
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -141,7 +141,7 @@ jobs:
           command: composer require guzzlehttp/psr7:~2.4 --no-interaction --no-update
 
       - name: Set PHPUnit
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5


### PR DESCRIPTION
`nick-fields/retry` v2 was still being used in the **tests** workflow, triggering warnings about deprecated Node.js version.  This PR ensures that any remaining uses of `nick-fields/retry` v2 are replaced with the latest version.

![image](https://github.com/laravel/framework/assets/45073703/b923a317-e389-4c92-b742-156242036613)
