### PR TITLE
[11.x] Fix adding multiple bootstrap providers with opcache

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -493,6 +493,10 @@ abstract class ServiceProvider
             return false;
         }
 
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($path, true);
+        }
+
         $providers = collect(require $path)
             ->merge([$provider])
             ->unique()


### PR DESCRIPTION
This PR fixes an issue when calling the `ServiceProvider::addProviderToBootstrapFile` method multiple times with opcache enabled.

Currently, subsequent calls to the method will overwrite any changes from previous calls because the `bootstrap/providers.php` file is cached on the initial read.

This was an issue with the Jetstream installer, especially when run inside Sail where opcache is enabled by default.

Fixes https://github.com/laravel/jetstream/issues/1454

Credit and thanks to @nunomaduro for this solution! My alternate idea was a static cache of the providers, but I prefer this one.