### PR TITLE
[11.x] Add default value for `get` and `getHidden` on `Context`

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -99,22 +99,24 @@ class Repository
      * Retrieve the given key's value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return mixed
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
-        return $this->data[$key] ?? null;
+        return $this->data[$key] ?? $default;
     }
 
     /**
      * Retrieve the given key's hidden value.
      *
      * @param  string  $key
+     * @param  mixed  $default
      * @return mixed
      */
-    public function getHidden($key)
+    public function getHidden($key, $default = null)
     {
-        return $this->hidden[$key] ?? null;
+        return $this->hidden[$key] ?? $default;
     }
 
     /**

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -104,7 +104,7 @@ class Repository
      */
     public function get($key, $default = null)
     {
-        return $this->data[$key] ?? $default;
+        return $this->data[$key] ?? value($default);
     }
 
     /**
@@ -116,7 +116,7 @@ class Repository
      */
     public function getHidden($key, $default = null)
     {
-        return $this->hidden[$key] ?? $default;
+        return $this->hidden[$key] ?? value($default);
     }
 
     /**


### PR DESCRIPTION
This PR adds a default value for `get` and `getHidden` on `Context`

Before:

```php
$isUser = Context::get('is_user'); //  If is not has in array return null forever
$isUser = Context::getHidden('is_user'); //  If is not has in array return null forever
```

After:

```php
$isUser = Context::get('is_user', false); // If is not has in array return false
$isUser = Context::getHidden('is_user', false); // If is not has in array return false
```
