### PR TITLE
[11.x] Fix doc block and  refactor `Check` and `Algorithm` methods

### DIFF
--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -22,7 +22,7 @@ class Argon2IdHasher extends ArgonHasher
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }
 
-        if (is_null($hashedValue) || strlen($hashedValue) === 0) {
+        if (is_null($hashedValue) || $hashedValue === '') {
             return false;
         }
 
@@ -43,9 +43,9 @@ class Argon2IdHasher extends ArgonHasher
     /**
      * Get the algorithm that should be used for hashing.
      *
-     * @return int
+     * @return string
      */
-    protected function algorithm()
+    protected function algorithm(): string
     {
         return PASSWORD_ARGON2ID;
     }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -76,9 +76,9 @@ class ArgonHasher extends AbstractHasher implements HasherContract
     /**
      * Get the algorithm that should be used for hashing.
      *
-     * @return int
+     * @return string
      */
-    protected function algorithm()
+    protected function algorithm(): string
     {
         return PASSWORD_ARGON2I;
     }


### PR DESCRIPTION
#### Refactor `Check` method:

The original condition `strlen($hashedValue) === 0` checks whether the length of `$hashedValue` is equal to 0, indicating an empty string. I used `$hashedValue === ''` which is faster and more readable than `strlen($hashedValue) === 0` . So:

```php

       // before
       if (is_null($hashedValue) || strlen($hashedValue) === 0) {
            return false;
        }

       // after
       if (is_null($hashedValue) || $hashedValue === '') {
            return false;
        }
```

#### Refactor `algorithm` method:
In this method, there is also a mistake in the doc block where it states `@return int`, which should be `@return string`. Additionally, since this method returns a constant value which inherently and explicitly is a string,
the return type of the function can be set to **string**


#### After
```php 
   /**
     * Get the algorithm that should be used for hashing.
     *
     * @return int
     */
    protected function algorithm()
    {
        return PASSWORD_ARGON2ID;
    }
```
#### Before

```php 
   /**
     * Get the algorithm that should be used for hashing.
     *
     * @return string
     */
    protected function algorithm(): string
    {
        return PASSWORD_ARGON2ID;
    }
```

### Files Changed

- `src\illuminate\Hashing\Argon2IdHasher.php`
- `src\illuminate\Hashing\ArgonHasher.php`