### PR TITLE
[11.x] Add an `emitAs` method to Events

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -315,7 +315,11 @@ class Dispatcher implements DispatcherContract
     protected function parseEventAndPayload($event, $payload)
     {
         if (is_object($event)) {
-            [$payload, $event] = [[$event], get_class($event)];
+            $eventName = method_exists($event, 'emitAs')
+                ? $event->emitAs()
+                : get_class($event);
+
+            [$payload, $event] = [[$event], $eventName];
         }
 
         return [$event, Arr::wrap($payload)];

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -357,6 +357,18 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('baz', $_SERVER['__event.test']);
     }
 
+    public function testClassesWithCustomEmitsWork()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen("event_with_custom_emit", function () {
+            $_SERVER['__event.test'] = 'biz';
+        });
+        $d->dispatch(new EventWithCustomEmit);
+
+        $this->assertSame('biz', $_SERVER['__event.test']);
+    }
+
     public function testClassesWorkWithAnonymousListeners()
     {
         unset($_SERVER['__event.test']);
@@ -626,6 +638,15 @@ class TestListenerInvokey
 class ExampleEvent
 {
     //
+}
+
+class EventWithCustomEmit
+{
+    public function emitAs()
+    {
+        return 'event_with_custom_emit';
+    }
+
 }
 
 interface SomeEventInterface

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -361,7 +361,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen("event_with_custom_emit", function () {
+        $d->listen('event_with_custom_emit', function () {
             $_SERVER['__event.test'] = 'biz';
         });
         $d->dispatch(new EventWithCustomEmit);
@@ -646,7 +646,6 @@ class EventWithCustomEmit
     {
         return 'event_with_custom_emit';
     }
-
 }
 
 interface SomeEventInterface


### PR DESCRIPTION
I'm contributing this as an idea to allow object events to be a bit more flexible. 

By using an `emitAs` method, this can override the default usage of the class as the event name, and allow the data that's been passed to the object determine the event name that should be emitted.

For example, if you had a `CommunicationSentEvent` and you pass it a`Communication` model containing a `type` attribute, using the `emitAs` method you can override the event name to be `communication.{type}` rather than the class name.

The new emitAs method is purely optional, and if a method is not present on the object, then it will fall back to the class name as default.

If this PR is merged into the 11.x branch, I'll create documentation supporting this new method 