### PR TITLE
New helper getNested() added to Arr.php

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -358,6 +358,32 @@ class Arr
     }
 
     /**
+     * Get an array piece from a nested array or collection.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function getNested($array, $key, $default = null)
+    {
+        foreach ($array as $k => $value) {
+            if ($k === $key) {
+                return value([$key => $value]);
+            }
+
+            if (is_array($value)) {
+                $result = self::getNested($value, $key);
+                if ($result) {
+                    return value($result);
+                }
+            }
+        }
+
+        return $default;
+    }
+
+    /**
      * Check if an item or items exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array


### PR DESCRIPTION
Get an array piece from a nested/multidimensional array.

### I couldn't find a way to get the value from a nested/multidimensional array. 
Example:
```
$data = [
    "id" => 0,
    "name" => 'John Doe',
    "posts" => [
        "id" => 0,
        "title" => "My post title",
        "files_attached" => [
            "images" => [0, 1, 2],
            "docs" => [0]
        ]
    ]
];
```
### In the Arr.php I've created the function getNested() 
...\Collections\Arr.php
```
public static function getNested($array, $key, $default = null)
    {
        foreach ($array as $k => $value) {
            if ($k === $key) {
                return value([$key => $value]);
            }

            if (is_array($value)) {
                $result = self::getNested($value, $key);
                if ($result) {
                    return value($result);
                }
            }
        }

        return $default;
    }
```
### Here's the comparision
```

Arr::get($data, 'images', 'not found'); // not found
Arr::getNested($data, 'images', 'not found'); // array["images" => [0,1,2]];

```