### PR TITLE
[11.x] Add a new helper for context

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -306,7 +306,6 @@ if (! function_exists('context')) {
         }
 
         if (is_array($key)) {
-
             if (count($key) !== 1) {
                 throw new InvalidArgumentException(
                     'When setting a value in the context, you must pass only one array of key / value pairs.'

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -288,6 +288,38 @@ if (! function_exists('config_path')) {
     }
 }
 
+if (! function_exists('context')) {
+    /**
+     * Get / set the specified context value.
+     *
+     * @param  array|string|null  $key
+     * @return mixed|\Illuminate\Log\Context\Repository
+     *
+     * @throws \InvalidArgumentException
+     */
+    function context($key)
+    {
+        $context = app(\Illuminate\Log\Context\Repository::class);
+
+        if (is_null($key)) {
+            return $context;
+        }
+
+        if (is_array($key)) {
+
+            if (count($key) !== 1) {
+                throw new InvalidArgumentException(
+                    'When setting a value in the context, you must pass only one array of key / value pairs.'
+                );
+            }
+
+            return $context->add($key);
+        }
+
+        return $context->get($key);
+    }
+}
+
 if (! function_exists('cookie')) {
     /**
      * Create a new cookie instance.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
@@ -293,16 +294,15 @@ if (! function_exists('context')) {
      * Get / set the specified context value.
      *
      * @param  array|string|null  $key
+     * @param  mixed  $default
      * @return mixed|\Illuminate\Log\Context\Repository
      *
      * @throws \InvalidArgumentException
      */
-    function context($key)
+    function context($key, $default = null)
     {
-        $context = app(\Illuminate\Log\Context\Repository::class);
-
         if (is_null($key)) {
-            return $context;
+            return app(ContextRepository::class);
         }
 
         if (is_array($key)) {
@@ -312,10 +312,10 @@ if (! function_exists('context')) {
                 );
             }
 
-            return $context->add($key);
+            return app(ContextRepository::class)->add($key);
         }
 
-        return $context->get($key);
+        return app(ContextRepository::class)->get($key, $default);
     }
 }
 


### PR DESCRIPTION
This PR introduces a new helper function for managing context in applications.

Example usage:

```php
context(['user' => auth()->user()]); // Add user information to the context

$context = context(); // Retrieve the context object

$user = context('user'); // Retrieve user information from the context
```

This enhancement simplifies the management of contextual data within the application, making it more efficient and readable.