### PR TITLE
adds hadUpdateAttempt flag to models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -114,6 +114,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public $wasRecentlyCreated = false;
 
     /**
+     * Indicates if the model had an update attempt during the object's lifecycle.
+     * Usefull when user updates the model but the model is not dirty
+     *
+     * @var bool
+     */
+    public $hadUpdateAttempt = false;
+
+    /**
      * Indicates that the object's string representation should be escaped when __toString is invoked.
      *
      * @var bool
@@ -1133,6 +1141,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if ($this->exists) {
             $saved = $this->isDirty() ?
                 $this->performUpdate($query) : true;
+            $this->hadUpdateAttempt = true;
         }
 
         // If the model is brand new, we'll insert it into our database and set the

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -115,7 +115,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
     /**
      * Indicates if the model had an update attempt during the object's lifecycle.
-     * Useful when user updates the model but the model is not dirty
+     * Useful when user updates the model but the model is not dirty.
      *
      * @var bool
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -115,7 +115,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
     /**
      * Indicates if the model had an update attempt during the object's lifecycle.
-     * Usefull when user updates the model but the model is not dirty
+     * Useful when user updates the model but the model is not dirty
      *
      * @var bool
      */

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -126,6 +126,26 @@ class EloquentModelTest extends DatabaseTestCase
             'analyze' => true,
         ]);
     }
+
+    public function testProperlyMarkModelWithUpdateAttempt()
+    {
+        $user = TestModel2::create([
+            'name' => $originalName = Str::random(),
+            'title' => Str::random(),
+        ]);
+
+        $this->assertTrue($user->wasRecentlyCreated);
+        $this->assertFalse($user->hadUpdateAttempt);
+        $this->assertFalse($user->wasChanged());
+
+        $user->update(['name' => $originalName]);
+        $this->assertTrue($user->hadUpdateAttempt);
+        $this->assertFalse($user->wasChanged());
+
+        $user->update(['name' => Str::random()]);
+        $this->assertTrue($user->hadUpdateAttempt);
+        $this->assertTrue($user->wasChanged());
+    }
 }
 
 class TestModel1 extends Model


### PR DESCRIPTION
This PR adds `hadUpdateAttempt` to models which is useful when user updates the model but the model is not dirty.

The [provided tests](https://github.com/laravel/framework/compare/11.x...mohammedmanssour:laravel-framework:model-had-update-attempt?expand=1#diff-cd112ff5f7688ec756b58d731024c28880a96211e870a45d244d57cfaf63c034R130) should explain the idea and show the difference done with this simple change. 