### PR TITLE
Prepend table name to dynamic whereSomething clauses when using joins

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2069,7 +2069,7 @@ class Builder implements BuilderContract
         // Prepend the table name to the column name, if we're using joins.
         $table = $this->joins ? "$this->from." : '';
 
-        $this->where($table . Str::snake($segment), '=', $parameters[$index], $bool);
+        $this->where($table.Str::snake($segment), '=', $parameters[$index], $bool);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2066,7 +2066,10 @@ class Builder implements BuilderContract
         // clause on the query. Then we'll increment the parameter index values.
         $bool = strtolower($connector);
 
-        $this->where(Str::snake($segment), '=', $parameters[$index], $bool);
+        // Prepend the table name to the column name, if we're using joins.
+        $table = $this->joins ? "$this->from." : '';
+
+        $this->where($table . Str::snake($segment), '=', $parameters[$index], $bool);
     }
 
     /**


### PR DESCRIPTION
Prevents "ambiguous column" errors when using joins and dynamic clauses in the same query. Existing functionality is not affected, but the change allows to use or keep existing dynamic where clauses when using joins.