### PR TITLE
[11.x] Adds `withSchedule` to `bootstrap/app.php` file

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Foundation\Configuration;
 
 use Closure;
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Application;
@@ -161,6 +163,21 @@ class ApplicationBuilder
         if (is_string($channels) && realpath($channels) !== false) {
             $this->withBroadcasting($channels);
         }
+
+        return $this;
+    }
+
+    /**
+     * Register the scheduling services for the application.
+     *
+     * @param  callable(Schedule $schedule): void  $callback
+     * @return $this
+     */
+    public function withSchedule(callable $callback)
+    {
+        $this->app->afterResolving(ConsoleKernel::class, function (ConsoleKernel $kernel) use ($callback) {
+            Artisan::starting(fn () => $callback($this->app->make(Schedule::class)));
+        });
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -168,21 +168,6 @@ class ApplicationBuilder
     }
 
     /**
-     * Register the scheduling services for the application.
-     *
-     * @param  callable(Schedule $schedule): void  $callback
-     * @return $this
-     */
-    public function withSchedule(callable $callback)
-    {
-        $this->app->afterResolving(ConsoleKernel::class, function (ConsoleKernel $kernel) use ($callback) {
-            Artisan::starting(fn () => $callback($this->app->make(Schedule::class)));
-        });
-
-        return $this;
-    }
-
-    /**
      * Create the routing callback for the application.
      *
      * @param  string|null  $web
@@ -293,6 +278,21 @@ class ApplicationBuilder
         $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($paths) {
             $this->app->booted(fn () => $kernel->addCommandRoutePaths($paths));
         });
+    }
+
+    /**
+     * Register the scheduled tasks for the application.
+     *
+     * @param  callable(Schedule $schedule): void  $callback
+     * @return $this
+     */
+    public function withSchedule(callable $callback)
+    {
+        $this->app->afterResolving(ConsoleKernel::class, function (ConsoleKernel $kernel) use ($callback) {
+            Artisan::starting(fn () => $callback($this->app->make(Schedule::class)));
+        });
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This pull request adds, as requested here https://github.com/laravel/framework/discussions/50493, the `withSchedule` method to `bootstrap/app.php` file:

```php
->withSchedule(function ($schedule) {
    $schedule->command('backup:database')->daily();
})
```