### PR TITLE
[11.x] Add Support for using a stub option in generator commands.

### DIFF
--- a/src/Illuminate/Console/Concerns/HasStubOption.php
+++ b/src/Illuminate/Console/Concerns/HasStubOption.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console\Concerns;
 
+use function Illuminate\Filesystem\join_paths;
+
 trait HasStubOption
 {
     /**

--- a/src/Illuminate/Console/Concerns/HasStubOption.php
+++ b/src/Illuminate/Console/Concerns/HasStubOption.php
@@ -39,7 +39,7 @@ trait HasStubOption
         $stub = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, trim($this->option('stub')));
 
         return match (true) {
-            file_exists($namedStub = $this->laravel->basePath('stubs'.DIRECTORY_SEPARATOR.$stub.'.stub')) => $namedStub,
+            file_exists($namedStub = $this->laravel->basePath(join_paths('stubs', $stub.'.stub'))) => $namedStub,
             file_exists($stubPath = $stub) => $stubPath,
             default => null,
         };

--- a/src/Illuminate/Console/Concerns/HasStubOption.php
+++ b/src/Illuminate/Console/Concerns/HasStubOption.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+trait HasStubOption
+{
+    /**
+     * Get the console command arguments.
+     */
+    abstract protected function getOptions(): array;
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    #[\Override]
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStubOption() ?? $this->getStub());
+
+        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Get a stub file for the generator from a stub option.
+     *
+     * @return string|null
+     */
+    protected function getStubOption()
+    {
+        if (! $this->hasOption('stub') || ! $this->option('stub')) {
+            return null;
+        }
+
+        $stub = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, trim($this->option('stub')));
+
+        return match (true) {
+            file_exists($namedStub = $this->laravel->basePath('stubs'.DIRECTORY_SEPARATOR.$stub.'.stub')) => $namedStub,
+            file_exists($stubPath = $stub) => $stubPath,
+            default => null,
+        };
+    }
+}


### PR DESCRIPTION
This pull request adds support for adding a stub option to commands which extend the `GeneratorCommand`, ie `make` commands. This is not a breaking change and it doesn't add any extra option to the `GeneratorCommand`: concrete commands have to add the option in order to use it.

### Why is this useful?
If for instance you are using `make:folio` to scaffold a bunch of views, it could be extremely useful to work with a set of stubs already shaped to your needs, and use different stubs for different types of views i.e index type views, shows, creates, etc. 

https://github.com/laravel/folio/pull/136
https://github.com/livewire/volt/pull/101


~~This involves two small changes in the abstract `Console/GeneratorCommand`~~

Originally I was going to submit this as changes directly within the abstract GeneratorCommand class. But it is probably better in the trait in the off chance that there are `generator` commands out there already using a `--stub` option. This way none of them will be affected, and it only requires importing the trait to use this feature.

1. Getting the stub from an option `Illuminate\Console\Concerns\HasStubOption::getStubOption()`
The first is a method for determining whether there is a `stub` option present, and if so returning the path to the stub (if found)

2. Using the stub in `Illuminate\Console\Concerns\HasStubOption::buildClass()` (if present and found)

# Example Usage
Using `laravel/folio`'s make command for generating pages as an example of a command that can benefit from this change.

in `laravel/folio/src/MakeCommand.php`
```diff
    /**
     * Get the console command arguments.
     */
    protected function getOptions(): array
    {
        return [
            ['force', 'f', InputOption::VALUE_NONE, 'Create the Folio page even if the page already exists'],
+           ['stub', 's', InputOption::VALUE_OPTIONAL, 'The stub file to use'],
        ];
    }
```

## Usage:
 After importing the trait and making the above change, `folio:make` would supports passing either the name of an existing stub, or full path to file to be used as a stub as an option

```bash
php artisan make:folio "todos/index" --stub="folio-index"
```
will find and use `base_path('stubs/folio-index.stub')` if it exists.

```bash
php artisan make:folio "todos/index" \
  --stub="/home/taylor/stubs/talks/laracon/2024/us/folio/todos-index.stub"
```

will find and use `/home/taylor/stubs/talks/laracon/2024/us/folio/todos-index.stub` if it exists.

If it cannot find a stub under the name or path, it will ignore the option altogether and behave as it always has.

### Addendum: Why is this being submitted here?

I'd like to submit some `PR`'s across the ecosystem that will use this feature, and this seems better than rewriting this trait everywhere. 
