### PR TITLE
[11.x] Replace file_exists() with is_file() in FileBasedMaintenanceMode

### DIFF
--- a/src/Illuminate/Foundation/FileBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/FileBasedMaintenanceMode.php
@@ -39,7 +39,7 @@ class FileBasedMaintenanceMode implements MaintenanceModeContract
      */
     public function active(): bool
     {
-        return file_exists($this->path());
+        return is_file($this->path());
     }
 
     /**


### PR DESCRIPTION
It looks like file_exists() is doing some extra checks that are not necessary for the purpose it serves in FileBasedMaintenanceMode.

The difference between the two is that file_exists() is more tolerant as it will return positive returns not just for files, but also for folders and links. The price it pays for that extra functionality is using the stats cache. 

Calls to check whether maintenance mode is on are performed on every web request (if PreventRequestsDuringMaintenance middleware is used). The default implementation is the "file" one. It is in FileBasedMaintenanceMode, and it is using file_exists(). It seems like we can shave off some of those additional checks as they are not needed in this context. The framework/down file flag is never going to be a folder or a link, and the extra stats cache checks look like a waste.

