### PR TITLE
[11.x] Add options to group() in RouteRegistrar

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -187,11 +187,12 @@ class RouteRegistrar
      * Create a route group with shared attributes.
      *
      * @param  \Closure|array|string  $callback
+     * @param  array  $options
      * @return $this
      */
-    public function group($callback)
+    public function group($callback, array $options = [])
     {
-        $this->router->group($this->attributes, $callback);
+        $this->router->group($this->attributes + $options, $callback);
 
         return $this;
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -382,6 +382,18 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('{account}.myapp.com', $this->getRoute()->getDomain());
     }
 
+    public function testCanRegisterGroupWithDomainAndExtraOptions()
+    {
+        $this->router->domain('{account}.myapp.com')->group(function ($router) {
+            $router->get('users', 'UsersController@index');
+        },[
+            'namespace' => 'App\Http\Controllers\Custom',
+        ]);
+
+        $this->assertSame('{account}.myapp.com', $this->getRoute()->getDomain());
+        $this->assertSame('App\Http\Controllers\Custom', $this->getRoute()->getAction()['namespace']);
+    }
+
     public function testCanRegisterGroupWithDomainAndNamePrefix()
     {
         $this->router->domain('{account}.myapp.com')->name('api.')->group(function ($router) {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -386,7 +386,7 @@ class RouteRegistrarTest extends TestCase
     {
         $this->router->domain('{account}.myapp.com')->group(function ($router) {
             $router->get('users', 'UsersController@index');
-        },[
+        }, [
             'namespace' => 'App\Http\Controllers\Custom',
         ]);
 


### PR DESCRIPTION
In `Router.php` one can do: 
```php
Route::group([options], $callback);
```
https://github.com/laravel/framework/blob/14c8e953fba1b125228b70a51ecb4911be1b7274/src/Illuminate/Routing/Router.php#L457

While if you do:
```php
Route::domain('something.com') //you now have a RouteRegistrar instance
        ->group($callback)
```

When you get a `RouteRegistrar` instance the `group()` method that calls the underlying `Router::group()` only accept either a closure or an array, not both.
https://github.com/laravel/framework/blob/14c8e953fba1b125228b70a51ecb4911be1b7274/src/Illuminate/Routing/RouteRegistrar.php#L192

I am not 100% happy with this solution, because the order of the parameters are not consistent in both methods, but still, better than nothing I guess ? 🤷 

```php
Route::domain('something')->group($callback, [options]);
Route::group([options], $callback);
```

I've added tests too, let me know if you don't agree with, or have a better alternative to it. 

Cheers