### PR TITLE
[11.x] Adds JSON (transport) helper class

### DIFF
--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -33,7 +33,8 @@
         }
     },
     "suggest": {
-        "symfony/var-dumper": "Required to use the dump method (^7.0)."
+        "symfony/var-dumper": "Required to use the dump method (^7.0).",
+        "symfony/http-foundation": "Required to transform Json into an HTTP response (^7.0)"
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Support/Json.php
+++ b/src/Illuminate/Support/Json.php
@@ -39,11 +39,12 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      *
      * @param  array-key  $key
      * @param  mixed  $value
+     * @param  bool  $overwrite
      * @return void
      */
-    public function set($key, $value): void
+    public function set($key, $value, $overwrite = true): void
     {
-        Arr::set($this->items, $key, $value);
+        data_set($this->items, $key, $value, $overwrite);
     }
 
     /**
@@ -55,9 +56,7 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      */
     public function fill($key, $value)
     {
-        if ($this->missing($key)) {
-            $this->set($key, $value);
-        }
+        $this->set($key, $value, false);
     }
 
     /**
@@ -70,7 +69,7 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      */
     public function get($key, $default = null)
     {
-        return Arr::get($this->items, $key, $default);
+        return data_get($this->items, $key, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Json.php
+++ b/src/Illuminate/Support/Json.php
@@ -63,6 +63,7 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      * Retrieves a value from the underlying JSON data.
      *
      * @template TDefault
+     *
      * @param  array-key  $key
      * @param  TDefault  $default
      * @return TDefault|mixed|null
@@ -91,7 +92,7 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      */
     public function missing($key)
     {
-        return !$this->has($key);
+        return ! $this->has($key);
     }
 
     /**
@@ -113,7 +114,7 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      */
     public function missingKey($key)
     {
-        return !$this->hasKey($key);
+        return ! $this->hasKey($key);
     }
 
     /**
@@ -166,7 +167,7 @@ class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Respons
      */
     public function toArray(): array
     {
-        return array_map(fn($value) => $value instanceof Arrayable ? $value->toArray() : $value, $this->items);
+        return array_map(fn ($value) => $value instanceof Arrayable ? $value->toArray() : $value, $this->items);
     }
 
     /**

--- a/src/Illuminate/Support/Json.php
+++ b/src/Illuminate/Support/Json.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Dumpable;
+use Illuminate\Support\Traits\Tappable;
+use JsonSerializable;
+use stdClass;
+use Stringable;
+
+class Json implements Arrayable, Jsonable, JsonSerializable, Stringable, Responsable, ArrayAccess
+{
+    use Conditionable, Dumpable, Tappable;
+
+    /**
+     * The JSON data array.
+     *
+     * @var array
+     */
+    protected $items;
+
+    /**
+     * Create a new JSON transport.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $items
+     */
+    public function __construct($items = [])
+    {
+        $this->items = $items instanceof Arrayable ? $items->toArray() : $items;
+    }
+
+    /**
+     * Adds a value to the underlying JSON data.
+     *
+     * @param  array-key  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function set($key, $value): void
+    {
+        Arr::set($this->items, $key, $value);
+    }
+
+    /**
+     * Fill in data where it's missing in the JSON data.
+     *
+     * @param  array-key  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function fill($key, $value)
+    {
+        if ($this->missing($key)) {
+            $this->set($key, $value);
+        }
+    }
+
+    /**
+     * Retrieves a value from the underlying JSON data.
+     *
+     * @template TDefault
+     * @param  array-key  $key
+     * @param  TDefault  $default
+     * @return TDefault|mixed|null
+     */
+    public function get($key, $default = null)
+    {
+        return Arr::get($this->items, $key, $default);
+    }
+
+    /**
+     * Determine if the given key in the JSON data exists and is not "null".
+     *
+     * @param  array-key  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->get($key) !== null;
+    }
+
+    /**
+     * Determine if the given key in the JSON data is missing or is "null".
+     *
+     * @param  array-key  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return !$this->has($key);
+    }
+
+    /**
+     * Determine if the given key in the JSON data is set.
+     *
+     * @param  array-key  $key
+     * @return bool
+     */
+    public function hasKey($key)
+    {
+        return $this->get($key, $placeholder = new stdClass) !== $placeholder;
+    }
+
+    /**
+     * Determine if the given key in the JSON data is not set.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missingKey($key)
+    {
+        return !$this->hasKey($key);
+    }
+
+    /**
+     * Forgets a given key from the JSON data.
+     *
+     * @param  array-key  $key
+     * @return void
+     */
+    public function forget($key)
+    {
+        Arr::forget($this->items, $key);
+    }
+
+    /**
+     * Returns the underlying JSON items.
+     *
+     * @return array
+     */
+    public function items()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0): string
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object to its JSON representation, or throw an exception.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJsonOrFail($options = 0): string
+    {
+        return $this->toJson($options | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return array_map(fn($value) => $value instanceof Arrayable ? $value->toArray() : $value, $this->items);
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @throws \JsonException
+     */
+    public function __toString(): string
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function toResponse($request)
+    {
+        return new \Symfony\Component\HttpFoundation\JsonResponse($this);
+    }
+
+    /**
+     * Dynamically retrieve a value from the JSON items.
+     *
+     * @param  string  $key
+     * @return mixed|null
+     */
+    public function __get(string $key)
+    {
+        return $this->get($key);
+    }
+
+    /**
+     * Dynamically set a value in the JSON items.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set(string $key, $value): void
+    {
+        $this->set($key, $value);
+    }
+
+    /**
+     * Dynamically check if a key in the JSON items exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset(string $key): bool
+    {
+        return $this->has($key);
+    }
+
+    /**
+     * Dynamically forget a key from the JSON items.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function __unset(string $key): void
+    {
+        $this->forget($key);
+    }
+
+    /**
+     * Whether an offset exists.
+     *
+     * @param  mixed  $offset
+     * @return bool
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->has($offset);
+    }
+
+    /**
+     * Offset to retrieve.
+     *
+     * @param  mixed  $offset
+     * @return mixed|null
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Offset to set.
+     *
+     * @param  array-key  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * Offset to unset.
+     *
+     * @param  array-key  $offset
+     * @return void
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->forget($offset);
+    }
+
+    /**
+     * Create a new instance from a JSON string.
+     *
+     * @param  string  $json
+     * @return static
+     */
+    public static function fromString(string $json): static
+    {
+        return new static(json_decode($json, true));
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param  array  $json
+     * @return $this
+     */
+    public static function make($json = []): static
+    {
+        return new static($json);
+    }
+}

--- a/tests/Support/JsonTest.php
+++ b/tests/Support/JsonTest.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Json;
 use JsonException;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Json;
+
 use function json_encode;
 
 class JsonTest extends TestCase
@@ -90,18 +91,20 @@ JSON, $json->toJson(JSON_PRETTY_PRINT));
 
     public function testToJsonOrFail()
     {
-        $a = new class {
+        $a = new class
+        {
             public $otherObject;
         };
 
-        $b = new class {
+        $b = new class
+        {
             public $otherObject;
         };
 
         $a->otherObject = $b;
         $b->otherObject = $a;
 
-        $json = new Json(["😓" => $a]);
+        $json = new Json(['😓' => $a]);
 
         $this->expectException(JsonException::class);
 

--- a/tests/Support/JsonTest.php
+++ b/tests/Support/JsonTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Collection;
+use JsonException;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Json;
+use function json_encode;
+
+class JsonTest extends TestCase
+{
+    public function testInstanceFromArrayable()
+    {
+        $json = new Json(new Json(['foo' => ['bar' => 'baz']]));
+
+        $this->assertSame(['foo' => ['bar' => 'baz']], $json->items());
+    }
+
+    public function testGetsAndSetsValues()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('baz', $json->get('foo.bar'));
+
+        $json->set('foo.bar', 'quz');
+
+        $this->assertSame('quz', $json->get('foo.bar'));
+    }
+
+    public function testGetsDefaultValue()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertNull($json->get('foo.invalid'));
+        $this->assertSame('default', $json->get('foo.invalid', 'default'));
+        $this->assertSame('default', $json->get('foo.invalid', fn () => 'default'));
+    }
+
+    public function testHasValue()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertTrue($json->has('foo'));
+        $this->assertFalse($json->missing('foo'));
+
+        $this->assertTrue($json->has('foo.bar'));
+        $this->assertFalse($json->missing('foo.bar'));
+
+        $this->assertFalse($json->has('invalid'));
+        $this->assertTrue($json->missing('invalid'));
+    }
+
+    public function testHasKey()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz', 'null' => null]]);
+
+        $this->assertTrue($json->hasKey('foo'));
+        $this->assertFalse($json->missingKey('foo'));
+
+        $this->assertTrue($json->hasKey('foo.null'));
+        $this->assertFalse($json->missingKey('foo.null'));
+
+        $this->assertFalse($json->hasKey('invalid'));
+        $this->assertTrue($json->missingKey('invalid'));
+    }
+
+    public function testForgetsValue()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $json->forget('foo.bar');
+
+        $this->assertNull($json->get('foo.bar'));
+    }
+
+    public function testToJson()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('{"foo":{"bar":"baz"}}', $json->toJson());
+        $this->assertSame(<<<'JSON'
+{
+    "foo": {
+        "bar": "baz"
+    }
+}
+JSON, $json->toJson(JSON_PRETTY_PRINT));
+    }
+
+    public function testToJsonOrFail()
+    {
+        $a = new class {
+            public $otherObject;
+        };
+
+        $b = new class {
+            public $otherObject;
+        };
+
+        $a->otherObject = $b;
+        $b->otherObject = $a;
+
+        $json = new Json(["😓" => $a]);
+
+        $this->expectException(JsonException::class);
+
+        $json->toJsonOrFail();
+    }
+
+    public function testToArray()
+    {
+        $this->assertSame(['foo' => ['bar' => 'baz']], (new Json(['foo' => ['bar' => 'baz']]))->toArray());
+
+        $arrayable = new Json(['foo' => new Collection(['bar' => 'baz'])]);
+
+        $this->assertSame(['foo' => ['bar' => 'baz']], $arrayable->toArray());
+    }
+
+    public function testJsonSerialization()
+    {
+        $json = new Json(['foo' => ['bar' => new Collection('baz')]]);
+
+        $this->assertSame('{"foo":{"bar":["baz"]}}', json_encode($json));
+    }
+
+    public function testToString()
+    {
+        $json = new Json(['foo' => ['bar' => new Collection('baz')]]);
+
+        $this->assertSame('{"foo":{"bar":["baz"]}}', (string) $json);
+    }
+
+    public function testObjectAccess()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('baz', $json->{'foo.bar'});
+        $this->assertTrue(isset($json->{'foo.bar'}));
+
+        $json->{'foo.bar'} = 'quz';
+
+        $this->assertSame('quz', $json->{'foo.bar'});
+
+        unset($json->{'foo.bar'});
+
+        $this->assertNull($json->{'foo.bar'});
+    }
+
+    public function testArrayAccess()
+    {
+        $json = new Json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('baz', $json['foo.bar']);
+        $this->assertTrue(isset($json['foo.bar']));
+
+        $json['foo.bar'] = 'quz';
+
+        $this->assertSame('quz', $json['foo.bar']);
+
+        unset($json['foo.bar']);
+
+        $this->assertNull($json['foo.bar']);
+    }
+
+    public function testFromString()
+    {
+        $this->assertSame(['foo' => ['bar' => 'baz']], Json::fromString('{"foo":{"bar":"baz"}}')->items());
+    }
+
+    public function testMake()
+    {
+        $this->assertSame([], Json::make()->items());
+        $this->assertSame(['foo' => ['bar' => 'baz']], Json::make(['foo' => ['bar' => 'baz']])->items());
+    }
+}


### PR DESCRIPTION
# What?

I'm tired of dealing with JSON strings with `Arr` and `data_*` all over the place, plus replicating the array across plethora of functions waiting for to reach memory limit because the array is copied on each function.

So I decided to make a PR to include a JSON utility to manage JSON data.

```php
use Illuminate\Support\Json;

$json = new Json(['items' => /* Somewhat a large piece of data */ ])

$json->set('foo', 'bar');

$json->when(true)->set('baz' => 'quz');

$json->dd();
```

It's made to handle arrays and Arrayable objects. It works like the Config Repository, in terms of retrieving and setting data. The main idea for this class is for developers to build JSON from their application, rather than push an array and a call it a day. This way, we can avoid the spiral of multiple `Arr` and `data_*` calls all over the place and passing the same object around.

Also, it includes everything except the kitchen sink: `Reponsable` (if `symfony/http-foundation` is installed, added to composer suggestions), `Stringable`, `JsonSerializable`, and `Arrayable`.

This object also paves the way for incorporating it into other parts of the framework where JSON is required to be manipulated.

- Why no using `Fluent`? Only top-level keys are supported.
- Why not config's `Repository`? It's more config-oriented than json-oriented.
- Why not `Collection`? It's very cool for lists, but not multidimensional arrays.