### PR TITLE
[10.x] Test Improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
         "nyholm/psr7": "^1.2",
-        "orchestra/testbench-core": "^8.18",
+        "orchestra/testbench-core": "^8.23.3",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^10.0.7",

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.5.1",
         "nyholm/psr7": "^1.2",
-        "orchestra/testbench-core": "^8.23.3",
+        "orchestra/testbench-core": "^8.23.4",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^10.0.7",

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2095,6 +2095,8 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testSortByMany($collection)
     {
+        $defaultLocale = setlocale(LC_ALL, 0);
+
         $data = new $collection([['item' => '1'], ['item' => '10'], ['item' => 5], ['item' => 20]]);
         $expected = $data->pluck('item')->toArray();
 
@@ -2172,6 +2174,8 @@ class SupportCollectionTest extends TestCase
         sort($expected, SORT_LOCALE_STRING);
         $data = $data->sortBy(['item'], SORT_LOCALE_STRING);
         $this->assertEquals($data->pluck('item')->toArray(), $expected);
+
+        setlocale(LC_ALL, $defaultLocale);
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 class SupportNumberTest extends TestCase
 {
+    #[RequiresPhpExtension('intl')]
     public function testFormat()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('0', Number::format(0));
         $this->assertSame('0', Number::format(0.0));
         $this->assertSame('0', Number::format(0.00));
@@ -40,10 +40,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('NaN', Number::format(NAN));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testFormatWithDifferentLocale()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('123,456,789', Number::format(123456789, locale: 'en'));
         $this->assertSame('123.456.789', Number::format(123456789, locale: 'de'));
         $this->assertSame('123 456 789', Number::format(123456789, locale: 'fr'));
@@ -51,10 +50,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('123 456 789', Number::format(123456789, locale: 'sv'));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testFormatWithAppLocale()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('123,456,789', Number::format(123456789));
 
         Number::useLocale('de');
@@ -70,17 +68,15 @@ class SupportNumberTest extends TestCase
         $this->assertSame('one point two', Number::spell(1.2));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testSpelloutWithLocale()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('trois', Number::spell(3, 'fr'));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testSpelloutWithThreshold()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('9', Number::spell(9, after: 10));
         $this->assertSame('10', Number::spell(10, after: 10));
         $this->assertSame('eleven', Number::spell(11, after: 10));
@@ -100,10 +96,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('3rd', Number::ordinal(3));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testToPercent()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('0%', Number::percentage(0, precision: 0));
         $this->assertSame('0%', Number::percentage(0));
         $this->assertSame('1%', Number::percentage(1));
@@ -124,10 +119,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testToCurrency()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('$0.00', Number::currency(0));
         $this->assertSame('$1.00', Number::currency(1));
         $this->assertSame('$10.00', Number::currency(10));
@@ -141,10 +135,9 @@ class SupportNumberTest extends TestCase
         $this->assertSame('$5.32', Number::currency(5.325));
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testToCurrencyWithDifferentLocale()
     {
-        $this->needsIntlExtension();
-
         $this->assertSame('1,00 €', Number::currency(1, 'EUR', 'de'));
         $this->assertSame('1,00 $', Number::currency(1, 'USD', 'de'));
         $this->assertSame('1,00 £', Number::currency(1, 'GBP', 'de'));
@@ -292,12 +285,5 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1.1T', Number::abbreviate(-1100000000000, maxPrecision: 1));
         $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
-    }
-
-    protected function needsIntlExtension()
-    {
-        if (! extension_loaded('intl')) {
-            $this->markTestSkipped('The intl extension is not installed. Please install the extension to enable '.__CLASS__);
-        }
     }
 }


### PR DESCRIPTION
* Use PHPUnit attributes to check if `intl` extension is required to run
  tests
* Reset locale changes made when running tests