### PR TITLE
[11.x] Change typehint for enum rule from string to class-string

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -160,7 +160,7 @@ class Rule
     /**
      * Get an enum constraint builder instance.
      *
-     * @param  string  $type
+     * @param  class-string  $type
      * @return \Illuminate\Validation\Rules\Enum
      */
     public static function enum($type)

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -15,7 +15,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * The type of the enum.
      *
-     * @var string
+     * @var class-string
      */
     protected $type;
 
@@ -43,7 +43,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Create a new rule instance.
      *
-     * @param  string  $type
+     * @param  class-string  $type
      * @return void
      */
     public function __construct($type)


### PR DESCRIPTION
This will allow static analysis tools to correctly determine non class string uses of the Enum rule.

Example using PHPStan: https://phpstan.org/r/ece3460a-e80b-4fcc-a289-40b6e0442906
