### PR TITLE
[11.x] Fixed `enum` and `enum.backed` stub paths after publish

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -42,10 +42,23 @@ class EnumMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($this->option('string') || $this->option('int')) {
-            return __DIR__.'/stubs/enum.backed.stub';
+            return $this->resolveStubPath('/stubs/enum.backed.stub');
         }
 
-        return __DIR__.'/stubs/enum.stub';
+        return $this->resolveStubPath('/stubs/enum.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**


### PR DESCRIPTION
The original code was making enums from the framework including stubs only

```PHP
/**
 * Get the stub file for the generator.
 *
 * @return string
 */
protected function getStub()
{
    if ($this->option('string') || $this->option('int')) {
        return __DIR__.'/stubs/enum.backed.stub';
    }

    return __DIR__.'/stubs/enum.stub';
}
```

It was changed to use published enum stubs (if there are any) in `make:enum` command.



