### PR TITLE
[11.x] Rehash user passwords when logging in once

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -253,8 +253,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->fireAttemptEvent($credentials);
 
         if ($this->validate($credentials)) {
-            $this->setUser($this->lastAttempted);
             $this->rehashPasswordIfRequired($this->lastAttempted, $credentials);
+
+            $this->setUser($this->lastAttempted);
 
             return true;
         }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -254,6 +254,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         if ($this->validate($credentials)) {
             $this->setUser($this->lastAttempted);
+            $this->rehashPasswordIfRequired($this->lastAttempted, $credentials);
 
             return true;
         }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -623,6 +623,7 @@ class AuthGuardTest extends TestCase
         });
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
+        $guard->getProvider()->shouldReceive('rehashPasswordIfRequired')->with($user, ['foo'])->once();
         $guard->shouldReceive('setUser')->once()->with($user);
         $this->assertTrue($guard->once(['foo']));
     }
@@ -637,6 +638,7 @@ class AuthGuardTest extends TestCase
         });
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
+        $guard->getProvider()->shouldNotReceive('rehashPasswordIfRequired');
         $this->assertFalse($guard->once(['foo']));
     }
 


### PR DESCRIPTION
This PR is a followup to #48665, it adds the automatic rehashing feature to `SessionGuard::once()`. I couldn't find any obvious reasons why this method wasn't included in the original PR, so I assume it was accidentally skipped.

My personal use-case is that we use `SessionGuard::once()` to perform the initial authentication of a user, we then decide if we require further authentication based on various factors. 