### PR TITLE
[10.x] Fixed incorrect assumption in `QueriesRelationships` that the owner key is necessarily the model key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -477,7 +477,7 @@ trait QueriesRelationships
 
         return $this->where(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), $relation->getRelatedKeyFrom($model));
+                ->where($relation->getForeignKeyName(), $relation->getOwnerKeyName());
         }, null, null, $boolean);
     }
 
@@ -506,7 +506,7 @@ trait QueriesRelationships
 
         return $this->whereNot(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), '<=>', $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), '<=>', $relation->getRelatedKeyFrom($model));
+                ->where($relation->getForeignKeyName(), '<=>', $relation->getOwnerKeyName());
         }, null, null, $boolean);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1,4 +1,4 @@
-<?php
+x<?php
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
@@ -477,7 +477,7 @@ trait QueriesRelationships
 
         return $this->where(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), $relation->getOwnerKeyName());
+                ->where($relation->getForeignKeyName(), $relation->getRelatedKeyFrom($model));
         }, null, null, $boolean);
     }
 
@@ -506,7 +506,7 @@ trait QueriesRelationships
 
         return $this->whereNot(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), '<=>', $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), '<=>', $relation->getOwnerKeyName());
+                ->where($relation->getForeignKeyName(), '<=>', $relation->getRelatedKeyFrom($model));
         }, null, null, $boolean);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -475,9 +475,9 @@ trait QueriesRelationships
             return $this->where($relation->getMorphType(), $model, null, $boolean);
         }
 
-        $ownerKeyName = $relation->getOwnerKeyName() ?? $model->getKeyName();
-
         return $this->where(function ($query) use ($relation, $model) {
+            $ownerKeyName = $relation->getOwnerKeyName() ?? $model->getKeyName();
+
             $query->where($relation->getMorphType(), $model->getMorphClass())
                 ->where($relation->getForeignKeyName(), $model->{$ownerKeyName});
         }, null, null, $boolean);
@@ -506,9 +506,9 @@ trait QueriesRelationships
             return $this->whereNot($relation->getMorphType(), '<=>', $model, $boolean);
         }
 
-        $ownerKeyName = $relation->getOwnerKeyName() ?? $model->getKeyName();
-
         return $this->whereNot(function ($query) use ($relation, $model) {
+            $ownerKeyName = $relation->getOwnerKeyName() ?? $model->getKeyName();
+
             $query->where($relation->getMorphType(), '<=>', $model->getMorphClass())
                 ->where($relation->getForeignKeyName(), '<=>', $model->{$ownerKeyName});
         }, null, null, $boolean);

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -475,9 +475,11 @@ trait QueriesRelationships
             return $this->where($relation->getMorphType(), $model, null, $boolean);
         }
 
+        $ownerKeyName = $relation->getOwnerKeyName() ?? model->getKeyName();
+
         return $this->where(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), $relation->getRelatedKeyFrom($model));
+                ->where($relation->getForeignKeyName(), $model->{$ownerKeyName});
         }, null, null, $boolean);
     }
 
@@ -504,9 +506,11 @@ trait QueriesRelationships
             return $this->whereNot($relation->getMorphType(), '<=>', $model, $boolean);
         }
 
+        $ownerKeyName = $relation->getOwnerKeyName() ?? model->getKeyName();
+
         return $this->whereNot(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), '<=>', $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), '<=>', $relation->getRelatedKeyFrom($model));
+                ->where($relation->getForeignKeyName(), '<=>', $model->{$ownerKeyName});
         }, null, null, $boolean);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -477,7 +477,7 @@ trait QueriesRelationships
 
         return $this->where(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), $model->getKey());
+                ->where($relation->getForeignKeyName(), $relation->getRelatedKeyFrom($model));
         }, null, null, $boolean);
     }
 
@@ -506,7 +506,7 @@ trait QueriesRelationships
 
         return $this->whereNot(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), '<=>', $model->getMorphClass())
-                ->where($relation->getForeignKeyName(), '<=>', $model->getKey());
+                ->where($relation->getForeignKeyName(), '<=>', $relation->getRelatedKeyFrom($model));
         }, null, null, $boolean);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -1,4 +1,4 @@
-x<?php
+<?php
 
 namespace Illuminate\Database\Eloquent\Concerns;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -475,7 +475,7 @@ trait QueriesRelationships
             return $this->where($relation->getMorphType(), $model, null, $boolean);
         }
 
-        $ownerKeyName = $relation->getOwnerKeyName() ?? model->getKeyName();
+        $ownerKeyName = $relation->getOwnerKeyName() ?? $model->getKeyName();
 
         return $this->where(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), $model->getMorphClass())
@@ -506,7 +506,7 @@ trait QueriesRelationships
             return $this->whereNot($relation->getMorphType(), '<=>', $model, $boolean);
         }
 
-        $ownerKeyName = $relation->getOwnerKeyName() ?? model->getKeyName();
+        $ownerKeyName = $relation->getOwnerKeyName() ?? $model->getKeyName();
 
         return $this->whereNot(function ($query) use ($relation, $model) {
             $query->where($relation->getMorphType(), '<=>', $model->getMorphClass())


### PR DESCRIPTION
Fixes a bug introduced earlier (#38668) that nobody noticed because:

1. Using a `whereMorphedTo` is a pretty rare use case. I've never used it before, and neither does any of the first party library code that I have locally.
2. Almost all of the time the owner id will be the same as the related model id, as that's the default and it's unusual to change it.