### PR TITLE
[11.x] Introduce HASH_VERIFY env var

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -30,7 +30,7 @@ return [
 
     'bcrypt' => [
         'rounds' => env('BCRYPT_ROUNDS', 12),
-        'verify' => true,
+        'verify' => env('HASH_VERIFY', true),
     ],
 
     /*
@@ -48,7 +48,7 @@ return [
         'memory' => env('ARGON_MEMORY', 65536),
         'threads' => env('ARGON_THREADS', 1),
         'time' => env('ARGON_TIME', 4),
-        'verify' => true,
+        'verify' => env('HASH_VERIFY', true),
     ],
 
     /*


### PR DESCRIPTION
To help solve part of the issue reported in #50627, exposing an env var to toggle hash verification avoids the need to manually implement the hashing.php file.

The documentation should be updated to include this, once it's final form has been decided.