### PR TITLE
[11.x] Add geo-coordinates points validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -700,7 +700,7 @@ trait ValidatesAttributes
 
         $latIsCorrect = with(
             $point($parameters[0] ?? 'lat', 0),
-            fn ($lat) => $this->validateLongitude($attribute, $lat)
+            fn ($lat) => $this->validateLatitude($attribute, $lat)
         );
         $lngIsCorrect = with(
             $point($parameters[1] ?? 'lng', 1),

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -292,14 +292,14 @@ class Validator implements ValidatorContract
      *
      * @var string[]
      */
-    protected $numericRules = ['Numeric', 'Integer', 'Decimal'];
+    protected $numericRules = ['Numeric', 'Integer', 'Decimal', 'Latitude', 'Longitude', 'GeoPoint'];
 
     /**
      * The default numeric related validation rules.
      *
      * @var string[]
      */
-    protected $defaultNumericRules = ['Numeric', 'Integer', 'Decimal'];
+    protected $defaultNumericRules = ['Numeric', 'Integer', 'Decimal', 'Latitude', 'Longitude', 'GeoPoint'];
 
     /**
      * The current placeholder for dots in rule keys.


### PR DESCRIPTION
As in title, simple validation for geo points: latitude and longitude
It is equal to: `['numeric', 'between:-90,90']` and so on.
Geo points are universal and I believe that many apps are using them already. 

There could be one more validation rule: `geo_point:latitude,longitude` where field is array and arguments are key names for coordinates. I can add it too.