### PR TITLE
[11.x] Register console commands, paths and routes after the app is booted

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -257,9 +257,11 @@ class ApplicationBuilder
             [$commands, $paths] = collect($commands)->partition(fn ($command) => class_exists($command));
             [$routes, $paths] = $paths->partition(fn ($path) => is_file($path));
 
-            $kernel->addCommands($commands->all());
-            $kernel->addCommandPaths($paths->all());
-            $kernel->addCommandRoutePaths($routes->all());
+            $this->app->booted(static function () use ($kernel, $commands, $paths, $routes) {
+                $kernel->addCommands($commands->all());
+                $kernel->addCommandPaths($paths->all());
+                $kernel->addCommandRoutePaths($routes->all());
+            });
         });
 
         return $this;


### PR DESCRIPTION
During new approach for application bootstrap, console kernel was loading commands, paths and routes shortly after resolving. At this moment, `bootstrap/providers.php` were not loaded yet.
Now kernel is loading resources after app is booted and ready to work.
I believe that tests are not needed at all here. It simply make sense.

This pull request is resolving issue: #50716