### PR TITLE
[11.x] Add fluent helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -155,6 +155,19 @@ if (! function_exists('filled')) {
     }
 }
 
+if (! function_exists('fluent')) {
+    /**
+     * Create an Fluent object from the given value.
+     *
+     * @param  object|array  $value
+     * @return \Illuminate\Support\Fluent
+     */
+    function fluent($value)
+    {
+        return new Fluent($value);
+    }
+}
+
 if (! function_exists('literal')) {
     /**
      * Return a new literal or anonymous object using named arguments.
@@ -469,18 +482,5 @@ if (! function_exists('with')) {
     function with($value, callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
-    }
-}
-
-if (! function_exists('fluent')) {
-    /**
-     * Create a fluent object from the given value.
-     *
-     * @param  object|array  $value
-     * @return Fluent
-     */
-    function fluent($value)
-    {
-        return new Fluent($value);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -476,11 +476,8 @@ if (! function_exists('fluent')) {
     /**
      * Create a fluent object from the given value.
      *
-     * @template TValue
-     * @template TReturn
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
-     * @return Fluent<TKey, TValue>
+     * @param  object|array  $value
+     * @return Fluent
      */
     function fluent($value)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -4,6 +4,7 @@ use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Once;
 use Illuminate\Support\Onceable;
@@ -468,5 +469,21 @@ if (! function_exists('with')) {
     function with($value, callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
+    }
+}
+
+if (! function_exists('fluent')) {
+    /**
+     * Create a fluent object from the given value.
+     *
+     * @template TValue
+     * @template TReturn
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
+     * @return Fluent<TKey, TValue>
+     */
+    function fluent($value)
+    {
+        return new Fluent($value);
     }
 }


### PR DESCRIPTION
The fluent helper seems to be a great addition to the `collect` helper when working with multi-dimension arrays and people [seem to like it](https://twitter.com/Philo01/status/1773743360102039787) and suggested to PR it into the core:


```php
$data = [
    'user' => [
        'name' => 'Philo',
        'address' => [
            'city' => 'Amsterdam',
            'country' => 'Netherlands',
        ]  
    ],
    'posts' => [
        [
            'title' => 'Post 1',                
        ],
        [
            'title' => 'Post 2',               
        ]
    ]
];

❌ collect($data)->get('user');
✅ fluent($data)->user

❌ collect($data)->get('user')['name'];
✅ fluent($data)->get('user.name');

❌ collect(collect($data)->get('posts'))->pluck('title');
✅ fluent($data)->collect('posts')->pluck('title');

❌ json_encode(collect($data)->get('user')['address']);
✅ fluent($data)->scope('user.address')->toJson();
````