### PR TITLE
[10.x] Fixed Validation in / not in breaks with values ending in backslash

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -280,7 +280,11 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        return static::ruleIsRegex($rule) ? [$parameter] : str_getcsv($parameter);
+        $uniquePlaceholder = '__' . uniqid() . '__';
+        $parameters = static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(
+            str_replace('\\\\', $uniquePlaceholder, trim($parameter, '"'))
+        );
+        return str_replace($uniquePlaceholder, '\\\\', $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -280,7 +280,7 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        $uniquePlaceholder = '__' . uniqid() . '__';
+        $uniquePlaceholder = '__'.uniqid().'__';
         $parameters = static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(
             str_replace('\\\\', $uniquePlaceholder, trim($parameter, '"'))
         );

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -284,7 +284,7 @@ class ValidationRuleParser
         $parameters = static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(
             str_replace('\\\\', $uniquePlaceholder, trim($parameter, '"'))
         );
-        
+
         return str_replace($uniquePlaceholder, '\\\\', $parameters);
     }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -280,7 +280,9 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        return array_map(function ($param) { return str_replace('\\\\', '\\', $param); },
+        return array_map(function ($param) { 
+            return str_replace('\\\\', '\\', $param); 
+        },
             static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(str_replace('\\', '\\\\', $parameter), ',', '"', "\\")
         );
     }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -281,8 +281,8 @@ class ValidationRuleParser
     protected static function parseParameters($rule, $parameter)
     {
         return array_map(function ($param) {
-            return str_replace('\\\\', '\\', $param); 
-        },
+                return str_replace('\\\\', '\\', $param);
+            },
             static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(str_replace('\\', '\\\\', $parameter), ',', '"', '\\')
         );
     }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -284,6 +284,7 @@ class ValidationRuleParser
         $parameters = static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(
             str_replace('\\\\', $uniquePlaceholder, trim($parameter, '"'))
         );
+        
         return str_replace($uniquePlaceholder, '\\\\', $parameters);
     }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -281,8 +281,8 @@ class ValidationRuleParser
     protected static function parseParameters($rule, $parameter)
     {
         return array_map(function ($param) {
-                return str_replace('\\\\', '\\', $param);
-            },
+            return str_replace('\\\\', '\\', $param);
+        },
             static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(str_replace('\\', '\\\\', $parameter), ',', '"', '\\')
         );
     }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -280,12 +280,9 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        $uniquePlaceholder = '__'.uniqid().'__';
-        $parameters = static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(
-            str_replace('\\\\', $uniquePlaceholder, trim($parameter, '"'))
+        return array_map(function ($param) { return str_replace('\\\\', '\\', $param); },
+            static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(str_replace('\\', '\\\\', $parameter), ',', '"', "\\")
         );
-
-        return str_replace($uniquePlaceholder, '\\\\', $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -280,10 +280,10 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        return array_map(function ($param) { 
+        return array_map(function ($param) {
             return str_replace('\\\\', '\\', $param); 
         },
-            static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(str_replace('\\', '\\\\', $parameter), ',', '"', "\\")
+            static::ruleIsRegex($rule) ? [$parameter] : str_getcsv(str_replace('\\', '\\\\', $parameter), ',', '"', '\\')
         );
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3741,10 +3741,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|In:foo,bar']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['a' => 'b\\'], ['a' => "not_in:b\\"]);
+        $v = new Validator($trans, ['a' => 'b\\'], ['a' => 'not_in:b\\']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['a' => 'b\\c'], ['a' => "not_in:b\\c"]);
+        $v = new Validator($trans, ['a' => 'b\\c'], ['a' => 'not_in:b\\c']);
         $this->assertFalse($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3740,6 +3740,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|In:foo,bar']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['a' => 'b\\'], ['a' => "not_in:b\\"]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['a' => 'b\\c'], ['a' => "not_in:b\\c"]);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateNotIn()


### PR DESCRIPTION
Fixed the bug outlined in (#50712)

Both of these cases now return false:

```php
Validator::make(['a' => 'b\\'], ['a' => Illuminate\Validation\Rule::notIn('b\\')])->passes();
Validator::make(['a' => 'b\\c'], ['a' => Illuminate\Validation\Rule::notIn('b\\c')])->passes();
```
whereas before the first one returned true (which was incorrect).