### PR TITLE
[10.x] Fix `Collection::concat()` return type

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -998,8 +998,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Push all of the given items onto the collection.
      *
-     * @param  iterable<array-key, TValue>  $source
-     * @return static
+     * @template TConcatKey of array-key
+     * @template TConcatValue
+     *
+     * @param  iterable<TConcatKey, TConcatValue>  $source
+     * @return static<TKey|TConcatKey, TValue|TConcatValue>
      */
     public function concat($source)
     {

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -789,8 +789,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Push all of the given items onto the collection.
      *
-     * @param  iterable<array-key, TValue>  $source
-     * @return static
+     * @template TConcatKey of array-key
+     * @template TConcatValue
+     *
+     * @param  iterable<TConcatKey, TConcatValue>  $source
+     * @return static<TKey|TConcatKey, TValue|TConcatValue>
      */
     public function concat($source);
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -991,8 +991,11 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Push all of the given items onto the collection.
      *
-     * @param  iterable<array-key, TValue>  $source
-     * @return static
+     * @template TConcatKey of array-key
+     * @template TConcatValue
+     *
+     * @param  iterable<TConcatKey, TConcatValue>  $source
+     * @return static<TKey|TConcatKey, TValue|TConcatValue>
      */
     public function concat($source)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -657,6 +657,7 @@ assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collecti
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->concat([2]));
 assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->concat(['string']));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->concat(['string']));
 
 assertType('Illuminate\Support\Collection<int, int>|int', $collection->make([1])->random(2));
 assertType('Illuminate\Support\Collection<int, string>|string', $collection->make(['string'])->random());

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -547,6 +547,7 @@ assertType('Illuminate\Support\LazyCollection<int<0, 1>, Illuminate\Support\Lazy
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->concat([2]));
 assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->concat(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make([1])->concat(['string']));
 
 assertType('Illuminate\Support\LazyCollection<int, int>|int', $collection->make([1])->random(2));
 assertType('Illuminate\Support\LazyCollection<int, string>|string', $collection->make(['string'])->random());


### PR DESCRIPTION
This PR fixes the return type of `Collection::concat()` and `LazyCollection::concat()`.

```php
Collection::make([1])->concat(['foo']);
```

Before:

```php
Collection<int, int>
```

After:

```php
Collection<int, int|string>
```