### PR TITLE
[11.x] Add @throws section to the doc blocks (contianer.php)

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -673,6 +673,8 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  callable|string  $callback
      * @return string|false
+     *
+     * @throws \ReflectionException
      */
     protected function getClassForCallable($callback)
     {
@@ -889,7 +891,8 @@ class Container implements ArrayAccess, ContainerContract
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     * @throws \Illuminate\Contracts\Container\CircularDependencyException
+     *
+     * @throws \ReflectionException
      */
     public function build($concrete)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -891,7 +891,6 @@ class Container implements ArrayAccess, ContainerContract
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     *
      * @throws \ReflectionException
      */
     public function build($concrete)


### PR DESCRIPTION
In this PR, Adding `@throw` to `build` and `getClassForCallable` Methods in `container.php`

### getClassForCallable()
In this method, an instance of the `ReflectionFunction` class is instantiated, which may encounter a `ReflectionException` exception.

```php
protected function getClassForCallable($callback)
    {
        if (is_callable($callback) &&
            ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
            return $reflector->getClosureScopeClass()->name ?? false;
        }

        return false;
    }
```
![image](https://github.com/laravel/framework/assets/36761585/9a1edcce-83ce-4bbe-b77e-3dc3182cc6df)
https://www.php.net/manual/en/reflectionfunction.construct.php

----

### build() method

In this method, an instance of the `ReflectionClass` class is instantiated, which may throw a `ReflectionException` exception.
remove redundant doc block (@throws \Illuminate\Contracts\Container\CircularDependencyException)

```php
public function build($concrete)
    {
        // If the concrete type is actually a Closure, we will just execute it and
        // hand back the results of the functions, which allows functions to be
        // used as resolvers for more fine-tuned resolution of these objects.
        if ($concrete instanceof Closure) {
            return $concrete($this, $this->getLastParameterOverride());
        }

        try {
            $reflector = new ReflectionClass($concrete);
        } catch (ReflectionException $e) {
            throw new BindingResolutionException("Target class [$concrete] does not exist.", 0, $e);
        }

       ........
```
![image](https://github.com/laravel/framework/assets/36761585/464bc606-2fb8-4698-bbff-7e9f9f84fe73)


https://www.php.net/manual/en/reflectionclass.construct.php


Thanks!