### PR TITLE
[11.x] Fixed make:session-table Artisan command cannot be executed if a migration exists

### DIFF
--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -63,10 +63,15 @@ class BatchesTableCommand extends MigrationGeneratorCommand
             return parent::migrationExists($table);
         }
 
-        return count($this->files->glob(sprintf(
-            '{%s,%s}',
+        foreach ([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000002_create_jobs_table.php'),
-        ))) !== 0;
+        ] as $path) {
+            if (count($this->files->glob($path)) !== 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -63,10 +63,15 @@ class FailedTableCommand extends MigrationGeneratorCommand
             return parent::migrationExists($table);
         }
 
-        return count($this->files->glob(sprintf(
-            '{%s,%s}',
+        foreach ([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000002_create_jobs_table.php'),
-        ))) !== 0;
+        ] as $path) {
+            if (count($this->files->glob($path)) !== 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -63,10 +63,15 @@ class TableCommand extends MigrationGeneratorCommand
             return parent::migrationExists($table);
         }
 
-        return count($this->files->glob(sprintf(
-            '{%s,%s}',
+        foreach ([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000002_create_jobs_table.php'),
-        ))) !== 0;
+        ] as $path) {
+            if (count($this->files->glob($path)) !== 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -59,10 +59,15 @@ class SessionTableCommand extends MigrationGeneratorCommand
      */
     protected function migrationExists($table)
     {
-        return count($this->files->glob(sprintf(
-            '{%s,%s}',
+        foreach ([
             join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
             join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000000_create_users_table.php'),
-        ))) !== 0;
+        ] as $path) {
+            if (count($this->files->glob($path)) !== 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
The original code did not check the existence properly.

```php
    protected function migrationExists($table)
    {
        return count($this->files->glob(sprintf(
            '{%s,%s}',
            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_create_'.$table.'_table.php'),
            join_paths($this->laravel->databasePath('migrations'), '0001_01_01_000000_create_users_table.php'),
        ))) !== 0;
    }
```

Changed to check the existence of targets in order

A similar issue also occurred with the following Artisan commands and has been fixed.

- make:queue-batches-table
- make:queue-failed-table
- make:queue-table
