### PR TITLE
[10.x] Prepend table name to dynamic whereSomething clauses when using joins

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2059,7 +2059,10 @@ class Builder implements BuilderContract
         // clause on the query. Then we'll increment the parameter index values.
         $bool = strtolower($connector);
 
-        $this->where(Str::snake($segment), '=', $parameters[$index], $bool);
+        // Prepend the table name to the column name, if we're using joins.
+        $table = count($this->joins ?? []) ? "$this->from." : '';
+
+        $this->where($table.Str::snake($segment), '=', $parameters[$index], $bool);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2030,6 +2030,25 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
+    public function testWhereDynamic()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->whereFoo('bar');
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "foo" = ?', $builder->toSql());
+        $this->assertEquals(['bar'], $builder->getBindings());
+    }
+
+    public function testWhereDynamicWithJoin()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->join('xyz', 'abc', '=', 'def')
+            ->whereFoo('bar');
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" inner join "xyz" on "abc" = "def" where "eloquent_builder_test_model_parent_stubs"."foo" = ?', $builder->toSql());
+        $this->assertEquals(['bar'], $builder->getBindings());
+    }
+
     public function testLatestWithoutColumnWithCreatedAt()
     {
         $model = $this->getMockModel();


### PR DESCRIPTION
Prevents "ambiguous column" errors when using joins and dynamic clauses in the same query. Existing functionality is not affected, but the change allows to use or keep existing dynamic where clauses when using joins.