### PR TITLE
[11.x] Refactor and improvement code ( more readability) in some traits

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -887,9 +887,7 @@ trait HasRelationships
      */
     public function withoutRelations()
     {
-        $model = clone $this;
-
-        return $model->unsetRelations();
+        return (clone $this)->unsetRelations();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -106,7 +106,7 @@ trait DatabaseTruncation
     {
         $prefix = $connection->getTablePrefix();
 
-        return strpos($table, $prefix) === 0
+        return str_starts_with($table, $prefix)
             ? substr($table, strlen($prefix))
             : $table;
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -39,7 +39,7 @@ trait InteractsWithContentTypes
     }
 
     /**
-     * Determines whether the current requests accepts a given content type.
+     * Determines whether the current request accepts a given content type.
      *
      * @param  string|array  $contentTypes
      * @return bool
@@ -117,7 +117,7 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return count($acceptable) === 0 || (
+        return empty($acceptable) || (
             isset($acceptable[0]) && ($acceptable[0] === '*/*' || $acceptable[0] === '*')
         );
     }


### PR DESCRIPTION
### 1. `DatabaseTruncation` trait

In the `withoutTablePrefix` method, the condition that checked the beginning of a string using `strpos` was replaced with `str_starts_with` for better readability.

```php
//before
return strpos($table, $prefix) === 0
            ? substr($table, strlen($prefix))
            : $table;

//after
return str_starts_with($table, $prefix)
            ? substr($table, strlen($prefix))
            : $table;
```

### 2. `HasRelationships.php` trait
```php

   // Before
    public function withoutRelations()
    {
        $model = clone $this;

        return $model->unsetRelations();
    }


   // After
    public function withoutRelations()
    {
        return (clone $this)->unsetRelations();
    }

```

### 3. `InteractsWithContentTypes.php` trait
using empty() function for array emptiness check, and fix doc block

```php

        // Before
        return count($acceptable) === 0 || (
            isset($acceptable[0]) && ($acceptable[0] === '*/*' || $acceptable[0] === '*')
        );

        // After
        return empty($acceptable) || (
            isset($acceptable[0]) && ($acceptable[0] === '*/*' || $acceptable[0] === '*')
        );

```

Thanks!