### PR TITLE
[11.x] Make DB::usingConnection() respect read/write type

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -134,6 +134,8 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     protected function parseConnectionName($name)
     {
+        $name = $name ?: $this->getDefaultConnection();
+
         return Str::endsWith($name, ['::read', '::write'])
                             ? explode('::', $name, 2) : [$name, null];
     }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -81,9 +81,9 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        [$database, $type] = $this->parseConnectionName($name);
+        $name = $name ?: $this->getDefaultConnection();
 
-        $name = $name ?: $database;
+        [$database, $type] = $this->parseConnectionName($name);
 
         // If we haven't created this connection, we'll create it based on the config
         // provided in the application. Once we've created the connections we will
@@ -134,8 +134,6 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     protected function parseConnectionName($name)
     {
-        $name = $name ?: $this->getDefaultConnection();
-
         return Str::endsWith($name, ['::read', '::write'])
                             ? explode('::', $name, 2) : [$name, null];
     }


### PR DESCRIPTION
fixes #50804 

Currently when DatabaseManager::connection() is used with default connection it doesn't get a $name param and it is resolved within a subsequent call to DatabaseManager::parseConnectionName() and then use only the first $database segment without the type to look for already created connection instance so the ::write part won't take effect.

This PR solves the issue by resolving the default connection's name before parsing it.