### PR TITLE
[11.x] Add `assertFinished` method to fake queue interactions

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -95,6 +95,23 @@ trait InteractsWithQueue
     }
 
     /**
+     * Assert that the job was not deleted from the queue nor was manually failed nor was released back to queue.
+     *
+     * @return $this
+     */
+    public function assertFinished()
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            ! $this->job->isDeleted() && ! $this->job->hasFailed() && $this->job->isReleased(),
+            'Job was expected to be finished, but was not.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the job was deleted from the queue.
      *
      * @return $this


### PR DESCRIPTION
Currently an assertion exists:
- to check if the job was released back on to queue
- to check if the job was manually deleted
- to check if the job has failed

But there is no way to check if none of those things happened and the job was just successfully finished. This PR fixes that by adding a `assertFinished` assertion:

```php
class TestJob
{
    public function __construct(
        public $value
    ) { }

    public function handle(): void
    {
        if ($this->value === 0) {
            $this->release(30);
        }

        if ($this->value < 10) {
            $this->delete();
        }

        if ($this->value < 20) {
            $this->fail();
        }

        \Log::info('success');
    }
}
``` 

```php
public function test_job_is_finished(): void
{
    $job = (new TestJob(value: 30))->withFakeQueueInteractions();

    $job->handle();

    $job->assertFinished();
}
```