### PR TITLE
[11.x] Use Default Schema Name on SQL Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -38,6 +38,16 @@ class SqlServerGrammar extends Grammar
     protected $fluentCommands = ['Default'];
 
     /**
+     * Compile a query to determine the name of the default schema.
+     *
+     * @return string
+     */
+    public function compileDefaultSchema()
+    {
+        return 'select schema_name()';
+    }
+
+    /**
      * Compile a create database command.
      *
      * @param  string  $name
@@ -64,16 +74,6 @@ class SqlServerGrammar extends Grammar
             'drop database if exists %s',
             $this->wrapValue($name)
         );
-    }
-
-    /**
-     * Compile the query to determine the name of the default schema of the caller.
-     *
-     * @return string
-     */
-    public function compileDefaultSchema()
-    {
-        return 'select schema_name()';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -67,6 +67,16 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the name of the default schema of the caller.
+     *
+     * @return string
+     */
+    public function compileDefaultSchema()
+    {
+        return 'select schema_name()';
+    }
+
+    /**
      * Compile the query to determine the tables.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -42,6 +42,7 @@ class SqlServerBuilder extends Builder
     {
         [$schema, $table] = $this->parseSchemaAndTable($table);
 
+        $schema ??= $this->getDefaultSchema();
         $table = $this->connection->getTablePrefix().$table;
 
         foreach ($this->getTables() as $value) {
@@ -64,6 +65,7 @@ class SqlServerBuilder extends Builder
     {
         [$schema, $view] = $this->parseSchemaAndTable($view);
 
+        $schema ??= $this->getDefaultSchema();
         $view = $this->connection->getTablePrefix().$view;
 
         foreach ($this->getViews() as $value) {
@@ -152,6 +154,16 @@ class SqlServerBuilder extends Builder
     }
 
     /**
+     * Get the default schema for the connection.
+     *
+     * @return string
+     */
+    protected function getDefaultSchema()
+    {
+        return $this->connection->scalar($this->grammar->compileDefaultSchema());
+    }
+
+    /**
      * Parse the database object reference and extract the schema and table.
      *
      * @param  string  $reference
@@ -159,7 +171,7 @@ class SqlServerBuilder extends Builder
      */
     protected function parseSchemaAndTable($reference)
     {
-        $parts = array_pad(explode('.', $reference, 2), -2, 'dbo');
+        $parts = array_pad(explode('.', $reference, 2), -2, null);
 
         if (str_contains($parts[1], '.')) {
             $database = $parts[0];

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -433,8 +433,25 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         }
 
         $connection = DB::connection($connection);
+        $schema = $connection->getSchemaBuilder();
 
-        var_dump($connection->scalar('select current_user'));
+        $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
+
+        $connection->statement('alter user dbo with default_schema=my_schema');
+
+        $this->assertEquals('my_schema', $connection->scalar('select schema_name()'));
+
+        $schema->create('table', function (Blueprint $table) {
+            $table->id();
+        });
+
+        $this->assertTrue($schema->hasTable('table'));
+        $this->assertTrue($schema->hasTable('my_schema.table'));
+        $this->assertFalse($schema->hasTable('dbo.table'));
+
+        $connection->statement('alter user dbo with default_schema=dbo');
+
+        $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
     }
 
     public static function connectionProvider(): array

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -437,13 +437,14 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
 
         try {
             $db->statement("create login my_user with password = 'Passw0rd'");
-            $db->statement("create user my_user for login my_user");
-        } catch(\Illuminate\Database\QueryException $e) {}
-        // $db->statement('grant select, insert, update, delete, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user]');
-        $db->statement('grant create table on SCHEMA::my_schema to my_user');
+            $db->statement('create user my_user for login my_user');
+        } catch(\Illuminate\Database\QueryException $e) {
+            //
+        }
         $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
+        $db->statement('grant create table to my_user');
         // GRANT SELECT ON SCHEMA::role TO [my_user];
-        // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user];
+        $db->statement('grant select, insert, update, delete, references, alter on SCHEMA::my_schema to my_user');
         // GRANT CREATE TABLE TO [my_user];
         // GRANT ALTER ON SCHEMA::my_schema TO [my_user];
 

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -433,27 +433,8 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         }
 
         $connection = DB::connection($connection);
-        $schema = $connection->getSchemaBuilder();
-
-        $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
 
         var_dump($connection->scalar('select current_user'));
-
-        $connection->statement('alter user SA with default_schema=my_schema');
-
-        $this->assertEquals('my_schema', $connection->scalar('select schema_name()'));
-
-        $schema->create('table', function (Blueprint $table) {
-            $table->id();
-        });
-
-        $this->assertTrue($schema->hasTable('table'));
-        $this->assertTrue($schema->hasTable('my_schema.table'));
-        $this->assertFalse($schema->hasTable('dbo.table'));
-
-        $connection->statement('alter user SA with default_schema=dbo');
-
-        $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
     }
 
     public static function connectionProvider(): array

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -435,7 +435,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $connection = DB::connection($connection);
         $schema = $connection->getSchemaBuilder();
 
-        var_dump($connection->select('SELECT * FROM sysusers'));
+        var_dump($connection->select('SELECT * FROM syslogins'));
 
         $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
 

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -435,10 +435,10 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $db = DB::connection($connection);
         $schema = $db->getSchemaBuilder();
 
-        $db->statement("create login my_user with password = 'Passw0rd'");
-        $db->statement('create user my_user for login my_user');
+        $db->statement("if suser_id(N'my_user') is null create login my_user with password = 'Passw0rd'");
+        $db->statement("if suser_id(N'my_user') is null create user my_user for login my_user");
+        $db->statement('grant create table to my_user');
         $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
-        // GRANT CREATE TABLE TO [my_user];
         // GRANT SELECT ON SCHEMA::role TO [my_user];
         // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user];
         // GRANT CREATE TABLE TO [my_user];

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -434,17 +434,17 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $connection = DB::connection($connection);
         $schema = $connection->getSchemaBuilder();
 
-        $connection->statement("create login [sample] with password = 'Passw0rd'");
-        $connection->statement('create user [sample] for login [sample]');
-        $connection->statement('alter user [sample] with default_schema = my_schema');
-        // GRANT CREATE TABLE TO [sample];
-        // GRANT SELECT ON SCHEMA::role TO [sample];
-        // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::sample TO [sample];
-        // GRANT CREATE TABLE TO [sample];
-        // GRANT ALTER ON SCHEMA::sample TO [sample];
+        $connection->statement("create login my_user with password = 'Passw0rd'");
+        $connection->statement('create user my_user for login my_user');
+        $connection->statement('alter user my_user with default_schema = my_schema');
+        // GRANT CREATE TABLE TO [my_user];
+        // GRANT SELECT ON SCHEMA::role TO [my_user];
+        // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user];
+        // GRANT CREATE TABLE TO [my_user];
+        // GRANT ALTER ON SCHEMA::my_schema TO [my_user];
 
         config([
-            'database.connections.sqlsrv.username' => 'sample',
+            'database.connections.sqlsrv.username' => 'my_user',
             'database.connections.sqlsrv.password' => 'Passw0rd',
         ]);
 

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -435,6 +435,8 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $connection = DB::connection($connection);
         $schema = $connection->getSchemaBuilder();
 
+        var_dump($connection->select('SELECT * FROM sysusers'));
+
         $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
 
         $connection->statement('alter user dbo with default_schema=my_schema');

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -435,8 +435,8 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $db = DB::connection($connection);
         $schema = $db->getSchemaBuilder();
 
-        $db->statement("if suser_id(N'my_user') is null create login my_user with password = 'Passw0rd'");
-        $db->statement("if suser_id(N'my_user') is null create user my_user for login my_user");
+        $db->statement("create login my_user with password = 'Passw0rd'");
+        $db->statement("create user my_user for login my_user");
         $db->statement('grant create table to my_user');
         $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
         // GRANT SELECT ON SCHEMA::role TO [my_user];

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -437,7 +437,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
 
         $db->statement("create login my_user with password = 'Passw0rd'");
         $db->statement('create user my_user for login my_user');
-        $db->statement('alter user my_user with default_schema = my_schema');
+        $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
         // GRANT CREATE TABLE TO [my_user];
         // GRANT SELECT ON SCHEMA::role TO [my_user];
         // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user];

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -435,9 +435,12 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $db = DB::connection($connection);
         $schema = $db->getSchemaBuilder();
 
-        $db->statement("create login my_user with password = 'Passw0rd'");
-        $db->statement("create user my_user for login my_user");
-        $db->statement('grant create table to my_user');
+        try {
+            $db->statement("create login my_user with password = 'Passw0rd'");
+            $db->statement("create user my_user for login my_user");
+        } catch(\Illuminate\Database\QueryException $e) {}
+        // $db->statement('grant select, insert, update, delete, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user]');
+        $db->statement('grant create table on SCHEMA::my_schema to my_user');
         $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
         // GRANT SELECT ON SCHEMA::role TO [my_user];
         // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user];

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -441,12 +441,13 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         } catch(\Illuminate\Database\QueryException $e) {
             //
         }
-        $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
+
         $db->statement('grant create table to my_user');
         // $db->statement('grant select on SCHEMA::role to my_user');
         $db->statement('grant select, insert, update, delete, references, alter on SCHEMA::my_schema to my_user');
-        $db->statement('grant create table to my_user');
+        // $db->statement('grant create table to my_user');
         $db->statement('grant alter on SCHEMA::my_schema to my_user');
+        $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
 
         config([
             'database.connections.'.$connection.'.username' => 'my_user',

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -425,37 +425,6 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         });
     }
 
-    #[DataProvider('connectionProvider')]
-    public function testHasTable($connection)
-    {
-        if ($this->driver !== 'sqlsrv') {
-            $this->markTestSkipped('Test requires a SQL Server connection.');
-        }
-
-        $connection = DB::connection($connection);
-        $schema = $connection->getSchemaBuilder();
-
-        var_dump($connection->select('SELECT * FROM syslogins'));
-
-        $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
-
-        $connection->statement('alter user dbo with default_schema=my_schema');
-
-        $this->assertEquals('my_schema', $connection->scalar('select schema_name()'));
-
-        $schema->create('table', function (Blueprint $table) {
-            $table->id();
-        });
-
-        $this->assertTrue($schema->hasTable('table'));
-        $this->assertTrue($schema->hasTable('my_schema.table'));
-        $this->assertFalse($schema->hasTable('dbo.table'));
-
-        $connection->statement('alter user dbo with default_schema=dbo');
-
-        $this->assertEquals('dbo', $connection->scalar('select schema_name()'));
-    }
-
     public static function connectionProvider(): array
     {
         return [

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -434,7 +434,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $connection = DB::connection($connection);
         $schema = $connection->getSchemaBuilder();
 
-        $connection->statement("create login [sample] with password = 'password'");
+        $connection->statement("create login [sample] with password = 'Passw0rd'");
         $connection->statement('create user [sample] for login [sample]');
         $connection->statement('alter user [sample] with default_schema = my_schema');
         // GRANT CREATE TABLE TO [sample];
@@ -445,7 +445,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
 
         config([
             'database.connections.sqlsrv.username' => 'sample',
-            'database.connections.sqlsrv.password' => 'password',
+            'database.connections.sqlsrv.password' => 'Passw0rd',
         ]);
 
         $this->assertEquals('my_schema', $connection->scalar('select schema_name()'));

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -443,10 +443,10 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         }
         $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
         $db->statement('grant create table to my_user');
-        // GRANT SELECT ON SCHEMA::role TO [my_user];
+        // $db->statement('grant select on SCHEMA::role to my_user');
         $db->statement('grant select, insert, update, delete, references, alter on SCHEMA::my_schema to my_user');
-        // GRANT CREATE TABLE TO [my_user];
-        // GRANT ALTER ON SCHEMA::my_schema TO [my_user];
+        $db->statement('grant create table to my_user');
+        $db->statement('grant alter on SCHEMA::my_schema to my_user');
 
         config([
             'database.connections.'.$connection.'.username' => 'my_user',

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -443,9 +443,6 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         }
 
         $db->statement('grant create table to my_user');
-        // $db->statement('grant select on SCHEMA::role to my_user');
-        $db->statement('grant select, insert, update, delete, references, alter on SCHEMA::my_schema to my_user');
-        // $db->statement('grant create table to my_user');
         $db->statement('grant alter on SCHEMA::my_schema to my_user');
         $db->statement("alter user my_user with default_schema = my_schema execute as user='my_user'");
 

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -431,12 +431,13 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         if ($this->driver !== 'sqlsrv') {
             $this->markTestSkipped('Test requires a SQL Server connection.');
         }
-        $connection = DB::connection($connection);
-        $schema = $connection->getSchemaBuilder();
 
-        $connection->statement("create login my_user with password = 'Passw0rd'");
-        $connection->statement('create user my_user for login my_user');
-        $connection->statement('alter user my_user with default_schema = my_schema');
+        $db = DB::connection($connection);
+        $schema = $db->getSchemaBuilder();
+
+        $db->statement("create login my_user with password = 'Passw0rd'");
+        $db->statement('create user my_user for login my_user');
+        $db->statement('alter user my_user with default_schema = my_schema');
         // GRANT CREATE TABLE TO [my_user];
         // GRANT SELECT ON SCHEMA::role TO [my_user];
         // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::my_schema TO [my_user];
@@ -444,11 +445,11 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         // GRANT ALTER ON SCHEMA::my_schema TO [my_user];
 
         config([
-            'database.connections.sqlsrv.username' => 'my_user',
-            'database.connections.sqlsrv.password' => 'Passw0rd',
+            'database.connections.'.$connection.'.username' => 'my_user',
+            'database.connections.'.$connection.'.password' => 'Passw0rd',
         ]);
 
-        $this->assertEquals('my_schema', $connection->scalar('select schema_name()'));
+        $this->assertEquals('my_schema', $db->scalar('select schema_name()'));
 
         $schema->create('table', function (Blueprint $table) {
             $table->id();

--- a/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
+++ b/tests/Integration/Database/SchemaBuilderSchemaNameTest.php
@@ -434,9 +434,9 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
         $connection = DB::connection($connection);
         $schema = $connection->getSchemaBuilder();
 
-        $connection->statement("create login [sample] with password = 'sample'");
-        $connection->statement("create user [sample] for login [sample]");
-        $connection->statement("alter user [sample] with default_schema = my_schema");
+        $connection->statement("create login [sample] with password = 'password'");
+        $connection->statement('create user [sample] for login [sample]');
+        $connection->statement('alter user [sample] with default_schema = my_schema');
         // GRANT CREATE TABLE TO [sample];
         // GRANT SELECT ON SCHEMA::role TO [sample];
         // GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, ALTER ON SCHEMA::sample TO [sample];
@@ -445,7 +445,7 @@ class SchemaBuilderSchemaNameTest extends DatabaseTestCase
 
         config([
             'database.connections.sqlsrv.username' => 'sample',
-            'database.connections.sqlsrv.password' => 'sample',
+            'database.connections.sqlsrv.password' => 'password',
         ]);
 
         $this->assertEquals('my_schema', $connection->scalar('select schema_name()'));


### PR DESCRIPTION
Fixes #50842

On SQL Server, `Schema` methods were always using `dbo` schema as default. This causes problem in a rare condition that user manually changes the default schema (e.g by calling `alter user my_user with default_schema = my_schema`). This PR fixes that by utilizing the actual default schema (not always `dbo`).