### PR TITLE
[11.x] Add whereDateTime and orWhereDateTime to query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query;
 
 use BackedEnum;
+use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Closure;
 use DateTimeInterface;
@@ -1467,6 +1468,58 @@ class Builder implements BuilderContract
         );
 
         return $this->whereDate($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a where statement to the query after converting the date to app.timezone
+     *
+     * @param string $column
+     * @param string|Carbon $operator
+     * @param Carbon|null $date
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    public function whereDateTime(string $column, string|Carbon $operator, Carbon|null $date = null)
+    {
+        [$date, $operator] = $this->prepareValueAndOperator(
+            $date, $operator, func_num_args() === 2
+        );
+
+        if( ! ($date instanceof Carbon) ) {
+            throw new InvalidArgumentException('Date must be a instance of Carbon');
+        }
+        if($date->timezone->getName() != config('app.timezone')) {
+            $date->setTimezone(config('app.timezone'));
+        }
+
+        return $this->where($column, $operator, $date->toDateTimeString());
+    }
+
+    /**
+     * Add an "or where" statement to the query after converting the date to app.timezone
+     *
+     * @param string $column
+     * @param string|Carbon $operator
+     * @param Carbon|null $date
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    public function orWhereDateTime(string $column, string|Carbon $operator, Carbon|null $date = null)
+    {
+        [$date, $operator] = $this->prepareValueAndOperator(
+            $date, $operator, func_num_args() === 2
+        );
+
+        if( ! ($date instanceof Carbon) ) {
+            throw new InvalidArgumentException('Date must be a instance of Carbon');
+        }
+        if($date->timezone->getName() != config('app.timezone')) {
+            $date->setTimezone(config('app.timezone'));
+        }
+
+        return $this->where($column, $operator, $date->toDateTimeString(), 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1471,11 +1471,11 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where statement to the query after converting the date to app.timezone
+     * Add a where statement to the query after converting the date to app.timezone.
      *
-     * @param string $column
-     * @param string|Carbon $operator
-     * @param Carbon|null $date
+     * @param  string  $column
+     * @param  string|Carbon  $operator
+     * @param  Carbon|null  $date
      * @return $this
      *
      * @throws InvalidArgumentException
@@ -1486,10 +1486,10 @@ class Builder implements BuilderContract
             $date, $operator, func_num_args() === 2
         );
 
-        if( ! ($date instanceof Carbon) ) {
+        if (! ($date instanceof Carbon)) {
             throw new InvalidArgumentException('Date must be a instance of Carbon');
         }
-        if($date->timezone->getName() != config('app.timezone')) {
+        if ($date->timezone->getName() != config('app.timezone')) {
             $date->setTimezone(config('app.timezone'));
         }
 
@@ -1497,11 +1497,11 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "or where" statement to the query after converting the date to app.timezone
+     * Add an "or where" statement to the query after converting the date to app.timezone.
      *
-     * @param string $column
-     * @param string|Carbon $operator
-     * @param Carbon|null $date
+     * @param  string  $column
+     * @param  string|Carbon  $operator
+     * @param  Carbon|null  $date
      * @return $this
      *
      * @throws InvalidArgumentException
@@ -1512,10 +1512,10 @@ class Builder implements BuilderContract
             $date, $operator, func_num_args() === 2
         );
 
-        if( ! ($date instanceof Carbon) ) {
+        if (! ($date instanceof Carbon)) {
             throw new InvalidArgumentException('Date must be a instance of Carbon');
         }
-        if($date->timezone->getName() != config('app.timezone')) {
+        if ($date->timezone->getName() != config('app.timezone')) {
             $date->setTimezone(config('app.timezone'));
         }
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -311,6 +311,24 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDate('created_at', new Carbon('2018-01-02'))->count());
     }
 
+    public function testWhereDateTime()
+    {
+        $this->assertSame(1, DB::table('posts')->whereDateTime('created_at', new Carbon('2017-11-12 13:14:15'))->count());
+        $this->assertSame(1, DB::table('posts')->whereDateTime('created_at', '>', new Carbon('2018-01-01'))->count());
+        $this->assertSame(config('app.timezone'), 'UTC');
+        $this->assertSame(0, DB::table('posts')->whereDateTime('created_at', '>', new Carbon('2018-01-02 00:00:00', 'America/Chicago'))->count());
+        $this->assertSame(1, DB::table('posts')->whereDateTime('created_at', '>', new Carbon('2018-01-02 00:00:00', 'UTC'))->count());
+    }
+
+    public function testOrWhereDateTime()
+    {
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDateTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDateTime('created_at', '>', new Carbon('2018-01-01'))->count());
+        $this->assertSame(config('app.timezone'), 'UTC');
+        $this->assertSame(1, DB::table('posts')->where('id', 1)->orWhereDateTime('created_at', '>', new Carbon('2018-01-02 00:00:00', 'America/Chicago'))->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDateTime('created_at', '>', new Carbon('2018-01-02 00:00:00', 'UTC'))->count());
+    }
+
     public function testWhereDay()
     {
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', '02')->count());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This adds two new methods to the query builder class to make it easier to work with multiple time zones. Dates are typically stored in UTC but it can be difficult to compare those dates when working with multiple timezones.

Using `->whereDate('created_at', '2024-03-01')`  would return all dates stored as March 1 2024 but this includes dates from the previous day and excludes dates from late on the day if the user not expecting UTC.

`whereDateTime()`  will convert a Carbon object to UTC (or whatever timezone is set in app.timezone) so that it can compare dates in the timezone that was expected.

`whereDateTime('created_at','>=', new Carbon('2024-03-01', 'America/Chicago'))` would return all rows with a created_at date of `2024-03-01 05:00:00` or after. (Chicago is currently -5 UTC)