### PR TITLE
[11.x] Dynamic Model Attribute Mutators

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2331,6 +2331,10 @@ trait HasAttributes
         $instance = is_object($class) ? $class : new $class;
 
         return collect((new ReflectionClass($instance))->getMethods())->filter(function ($method) use ($instance) {
+            if ($method->getNumberOfRequiredParameters() > 0) {
+                return false;
+            }
+
             $returnType = $method->getReturnType();
 
             if ($returnType instanceof ReflectionNamedType &&


### PR DESCRIPTION
This PR adds the ability to dynamically register model attribute mutators without having to declare them as methods.

See #50759 for a scenario where this would be useful.

Ideally, on the boot method of a model, or an external trait, these mutators could be added:

```php
class User extends Model
{
    public static function boot()
    {
        /** @var array<string,Attribute> */
        $attributes = [
            'example' => Attribute::make(...),
            /* ... some dynamic source ... */
        ];

        foreach ($attributes as $name => $attribute) {
            static::addDynamicAttribute($name, $attribute);
        }
    }
}

// echo $user->example;
// $user->example = 5;
```