### PR TITLE
feat: Add linux_os helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -454,6 +454,18 @@ if (! function_exists('windows_os')) {
     }
 }
 
+if (! function_exists('linux_os')) {
+    /**
+     * Determine whether the current environment is Linux based.
+     *
+     * @return bool
+     */
+    function linux_os()
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+}
+
 if (! function_exists('with')) {
     /**
      * Return the given value, optionally passed through the given callback.

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -426,7 +426,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanHaveErrorOutput()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -457,7 +457,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanThrowWithoutOutput()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -498,7 +498,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanThrowWithErrorOutput()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -543,7 +543,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanThrowWithOutput()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -567,7 +567,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanTimeout()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -584,7 +584,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanThrowIfTrue()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -598,7 +598,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesDoesntThrowIfFalse()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -612,7 +612,7 @@ class ProcessTest extends TestCase
 
     public function testRealProcessesCanUseStandardInput()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -624,7 +624,7 @@ class ProcessTest extends TestCase
 
     public function testProcessPipe()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -643,7 +643,7 @@ class ProcessTest extends TestCase
 
     public function testProcessPipeFailed()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -662,7 +662,7 @@ class ProcessTest extends TestCase
 
     public function testProcessSimplePipe()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 
@@ -681,7 +681,7 @@ class ProcessTest extends TestCase
 
     public function testProcessSimplePipeFailed()
     {
-        if (windows_os()) {
+        if (! linux_os()) {
             $this->markTestSkipped('Requires Linux.');
         }
 


### PR DESCRIPTION
## Description

This commit improves the performance of the code by creating a dedicated helper function named linux_os.

## Motivation and context

The function is used for test scenarios that need Linux Operating System.

## How has this been tested?

This function is verified to pass the related tests for Linux Operating System.

## Types of changes

Added a new helper function named linux_os to determine whether the current environment is Linux-based.

## Conclusion:

- I have created a branch for this patch/feature.
- Each individual commit in the pull request is meaningful.
