### PR TITLE
[12.x] Make method `repeatEvery` public in Sub-Minute Scheduled Tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -146,7 +146,7 @@ trait ManagesFrequencies
      * @param  int  $seconds
      * @return $this
      */
-    protected function repeatEvery($seconds)
+    public function repeatEvery($seconds)
     {
         if (60 % $seconds !== 0) {
             throw new InvalidArgumentException("The seconds [$seconds] are not evenly divisible by 60.");


### PR DESCRIPTION
Right now there is no way to use full power of [Sub-Minute Scheduled Tasks](https://github.com/laravel/framework/pull/47279) because `repeatEvery` method is protected and you can't set task to repeat every 3, 4, 6, 12 seconds. Moreover you can't pass dynamic number of seconds to schedule task.

My use case: I need to request some API every 3 seconds so `everyTwoSeconds` is too often and `everyFiveSeconds` is too rarely.

Although `repeatSeconds` property is public so we can do:

```php
$event = Schedule::command(Indicators::class)->runInBackground();
$event->repeatSeconds = 3;
$event->everyMinute();
```

Which is obviously not a Laravel way to do things. Now only this methods are available:

```
everySecond
everyTwoSeconds
everyFiveSeconds
everyTenSeconds
everyFifteenSeconds
everyTwentySeconds
everyThirtySeconds
```

After this change we can call:
```php
Schedule::command(Indicators::class)->repeatEvery(3);
```

Target is master because this is breaking change if someone inherits `Illuminate/Console/Scheduling/Event` class. 