### PR TITLE
[11.x] Accept non-backed enum in database queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
+use UnitEnum;
 
 class Builder implements BuilderContract
 {
@@ -3953,7 +3954,11 @@ class Builder implements BuilderContract
      */
     public function castBinding($value)
     {
-        return $value instanceof BackedEnum ? $value->value : $value;
+        if ($value instanceof UnitEnum) {
+            return $value instanceof BackedEnum ? $value->value : $value->name;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -30,6 +30,8 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
 
+include_once 'Enums.php';
+
 class DatabaseQueryBuilderTest extends TestCase
 {
     protected $called;
@@ -4472,6 +4474,14 @@ SQL;
         $builder->addBinding(['bar', 'baz'], 'having');
         $builder->addBinding(['foo'], 'where');
         $this->assertEquals(['foo', 'bar', 'baz'], $builder->getBindings());
+    }
+
+    public function testAddBindingWithEnum()
+    {
+        $builder = $this->getBuilder();
+        $builder->addBinding(IntegerStatus::done);
+        $builder->addBinding([NonBackedStatus::done]);
+        $this->assertEquals([2, 'done'], $builder->getBindings());
     }
 
     public function testMergeBuilders()

--- a/tests/Database/Enums.php
+++ b/tests/Database/Enums.php
@@ -18,6 +18,13 @@ enum IntegerStatus: int
     case done = 2;
 }
 
+enum NonBackedStatus
+{
+    case draft;
+    case pending;
+    case done;
+}
+
 enum ArrayableStatus: string implements Arrayable
 {
     case pending = 'pending';

--- a/tests/Integration/Database/Enums.php
+++ b/tests/Integration/Database/Enums.php
@@ -18,6 +18,13 @@ enum IntegerStatus: int
     case done = 2;
 }
 
+enum NonBackedStatus
+{
+    case draft;
+    case pending;
+    case done;
+}
+
 enum ArrayableStatus: string implements Arrayable
 {
     case pending = 'pending';

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -16,6 +16,7 @@ class QueryingWithEnumsTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('string_status', 100)->nullable();
             $table->integer('integer_status')->nullable();
+            $table->string('non_backed_status', 100)->nullable();
         });
     }
 
@@ -24,17 +25,21 @@ class QueryingWithEnumsTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
             'integer_status' => 1,
+            'non_backed_status' => 'pending',
         ]);
 
         $record = DB::table('enum_casts')->where('string_status', StringStatus::pending)->first();
         $record2 = DB::table('enum_casts')->where('integer_status', IntegerStatus::pending)->first();
         $record3 = DB::table('enum_casts')->whereIn('integer_status', [IntegerStatus::pending])->first();
+        $record4 = DB::table('enum_casts')->where('non_backed_status', NonBackedStatus::pending)->first();
 
         $this->assertNotNull($record);
         $this->assertNotNull($record2);
         $this->assertNotNull($record3);
+        $this->assertNotNull($record4);
         $this->assertSame('pending', $record->string_status);
         $this->assertEquals(1, $record2->integer_status);
+        $this->assertSame('pending', $record4->non_backed_status);
     }
 
     public function testCanInsertWithEnums()
@@ -42,6 +47,7 @@ class QueryingWithEnumsTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => StringStatus::pending,
             'integer_status' => IntegerStatus::pending,
+            'non_backed_status' => NonBackedStatus::pending,
         ]);
 
         $record = DB::table('enum_casts')->where('string_status', StringStatus::pending)->first();
@@ -49,5 +55,6 @@ class QueryingWithEnumsTest extends DatabaseTestCase
         $this->assertNotNull($record);
         $this->assertSame('pending', $record->string_status);
         $this->assertEquals(1, $record->integer_status);
+        $this->assertSame('pending', $record->non_backed_status);
     }
 }


### PR DESCRIPTION
This PR aims to implement non backed enums support for database queries, equivalent to the existing support for backed enums implemented in #39492 

Non backed enums can be already used as eloquent attribute casting:

```php
enum Status 
{
    case Active;
    case Archive;
}

class User extends Model 
{
  protected $casts = [
    'status' => Status::class,
  ];
}
```

The enumerative `name` property is used as the scalar value for Database storage.

```php
$user = new User();
$user->status = Status::Active; // Stored as 'Active' in the database
$user->save();
```

However, using the enum in the query builder returns an error:

```php
User::where('status', Status::Active)->get(); // ❌ ERROR: Object of class Status could not be converted to string

User::update([ 'status' => Status::Archive]); // ❌ ERROR: Object of class Status could not be converted to string
```

This PR enables this syntax, automatically casting each non-backed enumerative case to its `name`.



