### PR TITLE
[10.x] Prevent Redis connection error report flood on queue worker

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -71,6 +71,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000] [2002] The requested address is not valid in its context',
             'SQLSTATE[HY000] [2002] A socket operation was attempted to an unreachable network',
             'SQLSTATE[HY000]: General error: 3989',
+            'went away',
         ]);
     }
 }


### PR DESCRIPTION
Given setup of Laravel with Horizon, using Redis as a queue driver via phpredis.

In case of connection issue with Redis, every running worker starts continuously reporting RedisException, which leads to a large flood of errors into the error reporting system.

I believe it has to be prevented by `Illuminate/Queue/Worker.php:372` call of `$this->stopWorkerIfLostConnection($e);` but it doesn't happen for phpredis exception.

