### PR TITLE
[11.x] Remove `$except` property from `ExcludesPaths` trait

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -32,6 +32,6 @@ trait ExcludesPaths
      */
     public function getExcludedPaths()
     {
-        return $this->except;
+        return $this->except ?? [];
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Concerns/ExcludesPaths.php
@@ -5,13 +5,6 @@ namespace Illuminate\Foundation\Http\Middleware\Concerns;
 trait ExcludesPaths
 {
     /**
-     * The URIs that should be excluded.
-     *
-     * @var array<int, string>
-     */
-    protected $except = [];
-
-    /**
      * Determine if the request has a URI that should be excluded.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -22,6 +22,13 @@ class PreventRequestsDuringMaintenance
     protected $app;
 
     /**
+     * The URIs that should be excluded.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [];
+
+    /**
      * The URIs that should be accessible during maintenance.
      *
      * @var array

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -35,6 +35,13 @@ class VerifyCsrfToken
     protected $encrypter;
 
     /**
+     * The URIs that should be excluded.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [];
+
+    /**
      * The globally ignored URIs that should be excluded from CSRF verification.
      *
      * @var array


### PR DESCRIPTION
It is currently impossible to set the `$except` property in a class when using the `ExcludesPaths` trait.
```php
class FooBarMiddleware
{
    use ExcludesPaths;

    protected $except = [
        '/some/excluded/path', // adding a value here causes an error
    ];

    public function handle($request, $next)
    {
        // ...
    }
}
```
This causes the following error:
> PHP Fatal error:  App\Http\Middleware\FooBarMiddleware and Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths define the same property ($except) in the composition of App\Http\Middleware\FooBarMiddleware. However, the definition differs and is considered incompatible.

This is caused by the fact that the `$except` property is already set in trait. Removing it from the trait fixes that.