### PR TITLE
[11.x] Better database creation failure handling

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -204,7 +204,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
         $this->components->warn('The SQLite database configured for this application does not exist: '.$path);
 
         if (! confirm('Would you like to create it?', default: true)) {
-            $this->components->info('Operation cancelled! No database was created.');
+            $this->components->info('Operation cancelled. No database was created.');
 
             throw new RuntimeException('Database was not created. Aborting migration.');
         }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -233,7 +233,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
             $this->components->warn("The database '{$connection->getDatabaseName()}' does not exist on the '{$connection->getName()}' connection.");
 
             if (! confirm('Would you like to create it?', default: true)) {
-                $this->components->info('Operation cancelled! No database was created.');
+                $this->components->info('Operation cancelled. No database was created.');
 
                 throw new RuntimeException('Database was not created. Aborting migration.');
             }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Database\SqlServerConnection;
 use PDOException;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
@@ -187,6 +188,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
      *
      * @param  string  $path
      * @return bool
+     *
+     * @throws \RuntimeException
      */
     protected function createMissingSqliteDatabase($path)
     {
@@ -201,7 +204,9 @@ class MigrateCommand extends BaseCommand implements Isolatable
         $this->components->warn('The SQLite database configured for this application does not exist: '.$path);
 
         if (! confirm('Would you like to create it?', default: true)) {
-            return false;
+            $this->components->info('Operation cancelled! No database was created.');
+
+            throw new RuntimeException('Database was not created. Aborting migration.');
         }
 
         return touch($path);
@@ -211,6 +216,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
      * Create a missing MySQL database.
      *
      * @return bool
+     *
+     * @throws \RuntimeException
      */
     protected function createMissingMysqlDatabase($connection)
     {
@@ -226,7 +233,9 @@ class MigrateCommand extends BaseCommand implements Isolatable
             $this->components->warn("The database '{$connection->getDatabaseName()}' does not exist on the '{$connection->getName()}' connection.");
 
             if (! confirm('Would you like to create it?', default: true)) {
-                return false;
+                $this->components->info('Operation cancelled! No database was created.');
+
+                throw new RuntimeException('Database was not created. Aborting migration.');
             }
         }
 


### PR DESCRIPTION
Currently, when you try to migrate and your database isn't created yet, you'll be prompted to create it. However, if you choose to not do that, the migrate command will still continue to attempt to run database queries even though we know the database doesn't exists. This PR improves this flow by throwing an early exception to indicate the database couldn't be created and no subsequent queries are made anymore.

It's important to note that this PR doesn't changes behaviour as the user was already getting an exception. It's now just an informative message instead of the below query exception.

I stumbled upon this when running the Laravel installer to setup a new Jetstream app and wondered what would happen if I choose to not create the database.

<img width="2048" alt="Screenshot 2024-03-29 at 11 18 10" src="https://github.com/laravel/framework/assets/594614/ceec858f-8255-4127-be86-5ed335ba7dd2">
