### PR TITLE
[10.x] Fix belongs to many touch using key instead of owner key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1192,6 +1192,7 @@ class BelongsToMany extends Relation
         // to the parent models. This will help us keep any caching synced up here.
         if (count($ids = $this->allRelatedIds()) > 0) {
             $whereIn = $this->whereInMethod($this->related, $this->relatedKey);
+
             $this->getRelated()->newQueryWithoutRelationships()->{$whereIn}($this->relatedKey, $ids)->update($columns);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1191,7 +1191,8 @@ class BelongsToMany extends Relation
         // the related model's timestamps, to make sure these all reflect the changes
         // to the parent models. This will help us keep any caching synced up here.
         if (count($ids = $this->allRelatedIds()) > 0) {
-            $this->getRelated()->newQueryWithoutRelationships()->whereKey($ids)->update($columns);
+            $whereIn = $this->whereInMethod($this->related, $this->relatedKey);
+            $this->getRelated()->newQueryWithoutRelationships()->{$whereIn}($this->relatedKey, $ids)->update($columns);
         }
     }
 


### PR DESCRIPTION
The default is that the owner key is set to the related model's key, however this is just a default, and we need to respect if a non-default value for the owner key name is used.