### PR TITLE
[11.x] Allow `BackedEnum` and `UnitEnum` in `Rule::in` and `Rule::notIn`

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -26,7 +26,7 @@ class In implements Stringable
     /**
      * Create a new in rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|BackedEnum|UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return void
      */
     public function __construct($values)

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -26,7 +26,7 @@ class In implements Stringable
     /**
      * Create a new in rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|BackedEnum|UnitEnum|array|string  $values
      * @return void
      */
     public function __construct($values)

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -26,7 +26,7 @@ class NotIn implements Stringable
     /**
      * Create a new "not in" rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|BackedEnum|UnitEnum|array|string  $values
      * @return void
      */
     public function __construct($values)

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -26,7 +26,7 @@ class NotIn implements Stringable
     /**
      * Create a new "not in" rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|BackedEnum|UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
      * @return void
      */
     public function __construct($values)


### PR DESCRIPTION
Both `BackedEnum` and `UnitEnum` are allowed in `Rule::in` and `Rule::notIn`, but were not allowed according the docblocks.

![afbeelding](https://github.com/laravel/framework/assets/11609290/b2d9cc76-d7d6-4159-9a13-404d6acc56b6)
