### PR TITLE
[11.x] `GiveConfig` attribute for lazy loading DI config

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1031,6 +1031,11 @@ class Container implements ArrayAccess, ContainerContract
             return Util::unwrapIfClosure($concrete, $this);
         }
 
+        if (count($attributes = $parameter->getAttributes(GiveConfig::class))) {
+            $instance = $attributes[0]->newInstance();
+            return $instance->resolve($this);
+        }
+
         if ($parameter->isDefaultValueAvailable()) {
             return $parameter->getDefaultValue();
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1033,6 +1033,7 @@ class Container implements ArrayAccess, ContainerContract
 
         if (count($attributes = $parameter->getAttributes(GiveConfig::class))) {
             $instance = $attributes[0]->newInstance();
+
             return $instance->resolve($this);
         }
 

--- a/src/Illuminate/Container/GiveConfig.php
+++ b/src/Illuminate/Container/GiveConfig.php
@@ -11,11 +11,10 @@ class GiveConfig
         protected string $configKey,
         protected mixed $default = null,
     ) {
-	}
-
-    public function resolve($container): mixed
-	{
-        return $container->get('config')->get($this->configKey, $this->default);
     }
 
+    public function resolve($container): mixed
+    {
+        return $container->get('config')->get($this->configKey, $this->default);
+    }
 }

--- a/src/Illuminate/Container/GiveConfig.php
+++ b/src/Illuminate/Container/GiveConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Container;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class GiveConfig {
+
+    public function __construct(
+        protected string $configKey,
+        protected mixed $default = null,
+    ) {}
+
+    public function resolve($container) : mixed {
+        return $container->get('config')->get($this->configKey, $this->default);
+    }
+
+}

--- a/src/Illuminate/Container/GiveConfig.php
+++ b/src/Illuminate/Container/GiveConfig.php
@@ -5,14 +5,16 @@ namespace Illuminate\Container;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
-class GiveConfig {
-
+class GiveConfig
+{
     public function __construct(
         protected string $configKey,
         protected mixed $default = null,
-    ) {}
+    ) {
+	}
 
-    public function resolve($container) : mixed {
+    public function resolve($container): mixed
+	{
         return $container->get('config')->get($this->configKey, $this->default);
     }
 


### PR DESCRIPTION
I have A LOT of these in my service providers:

```php
$this->app->when(MoneybirdClient::class)->needs('$config')->giveConfig('services.moneybird');
```

and even though they're mostly lazy, they can be even more lazy, if that 'give config' were defined in the service class itself:

```php
use Illuminate\Container\GiveConfig;

class MoneybirdClient implements Platform {

	public function __construct(
		#[GiveConfig('services.google_analytics')]
		protected array $config,
	) {}

}
```

And the Container can figure it out, without **always** being bound/defined/abstracted in the container.

Supporting the rest of the `ContextualBindingBuilder` would be easy too, even without any more change in `Container`, if the `GiveConfig` attribute got a parent and `resolvePrimitive()` would load it with flag `ReflectionAttribute::IS_INSTANCEOF`. But I leave improvements up to you. First I need to know if this makes any sense. Is it Laravel enough?