### PR TITLE
[10.x] Better database creation failure handling

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -57,7 +57,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     /**
      * Flag to indicate if the database exists.
      *
-     * @var boolean
+     * @var bool
      */
     protected $databaseExists = true;
 
@@ -217,6 +217,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
 
             if (! confirm('Would you like to create it?', default: false)) {
                 $this->components->info('Operation cancelled! No database was created.');
+
                 return false;
             }
         }


### PR DESCRIPTION
Currently, when you try to migrate and your database isn't created yet, you'll be prompted to create it. However, if you choose to not do that, the migrate command will still continue to attempt to run database queries even though we know the database doesn't exists. This PR improves this flow by throwing an early exception to indicate the database couldn't be created and no subsequent queries are made anymore. We now show an informative message instead of the below query exception.

I stumbled upon this when running the Laravel installer to setup a new Jetstream app and wondered what would happen if I choose to not create the database.

<img width="2048" alt="Screenshot 2024-03-29 at 11 18 10" src="https://github.com/laravel/framework/assets/594614/ceec858f-8255-4127-be86-5ed335ba7dd2">
