### PR TITLE
[11.x] Prevent duplicate API route definition in bootstrap file

### DIFF
--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -100,6 +100,8 @@ class ApiInstallCommand extends Command
                 'api: ',
                 $appBootstrapPath,
             );
+        } elseif (str_contains($content, 'api:')) {
+            $this->components->warn('API route definition is already registered to bootstrap file.');
         } elseif (str_contains($content, 'web: __DIR__.\'/../routes/web.php\',')) {
             (new Filesystem)->replaceInFile(
                 'web: __DIR__.\'/../routes/web.php\',',


### PR DESCRIPTION
When running the `php artisan api:install --force` command while the API is already installed, it generates a duplicate API route definition within the bootstrap file. 

```
return Application::configure(basePath: dirname(__DIR__))
    ->withRouting(
        web: __DIR__.'/../routes/web.php',
        api: __DIR__.'/../routes/api.php',
        api: __DIR__.'/../routes/api.php',  //duplicate definition
        commands: __DIR__.'/../routes/console.php',
        health: '/up',
    )
    ->withMiddleware(function (Middleware $middleware) {
        //
    })
    ->withExceptions(function (Exceptions $exceptions) {
        //
    })->create();
```

This PR checks if API route definition is already registered and produces a warning instead of duplicating the definition.

