### PR TITLE
[10.x] Fix command alias registration and usage

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -29,8 +29,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -77,8 +75,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -125,8 +121,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -174,8 +168,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -221,8 +213,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -40,6 +40,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
@@ -85,6 +88,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
@@ -129,6 +135,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -176,6 +185,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
@@ -219,6 +231,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -30,6 +30,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
@@ -63,6 +66,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -106,6 +112,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
@@ -143,6 +152,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -56,8 +54,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -101,8 +97,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -135,8 +129,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       
       - name: Download & Extract beanstalkd
         run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -30,6 +28,9 @@ jobs:
           php-version: 8.1
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -61,6 +59,9 @@ jobs:
         env:
           REDIS_CONFIGURE_OPTS: --enable-redis --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --with-liblzf --enable-redis-zstd --with-libzstd --enable-redis-lz4 --with-liblz4
           REDIS_LIBS: liblz4-dev, liblzf-dev, libzstd-dev
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Set minimum PHP 8.1 versions
         uses: nick-fields/retry@v3
@@ -121,8 +122,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -131,6 +130,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, gmp, intl, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Set Minimum PHP 8.1 Versions
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,11 +78,7 @@ jobs:
         if: matrix.php >= 8.2
 
       - name: Install dependencies
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --display-deprecation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: '${GITHUB_SHA}'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ GITHUB_SHA }}
+          ref: ${{ vars.GITHUB_SHA }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git checkout HEAD^
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -121,7 +124,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ vars.GITHUB_SHA }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -78,7 +76,11 @@ jobs:
         if: matrix.php >= 8.2
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --display-deprecation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git checkout HEAD^
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: '${GITHUB_SHA}'
+          ref: ${{ GITHUB_SHA }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,11 @@
             "Illuminate\\Tests\\": "tests/"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "10.x-dev"
+        }
+    },
     "suggest": {
         "ext-apcu": "Required to use the APC cache driver.",
         "ext-fileinfo": "Required to use the Filesystem class.",

--- a/composer.json
+++ b/composer.json
@@ -150,11 +150,6 @@
             "Illuminate\\Tests\\": "tests/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "10.x-dev"
-        }
-    },
     "suggest": {
         "ext-apcu": "Required to use the APC cache driver.",
         "ext-fileinfo": "Required to use the Filesystem class.",

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -237,7 +237,9 @@ class Application extends SymfonyApplication implements ApplicationContract
     public function resolve($command)
     {
         if (is_subclass_of($command, SymfonyCommand::class) && ($commandName = $command::getDefaultName())) {
-            $this->commandMap[$commandName] = $command;
+            foreach (explode('|', $commandName) as $name) {
+                $this->commandMap[$name] = $command;
+            }
 
             return null;
         }

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -2,20 +2,27 @@
 
 namespace Illuminate\Tests\Integration\Console;
 
+use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Console\QueuedCommand;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 class ConsoleApplicationTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
+        Artisan::starting(function ($artisan) use ($commands) {
+            $artisan->resolveCommands([
+                FooCommandStub::class,
+                ZondaCommandStub::class,
+            ]);
+        });
 
-        $this->app[Kernel::class]->registerCommand(new FooCommandStub);
+        parent::setUp();
     }
 
     public function testArtisanCallUsingCommandName()
@@ -25,9 +32,30 @@ class ConsoleApplicationTest extends TestCase
         ])->assertExitCode(0);
     }
 
+    public function testArtisanCallUsingCommandNameAliases()
+    {
+        $this->artisan('app:foobar', [
+            'id' => 1,
+        ])->assertExitCode(0);
+    }
+
     public function testArtisanCallUsingCommandClass()
     {
         $this->artisan(FooCommandStub::class, [
+            'id' => 1,
+        ])->assertExitCode(0);
+    }
+
+    public function testArtisanCallUsingCommandNameUsingAsCommandAttribute()
+    {
+        $this->artisan('zonda', [
+            'id' => 1,
+        ])->assertExitCode(0);
+    }
+
+    public function testArtisanCallUsingCommandNameAliasesUsingAsCommandAttribute()
+    {
+        $this->artisan('app:zonda', [
             'id' => 1,
         ])->assertExitCode(0);
     }
@@ -85,6 +113,21 @@ class ConsoleApplicationTest extends TestCase
 class FooCommandStub extends Command
 {
     protected $signature = 'foo:bar {id}';
+
+    protected $aliases = ['app:foobar'];
+
+    public function handle()
+    {
+        //
+    }
+}
+
+#[AsCommand(name: 'zonda', aliases: ['app:zonda'])]
+class ZondaCommandStub extends Command
+{
+    protected $signature = 'zonda {id}';
+
+    protected $aliases = ['app:zonda'];
 
     public function handle()
     {

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -15,7 +15,7 @@ class ConsoleApplicationTest extends TestCase
 {
     protected function setUp(): void
     {
-        Artisan::starting(function ($artisan) use ($commands) {
+        Artisan::starting(function ($artisan) {
             $artisan->resolveCommands([
                 FooCommandStub::class,
                 ZondaCommandStub::class,


### PR DESCRIPTION
Backport PR #50617 to `10.x` release since this would cause issue using aliases with `$this->artisan()` under tests.