### PR TITLE
[11.x] Fix call static method(using self instead of $this)

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -101,7 +101,7 @@ trait InteractsWithContentTypes
 
                 $type = strtolower($type);
 
-                if ($this->matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
+                if (self::matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
                     return $contentType;
                 }
             }


### PR DESCRIPTION
`InteractsithContentTypes.php` \\ `preferes` method:

change `$this->matchesType` to `self::matchesType` because the `matchesType()` method is static method.


```php
/**
     * Determine if the given content types match.
     *
     * @param  string  $actual
     * @param  string  $type
     * @return bool
     */
    public static function matchesType($actual, $type)
    {
        if ($actual === $type) {
            return true;
        }

        $split = explode('/', $actual);

        return isset($split[1]) && preg_match('#'.preg_quote($split[0], '#').'/.+\+'.preg_quote($split[1], '#').'#', $type);
    }
```

Thanks!