### PR TITLE
[11.x] Password character customisation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -66,6 +66,48 @@ class Str
     protected static $randomStringFactory;
 
     /**
+     * The lowercase letters that should be used to generate random passwords.
+     *
+     * @var array
+     */
+    protected static array $passwordLettersLowercase = [
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+        'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+        'w', 'x', 'y', 'z',
+    ];
+
+    /**
+     * The uppercase letters that should be used to generate random passwords.
+     *
+     * @var array
+     */
+    protected static array $passwordLettersUppercase = [
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
+        'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+        'W', 'X', 'Y', 'Z',
+    ];
+
+    /**
+     * The numbers that should be used to generate random passwords.
+     *
+     * @var array
+     */
+    protected static array $passwordNumbers = [
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    ];
+
+    /**
+     * The symbols that should be used to generate random passwords.
+     *
+     * @var array
+     */
+    protected static array $passwordSymbols = [
+        '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
+        '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
+        ']', '|', ':', ';',
+    ];
+
+    /**
      * Get a new stringable object from the given string.
      *
      * @param  string  $string
@@ -885,6 +927,62 @@ class Str
     }
 
     /**
+     * Set the letters that will be used when generating passwords.
+     *
+     * @param  array  $letters
+     * @return void
+     */
+    public static function createPasswordsUsingLetters(array $letters)
+    {
+        static::createPasswordsUsingLowercaseLetters(array_map(strtolower(...), $letters));
+        static::createPasswordsUsingUppercaseLetters(array_map(strtoupper(...), $letters));
+    }
+
+    /**
+     * Set the uppercase letters that will be used when generating passwords.
+     *
+     * @param  array  $letters
+     * @return void
+     */
+    public static function createPasswordsUsingUppercaseLetters(array $letters)
+    {
+        static::$passwordLettersUppercase = $letters;
+    }
+
+    /**
+     * Set the lowercase letters that will be used when generating passwords.
+     *
+     * @param  array  $letters
+     * @return void
+     */
+    public static function createPasswordsUsingLowercaseLetters(array $letters)
+    {
+        static::$passwordLettersLowercase = $letters;
+    }
+
+    /**
+     * Set the numbers that will be used when generating passwords.
+     *
+     * @param  array  $numbers
+     * @return void
+     */
+    public static function createPasswordsUsingNumbers(array $numbers)
+    {
+        static::$passwordNumbers = $numbers;
+    }
+
+    /**
+     * Set the symbols that will be used when generating passwords.
+     *
+     * @param  array  $symbols
+     * @return void
+     */
+    public static function createPasswordsUsingSymbols(array $symbols)
+    {
+        static::$passwordSymbols = $symbols;
+    }
+
+    /**
      * Generate a random, secure password.
      *
      * @param  int  $length
@@ -900,20 +998,11 @@ class Str
 
         $options = (new Collection([
             'letters' => $letters === true ? [
-                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-                'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-                'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
-                'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                ...static::$passwordLettersLowercase,
+                ...static::$passwordLettersUppercase,
             ] : null,
-            'numbers' => $numbers === true ? [
-                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            ] : null,
-            'symbols' => $symbols === true ? [
-                '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
-                '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
-                ']', '|', ':', ';',
-            ] : null,
+            'numbers' => $numbers === true ? static::$passwordNumbers : null,
+            'symbols' => $symbols === true ? static::$passwordSymbols : null,
             'spaces' => $spaces === true ? [' '] : null,
         ]))->filter()->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)])
         )->flatten();

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1374,6 +1374,28 @@ class SupportStrTest extends TestCase
         );
     }
 
+    public function testPasswordCreationCustomLetters()
+    {
+        Str::createPasswordsUsingLetters(['a', 'b', 'c']);
+        $this->assertSame(1, preg_match('/^[abcABC]{32}$/', Str::password(32, true, false, false, false)));
+
+        Str::createPasswordsUsingLowercaseLetters(['f', 'o', 'o']);
+        Str::createPasswordsUsingUppercaseLetters(['B', 'A', 'R']);
+        $this->assertSame(1, preg_match('/^[fooBAR]{32}$/', Str::password(32, true, false, false, false)));
+    }
+
+    public function testPasswordCreationCustomNumbers()
+    {
+        Str::createPasswordsUsingNumbers(['1', '2', '3']);
+        $this->assertSame(1, preg_match('/^[123]{32}$/', Str::password(32, false, true, false, false)));
+    }
+
+    public function testPasswordCreationCustomSymbols()
+    {
+        Str::createPasswordsUsingSymbols(['(', '*', ')']);
+        $this->assertSame(1, preg_match('/^[()*]{32}$/', Str::password(32, false, false, true, false)));
+    }
+
     public function testToBase64()
     {
         $this->assertSame(base64_encode('foo'), Str::toBase64('foo'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This MR allows users to override the different character groups used for generating passwords. This allows more flexibility when generating passwords, e.g. to leave out certain letters and/or numbers that look very similar to the eye in various fonts and thus may confuse people reading it (e.g. l, 1 and I) or to allow adding additional letters, symbols or other characters.

Implementation note: there is no validation on "developer" input; which means that using this may have all weird kind of consequences, which are left as responsibility to the developer:
  - one may feed an alphabet of letters to the `createPasswordsUsingNumbers` and `createPasswordsUsingSymbols` helpers and thus end up with a password containing only letters
  - one may pass arrays containing strings of length > 1, meaning the password length is no longer necessarily equal to the provided number
  - one may severely limit the amount of characters that can be used, causing the password to be much less safe

However, for convenience, the `createPasswordsUsingLetters` helper does convert to proper distinct uppercase and lowercase arrays.

Finally, the distinguishing of uppercase vs. lowercase should make a future implementation of #48875 easier.