### PR TITLE
[11.x] Do not wipe database if it does not exists

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\DatabaseRefreshed;
+use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -29,6 +30,26 @@ class FreshCommand extends Command
     protected $description = 'Drop all tables and re-run all migrations';
 
     /**
+     * The migrator instance.
+     *
+     * @var \Illuminate\Database\Migrations\Migrator
+     */
+    protected $migrator;
+
+    /**
+     * Create a new fresh command instance.
+     *
+     * @param  \Illuminate\Database\Migrations\Migrator  $migrator
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct();
+
+        $this->migrator = $migrator;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -41,14 +62,16 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        $this->newLine();
+        if ($this->migrator->repositoryExists()) {
+            $this->newLine();
 
-        $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
-            '--database' => $database,
-            '--drop-views' => $this->option('drop-views'),
-            '--drop-types' => $this->option('drop-types'),
-            '--force' => true,
-        ])) == 0);
+            $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
+                '--database' => $database,
+                '--drop-views' => $this->option('drop-views'),
+                '--drop-types' => $this->option('drop-types'),
+                '--force' => true,
+            ])) == 0);
+        }
 
         $this->newLine();
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -130,7 +130,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton(FreshCommand::class);
+        $this->app->singleton(FreshCommand::class, function ($app) {
+            return new FreshCommand($app['migrator']);
+        });
     }
 
     /**


### PR DESCRIPTION
If the `migrate:fresh` command is called while there isn't any database created yet, it'll fail when it tries to wipe the database. This PR fixes this by first checking if the migrations table exists and if not, immediately go to the migrate command by skipping the `db:wipe` command. This will invoke the `migrate` command flow and subsequently will reach the point where the command will ask the user to create the database. 

In combination with https://github.com/laravel/framework/pull/50836 this will offer a more seamless experience for people attempting to install Jetstream through the Laravel installer and choosing to not create the database.

<img width="2048" alt="Screenshot 2024-03-29 at 12 23 26" src="https://github.com/laravel/framework/assets/594614/0b0f561c-b369-4a79-bc6f-5971f2b664ef">
