### PR TITLE
[11.x] Add `--without-reverb` and `--without-node` arguments to `install:broadcasting` command

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -23,7 +23,9 @@ class BroadcastingInstallCommand extends Command
      */
     protected $signature = 'install:broadcasting
                     {--composer=global : Absolute path to the Composer binary which should be used to install packages}
-                    {--force : Overwrite any existing broadcasting routes file}';
+                    {--force : Overwrite any existing broadcasting routes file}
+                    {--without-reverb : Do not prompt to install Laravel Reverb}
+                    {--without-node : Do not prompt to install Node dependencies}';
 
     /**
      * The console command description.
@@ -127,7 +129,7 @@ class BroadcastingInstallCommand extends Command
      */
     protected function installReverb()
     {
-        if (InstalledVersions::isInstalled('laravel/reverb')) {
+        if ($this->option('without-reverb') || InstalledVersions::isInstalled('laravel/reverb')) {
             return;
         }
 
@@ -159,7 +161,7 @@ class BroadcastingInstallCommand extends Command
      */
     protected function installNodeDependencies()
     {
-        if (! confirm('Would you like to install and build the Node dependencies required for broadcasting?', default: true)) {
+        if ($this->option('without-reverb') || ! confirm('Would you like to install and build the Node dependencies required for broadcasting?', default: true)) {
             return;
         }
 
@@ -188,7 +190,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         $command = Process::command(implode(' && ', $commands))
-                        ->path(base_path());
+            ->path(base_path());
 
         if (! windows_os()) {
             $command->tty(true);

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -190,7 +190,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         $command = Process::command(implode(' && ', $commands))
-                    ->path(base_path());
+                        ->path(base_path());
 
         if (! windows_os()) {
             $command->tty(true);

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -190,7 +190,7 @@ class BroadcastingInstallCommand extends Command
         }
 
         $command = Process::command(implode(' && ', $commands))
-            ->path(base_path());
+                    ->path(base_path());
 
         if (! windows_os()) {
             $command->tty(true);

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -161,7 +161,7 @@ class BroadcastingInstallCommand extends Command
      */
     protected function installNodeDependencies()
     {
-        if ($this->option('without-reverb') || ! confirm('Would you like to install and build the Node dependencies required for broadcasting?', default: true)) {
+        if ($this->option('without-node') || ! confirm('Would you like to install and build the Node dependencies required for broadcasting?', default: true)) {
             return;
         }
 


### PR DESCRIPTION
This pull request adds two additional arguments to the `install:broadcasting` command.

They allow developers to skip the "Install Reverb" and "Install Node dependencies" prompts when scaffolding the rest of the broadcasting stuff.

## Use Case

We have an optional "Collaboration" feature in our package. During the setup command, we give developers the option of which broadcasting connection they wish to use (eg. Reverb / Pusher / etc).

However, since we run `install:broadcasting` during the setup command, it'll install Reverb even if the developer picked to use Pusher or another driver.

It's a similar-ish situation with the Node dependencies. Since our package bundles with Laravel Echo, our developers don't need the `echo.js` file (& it's dependencies) added to their project.