### PR TITLE
Fix wrong param type: string to array

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -311,7 +311,7 @@ if (! function_exists('cookie')) {
             return $cookie;
         }
 
-        return $cookie->make($name, $value, $minutes, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+        return $cookie->make($name, [$value, $minutes, $path, $domain, $secure, $httpOnly, $raw, $sameSite]);
     }
 }
 
@@ -793,7 +793,7 @@ if (! function_exists('response')) {
             return $factory;
         }
 
-        return $factory->make($content, $status, $headers);
+        return $factory->make($content, [$status, $headers]);
     }
 }
 


### PR DESCRIPTION
src\Illuminate\Foundation\helpers.php
Gave errors.
make() method only accepts optional array as 2nd variable, not multiple variables

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
