### PR TITLE
[11.x] Fix retrieving generated columns on legacy PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -123,7 +123,7 @@ class PostgresGrammar extends Grammar
             .'(select tc.collcollate from pg_catalog.pg_collation tc where tc.oid = a.attcollation) as collation, '
             .'not a.attnotnull as nullable, '
             .'(select pg_get_expr(adbin, adrelid) from pg_attrdef where c.oid = pg_attrdef.adrelid and pg_attrdef.adnum = a.attnum) as default, '
-            .'a.attgenerated as generated, '
+            .(version_compare($this->connection?->getServerVersion(), '12.0', '>=') ? 'a.attgenerated as generated, ' : "'' as generated, ")
             .'col_description(c.oid, a.attnum) as comment '
             .'from pg_attribute a, pg_class c, pg_type t, pg_namespace n '
             .'where c.relname = %s and n.nspname = %s and a.attnum > 0 and a.attrelid = c.oid and a.atttypid = t.oid and n.oid = c.relnamespace '

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -123,7 +123,7 @@ class PostgresGrammar extends Grammar
             .'(select tc.collcollate from pg_catalog.pg_collation tc where tc.oid = a.attcollation) as collation, '
             .'not a.attnotnull as nullable, '
             .'(select pg_get_expr(adbin, adrelid) from pg_attrdef where c.oid = pg_attrdef.adrelid and pg_attrdef.adnum = a.attnum) as default, '
-            .(version_compare($this->connection?->getServerVersion(), '12.0', '>=') ? 'a.attgenerated as generated, ' : "'' as generated, ")
+            .(version_compare($this->connection?->getServerVersion(), '12.0', '<') ? "'' as generated, " : 'a.attgenerated as generated, ')
             .'col_description(c.oid, a.attnum) as comment '
             .'from pg_attribute a, pg_class c, pg_type t, pg_namespace n '
             .'where c.relname = %s and n.nspname = %s and a.attnum > 0 and a.attrelid = c.oid and a.atttypid = t.oid and n.oid = c.relnamespace '


### PR DESCRIPTION
This PR fixes retrieving generated columns on PostgreSQL < 12

We already have [an integration test](https://github.com/laravel/framework/blob/21d32cc25f10428d42c96f891c43968a01c52272/tests/Integration/Database/SchemaBuilderTest.php#L649-L693) for this.

As discussed on https://github.com/laravel/framework/pull/50329#issuecomment-2026964365, PostgreSQL 12+ support on Laravel 11 reverted on laravel/docs#9113 after PR #50329 get merged.
