### PR TITLE
Shortened "unless" methods

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -389,7 +389,7 @@ class PendingBatch
      */
     public function dispatchUnless($boolean)
     {
-        return ! value($boolean) ? $this->dispatch() : null;
+        return $this->dispatchIf(! value($boolean));
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -185,6 +185,6 @@ class PendingChain
      */
     public function dispatchUnless($boolean)
     {
-        return ! value($boolean) ? $this->dispatch() : null;
+        return $this->dispatchIf(! value($boolean));
     }
 }

--- a/src/Illuminate/Foundation/Events/Dispatchable.php
+++ b/src/Illuminate/Foundation/Events/Dispatchable.php
@@ -37,9 +37,7 @@ trait Dispatchable
      */
     public static function dispatchUnless($boolean, ...$arguments)
     {
-        if (! $boolean) {
-            return event(new static(...$arguments));
-        }
+        return self::dispatchIf(! $boolean, ...$arguments);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -82,9 +82,7 @@ if (! function_exists('abort_unless')) {
      */
     function abort_unless($boolean, $code, $message = '', array $headers = [])
     {
-        if (! $boolean) {
-            abort($code, $message, $headers);
-        }
+        abort_if(! $boolean, $code, $message, $headers);
     }
 }
 
@@ -693,9 +691,7 @@ if (! function_exists('report_unless')) {
      */
     function report_unless($boolean, $exception)
     {
-        if (! $boolean) {
-            report($exception);
-        }
+        report_if(! $boolean, $exception);
     }
 }
 


### PR DESCRIPTION
Some "unless" methods have the same body as methods that take inverse conditions ("..If" etc.). It's just that the condition is reversed. I connected these methods to inverse condition methods that have the same body as them.