### PR TITLE
[10.x] Fix Morph Class is integer

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -768,7 +768,7 @@ trait HasRelationships
         $morphMap = Relation::morphMap();
 
         if (! empty($morphMap) && in_array(static::class, $morphMap)) {
-            return array_search(static::class, $morphMap, true);
+            return $morphMap[array_search(static::class, $morphMap, true)];
         }
 
         if (static::class === Pivot::class) {


### PR DESCRIPTION
This PR is a fix for #50691.

It returns the morph class correctly, therefore it fixes issue when morph class incorrectly returned an integer instead of class name.