### PR TITLE
[11.x] Binding order is incorrect when using cursor paginate with multiple unions with a where

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -391,14 +391,14 @@ trait BuildsQueries
                         $cursor->parameter($previousColumn)
                     );
 
-                    $unionBuilders->each(function ($unionBuilder) use ($previousColumn, $cursor) {
+                    $unionBuilders->each(function ($unionBuilder, $builderIndex) use ($previousColumn, $cursor) {
                         $unionBuilder->where(
                             $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
                             '=',
                             $cursor->parameter($previousColumn)
                         );
 
-                        $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
+                        $this->addUnionBinding($unionBuilder->getRawBindings()['where'], $builderIndex);
                     });
                 }
 
@@ -419,8 +419,8 @@ trait BuildsQueries
                         });
                     }
 
-                    $unionBuilders->each(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
-                        $unionBuilder->where(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
+                    $unionBuilders->each(function ($unionBuilder, $builderIndex) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
+                        $unionBuilder->where(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions, $builderIndex) {
                             $unionBuilder->where(
                                 $this->getOriginalColumnNameForCursorPagination($this, $column),
                                 $direction === 'asc' ? '>' : '<',
@@ -433,7 +433,7 @@ trait BuildsQueries
                                 });
                             }
 
-                            $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
+                            $this->addUnionBinding($unionBuilder->getRawBindings()['where'], $builderIndex);
                         });
                     });
                 });

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2690,7 +2690,7 @@ class Builder implements BuilderContract
 
         $this->unions[] = compact('query', 'all');
 
-        $this->addBinding($query->getBindings(), 'union');
+        $this->addUnionBinding($query->getBindings());
 
         return $this;
     }
@@ -3941,6 +3941,36 @@ class Builder implements BuilderContract
             ));
         } else {
             $this->bindings[$type][] = $this->castBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a union binding to the query.
+     *
+     * @param  mixed  $value
+     * @param  int  $index
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function addUnionBinding($value, $index = null)
+    {
+        $unionBindings = [];
+        if (is_array($value)) {
+            $unionBindings = array_values(array_map(
+                [$this, 'castBinding'],
+                $value,
+            ));
+        } else {
+            $unionBindings[] = $this->castBinding($value);
+        }
+
+        if (is_null($index)) {
+            $this->bindings['union'][] = $unionBindings;
+        } else {
+            $this->bindings['union'][$index] = array_merge($this->bindings['union'][$index], $unionBindings);
         }
 
         return $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5305,7 +5305,7 @@ SQL;
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where ("start_time" > ?)) order by "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);
-            $this->assertEquals([$ts], $builder->bindings['union']);
+            $this->assertEquals([[$ts]], $builder->bindings['union']);
 
             return $results;
         });
@@ -5354,7 +5354,7 @@ SQL;
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where "extra" = ? and ("start_time" > ?)) union (select "id", "created_at", \'podcast\' as type from "podcasts" where "extra" = ? and ("start_time" > ?)) order by "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);
-            $this->assertEquals(['first', $ts, 'second', $ts], $builder->bindings['union']);
+            $this->assertEquals([['first', $ts], ['second', $ts]], $builder->bindings['union']);
 
             return $results;
         });
@@ -5401,7 +5401,7 @@ SQL;
                 '(select "id", "is_published", "start_time" as "created_at", \'video\' as type from "videos" where "is_published" = ? and ("start_time" > ?)) union (select "id", "is_published", "created_at", \'news\' as type from "news" where "is_published" = ? and ("start_time" > ?)) order by case when (id = 3 and type="news" then 0 else 1 end), "created_at" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([true, $ts], $builder->bindings['where']);
-            $this->assertEquals([true, $ts], $builder->bindings['union']);
+            $this->assertEquals([[true, $ts]], $builder->bindings['union']);
 
             return $results;
         });
@@ -5448,7 +5448,7 @@ SQL;
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ?)) union (select "id", "created_at", \'news\' as type from "news" where ("start_time" < ?)) order by "created_at" desc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts], $builder->bindings['where']);
-            $this->assertEquals([$ts], $builder->bindings['union']);
+            $this->assertEquals([[$ts]], $builder->bindings['union']);
 
             return $results;
         });
@@ -5495,7 +5495,7 @@ SQL;
                 '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ? or ("start_time" = ? and ("id" > ?)))) union (select "id", "created_at", \'news\' as type from "news" where ("start_time" < ? or ("start_time" = ? and ("id" > ?)))) order by "created_at" desc, "id" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([$ts, $ts, 1], $builder->bindings['where']);
-            $this->assertEquals([$ts, $ts, 1], $builder->bindings['union']);
+            $this->assertEquals([[$ts, $ts, 1]], $builder->bindings['union']);
 
             return $results;
         });

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5323,6 +5323,55 @@ SQL;
         ]), $result);
     }
 
+    public function testCursorPaginateWithMultipleUnionsAndMultipleWheres()
+    {
+        $ts = now()->toDateTimeString();
+
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['created_at' => $ts]);
+        $builder = $this->getMockQueryBuilder();
+        $builder->select('id', 'start_time as created_at')->selectRaw("'video' as type")->from('videos');
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'news' as type")->from('news')->where('extra', 'first'));
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'podcast' as type")->from('podcasts')->where('extra', 'second'));
+        $builder->orderBy('created_at');
+
+        $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
+            return new Builder($builder->connection, $builder->grammar, $builder->processor);
+        });
+
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([
+            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
+            ['id' => 3, 'created_at' => now(), 'type' => 'podcasts'],
+        ]);
+
+        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
+            $this->assertEquals(
+                '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where "extra" = ? and ("start_time" > ?)) union (select "id", "created_at", \'podcast\' as type from "podcasts" where "extra" = ? and ("start_time" > ?)) order by "created_at" asc limit 17',
+                $builder->toSql());
+            $this->assertEquals([$ts], $builder->bindings['where']);
+            $this->assertEquals(['first', $ts, 'second', $ts], $builder->bindings['union']);
+
+            return $results;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['created_at'],
+        ]), $result);
+    }
+
     public function testCursorPaginateWithUnionWheresWithRawOrderExpression()
     {
         $ts = now()->toDateTimeString();


### PR DESCRIPTION
When using `cursorPaginate` on a query that has multiple unions, the binding order is incorrect.

This happens because:

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Concerns/BuildsQueries.php#L436
adds the bindings for the cursor `where` to the end of the bindings and not in the position that they should be.

The result is a query that binds the wrong values to the wrong parameters in the query.

Possible solutions I can now think of are:

1. make the bindings for `union` a nested array until the bindings are resolved to make the query and add the cursor bindings to the right index
2. re-order the `union` bindings after adding the cursor bindings