### PR TITLE
[11.x] Allow Event Discovery to be disabled

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -408,13 +408,12 @@ class ApplicationBuilder
      * Registers the service provider if not already registered.
      *
      * @param  string  $serviceProvider
-     *
      * @return void
      */
     protected function registerServiceProvider(string $serviceProvider)
     {
         if (! isset($this->pendingProviders[$serviceProvider])) {
-            $this->app->booting(fn() => $this->app->register($serviceProvider));
+            $this->app->booting(fn () => $this->app->register($serviceProvider));
         }
 
         $this->pendingProviders[$serviceProvider] = true;

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -92,13 +92,7 @@ class ApplicationBuilder
             AppEventServiceProvider::setEventDiscoveryPaths($discover);
         }
 
-        if (! isset($this->pendingProviders[AppEventServiceProvider::class])) {
-            $this->app->booting(function () {
-                $this->app->register(AppEventServiceProvider::class);
-            });
-        }
-
-        $this->pendingProviders[AppEventServiceProvider::class] = true;
+        $this->registerServiceProvider(AppEventServiceProvider::class);
 
         return $this;
     }
@@ -399,5 +393,21 @@ class ApplicationBuilder
     public function create()
     {
         return $this->app;
+    }
+
+    /**
+     * Registers the service provider if not already registered.
+     *
+     * @param  string  $serviceProvider
+     *
+     * @return void
+     */
+    protected function registerServiceProvider(string $serviceProvider)
+    {
+        if (! isset($this->pendingProviders[$serviceProvider])) {
+            $this->app->booting(fn() => $this->app->register($serviceProvider));
+        }
+
+        $this->pendingProviders[$serviceProvider] = true;
     }
 }

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -97,6 +97,15 @@ class ApplicationBuilder
         return $this;
     }
 
+    public function withoutEventDiscovery()
+    {
+        AppEventServiceProvider::setShouldDiscoverEvents(false);
+
+        $this->registerServiceProvider(AppEventServiceProvider::class);
+
+        return $this;
+    }
+
     /**
      * Register the braodcasting services for the application.
      *

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -40,6 +40,13 @@ class EventServiceProvider extends ServiceProvider
     protected static $eventDiscoveryPaths;
 
     /**
+     * Indicates if event discovery should be enabled.
+     *
+     * @var bool
+     */
+    protected static $shouldDiscoverEvents = true;
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -127,7 +134,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function shouldDiscoverEvents()
     {
-        return get_class($this) === __CLASS__;
+        return static::$shouldDiscoverEvents && get_class($this) === __CLASS__;
     }
 
     /**
@@ -170,6 +177,17 @@ class EventServiceProvider extends ServiceProvider
     public static function setEventDiscoveryPaths(array $paths)
     {
         static::$eventDiscoveryPaths = $paths;
+    }
+
+    /**
+     * Set the event discovery status.
+     *
+     * @param  bool  $enable
+     * @return void
+     */
+    public static function setShouldDiscoverEvents(bool $enable)
+    {
+        static::$shouldDiscoverEvents = $enable;
     }
 
     /**

--- a/tests/Integration/Foundation/Configuration/WithoutEventDiscoveryTest.php
+++ b/tests/Integration/Foundation/Configuration/WithoutEventDiscoveryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Configuration;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class WithoutEventDiscoveryTest extends TestCase
+{
+    protected function resolveApplication()
+    {
+        return Application::configure(static::applicationBasePath())
+            ->withoutEventDiscovery()
+            ->create();
+    }
+
+
+    public function testDisablesEventDiscovery()
+    {
+        $this->assertFalse(
+            collect($this->app->getProviders(EventServiceProvider::class))
+                ->firstOrFail()
+                ->shouldDiscoverEvents()
+        );
+    }
+}

--- a/tests/Integration/Foundation/Configuration/WithoutEventDiscoveryTest.php
+++ b/tests/Integration/Foundation/Configuration/WithoutEventDiscoveryTest.php
@@ -15,7 +15,6 @@ class WithoutEventDiscoveryTest extends TestCase
             ->create();
     }
 
-
     public function testDisablesEventDiscovery()
     {
         $this->assertFalse(


### PR DESCRIPTION
Hi 👋

As mentioned in https://github.com/laravel/framework/issues/50805 I reckon that we need to offer a better way to turn off event auto discovery.

With this PR we'll allow to disable event/listeners to be auto discovered by just calling `->withoutEventDiscovery()` in the `bootstrap/app.php` file. Currently the only way is to create a custom `EventServiceProvider` and extend the one provided by the framework.

Despite that the above can be added to the documentation (PR will follow), to me it's not beginner friendly to create a new EventServiceProvider just to disable event auto discovery.

### Usage

```php
// bootstrap/app.php
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )
    ->withoutEventDiscovery()
    ->create();
```