### PR TITLE
[11.x] Allows asserting no output in Artisan commands

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -16,6 +16,13 @@ trait InteractsWithConsole
     public $mockConsoleOutput = true;
 
     /**
+     * Indicates if the command is expected to output anything or not.
+     *
+     * @var bool|null
+     */
+    public $expectsOutput;
+
+    /**
      * All of the expected output lines.
      *
      * @var array

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -16,7 +16,7 @@ trait InteractsWithConsole
     public $mockConsoleOutput = true;
 
     /**
-     * Indicates if the command is expected to output anything or not.
+     * Indicates if the command is expected to output anything.
      *
      * @var bool|null
      */

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -44,7 +44,7 @@ class ArtisanCommandTest extends TestCase
             ]);
 
             $this->table(['Name', 'Email'], [
-                ['Taylor Otwell', 'taylor@laravel.com',]
+                ['Taylor Otwell', 'taylor@laravel.com'],
             ]);
 
             $this->confirm('Do you want to continue?', true);

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Testing;
 
+use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Mockery as m;
 use Mockery\Exception\InvalidCountException;
@@ -31,6 +32,22 @@ class ArtisanCommandTest extends TestCase
             $this->line($this->ask('Who?'));
             $this->line($this->ask('What?'));
             $this->line($this->ask('Huh?'));
+        });
+
+        Artisan::command('interactions', function () {
+            /** @var Command $this */
+            $this->ask('What is your name?');
+            $this->choice('Which language do you prefer?', [
+                'PHP',
+                'PHP',
+                'PHP',
+            ]);
+
+            $this->table(['Name', 'Email'], [
+                ['Taylor Otwell', 'taylor@laravel.com',]
+            ]);
+
+            $this->confirm('Do you want to continue?', true);
         });
 
         Artisan::command('exit {code}', fn () => (int) $this->argument('code'));
@@ -144,6 +161,106 @@ class ArtisanCommandTest extends TestCase
         $this->artisan('contains')
              ->expectsOutputToContain('Taylor Otwell')
              ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_passes_if_outputs_something()
+    {
+        $this->artisan('contains')
+            ->expectsOutput()
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_passes_if_outputs_is_something_and_is_the_expected_output()
+    {
+        $this->artisan('contains')
+            ->expectsOutput()
+            ->expectsOutput('My name is Taylor Otwell')
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fail_if_doesnt_output_something()
+    {
+        $this->expectException(InvalidCountException::class);
+
+        $this->artisan('exit', ['code' => 0])
+            ->expectsOutput()
+            ->assertExitCode(0);
+
+        m::close();
+    }
+
+    public function test_console_command_that_fail_if_doesnt_output_something_and_is_not_the_expected_output()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->ignoringMockOnceExceptions(function () {
+            $this->artisan('exit', ['code' => 0])
+                ->expectsOutput()
+                ->expectsOutput('My name is Taylor Otwell')
+                ->assertExitCode(0);
+        });
+    }
+
+    public function test_console_command_that_passes_if_does_not_output_anything()
+    {
+        $this->artisan('exit', ['code' => 0])
+            ->doesntExpectOutput()
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_passes_if_does_not_output_anything_and_is_not_the_expected_output()
+    {
+        $this->artisan('exit', ['code' => 0])
+            ->doesntExpectOutput()
+            ->doesntExpectOutput('My name is Taylor Otwell')
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_passes_if_expects_output_and_there_is_interactions()
+    {
+        $this->artisan('interactions', ['--no-interaction' => true])
+            ->expectsOutput()
+            ->expectsQuestion('What is your name?', 'Taylor Otwell')
+            ->expectsChoice('Which language do you prefer?', 'PHP', ['PHP', 'PHP', 'PHP'])
+            ->expectsConfirmation('Do you want to continue?', true)
+            ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fails_if_doesnt_expect_output_but__there_is_interactions()
+    {
+        $this->expectException(InvalidCountException::class);
+
+        $this->artisan('interactions', ['--no-interaction' => true])
+            ->doesntExpectOutput()
+            ->expectsQuestion('What is your name?', 'Taylor Otwell')
+            ->expectsChoice('Which language do you prefer?', 'PHP', ['PHP', 'PHP', 'PHP'])
+            ->expectsConfirmation('Do you want to continue?', true)
+            ->assertExitCode(0);
+
+        m::close();
+    }
+
+    public function test_console_command_that_fails_if_doesnt_expect_output_but_outputs_something()
+    {
+        $this->expectException(InvalidCountException::class);
+
+        $this->artisan('contains')
+            ->doesntExpectOutput()
+            ->assertExitCode(0);
+
+        m::close();
+    }
+
+    public function test_console_command_that_fails_if_doesnt_expect_output_and_does_expect_output()
+    {
+        $this->expectException(InvalidCountException::class);
+
+        $this->artisan('contains')
+            ->doesntExpectOutput()
+            ->doesntExpectOutput('My name is Taylor Otwell')
+            ->assertExitCode(0);
+
+        m::close();
     }
 
     public function test_console_command_that_fails_if_the_output_does_not_contain()


### PR DESCRIPTION
This pull request allows to assert that Artisan commands don't provide any output:

```php
test('backups', function () {
    $this->artisan('backup')
            ->doesntExpectOutput()
            ->assertExitCode(0);
});
```

At the same time, for feature parity, you may test that a command outputs something:

```php
test('backups', function () {
    $this->artisan('say:hello') // outputs "hello"
            ->expectsOutput()
            ->assertExitCode(0);
});
```