### PR TITLE
[11.x] Added `interface` into `stub:publish` command and fixed paths after publish

### DIFF
--- a/src/Illuminate/Foundation/Console/InterfaceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/InterfaceMakeCommand.php
@@ -37,7 +37,20 @@ class InterfaceMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/interface.stub';
+        return $this->resolveStubPath('/stubs/interface.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -45,6 +45,7 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/console.stub' => 'console.stub',
             __DIR__.'/stubs/enum.stub' => 'enum.stub',
             __DIR__.'/stubs/enum.backed.stub' => 'enum.backed.stub',
+            __DIR__.'/stubs/interface.stub' => 'interface.stub',
             __DIR__.'/stubs/event.stub' => 'event.stub',
             __DIR__.'/stubs/job.queued.stub' => 'job.queued.stub',
             __DIR__.'/stubs/job.stub' => 'job.stub',


### PR DESCRIPTION
I've done 2 things in this PR.
- Add `interface.stub` into `stub:publish` command 
- Fixed paths after publishing so it will use published interface stubs (if there are any) in the `make:interface` command.