### PR TITLE
[11.x] Add support for stub option in Console/GeneratorCommand

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -337,9 +337,29 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function buildClass($name)
     {
-        $stub = $this->files->get($this->getStub());
+        $stub = $this->files->get($this->getStubOption() ?? $this->getStub());
 
         return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Get a stub file for the generator from a stub option.
+     * 
+     * @return string|null
+     */
+    protected function getStubOption()
+    {
+        if(! $this->hasOption('stub') || ! $this->option('stub')) {
+            return null;
+        }
+
+        $stub = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, trim($this->option('stub')));
+
+        return match (true) {
+            file_exists($namedStub = $this->laravel->basePath('stubs'. DIRECTORY_SEPARATOR .$stub.'.stub')) => $namedStub,
+            file_exists($stubPath = $stub) => $stubPath,
+            default => null,
+        };
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -344,19 +344,19 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
     /**
      * Get a stub file for the generator from a stub option.
-     * 
+     *
      * @return string|null
      */
     protected function getStubOption()
     {
-        if(! $this->hasOption('stub') || ! $this->option('stub')) {
+        if (! $this->hasOption('stub') || ! $this->option('stub')) {
             return null;
         }
 
         $stub = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, trim($this->option('stub')));
 
         return match (true) {
-            file_exists($namedStub = $this->laravel->basePath('stubs'. DIRECTORY_SEPARATOR .$stub.'.stub')) => $namedStub,
+            file_exists($namedStub = $this->laravel->basePath('stubs'.DIRECTORY_SEPARATOR.$stub.'.stub')) => $namedStub,
             file_exists($stubPath = $stub) => $stubPath,
             default => null,
         };


### PR DESCRIPTION
This pull request adds support for adding a stub option to commands which extend the `GeneratorCommand`, ie `make` commands. This is not a breaking change and it doesn't add any extra option to the `GeneratorCommand`: concrete commands have to add the option in order to use it.

https://github.com/laravel/folio/pull/136
https://github.com/livewire/volt/pull/101

This involves two small changes in the abstract `Console/GeneratorCommand`

1. Getting the stub from an option `Console/GeneratorCommand::getStubOption()`
The first is a method for determining whether there is a `stub` option present, and if so returning the path to the stub (if found)

2. Using the stub in `Console/GeneratorCommand::buildClass()` (if present and found)

# Example Usage
Using `laravel/folio`'s make command for generating pages as an example of a command that can benefit from this change.

in `laravel/folio/src/MakeCommand.php`
```diff
    /**
     * Get the console command arguments.
     */
    protected function getOptions(): array
    {
        return [
            ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
+           ['stub', 's', InputOption::VALUE_OPTIONAL, 'The stub file to use'],
        ];
    }
```

## Usage:
 After the above change, `folio:make` would supports passing either the name of an existing stub, or full path to file to be used as a stub as an option

```bash
php artisan make:folio "todos/index" --stub="folio-index"
```
will find and use `base_path('stubs/folio-index.stub')` if it exists.

```bash
php artisan make:folio "todos/index" \
  --stub="/home/taylor/stubs/talks/laracon/2024/us/folio/todos-index.stub"
```

will find and use `/home/taylor/stubs/talks/laracon/2024/us/folio/todos-index.stub` if it exists.

If it cannot find a stub under the name or path, it will ignore the option altogether and behave as it always has.
Likewise, if you do not add a stub option to the command, it will behave as it always has, and the above would simply result in the error `The "--stub" option does not exist.`
