### PR TITLE
[11.x] Adds `@throws` section to the Context's doc blocks

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -240,6 +240,8 @@ class Repository
      * @param  string  $key
      * @param  mixed  ...$values
      * @return $this
+     *
+     * @throws \RuntimeException
      */
     public function push($key, ...$values)
     {
@@ -261,6 +263,8 @@ class Repository
      * @param  string  $key
      * @param  mixed  ...$values
      * @return $this
+     *
+     * @throws \RuntimeException
      */
     public function pushHidden($key, ...$values)
     {
@@ -392,6 +396,8 @@ class Repository
      *
      * @param  ?array  $context
      * @return $this
+     *
+     * @throws \RuntimeException
      */
     public function hydrate($context)
     {


### PR DESCRIPTION
This PR adds doc blocks to the Context Repository where exceptions are thrown.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
