### PR TITLE
[11.x] Fixed `trait` stub paths after publish

### DIFF
--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -37,7 +37,20 @@ class TraitMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/trait.stub';
+        return $this->resolveStubPath('/stubs/trait.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
     }
 
     /**


### PR DESCRIPTION
The original code was making traits from the framework-included stubs only

```PHP
/**
 * Get the stub file for the generator.
 *
 * @return string
 */
protected function getStub()
{
    return __DIR__.'/stubs/trait.stub';
}
```

It is changed to use published trait stubs (if there are any) in `make:trait` command.