### PR TITLE
Added whereLike, whereNotLike, whereHasLike, and whereNotHasLike methods for flexible querying with 'like' conditions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -185,7 +185,7 @@ class Builder implements BuilderContract
      */
     public function withoutGlobalScope($scope)
     {
-        if (! is_string($scope)) {
+        if (!is_string($scope)) {
             $scope = get_class($scope);
         }
 
@@ -204,7 +204,7 @@ class Builder implements BuilderContract
      */
     public function withoutGlobalScopes(array $scopes = null)
     {
-        if (! is_array($scopes)) {
+        if (!is_array($scopes)) {
             $scopes = array_keys($this->scopes);
         }
 
@@ -330,7 +330,9 @@ class Builder implements BuilderContract
     public function orWhere($column, $operator = null, $value = null)
     {
         [$value, $operator] = $this->query->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->where($column, $operator, $value, 'or');
@@ -347,7 +349,7 @@ class Builder implements BuilderContract
      */
     public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->where($column, $operator, $value, $boolean.' not');
+        return $this->where($column, $operator, $value, $boolean . ' not');
     }
 
     /**
@@ -361,6 +363,74 @@ class Builder implements BuilderContract
     public function orWhereNot($column, $operator = null, $value = null)
     {
         return $this->whereNot($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "where like" clause to the query.
+     *
+     * @param  array|string  $columns
+     * @param  mixed  $q
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereLike($columns, $q, $boolean = 'or')
+    {
+        foreach ((array) $columns as $column) {
+            $this->query->where($column, 'like', '%' . $q . '%', $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a "where not like" clause to the query.
+     *
+     * @param  array|string  $columns
+     * @param  mixed  $q
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotLike($columns, $q, $boolean = 'or')
+    {
+        foreach ((array) $columns as $column) {
+            $this->query->where($column, 'not like', '%' . $q . '%', $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a "where has like" clause to the query.
+     *
+     * @param  string  $relation
+     * @param  array|string  $columns
+     * @param  mixed  $q
+     * @return $this
+     */
+    public function whereHasLike($relation, $columns, $q)
+    {
+        return $this->orWhereHas($relation, function ($query) use ($columns, $q) {
+            foreach ((array) $columns as $column) {
+                $query->orWhere($column, 'like', '%' . $q . '%');
+            }
+        });
+    }
+
+    /**
+     * Add a "where not has like" clause to the query.
+     *
+     * @param  string  $relation
+     * @param  array|string  $columns
+     * @param  mixed  $q
+     * @return $this
+     */
+    public function whereNotHasLike($relation, $columns, $q)
+    {
+        return $this->orWhereHas($relation, function ($query) use ($columns, $q) {
+            foreach ((array) $columns as $column) {
+                $query->where($column, 'not like', '%' . $q . '%');
+            }
+        });
     }
 
     /**
@@ -484,7 +554,8 @@ class Builder implements BuilderContract
         if (is_array($id)) {
             if (count($result) !== count(array_unique($id))) {
                 throw (new ModelNotFoundException)->setModel(
-                    get_class($this->model), array_diff($id, $result->modelKeys())
+                    get_class($this->model),
+                    array_diff($id, $result->modelKeys())
                 );
             }
 
@@ -493,7 +564,8 @@ class Builder implements BuilderContract
 
         if (is_null($result)) {
             throw (new ModelNotFoundException)->setModel(
-                get_class($this->model), $id
+                get_class($this->model),
+                $id
             );
         }
 
@@ -509,7 +581,7 @@ class Builder implements BuilderContract
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (! is_null($model = $this->find($id, $columns))) {
+        if (!is_null($model = $this->find($id, $columns))) {
             return $model;
         }
 
@@ -532,7 +604,7 @@ class Builder implements BuilderContract
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->find($id, $columns))) {
+        if (!is_null($model = $this->find($id, $columns))) {
             return $model;
         }
 
@@ -548,7 +620,7 @@ class Builder implements BuilderContract
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (!is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
@@ -564,7 +636,7 @@ class Builder implements BuilderContract
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
-        if (! is_null($instance = (clone $this)->where($attributes)->first())) {
+        if (!is_null($instance = (clone $this)->where($attributes)->first())) {
             return $instance;
         }
 
@@ -597,7 +669,7 @@ class Builder implements BuilderContract
     public function updateOrCreate(array $attributes, array $values = [])
     {
         return tap($this->firstOrCreate($attributes, $values), function ($instance) use ($values) {
-            if (! $instance->wasRecentlyCreated) {
+            if (!$instance->wasRecentlyCreated) {
                 $instance->fill($values)->save();
             }
         });
@@ -613,7 +685,7 @@ class Builder implements BuilderContract
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (!is_null($model = $this->first($columns))) {
             return $model;
         }
 
@@ -635,7 +707,7 @@ class Builder implements BuilderContract
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->first($columns))) {
+        if (!is_null($model = $this->first($columns))) {
             return $model;
         }
 
@@ -751,7 +823,7 @@ class Builder implements BuilderContract
             // For nested eager loads we'll skip loading them here and they will be set as an
             // eager load on the query to retrieve the relation so that they will be eager
             // loaded on that query, because that is where they get hydrated as models.
-            if (! str_contains($name, '.')) {
+            if (!str_contains($name, '.')) {
                 $models = $this->eagerLoadRelation($models, $name, $constraints);
             }
         }
@@ -783,7 +855,8 @@ class Builder implements BuilderContract
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
             $relation->initRelation($models, $name),
-            $relation->getEager(), $name
+            $relation->getEager(),
+            $name
         );
     }
 
@@ -833,7 +906,7 @@ class Builder implements BuilderContract
         // that start with the given top relations and adds them to our arrays.
         foreach ($this->eagerLoad as $name => $constraints) {
             if ($this->isNestedUnder($relation, $name)) {
-                $nested[substr($name, strlen($relation.'.'))] = $constraints;
+                $nested[substr($name, strlen($relation . '.'))] = $constraints;
             }
         }
 
@@ -849,7 +922,7 @@ class Builder implements BuilderContract
      */
     protected function isNestedUnder($relation, $name)
     {
-        return str_contains($name, '.') && str_starts_with($name, $relation.'.');
+        return str_contains($name, '.') && str_starts_with($name, $relation . '.');
     }
 
     /**
@@ -894,9 +967,11 @@ class Builder implements BuilderContract
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
         // columns are returned as you would expect from these Eloquent models.
-        if (! $this->model->hasGetMutator($column) &&
-            ! $this->model->hasCast($column) &&
-            ! in_array($column, $this->model->getDates())) {
+        if (
+            !$this->model->hasGetMutator($column) &&
+            !$this->model->hasCast($column) &&
+            !in_array($column, $this->model->getDates())
+        ) {
             return $results;
         }
 
@@ -993,7 +1068,7 @@ class Builder implements BuilderContract
         }
 
         $reverseDirection = function ($order) {
-            if (! isset($order['direction'])) {
+            if (!isset($order['direction'])) {
                 return $order;
             }
 
@@ -1007,7 +1082,7 @@ class Builder implements BuilderContract
             $this->query->unionOrders = collect($this->query->unionOrders)->map($reverseDirection)->toArray();
         }
 
-        $orders = ! empty($this->query->unionOrders) ? $this->query->unionOrders : $this->query->orders;
+        $orders = !empty($this->query->unionOrders) ? $this->query->unionOrders : $this->query->orders;
 
         return collect($orders)
             ->filter(fn ($order) => Arr::has($order, 'direction'))
@@ -1076,7 +1151,7 @@ class Builder implements BuilderContract
             return 0;
         }
 
-        if (! is_array(reset($values))) {
+        if (!is_array(reset($values))) {
             $values = [$values];
         }
 
@@ -1107,7 +1182,7 @@ class Builder implements BuilderContract
 
         $column = $this->model->getUpdatedAtColumn();
 
-        if (! $this->model->usesTimestamps() || is_null($column)) {
+        if (!$this->model->usesTimestamps() || is_null($column)) {
             return false;
         }
 
@@ -1125,7 +1200,9 @@ class Builder implements BuilderContract
     public function increment($column, $amount = 1, array $extra = [])
     {
         return $this->toBase()->increment(
-            $column, $amount, $this->addUpdatedAtColumn($extra)
+            $column,
+            $amount,
+            $this->addUpdatedAtColumn($extra)
         );
     }
 
@@ -1140,7 +1217,9 @@ class Builder implements BuilderContract
     public function decrement($column, $amount = 1, array $extra = [])
     {
         return $this->toBase()->decrement(
-            $column, $amount, $this->addUpdatedAtColumn($extra)
+            $column,
+            $amount,
+            $this->addUpdatedAtColumn($extra)
         );
     }
 
@@ -1152,14 +1231,16 @@ class Builder implements BuilderContract
      */
     protected function addUpdatedAtColumn(array $values)
     {
-        if (! $this->model->usesTimestamps() ||
-            is_null($this->model->getUpdatedAtColumn())) {
+        if (
+            !$this->model->usesTimestamps() ||
+            is_null($this->model->getUpdatedAtColumn())
+        ) {
             return $values;
         }
 
         $column = $this->model->getUpdatedAtColumn();
 
-        if (! array_key_exists($column, $values)) {
+        if (!array_key_exists($column, $values)) {
             $timestamp = $this->model->freshTimestampString();
 
             if (
@@ -1177,7 +1258,7 @@ class Builder implements BuilderContract
 
         $segments = preg_split('/\s+as\s+/i', $this->query->from);
 
-        $qualifiedColumn = end($segments).'.'.$column;
+        $qualifiedColumn = end($segments) . '.' . $column;
 
         $values[$qualifiedColumn] = Arr::get($values, $qualifiedColumn, $values[$column]);
 
@@ -1194,13 +1275,13 @@ class Builder implements BuilderContract
      */
     protected function addUniqueIdsToUpsertValues(array $values)
     {
-        if (! $this->model->usesUniqueIds()) {
+        if (!$this->model->usesUniqueIds()) {
             return $values;
         }
 
         foreach ($this->model->uniqueIds() as $uniqueIdAttribute) {
             foreach ($values as &$row) {
-                if (! array_key_exists($uniqueIdAttribute, $row)) {
+                if (!array_key_exists($uniqueIdAttribute, $row)) {
                     $row = array_merge([$uniqueIdAttribute => $this->model->newUniqueId()], $row);
                 }
             }
@@ -1217,7 +1298,7 @@ class Builder implements BuilderContract
      */
     protected function addTimestampsToUpsertValues(array $values)
     {
-        if (! $this->model->usesTimestamps()) {
+        if (!$this->model->usesTimestamps()) {
             return $values;
         }
 
@@ -1245,15 +1326,17 @@ class Builder implements BuilderContract
      */
     protected function addUpdatedAtToUpsertColumns(array $update)
     {
-        if (! $this->model->usesTimestamps()) {
+        if (!$this->model->usesTimestamps()) {
             return $update;
         }
 
         $column = $this->model->getUpdatedAtColumn();
 
-        if (! is_null($column) &&
-            ! array_key_exists($column, $update) &&
-            ! in_array($column, $update)) {
+        if (
+            !is_null($column) &&
+            !array_key_exists($column, $update) &&
+            !in_array($column, $update)
+        ) {
             $update[] = $column;
         }
 
@@ -1330,7 +1413,8 @@ class Builder implements BuilderContract
             // care of grouping the "wheres" properly so the logical order doesn't get
             // messed up when adding scopes. Then we'll return back out the builder.
             $builder = $builder->callNamedScope(
-                $scope, Arr::wrap($parameters)
+                $scope,
+                Arr::wrap($parameters)
             );
         }
 
@@ -1344,14 +1428,14 @@ class Builder implements BuilderContract
      */
     public function applyScopes()
     {
-        if (! $this->scopes) {
+        if (!$this->scopes) {
             return $this;
         }
 
         $builder = clone $this;
 
         foreach ($this->scopes as $identifier => $scope) {
-            if (! isset($builder->scopes[$identifier])) {
+            if (!isset($builder->scopes[$identifier])) {
                 continue;
             }
 
@@ -1392,7 +1476,7 @@ class Builder implements BuilderContract
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
         $originalWhereCount = is_null($query->wheres)
-                    ? 0 : count($query->wheres);
+            ? 0 : count($query->wheres);
 
         $result = $scope(...$parameters) ?? $this;
 
@@ -1434,11 +1518,13 @@ class Builder implements BuilderContract
         $query->wheres = [];
 
         $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, 0, $originalWhereCount)
+            $query,
+            array_slice($allWheres, 0, $originalWhereCount)
         );
 
         $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, $originalWhereCount)
+            $query,
+            array_slice($allWheres, $originalWhereCount)
         );
     }
 
@@ -1458,7 +1544,8 @@ class Builder implements BuilderContract
         // we don't add any unnecessary nesting thus keeping the query clean.
         if ($whereBooleans->contains(fn ($logicalOperator) => str_contains($logicalOperator, 'or'))) {
             $query->wheres[] = $this->createNestedWhere(
-                $whereSlice, str_replace(' not', '', $whereBooleans->first())
+                $whereSlice,
+                str_replace(' not', '', $whereBooleans->first())
             );
         } else {
             $query->wheres = array_merge($query->wheres, $whereSlice);
@@ -1587,7 +1674,7 @@ class Builder implements BuilderContract
         // syntax, we shall loop over the nested relations and prepend each key of
         // this array while flattening into the traditional dot notation format.
         foreach ($relations as $key => $value) {
-            if (! is_string($key) || ! is_array($value)) {
+            if (!is_string($key) || !is_array($value)) {
                 continue;
             }
 
@@ -1610,9 +1697,9 @@ class Builder implements BuilderContract
                 [$key, $value] = $this->parseNameAndAttributeSelectionConstraint($value);
             }
 
-            $preparedRelationships[$prefix.$key] = $this->combineConstraints([
+            $preparedRelationships[$prefix . $key] = $this->combineConstraints([
                 $value,
-                $preparedRelationships[$prefix.$key] ?? static function () {
+                $preparedRelationships[$prefix . $key] ?? static function () {
                     //
                 },
             ]);
@@ -1668,8 +1755,8 @@ class Builder implements BuilderContract
                 }
 
                 return $query instanceof BelongsToMany
-                        ? $query->getRelated()->getTable().'.'.$column
-                        : $column;
+                    ? $query->getRelated()->getTable() . '.' . $column
+                    : $column;
             }, explode(',', explode(':', $name)[1])));
         }];
     }
@@ -1691,7 +1778,7 @@ class Builder implements BuilderContract
         foreach (explode('.', $name) as $segment) {
             $progress[] = $segment;
 
-            if (! isset($results[$last = implode('.', $progress)])) {
+            if (!isset($results[$last = implode('.', $progress)])) {
                 $results[$last] = static function () {
                     //
                 };
@@ -1997,7 +2084,7 @@ class Builder implements BuilderContract
             return static::registerMixin($parameters[0], $parameters[1] ?? true);
         }
 
-        if (! static::hasGlobalMacro($method)) {
+        if (!static::hasGlobalMacro($method)) {
             static::throwBadMethodCallException($method);
         }
 
@@ -2024,7 +2111,7 @@ class Builder implements BuilderContract
         );
 
         foreach ($methods as $method) {
-            if ($replace || ! static::hasGlobalMacro($method->name)) {
+            if ($replace || !static::hasGlobalMacro($method->name)) {
                 static::macro($method->name, $method->invoke($mixin));
             }
         }


### PR DESCRIPTION
Added whereLike, whereNotLike, whereHasLike, and whereNotHasLike methods for flexible querying with 'like' conditions

This commit addresses the discussion on GitHub (https://github.com/laravel/framework/discussions/50288) where the need for more versatile 'like' clause querying methods was raised

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
