### PR TITLE
Add static methods to `Eloquent\Model` to qualify columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -565,6 +565,28 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  string  $column
      * @return string
      */
+    public static function getQualifiedColumn($column)
+    {
+        return (new static)->qualifyColumn($column);
+    }
+
+    /**
+     * Qualify the given columns with the model's table.
+     *
+     * @param  array  $columns
+     * @return array
+     */
+    public static function getQualifiedColumns($columns)
+    {
+        return (new static)->qualifyColumns($columns);
+    }
+
+    /**
+     * Qualify the given column name by the model's table.
+     *
+     * @param  string  $column
+     * @return string
+     */
     public function qualifyColumn($column)
     {
         if (str_contains($column, '.')) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1441,6 +1441,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('stub.column', $model->qualifyColumn('column'));
     }
 
+    public function testQualifyColumnStatically()
+    {
+        $this->assertSame('stub.column', EloquentModelStub::getQualifiedColumn('column'));
+    }
+
+    public function testQualifyColumnsStatically()
+    {
+        $this->assertEquals(['stub.column', 'stub.name'], EloquentModelStub::getQualifiedColumns(['column', 'name']));
+    }
+
     public function testForceFillMethodFillsGuardedAttributes()
     {
         $model = (new EloquentModelSaveStub)->forceFill(['id' => 21]);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1441,6 +1441,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('stub.column', $model->qualifyColumn('column'));
     }
 
+    public function testQualifyColumns()
+    {
+        $model = new EloquentModelStub;
+
+        $this->assertEquals(['stub.column', 'stub.name'], $model->qualifyColumns(['column', 'name']));
+    }
+
     public function testQualifyColumnStatically()
     {
         $this->assertSame('stub.column', EloquentModelStub::getQualifiedColumn('column'));


### PR DESCRIPTION
### Overview:

This PR introduces new static methods, `getQualifiedColumn` and `getQualifiedColumns`, to `Eloquent\Model`. The purpose of these methods is to provide a convenient way to qualify column names when dealing with database relations, without having to create `Model` or `Builder` instances.

### Benefits:

- Provides a more intuitive and concise way to qualify column names.
- Improves developer experience by offering static access to column qualification functionality. No more wondering how to get a model or builder instance to call `qualifyColumns` on.
- Enhances code readability and maintainability.
- Minimal changes to the framework, low burden to maintain

### Method naming considerations:

🤔 Help wanted: I am not fully happy with the naming of the static methods. I also considered `EloquentModelStub::qualifiedColumn()` so it starts the same or `EloquentModelStub::resolveQualifiedColumn()`. 

Ideally the static and instance methods would be called the same so we can do `EloquentModelStub::qualifyColumn()`, but this is only possible with magic methods AFAIK

Example before:

![image](https://github.com/laravel/framework/assets/9074391/044f5c95-8e8d-4800-9882-211a0ca117fb)

Example after:

![image](https://github.com/laravel/framework/assets/9074391/0d91578e-0efb-4c55-b790-f860ea461e2d)
