### PR TITLE
[11.x] Fix issue with missing 'js/' directory in broadcasting installation command

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '11.x';
+    const VERSION = '11.0.7';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '11.0.7';
+    const VERSION = '11.x';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -53,6 +53,11 @@ class BroadcastingInstallCommand extends Command
 
         // Install bootstrapping...
         if (! file_exists($echoScriptPath = $this->laravel->resourcePath('js/echo.js'))) {
+            $directory = $this->laravel->resourcePath('js');
+            if (! is_dir($directory)) {
+                mkdir($directory, 0755, true);
+            }
+            
             copy(__DIR__.'/stubs/echo-js.stub', $echoScriptPath);
         }
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -57,7 +57,7 @@ class BroadcastingInstallCommand extends Command
             if (! is_dir($directory)) {
                 mkdir($directory, 0755, true);
             }
-            
+
             copy(__DIR__.'/stubs/echo-js.stub', $echoScriptPath);
         }
 


### PR DESCRIPTION
### Issue

After installing a fresh Laravel app with the Breeze 'api' stack, the `install:broadcasting` command to enable broadcasting throws an error:

```bash
> php artisan install:broadcast 

  INFO Published 'broadcasting' configuration file.  

  INFO Published 'channels' route file.  


  ErrorException 

 copy(laravel-app\resources\js/echo.js): Failed to open stream: No such file or directory

 at vendor\laravel\framework\src\Illuminate\Foundation\Console\BroadcastingInstallCommand.php:56
   52▕     $this->enableBroadcastServiceProvider();
   53▕
   54▕     // Install bootstrapping...
   55▕     if (! file_exists($echoScriptPath = $this->laravel->resourcePath('js/echo.js'))) {
 ➜ 56▕       copy(__DIR__.'/stubs/echo-js.stub', $echoScriptPath);
   57▕     }
   58▕
   59▕     if (file_exists($bootstrapScriptPath = $this->laravel->resourcePath('js/bootstrap.js'))) {
   60▕       $bootstrapScript = file_get_contents(

 1  vendor\laravel\framework\src\Illuminate\Foundation\Console\BroadcastingInstallCommand.php:56

 2  vendor\laravel\framework\src\Illuminate\Container\BoundMethod.php:36
   Illuminate\Foundation\Console\BroadcastingInstallCommand::handle()
```

### Solution

The error is occurring because the 'js/' directory in the resource path doesn't exist yet. This can be fixed by creating the directory before copying `echo.js` inside it. This PR addresses the issue.