### PR TITLE
[11.x] Str trim methods

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class TrimStrings extends TransformsRequest
 {
@@ -65,7 +66,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}]+|[\s\x{FEFF}\x{200B}\x{200E}]+$~u', '', $value) ?? trim($value);
+        return Str::trim($value);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1418,6 +1418,13 @@ class Str
         return static::$snakeCache[$key][$delimiter] = $value;
     }
 
+    /**
+     * Remove all whitespace from both ends of a string.
+     *
+     * @param  string  $value
+     * @param  string|null  $charlist
+     * @return string
+     */
     public static function trim($value, $charlist = null)
     {
         if ($charlist === null) {
@@ -1427,6 +1434,13 @@ class Str
         return trim($value, $charlist);
     }
 
+    /**
+     * Remove all whitespace from the beginning of a string.
+     *
+     * @param  string  $value
+     * @param  string|null  $charlist
+     * @return string
+     */
     public static function ltrim($value, $charlist = null)
     {
         if ($charlist === null) {
@@ -1436,6 +1450,13 @@ class Str
         return ltrim($value, $charlist);
     }
 
+    /**
+     * Remove all whitespace from the end of a string.
+     *
+     * @param  string  $value
+     * @param  string|null  $charlist
+     * @return string
+     */
     public static function rtrim($value, $charlist = null)
     {
         if ($charlist === null) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1428,7 +1428,7 @@ class Str
     public static function trim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value);
+            return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
         }
 
         return trim($value, $charlist);
@@ -1444,7 +1444,7 @@ class Str
     public static function ltrim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~^[\s\x{FEFF}\x{200B}]+~u', '', $value);
+            return preg_replace('~^[\s\x{FEFF}\x{200B}]+~u', '', $value) ?? ltrim($value);
         }
 
         return ltrim($value, $charlist);
@@ -1460,7 +1460,7 @@ class Str
     public static function rtrim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~[\s\x{FEFF}\x{200B}]+$~u', '', $value);
+            return preg_replace('~[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? rtrim($value);
         }
 
         return rtrim($value, $charlist);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1428,7 +1428,7 @@ class Str
     public static function trim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
+            return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}]+|[\s\x{FEFF}\x{200B}\x{200E}]+$~u', '', $value) ?? trim($value);
         }
 
         return trim($value, $charlist);
@@ -1444,7 +1444,7 @@ class Str
     public static function ltrim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~^[\s\x{FEFF}\x{200B}]+~u', '', $value) ?? ltrim($value);
+            return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}]+~u', '', $value) ?? ltrim($value);
         }
 
         return ltrim($value, $charlist);
@@ -1460,7 +1460,7 @@ class Str
     public static function rtrim($value, $charlist = null)
     {
         if ($charlist === null) {
-            return preg_replace('~[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? rtrim($value);
+            return preg_replace('~[\s\x{FEFF}\x{200B}\x{200E}]+$~u', '', $value) ?? rtrim($value);
         }
 
         return rtrim($value, $charlist);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1418,6 +1418,15 @@ class Str
         return static::$snakeCache[$key][$delimiter] = $value;
     }
 
+    public static function trim($value, $charlist = null)
+    {
+        if ($charlist === null) {
+            return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value);
+        }
+
+        return trim($value, $charlist);
+    }
+
     /**
      * Remove all "extra" blank space from the given string.
      *
@@ -1426,7 +1435,7 @@ class Str
      */
     public static function squish($value)
     {
-        return preg_replace('~(\s|\x{3164}|\x{1160})+~u', ' ', preg_replace('~^[\s\x{FEFF}]+|[\s\x{FEFF}]+$~u', '', $value));
+        return preg_replace('~(\s|\x{3164}|\x{1160})+~u', ' ', static::trim($value));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1427,6 +1427,24 @@ class Str
         return trim($value, $charlist);
     }
 
+    public static function ltrim($value, $charlist = null)
+    {
+        if ($charlist === null) {
+            return preg_replace('~^[\s\x{FEFF}\x{200B}]+~u', '', $value);
+        }
+
+        return ltrim($value, $charlist);
+    }
+
+    public static function rtrim($value, $charlist = null)
+    {
+        if ($charlist === null) {
+            return preg_replace('~[\s\x{FEFF}\x{200B}]+$~u', '', $value);
+        }
+
+        return rtrim($value, $charlist);
+    }
+
     /**
      * Remove all "extra" blank space from the given string.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -968,7 +968,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function trim($characters = null)
     {
-        return new static(trim(...array_merge([$this->value], func_get_args())));
+        return new static(Str::trim(...array_merge([$this->value], func_get_args())));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -979,7 +979,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function ltrim($characters = null)
     {
-        return new static(ltrim(...array_merge([$this->value], func_get_args())));
+        return new static(Str::ltrim(...array_merge([$this->value], func_get_args())));
     }
 
     /**
@@ -990,7 +990,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function rtrim($characters = null)
     {
-        return new static(rtrim(...array_merge([$this->value], func_get_args())));
+        return new static(Str::rtrim(...array_merge([$this->value], func_get_args())));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -785,6 +785,28 @@ class SupportStrTest extends TestCase
         $this->assertSame('ム', Str::trim('   ム    '));
     }
 
+    public function testLtrim()
+    {
+        $this->assertSame('foo    bar ', Str::ltrim(" foo    bar "));
+
+        $this->assertSame('123    ', Str::ltrim('   123    '));
+        $this->assertSame('だ', Str::ltrim('だ'));
+        $this->assertSame('ム', Str::ltrim('ム'));
+        $this->assertSame('だ    ', Str::ltrim('   だ    '));
+        $this->assertSame('ム    ', Str::ltrim('   ム    '));
+    }
+
+    public function testRtrim()
+    {
+        $this->assertSame(' foo    bar', Str::rtrim(" foo    bar "));
+
+        $this->assertSame('   123', Str::rtrim('   123    '));
+        $this->assertSame('だ', Str::rtrim('だ'));
+        $this->assertSame('ム', Str::rtrim('ム'));
+        $this->assertSame('   だ', Str::rtrim('   だ    '));
+        $this->assertSame('   ム', Str::rtrim('   ム    '));
+    }
+
     public function testSquish()
     {
         $this->assertSame('laravel php framework', Str::squish(' laravel   php  framework '));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -776,7 +776,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo bar', Str::trim(' foo bar ', ' '));
         $this->assertSame('foo  bar', Str::trim('-foo  bar_', '-_'));
 
-        $this->assertSame('foo    bar', Str::trim(" foo    bar "));
+        $this->assertSame('foo    bar', Str::trim(' foo    bar '));
 
         $this->assertSame('123', Str::trim('   123    '));
         $this->assertSame('だ', Str::trim('だ'));
@@ -787,7 +787,7 @@ class SupportStrTest extends TestCase
 
     public function testLtrim()
     {
-        $this->assertSame('foo    bar ', Str::ltrim(" foo    bar "));
+        $this->assertSame('foo    bar ', Str::ltrim(' foo    bar '));
 
         $this->assertSame('123    ', Str::ltrim('   123    '));
         $this->assertSame('だ', Str::ltrim('だ'));
@@ -798,7 +798,7 @@ class SupportStrTest extends TestCase
 
     public function testRtrim()
     {
-        $this->assertSame(' foo    bar', Str::rtrim(" foo    bar "));
+        $this->assertSame(' foo    bar', Str::rtrim(' foo    bar '));
 
         $this->assertSame('   123', Str::rtrim('   123    '));
         $this->assertSame('だ', Str::rtrim('だ'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -798,6 +798,8 @@ class SupportStrTest extends TestCase
                 bar
             ')
         );
+
+        $this->assertSame("\xE9", Str::trim(" \xE9 "));
     }
 
     public function testLtrim()
@@ -817,6 +819,7 @@ class SupportStrTest extends TestCase
                 foo bar
             ')
         );
+        $this->assertSame("\xE9 ", Str::ltrim(" \xE9 "));
     }
 
     public function testRtrim()
@@ -836,6 +839,8 @@ class SupportStrTest extends TestCase
                 foo bar
             ')
         );
+
+        $this->assertSame(" \xE9", Str::rtrim(" \xE9 "));
     }
 
     public function testSquish()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -766,6 +766,25 @@ class SupportStrTest extends TestCase
         $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
     }
 
+    public function testTrim()
+    {
+        $this->assertSame('foo bar', Str::trim('   foo bar   '));
+        $this->assertSame('foo bar', Str::trim('foo bar   '));
+        $this->assertSame('foo bar', Str::trim('   foo bar'));
+        $this->assertSame('foo bar', Str::trim('foo bar'));
+        $this->assertSame(' foo bar ', Str::trim(' foo bar ', ''));
+        $this->assertSame('foo bar', Str::trim(' foo bar ', ' '));
+        $this->assertSame('foo  bar', Str::trim('-foo  bar_', '-_'));
+
+        $this->assertSame('foo    bar', Str::trim(" foo    bar "));
+
+        $this->assertSame('123', Str::trim('   123    '));
+        $this->assertSame('だ', Str::trim('だ'));
+        $this->assertSame('ム', Str::trim('ム'));
+        $this->assertSame('だ', Str::trim('   だ    '));
+        $this->assertSame('ム', Str::trim('   ム    '));
+    }
+
     public function testSquish()
     {
         $this->assertSame('laravel php framework', Str::squish(' laravel   php  framework '));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -783,6 +783,21 @@ class SupportStrTest extends TestCase
         $this->assertSame('ム', Str::trim('ム'));
         $this->assertSame('だ', Str::trim('   だ    '));
         $this->assertSame('ム', Str::trim('   ム    '));
+
+        $this->assertSame(
+            'foo bar',
+            Str::trim('
+                foo bar
+            ')
+        );
+        $this->assertSame(
+            'foo
+                bar',
+            Str::trim('
+                foo
+                bar
+            ')
+        );
     }
 
     public function testLtrim()
@@ -794,6 +809,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('ム', Str::ltrim('ム'));
         $this->assertSame('だ    ', Str::ltrim('   だ    '));
         $this->assertSame('ム    ', Str::ltrim('   ム    '));
+
+        $this->assertSame(
+            'foo bar
+            ',
+            Str::ltrim('
+                foo bar
+            ')
+        );
     }
 
     public function testRtrim()
@@ -805,6 +828,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('ム', Str::rtrim('ム'));
         $this->assertSame('   だ', Str::rtrim('   だ    '));
         $this->assertSame('   ム', Str::rtrim('   ム    '));
+
+        $this->assertSame(
+            '
+                foo bar',
+            Str::rtrim('
+                foo bar
+            ')
+        );
     }
 
     public function testSquish()


### PR DESCRIPTION
The native methods `trim()`, `ltrim()` and `rtrim()` don't remove the unicode whitecode character `NBSP`. 

`Str::squish()` removes these characters, as does `TrimStrings` middleware.

This PR adds `trim()`, `ltrim()` and `rtrim()` static methods to the `Str` helper, and also uses these methods in the corresponding Stringable calls.

Note: For reviewers the whitespace characters don't show up in the web UI.

Test screenshots attached to show them.

<img width="736" alt="image" src="https://github.com/laravel/framework/assets/571773/3a810822-094e-457d-9501-6bf1329840b3">

<img width="726" alt="image" src="https://github.com/laravel/framework/assets/571773/2919197a-0179-4a17-9ad0-65ab7f8f97b4">

<img width="730" alt="image" src="https://github.com/laravel/framework/assets/571773/ddefaa43-7a41-4270-948c-b942c21e80fe">


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
