### PR TITLE
[11.x] Dynamic Model Attribute Mutators

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2331,6 +2331,10 @@ trait HasAttributes
         $instance = is_object($class) ? $class : new $class;
 
         return collect((new ReflectionClass($instance))->getMethods())->filter(function ($method) use ($instance) {
+            if ($method->getNumberOfRequiredParameters() > 0) {
+                return false;
+            }
+
             $returnType = $method->getReturnType();
 
             if ($returnType instanceof ReflectionNamedType &&

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -691,7 +691,7 @@ trait HasAttributes
             return $this->attributeCastCache[$key];
         }
 
-        $attribute = $this->getMarkedAttribute($key);
+        $attribute = $this->getMarkedAttributeMutator($key);
 
         $value = call_user_func($attribute->get ?: function ($value) {
             return $value;
@@ -1109,7 +1109,7 @@ trait HasAttributes
      */
     protected function setAttributeMarkedMutatedAttributeValue($key, $value)
     {
-        $attribute = $this->getMarkedAttribute($key);
+        $attribute = $this->getMarkedAttributeMutator($key);
 
         $callback = $attribute->set ?: function ($value) use ($key) {
             $this->attributes[$key] = $value;
@@ -2385,7 +2385,7 @@ trait HasAttributes
      *
      * @return Attribute
      */
-    protected function getMarkedAttribute($name)
+    protected function getMarkedAttributeMutator($name)
     {
         if ($attribute = static::$dynamicAttributeMutatorCache[static::class][$name] ?? null) {
             return $attribute;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2358,9 +2358,8 @@ trait HasAttributes
     /**
      * Add the given dynamic attribute mutator.
      *
-     * @param string $name
-     * @param Attribute $attribute
-     *
+     * @param  string  $name
+     * @param  Attribute  $attribute
      * @return void
      */
     public static function addDynamicAttributeMutator($name, $attribute)
@@ -2381,8 +2380,7 @@ trait HasAttributes
     /**
      * Returns the marked attribute for the given attribute name.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return Attribute
      */
     protected function getMarkedAttributeMutator($name)

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -21,6 +21,18 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $attributes = $instance->getMutatedAttributes();
         $this->assertEquals(['some_attribute'], $attributes);
     }
+
+    public function testWithDynamicRegistration()
+    {
+        $instance = new HasAttributesWithDynamicRegistration([
+            'some_attribute' => new Attribute(function () {
+
+            })
+        ]);
+
+        $attributes = $instance->getMutatedAttributes();
+        $this->assertEquals(['some_attribute'], $attributes);
+    }
 }
 
 class HasAttributesWithoutConstructor
@@ -38,5 +50,15 @@ class HasAttributesWithConstructorArguments extends HasAttributesWithoutConstruc
 {
     public function __construct($someValue)
     {
+    }
+}
+
+class HasAttributesWithDynamicRegistration extends HasAttributesWithoutConstructor
+{
+    public function __construct($attributes)
+    {
+        foreach ($attributes as $name => $attribute) {
+            $this->addDynamicAttributeMutator($name, $attribute);
+        }
     }
 }

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -26,8 +26,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
     {
         $instance = new HasAttributesWithDynamicRegistration([
             'some_attribute' => new Attribute(function () {
-
-            })
+            }),
         ]);
 
         $attributes = $instance->getMutatedAttributes();


### PR DESCRIPTION
This PR adds the ability to dynamically register model attribute mutators without having to declare them as methods.

See #50759 for a scenario where this would be useful.

Ideally, on the boot method of a model, or an external trait, these mutators could be added:

```php
class User extends Model
{
    public static function boot()
    {
        /** @var array<string,Attribute> */
        $attributes = [
            'example' => Attribute::make(...),
            /* ... some dynamic source ... */
        ];

        foreach ($attributes as $name => $attribute) {
            static::addDynamicAttribute($name, $attribute);
        }
    }
}

// echo $user->example;
// $user->example = 5;
```