### PR TITLE
[11.x] Fix deprecation warning caused by Carbon 3.2

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -548,7 +548,7 @@ class Repository implements ArrayAccess, CacheContract
         $duration = $this->parseDateInterval($ttl);
 
         if ($duration instanceof DateTimeInterface) {
-            $duration = Carbon::now()->diffInRealSeconds($duration, false);
+            $duration = Carbon::now()->diffInSeconds($duration, false);
         }
 
         return (int) ($duration > 0 ? $duration : 0);


### PR DESCRIPTION
Since running `composer update` today, I noticed deprecation errors being logged for every Laravel request to my app:

> Use the method UTCInRealSeconds instead to make it more explicit about what it does. On next major version, "float" prefix will be removed (as all diff are now returning floating numbers) and "Real" methods will be removed in favor of "UTC" because what it actually does is to convert both dates to UTC timezone before comparison, while by default it does it only if both dates don't have exactly the same timezone (Note: 2 timezones with the same offset but different names are considered different as it's not safe to assume they will always have the same offset). in /Users/jack/Sites/site/vendor/nesbot/carbon/src/Carbon/Traits/Date.php on line 2627

I've replaced `diffInRealSeconds` with `diffInSeconds` to fix this, to retain compatibility with the Carbon v2 dependency as well.

Here's the [Carbon commit](https://github.com/briannesbitt/Carbon/commit/d58d22104b8cc0dc435caaf8da003aa4ee28feed?diff=unified&w=1) which caused this, [released in 3.2](https://github.com/briannesbitt/Carbon/releases/tag/3.2.0) yesterday.