### PR TITLE
[11.x] Trim invisible characters

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -65,7 +65,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return preg_replace('~^[\p{Cf}\x{FEFF}\x{200B}]+|[\p{Cf}\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
+        return preg_replace('~^[\s\x{FEFF}\x{200B}\x{200E}]+|[\s\x{FEFF}\x{200B}\x{200E}]+$~u', '', $value) ?? trim($value);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -65,7 +65,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
+        return preg_replace('~^[\p{Cf}\x{FEFF}\x{200B}]+|[\p{Cf}\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
     }
 
     /**

--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -132,4 +132,94 @@ class TrimStringsTest extends TestCase
             $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end', $req->title);
         });
     }
+
+    /**
+     * Test leading invisible character are trimmed [U+200E].
+     */
+    public function test_leading_invisible_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '‎This title contains a invisible character at the beginning',
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a invisible character at the beginning', $req->title);
+        });
+    }
+
+    /**
+     * Test trailing invisible character are trimmed [U+200E].
+     */
+    public function test_trailing_invisible_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => 'This title contains a invisible character at the end‎',
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a invisible character at the end', $req->title);
+        });
+    }
+
+    /**
+     * Test leading multiple invisible character are trimmed [U+200E].
+     */
+    public function test_leading_multiple_invisible_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '‎‎This title contains a invisible character at the beginning',
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a invisible character at the beginning', $req->title);
+        });
+    }
+
+    /**
+     * Test trailing multiple invisible character are trimmed [U+200E].
+     */
+    public function test_trailing_multiple_invisible_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => 'This title contains a invisible character at the end‎‎',
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a invisible character at the end', $req->title);
+        });
+    }
+
+    /**
+     * Test combination of leading and trailing multiple invisible characters are trimmed [U+200E].
+     */
+    public function test_combination_of_leading_and_trailing_multiple_invisible_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '‎‎This title contains a combination of a invisible character at beginning and the end‎‎',
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a combination of a invisible character at beginning and the end', $req->title);
+        });
+    }
 }


### PR DESCRIPTION
This PR addresses the issue where [invisible characters](https://invisible-characters.com/) are not trimmed during HTTP requests, which can cause problems when submitting forms. Users may include invisible characters to simply fill the input, resulting in a poor user experience.