### PR TITLE
[11.x] Fix dock block for create method in `InvalidArgumentException.php`

### DIFF
--- a/src/Illuminate/Testing/Exceptions/InvalidArgumentException.php
+++ b/src/Illuminate/Testing/Exceptions/InvalidArgumentException.php
@@ -9,6 +9,8 @@ class InvalidArgumentException extends Exception
     /**
      * Creates a new exception for an invalid argument.
      *
+     * @param  int  $argument
+     * @param  string  $type
      * @return static
      */
     public static function create(int $argument, string $type): static


### PR DESCRIPTION
This PR, fixed doc block for create method in `InvalidArgumentException.php`