### PR TITLE
[11.x] Fix: update `@param` in some doc block

### DIFF
--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -142,7 +142,7 @@ class Signals
     /**
      * Set the availability resolver.
      *
-     * @param  callable(): bool
+     * @param  callable(): bool $resolver
      * @return void
      */
     public static function resolveAvailabilityUsing($resolver)

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -142,7 +142,7 @@ class Signals
     /**
      * Set the availability resolver.
      *
-     * @param  callable(): bool  $resolver
+     * @param  (callable(): bool)  $resolver
      * @return void
      */
     public static function resolveAvailabilityUsing($resolver)

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -142,7 +142,7 @@ class Signals
     /**
      * Set the availability resolver.
      *
-     * @param  callable(): bool $resolver
+     * @param  callable(): bool  $resolver
      * @return void
      */
     public static function resolveAvailabilityUsing($resolver)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -277,7 +277,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Indicate that the given exception type should not be reported.
      *
-     * @param  array|string  $class
+     * @param  array|string  $exceptions
      * @return $this
      */
     public function ignore(array|string $exceptions)

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -170,7 +170,7 @@ class Vite implements Htmlable
     /**
      * Resolve asset paths using the provided resolver.
      *
-     * @param  callable|null  $urlResolver
+     * @param  callable|null  $resolver
      * @return $this
      */
     public function createAssetPathsUsing($resolver)

--- a/src/Illuminate/Mail/Mailables/Headers.php
+++ b/src/Illuminate/Mail/Mailables/Headers.php
@@ -76,7 +76,7 @@ class Headers
     /**
      * Set the headers for this message.
      *
-     * @param  array  $references
+     * @param  array  $text
      * @return $this
      */
     public function text(array $text)


### PR DESCRIPTION
This PR, fixed `@param` in some doc blocks.


Thanks!