### PR TITLE
[11.x] signature typo

### DIFF
--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -7,7 +7,7 @@ interface HasMiddleware
     /**
      * Get the middleware that should be assigned to the controller.
      *
-     * @return \Illuminate\Routing\Controllers\Middleware|array
+     * @return \Illuminate\Routing\Controllers\Middleware[]|array
      */
     public static function middleware();
 }

--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -7,7 +7,7 @@ interface HasMiddleware
     /**
      * Get the middleware that should be assigned to the controller.
      *
-     * @return \Illuminate\Routing\Controllers\Middleware[]|array
+     * @return \Illuminate\Routing\Controllers\Middleware[]
      */
     public static function middleware();
 }


### PR DESCRIPTION
One single `Illuminate\Routing\Controllers\Middleware` instance may break the request