### PR TITLE
[11.x] Apply default timezone when casting unix timestamps

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -374,9 +374,9 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             (int) $batch->failed_jobs,
             (array) json_decode($batch->failed_job_ids, true),
             $this->unserialize($batch->options),
-            CarbonImmutable::createFromTimestamp($batch->created_at),
-            $batch->cancelled_at ? CarbonImmutable::createFromTimestamp($batch->cancelled_at) : $batch->cancelled_at,
-            $batch->finished_at ? CarbonImmutable::createFromTimestamp($batch->finished_at) : $batch->finished_at
+            CarbonImmutable::createFromTimestamp($batch->created_at, date_default_timezone_get()),
+            $batch->cancelled_at ? CarbonImmutable::createFromTimestamp($batch->cancelled_at, date_default_timezone_get()) : $batch->cancelled_at,
+            $batch->finished_at ? CarbonImmutable::createFromTimestamp($batch->finished_at, date_default_timezone_get()) : $batch->finished_at
         );
     }
 

--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -411,9 +411,9 @@ class DynamoBatchRepository implements BatchRepository
             (int) $batch->failed_jobs,
             $batch->failed_job_ids,
             $this->unserialize($batch->options) ?? [],
-            CarbonImmutable::createFromTimestamp($batch->created_at),
-            $batch->cancelled_at ? CarbonImmutable::createFromTimestamp($batch->cancelled_at) : $batch->cancelled_at,
-            $batch->finished_at ? CarbonImmutable::createFromTimestamp($batch->finished_at) : $batch->finished_at
+            CarbonImmutable::createFromTimestamp($batch->created_at, date_default_timezone_get()),
+            $batch->cancelled_at ? CarbonImmutable::createFromTimestamp($batch->cancelled_at, date_default_timezone_get()) : $batch->cancelled_at,
+            $batch->finished_at ? CarbonImmutable::createFromTimestamp($batch->finished_at, date_default_timezone_get()) : $batch->finished_at
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1459,7 +1459,7 @@ trait HasAttributes
         // and format a Carbon object from this timestamp. This allows flexibility
         // when defining your date fields as they might be UNIX timestamps here.
         if (is_numeric($value)) {
-            return Date::createFromTimestamp($value);
+            return Date::createFromTimestamp($value, date_default_timezone_get());
         }
 
         // If the value is in simply year, month, day format, we will instantiate the

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -56,7 +56,7 @@ class SetCacheHeaders
 
         if (isset($options['last_modified'])) {
             if (is_numeric($options['last_modified'])) {
-                $options['last_modified'] = Carbon::createFromTimestamp($options['last_modified']);
+                $options['last_modified'] = Carbon::createFromTimestamp($options['last_modified'], date_default_timezone_get());
             } else {
                 $options['last_modified'] = Carbon::parse($options['last_modified']);
             }

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -119,7 +119,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
                 'payload' => $result['payload']['S'],
                 'exception' => $result['exception']['S'],
                 'failed_at' => Carbon::createFromTimestamp(
-                    (int) $result['failed_at']['N']
+                    (int) $result['failed_at']['N'], date_default_timezone_get()
                 )->format(DateTimeInterface::ISO8601),
             ];
         })->all();
@@ -152,7 +152,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
             'payload' => $result['Item']['payload']['S'],
             'exception' => $result['Item']['exception']['S'],
             'failed_at' => Carbon::createFromTimestamp(
-                (int) $result['Item']['failed_at']['N']
+                (int) $result['Item']['failed_at']['N'], date_default_timezone_get()
             )->format(DateTimeInterface::ISO8601),
         ];
     }

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -92,7 +92,7 @@ class Sleep
     public static function until($timestamp)
     {
         if (is_numeric($timestamp)) {
-            $timestamp = Carbon::createFromTimestamp($timestamp);
+            $timestamp = Carbon::createFromTimestamp($timestamp, date_default_timezone_get());
         }
 
         return new static(Carbon::now()->diff($timestamp));

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -432,7 +432,7 @@ class TestResponse implements ArrayAccess
             "Cookie [{$cookieName}] not present on response."
         );
 
-        $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
+        $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime(), date_default_timezone_get());
 
         PHPUnit::assertTrue(
             $cookie->getExpiresTime() !== 0 && $expiresAt->lessThan(Carbon::now()),
@@ -455,7 +455,7 @@ class TestResponse implements ArrayAccess
             "Cookie [{$cookieName}] not present on response."
         );
 
-        $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
+        $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime(), date_default_timezone_get());
 
         PHPUnit::assertTrue(
             $cookie->getExpiresTime() === 0 || $expiresAt->greaterThan(Carbon::now()),


### PR DESCRIPTION
[Carbon 3 no longer apply default timezone while creating from unix timestamp](https://github.com/briannesbitt/Carbon/issues/2948)

Laravel 11 supports both Carbon 2 and 3. I think it should behave the same regardless of installed Carbon version.
We may switch to the new behaviour in the next major version given that we'll drop support for Carbon 2.