### PR TITLE
[11.x] feat: add generics and $factory property to HasFactory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Factories;
 
+/**
+ * @template TFactory of \Illuminate\Database\Eloquent\Factories\Factory
+ */
 trait HasFactory
 {
     /**
@@ -9,7 +12,7 @@ trait HasFactory
      *
      * @param  callable|array|int|null  $count
      * @param  callable|array  $state
-     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     * @return TFactory
      */
     public static function factory($count = null, $state = [])
     {
@@ -23,10 +26,14 @@ trait HasFactory
     /**
      * Create a new factory instance for the model.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     * @return TFactory|null
      */
     protected static function newFactory()
     {
-        //
+        if (! isset(static::$factory)) {
+            return null;
+        }
+
+        return static::$factory::new();
     }
 }

--- a/types/Autoload.php
+++ b/types/Autoload.php
@@ -1,11 +1,26 @@
 <?php
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {
+    /** @use HasFactory<UserFactory> */
     use HasFactory;
+
+    protected static string $factory = UserFactory::class;
+}
+
+/** @extends Factory<User> */
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition()
+    {
+        return [];
+    }
 }
 
 enum UserType

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -2,5 +2,4 @@
 
 use function PHPStan\Testing\assertType;
 
-$factory = User::factory();
-assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', $factory);
+assertType('UserFactory', User::factory());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

This PR does two things:
- adds proper generics to the trait
- allow using a `$factory` property instead a method


This allows for better static analysis / auto-completion as the `::factory()` method will now return the exact factory class.

I  also grew tired of overriding the `newFactory` method so now the user has the option of defining a `$factory` static property on the model. For more complicated use-cases the user still has the option of overriding the method.

Example:
```php
class User extends Authenticable
{
    use HasFactory;

    protected function newFactory(): UserFactory
    {
        return UserFactory::new();
    }
}

// becomes

class User extends Authenticable
{
    /** @use HasFactory<UserFactory> */
    use HasFactory;

    protected static string $factory = UserFactory::class;
}
```

Thanks!