### PR TITLE
[11.x] Add bulkCreate function to Factory class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -297,6 +297,36 @@ abstract class Factory
     }
 
     /**
+     * Bulk create a collection of models and persist them to the database with one database hit (using QueryBuilder).
+     *
+     * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return int|bool
+     */
+    public function bulkCreate($attributes = [], ?Model $parent = null)
+    {
+        if (! empty($attributes)) {
+            return $this->state($attributes)->bulkCreate([], $parent);
+        }
+
+        $instances = $this->make($attributes, $parent);
+
+        if ($instances instanceof Model) {
+            $instances = collect([$instances]);
+        }
+
+        $modelName = $this->modelName();
+
+        $count = $instances->count();
+        for ($i = 0; $i < $count; $i++) {
+            $instances[$i] = $instances[$i]->getAttributes();
+        }
+        $instances = $instances->toArray();
+
+        return $modelName::insert($instances);
+    }
+
+    /**
      * Create a collection of models and persist them to the database without dispatching any model events.
      *
      * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -142,6 +142,18 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(10, $users);
     }
 
+    public function test_basic_model_can_be_bulk_created()
+    {
+        DB::connection()->enableQueryLog();
+        $result = FactoryTestUserFactory::times(100)->bulkCreate();
+        $queries = DB::getQueryLog();
+        $usersCount = FactoryTestUser::count();
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $queries);
+        $this->assertEquals(100, $usersCount);
+    }
+
     public function test_expanded_closure_attributes_are_resolved_and_passed_to_closures()
     {
         $user = FactoryTestUserFactory::new()->create([


### PR DESCRIPTION
Recently, I've noticed that the create functions in the Factory class hit the database as many as the instances should be made. That's really slow when you want to add lots of records using a factory. So I wrote a function named `bulkCreate` to do the same with only one database hit.

Caution: Since this function uses the QueryBuilder to save the records, any logic in the save function or elsewhere related to the Eloquent ecosystem will not be executed.