### PR TITLE
[11.x] Fix(src\illuminate\Queue): update doc block, Simplification of the code in RedisManager

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -255,7 +255,6 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  string  $from
      * @param  string  $to
-     * @param  int  $limit
      * @return array
      */
     public function migrateExpiredJobs($from, $to)

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -192,7 +192,7 @@ class RedisManager implements Factory
         }
 
         return array_filter($parsed, function ($key) {
-            return ! in_array($key, ['driver'], true);
+            return $key !== 'driver';
         }, ARRAY_FILTER_USE_KEY);
     }
 


### PR DESCRIPTION
This PR removes the redundant @param doc block

Given the method signature:

```php
    /**
     * Migrate the delayed jobs that are ready to the regular queue.
     *
     * @param  string  $from
     * @param  string  $to
     * @param  int  $limit
     * @return array
     */
    public function migrateExpiredJobs($from, $to)
    {
```

the `@param int $limit` expression is unnecessary and can be removed from the doc block.


### `parseConnectionConfiguration` method in RedisManger.php class

```php
//Before
return ! in_array($key, ['driver'], true);

//After
return $key !== 'driver';
```

It seems clearer to me.


Thanks!
