### PR TITLE
[11.x] Fix prompting for missing array arguments on artisan command

### DIFF
--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -37,7 +37,7 @@ trait PromptsForMissingInput
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         $prompted = collect($this->getDefinition()->getArguments())
-            ->filter(fn ($argument) => $argument->isRequired() && empty($input->getArgument($argument->getName())))
+            ->filter(fn ($argument) => $argument->isRequired() && (is_null($input->getArgument($argument->getName())) || (is_array($input->getArgument($argument->getName())) && count($input->getArgument($argument->getName())) === 0)))
             ->filter(fn ($argument) => $argument->getName() !== 'command')
             ->each(function ($argument) use ($input) {
                 $label = $this->promptForMissingArgumentsUsing()[$argument->getName()] ??

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -37,7 +37,7 @@ trait PromptsForMissingInput
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         $prompted = collect($this->getDefinition()->getArguments())
-            ->filter(fn ($argument) => $argument->isRequired() && is_null($input->getArgument($argument->getName())))
+            ->filter(fn ($argument) => $argument->isRequired() && empty($input->getArgument($argument->getName())))
             ->filter(fn ($argument) => $argument->getName() !== 'command')
             ->each(function ($argument) use ($input) {
                 $label = $this->promptForMissingArgumentsUsing()[$argument->getName()] ??

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -4,6 +4,8 @@ namespace Illuminate\Console\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Console\PromptsForMissingInput as PromptsForMissingInputContract;
+use Illuminate\Support\Arr;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -37,25 +39,30 @@ trait PromptsForMissingInput
     protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         $prompted = collect($this->getDefinition()->getArguments())
-            ->filter(fn ($argument) => $argument->isRequired() && (is_null($input->getArgument($argument->getName())) || (is_array($input->getArgument($argument->getName())) && count($input->getArgument($argument->getName())) === 0)))
-            ->filter(fn ($argument) => $argument->getName() !== 'command')
-            ->each(function ($argument) use ($input) {
+            ->reject(fn (InputArgument $argument) => $argument->getName() === 'command')
+            ->filter(fn (InputArgument $argument) => $argument->isRequired() && match (true) {
+                $argument->isArray() => empty($input->getArgument($argument->getName())),
+                default => is_null($input->getArgument($argument->getName())),
+            })
+            ->each(function (InputArgument $argument) use ($input) {
                 $label = $this->promptForMissingArgumentsUsing()[$argument->getName()] ??
                     'What is '.lcfirst($argument->getDescription() ?: ('the '.$argument->getName())).'?';
 
                 if ($label instanceof Closure) {
-                    return $input->setArgument($argument->getName(), $label());
+                    return $input->setArgument($argument->getName(), $argument->isArray() ? Arr::wrap($label()) : $label());
                 }
 
                 if (is_array($label)) {
                     [$label, $placeholder] = $label;
                 }
 
-                $input->setArgument($argument->getName(), text(
+                $answer = text(
                     label: $label,
                     placeholder: $placeholder ?? '',
                     validate: fn ($value) => empty($value) ? "The {$argument->getName()} is required." : null,
-                ));
+                );
+
+                $input->setArgument($argument->getName(), $argument->isArray() ? [$answer] : $answer);
             })
             ->isNotEmpty();
 

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Foundation\Application as FoundationApplication;
-use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithArrayInputPrompting;
+use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -211,7 +211,7 @@ class ConsoleApplicationTest extends TestCase
         $app->addCommands([$command = new FakeCommandWithArrayInputPrompting()]);
 
         $statusCode = $app->call('fake-command-for-testing-array', [
-            'arguments' => [ 'foo', 'bar', 'baz', ],
+            'arguments' => ['foo', 'bar', 'baz'],
         ]);
 
         $this->assertFalse($command->prompted);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Foundation\Application as FoundationApplication;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
+use Illuminate\Tests\Console\Fixtures\FakeCommandWithArrayInputPrompting;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -175,6 +176,42 @@ class ConsoleApplicationTest extends TestCase
 
         $statusCode = $app->call('fake-command-for-testing', [
             'name' => 'foo',
+        ]);
+
+        $this->assertFalse($command->prompted);
+        $this->assertSame(0, $statusCode);
+    }
+
+    public function testCommandInputPromptsWhenRequiredArgumentsAreMissing()
+    {
+        $app = new Application(
+            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $app->addCommands([$command = new FakeCommandWithArrayInputPrompting()]);
+
+        $command->setLaravel($laravel);
+
+        $statusCode = $app->call('fake-command-for-testing-array');
+
+        $this->assertTrue($command->prompted);
+        $this->assertSame(0, $statusCode);
+    }
+
+    public function testCommandInputDoesntPromptWhenRequiredArgumentsArePassed()
+    {
+        $app = new Application(
+            $app = new \Illuminate\Foundation\Application(__DIR__),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $app->addCommands([$command = new FakeCommandWithArrayInputPrompting()]);
+
+        $statusCode = $app->call('fake-command-for-testing-array', [
+            'arguments' => [ 'foo', 'bar', 'baz', ],
         ]);
 
         $this->assertFalse($command->prompted);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -161,6 +161,7 @@ class ConsoleApplicationTest extends TestCase
         $statusCode = $app->call('fake-command-for-testing');
 
         $this->assertTrue($command->prompted);
+        $this->assertSame('foo', $command->argument('name'));
         $this->assertSame(0, $statusCode);
     }
 
@@ -179,6 +180,7 @@ class ConsoleApplicationTest extends TestCase
         ]);
 
         $this->assertFalse($command->prompted);
+        $this->assertSame('foo', $command->argument('name'));
         $this->assertSame(0, $statusCode);
     }
 
@@ -197,6 +199,7 @@ class ConsoleApplicationTest extends TestCase
         $statusCode = $app->call('fake-command-for-testing-array');
 
         $this->assertTrue($command->prompted);
+        $this->assertSame(['foo'], $command->argument('names'));
         $this->assertSame(0, $statusCode);
     }
 
@@ -211,10 +214,11 @@ class ConsoleApplicationTest extends TestCase
         $app->addCommands([$command = new FakeCommandWithArrayInputPrompting()]);
 
         $statusCode = $app->call('fake-command-for-testing-array', [
-            'arguments' => ['foo', 'bar', 'baz'],
+            'names' => ['foo', 'bar', 'baz'],
         ]);
 
         $this->assertFalse($command->prompted);
+        $this->assertSame(['foo', 'bar', 'baz'], $command->argument('names'));
         $this->assertSame(0, $statusCode);
     }
 

--- a/tests/Console/Fixtures/FakeCommandWithArrayInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithArrayInputPrompting.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class FakeCommandWithArrayInputPrompting extends Command implements PromptsForMissingInput
 {
-    protected $signature = 'fake-command-for-testing-array {arguments* : arguments}';
+    protected $signature = 'fake-command-for-testing-array {names* : An array argument}';
 
     public $prompted = false;
 

--- a/tests/Console/Fixtures/FakeCommandWithArrayInputPrompting.php
+++ b/tests/Console/Fixtures/FakeCommandWithArrayInputPrompting.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Console\Fixtures;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Laravel\Prompts\Prompt;
+use Laravel\Prompts\TextPrompt;
+use Symfony\Component\Console\Input\InputInterface;
+
+class FakeCommandWithArrayInputPrompting extends Command implements PromptsForMissingInput
+{
+    protected $signature = 'fake-command-for-testing-array {arguments* : arguments}';
+
+    public $prompted = false;
+
+    protected function configurePrompts(InputInterface $input)
+    {
+        Prompt::interactive(true);
+        Prompt::fallbackWhen(true);
+
+        TextPrompt::fallbackUsing(function () {
+            $this->prompted = true;
+
+            return 'foo';
+        });
+    }
+
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
This PR fixes the bug below:

When an Artisan Command has array arguments configuration, like:

```php
protected $signature = 'app:foo {args*}';
```
`promptForMissingArgumentsUsing()` doesn't work,

because `$input->getArgument($argument->getName())` returns empty array, and judgement in `promptForMissingArguments()` method of `Illuminate\Console\Concerns\PromptsForMissingInput` uses `is_null()`, which should be replaced with `empty()` .
`empty()` method also covers string argument, like:

```php
protected $signature = 'app:foo {arg}';
```
