### PR TITLE
[11.x] Fix(ScheduleListCommand): fix doc block for listEvent method

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -104,13 +104,12 @@ class ScheduleListCommand extends Command
     /**
      * List the given even in the console.
      *
-     * @param  \Illuminate\Console\Scheduling\Event
+     * @param  \Illuminate\Console\Scheduling\Event  $event
      * @param  int  $terminalWidth
      * @param  array  $expressionSpacing
      * @param  int  $repeatExpressionSpacing
-     * @param  array  $repeatExpressionSpacing
      * @param  \DateTimeZone  $timezone
-     * @return \Illuminate\Support\DateTimeZone
+     * @return array
      */
     private function listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone)
     {


### PR DESCRIPTION
This PR, update doc block for `listEvent` method in `ScheduleListCommand.php`

```php
/**
     * List the given even in the console.
     *
     * @param  \Illuminate\Console\Scheduling\Event
     * @param  int  $terminalWidth
     * @param  array  $expressionSpacing
     * @param  int  $repeatExpressionSpacing
     * @param  array  $repeatExpressionSpacing
     * @param  \DateTimeZone  $timezone
     * @return \Illuminate\Support\DateTimeZone
     */
    private function listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone)
    {
```

- add $event as first parameter to doc block
- remove `@param  array  $repeatExpressionSpacing`
- since the output of this method is **explicitly** an array, we should have `@return array`.