### PR TITLE
[11.x] Preserve item type (array or object) when using Arr::select() or Collection::select()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -534,7 +534,7 @@ class Arr
                 }
             }
 
-            return $result;
+            return is_object($item) ? (object) $result : $result;
         });
     }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -982,7 +982,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                         }
                     }
 
-                    yield $result;
+                    yield is_object($item) ? (object) $result : $result;
                 }
             }
         });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3912,9 +3912,9 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals($data->all(), $data->select(null)->all());
-        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
-        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
 
         $this->assertEquals([
             (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
@@ -3941,9 +3941,9 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals($data->all(), $data->select(null)->all());
-        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
-        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
 
         $this->assertEquals([
             (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3912,9 +3912,9 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals($data->all(), $data->select(null)->all());
-        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
-        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([(object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals([(object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals([(object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
 
         $this->assertEquals([
             (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
@@ -3941,9 +3941,9 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals($data->all(), $data->select(null)->all());
-        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
-        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([ (object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals([(object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals([(object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals([(object) ['first' => 'Taylor'], (object) ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
 
         $this->assertEquals([
             (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3941,23 +3941,23 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals($data->all(), $data->select(null)->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
 
         $this->assertEquals([
-            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
+            (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            (object) ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select(['first', 'email'])->all());
 
         $this->assertEquals([
-            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
+            (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            (object) ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select('first', 'email')->all());
 
         $this->assertEquals([
-            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
+            (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            (object) ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select(collect(['first', 'email']))->all());
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3912,23 +3912,23 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals($data->all(), $data->select(null)->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
-        $this->assertEquals([['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
+        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(['first', 'missing'])->all());
+        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select('first', 'missing')->all());
+        $this->assertEquals( (object) [['first' => 'Taylor'], ['first' => 'Jess']], $data->select(collect(['first', 'missing']))->all());
 
         $this->assertEquals([
-            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
+            (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            (object) ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select(['first', 'email'])->all());
 
         $this->assertEquals([
-            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
+            (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            (object) ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select('first', 'email')->all());
 
         $this->assertEquals([
-            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
-            ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
+            (object) ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            (object) ['first' => 'Jess', 'email' => 'jessarcher@gmail.com'],
         ], $data->select(collect(['first', 'email']))->all());
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

10.44.0 added the `Collection::select()` and `Arr::select()` methods https://github.com/laravel/framework/pull/49845 and 10.45.0 updated it to work with ArrayAccess https://github.com/laravel/framework/pull/50072

However, these convert any item in either an array or the Collection into an array even if it is an object. See https://github.com/laravel/framework/blob/11.x/src/Illuminate/Collections/Arr.php#L532-L533

For example, if you have an array of objects and select a single column, it will become an array of arrays.
```php
$obj1 = new \stdClass;
$obj1->color = 'blue';
$obj1->temperature = 'warm';

$obj2 = new \stdClass;
$obj2->color = 'green';
$obj2->temperature = 'cool';

$arr = [$obj1, $obj2];

$selected = Arr::select($arr, 'color');
/* 
[
    [ 'color' => 'blue' ],
    [ 'color' => 'green' ],
]
*/
```

This is unexpected behavior as the Collection returned from Query Builder has each row of data represented as a `stdClass` object. Using `select` on that Collection then converts all the `stdClass` objects to `array` types, breaking downstream code.

The proposed change would coerce the individual value of the Collection or Array back into an `object` if the value was originally an object.