### PR TITLE
[11.x] Fix query builder `whereBetween` with CarbonPeriod and Carbon 3

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1316,7 +1316,7 @@ class Builder implements BuilderContract
         $type = 'between';
 
         if ($values instanceof CarbonPeriod) {
-            $values = [$values->start, $values->end];
+            $values = [$values->getStartDate(), $values->getEndDate()];
         }
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
@@ -2381,7 +2381,7 @@ class Builder implements BuilderContract
         $type = 'between';
 
         if ($values instanceof CarbonPeriod) {
-            $values = [$values->start, $values->end];
+            $values = [$values->getStartDate(), $values->getEndDate()];
         }
 
         $this->havings[] = compact('type', 'column', 'values', 'boolean', 'not');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -771,17 +771,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $period = now()->toPeriod(now()->addDay());
+        $period = now()->startOfDay()->toPeriod(now()->addDay()->startOfDay());
         $builder->select('*')->from('users')->whereBetween('created_at', $period);
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
-        $this->assertEquals([$period->start, $period->end], $builder->getBindings());
+        $this->assertEquals([now()->startOfDay(), now()->addDay()->startOfDay()], $builder->getBindings());
 
         // custom long carbon period date
         $builder = $this->getBuilder();
-        $period = now()->toPeriod(now()->addMonth());
+        $period = now()->startOfDay()->toPeriod(now()->addMonth()->startOfDay());
         $builder->select('*')->from('users')->whereBetween('created_at', $period);
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
-        $this->assertEquals([$period->start, $period->end], $builder->getBindings());
+        $this->assertEquals([now()->startOfDay(), now()->addMonth()->startOfDay()], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));


### PR DESCRIPTION
This PR fixes the query builder's `whereBetween()` and `havingBetween()` methods by calling `getStartDate()` and `getEndDate()` on `CarbonPeriod`, instead of using its `$start` and `$end` properties. Currently, using Carbon 3, `$period->start` is always `2000-01-01` and `$period->end` is always `null` (see https://github.com/briannesbitt/Carbon/issues/2982).

In Carbon 2 this is actually exactly what `$start` and `$end` already do—they are not defined, so they go through the `CarbonPeriod` class's `__get()` method, which calls `getStartDate()` and `getEndDate()` (https://github.com/briannesbitt/Carbon/blob/2.x/src/Carbon/CarbonPeriod.php#L757).

In Carbon 3 those getters are all still set up exactly the same way, but they don't work (I assume this was unintentional). `CarbonPeriod` now extends PHP's `DatePeriod` class, which actually defines `$start` and `$end` properties, so the getters are never called.