### PR TITLE
[11.x] `assertChain` and `assertNoChain` on job instance

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -5,8 +5,8 @@ namespace Illuminate\Bus;
 use Closure;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
-use RuntimeException;
 use PHPUnit\Framework\Assert as PHPUnit;
+use RuntimeException;
 
 trait Queueable
 {

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -276,7 +276,7 @@ trait Queueable
     }
 
     /**
-     * Assert that the job has the chained jobs.
+     * Assert that the job has the given chain of jobs attached to it.
      *
      * @param  array  $expectedChain
      * @return void
@@ -301,9 +301,8 @@ trait Queueable
     }
 
     /**
-     * Assert that the job has no chained jobs.
+     * Assert that the job has no remaining chained jobs.
      *
-     * @param  array  $expectedChain
      * @return void
      */
     public function assertNoChain()

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -281,7 +281,7 @@ trait Queueable
      * @param  array  $expectedChain
      * @return void
      */
-    public function assertChain($expectedChain)
+    public function assertHasChain($expectedChain)
     {
         PHPUnit::assertTrue(
             collect($expectedChain)->isNotEmpty(),
@@ -305,11 +305,8 @@ trait Queueable
      *
      * @return void
      */
-    public function assertNoChain()
+    public function assertDoesntHaveChain()
     {
-        PHPUnit::assertEmpty(
-            $this->chained,
-            'The job has chained jobs.'
-        );
+        PHPUnit::assertEmpty($this->chained, 'The job has chained jobs.');
     }
 }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -420,9 +420,9 @@ class SupportTestingQueueFakeTest extends TestCase
 
     public function testAssertChainUsingClassesOrObjectsArray()
     {
-        ($job = new JobWithChainStub([
+        $job = new JobWithChainStub([
             new JobStub,
-        ]));
+        ]);
 
         $job->assertChain([
             JobStub::class,

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -424,11 +424,11 @@ class SupportTestingQueueFakeTest extends TestCase
             new JobStub,
         ]);
 
-        $job->assertChain([
+        $job->assertHasChain([
             JobStub::class,
         ]);
 
-        $job->assertChain([
+        $job->assertHasChain([
             new JobStub(),
         ]);
     }
@@ -437,7 +437,7 @@ class SupportTestingQueueFakeTest extends TestCase
     {
         $job = new JobWithChainStub([]);
 
-        $job->assertNoChain();
+        $job->assertDoesntHaveChain();
     }
 
     public function testAssertChainErrorHandling()
@@ -447,14 +447,14 @@ class SupportTestingQueueFakeTest extends TestCase
         ]);
 
         try {
-            $job->assertChain([]);
+            $job->assertHasChain([]);
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The expected chain can not be empty.', $e->getMessage());
         }
 
         try {
-            $job->assertChain([
+            $job->assertHasChain([
                 new JobStub,
                 new JobStub,
             ]);
@@ -464,7 +464,7 @@ class SupportTestingQueueFakeTest extends TestCase
         }
 
         try {
-            $job->assertChain([
+            $job->assertHasChain([
                 JobStub::class,
                 JobStub::class,
             ]);
@@ -474,7 +474,7 @@ class SupportTestingQueueFakeTest extends TestCase
         }
 
         try {
-            $job->assertNoChain();
+            $job->assertDoesntHaveChain();
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The job has chained jobs.', $e->getMessage());


### PR DESCRIPTION
If you are testing a job in isolation and that job appends or prepends job(s) to its chain, then there is currently no easy way to test that.
```php
public function handle(): void
{
    $this->prependToChain(new FooBarJob());
}
```
This PR fixes that by introducing the `assertChain` method (and `assertNoChain` method):
```php
public function test_job_chains_foo_bar_job(): void
{
    $job = new TestJob();

    $job->handle();

    $job->assertChain([
        new FooBarJob();
    ]);

    // $job->assertNoChain();
}
```