### PR TITLE
[11.x] Fixes `ApplicationBuilder::withCommandRouting()` usage

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -274,9 +274,7 @@ class ApplicationBuilder
     protected function withCommandRouting(array $paths)
     {
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
-            $this->app->booted(function () use ($kernel, $paths) {
-                $kernel->addCommandRoutePaths($paths);
-            });
+            $this->app->booted(fn () => $kernel->addCommandRoutePaths($paths));
         });
     }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -274,7 +274,9 @@ class ApplicationBuilder
     protected function withCommandRouting(array $paths)
     {
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
-            $kernel->setCommandRoutePaths($paths);
+            $this->app->booted(function () {
+                $kernel->addCommandRoutePaths($paths);
+            });
         });
     }
 

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -274,7 +274,7 @@ class ApplicationBuilder
     protected function withCommandRouting(array $paths)
     {
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
-            $this->app->booted(function () use ($paths) {
+            $this->app->booted(function () use ($kernel, $paths) {
                 $kernel->addCommandRoutePaths($paths);
             });
         });

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -273,8 +273,8 @@ class ApplicationBuilder
      */
     protected function withCommandRouting(array $paths)
     {
-        $this->app->afterResolving(ConsoleKernel::class, function ($kernel) {
-            $this->app->booted(function () {
+        $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
+            $this->app->booted(function () use ($paths) {
                 $kernel->addCommandRoutePaths($paths);
             });
         });

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -273,7 +273,7 @@ class ApplicationBuilder
      */
     protected function withCommandRouting(array $paths)
     {
-        $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
+        $this->app->afterResolving(ConsoleKernel::class, function ($kernel) {
             $this->app->booted(function () {
                 $kernel->addCommandRoutePaths($paths);
             });


### PR DESCRIPTION
This also apply the changes from PR #50738 for `withCommandRouting()` method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
