### PR TITLE
[11.x] Add `withRateLimiting` method to ApplicationBuilder

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Configuration;
 
 use Closure;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
@@ -240,6 +241,19 @@ class ApplicationBuilder
             }
         });
 
+        return $this;
+    }
+
+    /**
+     * Register the rate limiting providers for the application.
+     *
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function withRateLimiting(?callable $callback = null)
+    {
+        $this->app->booted(fn () => $callback($this->app->make(RateLimiter::class)));
+        
         return $this;
     }
 


### PR DESCRIPTION
I recently stumbled upon a problem while using Sanctum and the `api` middleware group.

When using `ThrottleRequests:api` *and* requiring authentication on a route, the throttle middleware would try to access an `api` property on the model.
That is due to [this block of code](https://github.com/laravel/framework/blob/954c226343f438c453019019c00eb3ae54923b2c/src/Illuminate/Routing/Middleware/ThrottleRequests.php#L185-L187),

[If there is a matching named rate limiter](https://github.com/laravel/framework/blob/954c226343f438c453019019c00eb3ae54923b2c/src/Illuminate/Routing/Middleware/ThrottleRequests.php#L84C1-L88C10), it doesn't execute that block of code.

In previous versions, the Laravel skeleton shipped with a [default rate limiting for API routes](https://github.com/laravel/laravel/blob/10.x/app/Providers/RouteServiceProvider.php#L27-L29), so that error didn't happen, but it no longer does on 11.

I'm not sure if `withRateLimiting` is idiomatic enough, but it could be a solution. For now, I just set up a default `RouteServiceProvider`on the app. 

Here's a repo replicating the issue: https://github.com/mateusjatenee/laravel/tree/missing-rate-limiter
Here's the specific commit: https://github.com/mateusjatenee/laravel/commit/1260c84af9cde174f6b41e1b8c5afae3c427fb8e

If this ends up getting merged, it'd probably be good for us to add it to the skeleton too.