### PR TITLE
[11.x] Introduces `Exceptions` facade

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -76,7 +76,8 @@ trait InteractsWithExceptionHandling
                 : $currentExceptionHandler;
         }
 
-        $exceptionHandler = new class($this->originalExceptionHandler, $except) implements ExceptionHandler, WithoutExceptionHandlingHandler {
+        $exceptionHandler = new class($this->originalExceptionHandler, $except) implements ExceptionHandler, WithoutExceptionHandlingHandler
+        {
             protected $except;
             protected $originalHandler;
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -76,8 +76,7 @@ trait InteractsWithExceptionHandling
                 : $currentExceptionHandler;
         }
 
-        $exceptionHandler = new class($this->originalExceptionHandler, $except) implements ExceptionHandler
-        {
+        $exceptionHandler = new class($this->originalExceptionHandler, $except) implements ExceptionHandler, WithoutExceptionHandlingHandler {
             protected $except;
             protected $originalHandler;
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
 use Illuminate\Testing\Assert;
 use Illuminate\Validation\ValidationException;
-use RuntimeException;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;

--- a/src/Illuminate/Foundation/Testing/Concerns/WithoutExceptionHandlingHandler.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/WithoutExceptionHandlingHandler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+interface WithoutExceptionHandlingHandler
+{
+    //
+}

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static \Illuminate\Contracts\Debug\ExceptionHandler handler()
  * @method static void assertNothingReported()
  * @method static void assertReported(\Closure|string $exception)
+ * @method static void assertReportedCount(int $count)
  * @method static void assertNotReported(\Closure|string $exception)
  * @method static void renderForConsole(\Symfony\Component\Console\Output\OutputInterface $output, \Throwable $e)
  * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwReported()

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -29,6 +29,9 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static void assertReported(\Closure|string $exception)
  * @method static void assertNotReported(\Closure|string $exception)
  * @method static void renderForConsole(\Symfony\Component\Console\Output\OutputInterface $output, \Throwable $e)
+ * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwOnReport()
+ * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwReported()
+ * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake setHandler(\Illuminate\Contracts\Debug\ExceptionHandler $handler)
  *
  * @see \Illuminate\Foundation\Exceptions\Handler
  * @see \Illuminate\Contracts\Debug\ExceptionHandler

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
+use Illuminate\Support\Testing\Fakes\MailFake;
+
+/**
+ * @method static void register()
+ * @method static \Illuminate\Foundation\Exceptions\ReportableHandler reportable(callable $reportUsing)
+ * @method static \Illuminate\Foundation\Exceptions\Handler renderable(callable $renderUsing)
+ * @method static \Illuminate\Foundation\Exceptions\Handler map(\Closure|string $from, \Closure|string|null $to = null)
+ * @method static \Illuminate\Foundation\Exceptions\Handler dontReport(array|string $exceptions)
+ * @method static \Illuminate\Foundation\Exceptions\Handler ignore(array|string $exceptions)
+ * @method static \Illuminate\Foundation\Exceptions\Handler dontFlash(array|string $attributes)
+ * @method static \Illuminate\Foundation\Exceptions\Handler level(string $type, void $level)
+ * @method static void report(\Throwable $e)
+ * @method static bool shouldReport(\Throwable $e)
+ * @method static \Illuminate\Foundation\Exceptions\Handler throttleUsing(callable $throttleUsing)
+ * @method static \Illuminate\Foundation\Exceptions\Handler stopIgnoring(array|string $exceptions)
+ * @method static \Illuminate\Foundation\Exceptions\Handler buildContextUsing(\Closure $contextCallback)
+ * @method static \Symfony\Component\HttpFoundation\Response render(\Illuminate\Http\Request $request, \Throwable $e)
+ * @method static \Illuminate\Foundation\Exceptions\Handler respondUsing(callable $callback)
+ * @method static \Illuminate\Foundation\Exceptions\Handler shouldRenderJsonWhen(callable $callback)
+ * @method static \Illuminate\Foundation\Exceptions\Handler dontReportDuplicates()
+ * @method static \Illuminate\Contracts\Debug\ExceptionHandler handler()
+ * @method static void assertNothingReported()
+ * @method static void assertReported(\Closure|string $exception)
+ * @method static void assertNotReported(\Closure|string $exception)
+ * @method static void renderForConsole(\Symfony\Component\Console\Output\OutputInterface $output, \Throwable $e)
+ *
+ * @see \Illuminate\Foundation\Exceptions\Handler
+ * @see \Illuminate\Contracts\Debug\ExceptionHandler
+ * @see \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
+ */
+class Exceptions extends Facade
+{
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
+     */
+    public static function fake()
+    {
+        $exceptionHandler = static::isFake()
+            ? static::getFacadeRoot()->handler()
+            : static::getFacadeRoot();
+
+        return tap(new ExceptionHandlerFake($exceptionHandler), function ($fake) {
+            static::swap($fake);
+        });
+    }
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return ExceptionHandler::class;
+    }
+}

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support\Facades;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
-use Illuminate\Support\Testing\Fakes\MailFake;
 
 /**
  * @method static void register()

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static void assertReportedCount(int $count)
  * @method static void assertNotReported(\Closure|string $exception)
  * @method static void renderForConsole(\Symfony\Component\Console\Output\OutputInterface $output, \Throwable $e)
- * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwReported()
+ * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwFirstReported()
  * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake setHandler(\Illuminate\Contracts\Debug\ExceptionHandler $handler)
  *
  * @see \Illuminate\Foundation\Exceptions\Handler

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
 use Illuminate\Support\Testing\Fakes\MailFake;
 
@@ -39,15 +40,16 @@ class Exceptions extends Facade
     /**
      * Replace the bound instance with a fake.
      *
+     * @param  array<int, class-string<\Throwable>>|class-string<\Throwable>  $exceptions
      * @return \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
      */
-    public static function fake()
+    public static function fake(array|string $exceptions = [])
     {
         $exceptionHandler = static::isFake()
             ? static::getFacadeRoot()->handler()
             : static::getFacadeRoot();
 
-        return tap(new ExceptionHandlerFake($exceptionHandler), function ($fake) {
+        return tap(new ExceptionHandlerFake($exceptionHandler, Arr::wrap($exceptions)), function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -29,7 +29,6 @@ use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
  * @method static void assertReported(\Closure|string $exception)
  * @method static void assertNotReported(\Closure|string $exception)
  * @method static void renderForConsole(\Symfony\Component\Console\Output\OutputInterface $output, \Throwable $e)
- * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwOnReport()
  * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake throwReported()
  * @method static \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake setHandler(\Illuminate\Contracts\Debug\ExceptionHandler $handler)
  *
@@ -54,6 +53,17 @@ class Exceptions extends Facade
         return tap(new ExceptionHandlerFake($exceptionHandler, Arr::wrap($exceptions)), function ($fake) {
             static::swap($fake);
         });
+    }
+
+    /**
+     * Throw exceptions when they are reported.
+     *
+     * @param  array<int, class-string<\Throwable>>|class-string<\Throwable>  $exceptions
+     * @return \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
+     */
+    public static function throwOnReport(array|string $exceptions = [])
+    {
+        return static::fake($exceptions)->throwOnReport();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Exceptions.php
+++ b/src/Illuminate/Support/Facades/Exceptions.php
@@ -57,17 +57,6 @@ class Exceptions extends Facade
     }
 
     /**
-     * Throw exceptions when they are reported.
-     *
-     * @param  array<int, class-string<\Throwable>>|class-string<\Throwable>  $exceptions
-     * @return \Illuminate\Support\Testing\Fakes\ExceptionHandlerFake
-     */
-    public static function throwOnReport(array|string $exceptions = [])
-    {
-        return static::fake($exceptions)->throwOnReport();
-    }
-
-    /**
      * Get the registered name of the component.
      *
      * @return string

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Testing\Assert;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\ExpectationFailedException;
-use ReflectionClass;
 use Throwable;
 
 /**

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Testing\Concerns\WithoutExceptionHandlingHandler;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Testing\Assert;
@@ -193,7 +194,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     protected function runningWithoutExceptionHandling()
     {
-        return (new ReflectionClass($this->handler))->isAnonymous();
+        return $this->handler instanceof WithoutExceptionHandlingHandler;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Testing\Assert;
+use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionClass;
 use Throwable;
@@ -97,6 +98,22 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
                 fn (Throwable $e) => $this->firstClosureParameterType($exception) === get_class($e)
                     && $exception($e) === true,
             ), $message,
+        );
+    }
+
+    /**
+     * Assert the number of exceptions that have been reported.
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function assertReportedCount(int $count)
+    {
+        $total = collect($this->reported)->count();
+
+        PHPUnit::assertSame(
+            $count, $total,
+            "The total number of exceptions reported was {$total} instead of {$count}."
         );
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -147,15 +147,21 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     public function report($e)
     {
-        if ($this->shouldReport($e) && $this->isFakedException($e)) {
-            $this->reported[] = $e;
+        if ($this->isFakedException($e) === false) {
+            $this->handler->report($e);
 
-            if ($this->throwOnReport) {
-                throw $e;
-            }
+            return;
         }
 
-        $this->handler->report($e);
+        if ($this->shouldReport($e) === false) {
+            return;
+        }
+
+        $this->reported[] = $e;
+
+        if ($this->throwOnReport) {
+            throw $e;
+        }
     }
 
     /**
@@ -206,13 +212,13 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     }
 
     /**
-     * Throw all of the exceptions that have been reported.
+     * Throw the first reported exception.
      *
      * @return $this
      *
      * @throws \Throwable
      */
-    public function throwReported()
+    public function throwFirstReported()
     {
         foreach ($this->reported as $e) {
             throw $e;

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -71,7 +71,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     public function assertReported(Closure|string $exception)
     {
         $message = sprintf(
-            "The expected [%s] exception was not reported.",
+            'The expected [%s] exception was not reported.',
             is_string($exception) ? $exception : $this->firstClosureParameterType($exception)
         );
 
@@ -107,7 +107,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
         }
 
         throw new ExpectationFailedException(sprintf(
-            "The expected [%s] exception was not reported.",
+            'The expected [%s] exception was not reported.',
             is_string($exception) ? $exception : $this->firstClosureParameterType($exception)
         ));
     }

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Closure;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\ReflectsClosures;
+use Illuminate\Testing\Assert;
+use PHPUnit\Framework\ExpectationFailedException;
+use Throwable;
+
+/**
+ * @mixin \Illuminate\Foundation\Exceptions\Handler
+ */
+class ExceptionHandlerFake implements ExceptionHandler, Fake
+{
+    use ForwardsCalls, ReflectsClosures;
+
+    /**
+     * All of the exceptions that have been reported.
+     *
+     * @var array<int, class-string<\Throwable>>
+     */
+    protected $reported = [];
+
+    /**
+     * Create a new mail fake.
+     *
+     * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
+     * @return void
+     */
+    public function __construct(
+        protected ExceptionHandler $handler
+    ) {
+        //
+    }
+
+    /**
+     * Get the underlying handler implementation.
+     *
+     * @return \Illuminate\Contracts\Debug\ExceptionHandler
+     */
+    public function handler()
+    {
+        return $this->handler;
+    }
+
+    /**
+     * Assert nothing has been reported.
+     *
+     * @return void
+     */
+    public function assertNothingReported()
+    {
+        Assert::assertEmpty(
+            $this->reported,
+            sprintf(
+                'The following exceptions were reported: %s.',
+                implode(', ', array_map('get_class', $this->reported)),
+            ),
+        );
+    }
+
+    /**
+     * Assert if an exception of the given type has been reported.
+     *
+     * @param  \Closure|string  $exception
+     * @return void
+     */
+    public function assertReported(Closure|string $exception)
+    {
+        $message = sprintf(
+            "The expected [%s] exception was not reported.",
+            is_string($exception) ? $exception : $this->firstClosureParameterType($exception)
+        );
+
+        if (is_string($exception)) {
+            Assert::assertTrue(
+                in_array($exception, array_map('get_class', $this->reported), true),
+                $message,
+            );
+
+            return;
+        }
+
+        Assert::assertTrue(
+            collect($this->reported)->contains(
+                fn (Throwable $e) => $this->firstClosureParameterType($exception) === get_class($e)
+                    && $exception($e) === true,
+            ), $message,
+        );
+    }
+
+    /**
+     * Assert if an exception of the given type has not been reported.
+     *
+     * @param  \Closure|string  $exception
+     * @return void
+     */
+    public function assertNotReported(Closure|string $exception)
+    {
+        try {
+            $this->assertReported($exception);
+        } catch (ExpectationFailedException $e) {
+            return;
+        }
+
+        throw new ExpectationFailedException(sprintf(
+            "The expected [%s] exception was not reported.",
+            is_string($exception) ? $exception : $this->firstClosureParameterType($exception)
+        ));
+    }
+
+    /**
+     * Report or log an exception.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function report($e)
+    {
+        if ($this->shouldReport($e)) {
+            $this->reported[] = $e;
+        }
+
+        return $this->handler->report($e);
+    }
+
+    /**
+     * Determine if the exception should be reported.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    public function shouldReport($e)
+    {
+        return $this->handler->shouldReport($e);
+    }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Throwable  $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function render($request, $e)
+    {
+        return $this->handler->render($request, $e);
+    }
+
+    /**
+     * Render an exception to the console.
+     *
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function renderForConsole($output, Throwable $e)
+    {
+        return $this->handler->renderForConsole($output, $e);
+    }
+
+    /**
+     * Handle dynamic method calls to the mailer.
+     *
+     * @param  string  $method
+     * @param  array<string, mixed>  $parameters
+     * @return mixed
+     */
+    public function __call(string $method, array $parameters)
+    {
+        return $this->forwardCallTo($this->handler, $method, $parameters);
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -20,9 +20,14 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     /**
      * All of the exceptions that have been reported.
      *
-     * @var array<int, class-string<\Throwable>>
+     * @var array<int, \Throwable>
      */
     protected $reported = [];
+
+    /**
+     * If the fake should throw exceptions when they are reported.
+     */
+    protected $throwOnReport = false;
 
     /**
      * Create a new mail fake.
@@ -126,7 +131,11 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
             $this->reported[] = $e;
         }
 
-        return $this->handler->report($e);
+        if ($this->isFakedException($e) && $this->throwOnReport) {
+            throw $e;
+        }
+
+        $this->handler->report($e);
     }
 
     /**
@@ -161,7 +170,48 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     public function renderForConsole($output, Throwable $e)
     {
-        return $this->handler->renderForConsole($output, $e);
+        $this->handler->renderForConsole($output, $e);
+    }
+
+    /**
+     * Throw exceptions when they are reported.
+     *
+     * @return $this
+     */
+    public function throwOnReport()
+    {
+        $this->throwOnReport = true;
+
+        return $this;
+    }
+
+    /**
+     * Throw all of the exceptions that have been reported.
+     *
+     * @return $this
+     *
+     * @throws \Throwable
+     */
+    public function throwReported()
+    {
+        foreach ($this->reported as $e) {
+            throw $e;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the "original" handler that should be used by the fake.
+     *
+     * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
+     * @return $this
+     */
+    public function setHandler(ExceptionHandler $handler)
+    {
+        $this->handler = $handler;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -34,7 +34,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     protected $throwOnReport = false;
 
     /**
-     * Create a new mail fake.
+     * Create a new exception handler fake.
      *
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
      * @param  array<int, class-string<\Throwable>>  $exceptions

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -28,10 +28,12 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      * Create a new mail fake.
      *
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
+     * @param  array<int, class-string<\Throwable>>  $exceptions
      * @return void
      */
     public function __construct(
-        protected ExceptionHandler $handler
+        protected ExceptionHandler $handler,
+        protected array $exceptions = [],
     ) {
         //
     }
@@ -120,7 +122,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     public function report($e)
     {
-        if ($this->shouldReport($e)) {
+        if ($this->shouldReport($e) && $this->isFakedException($e)) {
             $this->reported[] = $e;
         }
 
@@ -172,5 +174,16 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     public function __call(string $method, array $parameters)
     {
         return $this->forwardCallTo($this->handler, $method, $parameters);
+    }
+
+    /**
+     * Determine if the given exception is faked.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    protected function isFakedException(Throwable $e)
+    {
+        return count($this->exceptions) === 0 || in_array(get_class($e), $this->exceptions, true);
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -28,6 +28,8 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
 
     /**
      * If the fake should throw exceptions when they are reported.
+     *
+     * @var bool
      */
     protected $throwOnReport = false;
 

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -58,22 +58,6 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     }
 
     /**
-     * Assert nothing has been reported.
-     *
-     * @return void
-     */
-    public function assertNothingReported()
-    {
-        Assert::assertEmpty(
-            $this->reported,
-            sprintf(
-                'The following exceptions were reported: %s.',
-                implode(', ', array_map('get_class', $this->reported)),
-            ),
-        );
-    }
-
-    /**
      * Assert if an exception of the given type has been reported.
      *
      * @param  \Closure|string  $exception
@@ -140,6 +124,22 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     }
 
     /**
+     * Assert nothing has been reported.
+     *
+     * @return void
+     */
+    public function assertNothingReported()
+    {
+        Assert::assertEmpty(
+            $this->reported,
+            sprintf(
+                'The following exceptions were reported: %s.',
+                implode(', ', array_map('get_class', $this->reported)),
+            ),
+        );
+    }
+
+    /**
      * Report or log an exception.
      *
      * @param  \Throwable  $e
@@ -147,13 +147,13 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     public function report($e)
     {
-        if ($this->isFakedException($e) === false) {
+        if (! $this->isFakedException($e)) {
             $this->handler->report($e);
 
             return;
         }
 
-        if ($this->shouldReport($e) === false) {
+        if (! $this->shouldReport($e)) {
             return;
         }
 
@@ -165,6 +165,17 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     }
 
     /**
+     * Determine if the given exception is faked.
+     *
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    protected function isFakedException(Throwable $e)
+    {
+        return count($this->exceptions) === 0 || in_array(get_class($e), $this->exceptions, true);
+    }
+
+    /**
      * Determine if the exception should be reported.
      *
      * @param  \Throwable  $e
@@ -173,6 +184,16 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     public function shouldReport($e)
     {
         return $this->runningWithoutExceptionHandling() || $this->handler->shouldReport($e);
+    }
+
+    /**
+     * Determine if the handler is running without exception handling.
+     *
+     * @return bool
+     */
+    protected function runningWithoutExceptionHandling()
+    {
+        return (new ReflectionClass($this->handler))->isAnonymous();
     }
 
     /**
@@ -250,26 +271,5 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     public function __call(string $method, array $parameters)
     {
         return $this->forwardCallTo($this->handler, $method, $parameters);
-    }
-
-    /**
-     * Determine if the given exception is faked.
-     *
-     * @param  \Throwable  $e
-     * @return bool
-     */
-    protected function isFakedException(Throwable $e)
-    {
-        return count($this->exceptions) === 0 || in_array(get_class($e), $this->exceptions, true);
-    }
-
-    /**
-     * Determine if the handler is running without exception handling.
-     *
-     * @return bool
-     */
-    protected function runningWithoutExceptionHandling()
-    {
-        return (new ReflectionClass($this->handler))->isAnonymous();
     }
 }

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -245,7 +245,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testThrowOnReport()
     {
-        Exceptions::throwOnReport();
+        Exceptions::fake()->throwOnReport();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Test exception');
@@ -255,7 +255,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testThrowOnReportDoesNotThrowExceptionsThatShouldNotBeReported()
     {
-        Exceptions::throwOnReport();
+        Exceptions::fake()->throwOnReport();
 
         Route::get('/302', function () {
             Validator::validate(['name' => ''], ['name' => 'required']);
@@ -325,7 +325,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testThrowOnReportRegardlessOfTheCallingOrderOfWithExceptionHandling()
     {
-        Exceptions::throwOnReport();
+        Exceptions::fake()->throwOnReport();
 
         $this->withoutExceptionHandling()
             ->withExceptionHandling()
@@ -355,7 +355,7 @@ class ExceptionsFacadeTest extends TestCase
 
     public function testThrowOnReportWithFakedExceptionsFromFacade()
     {
-        Exceptions::throwOnReport([InvalidArgumentException::class]);
+        Exceptions::fake([InvalidArgumentException::class])->throwOnReport();
 
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -25,6 +25,23 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 2');
     }
 
+    public function testFakeAssertReportedWithFakedExceptions()
+    {
+        Exceptions::fake([
+            RuntimeException::class,
+        ]);
+
+        Exceptions::report(new RuntimeException('test 1'));
+        report(new RuntimeException('test 2'));
+        report(new InvalidArgumentException('test 3'));
+
+        Exceptions::assertReported(RuntimeException::class);
+        Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 1');
+        Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 2');
+
+        Exceptions::assertNotReported(InvalidArgumentException::class);
+    }
+
     public function testFakeAssertReportedAsStringMayFail()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -49,6 +66,20 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::assertReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 2');
     }
 
+    public function testFakeAssertReportedWithFakedExceptionsMayFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+
+        Exceptions::fake(InvalidArgumentException::class);
+
+        Exceptions::report(new InvalidArgumentException('test 1'));
+        report(new RuntimeException('test 2'));
+
+        Exceptions::assertReported(InvalidArgumentException::class);
+        Exceptions::assertReported(RuntimeException::class);
+    }
+
     public function testFakeAssertNotReported()
     {
         Exceptions::fake();
@@ -61,6 +92,18 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 2');
         Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 3');
         Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 4');
+    }
+
+    public function testFakeAssertNotReportedWithFakedExceptions()
+    {
+        Exceptions::fake([
+            InvalidArgumentException::class,
+        ]);
+
+        report(new RuntimeException('test 2'));
+
+        Exceptions::assertNotReported(InvalidArgumentException::class);
+        Exceptions::assertNotReported(RuntimeException::class);
     }
 
     public function testFakeAssertNotReportedMayFail()
@@ -98,6 +141,17 @@ class ExceptionsFacadeTest extends TestCase
     public function testFakeAssertNothingReported()
     {
         Exceptions::fake();
+
+        Exceptions::assertNothingReported();
+    }
+
+    public function testFakeAssertNothingReportedWithFakedExceptions()
+    {
+        Exceptions::fake([
+            InvalidArgumentException::class,
+        ]);
+
+        report(new RuntimeException('test 1'));
 
         Exceptions::assertNothingReported();
     }

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -380,6 +380,19 @@ class ExceptionsFacadeTest extends TestCase
         report(new Exception('Test exception'));
     }
 
+    public function testAppReportablesAreNotCalledIfExceptionIsNotFaked()
+    {
+        app(ExceptionHandler::class)->reportable(function (Throwable $e) {
+            throw new InvalidArgumentException($e->getMessage());
+        });
+
+        Exceptions::fake([RuntimeException::class, Exception::class]);
+
+        report(new Exception('My exception message'));
+
+        Exceptions::assertReported(Exception::class);
+    }
+
     public function testThrowOnReportLeaveAppReportablesUntouched()
     {
         app(ExceptionHandler::class)->reportable(function (Throwable $e) {
@@ -403,7 +416,7 @@ class ExceptionsFacadeTest extends TestCase
 
         report(new Exception('Test exception'));
 
-        Exceptions::throwReported();
+        Exceptions::throwFirstReported();
     }
 
     public function testThrowReportedExceptionsWithFakedExceptions()
@@ -416,20 +429,20 @@ class ExceptionsFacadeTest extends TestCase
         report(new RuntimeException('Test exception'));
         report(new InvalidArgumentException('Test exception'));
 
-        Exceptions::throwReported();
+        Exceptions::throwFirstReported();
     }
 
     public function testThrowReportedExceptionsWhenThereIsNone()
     {
         Exceptions::fake();
 
-        Exceptions::throwReported();
+        Exceptions::throwFirstReported();
 
         Exceptions::fake([InvalidArgumentException::class]);
 
         report(new RuntimeException('Test exception'));
 
-        Exceptions::throwReported();
+        Exceptions::throwFirstReported();
 
         $this->doesNotPerformAssertions();
     }

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Exceptions\Handler;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
+use InvalidArgumentException;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\ExpectationFailedException;
+use RuntimeException;
+
+class ExceptionsFacadeTest extends TestCase
+{
+    public function testFakeAssertReported()
+    {
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+        report(new RuntimeException('test 2'));
+
+        Exceptions::assertReported(RuntimeException::class);
+        Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 1');
+        Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 2');
+    }
+
+    public function testFakeAssertReportedAsStringMayFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [InvalidArgumentException] exception was not reported.');
+
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+
+        Exceptions::assertReported(InvalidArgumentException::class);
+    }
+
+    public function testFakeAssertReportedAsClosureMayFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [InvalidArgumentException] exception was not reported.');
+
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+
+        Exceptions::assertReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 2');
+    }
+
+    public function testFakeAssertNotReported()
+    {
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+        report(new RuntimeException('test 2'));
+
+        Exceptions::assertNotReported(InvalidArgumentException::class);
+        Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 1');
+        Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 2');
+        Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 3');
+        Exceptions::assertNotReported(fn (InvalidArgumentException $e) => $e->getMessage() === 'test 4');
+    }
+
+    public function testFakeAssertNotReportedMayFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+
+        Exceptions::assertNotReported(RuntimeException::class);
+    }
+
+    public function testFakeAssertNotReportedAsClosureMayFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected [RuntimeException] exception was not reported.');
+
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+
+        Exceptions::assertNotReported(fn (RuntimeException $e) => $e->getMessage() === 'test 1');
+    }
+
+    public function testResolvesExceptionHandler()
+    {
+        $this->assertInstanceOf(
+            ExceptionHandler::class,
+            Exceptions::getFacadeRoot()
+        );
+    }
+
+    public function testFakeAssertNothingReported()
+    {
+        Exceptions::fake();
+
+        Exceptions::assertNothingReported();
+    }
+
+    public function testFakeAssertNothingReportedMayFail()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The following exceptions were reported: RuntimeException, RuntimeException, InvalidArgumentException.');
+
+        Exceptions::fake();
+
+        Exceptions::report(new RuntimeException('test 1'));
+        report(new RuntimeException('test 2'));
+        report(new InvalidArgumentException('test 3'));
+
+        Exceptions::assertNothingReported();
+    }
+
+    public function testFakeMethodReturnsExceptionHandlerFake()
+    {
+        $this->assertInstanceOf(ExceptionHandlerFake::class, $fake = Exceptions::fake());
+        $this->assertInstanceOf(ExceptionHandlerFake::class, Exceptions::getFacadeRoot());
+        $this->assertInstanceOf(Handler::class, $fake->handler());
+
+        $this->assertInstanceOf(ExceptionHandlerFake::class, $fake = Exceptions::fake());
+        $this->assertInstanceOf(ExceptionHandlerFake::class, Exceptions::getFacadeRoot());
+        $this->assertInstanceOf(Handler::class, $fake->handler());
+    }
+
+    public function testResolvesExceptionHandlerAsSingleton()
+    {
+        $this->assertSame(
+            Exceptions::getFacadeRoot(),
+            Exceptions::getFacadeRoot()
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `Exceptions` facade to provide a consistent way to test exceptions in Laravel applications. Here is the list of methods that the `Exceptions` facade provides:

- [assertReported](#assertreported-method)
- [assertReportedCount](#assertreportedcount-method)
- [assertNotReported](#assertnotreported-method)
- [assertNothingReported](#assertnothingreported-method)
- [throwOnReport](#throwonreport-method)
- [throwFirstReported](#throwfirstreported-method)

All the examples below assume the following route:

```php
Route::post('/generate-report', function () {
    return request()->throw
        ? throw new ServiceUnavailableException('Service is currently unavailable')
        : response()->json(['message' => 'Report generated successfully']); 
});
```

## `assertReported` method

The `assertReported` method allows you to assert that an exception was reported:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake();
    
    $this->post('/generate-report', [
        'throw' => 'true',
    ])->assertStatus(503); // Service Unavailable
    
    Exceptions::assertReported(ServiceUnavailableException::class);
    
    // or
    Exceptions::assertReported(function (ServiceUnavailableException $exception) {
        return $exception->getMessage() === 'Service is currently unavailable';
    });
});
```

## `assertReportedCount` method

The `assertReportedCount` method allows you to assert the number of exceptions reported:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake();
    
    $this->post('/generate-report', [
        'throw' => 'true',
    ])->assertStatus(503); // Service Unavailable
    
    Exceptions::assertReportedCount(1);
});
```

## `assertNotReported` method

The `assertNotReported` method allows you to assert that an exception was not reported:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake();
    
    $this->post('/generate-report', [
        'throw' => 'false',
    ])->assertStatus(200);
    
    Exceptions::assertNotReported(ServiceUnavailableException::class);
    
    // or
    Exceptions::assertNotReported(function (ServiceUnavailableException $exception) {
        return $exception->getMessage() === 'Service is currently unavailable';
    });
});
```

## `assertNothingReported` method

The `assertNothingReported` method allows you to assert that no exceptions were reported:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake();
    
    $this->post('/generate-report', [
        'throw' => 'false',
    ])->assertStatus(200);
    
    Exceptions::assertNothingReported();
});
```

Optionally, you may specify a list of exceptions you wish to capture:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake([AnotherException::class]);
   
    $this->post('/generate-report', [
        'throw' => 'true',
    ])->assertStatus(503); // Service Unavailable
    
    Exceptions::assertNothingReported();
});
```

## `throwOnReport` method

The `throwOnReport` method allows you to throw any reported exceptions:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::throwOnReport();
    
    $this->post('/generate-report', [
        'throw' => 'true',
    ]); // throws ServiceUnavailableException
});
```

Optionally, you may specify a list of exceptions you wish to capture:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::throwOnReport([AnotherException::class]);
    
    $this->post('/generate-report', [
        'throw' => 'true',
    ])->assertStatus(503); // Service Unavailable
    
    // test passes...
});
```

## `throwFirstReported` method

The `throwFirstReported` method allows you to throw the previous reported exceptions:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake();

    $this->post('/generate-report', [
        'throw' => 'true',
    ])->assertStatus(503);
    
    Exceptions::throwFirstReported(); // throws ServiceUnavailableException
});
```

Optionally, you may specify a list of exceptions you wish to capture:

```php
use Illuminate\Support\Facades\Exceptions;

test('example', function () {
    Exceptions::fake([AnotherException::class]);
    
    $this->post('/generate-report', [
        'throw' => 'true',
    ])->assertStatus(503); // Service Unavailable
    
    Exceptions::throwFirstReported(); // throws nothing, nad test passes...
});
```

