### PR TITLE
[11.x] Refactored Date Formatting to Use DateTimeInterface::ATOM(due to deprication)

### DIFF
--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -120,7 +120,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
                 'exception' => $result['exception']['S'],
                 'failed_at' => Carbon::createFromTimestamp(
                     (int) $result['failed_at']['N']
-                )->format(DateTimeInterface::ISO8601),
+                )->format(DateTimeInterface::ATOM),
             ];
         })->all();
     }
@@ -153,7 +153,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
             'exception' => $result['Item']['exception']['S'],
             'failed_at' => Carbon::createFromTimestamp(
                 (int) $result['Item']['failed_at']['N']
-            )->format(DateTimeInterface::ISO8601),
+            )->format(DateTimeInterface::ATOM),
         ];
     }
 

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -94,7 +94,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
                 'queue' => 'queue',
                 'payload' => 'payload',
                 'exception' => 'exception',
-                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ISO8601),
+                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ATOM),
             ],
         ], $response);
     }
@@ -135,7 +135,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
                 'queue' => 'queue',
                 'payload' => 'payload',
                 'exception' => 'exception',
-                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ISO8601),
+                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ATOM),
             ], $response
         );
     }


### PR DESCRIPTION
This PR updates the date formatting in the codebase, replacing the deprecated `DateTimeInterface::ISO8601` with `DateTimeInterface::ATOM`

As of the specified version, the term `DateTimeInterface::ISO8601` has been deprecated.'"


![image](https://github.com/laravel/framework/assets/36761585/ea49e7fc-c208-441c-81c9-4be2a2431a0d)

note:
https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.iso8601


Thanks!