### PR TITLE
[10.x] Explicitly set `composer config version` to avoid pulling all branches and tags for GitHub Actions

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -29,8 +29,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -39,6 +37,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -74,8 +75,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -84,6 +83,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -119,8 +121,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -129,6 +129,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -165,8 +168,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -175,6 +176,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_pgsql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -209,8 +213,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -219,6 +221,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -29,6 +27,9 @@ jobs:
           php-version: 8.1
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -29,6 +27,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -53,8 +54,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -63,6 +62,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -95,8 +97,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -105,6 +105,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3
@@ -126,8 +129,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       
       - name: Download & Extract beanstalkd
         run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz
@@ -143,6 +144,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -30,6 +28,9 @@ jobs:
           php-version: 8.1
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Install dependencies
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -61,6 +59,9 @@ jobs:
         env:
           REDIS_CONFIGURE_OPTS: --enable-redis --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --with-liblzf --enable-redis-zstd --with-libzstd --enable-redis-lz4 --with-liblz4
           REDIS_LIBS: liblz4-dev, liblzf-dev, libzstd-dev
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Set minimum PHP 8.1 versions
         uses: nick-fields/retry@v3
@@ -121,8 +122,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -131,6 +130,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, gmp, intl, :php-psr
           tools: composer:v2
           coverage: none
+
+      - name: Set Framework version
+        run: composer config version "10.x-dev"
 
       - name: Set Minimum PHP 8.1 Versions
         uses: nick-fields/retry@v3


### PR DESCRIPTION
Fixes error such as when running on non-default branch:

![image](https://github.com/laravel/framework/assets/172966/89d36b05-6574-407e-9855-a3df105a2089)
