### PR TITLE
[11.x] Fix command alias registration and usage.

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Cache\Console;
 use Illuminate\Console\MigrationGeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:cache-table')]
+#[AsCommand(name: 'make:cache-table', aliases: ['cache:table'])]
 class CacheTableCommand extends MigrationGeneratorCommand
 {
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -238,7 +238,9 @@ class Application extends SymfonyApplication implements ApplicationContract
     public function resolve($command)
     {
         if (is_subclass_of($command, SymfonyCommand::class) && ($commandName = $command::getDefaultName())) {
-            $this->commandMap[$commandName] = $command;
+            foreach (explode('|', $commandName) as $name) {
+                $this->commandMap[$name] = $command;
+            }
 
             return null;
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'schedule:clear-cache')]
 class ScheduleClearCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -4,9 +4,11 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\ConfigurationUrlParser;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
 
+#[AsCommand(name: 'db')]
 class DbCommand extends Command
 {
     /**

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -6,8 +6,10 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\DatabaseRefreshed;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'migrate:fresh')]
 class FreshCommand extends Command
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -4,8 +4,10 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
 use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'migrate:install')]
 class InstallCommand extends Command
 {
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -10,10 +10,12 @@ use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Database\SqlServerConnection;
 use PDOException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
 use function Laravel\Prompts\confirm;
 
+#[AsCommand(name: 'migrate')]
 class MigrateCommand extends BaseCommand implements Isolatable
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'make:migration')]
 class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 {
     /**

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -6,8 +6,10 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\DatabaseRefreshed;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'migrate:refresh')]
 class RefreshCommand extends Command
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -4,8 +4,10 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'migrate:reset')]
 class ResetCommand extends BaseCommand
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -4,8 +4,10 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand('migrate:rollback')]
 class RollbackCommand extends BaseCommand
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -4,8 +4,10 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\Collection;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'migrate:status')]
 class StatusCommand extends BaseCommand
 {
     /**

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -12,8 +12,10 @@ use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Finder\Finder;
 
+#[AsCommand(name: 'model:prune')]
 class PruneCommand extends Command
 {
     /**

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Notifications\Console;
 use Illuminate\Console\MigrationGeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:notifications-table')]
+#[AsCommand(name: 'make:notifications-table', aliases: ['notifications:table'])]
 class NotificationTableCommand extends MigrationGeneratorCommand
 {
     /**

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[AsCommand(name: 'make:queue-batches-table')]
+#[AsCommand(name: 'make:queue-batches-table', aliases: ['queue:batches-table'])]
 class BatchesTableCommand extends MigrationGeneratorCommand
 {
     /**

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[AsCommand(name: 'make:queue-failed-table')]
+#[AsCommand(name: 'make:queue-failed-table', aliases: ['queue:failed-table'])]
 class FailedTableCommand extends MigrationGeneratorCommand
 {
     /**

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[AsCommand(name: 'make:queue-table')]
+#[AsCommand(name: 'make:queue-table', aliases: ['queue:table'])]
 class TableCommand extends MigrationGeneratorCommand
 {
     /**

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Illuminate\Filesystem\join_paths;
 
-#[AsCommand(name: 'make:session-table')]
+#[AsCommand(name: 'make:session-table', aliases: ['session:table'])]
 class SessionTableCommand extends MigrationGeneratorCommand
 {
     /**

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Foundation\Application as FoundationApplication;
-use Illuminate\Foundation\Console\Kernel;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -6,10 +6,16 @@ use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Events\Dispatcher as EventsDispatcher;
+use Illuminate\Foundation\Application as FoundationApplication;
+use Illuminate\Foundation\Console\Kernel;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Throwable;
 
 class ConsoleApplicationTest extends TestCase
 {
@@ -49,6 +55,68 @@ class ConsoleApplicationTest extends TestCase
         $result = $app->resolve('foo');
 
         $this->assertEquals($command, $result);
+    }
+
+    public function testResolvingCommandsWithAliasViaAttribute()
+    {
+        $container = new FoundationApplication();
+        $app = new Application($container, new EventsDispatcher($container), $container->version());
+        $app->resolve(CommandWithAliasViaAttribute::class);
+        $app->setContainerCommandLoader();
+
+        $this->assertInstanceOf(CommandWithAliasViaAttribute::class, $app->get('command-name'));
+        $this->assertInstanceOf(CommandWithAliasViaAttribute::class, $app->get('command-alias'));
+        $this->assertArrayHasKey('command-name', $app->all());
+        $this->assertArrayHasKey('command-alias', $app->all());
+    }
+
+    public function testResolvingCommandsWithAliasViaProperty()
+    {
+        $container = new FoundationApplication();
+        $app = new Application($container, new EventsDispatcher($container), $container->version());
+        $app->resolve(CommandWithAliasViaProperty::class);
+        $app->setContainerCommandLoader();
+
+        $this->assertInstanceOf(CommandWithAliasViaProperty::class, $app->get('command-name'));
+        $this->assertInstanceOf(CommandWithAliasViaProperty::class, $app->get('command-alias'));
+        $this->assertArrayHasKey('command-name', $app->all());
+        $this->assertArrayHasKey('command-alias', $app->all());
+    }
+
+    public function testResolvingCommandsWithNoAliasViaAttribute()
+    {
+        $container = new FoundationApplication();
+        $app = new Application($container, new EventsDispatcher($container), $container->version());
+        $app->resolve(CommandWithNoAliasViaAttribute::class);
+        $app->setContainerCommandLoader();
+
+        $this->assertInstanceOf(CommandWithNoAliasViaAttribute::class, $app->get('command-name'));
+        try {
+            $app->get('command-alias');
+            $this->fail();
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(CommandNotFoundException::class, $e);
+        }
+        $this->assertArrayHasKey('command-name', $app->all());
+        $this->assertArrayNotHasKey('command-alias', $app->all());
+    }
+
+    public function testResolvingCommandsWithNoAliasViaProperty()
+    {
+        $container = new FoundationApplication();
+        $app = new Application($container, new EventsDispatcher($container), $container->version());
+        $app->resolve(CommandWithNoAliasViaProperty::class);
+        $app->setContainerCommandLoader();
+
+        $this->assertInstanceOf(CommandWithNoAliasViaProperty::class, $app->get('command-name'));
+        try {
+            $app->get('command-alias');
+            $this->fail();
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(CommandNotFoundException::class, $e);
+        }
+        $this->assertArrayHasKey('command-name', $app->all());
+        $this->assertArrayNotHasKey('command-alias', $app->all());
     }
 
     public function testCallFullyStringCommandLine()
@@ -123,4 +191,26 @@ class ConsoleApplicationTest extends TestCase
             $app, $events, 'test-version',
         ])->getMock();
     }
+}
+
+#[AsCommand('command-name')]
+class CommandWithNoAliasViaAttribute extends Command
+{
+    //
+}
+#[AsCommand('command-name', aliases: ['command-alias'])]
+class CommandWithAliasViaAttribute extends Command
+{
+    //
+}
+
+class CommandWithNoAliasViaProperty extends Command
+{
+    public $name = 'command-name';
+}
+
+class CommandWithAliasViaProperty extends Command
+{
+    public $name = 'command-name';
+    public $aliases = ['command-alias'];
 }


### PR DESCRIPTION
Our commands are not currently able to be run via their aliases defined in the class property. This is due to the `AsCommand` attribute.

```
composer create-project laravel/laravel command-test && \
    cd command-test && \
    php artisan session:table
```

## Attribute with: name

```php
#[AsCommand(name: 'make:session-table')]
class SessionTableCommand extends MigrationGeneratorCommand
{
    protected $name = 'make:session-table';

    protected $aliases = ['session:table'];
```

```
php artisan make:session-table ✅
php artisan session:table ❌
```

## Attribute with: name, aliases

```php
#[AsCommand(name: 'make:session-table', aliases: ['session:table')]
class SessionTableCommand extends MigrationGeneratorCommand
{
    protected $name = 'make:session-table';

    protected $aliases = ['session:table'];
```

```
php artisan make:session-table ✅
php artisan session:table ✅
```

## What does the `AsCommand` attribute do for Laravel?

Applying the attribute allows us to not instantiate a command when running a _different_ command.

For example, if we have the following command with no attribute:

```php
class SessionTableCommand extends MigrationGeneratorCommand
{
    protected $name = 'make:session-table';

    protected $aliases = ['session:table'];
```

and we proceed to run `php artisan view:clear` the `SessionTableCommand` will be instantiated even though it is not needed.

Commands are always instantiated when calling `php artisan list`

## Ecosystem PRs

I believe I've updated the most important open source commands to make them lazy and align across the ecosystem. I've also ensured that aliases are defined where needed.

- https://github.com/nunomaduro/collision/pull/303
- https://github.com/laravel/horizon/pull/1399
- https://github.com/laravel/telescope/pull/1448
- https://github.com/laravel/jetstream/pull/1455
- https://github.com/laravel/octane/pull/857
- https://github.com/laravel/dusk/pull/1092
- https://github.com/laravel/passport/pull/1731
- https://github.com/laravel/sanctum/pull/502
- https://github.com/laravel/pulse/pull/341
- https://github.com/laravel/sail/pull/683
- https://github.com/laravel/breeze/pull/373
- https://github.com/laravel/scout/pull/815
- https://github.com/laravel/cashier-stripe/pull/1667
- https://github.com/laravel/ui/pull/264
- https://github.com/laravel/fortify/pull/527
- https://github.com/laravel/pail/pull/32
- https://github.com/laravel/reverb/pull/98
- https://github.com/laravel/folio/pull/135
- https://github.com/laravel/vapor-ui/pull/97
- https://github.com/inertiajs/inertia-laravel/pull/601

Cannot update `tinker` or `vapor-core` due to them supporting older version of `symfony/console`