### PR TITLE
[11.x] Pass app instance into application builder callbacks

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -227,7 +227,7 @@ class ApplicationBuilder
                 ->redirectGuestsTo(fn () => route('login'));
 
             if (! is_null($callback)) {
-                $callback($middleware);
+                $callback($middleware, $this->app);
             }
 
             $this->pageMiddleware = $middleware->getPageMiddleware();
@@ -285,12 +285,12 @@ class ApplicationBuilder
     /**
      * Register the scheduled tasks for the application.
      *
-     * @param  callable(Schedule $schedule): void  $callback
+     * @param  callable(Schedule $schedule, Application $app): void  $callback
      * @return $this
      */
     public function withSchedule(callable $callback)
     {
-        Artisan::starting(fn () => $callback($this->app->make(Schedule::class)));
+        Artisan::starting(fn () => $callback($this->app->make(Schedule::class), $this->app));
 
         return $this;
     }
@@ -312,7 +312,7 @@ class ApplicationBuilder
 
         $this->app->afterResolving(
             \Illuminate\Foundation\Exceptions\Handler::class,
-            fn ($handler) => $using(new Exceptions($handler)),
+            fn ($handler) => $using(new Exceptions($handler), $this->app),
         );
 
         return $this;


### PR DESCRIPTION
This PR adds passing of app instance into middleware, schedule and exceptions building callbacks of `ApplicationBuilder`.
This allows simple logic based on application state, e.g.:

```php
->withSchedule(function (Schedule $schedule, Application $app) {
    if ($app->isProduction()) {
        $schedule->command('only-in-production')->daily();
    }
})
```
