### PR TITLE
[10.x] Test Improvements

### DIFF
--- a/tests/Integration/Auth/RehashOnLogoutOtherDevicesTest.php
+++ b/tests/Integration/Auth/RehashOnLogoutOtherDevicesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\Factories\UserFactory;
+use Orchestra\Testbench\TestCase;
+
+#[WithMigration]
+#[WithEnv('BCRYPT_ROUNDS', 12)]
+#[WithConfig('app.key', 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=')]
+class RehashOnLogoutOtherDevicesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function defineRoutes($router)
+    {
+        $router->post('logout', function (Request $request) {
+            auth()->logoutOtherDevices($request->input('password'));
+
+            return response()->noContent();
+        })->middleware(['web', 'auth']);
+    }
+
+    public function testItRehashThePasswordUsingLogoutOtherDevices()
+    {
+        $this->withoutExceptionHandling();
+
+        $user = UserFactory::new()->create();
+
+        $password = $user->password;
+
+        $this->actingAs($user);
+
+        $this->post('logout', [
+            'password' => 'password',
+        ])->assertStatus(204);
+
+        $user->refresh();
+
+        $this->assertNotSame($password, $user->password);
+    }
+}


### PR DESCRIPTION
Add tests to verify using `auth()->logoutOtherDevices()` will rehash the password.

Made a mistake targeting `11.x` branch yesterday. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
