### PR TITLE
[11.x] Fix(Router.php): using null-safe operator

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1243,7 +1243,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function input($key, $default = null)
     {
-        return $this->current()->parameter($key, $default);
+        return $this->current()?->parameter($key, $default);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1302,7 +1302,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function currentRouteName()
     {
-        return $this->current() ? $this->current()->getName() : null;
+        return $this->current()?->getName();
     }
 
     /**


### PR DESCRIPTION

### First Change (fix bug) : Implementing Null-Safe Operator to Handle Potential Null Return in current() Method

If `$this->current()` returns null, an error of type `Error: Call to a member function parameter() on null` occurs, which could also happen within the `current()` method if it returns null.

Therefore, it's better to use the null-safe operator to return null if `$this->current()` evaluates to null, instead of encountering an error.

```php

    /**
     * Get a route parameter for the current route.
     *
     * @param  string  $key
     * @param  string|null  $default
     * @return mixed
     */
    public function input($key, $default = null)
    {
        return $this->current()?->parameter($key, $default);
    }
```

### Second Change (refactor)

```php 

    // before
    public function currentRouteName()
    {
        return $this->current() ? $this->current()->getName() : null;
    }


   // after
    public function currentRouteName()
    {
        return $this->current()?->getName();
    }
```