### PR TITLE
[11.x] Fixed `class` and `class.invokable` stub paths after publish

### DIFF
--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -37,11 +37,22 @@ class ClassMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        if ($this->option('invokable')) {
-            return __DIR__.'/stubs/class.invokable.stub';
-        }
+        return $this->option('invokable') 
+            ? $this->resolveStubPath('/stubs/class.invokable.stub') 
+            : $this->resolveStubPath('/stubs/class.stub');
+    }
 
-        return __DIR__.'/stubs/class.stub';
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ClassMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ClassMakeCommand.php
@@ -37,8 +37,8 @@ class ClassMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->option('invokable') 
-            ? $this->resolveStubPath('/stubs/class.invokable.stub') 
+        return $this->option('invokable')
+            ? $this->resolveStubPath('/stubs/class.invokable.stub')
             : $this->resolveStubPath('/stubs/class.stub');
     }
 


### PR DESCRIPTION
The original code was making classes from the framework-included stubs only

```PHP
/**
 * Get the stub file for the generator.
 *
 * @return string
 */
protected function getStub()
{
    if ($this->option('invokable')) {
        return __DIR__.'/stubs/class.invokable.stub';
    }

    return __DIR__.'/stubs/class.stub';
}
```

It is changed to use published class stubs (if there are any) in `make:class` command.